### PR TITLE
Parser yaml config

### DIFF
--- a/packages/compiler/src/parser/interfaces.ts
+++ b/packages/compiler/src/parser/interfaces.ts
@@ -13,6 +13,11 @@ export interface Fragment extends BaseNode {
   children: TemplateNode[]
 }
 
+export interface Config extends BaseNode {
+  type: 'Config'
+  value: Record<string, any>
+}
+
 export interface Text extends BaseNode {
   type: 'Text'
   data: string

--- a/packages/compiler/src/parser/state/config.ts
+++ b/packages/compiler/src/parser/state/config.ts
@@ -1,0 +1,32 @@
+import yaml from 'yaml'
+
+import { Parser } from '..'
+import PARSER_ERRORS from '../../error/errors'
+
+export function config(parser: Parser) {
+  const start = parser.index
+  parser.eat('---')
+
+  // Read until there is a line break followed by a triple dash
+  const data = parser.readUntil(/\n\s*\-\-\-\s*/)
+
+  parser.allowWhitespace()
+  parser.eat('---', true)
+
+  let parsedData
+  try {
+    parsedData = yaml.parse(data)
+  } catch (error) {
+    parser.error(PARSER_ERRORS.invalidConfig((error as Error).message), start)
+  }
+
+  const node = {
+    start,
+    end: parser.index,
+    type: 'Config',
+    raw: data,
+    value: parsedData,
+  }
+
+  parser.current().children!.push(node)
+}

--- a/packages/compiler/src/parser/state/fragment.ts
+++ b/packages/compiler/src/parser/state/fragment.ts
@@ -1,5 +1,6 @@
 import { Parser } from '..'
 import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
+import { config } from './config'
 import { multiLineComment } from './multi_line_comment'
 import { mustache } from './mustache'
 import { tag } from './tag'
@@ -14,6 +15,13 @@ export default function fragment(parser: Parser): (parser: Parser) => void {
   }
   if (parser.match('/*') || parser.match('*/')) {
     return multiLineComment
+  }
+  if (parser.match('---')) {
+    // Only parse config if it's the first thing in the file
+    const isFirst = parser.template.slice(0, parser.index).trim() === '' // Ignore any whitespace
+    if (isFirst) {
+      return config
+    }
   }
 
   return text

--- a/packages/compiler/src/parser/state/text.ts
+++ b/packages/compiler/src/parser/state/text.ts
@@ -2,7 +2,7 @@ import { type Parser } from '..'
 import { CUSTOM_TAG_START } from '../constants'
 
 const ENDS_WITH_ESCAPE_REGEX = /(?<!\\)(\\\\)*\\$/
-const RESERVED_DELIMITERS = [CUSTOM_TAG_START, '/*', '<', '---']
+const RESERVED_DELIMITERS = [CUSTOM_TAG_START, '/*', '<']
 
 export function text(parser: Parser) {
   const start = parser.index
@@ -11,6 +11,12 @@ export function text(parser: Parser) {
   while (parser.index < parser.template.length) {
     const isEscaping = ENDS_WITH_ESCAPE_REGEX.test(data)
     if (isEscaping) data = data.slice(0, -1) // Remove the escape character
+
+    if (!isEscaping && parser.match('---')) {
+      // Only parse config if it's the first thing in the file
+      const isFirst = parser.template.slice(0, parser.index).trim() === '' // Ignore any whitespace
+      if (isFirst) break
+    }
 
     if (
       !isEscaping &&


### PR DESCRIPTION
🚂 TRENECITO
Destination: #8 

---
Parse any YAML-like config if it's surrounded by `---`. As a requirement, it MUST be the first thing in the file. Otherwise, it will just be treated as text.

For example:
```md
---
model: gpt-4o
temperature: 0.2
tools:
    - user_search
---
/* Rest of conversation */
```

Contents inside this block will simply be parsed as YAML. This content must be static, so no custom logic is applied via `{{ }}` tags.

---

Previous stop: #9 
Next stop: #12 