### PR TITLE
Compiler: Read metadata

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "acorn": "^8.9.0",
+    "ajv": "^8.16.0",
     "code-red": "^1.0.3",
     "locate-character": "^3.0.0",
     "yaml": "^2.4.5"

--- a/packages/compiler/src/compiler/config.ts
+++ b/packages/compiler/src/compiler/config.ts
@@ -1,10 +1,28 @@
+import Ajv from 'ajv'
+import type { ErrorObject, JTDDataType } from 'ajv/dist/core'
+
 import { Fragment } from '../parser/interfaces'
 
-export function readConfig(fragment: Fragment): Record<string, unknown> {
+export function readConfig<ConfigSchema>(
+  fragment: Fragment,
+): JTDDataType<ConfigSchema> {
   for (const node of fragment.children) {
     if (node.type === 'Config') {
-      return node.value
+      return node.value as JTDDataType<ConfigSchema>
     }
   }
-  return {}
+  return {} as JTDDataType<ConfigSchema>
+}
+
+export function validateConfig(
+  config: object,
+  schema: object,
+): true | ErrorObject[] {
+  const ajv = new Ajv()
+  type Config = JTDDataType<typeof schema>
+
+  const validate = ajv.compile<Config>(schema)
+  const valid = validate(config)
+  if (valid) return true
+  return validate.errors!
 }

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -1,5 +1,6 @@
-import { Conversation } from '../types'
+import { Conversation, ConversationMetadata } from '../types'
 import { Compile, type ReferencePromptFn } from './compile'
+import { ReadMetadata } from './readMetadata'
 
 export function compile({
   prompt,
@@ -11,4 +12,16 @@ export function compile({
   referenceFn?: ReferencePromptFn
 }): Promise<Conversation> {
   return new Compile({ prompt, parameters, referenceFn }).run()
+}
+
+export function readMetadata({
+  prompt,
+  referenceFn,
+  configSchema,
+}: {
+  prompt: string
+  referenceFn?: ReferencePromptFn
+  configSchema?: object
+}): Promise<ConversationMetadata<typeof configSchema>> {
+  return new ReadMetadata({ prompt, referenceFn, configSchema }).run()
 }

--- a/packages/compiler/src/compiler/logic/index.ts
+++ b/packages/compiler/src/compiler/logic/index.ts
@@ -1,7 +1,11 @@
 import type { Node } from 'estree'
 
-import { nodeResolvers } from './nodes'
-import type { NodeType, ResolveNodeProps } from './types'
+import { nodeResolvers, updateScopeContextResolvers } from './nodes'
+import type {
+  NodeType,
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from './types'
 
 /**
  * Given a node, calculates the resulting value.
@@ -14,4 +18,20 @@ export async function resolveLogicNode(props: ResolveNodeProps<Node>) {
 
   const nodeResolver = nodeResolvers[props.node.type as NodeType]
   return nodeResolver(props)
+}
+
+/**
+ * Given a node, keeps track of the defined variables.
+ */
+export async function updateScopeContextForNode(
+  props: UpdateScopeContextProps<Node>,
+) {
+  const type = props.node.type as NodeType
+  if (!nodeResolvers[type]) {
+    throw new Error(`Unknown node type: ${type}`)
+  }
+
+  const updateScopeContextFn =
+    updateScopeContextResolvers[props.node.type as NodeType]
+  return updateScopeContextFn(props)
 }

--- a/packages/compiler/src/compiler/logic/nodes/arrayExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/arrayExpression.ts
@@ -1,9 +1,9 @@
 import type { ArrayExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import errors from '../../../error/errors'
 import { isIterable } from '../../utils'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### ArrayExpression
@@ -42,4 +42,18 @@ export async function resolve({
   }
 
   return resolvedArray
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<ArrayExpression>) {
+  for (const element of node.elements) {
+    if (!element) continue
+
+    updateScopeContextForNode({
+      node: element.type === 'SpreadElement' ? element.argument : element,
+      ...props,
+    })
+  }
 }

--- a/packages/compiler/src/compiler/logic/nodes/binaryExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/binaryExpression.ts
@@ -1,9 +1,9 @@
 import type { BinaryExpression, LogicalExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import errors from '../../../error/errors'
 import { BINARY_OPERATOR_METHODS } from '../operators'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### BinaryExpression
@@ -32,4 +32,17 @@ export async function resolve({
   })
 
   return BINARY_OPERATOR_METHODS[binaryOperator]?.(leftOperand, rightOperand)
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<BinaryExpression | LogicalExpression>) {
+  const binaryOperator = node.operator
+  if (!(binaryOperator in BINARY_OPERATOR_METHODS)) {
+    props.raiseError(errors.unsupportedOperator(binaryOperator), node)
+  }
+
+  updateScopeContextForNode({ node: node.left, ...props })
+  updateScopeContextForNode({ node: node.right, ...props })
 }

--- a/packages/compiler/src/compiler/logic/nodes/callExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/callExpression.ts
@@ -1,9 +1,9 @@
 import type { SimpleCallExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import CompileError from '../../../error/error'
 import errors from '../../../error/errors'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### CallExpression
@@ -54,5 +54,15 @@ async function runMethod({
   } catch (error: unknown) {
     if (error instanceof CompileError) throw error
     raiseError(errors.functionCallError(error), node)
+  }
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<SimpleCallExpression>) {
+  updateScopeContextForNode({ node: node.callee, ...props })
+  for (const arg of node.arguments) {
+    updateScopeContextForNode({ node: arg, ...props })
   }
 }

--- a/packages/compiler/src/compiler/logic/nodes/chainExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/chainExpression.ts
@@ -1,7 +1,7 @@
 import type { ChainExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
-import type { ResolveNodeProps } from '../types'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### Chain Expression
@@ -15,4 +15,11 @@ export async function resolve({
     node: node.expression,
     ...props,
   })
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<ChainExpression>) {
+  updateScopeContextForNode({ node: node.expression, ...props })
 }

--- a/packages/compiler/src/compiler/logic/nodes/conditionalExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/conditionalExpression.ts
@@ -1,7 +1,7 @@
 import type { ConditionalExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
-import type { ResolveNodeProps } from '../types'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### ConditionalExpression
@@ -18,4 +18,13 @@ export async function resolve({
     node: condition ? node.consequent : node.alternate,
     ...props,
   })
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<ConditionalExpression>) {
+  updateScopeContextForNode({ node: node.test, ...props })
+  updateScopeContextForNode({ node: node.consequent, ...props })
+  updateScopeContextForNode({ node: node.alternate, ...props })
 }

--- a/packages/compiler/src/compiler/logic/nodes/identifier.ts
+++ b/packages/compiler/src/compiler/logic/nodes/identifier.ts
@@ -1,7 +1,7 @@
 import type { Identifier } from 'estree'
 
 import errors from '../../../error/errors'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### Identifier
@@ -16,4 +16,13 @@ export async function resolve({
     raiseError(errors.variableNotDeclared(node.name), node)
   }
   return scope.get(node.name)
+}
+
+export function updateScopeContext({
+  node,
+  scopeContext,
+}: UpdateScopeContextProps<Identifier>) {
+  if (!scopeContext.definedVariables.has(node.name)) {
+    scopeContext.usedUndefinedVariables.add(node.name)
+  }
 }

--- a/packages/compiler/src/compiler/logic/nodes/index.ts
+++ b/packages/compiler/src/compiler/logic/nodes/index.ts
@@ -1,21 +1,61 @@
 import { Node } from 'estree'
 
-import { NodeType, ResolveNodeProps } from '../types'
-import { resolve as resolveArrayExpression } from './arrayExpression'
-import { resolve as resolveAssignmentExpression } from './assignmentExpression'
-import { resolve as resolveBinaryExpression } from './binaryExpression'
-import { resolve as resolveCallExpression } from './callExpression'
-import { resolve as resolveChainExpression } from './chainExpression'
-import { resolve as resolveConditionalExpression } from './conditionalExpression'
-import { resolve as resolveIdentifier } from './identifier'
-import { resolve as resolveLiteral } from './literal'
-import { resolve as resolveMemberExpression } from './memberExpression'
-import { resolve as resolveObjectExpression } from './objectExpression'
-import { resolve as resolveSequenceExpression } from './sequenceExpression'
-import { resolve as resolveUnaryExpression } from './unaryExpression'
-import { resolve as resolveUpdateExpression } from './updateExpression'
+import { NodeType, ResolveNodeProps, UpdateScopeContextProps } from '../types'
+import {
+  resolve as resolveArrayExpression,
+  updateScopeContext as updateArrayScopeContext,
+} from './arrayExpression'
+import {
+  resolve as resolveAssignmentExpression,
+  updateScopeContext as updateAssignmentScopeContext,
+} from './assignmentExpression'
+import {
+  resolve as resolveBinaryExpression,
+  updateScopeContext as updateBinaryScopeContext,
+} from './binaryExpression'
+import {
+  resolve as resolveCallExpression,
+  updateScopeContext as updateCallScopeContext,
+} from './callExpression'
+import {
+  resolve as resolveChainExpression,
+  updateScopeContext as updateChainScopeContext,
+} from './chainExpression'
+import {
+  resolve as resolveConditionalExpression,
+  updateScopeContext as updateConditionalScopeContext,
+} from './conditionalExpression'
+import {
+  resolve as resolveIdentifier,
+  updateScopeContext as updateIdentifierScopeContext,
+} from './identifier'
+import {
+  resolve as resolveLiteral,
+  updateScopeContext as updateLiteralScopeContext,
+} from './literal'
+import {
+  resolve as resolveMemberExpression,
+  updateScopeContext as updateMemberScopeContext,
+} from './memberExpression'
+import {
+  resolve as resolveObjectExpression,
+  updateScopeContext as updateObjectScopeContext,
+} from './objectExpression'
+import {
+  resolve as resolveSequenceExpression,
+  updateScopeContext as updateSequenceScopeContext,
+} from './sequenceExpression'
+import {
+  resolve as resolveUnaryExpression,
+  updateScopeContext as updateUnaryScopeContext,
+} from './unaryExpression'
+import {
+  resolve as resolveUpdateExpression,
+  updateScopeContext as updateUpdateScopeContext,
+} from './updateExpression'
 
 type ResolveNodeFn = (props: ResolveNodeProps<Node>) => Promise<unknown>
+type UpdateScopeContextFn = (props: UpdateScopeContextProps<Node>) => void
 
 export const nodeResolvers: Record<NodeType, ResolveNodeFn> = {
   [NodeType.ArrayExpression]: resolveArrayExpression as ResolveNodeFn,
@@ -33,4 +73,28 @@ export const nodeResolvers: Record<NodeType, ResolveNodeFn> = {
   [NodeType.SequenceExpression]: resolveSequenceExpression as ResolveNodeFn,
   [NodeType.UnaryExpression]: resolveUnaryExpression as ResolveNodeFn,
   [NodeType.UpdateExpression]: resolveUpdateExpression as ResolveNodeFn,
+}
+
+export const updateScopeContextResolvers: Record<
+  NodeType,
+  UpdateScopeContextFn
+> = {
+  [NodeType.ArrayExpression]: updateArrayScopeContext as UpdateScopeContextFn,
+  [NodeType.AssignmentExpression]:
+    updateAssignmentScopeContext as UpdateScopeContextFn,
+  [NodeType.BinaryExpression]: updateBinaryScopeContext as UpdateScopeContextFn,
+  [NodeType.CallExpression]: updateCallScopeContext as UpdateScopeContextFn,
+  [NodeType.ChainExpression]: updateChainScopeContext as UpdateScopeContextFn,
+  [NodeType.ConditionalExpression]:
+    updateConditionalScopeContext as UpdateScopeContextFn,
+  [NodeType.Identifier]: updateIdentifierScopeContext as UpdateScopeContextFn,
+  [NodeType.Literal]: updateLiteralScopeContext as UpdateScopeContextFn,
+  [NodeType.LogicalExpression]:
+    updateBinaryScopeContext as UpdateScopeContextFn,
+  [NodeType.ObjectExpression]: updateObjectScopeContext as UpdateScopeContextFn,
+  [NodeType.MemberExpression]: updateMemberScopeContext as UpdateScopeContextFn,
+  [NodeType.SequenceExpression]:
+    updateSequenceScopeContext as UpdateScopeContextFn,
+  [NodeType.UnaryExpression]: updateUnaryScopeContext as UpdateScopeContextFn,
+  [NodeType.UpdateExpression]: updateUpdateScopeContext as UpdateScopeContextFn,
 }

--- a/packages/compiler/src/compiler/logic/nodes/literal.ts
+++ b/packages/compiler/src/compiler/logic/nodes/literal.ts
@@ -9,3 +9,7 @@ import { type ResolveNodeProps } from '../types'
 export async function resolve({ node }: ResolveNodeProps<Literal>) {
   return node.value
 }
+
+export function updateScopeContext() {
+  // Do nothing
+}

--- a/packages/compiler/src/compiler/logic/nodes/memberExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/memberExpression.ts
@@ -1,8 +1,8 @@
 import type { Identifier, MemberExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import { MEMBER_EXPRESSION_METHOD } from '../operators'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### MemberExpression
@@ -28,4 +28,14 @@ export async function resolve({
     : (node.property as Identifier).name
 
   return MEMBER_EXPRESSION_METHOD(object, property)
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<MemberExpression>) {
+  updateScopeContextForNode({ node: node.object, ...props })
+  if (node.computed) {
+    updateScopeContextForNode({ node: node.property, ...props })
+  }
 }

--- a/packages/compiler/src/compiler/logic/nodes/objectExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/objectExpression.ts
@@ -1,8 +1,8 @@
 import { type Identifier, type ObjectExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import errors from '../../../error/errors'
-import { type ResolveNodeProps } from '../types'
+import { UpdateScopeContextProps, type ResolveNodeProps } from '../types'
 
 /**
  * ### ObjectExpression
@@ -45,4 +45,21 @@ export async function resolve({
     throw raiseError(errors.invalidObjectKey, prop)
   }
   return resolvedObject
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<ObjectExpression>) {
+  for (const prop of node.properties) {
+    if (prop.type === 'SpreadElement') {
+      updateScopeContextForNode({ node: prop.argument, ...props })
+      continue
+    }
+    if (prop.type === 'Property') {
+      updateScopeContextForNode({ node: prop.value, ...props })
+      continue
+    }
+    props.raiseError(errors.invalidObjectKey, prop)
+  }
 }

--- a/packages/compiler/src/compiler/logic/nodes/sequenceExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/sequenceExpression.ts
@@ -1,7 +1,7 @@
 import type { SequenceExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
-import type { ResolveNodeProps } from '../types'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### SequenceExpression
@@ -16,4 +16,13 @@ export async function resolve({
       resolveLogicNode({ node: expression, ...props }),
     ),
   )
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<SequenceExpression>) {
+  for (const expression of node.expressions) {
+    updateScopeContextForNode({ node: expression, ...props })
+  }
 }

--- a/packages/compiler/src/compiler/logic/nodes/unaryExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/unaryExpression.ts
@@ -1,9 +1,9 @@
 import type { UnaryExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import errors from '../../../error/errors'
 import { UNARY_OPERATOR_METHODS } from '../operators'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### UnaryExpression
@@ -28,4 +28,17 @@ export async function resolve({
   })
   const unaryPrefix = node.prefix
   return UNARY_OPERATOR_METHODS[unaryOperator]?.(unaryArgument, unaryPrefix)
+}
+
+export function updateScopeContext({
+  node,
+  scopeContext,
+  ...props
+}: UpdateScopeContextProps<UnaryExpression>) {
+  const unaryOperator = node.operator
+  if (!(unaryOperator in UNARY_OPERATOR_METHODS)) {
+    props.raiseError(errors.unsupportedOperator(unaryOperator), node)
+  }
+
+  updateScopeContextForNode({ node: node.argument, scopeContext, ...props })
 }

--- a/packages/compiler/src/compiler/logic/nodes/updateExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/updateExpression.ts
@@ -1,8 +1,8 @@
 import type { AssignmentExpression, UpdateExpression } from 'estree'
 
-import { resolveLogicNode } from '..'
+import { resolveLogicNode, updateScopeContextForNode } from '..'
 import errors from '../../../error/errors'
-import type { ResolveNodeProps } from '../types'
+import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### UpdateExpression
@@ -68,4 +68,16 @@ export async function resolve({
   })
 
   return node.prefix ? updatedValue : originalValue
+}
+
+export function updateScopeContext({
+  node,
+  ...props
+}: UpdateScopeContextProps<UpdateExpression>) {
+  const updateOperator = node.operator
+  if (!['++', '--'].includes(updateOperator)) {
+    props.raiseError(errors.unsupportedOperator(updateOperator), node)
+  }
+
+  updateScopeContextForNode({ node: node.argument, ...props })
 }

--- a/packages/compiler/src/compiler/logic/types.ts
+++ b/packages/compiler/src/compiler/logic/types.ts
@@ -1,6 +1,6 @@
 import { Node } from 'estree'
 
-import Scope from '../scope'
+import Scope, { ScopeContext } from '../scope'
 
 export enum NodeType {
   Literal = 'Literal',
@@ -19,11 +19,19 @@ export enum NodeType {
   ChainExpression = 'ChainExpression',
 }
 
+type RaiseErrorFn = (
+  { code, message }: { code: string; message: string },
+  node: Node,
+) => never
+
 export type ResolveNodeProps<N extends Node> = {
   node: N
   scope: Scope
-  raiseError: (
-    { code, message }: { code: string; message: string },
-    node: Node,
-  ) => never
+  raiseError: RaiseErrorFn
+}
+
+export type UpdateScopeContextProps<N extends Node> = {
+  node: N
+  scopeContext: ScopeContext
+  raiseError: RaiseErrorFn
 }

--- a/packages/compiler/src/compiler/readMetadata.test.ts
+++ b/packages/compiler/src/compiler/readMetadata.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { readMetadata } from '.'
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
+import CompileError from '../error/error'
+import { removeCommonIndent } from './utils'
+
+const getExpectedError = async <T>(
+  action: () => Promise<unknown>,
+  errorClass: new () => T,
+): Promise<T> => {
+  try {
+    await action()
+  } catch (err) {
+    expect(err).toBeInstanceOf(errorClass)
+    return err as T
+  }
+  throw new Error('Expected an error to be thrown')
+}
+
+describe('hash', async () => {
+  it('always returns the same hash for the same prompt', async () => {
+    const prompt = `
+      foo
+      bar
+    `
+
+    const metadata1 = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    const metadata2 = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata1.hash).toBe(metadata2.hash)
+  })
+
+  it('always returns different hashes for different prompts', async () => {
+    const prompt1 = `
+      foo
+      bar
+    `
+    const prompt2 = `
+      foo
+      baz
+    `
+
+    const metadata1 = await readMetadata({
+      prompt: removeCommonIndent(prompt1),
+    })
+
+    const metadata2 = await readMetadata({
+      prompt: removeCommonIndent(prompt2),
+    })
+
+    expect(metadata1.hash).not.toBe(metadata2.hash)
+  })
+})
+
+describe('config', async () => {
+  it('compiles the YAML written in the config section and returns it as the config attribute in the result', async () => {
+    const prompt = `
+      ---
+      foo: bar
+      baz:
+       - qux
+       - quux
+      ---
+    `
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata.config).toEqual({
+      foo: 'bar',
+      baz: ['qux', 'quux'],
+    })
+  })
+
+  it('does not compile the prompt as YAML when it is not the first element in the prompt', async () => {
+    const prompt = `
+      Lorem ipsum
+      ---
+      foo: bar
+      baz:
+       - qux
+       - quux
+      ---
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata.config).toEqual({})
+  })
+})
+
+describe('config validation', async () => {
+  it('returns true when the configuration schema is valid', async () => {
+    const configSchema = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        baz: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+    }
+
+    const prompt = `
+      ---
+      foo: bar
+      baz:
+       - qux
+       - quux
+      ---
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+      configSchema,
+    })
+
+    expect(metadata.schemaValidation).toBe(true)
+  })
+
+  it('returns an array of errors when the configuration schema is invalid', async () => {
+    const configSchema = {
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+        baz: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+      },
+      required: ['baz'],
+    } as const
+
+    const prompt = `
+      ---
+      foo:
+       - 1
+       - 2
+      ---
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+      configSchema,
+    })
+
+    expect(metadata.schemaValidation).toBeInstanceOf(Array)
+  })
+
+  it('returns undefined when the configuration schema is not provided', async () => {
+    const prompt = `
+      ---
+      foo: bar
+      baz:
+       - qux
+       - quux
+      ---
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata.schemaValidation).toBeUndefined()
+  })
+})
+
+describe('parameters', async () => {
+  it('detects undefined variables being used in the prompt', async () => {
+    const prompt = `
+      ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata.parameters).toEqual(new Set(['foo']))
+  })
+
+  it('ignores variables that are defined in the prompt', async () => {
+    const prompt = `
+      ${CUSTOM_TAG_START}foo = 5${CUSTOM_TAG_END}
+      ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}
+    `
+
+    const metadata = await readMetadata({
+      prompt: removeCommonIndent(prompt),
+    })
+
+    expect(metadata.parameters).toEqual(new Set())
+  })
+})
+
+describe('referenced prompts', async () => {
+  it('changes the parent hash with the referenced prompt has changed', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        This is the parent prompt.
+        <ref prompt="child" />
+        The end.
+      `),
+      child: removeCommonIndent('Lorem ipsum'),
+    } as Record<string, string>
+
+    const referenceFn = async (promptPath: string): Promise<string> => {
+      return prompts[promptPath]!
+    }
+
+    const metadata1 = await readMetadata({
+      prompt: prompts['parent']!,
+      referenceFn,
+    })
+
+    prompts['child'] = 'Latitude Rocks' // Modify child prompt
+
+    const metadata2 = await readMetadata({
+      prompt: prompts['parent']!,
+      referenceFn,
+    })
+
+    expect(metadata1.hash).not.toBe(metadata2.hash)
+  })
+
+  it('returns a list of all referenced prompts', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        This is the parent prompt.
+        <ref prompt="child1" />
+        <ref prompt="child2" />
+        The end.
+      `),
+      child1: removeCommonIndent('Lorem ipsum'),
+      child2: removeCommonIndent('<ref prompt="grandchild" />'),
+      grandchild: removeCommonIndent('Foo bar'),
+    } as Record<string, string>
+
+    const referenceFn = async (promptPath: string): Promise<string> => {
+      return prompts[promptPath]!
+    }
+
+    const metadata = await readMetadata({
+      prompt: prompts['parent']!,
+      referenceFn,
+    })
+
+    expect(metadata.referencedPrompts).toEqual(
+      new Set(['child1', 'child2', 'grandchild']),
+    )
+  })
+
+  it('includes parameters from referenced prompts', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        This is the parent prompt.
+        ${CUSTOM_TAG_START}parentParam${CUSTOM_TAG_END}
+        ${CUSTOM_TAG_START}parentDefinedVar = 5${CUSTOM_TAG_END}
+        <ref prompt="child" />
+        The end.
+      `),
+      child: removeCommonIndent(`
+        ${CUSTOM_TAG_START}childParam${CUSTOM_TAG_END}
+        ${CUSTOM_TAG_START}parentDefinedVar${CUSTOM_TAG_END}
+      `),
+    } as Record<string, string>
+
+    const referenceFn = async (promptPath: string): Promise<string> => {
+      return prompts[promptPath]!
+    }
+
+    const metadata = await readMetadata({
+      prompt: prompts['parent']!,
+      referenceFn,
+    })
+
+    // parentDefinedVar should not be included as parameter
+    expect(metadata.parameters).toEqual(new Set(['parentParam', 'childParam']))
+  })
+})
+
+describe('syntax errors', async () => {
+  it('throws CompileErrors when the prompt syntax is invalid', async () => {
+    const prompt = `
+      <user>
+        <user>
+        </user>
+      </user>
+    `
+
+    const action = async () => {
+      await readMetadata({
+        prompt,
+      })
+    }
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error).toBeTruthy()
+  })
+})

--- a/packages/compiler/src/compiler/readMetadata.ts
+++ b/packages/compiler/src/compiler/readMetadata.ts
@@ -1,0 +1,327 @@
+import { createHash } from 'crypto'
+
+import { Node as LogicalExpression } from 'estree'
+
+import {
+  CUSTOM_MESSAGE_TAG,
+  REFERENCE_PROMPT_ATTR,
+  REFERENCE_PROMPT_TAG,
+} from '../constants'
+import CompileError, { error } from '../error/error'
+import errors from '../error/errors'
+import parse from '../parser/index'
+import type { Attribute, BaseNode } from '../parser/interfaces'
+import { ContentType, ConversationMetadata, MessageRole } from '../types'
+import { ReferencePromptFn } from './compile'
+import { readConfig, validateConfig } from './config'
+import { updateScopeContextForNode } from './logic'
+import { ScopeContext } from './scope'
+
+function copyScopeContext(scopeContext: ScopeContext): ScopeContext {
+  return {
+    ...scopeContext,
+    definedVariables: new Set(scopeContext.definedVariables),
+  }
+}
+
+export class ReadMetadata {
+  private rawText: string
+  private referenceFn?: ReferencePromptFn
+  private configSchema?: object
+
+  private referencedPrompts: Record<string, string> = {} // Prompt path -> Prompt hash
+
+  constructor({
+    prompt,
+    referenceFn,
+    configSchema,
+  }: {
+    prompt: string
+    referenceFn?: ReferencePromptFn
+    configSchema?: object
+  }) {
+    this.rawText = prompt
+    this.referenceFn = referenceFn
+    this.configSchema = configSchema
+  }
+
+  /**
+   * Resolves every block, expression, and function inside the SQL and returns the final query.
+   *
+   * Note: Compiling a query may take time in some cases, as some queries may contain expensive
+   * functions that need to be resolved at runtime.
+   */
+  async run(): Promise<ConversationMetadata<typeof this.configSchema>> {
+    const fragment = parse(this.rawText)
+    const config = readConfig<typeof this.configSchema>(fragment)
+    const scopeContext = {
+      usedUndefinedVariables: new Set<string>(),
+      definedVariables: new Set<string>(),
+    }
+    await this.readBaseMetadata({
+      node: fragment,
+      scopeContext,
+      isInMessageTag: false,
+      isInContentTag: false,
+    })
+
+    const hash = createHash('sha256')
+    hash.update(this.rawText)
+    Object.values(this.referencedPrompts).forEach((refHash: string) => {
+      hash.update(refHash)
+    })
+    const hashValue = hash.digest('hex')
+
+    return {
+      hash: hashValue,
+      parameters: scopeContext.usedUndefinedVariables,
+      referencedPrompts: new Set(Object.keys(this.referencedPrompts)),
+      schemaValidation: this.configSchema
+        ? validateConfig(config as object, this.configSchema as object)
+        : undefined,
+      config,
+    }
+  }
+
+  private async updateScopeContext({
+    node,
+    scopeContext,
+  }: {
+    node: LogicalExpression
+    scopeContext: ScopeContext
+  }): Promise<void> {
+    await updateScopeContextForNode({
+      node,
+      scopeContext,
+      raiseError: this.expressionError.bind(this),
+    })
+  }
+
+  private async readBaseMetadata({
+    node,
+    scopeContext,
+    isInMessageTag,
+    isInContentTag,
+  }: {
+    node: BaseNode
+    scopeContext: ScopeContext
+    isInMessageTag: boolean
+    isInContentTag: boolean
+  }): Promise<void> {
+    if (node.type === 'Fragment') {
+      for await (const childNode of node.children ?? []) {
+        await this.readBaseMetadata({
+          node: childNode,
+          scopeContext,
+          isInMessageTag,
+          isInContentTag,
+        })
+      }
+      return
+    }
+
+    if (
+      node.type === 'Config' ||
+      node.type === 'Comment' ||
+      node.type === 'Text'
+    ) {
+      /* do nothing */
+      return
+    }
+
+    if (node.type === 'MustacheTag') {
+      await this.updateScopeContext({ node: node.expression, scopeContext })
+    }
+
+    if (node.type === 'IfBlock') {
+      await this.updateScopeContext({ node: node.expression, scopeContext })
+
+      for await (const childNode of node.children ?? []) {
+        await this.readBaseMetadata({
+          node: childNode,
+          scopeContext: copyScopeContext(scopeContext),
+          isInMessageTag,
+          isInContentTag,
+        })
+      }
+      if (node.else) {
+        for await (const childNode of node.else.children ?? []) {
+          await this.readBaseMetadata({
+            node: childNode,
+            scopeContext: copyScopeContext(scopeContext),
+            isInMessageTag,
+            isInContentTag,
+          })
+        }
+      }
+      return
+    }
+
+    if (node.type === 'EachBlock') {
+      await this.updateScopeContext({ node: node.expression, scopeContext })
+      await this.updateScopeContext({ node: node.context, scopeContext })
+      const contextVarName = node.context.name
+      const indexVarName = node.index === null ? null : node.index.name
+
+      if (node.index) {
+        await this.updateScopeContext({ node: node.index, scopeContext })
+      }
+      if (node.key) {
+        const keyScopeContext = copyScopeContext(scopeContext)
+        keyScopeContext.definedVariables.add(contextVarName)
+        await this.updateScopeContext({ node: node.key, scopeContext })
+      }
+
+      for await (const childNode of node.children ?? []) {
+        const childScopeContext = copyScopeContext(scopeContext)
+        childScopeContext.definedVariables.add(contextVarName)
+        if (indexVarName) childScopeContext.definedVariables.add(indexVarName)
+
+        await this.readBaseMetadata({
+          node: childNode,
+          scopeContext: copyScopeContext(scopeContext),
+          isInMessageTag,
+          isInContentTag,
+        })
+      }
+      if (node.else) {
+        for await (const childNode of node.else.children ?? []) {
+          await this.readBaseMetadata({
+            node: childNode,
+            scopeContext: copyScopeContext(scopeContext),
+            isInMessageTag,
+            isInContentTag,
+          })
+        }
+      }
+    }
+
+    if (node.type === 'ElementTag') {
+      if (
+        node.name === CUSTOM_MESSAGE_TAG ||
+        Object.values(MessageRole).includes(node.name as MessageRole)
+      ) {
+        /* Message tag */
+        if (isInMessageTag) {
+          this.baseNodeError(errors.messageTagInsideMessage, node)
+        }
+      } else if (
+        Object.values(ContentType).includes(node.name as ContentType)
+      ) {
+        /* Content tag */
+        if (isInContentTag) {
+          this.baseNodeError(errors.contentTagInsideContent, node)
+        }
+      } else if (node.name === REFERENCE_PROMPT_TAG) {
+        /* Reference tag */
+        if (isInMessageTag) {
+          this.baseNodeError(
+            errors.invalidTagPlacement(node.name, 'message'),
+            node,
+          )
+        }
+        if (isInContentTag) {
+          this.baseNodeError(
+            errors.invalidTagPlacement(node.name, 'content'),
+            node,
+          )
+        }
+
+        if (node.children?.length ?? 0 > 0) {
+          this.baseNodeError(errors.referenceTagHasContent, node)
+        }
+
+        const refPromptAttribute = node.attributes.find(
+          (attribute: Attribute) => attribute.name === REFERENCE_PROMPT_ATTR,
+        ) as Attribute | undefined
+        if (!refPromptAttribute) {
+          this.baseNodeError(errors.referenceTagWithoutPrompt, node)
+        }
+
+        if (
+          refPromptAttribute.value === true ||
+          refPromptAttribute.value.some((node) => node.type === 'MustacheTag')
+        ) {
+          this.baseNodeError(
+            errors.invalidStaticAttribute(REFERENCE_PROMPT_ATTR),
+            refPromptAttribute,
+          )
+        }
+
+        // Obtain the referenced prompt
+        if (!this.referenceFn) {
+          this.baseNodeError(errors.missingReferenceFunction, node)
+        }
+
+        const refPromptPath = refPromptAttribute.value
+          .map((node) => node.data)
+          .join('')
+        if (this.referencedPrompts[refPromptPath]) return
+
+        try {
+          const refPrompt = await this.referenceFn(refPromptPath)
+
+          const refReadMetadata = new ReadMetadata({
+            prompt: refPrompt,
+            referenceFn: this.referenceFn,
+          })
+          refReadMetadata.referencedPrompts = this.referencedPrompts
+
+          const refPromptMetadata = await refReadMetadata.run()
+          refPromptMetadata.parameters.forEach((param: string) => {
+            if (!scopeContext.definedVariables.has(param)) {
+              scopeContext.usedUndefinedVariables.add(param)
+            }
+          })
+
+          this.referencedPrompts[refPromptPath] = refPromptMetadata.hash
+        } catch (error: unknown) {
+          if (error instanceof CompileError) throw error
+          this.baseNodeError(errors.referenceError(error), node)
+        }
+
+        return
+      }
+
+      /* Unknown tag */
+      this.baseNodeError(errors.invalidMessageRole(node.name), node)
+    }
+  }
+
+  private baseNodeError(
+    { code, message }: { code: string; message: string },
+    node: BaseNode,
+  ): never {
+    error(message, {
+      name: 'CompileError',
+      code,
+      source: this.rawText || '',
+      start: node.start || 0,
+      end: node.end || undefined,
+    })
+  }
+
+  private expressionError(
+    { code, message }: { code: string; message: string },
+    node: LogicalExpression,
+  ): never {
+    const source = (node.loc?.source ?? this.rawText)!.split('\n')
+    const start =
+      source
+        .slice(0, node.loc?.start.line! - 1)
+        .reduce((acc, line) => acc + line.length + 1, 0) +
+      node.loc?.start.column!
+    const end =
+      source
+        .slice(0, node.loc?.end.line! - 1)
+        .reduce((acc, line) => acc + line.length + 1, 0) + node.loc?.end.column!
+
+    error(message, {
+      name: 'CompileError',
+      code,
+      source: this.rawText || '',
+      start,
+      end,
+    })
+  }
+}

--- a/packages/compiler/src/compiler/scope.ts
+++ b/packages/compiler/src/compiler/scope.ts
@@ -67,3 +67,8 @@ export default class Scope {
     return scope
   }
 }
+
+export type ScopeContext = {
+  usedUndefinedVariables: Set<string> // Variables that are not in current scope but have been used
+  definedVariables: Set<string> // Variables that are in current scope
+}

--- a/packages/compiler/src/error/errors.ts
+++ b/packages/compiler/src/error/errors.ts
@@ -219,6 +219,10 @@ export default {
     code: 'message-tag-inside-message',
     message: 'Message tags cannot be inside of another message',
   },
+  contentTagInsideContent: {
+    code: 'content-tag-inside-content',
+    message: 'Content tags cannot be inside of another content',
+  },
   invalidMessageRole: (name: string) => ({
     code: 'invalid-message-role',
     message: `Invalid message role: ${name}`,
@@ -242,6 +246,10 @@ export default {
       code: 'reference-error',
       message: `There was an error referencing the prompt: \n${errorKlassName} ${error.message}`,
     }
+  },
+  referenceTagHasContent: {
+    code: 'reference-tag-has-content',
+    message: 'Reference tags cannot have content',
   },
   invalidContentType: (name: string) => ({
     code: 'invalid-content-type',

--- a/packages/compiler/src/parser/interfaces.ts
+++ b/packages/compiler/src/parser/interfaces.ts
@@ -1,4 +1,4 @@
-import { Identifier, type Node } from 'estree'
+import { Identifier, type Node as LogicalExpression } from 'estree'
 
 import { ContentType, MessageRole } from '../types'
 
@@ -46,11 +46,11 @@ export type MessageTag = IElementTag & {
   name: MessageRole
 }
 
-export type ElementTag = ContentTag | MessageTag
+export type ElementTag = ContentTag | MessageTag | IElementTag
 
 export interface MustacheTag extends BaseNode {
   type: 'MustacheTag'
-  expression: Node
+  expression: LogicalExpression
 }
 
 export interface Comment extends BaseNode {
@@ -59,28 +59,31 @@ export interface Comment extends BaseNode {
   ignores: string[]
 }
 
-export interface IfBlock extends BaseNode {
-  type: 'IfBlock'
-  condition: Node
-}
-
 export interface ElseBlock extends BaseNode {
   type: 'ElseBlock'
 }
 
+export interface IfBlock extends BaseNode {
+  type: 'IfBlock'
+  expression: LogicalExpression
+  else: ElseBlock | null
+}
+
 export interface EachBlock extends BaseNode {
   type: 'EachBlock'
-  expression: Node
+  expression: LogicalExpression
   context: Identifier
   index: Identifier | null
+  key: LogicalExpression
+  else: ElseBlock | null
 }
 
 export type TemplateNode =
-  | BaseNode
+  | Fragment
+  | Config
   | Text
+  | ElementTag
   | MustacheTag
   | Comment
-  | ElementTag
   | IfBlock
-  | ElseBlock
   | EachBlock

--- a/packages/compiler/src/types/index.ts
+++ b/packages/compiler/src/types/index.ts
@@ -1,10 +1,19 @@
+import type { ErrorObject } from 'ajv'
+import { JTDDataType } from 'ajv/dist/core'
+
 import { Message } from './message'
 
-export type Config = { [key: string]: unknown }
-
 export type Conversation = {
-  config: Config
+  config: Record<string, unknown>
   messages: Message[]
+}
+
+export type ConversationMetadata<ConfigSchema> = {
+  hash: string // Unique string identifying the conversation
+  config: JTDDataType<ConfigSchema>
+  parameters: Set<string> // Variables used in the prompt that have not been defined in runtime
+  referencedPrompts: Set<string>
+  schemaValidation: undefined | true | ErrorObject[] // True if the configuration schema is valid, or an array of errors otherwise. Undefined if the schema is not provided.
 }
 
 export * from './message'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       acorn:
         specifier: ^8.9.0
         version: 8.12.0
+      ajv:
+        specifier: ^8.16.0
+        version: 8.16.0
       code-red:
         specifier: ^1.0.3
         version: 1.0.4
@@ -2786,6 +2789,15 @@ packages:
       uri-js: 4.4.1
     dev: true
 
+  /ajv@8.16.0:
+    resolution: {integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+    dev: false
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -4386,7 +4398,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -5133,6 +5144,10 @@ packages:
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
+
+  /json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -5927,7 +5942,6 @@ packages:
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
-    dev: true
 
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -6049,6 +6063,11 @@ packages:
     dependencies:
       jsesc: 0.5.0
     dev: true
+
+  /require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6953,7 +6972,6 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
-    dev: true
 
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}


### PR DESCRIPTION
Read metadata from a prompt without actually resolving it. Reading metadata will return the following information:
- `hash`: A unique hash representing the prompt contents. Modifying this prompt, or any that it references, will update this value.
- `config`: The configuration of the config
- `parameters`: A list of all the variables being used in the prompt that must be passed as parameters.
- `referencedPrompts`: A list of all prompts that are being referenced in the query
- `schemaValidation`: Whether the config follows the given schema, or a list of schema errors otherwise.

The function will take the following parameters:
- `prompt`: The prompt to be read
- `referenceFn`: (optional) A function to obtain a prompt given the prompt name/path. It is not needed if no refs are called in the prompt.
- `configSchema`: (optional) The config schema for validation. `schemaValidation` will be `undefined` if not provided.

```ts
const {
  hash,
  config,
  parameters,
  referencedPrompts,
  schemaValidation
} = await readMetadata({ prompt, referenceFn, configSchema })
```