### PR TITLE
Compiler: clean package

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,6 +19,7 @@
     "@types/node": "^20.12.12",
     "rollup": "^4.10.0",
     "typescript": "^5.2.2",
+    "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.2.2"
   },
   "dependencies": {

--- a/packages/compiler/rollup.config.mjs
+++ b/packages/compiler/rollup.config.mjs
@@ -34,5 +34,5 @@ export default {
       exclude: ['**/__tests__', '**/*.test.ts'],
     }),
   ],
-  external: ['acorn', 'locate-character', 'code-red', 'node:crypto', 'yaml'],
+  external: ['acorn', 'locate-character', 'code-red', 'node:crypto', 'yaml', 'crypto', 'ajv'],
 }

--- a/packages/compiler/src/compiler/compile.test.ts
+++ b/packages/compiler/src/compiler/compile.test.ts
@@ -1,9 +1,9 @@
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+import CompileError from '$/error/error'
+import { Message } from '$/types'
 import { describe, expect, it, vi } from 'vitest'
 
 import { compile } from '.'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
-import CompileError from '../error/error'
-import { Message } from '../types'
 import { removeCommonIndent } from './utils'
 
 const getExpectedError = async <T>(
@@ -123,7 +123,7 @@ describe('messages', async () => {
       <system>system message</system>
       <user>user message</user>
       <assistant>assistant message</assistant>
-      <tool>tool message</tool>
+      <tool id="123">tool message</tool>
     `
     const result = await compile({
       prompt: removeCommonIndent(propmt),

--- a/packages/compiler/src/compiler/config.ts
+++ b/packages/compiler/src/compiler/config.ts
@@ -1,7 +1,6 @@
+import { Fragment } from '$/parser/interfaces'
 import Ajv from 'ajv'
 import type { ErrorObject, JTDDataType } from 'ajv/dist/core'
-
-import { Fragment } from '../parser/interfaces'
 
 export function readConfig<ConfigSchema>(
   fragment: Fragment,

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -1,4 +1,5 @@
-import { Conversation, ConversationMetadata } from '../types'
+import { Conversation, ConversationMetadata } from '$/types'
+
 import { Compile, type ReferencePromptFn } from './compile'
 import { ReadMetadata } from './readMetadata'
 

--- a/packages/compiler/src/compiler/logic/nodes/arrayExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/arrayExpression.ts
@@ -1,9 +1,11 @@
+import { resolveLogicNode, updateScopeContextForNode } from '$/compiler/logic'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import { isIterable } from '$/compiler/utils'
+import errors from '$/error/errors'
 import type { ArrayExpression } from 'estree'
-
-import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import { isIterable } from '../../utils'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### ArrayExpression

--- a/packages/compiler/src/compiler/logic/nodes/assignmentExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/assignmentExpression.ts
@@ -1,3 +1,9 @@
+import { ASSIGNMENT_OPERATOR_METHODS } from '$/compiler/logic/operators'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import type {
   AssignmentExpression,
   AssignmentOperator,
@@ -6,9 +12,6 @@ import type {
 } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import { ASSIGNMENT_OPERATOR_METHODS } from '../operators'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### AssignmentExpression

--- a/packages/compiler/src/compiler/logic/nodes/binaryExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/binaryExpression.ts
@@ -1,9 +1,12 @@
+import { BINARY_OPERATOR_METHODS } from '$/compiler/logic/operators'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import type { BinaryExpression, LogicalExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import { BINARY_OPERATOR_METHODS } from '../operators'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### BinaryExpression

--- a/packages/compiler/src/compiler/logic/nodes/callExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/callExpression.ts
@@ -1,9 +1,12 @@
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import CompileError from '$/error/error'
+import errors from '$/error/errors'
 import type { SimpleCallExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import CompileError from '../../../error/error'
-import errors from '../../../error/errors'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### CallExpression

--- a/packages/compiler/src/compiler/logic/nodes/chainExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/chainExpression.ts
@@ -1,7 +1,10 @@
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
 import type { ChainExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### Chain Expression

--- a/packages/compiler/src/compiler/logic/nodes/conditionalExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/conditionalExpression.ts
@@ -1,7 +1,10 @@
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
 import type { ConditionalExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### ConditionalExpression

--- a/packages/compiler/src/compiler/logic/nodes/identifier.ts
+++ b/packages/compiler/src/compiler/logic/nodes/identifier.ts
@@ -1,7 +1,9 @@
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import type { Identifier } from 'estree'
-
-import errors from '../../../error/errors'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### Identifier

--- a/packages/compiler/src/compiler/logic/nodes/index.ts
+++ b/packages/compiler/src/compiler/logic/nodes/index.ts
@@ -1,6 +1,10 @@
+import {
+  NodeType,
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
 import { Node } from 'estree'
 
-import { NodeType, ResolveNodeProps, UpdateScopeContextProps } from '../types'
 import {
   resolve as resolveArrayExpression,
   updateScopeContext as updateArrayScopeContext,

--- a/packages/compiler/src/compiler/logic/nodes/literal.ts
+++ b/packages/compiler/src/compiler/logic/nodes/literal.ts
@@ -1,6 +1,5 @@
+import { type ResolveNodeProps } from '$/compiler/logic/types'
 import { type Literal } from 'estree'
-
-import { type ResolveNodeProps } from '../types'
 
 /**
  * ### Literal

--- a/packages/compiler/src/compiler/logic/nodes/memberExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/memberExpression.ts
@@ -1,8 +1,11 @@
+import { MEMBER_EXPRESSION_METHOD } from '$/compiler/logic/operators'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
 import type { Identifier, MemberExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import { MEMBER_EXPRESSION_METHOD } from '../operators'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### MemberExpression

--- a/packages/compiler/src/compiler/logic/nodes/objectExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/objectExpression.ts
@@ -1,8 +1,10 @@
+import { resolveLogicNode, updateScopeContextForNode } from '$/compiler/logic'
+import {
+  UpdateScopeContextProps,
+  type ResolveNodeProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import { type Identifier, type ObjectExpression } from 'estree'
-
-import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import { UpdateScopeContextProps, type ResolveNodeProps } from '../types'
 
 /**
  * ### ObjectExpression

--- a/packages/compiler/src/compiler/logic/nodes/sequenceExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/sequenceExpression.ts
@@ -1,7 +1,9 @@
+import { resolveLogicNode, updateScopeContextForNode } from '$/compiler/logic'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
 import type { SequenceExpression } from 'estree'
-
-import { resolveLogicNode, updateScopeContextForNode } from '..'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### SequenceExpression

--- a/packages/compiler/src/compiler/logic/nodes/unaryExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/unaryExpression.ts
@@ -1,9 +1,12 @@
+import { UNARY_OPERATOR_METHODS } from '$/compiler/logic/operators'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import type { UnaryExpression } from 'estree'
 
 import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import { UNARY_OPERATOR_METHODS } from '../operators'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### UnaryExpression

--- a/packages/compiler/src/compiler/logic/nodes/updateExpression.ts
+++ b/packages/compiler/src/compiler/logic/nodes/updateExpression.ts
@@ -1,8 +1,10 @@
+import { resolveLogicNode, updateScopeContextForNode } from '$/compiler/logic'
+import type {
+  ResolveNodeProps,
+  UpdateScopeContextProps,
+} from '$/compiler/logic/types'
+import errors from '$/error/errors'
 import type { AssignmentExpression, UpdateExpression } from 'estree'
-
-import { resolveLogicNode, updateScopeContextForNode } from '..'
-import errors from '../../../error/errors'
-import type { ResolveNodeProps, UpdateScopeContextProps } from '../types'
 
 /**
  * ### UpdateExpression

--- a/packages/compiler/src/compiler/logic/types.ts
+++ b/packages/compiler/src/compiler/logic/types.ts
@@ -1,6 +1,5 @@
+import Scope, { ScopeContext } from '$/compiler/scope'
 import { Node } from 'estree'
-
-import Scope, { ScopeContext } from '../scope'
 
 export enum NodeType {
   Literal = 'Literal',

--- a/packages/compiler/src/compiler/readMetadata.test.ts
+++ b/packages/compiler/src/compiler/readMetadata.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+import CompileError from '$/error/error'
+import { describe, expect, it } from 'vitest'
 
 import { readMetadata } from '.'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
-import CompileError from '../error/error'
 import { removeCommonIndent } from './utils'
 
 const getExpectedError = async <T>(

--- a/packages/compiler/src/compiler/readMetadata.ts
+++ b/packages/compiler/src/compiler/readMetadata.ts
@@ -1,17 +1,17 @@
 import { createHash } from 'crypto'
 
-import { Node as LogicalExpression } from 'estree'
-
 import {
   CUSTOM_MESSAGE_TAG,
   REFERENCE_PROMPT_ATTR,
   REFERENCE_PROMPT_TAG,
-} from '../constants'
-import CompileError, { error } from '../error/error'
-import errors from '../error/errors'
-import parse from '../parser/index'
-import type { Attribute, BaseNode } from '../parser/interfaces'
-import { ContentType, ConversationMetadata, MessageRole } from '../types'
+} from '$/constants'
+import CompileError, { error } from '$/error/error'
+import errors from '$/error/errors'
+import parse from '$/parser/index'
+import type { Attribute, BaseNode } from '$/parser/interfaces'
+import { ContentType, ConversationMetadata, MessageRole } from '$/types'
+import { Node as LogicalExpression } from 'estree'
+
 import { ReferencePromptFn } from './compile'
 import { readConfig, validateConfig } from './config'
 import { updateScopeContextForNode } from './logic'

--- a/packages/compiler/src/compiler/scope.ts
+++ b/packages/compiler/src/compiler/scope.ts
@@ -22,8 +22,8 @@ export default class Scope {
   private globalStash: unknown[] = [] // Stash of every variable value in the global scope
   private localPointers: Record<string, number> = {} // Index of every variable in the stash in the current scope
 
-  constructor(globalScope: Record<string, unknown> = {}) {
-    for (const [key, value] of Object.entries(globalScope)) {
+  constructor(initialState: Record<string, unknown> = {}) {
+    for (const [key, value] of Object.entries(initialState)) {
       this.localPointers[key] = this.addToStash(value)
     }
   }

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -2,9 +2,12 @@ export const CUSTOM_TAG_START = '{{'
 export const CUSTOM_TAG_END = '}}'
 
 // <message role="…">
-export const CUSTOM_MESSAGE_TAG = 'message'
-export const CUSTOM_MESSAGE_ROLE_ATTR = 'role'
+export const CUSTOM_MESSAGE_TAG = 'message' as const
+export const CUSTOM_MESSAGE_ROLE_ATTR = 'role' as const
 
 // <ref prompt="…">
-export const REFERENCE_PROMPT_TAG = 'ref'
-export const REFERENCE_PROMPT_ATTR = 'prompt'
+export const REFERENCE_PROMPT_TAG = 'ref' as const
+export const REFERENCE_PROMPT_ATTR = 'prompt' as const
+
+// <tool_call id="…" name="…">{ content }</tool_call>
+export const TOOL_CALL_TAG = 'tool_call' as const

--- a/packages/compiler/src/error/errors.ts
+++ b/packages/compiler/src/error/errors.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
 
 function getKlassName(error: unknown): string {
   const errorKlass = error as Error
@@ -91,52 +91,15 @@ export default {
     code: 'invalid-config',
     message: `Invalid config: ${message}`,
   }),
-  invalidConfigPosition: {
-    code: 'invalid-config-position',
-    message: 'Configs must be defined on the first line of the file',
-  },
   unexpectedTagClose: (name: string) => ({
     code: 'unexpected-tag-close',
     message: `Unexpected closing tag for ${name}`,
   }),
 
   // Compiler errors:
-  queryNotFound: (name: string) => ({
-    code: 'query-not-found',
-    message: `Query '${name}' not found`,
-  }),
   unsupportedBaseNodeType: (type: string) => ({
     code: 'unsupported-base-node-type',
     message: `Unsupported base node type: ${type}`,
-  }),
-  unsupportedExpressionType: (type: string) => ({
-    code: 'unsupported-expression-type',
-    message: `Unsupported expression type: ${type}`,
-  }),
-  invalidConstantDefinition: {
-    code: 'invalid-constant-definition',
-    message: 'Constant definitions must assign a value to a variable',
-  },
-  invalidConfigDefinition: {
-    code: 'invalid-config-definition',
-    message: 'Config definitions must assign a value to an option',
-  },
-  invalidConfigValue: {
-    code: 'invalid-config-value',
-    message:
-      'Config values must be literals. Cannot use variables or expressions',
-  },
-  configInsideBlock: {
-    code: 'config-inside-block',
-    message: 'Cannot must be defined at root level. Cannot be inside a block',
-  },
-  configDefinitionFailed: (name: string, message: string) => ({
-    code: 'config-definition-failed',
-    message: `Config definition for '${name}' failed: ${message}`,
-  }),
-  configAlreadyDefined: (name: string) => ({
-    code: 'config-already-defined',
-    message: `Config definition for '${name}' failed: Option already configured`,
   }),
   variableAlreadyDeclared: (name: string) => ({
     code: 'variable-already-declared',
@@ -162,10 +125,6 @@ export default {
     code: 'unsupported-operator',
     message: `Unsupported operator: ${operator}`,
   }),
-  constantReassignment: {
-    code: 'constant-reassignment',
-    message: 'Cannot reassign a constant',
-  },
   invalidAssignment: {
     code: 'invalid-assignment',
     message: 'Invalid assignment',
@@ -174,14 +133,9 @@ export default {
     code: 'invalid-update',
     message: `Cannot use ${operation} operation on ${type}`,
   }),
-
   propertyNotExists: (property: string) => ({
     code: 'property-not-exists',
     message: `Property '${property}' does not exist on object`,
-  }),
-  unknownFunction: (name: string) => ({
-    code: 'unknown-function',
-    message: `Unknown function: ${name}`,
   }),
   notAFunction: (objectType: string) => ({
     code: 'not-a-function',
@@ -195,22 +149,6 @@ export default {
       message: `Error calling function: \n${errorKlassName} ${error.message}`,
     }
   },
-  functionRequiresStaticArguments: (name: string) => ({
-    code: 'function-requires-static-arguments',
-    message: `Function '${name}' can only receive literal values as arguments`,
-  }),
-  functionRequiresInterpolation: (name: string) => ({
-    code: 'function-requires-interpolation',
-    message: `Function '${name}' cannot be used inside a logic block. It must be directly interpolated into the query`,
-  }),
-  functionDisallowsInterpolation: (name: string) => ({
-    code: 'function-disallows-interpolation',
-    message: `Function '${name}' cannot be directly interpolated into the query`,
-  }),
-  invalidFunctionResultInterpolation: {
-    code: 'invalid-function-result-interpolation',
-    message: 'Functions called for interpolation must return a string',
-  },
   invalidTagPlacement: (name: string, parent: string) => ({
     code: 'invalid-tag-placement',
     message: `Cannot have a ${name} tag inside of a ${parent} tag`,
@@ -221,7 +159,27 @@ export default {
   },
   contentTagInsideContent: {
     code: 'content-tag-inside-content',
-    message: 'Content tags cannot be inside of another content',
+    message: 'Content tags must be directly inside message tags',
+  },
+  toolCallTagInsideContent: {
+    code: 'tool-call-tag-inside-content',
+    message: 'Tool calls must be directly inside message tags',
+  },
+  toolCallTagWithoutId: {
+    code: 'tool-call-tag-without-id',
+    message: 'Tool call tags must have an id attribute',
+  },
+  toolMessageWithoutId: {
+    code: 'tool-message-without-id',
+    message: 'Tool messages must have an id attribute',
+  },
+  toolCallWithoutName: {
+    code: 'tool-call-without-name',
+    message: 'Tool calls must have a name attribute',
+  },
+  invalidToolCallArguments: {
+    code: 'invalid-tool-call-arguments',
+    message: 'Tool calls must contain a valid JSON object as arguments',
   },
   invalidMessageRole: (name: string) => ({
     code: 'invalid-message-role',
@@ -230,6 +188,10 @@ export default {
   messageTagWithoutRole: {
     code: 'message-tag-without-role',
     message: 'Message tags must have a role attribute',
+  },
+  invalidReferencePromptPlacement: {
+    code: 'invalid-reference-prompt-placement',
+    message: 'Reference tags must not be inside of other tags',
   },
   referenceTagWithoutPrompt: {
     code: 'reference-tag-without-prompt',

--- a/packages/compiler/src/parser/index.ts
+++ b/packages/compiler/src/parser/index.ts
@@ -1,10 +1,10 @@
+import type CompileError from '$/error/error'
+import { error } from '$/error/error'
+import PARSER_ERRORS from '$/error/errors'
+import { reserved } from '$/utils/names'
 import { isIdentifierChar, isIdentifierStart } from 'acorn'
 
-import type CompileError from '../error/error'
-import { error } from '../error/error'
-import PARSER_ERRORS from '../error/errors'
-import { reserved } from '../utils/names'
-import { type Fragment, type TemplateNode } from './interfaces'
+import type { BaseNode, Fragment } from './interfaces'
 import fragment from './state/fragment'
 import fullCharCodeAt from './utils/full_char_code_at'
 
@@ -17,7 +17,7 @@ type AutoClosedTag = { tag: string; reason: string; depth: number }
 
 export class Parser {
   index: number = 0
-  stack: TemplateNode[] = []
+  stack: BaseNode[] = []
   lastAutoClosedTag: AutoClosedTag | null = null
 
   constructor(public template: string) {}
@@ -65,7 +65,7 @@ export class Parser {
     return template
   }
 
-  current(): TemplateNode {
+  current(): BaseNode {
     return this.stack[this.stack.length - 1]!
   }
 

--- a/packages/compiler/src/parser/interfaces.ts
+++ b/packages/compiler/src/parser/interfaces.ts
@@ -1,8 +1,12 @@
+import {
+  CUSTOM_MESSAGE_TAG,
+  REFERENCE_PROMPT_TAG,
+  TOOL_CALL_TAG,
+} from '$/constants'
+import { ContentType, MessageRole } from '$/types'
 import { Identifier, type Node as LogicalExpression } from 'estree'
 
-import { ContentType, MessageRole } from '../types'
-
-export interface BaseNode {
+export type BaseNode = {
   start: number | null
   end: number | null
   type: string
@@ -10,66 +14,67 @@ export interface BaseNode {
   [propName: string]: any
 }
 
-export interface Fragment extends BaseNode {
+export type Fragment = BaseNode & {
   type: 'Fragment'
   children: TemplateNode[]
 }
 
-export interface Config extends BaseNode {
+export type Config = BaseNode & {
   type: 'Config'
   value: Record<string, any>
 }
 
-export interface Text extends BaseNode {
+export type Text = BaseNode & {
   type: 'Text'
   data: string
 }
 
-export interface Attribute extends BaseNode {
+export type Attribute = BaseNode & {
   type: 'Attribute'
   name: string
   value: TemplateNode[] | true
 }
 
-interface IElementTag extends BaseNode {
+type IElementTag<T extends string> = BaseNode & {
   type: 'ElementTag'
-  name: string
+  name: T
   attributes: Attribute[]
   children: TemplateNode[]
 }
 
-export type ContentTag = IElementTag & {
-  name: ContentType
-}
+export type ContentTag = IElementTag<ContentType>
+export type MessageTag =
+  | IElementTag<MessageRole>
+  | IElementTag<typeof CUSTOM_MESSAGE_TAG>
+export type ReferenceTag = IElementTag<typeof REFERENCE_PROMPT_TAG>
+export type ToolCallTag = IElementTag<typeof TOOL_CALL_TAG>
+export type ElementTag =
+  | ContentTag
+  | MessageTag
+  | ReferenceTag
+  | IElementTag<string>
 
-export type MessageTag = IElementTag & {
-  name: MessageRole
-}
-
-export type ElementTag = ContentTag | MessageTag | IElementTag
-
-export interface MustacheTag extends BaseNode {
+export type MustacheTag = BaseNode & {
   type: 'MustacheTag'
   expression: LogicalExpression
 }
 
-export interface Comment extends BaseNode {
+export type Comment = BaseNode & {
   type: 'Comment'
   data: string
-  ignores: string[]
 }
 
-export interface ElseBlock extends BaseNode {
+export type ElseBlock = BaseNode & {
   type: 'ElseBlock'
 }
 
-export interface IfBlock extends BaseNode {
+export type IfBlock = BaseNode & {
   type: 'IfBlock'
   expression: LogicalExpression
   else: ElseBlock | null
 }
 
-export interface EachBlock extends BaseNode {
+export type EachBlock = BaseNode & {
   type: 'EachBlock'
   expression: LogicalExpression
   context: Identifier

--- a/packages/compiler/src/parser/parser.test.ts
+++ b/packages/compiler/src/parser/parser.test.ts
@@ -1,8 +1,8 @@
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+import CompileError from '$/error/error'
 import { describe, expect, it } from 'vitest'
 
 import parse from '.'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../constants'
-import CompileError from '../error/error'
 import { TemplateNode } from './interfaces'
 
 const getExpectedError = <T>(

--- a/packages/compiler/src/parser/read/context.ts
+++ b/packages/compiler/src/parser/read/context.ts
@@ -1,17 +1,17 @@
-import { isIdentifierStart } from 'acorn'
-import { Pattern } from 'estree'
-
-import { Parser } from '..'
-import type CompileError from '../../error/error'
-import PARSER_ERRORS from '../../error/errors'
-import { parseExpressionAt } from '../utils/acorn'
+import type CompileError from '$/error/error'
+import PARSER_ERRORS from '$/error/errors'
+import { parseExpressionAt } from '$/parser/utils/acorn'
 import {
   getBracketClose,
   isBracketClose,
   isBracketOpen,
   isBracketPair,
-} from '../utils/bracket'
-import fullCharCodeAt from '../utils/full_char_code_at'
+} from '$/parser/utils/bracket'
+import fullCharCodeAt from '$/parser/utils/full_char_code_at'
+import { isIdentifierStart } from 'acorn'
+import { Pattern } from 'estree'
+
+import { Parser } from '..'
 
 export default function readContext(
   parser: Parser,

--- a/packages/compiler/src/parser/read/expression.ts
+++ b/packages/compiler/src/parser/read/expression.ts
@@ -1,7 +1,7 @@
-import { Parser } from '..'
-import CompileError from '../../error/error'
-import PARSER_ERRORS from '../../error/errors'
-import { parseExpressionAt } from '../utils/acorn'
+import CompileError from '$/error/error'
+import PARSER_ERRORS from '$/error/errors'
+import { Parser } from '$/parser'
+import { parseExpressionAt } from '$/parser/utils/acorn'
 
 export default function readExpression(parser: Parser) {
   try {

--- a/packages/compiler/src/parser/state/config.ts
+++ b/packages/compiler/src/parser/state/config.ts
@@ -1,7 +1,7 @@
+import PARSER_ERRORS from '$/error/errors'
+import { Parser } from '$/parser'
+import type { Config } from '$/parser/interfaces'
 import yaml from 'yaml'
-
-import { Parser } from '..'
-import PARSER_ERRORS from '../../error/errors'
 
 export function config(parser: Parser) {
   const start = parser.index
@@ -26,7 +26,7 @@ export function config(parser: Parser) {
     type: 'Config',
     raw: data,
     value: parsedData,
-  }
+  } as Config
 
   parser.current().children!.push(node)
 }

--- a/packages/compiler/src/parser/state/fragment.ts
+++ b/packages/compiler/src/parser/state/fragment.ts
@@ -1,5 +1,6 @@
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+
 import { Parser } from '..'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../../constants'
 import { config } from './config'
 import { multiLineComment } from './multi_line_comment'
 import { mustache } from './mustache'

--- a/packages/compiler/src/parser/state/multi_line_comment.ts
+++ b/packages/compiler/src/parser/state/multi_line_comment.ts
@@ -1,5 +1,7 @@
+import PARSER_ERRORS from '$/error/errors'
+import type { Comment } from '$/parser/interfaces'
+
 import { Parser } from '..'
-import PARSER_ERRORS from '../../error/errors'
 
 export function multiLineComment(parser: Parser) {
   if (parser.match('*/')) {
@@ -24,7 +26,7 @@ export function multiLineComment(parser: Parser) {
     type: 'Comment',
     raw: data,
     data: data.substring(2, data.length - 2),
-  }
+  } as Comment
 
   parser.current().children!.push(node)
 }

--- a/packages/compiler/src/parser/state/mustache.ts
+++ b/packages/compiler/src/parser/state/mustache.ts
@@ -1,9 +1,14 @@
-import { type Parser } from '..'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../../constants'
-import PARSER_ERRORS from '../../error/errors'
-import { type TemplateNode } from '../interfaces'
-import readContext from '../read/context'
-import readExpression from '../read/expression'
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+import PARSER_ERRORS from '$/error/errors'
+import { type Parser } from '$/parser'
+import type {
+  BaseNode,
+  EachBlock,
+  ElseBlock,
+  IfBlock,
+} from '$/parser/interfaces'
+import readContext from '$/parser/read/context'
+import readExpression from '$/parser/read/expression'
 
 export function mustache(parser: Parser) {
   if (parser.match(CUSTOM_TAG_END)) {
@@ -14,7 +19,7 @@ export function mustache(parser: Parser) {
   parser.allowWhitespace()
   // {{/if}}, {{/each}}, {{/await}} or {{/key}}
   if (parser.eat('/')) {
-    let block = parser.current()
+    let block = parser.current() as BaseNode
     let expected: string
     if (block.type === 'ElseBlock') {
       block.end = start
@@ -80,9 +85,9 @@ export function mustache(parser: Parser) {
             expression,
             children: [],
           },
-        ],
-      }
-      parser.stack.push(block.else.children[0])
+        ] as BaseNode[],
+      } as ElseBlock
+      parser.stack.push(block.else.children![0])
     } else {
       // :else
       const block = parser.current()
@@ -115,7 +120,7 @@ export function mustache(parser: Parser) {
     const type = isIf ? 'IfBlock' : 'EachBlock'
     parser.requireWhitespace()
     const expression = readExpression(parser)
-    const block: TemplateNode = {
+    const block: BaseNode = {
       start,
       end: start,
       type,
@@ -144,7 +149,7 @@ export function mustache(parser: Parser) {
       }
     }
     parser.eat(CUSTOM_TAG_END, true)
-    parser.current().children!.push(block)
+    parser.current().children!.push(block as EachBlock | IfBlock)
     parser.stack.push(block)
   } else {
     const expression = readExpression(parser)
@@ -160,7 +165,7 @@ export function mustache(parser: Parser) {
 }
 
 function trimWhitespace(
-  block: TemplateNode,
+  block: BaseNode,
   trimBefore: boolean = false,
   trimAfter: boolean = false,
 ) {
@@ -183,7 +188,7 @@ function trimWhitespace(
   }
 }
 
-function toString(node: TemplateNode) {
+function toString(node: BaseNode) {
   switch (node.type) {
     case 'IfBlock':
       return `${CUSTOM_TAG_START}#if${CUSTOM_TAG_END} block`

--- a/packages/compiler/src/parser/state/tag.ts
+++ b/packages/compiler/src/parser/state/tag.ts
@@ -1,10 +1,10 @@
-import { type Parser } from '..'
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '../../constants'
-import CompileError from '../../error/error'
-import PARSER_ERRORS from '../../error/errors'
-import { Attribute, ElementTag, TemplateNode, Text } from '../interfaces'
-import read_expression from '../read/expression'
-import { decode_character_references } from '../utils/html'
+import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$/constants'
+import CompileError from '$/error/error'
+import PARSER_ERRORS from '$/error/errors'
+import { type Parser } from '$/parser'
+import { Attribute, ElementTag, TemplateNode, Text } from '$/parser/interfaces'
+import read_expression from '$/parser/read/expression'
+import { decode_character_references } from '$/parser/utils/html'
 
 const validTagName = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/
 

--- a/packages/compiler/src/parser/state/text.ts
+++ b/packages/compiler/src/parser/state/text.ts
@@ -1,5 +1,6 @@
-import { type Parser } from '..'
-import { CUSTOM_TAG_START } from '../../constants'
+import { CUSTOM_TAG_START } from '$/constants'
+import { type Parser } from '$/parser'
+import type { Text } from '$/parser/interfaces'
 
 const ENDS_WITH_ESCAPE_REGEX = /(?<!\\)(\\\\)*\\$/
 const RESERVED_DELIMITERS = [CUSTOM_TAG_START, '/*', '<']
@@ -33,7 +34,7 @@ export function text(parser: Parser) {
     type: 'Text',
     raw: data,
     data: data.replace(/(?<!\\)\\{{/g, '{{').replace(/(?<!\\)\\}}/g, '}}'),
-  }
+  } as Text
 
   parser.current().children!.push(node)
 }

--- a/packages/compiler/src/types/message.ts
+++ b/packages/compiler/src/types/message.ts
@@ -28,7 +28,8 @@ export type MessageContent = TextContent | ImageContent
 
 export type ToolCall = {
   id: string
-  data: Record<string, unknown>
+  name: string
+  arguments: Record<string, unknown>
 }
 
 interface IMessage {

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -4,7 +4,14 @@
     "rootDir": "src",
     "outDir": "dist",
     "moduleResolution": "node",
-    "typeRoots": ["node_modules/@types", "node_modules/@latitude-data/typescript-config/types"],
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules/@latitude-data/typescript-config/types"
+    ],
+    "baseUrl": "./",
+    "paths": {
+      "$/*": ["src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/compiler/vitest.config.ts
+++ b/packages/compiler/vitest.config.ts
@@ -1,6 +1,8 @@
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     globals: true,
     environment: 'node',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.5.3
+      vite-tsconfig-paths:
+        specifier: ^4.3.2
+        version: 4.3.2(typescript@5.5.3)
       vitest:
         specifier: ^1.2.2
         version: 1.6.0(@types/node@20.14.9)


### PR DESCRIPTION
# WIP
Finish cleaning the compiler package.

Changes:
 - Changed the `compile` method to use a recursive approach instead of an iterative one. This makes the code way more readable and organized. The tests have not been changed to check that everything still works as expected.
 - Improved typing for AST nodes
 - Updated `ToolCall` object to contain both function's `name` and `arguments`
 - Added alias
 - Removed unused error definitions