### PR TITLE
Compiler: serialize

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -9,7 +9,9 @@
     "build": "rollup -c",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prettier": "prettier --write src/**/*.ts"
+    "prettier": "prettier --write src/**/*.ts",
+    "lint": "eslint . --max-warnings 0 --ext .ts src",
+    "tc": "tsc --noEmit"
   },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types'
 export * from './compiler'
+export * from './serializer'

--- a/packages/compiler/src/parser/state/config.ts
+++ b/packages/compiler/src/parser/state/config.ts
@@ -8,7 +8,7 @@ export function config(parser: Parser) {
   parser.eat('---')
 
   // Read until there is a line break followed by a triple dash
-  const data = parser.readUntil(/\n\s*\-\-\-\s*/)
+  const data = parser.readUntil(/\n\s*---\s*/)
 
   parser.allowWhitespace()
   parser.eat('---', true)

--- a/packages/compiler/src/parser/state/tag.ts
+++ b/packages/compiler/src/parser/state/tag.ts
@@ -6,7 +6,7 @@ import { Attribute, ElementTag, TemplateNode, Text } from '$/parser/interfaces'
 import read_expression from '$/parser/read/expression'
 import { decode_character_references } from '$/parser/utils/html'
 
-const validTagName = /^\!?[a-zA-Z]{1,}:?[a-zA-Z0-9\-]*/
+const validTagName = /^!?[a-zA-Z]{1,}:?[a-zA-Z0-9-]*/
 
 /** Invalid attribute characters if the attribute is not surrounded by quotes */
 const regexStartsWithInvalidAttrValue = /^(\/>|[\s"'=<>`])/

--- a/packages/compiler/src/serializer/index.ts
+++ b/packages/compiler/src/serializer/index.ts
@@ -1,0 +1,71 @@
+import { TOOL_CALL_TAG } from '$/constants'
+import { Conversation, MessageRole } from '$/types'
+import yaml from 'yaml'
+
+function addIndent(text: string, indent: number): string {
+  return text
+    .split('\n')
+    .map((line) => ' '.repeat(indent) + line)
+    .join('\n')
+}
+
+export function serialize(conversation: Conversation): string {
+  let output = ''
+
+  if (Object.keys(conversation.config).length > 0) {
+    const yamlConfig = yaml.stringify(conversation.config, { indent: 2 }).trim()
+    output += `---\n${yamlConfig}\n---\n`
+  }
+
+  for (const message of conversation.messages) {
+    // Tag Attributes
+    const msgAttrs: Record<string, unknown> = {}
+    if (message.role === MessageRole.user) {
+      if (message.name !== undefined) {
+        msgAttrs.name = message.name
+      }
+    }
+    if (message.role === MessageRole.tool) {
+      if (message.id !== undefined) {
+        msgAttrs.id = message.id
+      }
+    }
+
+    output += `<${message.role}`
+    for (const [attrKey, attrVal] of Object.entries(msgAttrs)) {
+      output += ` ${attrKey}=${JSON.stringify(attrVal)}`
+    }
+    output += '>\n'
+
+    for (const content of message.content) {
+      if (content.type === 'text') {
+        output += addIndent(content.value, 2) + '\n'
+        continue
+      }
+
+      output += addIndent(`<${content.type}>`, 2) + '\n'
+      output += addIndent(content.value, 4) + '\n'
+      output += addIndent(`</${content.type}>`, 2) + '\n'
+    }
+
+    if (message.role === MessageRole.assistant) {
+      for (const toolCall of message.toolCalls) {
+        const hasArgs = Object.keys(toolCall.arguments ?? {}).length > 0
+        output +=
+          addIndent(
+            `<${TOOL_CALL_TAG} id="${toolCall.id}" name="${toolCall.name}"${hasArgs ? '' : ' /'}>`,
+            2,
+          ) + '\n'
+        if (hasArgs) {
+          const toolArgs = JSON.stringify(toolCall.arguments ?? {}, null, 2)
+          output += addIndent(toolArgs, 4) + '\n'
+        }
+        output += `</${TOOL_CALL_TAG}>\n`
+      }
+    }
+
+    output += `</${message.role}>\n`
+  }
+
+  return output.trim()
+}

--- a/packages/compiler/src/serializer/serialize.test.ts
+++ b/packages/compiler/src/serializer/serialize.test.ts
@@ -1,0 +1,249 @@
+import { compile } from '$/compiler'
+import { removeCommonIndent } from '$/compiler/utils'
+import { describe, expect, it } from 'vitest'
+
+import { serialize } from '.'
+
+describe('serialize', async () => {
+  it('serializes a simple system message', async () => {
+    const prompt = removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: {},
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+    `),
+    )
+  })
+
+  it('serializes a conversation with a config section', async () => {
+    const prompt = removeCommonIndent(`
+      ---
+      foo: bar
+      baz:
+        - qux
+        - quux
+      ---
+      <system>
+        This is a test
+      </system>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: {},
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      ---
+      foo: bar
+      baz:
+        - qux
+        - quux
+      ---
+      <system>
+        This is a test
+      </system>
+    `),
+    )
+  })
+
+  it('serializes a conversation with a config section and messages', async () => {
+    const prompt = removeCommonIndent(`
+      ---
+      foo: bar
+      baz:
+        - qux
+        - quux
+      ---
+      <system>
+        This is a test
+      </system>
+      <user>
+        User message
+      </user>
+      <assistant>
+        Assistant message
+      </assistant>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: {},
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      ---
+      foo: bar
+      baz:
+        - qux
+        - quux
+      ---
+      <system>
+        This is a test
+      </system>
+      <user>
+        User message
+      </user>
+      <assistant>
+        Assistant message
+      </assistant>
+    `),
+    )
+  })
+
+  it('serializes multiple message roles', async () => {
+    const prompt = removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user name="John Doe">
+        User message
+      </user>
+      <assistant>
+        Assistant message
+      </assistant>
+      <tool id="123">
+        Tool message
+      </tool>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: {},
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user name="John Doe">
+        User message
+      </user>
+      <assistant>
+        Assistant message
+      </assistant>
+      <tool id="123">
+        Tool message
+      </tool>
+    `),
+    )
+  })
+
+  it('includes referenced prompts', async () => {
+    const prompts = {
+      main: removeCommonIndent(`
+        Take a look at this:
+        <ref prompt="child" />
+      `),
+      child: removeCommonIndent(`
+        <system>
+          This is a test
+        </system>
+      `),
+    } as Record<string, string>
+
+    const conversation = await compile({
+      prompt: prompts.main!,
+      parameters: {},
+      referenceFn: (id: string) => Promise.resolve(prompts[id]!),
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      <system>
+        Take a look at this:
+      </system>
+      <system>
+        This is a test
+      </system>
+    `),
+    )
+  })
+
+  it('serializes a conversation with multiple user messages', async () => {
+    const prompt = removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user name="Anna">
+        First user message
+      </user>
+      <user name="Bob">
+        Second user message
+      </user>
+      <assistant>
+        Assistant response
+      </assistant>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: {},
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user name="Anna">
+        First user message
+      </user>
+      <user name="Bob">
+        Second user message
+      </user>
+      <assistant>
+        Assistant response
+      </assistant>
+    `),
+    )
+  })
+
+  it('serializes a conversation with parameters', async () => {
+    const prompt = removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user>
+        User message with parameter {{param}}
+      </user>
+    `)
+
+    const conversation = await compile({
+      prompt,
+      parameters: { param: 'value' },
+    })
+
+    const serialized = serialize(conversation)
+    expect(serialized).toBe(
+      removeCommonIndent(`
+      <system>
+        This is a test
+      </system>
+      <user>
+        User message with parameter value
+      </user>
+    `),
+    )
+  })
+})

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -10,7 +10,8 @@
     ],
     "baseUrl": "./",
     "paths": {
-      "$/*": ["src/*"]
+      "$/*": ["src/*"],
+      "acorn": ["node_modules/@latitude-data/typescript-config/types/acorn"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
New `serialize` method where, given a `Conversation` object, it returns the prompt's object that defines it.

```ts
const prompt = `
---
model: gpt-3.5-turbo
---
<system>
  Tell me a {{type}} joke
</system>
`

const conversation = compile({
  prompt, 
  parameters: { type: 'funny' }
})

conversation.messages.push({
  role: 'assistant',
  content: "Why don't scientists trust atoms? Because they make up everything!"
})

console.log(serialize(conversation))
/*
---
model: gpt-3.5-turbo
---
<system>
  Tell me a funny joke
</system>
<assistant>
  Why don't scientists trust atoms? Because they make up everything!
</assistant>
*/
```