### PR TITLE
List all parse and compile errors on ReadMeatadata

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -25,10 +25,12 @@
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript-config": "workspace:*",
+    "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/estree": "^1.0.1",
     "@types/node": "^20.12.12",
     "rollup": "^4.10.0",
+    "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.2.2",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.2.2"

--- a/packages/compiler/rollup.config.mjs
+++ b/packages/compiler/rollup.config.mjs
@@ -1,4 +1,8 @@
 import typescript from '@rollup/plugin-typescript'
+import * as path from 'path'
+import * as url from 'url'
+import { dts } from 'rollup-plugin-dts'
+import alias from '@rollup/plugin-alias'
 
 /**
  * We have a internal circular dependency in the compiler,
@@ -15,24 +19,46 @@ function isInternalCircularDependency(warning) {
   )
 }
 
-/** @type {import('rollup').RollupOptions} */
-export default {
-  onwarn: (warning, warn) => {
-    if (isInternalCircularDependency(warning)) return
-
-    warn(warning)
-  },
-  input: 'src/index.ts',
-  output: [
-    {
-      file: 'dist/index.js',
-      sourcemap: true,
-    },
-  ],
-  plugins: [
-    typescript({
-      exclude: ['**/__tests__', '**/*.test.ts'],
-    }),
-  ],
-  external: ['acorn', 'locate-character', 'code-red', 'node:crypto', 'yaml', 'crypto', 'ajv'],
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+const aliasEntries = {
+  entries: [{ find: '$', replacement: path.resolve(__dirname, 'src') }],
 }
+
+/** @type {import('rollup').RollupOptions} */
+export default [
+  {
+    onwarn: (warning, warn) => {
+      if (isInternalCircularDependency(warning)) return
+
+      warn(warning)
+    },
+    input: 'src/index.ts',
+    output: [
+      {
+        file: 'dist/index.js',
+        sourcemap: true,
+      },
+    ],
+    plugins: [
+      typescript({
+        noEmit: true,
+        tsconfig: './tsconfig.json',
+        exclude: ['**/__tests__', '**/*.test.ts'],
+      }),
+    ],
+    external: [
+      'acorn',
+      'locate-character',
+      'code-red',
+      'node:crypto',
+      'yaml',
+      'crypto',
+      'ajv',
+    ],
+  },
+  {
+    input: 'src/index.ts',
+    output: [{ file: 'dist/index.d.ts', format: 'es' }],
+    plugins: [alias(aliasEntries), dts()],
+  },
+]

--- a/packages/compiler/src/compiler/errors.test.ts
+++ b/packages/compiler/src/compiler/errors.test.ts
@@ -33,15 +33,19 @@ const expectBothErrors = async ({
       referenceFn,
     })
   }, `Expected compile to throw '${code}'`)
-  const metadataError = await getExpectedError(async () => {
-    await readMetadata({
-      prompt: removeCommonIndent(prompt),
-      referenceFn,
-    })
-  }, `Expected readMetadata to throw '${code}'`)
-
-  expect(compileError.code).toBe(metadataError.code)
   expect(compileError.code).toBe(code)
+
+  const metadata = await readMetadata({
+    prompt: removeCommonIndent(prompt),
+    referenceFn,
+  })
+  if (metadata.errors.length === 0) {
+    throw new Error(`Expected readMetadata to throw '${code}'`)
+  }
+  const metadataError = metadata.errors[0]!
+
+  expect(metadataError.code).toBe(code)
+  expect(compileError.code).toBe(metadataError.code)
 }
 
 describe(`all compilation errors that don't require value resolution are caught both in compile and readMetadata`, () => {

--- a/packages/compiler/src/compiler/logic/types.ts
+++ b/packages/compiler/src/compiler/logic/types.ts
@@ -18,19 +18,19 @@ export enum NodeType {
   ChainExpression = 'ChainExpression',
 }
 
-type RaiseErrorFn = (
+type RaiseErrorFn<T = void | never> = (
   { code, message }: { code: string; message: string },
   node: Node,
-) => never
+) => T
 
 export type ResolveNodeProps<N extends Node> = {
   node: N
   scope: Scope
-  raiseError: RaiseErrorFn
+  raiseError: RaiseErrorFn<never>
 }
 
 export type UpdateScopeContextProps<N extends Node> = {
   node: N
   scopeContext: ScopeContext
-  raiseError: RaiseErrorFn
+  raiseError: RaiseErrorFn<void>
 }

--- a/packages/compiler/src/compiler/readMetadata.test.ts
+++ b/packages/compiler/src/compiler/readMetadata.test.ts
@@ -5,19 +5,6 @@ import { describe, expect, it } from 'vitest'
 import { readMetadata } from '.'
 import { removeCommonIndent } from './utils'
 
-const getExpectedError = async <T>(
-  action: () => Promise<unknown>,
-  errorClass: new () => T,
-): Promise<T> => {
-  try {
-    await action()
-  } catch (err) {
-    expect(err).toBeInstanceOf(errorClass)
-    return err as T
-  }
-  throw new Error('Expected an error to be thrown')
-}
-
 describe('hash', async () => {
   it('always returns the same hash for the same prompt', async () => {
     const prompt = `
@@ -211,7 +198,7 @@ describe('referenced prompts', async () => {
 })
 
 describe('syntax errors', async () => {
-  it('throws CompileErrors when the prompt syntax is invalid', async () => {
+  it('returns CompileErrors when the prompt syntax is invalid', async () => {
     const prompt = `
       <user>
         <user>
@@ -219,13 +206,11 @@ describe('syntax errors', async () => {
       </user>
     `
 
-    const action = async () => {
-      await readMetadata({
-        prompt,
-      })
-    }
+    const metadata = await readMetadata({
+      prompt,
+    })
 
-    const error = await getExpectedError(action, CompileError)
-    expect(error).toBeTruthy()
+    expect(metadata.errors.length).toBe(1)
+    expect(metadata.errors[0]).toBeInstanceOf(CompileError)
   })
 })

--- a/packages/compiler/src/error/error.ts
+++ b/packages/compiler/src/error/error.ts
@@ -1,3 +1,4 @@
+import { Fragment } from '$/parser/interfaces'
 import { locate } from 'locate-character'
 
 export interface Position {
@@ -11,6 +12,7 @@ type CompileErrorProps = {
   source: string
   start: number
   end?: number
+  fragment?: Fragment
 }
 
 export default class CompileError extends Error {
@@ -19,6 +21,7 @@ export default class CompileError extends Error {
   end?: Position
   pos?: number
   frame?: string
+  fragment?: Fragment
 
   toString() {
     if (!this.start) return this.message
@@ -74,5 +77,6 @@ export function error(message: string, props: CompileErrorProps): never {
     start?.column ?? 0,
     end?.column,
   )
+  error.fragment = props.fragment
   throw error
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,1 +1,3 @@
 export * from './types'
+export * from './compiler'
+export { default as CompileError } from './error/error'

--- a/packages/compiler/src/types/index.ts
+++ b/packages/compiler/src/types/index.ts
@@ -1,3 +1,5 @@
+import CompileError from '$/error/error'
+
 import { Message } from './message'
 
 export type Config = Record<string, unknown>
@@ -10,6 +12,7 @@ export type Conversation = {
 export type ConversationMetadata = {
   hash: string // Unique string identifying the conversation
   config: Config
+  errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime
   referencedPrompts: Set<string>
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       '@latitude-data/typescript-config':
         specifier: workspace:*
         version: link:../../tools/typescript
+      '@rollup/plugin-alias':
+        specifier: ^5.1.0
+        version: 5.1.0(rollup@4.18.0)
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
         version: 11.1.6(rollup@4.18.0)(typescript@5.5.3)
@@ -254,6 +257,9 @@ importers:
       rollup:
         specifier: ^4.10.0
         version: 4.18.0
+      rollup-plugin-dts:
+        specifier: ^6.1.1
+        version: 6.1.1(rollup@4.18.0)(typescript@5.5.3)
       typescript:
         specifier: ^5.2.2
         version: 5.5.3
@@ -3193,6 +3199,7 @@ packages:
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       color-convert: 1.9.3
 
@@ -3630,6 +3637,7 @@ packages:
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+    requiresBuild: true
     dependencies:
       color-name: 1.1.3
 
@@ -3641,6 +3649,7 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    requiresBuild: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -5450,6 +5459,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    requiresBuild: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -7632,6 +7642,7 @@ packages:
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
+    requiresBuild: true
     dependencies:
       has-flag: 3.0.0
 


### PR DESCRIPTION
Now, `ReadMetadata` stores any error in a list and continues compiling after it, rather than throwing the first error it encounters.
The list of errors is then returned as an attribute of the returned `metadata` object.