### PR TITLE
Fix production build broken by missing env DATABASE_URL at build time 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,12 @@
+Dockerfile
+.dockerignore
 node_modules
 npm-debug.log
 .pnpm-store
 out
 dist
 *.md
+.git
+.next
+!.next/static
+!.next/standalone

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -5,9 +5,11 @@ COPY . .
 
 RUN turbo prune @latitude-data/web --docker
 
-# COMMON stage (installer)
+# BUILDER stage
 # ------------------------------------------------------
-FROM base AS installer
+FROM base AS builder
+WORKDIR /app
+
 COPY --from=base /app/out/json/ .
 COPY --from=base /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=base /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
@@ -17,38 +19,48 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install \
   --frozen-lockfile \
   --filter "@latitude-data/web..."
 
-# PRODUCTION stage
-# ------------------------------------------------------
-FROM installer AS builder
-
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
   BUILDING_CONTAINER=true \
   pnpm turbo build --filter='@latitude-data/web...'
 
-FROM base AS runner
+FROM base as prod-deps
+WORKDIR /app
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install \
+  --prod \
+  --frozen-lockfile \
+  --filter "@latitude-data/web..."
 
+# PRODUCTION
+FROM base AS production
 WORKDIR /app-prod
 
-# Don't run production as root
+# Public files doesn't have the unpriviledged user
+COPY --from=base /app/apps/web/public ./apps/web/public
+
+# Unpriviledged user
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 USER nextjs
 
-COPY --from=installer /app/apps/web/next.config.mjs .
-COPY --from=installer /app/apps/web/package.json .
-COPY --from=installer /app/node_modules ./node_modules
-COPY --from=installer /app/apps/web/package.json ./apps/web/package.json
+COPY --from=builder /app/apps/web/next.config.mjs .
+COPY --from=builder /app/apps/web/package.json .
+COPY --from=prod-deps /app/node_modules ./node_modules
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=prod-builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./apps
-COPY --from=prod-builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
-COPY --from=prod-builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./apps
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 
 ARG PORT=3000
 ENV PORT $PORT
+
+# Configure host name. Important for setting the domain.
+ARG HOSTNAME="0.0.0.0"
+ENV HOSTNAME $HOSTNAME
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+
 EXPOSE 3000
 
-CMD HOSTNAME="0.0.0.0" node apps/web/server.js -p $PORT
+CMD node apps/web/server.js -p $PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,14 @@ services:
       context: .
       dockerfile: docker/Dockerfile.base
     restart: 'none'
+
   elastic:
     image: elasticsearch:8.14.1
     environment:
       - 'discovery.type=single-node'
       - 'ELASTIC_USERNAME=latitude'
       - 'ELASTIC_PASSWORD=secret'
+
   db:
     image: postgres
     environment:
@@ -21,7 +23,26 @@ services:
     volumes:
       - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
       - ./docker/pgdata:/var/lib/postgresql/data
+
   redis:
     image: redis
     ports:
       - '6379:6379'
+
+  web:
+    build:
+      context: .
+      target: production
+      dockerfile: apps/web/docker/Dockerfile
+    # This enables to have this service for testing production build
+    # It will not run when doing docker compose up
+    profiles: [building]
+    volumes:
+      - ./packages/env:/app/packages/env
+      - ./packages/core:/app/packages/core
+      - ./packages/jobs:/app/packages/jobs
+      - ./packages/web-ui:/app/packages/web-ui
+      - ./apps/web:/app/apps/web
+    depends_on:
+      - base
+      - db

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@latitude-data/env": "workspace:^",
+    "@t3-oss/env-core": "^0.10.1",
     "bcrypt": "^5.1.1",
     "drizzle-orm": "0.31.4",
     "lodash-es": "^4.17.21",

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,16 +1,13 @@
+import { createEnv } from '@t3-oss/env-core'
 import z from 'zod'
 
 import '@latitude-data/env'
 
-const envvars = z.object({
-  NODE_ENV: z.string(),
-  DATABASE_URL: z.string(),
+export default createEnv({
+  skipValidation: process.env.BUILDING_CONTAINER == 'true',
+  server: {
+    NODE_ENV: z.string(),
+    DATABASE_URL: z.string().url(),
+  },
+  runtimeEnv: process.env,
 })
-
-export default envvars.parse(process.env)
-
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv extends z.infer<typeof envvars> {}
-  }
-}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@latitude-data/typescript-config/base.json",
   "compilerOptions": {
+    "moduleResolution": "Bundler",
     "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@latitude-data/env':
         specifier: workspace:^
         version: link:../env
+      '@t3-oss/env-core':
+        specifier: ^0.10.1
+        version: 0.10.1(typescript@5.5.3)(zod@3.23.8)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1


### PR DESCRIPTION
# What?
We moved DB initialization to core: https://github.com/latitude-dev/latitude-llm/pull/34 This breaks production build because at build time DATABASE_URL is not and should never be defined

## TODO
- [x] QA the build works 