### PR TITLE
Sort tree alphabetically

### DIFF
--- a/packages/web-ui/src/sections/DocumentsSidebar/useTree/index.test.ts
+++ b/packages/web-ui/src/sections/DocumentsSidebar/useTree/index.test.ts
@@ -1,88 +1,79 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
+import { Node, useTree } from './index'
+
 const FAKE_RANDOM_ID = 'RANDOM_ID'
 
+function fakeRandomId({ uuid }: { uuid?: string } = {}) {
+  if (uuid) return uuid
+
+  return FAKE_RANDOM_ID
+}
+
+function nodeToJson(node: Node): object {
+  return {
+    name: node.name,
+    id: node.id,
+    children: node.children.map(nodeToJson),
+  }
+}
+
 let list = [
-  { path: 'things/doc1', doumentUuid: '1' },
-  { path: 'things/doc2', doumentUuid: '2' },
-  { path: 'things/other-things/doc3', doumentUuid: '3' },
-  { path: 'something-else/doc4', doumentUuid: '4' },
+  { path: 'a_thing/doc1', doumentUuid: '1' },
+  { path: 'a_thing/doc2', doumentUuid: '2' },
+  { path: 'a_thing/other-things/doc3', doumentUuid: '3' },
+  { path: 'z_thing/doc5', doumentUuid: '5' },
+  { path: 'b_thing/doc4', doumentUuid: '4' },
+  { path: 'b_doc_6', doumentUuid: '6' },
+  { path: 'a_doc_7', doumentUuid: '7' },
 ]
 
 describe('useTree', () => {
-  it('should return a tree with children', async () => {
-    const resultImport = await import('./index')
-    const { useTree } = resultImport
-
+  it('return all node attributes', async () => {
     const { result } = renderHook(() =>
-      useTree({
-        documents: list,
-        generateNodeId: ({ uuid }: { uuid?: string } = {}) => {
-          if (uuid) return uuid
-
-          return FAKE_RANDOM_ID
-        },
-      }),
+      useTree({ documents: list, generateNodeId: fakeRandomId }),
     )
-    expect(result.current.toJSON()).toEqual({
+    const root = result.current
+    expect(root.id).toBe(FAKE_RANDOM_ID)
+    expect(root.doc).toBeUndefined()
+    expect(root.name).toBe('root')
+    expect(root.children).toHaveLength(5)
+  })
+
+  it('should return a tree with children', async () => {
+    const { result } = renderHook(() =>
+      useTree({ documents: list, generateNodeId: fakeRandomId }),
+    )
+    expect(nodeToJson(result.current)).toEqual({
       id: FAKE_RANDOM_ID,
-      doc: undefined,
-      isRoot: true,
       name: 'root',
       children: [
         {
           id: FAKE_RANDOM_ID,
-          doc: undefined,
-          name: 'things',
-          isRoot: false,
+          name: 'a_thing',
           children: [
             {
-              id: '1',
-              name: 'doc1',
-              isRoot: false,
-              doc: { path: 'things/doc1', doumentUuid: '1' },
-              children: [],
-            },
-            {
-              id: '2',
-              name: 'doc2',
-              isRoot: false,
-              doc: { path: 'things/doc2', doumentUuid: '2' },
-              children: [],
-            },
-            {
-              id: FAKE_RANDOM_ID,
-              isRoot: false,
-              doc: undefined,
               name: 'other-things',
-              children: [
-                {
-                  id: '3',
-                  isRoot: false,
-                  name: 'doc3',
-                  doc: { path: 'things/other-things/doc3', doumentUuid: '3' },
-                  children: [],
-                },
-              ],
+              id: FAKE_RANDOM_ID,
+              children: [{ id: '3', name: 'doc3', children: [] }],
             },
+            { id: '1', name: 'doc1', children: [] },
+            { id: '2', name: 'doc2', children: [] },
           ],
         },
         {
+          name: 'b_thing',
           id: FAKE_RANDOM_ID,
-          isRoot: false,
-          doc: undefined,
-          name: 'something-else',
-          children: [
-            {
-              id: '4',
-              name: 'doc4',
-              isRoot: false,
-              doc: { path: 'something-else/doc4', doumentUuid: '4' },
-              children: [],
-            },
-          ],
+          children: [{ id: '4', name: 'doc4', children: [] }],
         },
+        {
+          id: FAKE_RANDOM_ID,
+          name: 'z_thing',
+          children: [{ id: '5', name: 'doc5', children: [] }],
+        },
+        { id: '7', name: 'a_doc_7', children: [] },
+        { id: '6', name: 'b_doc_6', children: [] },
       ],
     })
   })


### PR DESCRIPTION
# What?
Sort folder (first) and files alphabetically 

## From this
```
let list = [
  { path: 'z_thing/doc5', doumentUuid: '5' },
  { path: 'a_thing/doc1', doumentUuid: '1' },
  { path: 'a_thing/doc2', doumentUuid: '2' },
  { path: 'b_doc_6', doumentUuid: '6' },
  { path: 'a_doc_7', doumentUuid: '7' },
  { path: 'a_thing/other-things/doc3', doumentUuid: '3' },
  { path: 'b_thing/doc4', doumentUuid: '4' },
]
```

## To this
```bash
root/
├─ a_thing/
│  ├─ doc1
│  ├─ doc2
│  ├─ other-things/
│  │  ├─ doc3
├─ b_thing/
│  ├─ doc4
├─ z_thing/
│  ├─ doc5
├─ a_doc_7
├─ b_doc_6
```