### PR TITLE
Sidebar add and remove temporal folders to sidebar

### DIFF
--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -30,6 +30,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",

--- a/packages/web-ui/src/ds/atoms/Button/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Button/index.tsx
@@ -2,6 +2,8 @@ import { ButtonHTMLAttributes, forwardRef, ReactNode } from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { Slot, Slottable } from '@radix-ui/react-slot'
 
+import { IconProps, Icons } from '$ui/ds/atoms/Icons'
+import { colors } from '$ui/ds/tokens'
 import { cn } from '$ui/lib/utils'
 
 const buttonVariants = cva(
@@ -21,11 +23,12 @@ const buttonVariants = cva(
           'border border-input hover:bg-accent hover:text-accent-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        ghost: 'shadow-none bg-transparent',
         link: 'underline-offset-4 hover:underline text-primary',
       },
       size: {
         default: 'py-1.5 px-3',
+        small: 'py-1 px-1.5',
       },
     },
     defaultVariants: {
@@ -35,20 +38,24 @@ const buttonVariants = cva(
   },
 )
 
-export interface ButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  children: ReactNode
-  fullWidth?: boolean
-  asChild?: boolean
-  isLoading?: boolean
-}
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    children: ReactNode
+    icon?: {
+      name: keyof typeof Icons
+      props?: IconProps
+    }
+    fullWidth?: boolean
+    asChild?: boolean
+    isLoading?: boolean
+  }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
     className,
     variant,
     size,
+    icon,
     fullWidth = false,
     asChild = false,
     isLoading,
@@ -58,6 +65,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   ref,
 ) {
   const Comp = asChild ? Slot : 'button'
+  const ButtonIcon = icon ? Icons[icon.name] : null
+  const iconProps = icon?.props ?? {}
   return (
     <Comp
       disabled={isLoading}
@@ -67,7 +76,20 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       ref={ref}
       {...props}
     >
-      <Slottable>{children}</Slottable>
+      <Slottable>
+        <div className='flex flex-row items-center gap-x-1'>
+          {ButtonIcon ? (
+            <ButtonIcon
+              className={cn({
+                [colors.textColors[iconProps.color!]]: iconProps.color,
+                'w-4': !iconProps.widthClass,
+                'h-4': !iconProps.heightClass,
+              })}
+            />
+          ) : null}
+          {children}
+        </div>
+      </Slottable>
     </Comp>
   )
 })

--- a/packages/web-ui/src/ds/atoms/DropdownMenu/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/DropdownMenu/Primitives/index.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import * as React from 'react'
+import { Check, ChevronRight, Circle } from 'lucide-react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+
+import { cn } from '$ui/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className='ml-auto h-4 w-4' />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className='h-4 w-4' />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+))
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}
+  >
+    <span className='absolute left-2 flex h-3.5 w-3.5 items-center justify-center'>
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className='h-2 w-2 fill-current' />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+))
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 text-sm font-semibold',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn('ml-auto text-xs tracking-widest opacity-60', className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut'
+
+type ContentProps = DropdownMenuPrimitive.DropdownMenuContentProps
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+  type ContentProps,
+}

--- a/packages/web-ui/src/ds/atoms/DropdownMenu/index.tsx
+++ b/packages/web-ui/src/ds/atoms/DropdownMenu/index.tsx
@@ -1,0 +1,135 @@
+import { ReactNode, useCallback, useState } from 'react'
+
+import { Button, type ButtonProps } from '$ui/ds/atoms/Button'
+import Text from '$ui/ds/atoms/Text'
+
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+  DropdownMenu as Root,
+  type ContentProps,
+} from './Primitives'
+
+export type TriggerButtonProps = Omit<ButtonProps, 'children'> & {
+  label?: string
+}
+const TriggerButton = ({
+  label,
+  variant = 'ghost',
+  icon = { name: 'ellipsisVertical', props: { color: 'foregroundMuted' } },
+  ...buttonProps
+}: TriggerButtonProps) => {
+  return (
+    <DropdownMenuTrigger asChild className='flex focus:outline-none'>
+      <Button
+        asChild
+        size='small'
+        variant={variant}
+        icon={icon}
+        {...buttonProps}
+      >
+        <div>{label ? label : null}</div>
+      </Button>
+    </DropdownMenuTrigger>
+  )
+}
+
+export type MenuOption = {
+  label: string
+  onClick: () => void
+  type?: 'normal' | 'destructive'
+  icon?: ReactNode
+  disabled?: boolean
+  shortcut?: string
+}
+function DropdownItem({
+  icon,
+  onClick,
+  type = 'normal',
+  label,
+  shortcut,
+  disabled,
+}: MenuOption) {
+  const onSelect = useCallback(() => {
+    if (disabled) return
+    onClick()
+  }, [disabled, onClick])
+  return (
+    <DropdownMenuItem onSelect={onSelect} disabled={disabled}>
+      {icon}
+      <Text.H5M color={type === 'destructive' ? 'destructive' : 'foreground'}>
+        {label}
+      </Text.H5M>
+      {shortcut && <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut>}
+    </DropdownMenuItem>
+  )
+}
+
+type RenderTriggerProps = { open: boolean }
+type TriggerButtonPropsFn = (open: boolean) => TriggerButtonProps
+type Props = ContentProps & {
+  triggerButtonProps?: TriggerButtonProps | TriggerButtonPropsFn
+  trigger?: (renderTriggerProps: RenderTriggerProps) => ReactNode
+  title?: string
+  options: MenuOption[]
+  onOpenChange?: (open: boolean) => void
+  controlledOpen?: boolean
+}
+export function DropdownMenu({
+  triggerButtonProps,
+  trigger,
+  title,
+  side,
+  sideOffset,
+  align,
+  alignOffset,
+  options,
+  onOpenChange,
+  controlledOpen,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const isFn = typeof triggerButtonProps === 'function'
+  return (
+    <Root
+      onOpenChange={(newOpen: boolean) => {
+        onOpenChange?.(newOpen)
+        setOpen(newOpen)
+      }}
+      open={controlledOpen !== undefined ? controlledOpen : open}
+    >
+      {triggerButtonProps ? (
+        <TriggerButton
+          {...(isFn ? triggerButtonProps(open) : triggerButtonProps)}
+        />
+      ) : trigger ? (
+        trigger({ open })
+      ) : (
+        <TriggerButton />
+      )}
+      <DropdownMenuPortal>
+        <DropdownMenuContent
+          side={side}
+          sideOffset={sideOffset}
+          align={align}
+          alignOffset={alignOffset}
+          className='w-52'
+        >
+          {title && (
+            <>
+              <DropdownMenuLabel>{title}</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {options.map((option, index) => (
+            <DropdownItem key={index} {...option} />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenuPortal>
+    </Root>
+  )
+}

--- a/packages/web-ui/src/ds/atoms/FormField/index.tsx
+++ b/packages/web-ui/src/ds/atoms/FormField/index.tsx
@@ -9,6 +9,8 @@ import {
 import { Slot } from '@radix-ui/react-slot'
 
 import { Label } from '$ui/ds/atoms/Label'
+import Text from '$ui/ds/atoms/Text'
+import { Tooltip } from '$ui/ds/atoms/Tooltip'
 import { cn } from '$ui/lib/utils'
 
 function FormDescription({
@@ -28,7 +30,19 @@ function FormDescription({
   )
 }
 
-function FormMessage({ error, id }: { id: string; error: string | undefined }) {
+function TooltipMessage({ error }: { error: string | undefined }) {
+  if (!error) return null
+
+  return <Text.H6B color='white'>{error}</Text.H6B>
+}
+
+function InlineFormMessage({
+  error,
+  id,
+}: {
+  id: string
+  error: string | undefined
+}) {
   if (!error) return null
 
   return (
@@ -70,6 +84,7 @@ export type FormFieldProps = Omit<
   label?: string
   description?: string | ReactNode
   errors?: string[] | null | undefined
+  errorStyle?: 'inline' | 'tooltip'
 }
 function FormField({
   children,
@@ -77,6 +92,7 @@ function FormField({
   description,
   className,
   errors,
+  errorStyle = 'inline',
 }: FormFieldProps) {
   const error = errors?.[0]
   const id = useId()
@@ -85,35 +101,51 @@ function FormField({
   const formMessageId = `${id}-form-item-message`
 
   return (
-    <div
-      className={cn('space-y-2 w-full', className)}
-      aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
+    <Tooltip
+      side='bottom'
+      align='start'
+      open={!!error && errorStyle === 'tooltip'}
+      trigger={
+        <div
+          className={cn('space-y-2 w-full', className)}
+          aria-describedby={
+            !error
+              ? `${formDescriptionId}`
+              : `${formDescriptionId} ${formMessageId}`
+          }
+          aria-invalid={!!error}
+        >
+          {label ? (
+            <Label
+              variant={error ? 'destructive' : 'default'}
+              htmlFor={formItemId}
+            >
+              {label}
+            </Label>
+          ) : null}
+          <FormControl
+            error={error}
+            formItemId={formItemId}
+            formDescriptionId={formDescriptionId}
+            formMessageId={formMessageId}
+          >
+            {children}
+          </FormControl>
+
+          {description && (
+            <FormDescription id={formDescriptionId}>
+              {description}
+            </FormDescription>
+          )}
+
+          {errorStyle === 'inline' ? (
+            <InlineFormMessage error={error} id={formMessageId} />
+          ) : null}
+        </div>
       }
-      aria-invalid={!!error}
     >
-      {label ? (
-        <Label variant={error ? 'destructive' : 'default'} htmlFor={formItemId}>
-          {label}
-        </Label>
-      ) : null}
-      <FormControl
-        error={error}
-        formItemId={formItemId}
-        formDescriptionId={formDescriptionId}
-        formMessageId={formMessageId}
-      >
-        {children}
-      </FormControl>
-
-      {description && (
-        <FormDescription id={formDescriptionId}>{description}</FormDescription>
-      )}
-
-      <FormMessage error={error} id={formMessageId} />
-    </div>
+      <TooltipMessage error={error} />
+    </Tooltip>
   )
 }
 

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -2,15 +2,23 @@ import {
   ChevronDown,
   ChevronRight,
   Copy,
+  EllipsisVertical,
   File,
   FolderClosed,
   FolderOpen,
   type LucideIcon,
 } from 'lucide-react'
 
+import { type TextColor } from '$ui/ds/tokens'
+
 import { LatitudeLogo, LatitudeLogoMonochrome } from './custom-icons'
 
 export type Icon = LucideIcon
+export type IconProps = {
+  color?: TextColor
+  widthClass?: string
+  heightClass?: string
+}
 
 export const Icons = {
   logo: LatitudeLogo,
@@ -21,4 +29,5 @@ export const Icons = {
   file: File,
   folderOpen: FolderOpen,
   clipboard: Copy,
+  ellipsisVertical: EllipsisVertical,
 }

--- a/packages/web-ui/src/ds/atoms/Input/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Input/index.tsx
@@ -1,28 +1,67 @@
 import { forwardRef, InputHTMLAttributes } from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 import { FormField, type FormFieldProps } from '$ui/ds/atoms/FormField'
 import { font } from '$ui/ds/tokens'
 import { cn } from '$ui/lib/utils'
 
-export type InputProps = InputHTMLAttributes<HTMLInputElement> &
-  Omit<FormFieldProps, 'children'>
+const inputVariants = cva(
+  cn(
+    'flex w-full border border-input bg-background ring-offset-background',
+    'file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground',
+    'focus-visible:outline-none focus-visible:ring-ring rounded-md focus-visible:ring-2',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    font.size.h5,
+  ),
+  {
+    variants: {
+      size: {
+        normal: 'h-8 px-2 py-1  focus-visible:ring-offset-2',
+        small: 'px-1 rounded-sm focus-visible:ring-offset-1',
+      },
+    },
+    defaultVariants: {
+      size: 'normal',
+    },
+  },
+)
+export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> &
+  VariantProps<typeof inputVariants> &
+  Omit<FormFieldProps, 'children'> & {
+    artificialFocused?: boolean
+  }
 const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className, label, errors, description, type, ...props },
+  {
+    artificialFocused = false,
+    className,
+    label,
+    errors,
+    errorStyle,
+    description,
+    type,
+    size,
+    ...props
+  },
   ref,
 ) {
   return (
-    <FormField label={label} description={description} errors={errors}>
+    <FormField
+      label={label}
+      description={description}
+      errors={errors}
+      errorStyle={errorStyle}
+    >
       <input
         ref={ref}
         type={type}
-        className={cn(
-          'flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-          font.size.h5,
-          className,
-          {
-            'border-red-500 focus-visible:ring-red-500': errors,
-          },
-        )}
+        className={cn(inputVariants({ size }), className, {
+          'border-red-500 focus-visible:ring-red-500': errors,
+          'ring-2': artificialFocused,
+          'ring-ring': artificialFocused && !errors,
+          'ring-red-500': artificialFocused && errors,
+          'ring-offset-2': artificialFocused && size === 'normal',
+          'ring-offset-1': artificialFocused && size === 'small',
+        })}
         {...props}
       />
     </FormField>

--- a/packages/web-ui/src/ds/atoms/Tooltip/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Tooltip/index.tsx
@@ -16,19 +16,29 @@ const TooltipRoot = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
+type TooltipVariant = 'default' | 'destructive'
 type PropviderProps = ComponentPropsWithoutRef<typeof TooltipProvider>
 type RootProps = ComponentPropsWithoutRef<typeof TooltipRoot>
-type ContentProps = ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+type ContentProps = ComponentPropsWithoutRef<
+  typeof TooltipPrimitive.Content
+> & {
+  variant?: TooltipVariant
+}
 const TooltipContent = forwardRef<
   ElementRef<typeof TooltipPrimitive.Content>,
   ContentProps
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, variant = 'default', sideOffset = 4, ...props }, ref) => (
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 overflow-hidden rounded-md bg-foreground text-white px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 overflow-hidden rounded-md text-white px-3 py-1.5 text-xs animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'max-w-72',
       className,
+      {
+        'bg-foreground': variant === 'default',
+        'bg-destructive': variant === 'destructive',
+      },
     )}
     {...props}
   />
@@ -54,6 +64,7 @@ function Tooltip({
   onOpenChange,
 
   // Content
+  variant,
   side,
   sideOffset,
   align,
@@ -79,6 +90,7 @@ function Tooltip({
       </TooltipTrigger>
       <TooltipPrimitive.Portal>
         <TooltipContent
+          variant={variant}
           side={side}
           sideOffset={sideOffset}
           align={align}

--- a/packages/web-ui/src/ds/tokens/colors.ts
+++ b/packages/web-ui/src/ds/tokens/colors.ts
@@ -7,6 +7,8 @@ export const colors = {
     foreground: 'text-foreground',
     foregroundMuted: 'text-muted-foreground',
     accent: 'text-accent',
+    destructive: 'text-destructive',
+    destructiveForeground: 'text-destructive-foreground',
     accentForeground: 'text-accent-foreground',
   },
   borderColors: {

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/FilesProvider/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/FilesProvider/index.tsx
@@ -1,0 +1,43 @@
+import { createContext, ReactNode, useContext } from 'react'
+
+type IFilesContext = {
+  currentPath?: string
+  onCreateFile: (path: string) => void
+  onDeleteFile: (documentUuid: string) => void
+  onDeleteFolder: (path: string) => void
+  onNavigateToDocument: (documentUuid: string) => void
+}
+const FileTreeContext = createContext({} as IFilesContext)
+
+const FileTreeProvider = ({
+  children,
+  currentPath,
+  onCreateFile,
+  onDeleteFile,
+  onDeleteFolder,
+  onNavigateToDocument,
+}: { children: ReactNode } & IFilesContext) => {
+  return (
+    <FileTreeContext.Provider
+      value={{
+        currentPath,
+        onCreateFile,
+        onDeleteFile,
+        onDeleteFolder,
+        onNavigateToDocument,
+      }}
+    >
+      {children}
+    </FileTreeContext.Provider>
+  )
+}
+
+const useFileTreeContext = () => {
+  const fileTreeContext = useContext(FileTreeContext)
+  if (!fileTreeContext) {
+    throw new Error('useFileTreeContext must be used within a FileTreeProvider')
+  }
+  return fileTreeContext
+}
+
+export { FileTreeProvider, useFileTreeContext }

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
@@ -1,22 +1,39 @@
 'use client'
 
-import { ReactNode, useCallback, useEffect, useState } from 'react'
+import {
+  forwardRef,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
+import { DropdownMenu, MenuOption } from '$ui/ds/atoms/DropdownMenu'
 import { Icons } from '$ui/ds/atoms/Icons'
+import { Input } from '$ui/ds/atoms/Input'
 import Text from '$ui/ds/atoms/Text'
 import { cn } from '$ui/lib/utils'
+import {
+  FileTreeProvider,
+  useFileTreeContext,
+} from '$ui/sections/Document/Sidebar/Files/FilesProvider'
+import { useNodeValidator } from '$ui/sections/Document/Sidebar/Files/useNodeValidator'
+import { useTempNodes } from '$ui/sections/Document/Sidebar/Files/useTempNodes'
 
 import { useOpenPaths } from './useOpenPaths'
 import { Node, SidebarDocument, useTree } from './useTree'
 
-const ICON_CLASS = 'w-6 h-6 text-muted-foreground'
+const ICON_CLASS = 'min-w-6 h-6 text-muted-foreground'
 
 type IndentType = { isLast: boolean }
+
 function IndentationBar({
   indentation,
-  open,
+  hasChildren,
 }: {
-  open: boolean
+  hasChildren: boolean
   indentation: IndentType[]
 }) {
   return indentation.map((indent, index) => {
@@ -25,16 +42,16 @@ function IndentationBar({
       .find((i) => !i.isLast)
     const showBorder = anyNextIndentIsNotLast ? false : indent.isLast
     return (
-      <div key={index} className='h-6 w-6'>
+      <div key={index} className='h-6 min-w-6'>
         {index > 0 ? (
-          <div className='-ml-px relative w-6 h-full flex justify-center'>
-            {!open && showBorder ? (
-              <div className='relative -mt-1'>
-                <div className='border-l h-3' />
-                <div className='absolute top-3 border-l border-b h-2 w-2 rounded-bl-sm' />
-              </div>
-            ) : (
+          <div className='-ml-[3px] relative w-6 h-full flex justify-center'>
+            {hasChildren || !showBorder ? (
               <div className='bg-border w-px h-8 -mt-1' />
+            ) : (
+              <div className='relative -mt-1'>
+                <div className='border-l h-2.5' />
+                <div className='absolute top-2.5 border-l border-b h-2 w-2 rounded-bl-sm' />
+              </div>
             )}
           </div>
         ) : null}
@@ -43,61 +60,160 @@ function IndentationBar({
   })
 }
 
-function NodeHeaderWrapper({
-  open,
-  selected = false,
-  onClick,
-  children,
-  indentation,
-}: {
+type WrapperProps = {
   open: boolean
+  node: Node
   selected?: boolean
   onClick?: () => void
   children: ReactNode
   indentation: IndentType[]
-}) {
+}
+const NodeHeaderWrapper = forwardRef<HTMLDivElement, WrapperProps>(function Foo(
+  { node, open, selected = false, onClick, children, indentation },
+  ref,
+) {
   return (
     <div
+      ref={ref}
       onClick={onClick}
-      className={cn('flex flex-row my-0.5 cursor-pointer', {
-        'hover:bg-muted': !selected,
-        'bg-accent': selected,
-      })}
+      className={cn(
+        'max-w-full group/row flex flex-row my-0.5 cursor-pointer',
+        {
+          'hover:bg-muted': !selected,
+          'bg-accent': selected,
+        },
+      )}
     >
-      <IndentationBar indentation={indentation} open={open} />
+      <IndentationBar
+        indentation={indentation}
+        hasChildren={open && node.children.length > 0}
+      />
       {children}
     </div>
   )
-}
+})
 
 function FolderHeader({
   node,
   open,
   indentation,
+  onToggleOpen,
 }: {
-  isLast: boolean
   node: Node
   open: boolean
   indentation: IndentType[]
+  onToggleOpen: () => void
 }) {
-  const togglePath = useOpenPaths((state) => state.togglePath)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const nodeRef = useRef<HTMLDivElement>(null)
+  const { onDeleteFolder } = useFileTreeContext()
+  const { openPaths, togglePath } = useOpenPaths((state) => ({
+    togglePath: state.togglePath,
+    openPaths: state.openPaths,
+  }))
+  const { addFolder, updateFolder, deleteTmpFolder } = useTempNodes(
+    (state) => ({
+      addFolder: state.addFolder,
+      updateFolder: state.updateFolder,
+      deleteTmpFolder: state.deleteTmpFolder,
+    }),
+  )
+  const { isEditing, error, onInputChange, onInputKeyDown, keepFocused } =
+    useNodeValidator({
+      node,
+      nodeRef,
+      inputRef,
+      saveValue: async ({ path }: { path: string }) => {
+        return updateFolder({ path, id: node.id })
+      },
+      leaveWithoutSave: () => {
+        deleteTmpFolder({ id: node.id })
+      },
+    })
   const FolderIcon = open ? Icons.folderOpen : Icons.folderClose
   const ChevronIcon = open ? Icons.chevronDown : Icons.chevronRight
-  const onTooglePath = useCallback(() => {
-    togglePath(node.path)
-  }, [togglePath, node.path])
+  const options = useMemo<MenuOption[]>(
+    () => [
+      {
+        label: 'New folder',
+        onClick: () => {
+          if (!open) {
+            togglePath(node.path)
+          }
+          addFolder({ parentPath: node.path, parentId: node.id })
+        },
+      },
+      {
+        label: 'New Prompt',
+        onClick: () => {},
+      },
+      {
+        label: 'Delete folder',
+        type: 'destructive',
+        onClick: () => {
+          if (node.isPersisted) {
+            onDeleteFolder(node.path)
+          } else {
+            deleteTmpFolder({ id: node.id })
+          }
+        },
+      },
+    ],
+    [
+      addFolder,
+      onDeleteFolder,
+      deleteTmpFolder,
+      node.path,
+      node.isPersisted,
+      openPaths,
+      togglePath,
+    ],
+  )
   return (
-    <NodeHeaderWrapper open={open} indentation={indentation}>
+    <NodeHeaderWrapper
+      ref={nodeRef}
+      node={node}
+      open={open}
+      indentation={indentation}
+    >
       <div
-        onClick={onTooglePath}
-        className='flex-1 flex flex-row items-center gap-x-1'
+        onClick={onToggleOpen}
+        className='min-w-0 flex-grow flex flex-row justify-between items-center gap-x-1 py-0.5'
       >
-        <div className='w-6 flex justify-center'>
+        <div className='min-w-6 h-6 flex items-center justify-center'>
           <ChevronIcon className={cn(ICON_CLASS, 'h-4 w-4')} />
         </div>
         <FolderIcon className={ICON_CLASS} />
-        <Text.H5M userSelect={false}>{node.name}</Text.H5M>
+
+        {isEditing ? (
+          <div className='pr-1 flex items-center'>
+            <Input
+              autoFocus
+              artificialFocused={keepFocused}
+              ref={inputRef}
+              name='name'
+              type='text'
+              size='small'
+              onKeyDown={onInputKeyDown}
+              onChange={onInputChange}
+              errors={error ? [error] : undefined}
+              errorStyle='tooltip'
+            />
+          </div>
+        ) : (
+          <div className='flex-grow flex-shrink truncate'>
+            <Text.H5M ellipsis noWrap userSelect={false}>
+              {node.name}
+            </Text.H5M>
+          </div>
+        )}
       </div>
+
+      {!isEditing ? (
+        <div className='flex items-center opacity-0 group-hover/row:opacity-100'>
+          <DropdownMenu options={options} side='bottom' align='end' />
+        </div>
+      ) : null}
     </NodeHeaderWrapper>
   )
 }
@@ -107,59 +223,77 @@ function FileHeader({
   selected,
   node,
   indentation,
-  navigateToDocument,
 }: {
   open: boolean
   selected: boolean
   node: Node
   indentation: IndentType[]
-  navigateToDocument: (documentUuid: string) => void
 }) {
+  const { onDeleteFile, onNavigateToDocument } = useFileTreeContext()
   const handleClick = useCallback(() => {
     if (selected) return
 
-    navigateToDocument(node.doc!.documentUuid)
+    onNavigateToDocument(node.doc!.documentUuid)
   }, [node.doc!.documentUuid, selected])
+  const options = useMemo<MenuOption[]>(
+    () => [
+      {
+        label: 'Delete file',
+        type: 'destructive',
+        onClick: () => {
+          onDeleteFile(node.doc!.documentUuid)
+        },
+      },
+    ],
+    [node.doc!.documentUuid, onDeleteFile],
+  )
   return (
     <NodeHeaderWrapper
       open={open}
+      node={node}
       selected={selected}
       indentation={indentation}
       onClick={handleClick}
     >
-      <div className='flex flex-row items-center gap-x-1 py-0.5'>
+      <div className='min-w-0 flex-grow flex flex-row items-center justify-between gap-x-1 py-0.5'>
         <Icons.file
           className={cn(ICON_CLASS, {
             'text-accent-foreground': selected,
           })}
         />
-        <Text.H5M
-          userSelect={false}
-          color={selected ? 'accentForeground' : 'foreground'}
-        >
-          {node.name}
-        </Text.H5M>
+        <div className='flex-grow flex-shrink truncate'>
+          <Text.H5M
+            userSelect={false}
+            ellipsis
+            noWrap
+            color={selected ? 'accentForeground' : 'foreground'}
+          >
+            {node.name}
+          </Text.H5M>
+        </div>
+        <div className='opacity-0 group-hover/row:opacity-100'>
+          <DropdownMenu options={options} side='bottom' align='end' />
+        </div>
       </div>
     </NodeHeaderWrapper>
   )
 }
 
 function NodeHeader({
-  isLast,
   selected,
-  node,
   open,
+  onToggleOpen,
+  node,
   indentation,
-  navigateToDocument,
 }: {
-  isLast: boolean
   selected: boolean
-  node: Node
   open: boolean
+  node: Node
   indentation: IndentType[]
-  navigateToDocument: (documentUuid: string) => void
+  onToggleOpen: () => void
 }) {
   if (node.isRoot) return null
+
   if (node.isFile) {
     return (
       <FileHeader
@@ -167,50 +301,61 @@ function NodeHeader({
         selected={selected}
         node={node}
         indentation={indentation}
-        navigateToDocument={navigateToDocument}
       />
     )
   }
 
   return (
     <FolderHeader
-      isLast={isLast}
       node={node}
       open={open}
       indentation={indentation}
+      onToggleOpen={onToggleOpen}
     />
   )
 }
 
 function FileNode({
-  isLast = false,
   node,
-  currentPath,
   indentation = [],
-  navigateToDocument,
 }: {
   node: Node
-  currentPath: string | undefined
-  isLast?: boolean
   indentation?: IndentType[]
-  navigateToDocument: (documentUuid: string) => void
 }) {
+  const allTmpFolders = useTempNodes((state) => state.tmpFolders)
+  const tmpNodes = allTmpFolders[node.path] ?? []
+  const { currentPath } = useFileTreeContext()
   const [selected, setSelected] = useState(currentPath === node.path)
-  const openPaths = useOpenPaths((state) => state.openPaths)
-  const open = node.isRoot || openPaths.includes(node.path)
-  const lastIdx = node.children.length - 1
+  const allNodes = useMemo(
+    () => [...tmpNodes, ...node.children],
+    [tmpNodes, node.children],
+  )
+  const lastIdx = allNodes.length - 1
+  const { togglePath, openPaths } = useOpenPaths((state) => ({
+    openPaths: state.openPaths,
+    togglePath: state.togglePath,
+  }))
+  const open = !!openPaths[node.path]
+
+  const onToggleOpen = useCallback(() => {
+    const lastSegment = node.path.split('/').pop()
+    if (lastSegment === '' || lastSegment === ' ') return
+
+    togglePath(node.path)
+  }, [togglePath, node.path, node.isPersisted])
+
   useEffect(() => {
     setSelected(currentPath === node.path)
   }, [currentPath])
+
   return (
     <div className='w-full'>
       <NodeHeader
-        isLast={isLast}
         indentation={indentation}
         node={node}
         selected={selected}
         open={open}
-        navigateToDocument={navigateToDocument}
+        onToggleOpen={onToggleOpen}
       />
 
       {node.isFile ? null : (
@@ -219,17 +364,16 @@ function FileNode({
             hidden: !open && !node.isRoot,
           })}
         >
-          {node.children.map((node, idx) => (
-            <li key={node.id}>
-              <FileNode
-                currentPath={currentPath}
-                indentation={[...indentation, { isLast: idx === lastIdx }]}
-                node={node}
-                isLast={idx === lastIdx}
-                navigateToDocument={navigateToDocument}
-              />
-            </li>
-          ))}
+          {allNodes.map((node, idx) => {
+            return (
+              <li key={node.id}>
+                <FileNode
+                  indentation={[...indentation, { isLast: idx === lastIdx }]}
+                  node={node}
+                />
+              </li>
+            )
+          })}
         </ul>
       )}
     </div>
@@ -255,10 +399,20 @@ export function FilesTree({
   }, [currentPath, togglePath])
 
   return (
-    <FileNode
+    <FileTreeProvider
       currentPath={currentPath}
-      node={rootNode}
-      navigateToDocument={navigateToDocument}
-    />
+      onNavigateToDocument={navigateToDocument}
+      onCreateFile={(path) => {
+        console.log('onCreateFile', path)
+      }}
+      onDeleteFile={(documentUuid) => {
+        console.log('onDeleteFile', documentUuid)
+      }}
+      onDeleteFolder={(path) => {
+        console.log('onDeleteFolder', path)
+      }}
+    >
+      <FileNode node={rootNode} />
+    </FileTreeProvider>
   )
 }

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
@@ -46,16 +46,19 @@ function IndentationBar({
 function NodeHeaderWrapper({
   open,
   selected = false,
+  onClick,
   children,
   indentation,
 }: {
   open: boolean
   selected?: boolean
+  onClick?: () => void
   children: ReactNode
   indentation: IndentType[]
 }) {
   return (
     <div
+      onClick={onClick}
       className={cn('flex flex-row my-0.5 cursor-pointer', {
         'hover:bg-muted': !selected,
         'bg-accent': selected,
@@ -87,7 +90,7 @@ function FolderHeader({
     <NodeHeaderWrapper open={open} indentation={indentation}>
       <div
         onClick={onTooglePath}
-        className='flex flex-row items-center gap-x-1'
+        className='flex-1 flex flex-row items-center gap-x-1'
       >
         <div className='w-6 flex justify-center'>
           <ChevronIcon className={cn(ICON_CLASS, 'h-4 w-4')} />
@@ -122,11 +125,9 @@ function FileHeader({
       open={open}
       selected={selected}
       indentation={indentation}
+      onClick={handleClick}
     >
-      <div
-        className='flex flex-row items-center gap-x-1 py-0.5'
-        onClick={handleClick}
-      >
+      <div className='flex flex-row items-center gap-x-1 py-0.5'>
         <Icons.file
           className={cn(ICON_CLASS, {
             'text-accent-foreground': selected,

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useNodeValidator/index.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useNodeValidator/index.ts
@@ -1,0 +1,123 @@
+import {
+  ChangeEventHandler,
+  KeyboardEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
+
+import { Node as SidebarNode } from '$ui/sections/Document/Sidebar/Files/useTree'
+
+function useOnClickOutside<E extends HTMLElement>({
+  enabled,
+  ref,
+  handler,
+}: {
+  enabled: boolean
+  ref: RefObject<E>
+  handler: (event: MouseEvent | TouchEvent) => void
+}) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!(event.target instanceof Node)) return
+
+      const insideWrapper = ref.current?.contains?.(event.target)
+      if (insideWrapper) return
+
+      handler(event)
+    }
+
+    if (!enabled) return
+
+    document.addEventListener('mousedown', listener)
+    document.addEventListener('touchstart', listener)
+
+    return () => {
+      document.removeEventListener('mousedown', listener)
+      document.removeEventListener('touchstart', listener)
+    }
+  }, [ref, handler, enabled])
+}
+
+const PATH_REGEXP = /^([\w-]+\/)*([\w-.])+$/
+const INVALID_MSG =
+  "Invalid path, no spaces. Only letters, numbers, '-' and '_'"
+export function useNodeValidator({
+  node,
+  inputRef,
+  nodeRef,
+  leaveWithoutSave,
+  saveValue,
+}: {
+  node: SidebarNode
+  inputRef: RefObject<HTMLInputElement>
+  nodeRef: RefObject<HTMLDivElement>
+  saveValue: (args: { path: string }) => Promise<void>
+  leaveWithoutSave?: () => void
+}) {
+  const [value, setValue] = useState(node.name?.trim() ?? '')
+  const [isEditing, setIsEditing] = useState(node.name === ' ')
+  const [validationError, setError] = useState<string>()
+  const onInputChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      const value = event.target.value
+      const isValid = PATH_REGEXP.test(value)
+
+      let error = undefined
+
+      if (!isValid) {
+        error = INVALID_MSG
+      }
+
+      setError(error)
+    },
+    [setError],
+  )
+  const onClickOutside = useCallback(async () => {
+    const val = inputRef.current?.value ?? ''
+    const value = val.trim()
+    setValue(value)
+
+    if (!value) {
+      leaveWithoutSave?.()
+      return
+    }
+
+    const isValid = PATH_REGEXP.test(value)
+    if (!isValid) return
+
+    await saveValue({ path: value })
+    setIsEditing(false)
+  }, [inputRef, validationError, saveValue, leaveWithoutSave])
+
+  useOnClickOutside({
+    ref: nodeRef,
+    handler: onClickOutside,
+    enabled: isEditing,
+  })
+
+  const onInputKeyDown = useCallback(
+    async (event: KeyboardEvent<HTMLInputElement>) => {
+      const val = inputRef.current?.value ?? ''
+      const value = val.trim()
+      const isValid = PATH_REGEXP.test(value)
+
+      if (event.key === 'Escape') {
+        leaveWithoutSave?.()
+      } else if (event.key === 'Enter' && isValid) {
+        await saveValue({ path: value })
+        setIsEditing(false)
+      }
+    },
+    [saveValue, leaveWithoutSave, inputRef, setIsEditing],
+  )
+
+  return {
+    isEditing,
+    onInputChange,
+    onInputKeyDown,
+    error: validationError,
+    keepFocused: !value,
+  }
+}

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useOpenPaths/index.test.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useOpenPaths/index.test.ts
@@ -1,32 +1,42 @@
 import { act, renderHook } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { useOpenPaths } from './index'
 
 describe('useOpenPaths', () => {
+  afterEach(() => {
+    useOpenPaths.getState().reset()
+  })
+
   it('shout add the paths', async () => {
     const { result } = renderHook(() => useOpenPaths((state) => state))
     act(() => {
       result.current.togglePath('some-folder/nested-folder/doc1')
     })
 
-    expect(result.current.openPaths).toEqual([
-      '',
-      'some-folder',
-      'some-folder/nested-folder',
-      'some-folder/nested-folder/doc1',
-    ])
+    expect(result.current.openPaths).toEqual({
+      'some-folder': true,
+      'some-folder/nested-folder': true,
+      'some-folder/nested-folder/doc1': true,
+    })
   })
 
-  it('shout remove nested paths', async () => {
+  it('should close nested-folder', async () => {
     const { result } = renderHook(() => useOpenPaths((state) => state))
     act(() => {
-      result.current.togglePath('some-folder/nested-folder/doc1')
+      result.current.togglePath('some-folder/level1/level2/level3/doc1')
     })
 
     act(() => {
-      result.current.togglePath('some-folder/nested-folder')
+      result.current.togglePath('some-folder/level1/level2')
     })
-    expect(result.current.openPaths).toEqual(['', 'some-folder'])
+
+    expect(result.current.openPaths).toEqual({
+      'some-folder': true,
+      'some-folder/level1': true,
+      'some-folder/level1/level2': false,
+      'some-folder/level1/level2/level3': true,
+      'some-folder/level1/level2/level3/doc1': true,
+    })
   })
 })

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.test.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook } from '@testing-library/react'
+import { Node } from '$ui/sections/Document/Sidebar/Files/useTree'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useTempNodes } from './index'
+
+describe('useTempNodes', () => {
+  afterEach(() => {
+    useTempNodes.getState().reset()
+  })
+
+  it('should add a folder', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder',
+        parentId: 'fake-id',
+      }),
+    )
+
+    expect(result.current.tmpFolders).toEqual({
+      'some-folder': [
+        new Node({
+          id: expect.any(String),
+          path: 'some-folder/ ',
+          name: ' ',
+          isPersisted: false,
+        }),
+      ],
+    })
+  })
+
+  it('should update a folder', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder',
+        parentId: 'fake-id',
+      }),
+    )
+    const id = result?.current?.tmpFolders?.['some-folder']?.[0]?.id
+    act(() => result.current.updateFolder({ id: id!, path: 'new-name' }))
+
+    expect(result.current.tmpFolders).toEqual({
+      'some-folder': [
+        new Node({
+          id: expect.any(String),
+          path: 'some-folder/new-name',
+          name: 'new-name',
+          isPersisted: false,
+        }),
+      ],
+    })
+  })
+
+  it('should delete a folder', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder',
+        parentId: 'fake-id',
+      }),
+    )
+    const id = result?.current?.tmpFolders?.['some-folder']?.[0]?.id
+    act(() => result.current.deleteTmpFolder({ id: id! }))
+
+    expect(result.current.tmpFolders).toEqual({ 'some-folder': [] })
+  })
+
+  it('should delete a folder children of another tmp folder', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder',
+        parentId: 'fake-id',
+      }),
+    )
+    const id = result?.current?.tmpFolders?.['some-folder']?.[0]?.id
+    act(() =>
+      result.current.updateFolder({ id: id!, path: 'parent-tmp-folder' }),
+    )
+
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder/parent-tmp-folder',
+        parentId: id!,
+      }),
+    )
+
+    const childId =
+      result?.current?.tmpFolders?.['some-folder']?.[0]?.children?.[0]?.id
+    act(() =>
+      result.current.updateFolder({ id: childId!, path: 'child-tmp-folder' }),
+    )
+    act(() => result.current.deleteTmpFolder({ id: childId! }))
+
+    expect(result.current.tmpFolders).toEqual({
+      'some-folder': [
+        new Node({
+          id: expect.any(String),
+          path: 'some-folder/parent-tmp-folder',
+          name: 'parent-tmp-folder',
+          isPersisted: false,
+          children: [],
+        }),
+      ],
+    })
+  })
+
+  it('should update the parent folder children', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder',
+        parentId: 'fake-id',
+      }),
+    )
+    const id = result?.current?.tmpFolders?.['some-folder']?.[0]?.id
+    act(() =>
+      result.current.updateFolder({ id: id!, path: 'parent-tmp-folder' }),
+    )
+
+    act(() =>
+      result.current.addFolder({
+        parentPath: 'some-folder/parent-tmp-folder',
+        parentId: id!,
+      }),
+    )
+
+    const childId =
+      result?.current?.tmpFolders?.['some-folder']?.[0]?.children?.[0]?.id
+
+    act(() =>
+      result.current.updateFolder({ id: childId!, path: 'child-tmp-folder' }),
+    )
+
+    const child = new Node({
+      id: expect.any(String),
+      path: 'some-folder/parent-tmp-folder/child-tmp-folder',
+      name: 'child-tmp-folder',
+      isPersisted: false,
+      isRoot: false,
+    })
+    const rootTmpNode = new Node({
+      id: expect.any(String),
+      path: 'some-folder/parent-tmp-folder',
+      name: 'parent-tmp-folder',
+      isPersisted: false,
+      children: [child],
+    })
+    child.parent = rootTmpNode
+    rootTmpNode.children[0]!.parent = rootTmpNode
+    expect(result.current.tmpFolders).toEqual({
+      'some-folder': [rootTmpNode],
+    })
+  })
+})

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.ts
@@ -1,0 +1,202 @@
+import { create } from 'zustand'
+
+import { defaultGenerateNodeUuid, Node } from '../useTree'
+
+type TmpFoldersState = {
+  tmpFolders: Record<string, Node[]>
+  addFolder: (args: { parentPath: string; parentId: string }) => void
+  updateFolder: (args: { id: string; path: string }) => void
+  deleteTmpFolder: (args: { id: string }) => void
+  reset: () => void
+}
+
+function nodeAndChildren(node: Node): Node[] {
+  return [node, ...node.children.flatMap(nodeAndChildren)]
+}
+
+function allTmpNodes(tmpFolders: TmpFoldersState['tmpFolders']) {
+  return Object.values(tmpFolders)
+    .flatMap((nodes) => nodes.map(nodeAndChildren))
+    .flat()
+}
+
+function createEmptyNode({
+  parentPath,
+  parent,
+}: {
+  parentPath: string
+  parent: Node | undefined
+}) {
+  const emptyName = ' '
+  return new Node({
+    id: defaultGenerateNodeUuid(),
+    name: emptyName,
+    path: `${parentPath}/${emptyName}`,
+    isPersisted: false,
+    parent,
+  })
+}
+
+function findRootParent(node: Node) {
+  if (!node.parent) return node
+
+  return findRootParent(node.parent)
+}
+
+function insertItemInTheirPosition(list: Node[], item: Node) {
+  const idx = list.findIndex((n) => n.id === item.id)!
+  const before = list.slice(0, idx)
+  const after = list.slice(idx + 1) ?? []
+
+  return [...before, item, ...after]
+}
+
+function cloneNode(node: Node) {
+  const clonedNode = new Node({
+    id: node.id,
+    name: node.name,
+    path: node.path,
+    parent: node.parent,
+    isPersisted: node.isPersisted,
+  })
+  return clonedNode
+}
+
+function findAndReplaceParentNodeInRootNode(
+  rootNode: Node,
+  node: Node,
+  replaceNode: Node,
+) {
+  if (rootNode.id === node.id) return replaceNode
+
+  const children = rootNode.children.map((child) =>
+    findAndReplaceParentNodeInRootNode(child, node, replaceNode),
+  )
+
+  rootNode.children = children
+  return rootNode
+}
+
+export const useTempNodes = create<TmpFoldersState>((set) => ({
+  tmpFolders: {},
+  reset: () => {
+    set({
+      tmpFolders: {},
+    })
+  },
+  addFolder: ({ parentPath, parentId }) => {
+    set((state) => {
+      const allNodes = allTmpNodes(state.tmpFolders)
+      const parentNode = allNodes.find((node) => node.id === parentId)
+
+      const node = createEmptyNode({
+        parentPath: parentNode ? parentNode.path : parentPath,
+        parent: parentNode,
+      })
+
+      // When adding to an existing tmp node we
+      // clone parent node and replace it in the root node
+      // in their right position in the tree
+      if (parentNode) {
+        const parentClone = cloneNode(parentNode)
+        node.parent = parentClone
+        parentClone.children = [node, ...(parentNode.children || [])]
+        const rootParent = findRootParent(node)
+        const newRootNode = findAndReplaceParentNodeInRootNode(
+          rootParent,
+          parentNode,
+          parentClone,
+        )
+
+        const rootParentPath = newRootNode.path
+          .split('/')
+          .slice(0, -1)
+          .join('/')
+        const rootTmpFolder = state.tmpFolders[rootParentPath]!
+
+        return {
+          tmpFolders: {
+            ...state.tmpFolders,
+            [rootParentPath]: insertItemInTheirPosition(
+              rootTmpFolder,
+              newRootNode,
+            ),
+          },
+        }
+      }
+
+      const prevNodes = state.tmpFolders[parentPath]
+      const newState = {
+        tmpFolders: {
+          ...state.tmpFolders,
+          [parentPath]: prevNodes ? [node, ...prevNodes] : [node],
+        },
+      }
+      return newState
+    })
+  },
+  updateFolder: ({ id, path }) => {
+    set((state) => {
+      const allNodes = allTmpNodes(state.tmpFolders)
+      const node = allNodes.find((node) => node.id === id)
+      if (!node) return state
+
+      const parentPath = node.path.split('/').slice(0, -1).join('/')
+      node.name = path
+      node.path = `${parentPath}/${path}`
+
+      return state
+    })
+  },
+  deleteTmpFolder: ({ id }) => {
+    set((state) => {
+      const allNodes = allTmpNodes(state.tmpFolders)
+      const node = allNodes.find((node) => node.id === id)
+      if (!node) return state
+
+      // When no parent it means is a root tmp node
+      if (!node.parent) {
+        const parentPath = node.path.split('/').slice(0, -1).join('/')
+        const parent = state.tmpFolders[parentPath]
+        if (!parent) return state
+
+        const idx = parent.findIndex((n) => n.id === id)
+        return {
+          tmpFolders: {
+            ...state.tmpFolders,
+            [parentPath]: [...parent.slice(0, idx), ...parent.slice(idx + 1)],
+          },
+        }
+      }
+
+      const parentNode = node.parent
+      const parentClone = cloneNode(parentNode)
+      const idx = parentClone.children.findIndex((n) => n.id === node.id)
+
+      // Remove node from children
+      parentClone.children = [
+        ...parentClone.children.slice(0, idx),
+        ...(parentClone.children.slice(idx + 1) ?? []),
+      ]
+      const rootParent = findRootParent(node)
+      const newRootNode = findAndReplaceParentNodeInRootNode(
+        rootParent,
+        parentNode,
+        parentClone,
+      )
+
+      const rootParentPath = newRootNode.path.split('/').slice(0, -1).join('/')
+      const rootTmpFolder = state.tmpFolders[rootParentPath]!
+
+      return {
+        tmpFolders: {
+          ...state.tmpFolders,
+          [rootParentPath]: insertItemInTheirPosition(
+            rootTmpFolder,
+            newRootNode,
+          ),
+        },
+      }
+    })
+  },
+}))

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useTree/index.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useTree/index.ts
@@ -9,15 +9,19 @@ export class Node {
   public id: string
   public name: string
   public path: string
+  public isPersisted: boolean
   public isRoot: boolean = false
   public isFile: boolean = false
   public depth: number = 0
   public children: Node[] = []
+  public parent?: Node
   public doc?: SidebarDocument
 
   constructor({
     id,
     doc,
+    parent,
+    isPersisted,
     children = [],
     isRoot = false,
     path,
@@ -25,6 +29,8 @@ export class Node {
   }: {
     id: string
     path: string
+    parent?: Node
+    isPersisted: boolean
     doc?: SidebarDocument
     children?: Node[]
     isRoot?: boolean
@@ -32,6 +38,8 @@ export class Node {
   }) {
     this.id = id
     this.path = path
+    this.parent = parent
+    this.isPersisted = isPersisted
     this.name = isRoot ? 'root' : name
     this.isRoot = isRoot
     this.isFile = !!doc
@@ -93,6 +101,7 @@ function buildTree({
         const uuid = isFile ? doc.documentUuid : undefined
         const node = new Node({
           id: generateNodeId({ uuid }),
+          isPersisted: true,
           name: segment,
           path,
           doc: file,
@@ -114,6 +123,8 @@ function buildTree({
         } else {
           parent.children.splice(index, 0, node)
         }
+
+        node.parent = parent
       }
     })
   })
@@ -131,12 +142,14 @@ export function useTree({
   return useMemo(() => {
     const root = new Node({
       id: generateNodeId(),
+      isPersisted: true,
       path: '',
       children: [],
       isRoot: true,
     })
     const nodeMap = new Map<string, Node>()
     nodeMap.set('', root)
+
     const sorted = documents.slice().sort(sortByPathDepth)
 
     const tree = buildTree({

--- a/packages/web-ui/src/sections/Document/Sidebar/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/index.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react'
 
 export default function DocumentSidebar({ children }: { children: ReactNode }) {
   return (
-    <aside className='flex flex-col gap-y-2 w-72 border-r border-b-border'>
+    <aside className='flex flex-col gap-y-2 max-w-72 min-w-72 border-r border-b-border'>
       <div className='p-4 h-6'>HERE GOES FILE_TOOLBAR</div>
       {children}
     </aside>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.1
+        version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.0)
@@ -2524,6 +2527,32 @@ packages:
       react-dom: 18.3.0(react@18.3.0)
     dev: false
 
+  /@radix-ui/react-dropdown-menu@2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0):
+    resolution: {integrity: sha512-y8E+x9fBq9qvteD2Zwa4397pUVhYsh9iq44b5RD5qu1GMJWBCBuVg1hMyItbc6+zH00TxGRqd9Iot4wzf3OoBQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-menu': 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@types/react': 18.3.0
+      '@types/react-dom': 18.3.0
+      react: 18.3.0
+      react-dom: 18.3.0(react@18.3.0)
+    dev: false
+
   /@radix-ui/react-focus-guards@1.1.0(@types/react@18.3.0)(react@18.3.0):
     resolution: {integrity: sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==}
     peerDependencies:
@@ -2599,6 +2628,43 @@ packages:
       '@types/react-dom': 18.3.0
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
+    dev: false
+
+  /@radix-ui/react-menu@2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0):
+    resolution: {integrity: sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@types/react': 18.3.0
+      '@types/react-dom': 18.3.0
+      aria-hidden: 1.2.4
+      react: 18.3.0
+      react-dom: 18.3.0(react@18.3.0)
+      react-remove-scroll: 2.5.7(@types/react@18.3.0)(react@18.3.0)
     dev: false
 
   /@radix-ui/react-popover@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0):
@@ -2720,6 +2786,34 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-slot': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@types/react': 18.3.0
+      '@types/react-dom': 18.3.0
+      react: 18.3.0
+      react-dom: 18.3.0(react@18.3.0)
+    dev: false
+
+  /@radix-ui/react-roving-focus@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0):
+    resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || 19.x
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.0)(react@18.3.0)
       '@types/react': 18.3.0
       '@types/react-dom': 18.3.0
       react: 18.3.0


### PR DESCRIPTION
# What?
This iteration add the functionality for adding and removing tmp folders in the sidebar. Also
handle click outside and `ESC`

## TODO
- [x] Add tmp folder 
- [x] Destroy tmp folder
- [x] Ellipsis folders and files
- [x] Fix creating a tmp folder with the parent folder open. For some reason it does not work
- [x] Deleting temp sub-folders does not work
- [x] Click outside or ESC does not work on temp sub-folders

![image](https://github.com/user-attachments/assets/bf1be22e-83bb-4b05-8485-7dbc8359f494)


### Next PR
- [ ] Resizable sidebar 
- [ ] Add file IMPLEMENT server action
- [ ] When creating a file reseting tmpFolders zustand store
- [ ] Destroy file Implement server action + refresh tree
- [ ] Make sidebar files tree vertical scrollable. Custom scrollbar styles
- [ ] Sidebar header with File + | Folder +
