### PR TITLE
Resolve prompt references

### DIFF
--- a/packages/compiler/src/compiler/base/nodes/comment.ts
+++ b/packages/compiler/src/compiler/base/nodes/comment.ts
@@ -1,0 +1,7 @@
+import { Comment } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile(_: CompileNodeContext<Comment>) {
+  /* do nothing */
+}

--- a/packages/compiler/src/compiler/base/nodes/config.ts
+++ b/packages/compiler/src/compiler/base/nodes/config.ts
@@ -1,0 +1,7 @@
+import { Config } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile(_: CompileNodeContext<Config>) {
+  /* do nothing */
+}

--- a/packages/compiler/src/compiler/base/nodes/each.ts
+++ b/packages/compiler/src/compiler/base/nodes/each.ts
@@ -1,0 +1,67 @@
+import { hasContent, isIterable } from '$compiler/compiler/utils'
+import errors from '$compiler/error/errors'
+import { EachBlock } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile({
+  node,
+  scope,
+  isInsideContentTag,
+  isInsideMessageTag,
+  resolveBaseNode,
+  resolveExpression,
+  expressionError,
+}: CompileNodeContext<EachBlock>) {
+  const iterableElement = await resolveExpression(node.expression, scope)
+  if (!isIterable(iterableElement) || !(await hasContent(iterableElement))) {
+    const childScope = scope.copy()
+    for await (const childNode of node.else?.children ?? []) {
+      await resolveBaseNode({
+        node: childNode,
+        scope: childScope,
+        isInsideMessageTag,
+        isInsideContentTag,
+      })
+    }
+    return
+  }
+
+  const contextVarName = node.context.name
+  const indexVarName = node.index?.name
+  if (scope.exists(contextVarName)) {
+    throw expressionError(
+      errors.variableAlreadyDeclared(contextVarName),
+      node.context,
+    )
+  }
+
+  if (indexVarName && scope.exists(indexVarName)) {
+    throw expressionError(
+      errors.variableAlreadyDeclared(indexVarName),
+      node.index!,
+    )
+  }
+
+  let i = 0
+  for await (const element of iterableElement) {
+    const localScope = scope.copy()
+    localScope.set(contextVarName, element)
+    if (indexVarName) {
+      let indexValue: unknown = i
+      if (node.key) {
+        indexValue = await resolveExpression(node.key, localScope)
+      }
+      localScope.set(indexVarName, indexValue)
+    }
+    for await (const childNode of node.children ?? []) {
+      await resolveBaseNode({
+        node: childNode,
+        scope: localScope,
+        isInsideMessageTag,
+        isInsideContentTag,
+      })
+    }
+    i++
+  }
+}

--- a/packages/compiler/src/compiler/base/nodes/fragment.ts
+++ b/packages/compiler/src/compiler/base/nodes/fragment.ts
@@ -1,0 +1,20 @@
+import { Fragment } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile({
+  node,
+  scope,
+  isInsideContentTag,
+  isInsideMessageTag,
+  resolveBaseNode,
+}: CompileNodeContext<Fragment>) {
+  for await (const childNode of node.children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope,
+      isInsideMessageTag,
+      isInsideContentTag,
+    })
+  }
+}

--- a/packages/compiler/src/compiler/base/nodes/if.ts
+++ b/packages/compiler/src/compiler/base/nodes/if.ts
@@ -1,0 +1,24 @@
+import { IfBlock } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile({
+  node,
+  scope,
+  isInsideContentTag,
+  isInsideMessageTag,
+  resolveBaseNode,
+  resolveExpression,
+}: CompileNodeContext<IfBlock>) {
+  const condition = await resolveExpression(node.expression, scope)
+  const children = (condition ? node.children : node.else?.children) ?? []
+  const childScope = scope.copy()
+  for await (const childNode of children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope: childScope,
+      isInsideMessageTag,
+      isInsideContentTag,
+    })
+  }
+}

--- a/packages/compiler/src/compiler/base/nodes/mustache.ts
+++ b/packages/compiler/src/compiler/base/nodes/mustache.ts
@@ -1,0 +1,15 @@
+import { MustacheTag } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile({
+  node,
+  scope,
+  addStrayText,
+  resolveExpression,
+}: CompileNodeContext<MustacheTag>) {
+  const expression = node.expression
+  const value = await resolveExpression(expression, scope)
+  if (value === undefined) return
+  addStrayText(String(value))
+}

--- a/packages/compiler/src/compiler/base/nodes/tag.ts
+++ b/packages/compiler/src/compiler/base/nodes/tag.ts
@@ -1,0 +1,104 @@
+import {
+  isContentTag,
+  isMessageTag,
+  isRefTag,
+  isToolCallTag,
+} from '$compiler/compiler/utils'
+import errors from '$compiler/error/errors'
+import {
+  ContentTag,
+  ElementTag,
+  MessageTag,
+  ReferenceTag,
+  ToolCallTag,
+} from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+import { compile as resolveContent } from './tags/content'
+import { compile as resolveMessage } from './tags/message'
+import { compile as resolveRef } from './tags/ref'
+import { compile as resolveToolCall } from './tags/toolCall'
+
+async function resolveTagAttributes({
+  node: tagNode,
+  scope,
+  resolveExpression,
+}: CompileNodeContext<ElementTag>): Promise<Record<string, unknown>> {
+  const attributeNodes = tagNode.attributes
+  if (attributeNodes.length === 0) return {}
+
+  const attributes: Record<string, unknown> = {}
+  for (const attributeNode of attributeNodes) {
+    const { name, value } = attributeNode
+    if (value === true) {
+      attributes[name] = true
+      continue
+    }
+
+    let totalValue: string = ''
+    for await (const node of value) {
+      if (node.type === 'Text') {
+        totalValue += node.data
+        continue
+      }
+
+      if (node.type === 'MustacheTag') {
+        const expression = node.expression
+        const resolvedValue = await resolveExpression(expression, scope)
+        if (resolvedValue === undefined) continue
+        totalValue += String(resolvedValue)
+        continue
+      }
+    }
+
+    attributes[name] = totalValue
+  }
+
+  return attributes
+}
+
+export async function compile(props: CompileNodeContext<ElementTag>) {
+  const {
+    node,
+    scope,
+    isInsideContentTag,
+    isInsideMessageTag,
+    resolveBaseNode,
+    baseNodeError,
+    groupStrayText,
+  } = props
+  groupStrayText()
+
+  const attributes = await resolveTagAttributes(props)
+
+  if (isToolCallTag(node)) {
+    await resolveToolCall(props as CompileNodeContext<ToolCallTag>, attributes)
+    return
+  }
+
+  if (isContentTag(node)) {
+    await resolveContent(props as CompileNodeContext<ContentTag>, attributes)
+    return
+  }
+
+  if (isMessageTag(node)) {
+    await resolveMessage(props as CompileNodeContext<MessageTag>, attributes)
+    return
+  }
+
+  if (isRefTag(node)) {
+    await resolveRef(props as CompileNodeContext<ReferenceTag>, attributes)
+    return
+  }
+
+  baseNodeError(errors.unknownTag(node.name), node)
+
+  for await (const childNode of node.children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope,
+      isInsideMessageTag,
+      isInsideContentTag,
+    })
+  }
+}

--- a/packages/compiler/src/compiler/base/nodes/tags/content.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/content.ts
@@ -1,0 +1,38 @@
+import errors from '$compiler/error/errors'
+import { ContentTag } from '$compiler/parser/interfaces'
+import { ContentType } from '$compiler/types'
+
+import { CompileNodeContext } from '../../types'
+
+export async function compile(
+  {
+    node,
+    scope,
+    isInsideMessageTag,
+    isInsideContentTag,
+    resolveBaseNode,
+    baseNodeError,
+    popStrayText,
+    addContent,
+  }: CompileNodeContext<ContentTag>,
+  _: Record<string, unknown>,
+) {
+  if (isInsideContentTag) {
+    baseNodeError(errors.contentTagInsideContent, node)
+  }
+
+  for await (const childNode of node.children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope,
+      isInsideMessageTag,
+      isInsideContentTag: true,
+    })
+  }
+  const textContent = popStrayText()
+
+  addContent({
+    type: node.name as ContentType,
+    value: textContent,
+  })
+}

--- a/packages/compiler/src/compiler/base/nodes/tags/message.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/message.ts
@@ -1,0 +1,131 @@
+import { ToolCallReference } from '$compiler/compiler/types'
+import {
+  CUSTOM_MESSAGE_ROLE_ATTR,
+  CUSTOM_MESSAGE_TAG,
+} from '$compiler/constants'
+import errors from '$compiler/error/errors'
+import { MessageTag } from '$compiler/parser/interfaces'
+import {
+  AssistantMessage,
+  Message,
+  MessageContent,
+  MessageRole,
+  SystemMessage,
+  ToolMessage,
+  UserMessage,
+} from '$compiler/types'
+
+import { CompileNodeContext } from '../../types'
+
+export async function compile(
+  props: CompileNodeContext<MessageTag>,
+  attributes: Record<string, unknown>,
+) {
+  const {
+    node,
+    scope,
+    isInsideMessageTag,
+    isInsideContentTag,
+    resolveBaseNode,
+    baseNodeError,
+    groupContent,
+    groupStrayText,
+    popContent,
+    popToolCalls,
+    addMessage,
+  } = props
+
+  if (isInsideContentTag || isInsideMessageTag) {
+    baseNodeError(errors.messageTagInsideMessage, node)
+  }
+
+  groupContent()
+
+  let role = node.name as MessageRole
+  if (node.name === CUSTOM_MESSAGE_TAG) {
+    if (attributes[CUSTOM_MESSAGE_ROLE_ATTR] === undefined) {
+      baseNodeError(errors.messageTagWithoutRole, node)
+    }
+    role = attributes[CUSTOM_MESSAGE_ROLE_ATTR] as MessageRole
+    delete attributes[CUSTOM_MESSAGE_ROLE_ATTR]
+  }
+
+  for await (const childNode of node.children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope,
+      isInsideMessageTag: true,
+      isInsideContentTag,
+    })
+  }
+
+  groupStrayText()
+  const messageContent = popContent()
+  const toolCalls = popToolCalls()
+
+  const message = buildMessage(props as CompileNodeContext<MessageTag>, {
+    role,
+    attributes,
+    content: messageContent,
+    toolCalls,
+  })!
+  addMessage(message)
+}
+
+function buildMessage(
+  { node, baseNodeError }: CompileNodeContext<MessageTag>,
+  {
+    role,
+    attributes,
+    content,
+    toolCalls,
+  }: {
+    role: MessageRole
+    attributes: Record<string, unknown>
+    content: MessageContent[]
+    toolCalls: ToolCallReference[]
+  },
+): Message | undefined {
+  if (role !== MessageRole.assistant) {
+    toolCalls.forEach(({ node: toolNode }) => {
+      baseNodeError(errors.invalidToolCallPlacement, toolNode)
+    })
+  }
+
+  if (role === MessageRole.system) {
+    return {
+      role,
+      content,
+    } as SystemMessage
+  }
+
+  if (role === MessageRole.user) {
+    return {
+      role,
+      name: attributes.name ? String(attributes.name) : undefined,
+      content,
+    } as UserMessage
+  }
+
+  if (role === MessageRole.assistant) {
+    return {
+      role,
+      toolCalls: toolCalls.map(({ value }) => value),
+      content,
+    } as AssistantMessage
+  }
+
+  if (role === MessageRole.tool) {
+    if (attributes.id === undefined) {
+      baseNodeError(errors.toolMessageWithoutId, node)
+    }
+
+    return {
+      role,
+      id: String(attributes.id),
+      content,
+    } as ToolMessage
+  }
+
+  baseNodeError(errors.invalidMessageRole(role), node)
+}

--- a/packages/compiler/src/compiler/base/nodes/tags/ref.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/ref.ts
@@ -1,0 +1,11 @@
+import errors from '$compiler/error/errors'
+import { ReferenceTag } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../../types'
+
+export async function compile(
+  { node, baseNodeError }: CompileNodeContext<ReferenceTag>,
+  _: Record<string, unknown>,
+) {
+  baseNodeError(errors.didNotResolveReferences, node)
+}

--- a/packages/compiler/src/compiler/base/nodes/tags/toolCall.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/toolCall.ts
@@ -1,0 +1,61 @@
+import errors from '$compiler/error/errors'
+import { ToolCallTag } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../../types'
+
+export async function compile(
+  {
+    node,
+    scope,
+    isInsideMessageTag,
+    isInsideContentTag,
+    resolveBaseNode,
+    baseNodeError,
+    popStrayText,
+    addToolCall,
+  }: CompileNodeContext<ToolCallTag>,
+  attributes: Record<string, unknown>,
+) {
+  if (isInsideContentTag) {
+    baseNodeError(errors.toolCallTagInsideContent, node)
+  }
+
+  if (attributes['id'] === undefined) {
+    baseNodeError(errors.toolCallTagWithoutId, node)
+  }
+
+  if (attributes['name'] === undefined) {
+    baseNodeError(errors.toolCallWithoutName, node)
+  }
+
+  for await (const childNode of node.children ?? []) {
+    await resolveBaseNode({
+      node: childNode,
+      scope,
+      isInsideMessageTag,
+      isInsideContentTag: true,
+    })
+  }
+
+  const textContent = popStrayText()
+
+  let jsonContent: Record<string, unknown> = {}
+  if (textContent) {
+    try {
+      jsonContent = JSON.parse(textContent)
+    } catch (error: unknown) {
+      if (error instanceof SyntaxError) {
+        baseNodeError(errors.invalidToolCallArguments, node)
+      }
+    }
+  }
+
+  addToolCall({
+    node: node as ToolCallTag,
+    value: {
+      id: String(attributes['id']),
+      name: String(attributes['name']),
+      arguments: jsonContent,
+    },
+  })
+}

--- a/packages/compiler/src/compiler/base/nodes/text.ts
+++ b/packages/compiler/src/compiler/base/nodes/text.ts
@@ -1,0 +1,10 @@
+import { Text } from '$compiler/parser/interfaces'
+
+import { CompileNodeContext } from '../types'
+
+export async function compile({
+  node,
+  addStrayText,
+}: CompileNodeContext<Text>) {
+  addStrayText(node.data)
+}

--- a/packages/compiler/src/compiler/base/types.ts
+++ b/packages/compiler/src/compiler/base/types.ts
@@ -1,0 +1,53 @@
+import Scope from '$compiler/compiler/scope'
+import { TemplateNode } from '$compiler/parser/interfaces'
+import { Message, MessageContent } from '$compiler/types'
+import type { Node as LogicalExpression } from 'estree'
+
+import { ResolveBaseNodeProps, ToolCallReference } from '../types'
+
+export enum NodeType {
+  Literal = 'Literal',
+  Identifier = 'Identifier',
+  ObjectExpression = 'ObjectExpression',
+  ArrayExpression = 'ArrayExpression',
+  SequenceExpression = 'SequenceExpression',
+  LogicalExpression = 'LogicalExpression',
+  BinaryExpression = 'BinaryExpression',
+  UnaryExpression = 'UnaryExpression',
+  AssignmentExpression = 'AssignmentExpression',
+  UpdateExpression = 'UpdateExpression',
+  MemberExpression = 'MemberExpression',
+  ConditionalExpression = 'ConditionalExpression',
+  CallExpression = 'CallExpression',
+  ChainExpression = 'ChainExpression',
+}
+
+type RaiseErrorFn<T = void | never, N = TemplateNode | LogicalExpression> = (
+  { code, message }: { code: string; message: string },
+  node: N,
+) => T
+
+export type CompileNodeContext<N extends TemplateNode> = {
+  node: N
+  scope: Scope
+  resolveExpression: (
+    expression: LogicalExpression,
+    scope: Scope,
+  ) => Promise<unknown>
+  resolveBaseNode: (props: ResolveBaseNodeProps<TemplateNode>) => Promise<void>
+  baseNodeError: RaiseErrorFn<never, TemplateNode>
+  expressionError: RaiseErrorFn<never, LogicalExpression>
+
+  isInsideMessageTag: boolean
+  isInsideContentTag: boolean
+
+  addMessage: (message: Message) => void
+  addStrayText: (text: string) => void
+  popStrayText: () => string
+  groupStrayText: () => void
+  addContent: (content: MessageContent) => void
+  popContent: () => MessageContent[]
+  groupContent: () => void
+  addToolCall: (toolCallRef: ToolCallReference) => void
+  popToolCalls: () => ToolCallReference[]
+}

--- a/packages/compiler/src/compiler/compile.ts
+++ b/packages/compiler/src/compiler/compile.ts
@@ -1,51 +1,36 @@
-import {
-  CUSTOM_MESSAGE_ROLE_ATTR,
-  CUSTOM_MESSAGE_TAG,
-  REFERENCE_PROMPT_ATTR,
-} from '$compiler/constants'
-import CompileError, { error } from '$compiler/error/error'
+import { error } from '$compiler/error/error'
 import errors from '$compiler/error/errors'
 import parse from '$compiler/parser/index'
-import type {
-  BaseNode,
-  ElementTag,
-  MessageTag,
-  TemplateNode,
-  ToolCallTag,
-} from '$compiler/parser/interfaces'
+import type { BaseNode, TemplateNode } from '$compiler/parser/interfaces'
 import {
-  AssistantMessage,
   ContentType,
   Conversation,
   Message,
   MessageContent,
   MessageRole,
   SystemMessage,
-  ToolCall,
-  ToolMessage,
-  UserMessage,
 } from '$compiler/types'
 import type { Node as LogicalExpression } from 'estree'
 
+import { compile as resolveComment } from './base/nodes/comment'
+import { compile as resolveConfig } from './base/nodes/config'
+import { compile as resolveEachBlock } from './base/nodes/each'
+import { compile as resolveFragment } from './base/nodes/fragment'
+import { compile as resolveIfBlock } from './base/nodes/if'
+import { compile as resolveMustache } from './base/nodes/mustache'
+import { compile as resolveElementTag } from './base/nodes/tag'
+import { compile as resolveText } from './base/nodes/text'
+import { CompileNodeContext } from './base/types'
 import { readConfig } from './config'
 import { resolveLogicNode } from './logic'
 import Scope from './scope'
-import {
-  hasContent,
-  isContentTag,
-  isIterable,
-  isMessageTag,
-  isRefTag,
-  isToolCallTag,
-  removeCommonIndent,
-} from './utils'
+import type { ResolveBaseNodeProps, ToolCallReference } from './types'
+import { removeCommonIndent } from './utils'
 
 export type ReferencePromptFn = (prompt: string) => Promise<string>
-type ToolCallReference = { node: ToolCallTag; value: ToolCall }
 
 export class Compile {
   private rawText: string
-  private referenceFn?: ReferencePromptFn
 
   private initialScope: Scope
 
@@ -57,28 +42,15 @@ export class Compile {
   constructor({
     prompt,
     parameters,
-    referenceFn,
   }: {
     prompt: string
     parameters: Record<string, unknown>
-    referenceFn?: ReferencePromptFn
   }) {
     this.rawText = prompt
-    this.referenceFn = referenceFn
     this.initialScope = new Scope(parameters)
   }
 
   async run(): Promise<Conversation> {
-    const conversation = await this.runWithoutGrouping()
-    this.groupAccumulatedContentAsMessage()
-
-    return {
-      config: conversation.config,
-      messages: this.messages,
-    }
-  }
-
-  private async runWithoutGrouping(): Promise<Conversation> {
     const fragment = parse(this.rawText)
     const config = readConfig(fragment) as Record<string, unknown>
     await this.resolveBaseNode({
@@ -87,6 +59,7 @@ export class Compile {
       isInsideMessageTag: false,
       isInsideContentTag: false,
     })
+    this.groupContent()
 
     return {
       config,
@@ -105,62 +78,15 @@ export class Compile {
     })
   }
 
-  private async resolveTagAttributes({
-    tagNode,
-    scope,
-    literalAttributes = [], // Tags that don't allow Mustache expressions
-  }: {
-    tagNode: ElementTag
-    scope: Scope
-    literalAttributes?: string[]
-  }): Promise<Record<string, unknown>> {
-    const attributeNodes = tagNode.attributes
-    if (attributeNodes.length === 0) return {}
-
-    const attributes: Record<string, unknown> = {}
-    for (const attributeNode of attributeNodes) {
-      const { name, value } = attributeNode
-      if (value === true) {
-        attributes[name] = true
-        continue
-      }
-
-      if (literalAttributes.includes(name)) {
-        if (value.some((node) => node.type === 'MustacheTag')) {
-          this.baseNodeError(
-            errors.invalidStaticAttribute(name),
-            value.find((node) => node.type === 'MustacheTag')!,
-          )
-        }
-      }
-
-      let totalValue: string = ''
-      for await (const node of value) {
-        if (node.type === 'Text') {
-          totalValue += node.data
-          continue
-        }
-
-        if (node.type === 'MustacheTag') {
-          const expression = node.expression
-          const resolvedValue = await this.resolveExpression(expression, scope)
-          if (resolvedValue === undefined) continue
-          totalValue += String(resolvedValue)
-          continue
-        }
-      }
-
-      attributes[name] = totalValue
-    }
-
-    return attributes
+  private addMessage(message: Message): void {
+    this.messages.push(message)
   }
 
-  private addText(text: string) {
+  private addStrayText(text: string) {
     this.accumulatedText += text
   }
 
-  private groupAccumulatedTextAsContent(): void {
+  private groupStrayText(): void {
     if (this.accumulatedText.trim() !== '') {
       this.accumulatedContent.push({
         type: ContentType.text,
@@ -170,31 +96,51 @@ export class Compile {
     this.accumulatedText = ''
   }
 
-  private addToolCall(toolCallTag: ToolCallTag, toolCall: ToolCall): void {
-    this.groupAccumulatedTextAsContent()
-    this.accumulatedToolCalls.push({ node: toolCallTag, value: toolCall })
+  private popStrayText(): string {
+    const text = this.accumulatedText
+    this.accumulatedText = ''
+    return text
   }
 
   private addContent(content: MessageContent): void {
-    this.groupAccumulatedTextAsContent()
+    this.groupStrayText()
     this.accumulatedContent.push(content)
   }
 
-  private groupAccumulatedContentAsMessage(): void {
-    this.groupAccumulatedTextAsContent()
+  private groupContent(): void {
+    this.groupStrayText()
+    const toolCalls = this.popToolCalls()
+    const content = this.popContent()
 
-    if (this.accumulatedContent.length > 0) {
-      const message = this.buildMessage({
+    toolCalls.forEach(({ node: toolNode }) => {
+      this.baseNodeError(errors.invalidToolCallPlacement, toolNode)
+    })
+
+    if (content.length > 0) {
+      const message = {
         role: MessageRole.system,
-        attributes: {},
-        content: this.accumulatedContent,
-        toolCalls: this.accumulatedToolCalls,
-      })
-      this.messages.push(message)
-    }
+        content,
+      } as SystemMessage
 
+      this.addMessage(message)
+    }
+  }
+
+  private popContent(): MessageContent[] {
+    const content = this.accumulatedContent
     this.accumulatedContent = []
+    return content
+  }
+
+  private addToolCall(toolCallRef: ToolCallReference): void {
+    this.groupStrayText()
+    this.accumulatedToolCalls.push(toolCallRef)
+  }
+
+  private popToolCalls(): ToolCallReference[] {
+    const toolCalls = this.accumulatedToolCalls
     this.accumulatedToolCalls = []
+    return toolCalls
   }
 
   private async resolveBaseNode({
@@ -202,351 +148,46 @@ export class Compile {
     scope,
     isInsideMessageTag,
     isInsideContentTag,
-  }: {
-    node: TemplateNode
-    scope: Scope
-    isInsideMessageTag: boolean
-    isInsideContentTag: boolean
-  }): Promise<void> {
-    if (node.type === 'Fragment') {
-      for await (const childNode of node.children ?? []) {
-        await this.resolveBaseNode({
-          node: childNode,
-          scope,
-          isInsideMessageTag,
-          isInsideContentTag,
-        })
-      }
-      return
+  }: ResolveBaseNodeProps<TemplateNode>): Promise<void> {
+    const context: CompileNodeContext<TemplateNode> = {
+      node,
+      scope,
+      isInsideMessageTag,
+      isInsideContentTag,
+      resolveBaseNode: this.resolveBaseNode.bind(this),
+      resolveExpression: this.resolveExpression.bind(this),
+      baseNodeError: this.baseNodeError.bind(this),
+      expressionError: this.expressionError.bind(this),
+      addMessage: this.addMessage.bind(this),
+      addStrayText: this.addStrayText.bind(this),
+      popStrayText: this.popStrayText.bind(this),
+      groupStrayText: this.groupStrayText.bind(this),
+      addContent: this.addContent.bind(this),
+      popContent: this.popContent.bind(this),
+      groupContent: this.groupContent.bind(this),
+      addToolCall: this.addToolCall.bind(this),
+      popToolCalls: this.popToolCalls.bind(this),
     }
 
-    if (node.type === 'Config' || node.type === 'Comment') {
-      /* do nothing */
-      return
+    const nodeResolver = {
+      Fragment: resolveFragment,
+      Config: resolveConfig,
+      Comment: resolveComment,
+      Text: resolveText,
+      MustacheTag: resolveMustache,
+      IfBlock: resolveIfBlock,
+      EachBlock: resolveEachBlock,
+      ElementTag: resolveElementTag,
     }
 
-    if (node.type === 'Text') {
-      this.addText(node.data)
-      return
+    if (!(node.type in nodeResolver)) {
+      this.baseNodeError(errors.unsupportedBaseNodeType(node.type), node)
     }
 
-    if (node.type === 'MustacheTag') {
-      const expression = node.expression
-      const value = await this.resolveExpression(expression, scope)
-      if (value === undefined) return
-      this.addText(String(value))
-      return
-    }
-
-    if (node.type === 'IfBlock') {
-      const condition = await this.resolveExpression(node.expression, scope)
-      const children = (condition ? node.children : node.else?.children) ?? []
-      const childScope = scope.copy()
-      for await (const childNode of children ?? []) {
-        await this.resolveBaseNode({
-          node: childNode,
-          scope: childScope,
-          isInsideMessageTag,
-          isInsideContentTag,
-        })
-      }
-      return
-    }
-
-    if (node.type === 'EachBlock') {
-      const iterableElement = await this.resolveExpression(
-        node.expression,
-        scope,
-      )
-      if (
-        !isIterable(iterableElement) ||
-        !(await hasContent(iterableElement))
-      ) {
-        const childScope = scope.copy()
-        for await (const childNode of node.else?.children ?? []) {
-          await this.resolveBaseNode({
-            node: childNode,
-            scope: childScope,
-            isInsideMessageTag,
-            isInsideContentTag,
-          })
-        }
-        return
-      }
-
-      const contextVarName = node.context.name
-      const indexVarName = node.index?.name
-      if (scope.exists(contextVarName)) {
-        throw this.expressionError(
-          errors.variableAlreadyDeclared(contextVarName),
-          node.context,
-        )
-      }
-      if (indexVarName && scope.exists(indexVarName)) {
-        throw this.expressionError(
-          errors.variableAlreadyDeclared(indexVarName),
-          node.index!,
-        )
-      }
-
-      let i = 0
-      for await (const element of iterableElement) {
-        const localScope = scope.copy()
-        localScope.set(contextVarName, element)
-        if (indexVarName) {
-          let indexValue: unknown = i
-          if (node.key) {
-            indexValue = await this.resolveExpression(node.key, localScope)
-          }
-          localScope.set(indexVarName, indexValue)
-        }
-        for await (const childNode of node.children ?? []) {
-          await this.resolveBaseNode({
-            node: childNode,
-            scope: localScope,
-            isInsideMessageTag,
-            isInsideContentTag,
-          })
-        }
-        i++
-      }
-      return
-    }
-
-    if (node.type === 'ElementTag') {
-      this.groupAccumulatedTextAsContent()
-
-      if (isToolCallTag(node)) {
-        if (isInsideContentTag) {
-          this.baseNodeError(errors.toolCallTagInsideContent, node)
-        }
-
-        const attributes = await this.resolveTagAttributes({
-          tagNode: node,
-          scope,
-        })
-
-        if (attributes['id'] === undefined) {
-          this.baseNodeError(errors.toolCallTagWithoutId, node)
-        }
-
-        if (attributes['name'] === undefined) {
-          this.baseNodeError(errors.toolCallWithoutName, node)
-        }
-
-        for await (const childNode of node.children ?? []) {
-          await this.resolveBaseNode({
-            node: childNode,
-            scope,
-            isInsideMessageTag,
-            isInsideContentTag: true,
-          })
-        }
-
-        const textContent = this.accumulatedText
-        this.accumulatedText = ''
-
-        let jsonContent: Record<string, unknown> = {}
-        if (textContent) {
-          try {
-            jsonContent = JSON.parse(textContent)
-          } catch (error: unknown) {
-            if (error instanceof SyntaxError) {
-              this.baseNodeError(errors.invalidToolCallArguments, node)
-            }
-          }
-        }
-
-        this.addToolCall(node as ToolCallTag, {
-          id: String(attributes['id']),
-          name: String(attributes['name']),
-          arguments: jsonContent,
-        })
-        return
-      }
-
-      if (isContentTag(node)) {
-        if (isInsideContentTag) {
-          this.baseNodeError(errors.contentTagInsideContent, node)
-        }
-
-        this.groupAccumulatedTextAsContent()
-        for await (const childNode of node.children ?? []) {
-          await this.resolveBaseNode({
-            node: childNode,
-            scope,
-            isInsideMessageTag,
-            isInsideContentTag: true,
-          })
-        }
-        const textContent = this.accumulatedText
-        this.accumulatedText = ''
-
-        this.addContent({
-          type: node.name as ContentType,
-          value: textContent,
-        })
-        return
-      }
-
-      if (isMessageTag(node)) {
-        if (isInsideContentTag || isInsideMessageTag) {
-          this.baseNodeError(errors.messageTagInsideMessage, node)
-        }
-
-        this.groupAccumulatedContentAsMessage()
-
-        const attributes = await this.resolveTagAttributes({
-          tagNode: node,
-          scope,
-        })
-
-        let role = node.name as MessageRole
-        if (node.name === CUSTOM_MESSAGE_TAG) {
-          if (attributes[CUSTOM_MESSAGE_ROLE_ATTR] === undefined) {
-            this.baseNodeError(errors.messageTagWithoutRole, node)
-          }
-          role = attributes[CUSTOM_MESSAGE_ROLE_ATTR] as MessageRole
-          delete attributes[CUSTOM_MESSAGE_ROLE_ATTR]
-        }
-
-        for await (const childNode of node.children ?? []) {
-          await this.resolveBaseNode({
-            node: childNode,
-            scope,
-            isInsideMessageTag: true,
-            isInsideContentTag,
-          })
-        }
-
-        this.groupAccumulatedTextAsContent()
-        const messageContent = this.accumulatedContent
-        const toolCalls = this.accumulatedToolCalls
-
-        this.accumulatedContent = []
-        this.accumulatedToolCalls = []
-
-        const message = this.buildMessage({
-          node: node as MessageTag,
-          role,
-          attributes,
-          content: messageContent,
-          toolCalls,
-        })
-        this.messages.push(message)
-        return
-      }
-
-      if (isRefTag(node)) {
-        if (isInsideMessageTag || isInsideContentTag) {
-          this.baseNodeError(errors.invalidReferencePromptPlacement, node)
-        }
-
-        if (node.children?.length ?? 0 > 0) {
-          this.baseNodeError(errors.referenceTagHasContent, node)
-        }
-
-        const attributes = await this.resolveTagAttributes({
-          tagNode: node,
-          scope,
-          literalAttributes: [REFERENCE_PROMPT_ATTR],
-        })
-
-        if (typeof attributes[REFERENCE_PROMPT_ATTR] !== 'string') {
-          this.baseNodeError(errors.referenceTagWithoutPrompt, node)
-        }
-
-        if (!this.referenceFn) {
-          this.baseNodeError(errors.missingReferenceFunction, node)
-        }
-
-        const refPromptPath = attributes[REFERENCE_PROMPT_ATTR]
-        try {
-          const refPrompt = await this.referenceFn(refPromptPath)
-          const refPromptCompile = new Compile({
-            prompt: refPrompt,
-            parameters: {},
-            referenceFn: this.referenceFn,
-          })
-          refPromptCompile.initialScope = scope // This will let the ref prompt modify variables from this one
-          refPromptCompile.accumulatedText = this.accumulatedText
-          refPromptCompile.accumulatedContent = this.accumulatedContent
-          refPromptCompile.accumulatedToolCalls = this.accumulatedToolCalls
-
-          const refConversation = await refPromptCompile.runWithoutGrouping()
-          this.messages.push(...refConversation.messages)
-          this.accumulatedText = refPromptCompile.accumulatedText
-          this.accumulatedContent = refPromptCompile.accumulatedContent
-          this.accumulatedToolCalls = refPromptCompile.accumulatedToolCalls
-        } catch (error: unknown) {
-          if (error instanceof CompileError) throw error
-          this.baseNodeError(errors.referenceError(error), node)
-        }
-        return
-      }
-
-      this.baseNodeError(errors.unknownTag(node.name), node)
-    }
-
-    //@ts-ignore - Linter knows this should be unreachable. That's what this error is for.
-    this.baseNodeError(errors.unsupportedBaseNodeType(node.type), node)
-  }
-
-  private buildMessage({
-    node,
-    role,
-    attributes,
-    content,
-    toolCalls,
-  }: {
-    node?: MessageTag
-    role: MessageRole
-    attributes: Record<string, unknown>
-    content: MessageContent[]
-    toolCalls: ToolCallReference[]
-  }): Message {
-    if (role !== MessageRole.assistant) {
-      toolCalls.forEach(({ node: toolNode }) => {
-        this.baseNodeError(errors.invalidToolCallPlacement, toolNode)
-      })
-    }
-
-    if (role === MessageRole.system) {
-      return {
-        role,
-        content,
-      } as SystemMessage
-    }
-
-    if (role === MessageRole.user) {
-      return {
-        role,
-        name: attributes.name ? String(attributes.name) : undefined,
-        content,
-      } as UserMessage
-    }
-
-    if (role === MessageRole.assistant) {
-      return {
-        role,
-        toolCalls: toolCalls.map(({ value }) => value),
-        content,
-      } as AssistantMessage
-    }
-
-    if (role === MessageRole.tool) {
-      if (attributes.id === undefined) {
-        this.baseNodeError(errors.toolMessageWithoutId, node!)
-      }
-
-      return {
-        role,
-        id: String(attributes.id),
-        content,
-      } as ToolMessage
-    }
-
-    this.baseNodeError(errors.invalidMessageRole(role), node!)
+    const resolverFn = nodeResolver[node.type] as (
+      context: CompileNodeContext<TemplateNode>,
+    ) => Promise<void>
+    await resolverFn(context)
   }
 
   private baseNodeError(

--- a/packages/compiler/src/compiler/errors.test.ts
+++ b/packages/compiler/src/compiler/errors.test.ts
@@ -20,24 +20,20 @@ const getExpectedError = async (
 const expectBothErrors = async ({
   code,
   prompt,
-  referenceFn,
 }: {
   code: string
   prompt: string
-  referenceFn?: (promptPath: string) => Promise<string>
 }) => {
   const compileError = await getExpectedError(async () => {
     await compile({
       prompt: removeCommonIndent(prompt),
       parameters: {},
-      referenceFn,
     })
   }, `Expected compile to throw '${code}'`)
   expect(compileError.code).toBe(code)
 
   const metadata = await readMetadata({
     prompt: removeCommonIndent(prompt),
-    referenceFn,
   })
   if (metadata.errors.length === 0) {
     throw new Error(`Expected readMetadata to throw '${code}'`)
@@ -218,80 +214,6 @@ describe(`all compilation errors that don't require value resolution are caught 
 
     await expectBothErrors({
       code: 'message-tag-without-role',
-      prompt,
-    })
-  })
-
-  it('invalid-reference-prompt-placement', async () => {
-    const prompt = `
-      <user>
-        <ref prompt="foo" />
-      </user>
-    `
-
-    await expectBothErrors({
-      code: 'invalid-reference-prompt-placement',
-      prompt,
-      referenceFn: () => Promise.resolve('bar'),
-    })
-  })
-
-  it('reference-tag-without-prompt', async () => {
-    const prompt = `
-      <ref />
-    `
-
-    await expectBothErrors({
-      code: 'reference-tag-without-prompt',
-      prompt,
-      referenceFn: () => Promise.resolve('bar'),
-    })
-  })
-
-  it('missing-reference-function', async () => {
-    const prompt = `
-      <ref prompt="foo" />
-    `
-
-    await expectBothErrors({
-      code: 'missing-reference-function',
-      prompt,
-    })
-  })
-
-  it('reference-error', async () => {
-    const prompt = `
-      <ref prompt="foo" />
-    `
-
-    await expectBothErrors({
-      code: 'reference-error',
-      prompt,
-      referenceFn: () => Promise.reject(new Error('foo')),
-    })
-  })
-
-  it('reference-tag-has-content', async () => {
-    const prompt = `
-      <ref prompt="foo">
-        Foo
-      </ref>
-    `
-
-    await expectBothErrors({
-      code: 'reference-tag-has-content',
-      prompt,
-      referenceFn: () => Promise.resolve('bar'),
-    })
-  })
-
-  it('invalid-static-attribute', async () => {
-    const prompt = `
-      <ref prompt={{foo}} />
-    `
-
-    await expectBothErrors({
-      code: 'invalid-static-attribute',
       prompt,
     })
   })

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -6,13 +6,11 @@ import { ReadMetadata } from './readMetadata'
 export function compile({
   prompt,
   parameters,
-  referenceFn,
 }: {
   prompt: string
   parameters: Record<string, unknown>
-  referenceFn?: ReferencePromptFn
 }): Promise<Conversation> {
-  return new Compile({ prompt, parameters, referenceFn }).run()
+  return new Compile({ prompt, parameters }).run()
 }
 
 export function readMetadata({

--- a/packages/compiler/src/compiler/types.ts
+++ b/packages/compiler/src/compiler/types.ts
@@ -1,0 +1,13 @@
+import { TemplateNode, ToolCallTag } from '$compiler/parser/interfaces'
+import { ToolCall } from '$compiler/types'
+
+import type Scope from './scope'
+
+export type ResolveBaseNodeProps<N extends TemplateNode> = {
+  node: N
+  scope: Scope
+  isInsideMessageTag: boolean
+  isInsideContentTag: boolean
+}
+
+export type ToolCallReference = { node: ToolCallTag; value: ToolCall }

--- a/packages/compiler/src/error/errors.ts
+++ b/packages/compiler/src/error/errors.ts
@@ -170,6 +170,11 @@ export default {
     code: 'missing-reference-function',
     message: 'A reference function was not provided',
   },
+  didNotResolveReferences: {
+    code: 'did-not-resolve-references',
+    message:
+      'Cannot compile reference tags. Make sure you have resolved the references before compiling.',
+  },
   referenceError: (err: unknown) => {
     const error = err as Error
     const errorKlassName = getKlassName(error)

--- a/packages/compiler/src/parser/state/config.ts
+++ b/packages/compiler/src/parser/state/config.ts
@@ -12,6 +12,7 @@ export function config(parser: Parser) {
 
   parser.allowWhitespace()
   parser.eat('---', true)
+  parser.eat('\n')
 
   let parsedData
   try {

--- a/packages/compiler/src/parser/state/multi_line_comment.ts
+++ b/packages/compiler/src/parser/state/multi_line_comment.ts
@@ -22,7 +22,7 @@ export function multiLineComment(parser: Parser) {
 
   const node = {
     start,
-    end: parser.index + 1,
+    end: parser.index,
     type: 'Comment',
     raw: data,
     data: data.substring(2, data.length - 2),

--- a/packages/compiler/src/serializer/serialize.test.ts
+++ b/packages/compiler/src/serializer/serialize.test.ts
@@ -147,38 +147,6 @@ describe('serialize', async () => {
     )
   })
 
-  it('includes referenced prompts', async () => {
-    const prompts = {
-      main: removeCommonIndent(`
-        Take a look at this:
-        <ref prompt="child" />
-      `),
-      child: removeCommonIndent(`
-        <system>
-          This is a test
-        </system>
-      `),
-    } as Record<string, string>
-
-    const conversation = await compile({
-      prompt: prompts.main!,
-      parameters: {},
-      referenceFn: (id: string) => Promise.resolve(prompts[id]!),
-    })
-
-    const serialized = serialize(conversation)
-    expect(serialized).toBe(
-      removeCommonIndent(`
-      <system>
-        Take a look at this:
-      </system>
-      <system>
-        This is a test
-      </system>
-    `),
-    )
-  })
-
   it('serializes a conversation with multiple user messages', async () => {
     const prompt = removeCommonIndent(`
       <system>

--- a/packages/compiler/src/types/index.ts
+++ b/packages/compiler/src/types/index.ts
@@ -10,11 +10,10 @@ export type Conversation = {
 }
 
 export type ConversationMetadata = {
-  hash: string // Unique string identifying the conversation
+  resolvedPrompt: string
   config: Config
   errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime
-  referencedPrompts: Set<string>
 }
 
 export * from './message'

--- a/packages/core/drizzle/0007_secret_may_parker.sql
+++ b/packages/core/drizzle/0007_secret_may_parker.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "latitude"."document_versions" ADD COLUMN "resolved_content" text;--> statement-breakpoint
+ALTER TABLE "latitude"."document_versions" DROP COLUMN IF EXISTS "hash";

--- a/packages/core/drizzle/meta/0007_snapshot.json
+++ b/packages/core/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,654 @@
+{
+  "id": "4a4bcd53-4c0d-4f9e-9e42-b968270f5ba8",
+  "prevId": "147b5696-593a-4fbb-a871-4e9038ee7635",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "latitude.users": {
+      "name": "users",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "latitude.sessions": {
+      "name": "sessions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.workspaces": {
+      "name": "workspaces",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_creator_id_users_id_fk": {
+          "name": "workspaces_creator_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.memberships": {
+      "name": "memberships",
+      "schema": "latitude",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_workspace_id_user_id_pk": {
+          "name": "memberships_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "latitude.api_keys": {
+      "name": "api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspace_id_idx": {
+          "name": "workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_uuid_unique": {
+          "name": "api_keys_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "latitude.projects": {
+      "name": "projects",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_idx": {
+          "name": "workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.commits": {
+      "name": "commits",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_commit_order_idx": {
+          "name": "project_commit_order_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commits_uuid_unique": {
+          "name": "commits_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "latitude.document_versions": {
+      "name": "document_versions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved_content": {
+          "name": "resolved_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_uuid_commit_id_idx": {
+          "name": "document_uuid_commit_id_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_commit_id_commits_id_fk": {
+          "name": "document_versions_commit_id_commits_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_uuid_commit_id": {
+          "name": "unique_document_uuid_commit_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_uuid",
+            "commit_id"
+          ]
+        },
+        "unique_path_commit_id": {
+          "name": "unique_path_commit_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path",
+            "commit_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "latitude": "latitude"
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1721396158426,
       "tag": "0006_strong_norman_osborn",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1721831263108,
+      "tag": "0007_secret_may_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/schema/models/documentVersions.ts
+++ b/packages/core/src/schema/models/documentVersions.ts
@@ -21,7 +21,7 @@ export const documentVersions = latitudeSchema.table(
     documentUuid: uuid('document_uuid').notNull().defaultRandom(),
     path: varchar('path').notNull(),
     content: text('content').notNull().default(''),
-    hash: varchar('hash'),
+    resolvedContent: text('resolved_content'),
     commitId: bigint('commit_id', { mode: 'number' })
       .notNull()
       .references(() => commits.id),

--- a/packages/core/src/services/documents/create.ts
+++ b/packages/core/src/services/documents/create.ts
@@ -2,6 +2,7 @@ import { findCommitById, getDocumentsAtCommit } from '$core/data-access'
 import { Result, Transaction, TypedResult } from '$core/lib'
 import { BadRequestError } from '$core/lib/errors'
 import { DocumentVersion, documentVersions } from '$core/schema'
+import { eq } from 'drizzle-orm'
 
 export async function createNewDocument({
   commitId,
@@ -33,6 +34,12 @@ export async function createNewDocument({
         content: content ?? '',
       })
       .returning()
+
+    // Invalidate all resolvedContent for this commit
+    await tx
+      .update(documentVersions)
+      .set({ resolvedContent: null })
+      .where(eq(documentVersions.commitId, commitId))
 
     return Result.ok(newDoc[0]!)
   })

--- a/packages/core/src/services/documents/utils.ts
+++ b/packages/core/src/services/documents/utils.ts
@@ -104,7 +104,7 @@ export async function resolveDocumentChanges({
 
       return {
         ...d,
-        hash: metadata.hash,
+        resolvedContent: metadata.resolvedPrompt,
       }
     }),
   )
@@ -114,7 +114,7 @@ export async function resolveDocumentChanges({
       !originalDocuments.find(
         (oldDoc) =>
           oldDoc.documentUuid === newDoc.documentUuid &&
-          oldDoc.hash === newDoc.hash &&
+          oldDoc.resolvedContent === newDoc.resolvedContent &&
           oldDoc.path === newDoc.path,
       ),
   )


### PR DESCRIPTION
Replaced the `hash` property in compiler's metadata with a `resolvedPrompt`, which represents the complete prompt, with all of the references replaced with the actual content.

This leads to a better optimization of prompt compiling, since there is no need to obtain referenced prompts when compiling the parent.