### PR TITLE
Compile iterator

### DIFF
--- a/packages/compiler/src/compiler/base/nodes/config.ts
+++ b/packages/compiler/src/compiler/base/nodes/config.ts
@@ -1,7 +1,10 @@
-import { Config } from '$compiler/parser/interfaces'
+import { Config as ConfigNode } from '$compiler/parser/interfaces'
 
 import { CompileNodeContext } from '../types'
 
-export async function compile(_: CompileNodeContext<Config>) {
-  /* do nothing */
+export async function compile({
+  node,
+  setConfig,
+}: CompileNodeContext<ConfigNode>): Promise<void> {
+  setConfig(node.value)
 }

--- a/packages/compiler/src/compiler/base/nodes/tag.ts
+++ b/packages/compiler/src/compiler/base/nodes/tag.ts
@@ -1,4 +1,5 @@
 import {
+  isChainStepTag,
   isContentTag,
   isMessageTag,
   isRefTag,
@@ -6,6 +7,7 @@ import {
 } from '$compiler/compiler/utils'
 import errors from '$compiler/error/errors'
 import {
+  ChainStepTag,
   ContentTag,
   ElementTag,
   MessageTag,
@@ -14,6 +16,7 @@ import {
 } from '$compiler/parser/interfaces'
 
 import { CompileNodeContext } from '../types'
+import { compile as resolveChainStep } from './tags/chainStep'
 import { compile as resolveContent } from './tags/content'
 import { compile as resolveMessage } from './tags/message'
 import { compile as resolveRef } from './tags/ref'
@@ -91,8 +94,18 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
     return
   }
 
+  if (isChainStepTag(node)) {
+    await resolveChainStep(
+      props as CompileNodeContext<ChainStepTag>,
+      attributes,
+    )
+    return
+  }
+
+  //@ts-ignore - Linter knows there *should* not be another type of tag.
   baseNodeError(errors.unknownTag(node.name), node)
 
+  //@ts-ignore - ditto
   for await (const childNode of node.children ?? []) {
     await resolveBaseNode({
       node: childNode,

--- a/packages/compiler/src/compiler/base/nodes/tags/chainStep.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/chainStep.ts
@@ -1,0 +1,53 @@
+import { tagAttributeIsLiteral } from '$compiler/compiler/utils'
+import errors from '$compiler/error/errors'
+import { ChainStepTag } from '$compiler/parser/interfaces'
+import { Config, ContentType } from '$compiler/types'
+
+import { CompileNodeContext } from '../../types'
+
+function isValidConfig(value: unknown): value is Config | undefined {
+  if (value === undefined) return true
+  if (Array.isArray(value)) return false
+  return typeof value === 'object'
+}
+
+export async function compile(
+  {
+    node,
+    scope,
+    popStepResponse,
+    addMessage,
+    groupContent,
+    baseNodeError,
+    stop,
+  }: CompileNodeContext<ChainStepTag>,
+  attributes: Record<string, unknown>,
+) {
+  const stepResponse = popStepResponse()
+
+  const { as: varName, ...config } = attributes
+
+  if (stepResponse === undefined) {
+    if (!isValidConfig(config)) {
+      baseNodeError(errors.invalidStepConfig, node)
+    }
+
+    stop(config as Config)
+  }
+
+  if ('as' in attributes) {
+    if (!tagAttributeIsLiteral(node, 'as')) {
+      baseNodeError(errors.invalidStaticAttribute('as'), node)
+    }
+
+    const responseText = stepResponse?.content
+      .filter((c) => c.type === ContentType.text)
+      .map((c) => c.value)
+      .join(' ')
+
+    scope.set(String(varName), responseText)
+  }
+
+  groupContent()
+  addMessage(stepResponse!)
+}

--- a/packages/compiler/src/compiler/base/types.ts
+++ b/packages/compiler/src/compiler/base/types.ts
@@ -1,6 +1,11 @@
-import Scope from '$compiler/compiler/scope'
+import Scope, { ScopePointers } from '$compiler/compiler/scope'
 import { TemplateNode } from '$compiler/parser/interfaces'
-import { Message, MessageContent } from '$compiler/types'
+import {
+  AssistantMessage,
+  Config,
+  Message,
+  MessageContent,
+} from '$compiler/types'
 import type { Node as LogicalExpression } from 'estree'
 
 import { ResolveBaseNodeProps, ToolCallReference } from '../types'
@@ -27,6 +32,16 @@ type RaiseErrorFn<T = void | never, N = TemplateNode | LogicalExpression> = (
   node: N,
 ) => T
 
+type NodeStatus = {
+  completedAs?: unknown
+  scopePointers?: ScopePointers | undefined
+  eachIterationIndex?: number
+}
+
+export type TemplateNodeWithStatus = TemplateNode & {
+  status?: NodeStatus
+}
+
 export type CompileNodeContext<N extends TemplateNode> = {
   node: N
   scope: Scope
@@ -41,6 +56,7 @@ export type CompileNodeContext<N extends TemplateNode> = {
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
 
+  setConfig: (config: Config) => void
   addMessage: (message: Message) => void
   addStrayText: (text: string) => void
   popStrayText: () => string
@@ -50,4 +66,7 @@ export type CompileNodeContext<N extends TemplateNode> = {
   groupContent: () => void
   addToolCall: (toolCallRef: ToolCallReference) => void
   popToolCalls: () => ToolCallReference[]
+  popStepResponse: () => AssistantMessage | undefined
+
+  stop: (config?: Config) => void
 }

--- a/packages/compiler/src/compiler/chain.test.ts
+++ b/packages/compiler/src/compiler/chain.test.ts
@@ -1,0 +1,486 @@
+import { CHAIN_STEP_TAG } from '$compiler/constants'
+import CompileError from '$compiler/error/error'
+import {
+  AssistantMessage,
+  ContentType,
+  Conversation,
+  MessageRole,
+} from '$compiler/types'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Chain } from './chain'
+import { removeCommonIndent } from './utils'
+
+const getExpectedError = async <T>(
+  action: () => Promise<unknown>,
+  errorClass: new () => T,
+): Promise<T> => {
+  try {
+    await action()
+  } catch (err) {
+    expect(err).toBeInstanceOf(errorClass)
+    return err as T
+  }
+  throw new Error('Expected an error to be thrown')
+}
+
+const assistantMessage = (content?: string): AssistantMessage => ({
+  role: MessageRole.assistant,
+  content: [
+    {
+      type: ContentType.text,
+      value: content ?? '',
+    },
+  ],
+  toolCalls: [],
+})
+
+async function defaultCallback(): Promise<AssistantMessage> {
+  return assistantMessage('')
+}
+
+async function complete({
+  chain,
+  callback,
+  maxSteps = 50,
+}: {
+  chain: Chain
+  callback?: (convo: Conversation) => Promise<AssistantMessage | undefined>
+  maxSteps?: number
+}): Promise<Conversation> {
+  let steps = 0
+  let response: AssistantMessage | undefined = undefined
+  while (true) {
+    const { completed, conversation } = await chain.step(response)
+    if (completed) return conversation
+    response = await (callback ?? defaultCallback)(conversation)
+
+    steps++
+    if (steps > maxSteps) throw new Error('too many chain steps')
+  }
+}
+
+describe('chain', async () => {
+  it('computes in a single iteration when there is no step tag', async () => {
+    const prompt = removeCommonIndent(`
+      {{ foo = 'foo' }}
+      System messate
+
+      {{#each [1, 2, 3] as element}}
+        <user>
+          User message: {{element}}
+        </user>
+      {{/each}}
+
+      <assistant>
+        Assistant message: {{foo}}
+      </assistant>
+    `)
+
+    const chain = new Chain({
+      prompt: removeCommonIndent(prompt),
+      parameters: {},
+    })
+    const { completed } = await chain.step()
+    expect(completed).toBe(true)
+  })
+
+  it('correctly computes the whole prompt in a single iteration', async () => {
+    const prompt = removeCommonIndent(`
+      {{foo = 'foo'}}
+      System message
+
+      {{#each [1, 2, 3] as element}}
+        <user>
+          User message: {{element}}
+        </user>
+      {{/each}}
+
+      <assistant>
+        Assistant message: {{foo}}
+      </assistant>
+    `)
+
+    const chain = new Chain({
+      prompt: removeCommonIndent(prompt),
+      parameters: {},
+    })
+
+    const { conversation } = await chain.step()
+    expect(conversation.messages.length).toBe(5)
+
+    const systemMessage = conversation.messages[0]!
+    expect(systemMessage.role).toBe('system')
+    expect(systemMessage.content[0]!.value).toBe('System message')
+
+    const userMessage = conversation.messages[1]!
+    expect(userMessage.role).toBe('user')
+    expect(userMessage.content[0]!.value).toBe('User message: 1')
+
+    const userMessage2 = conversation.messages[2]!
+    expect(userMessage2.role).toBe('user')
+    expect(userMessage2.content[0]!.value).toBe('User message: 2')
+
+    const userMessage3 = conversation.messages[3]!
+    expect(userMessage3.role).toBe('user')
+    expect(userMessage3.content[0]!.value).toBe('User message: 3')
+
+    const assistantMessage = conversation.messages[4]!
+    expect(assistantMessage.role).toBe('assistant')
+    expect(assistantMessage.content[0]!.value).toBe('Assistant message: foo')
+  })
+
+  it('stops at a step tag', async () => {
+    const prompt = removeCommonIndent(`
+      Message 1
+
+      <${CHAIN_STEP_TAG} />
+
+      Message 2
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const { completed: completed1, conversation: conversation1 } =
+      await chain.step()
+
+    expect(completed1).toBe(false)
+    expect(conversation1.messages.length).toBe(1)
+    expect(conversation1.messages[0]!.content[0]!.value).toBe('Message 1')
+
+    const { completed: completed2, conversation: conversation2 } =
+      await chain.step(assistantMessage('response'))
+
+    expect(completed2).toBe(true)
+    expect(conversation2.messages.length).toBe(3)
+    expect(conversation2.messages[0]!.content[0]!.value).toBe('Message 1')
+    expect(conversation2.messages[1]!.content[0]!.value).toBe('response')
+    expect(conversation2.messages[2]!.content[0]!.value).toBe('Message 2')
+  })
+
+  it('fails when an assistant message is not provided in followup steps', async () => {
+    const prompt = removeCommonIndent(`
+      Before step
+      <${CHAIN_STEP_TAG} />
+      After step
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    await chain.step()
+    const action = () => chain.step()
+    const error = await getExpectedError(action, Error)
+    expect(error.message).toBe('A response is required to continue a chain')
+  })
+
+  it('fails when an assistant message is provided in the initial step', async () => {
+    const prompt = removeCommonIndent(`
+      Before step
+      <${CHAIN_STEP_TAG} />
+      After step
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const action = () => chain.step(assistantMessage())
+    const error = await getExpectedError(action, Error)
+    expect(error.message).toBe(
+      'A response is not allowed before the chain has started',
+    )
+  })
+
+  it('fails when calling step after the chain has completed', async () => {
+    const prompt = removeCommonIndent(`
+      <${CHAIN_STEP_TAG} />
+      <${CHAIN_STEP_TAG} />
+      <${CHAIN_STEP_TAG} />
+      <${CHAIN_STEP_TAG} />
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    let { completed: stop } = await chain.step()
+    while (!stop) {
+      const { completed } = await chain.step(assistantMessage())
+      stop = completed
+    }
+
+    const action = () => chain.step()
+    const error = await getExpectedError(action, Error)
+    expect(error.message).toBe('The chain has already completed')
+  })
+
+  it('does not reevaluate nodes', async () => {
+    const prompt = removeCommonIndent(`
+      {{func1()}}
+
+      <${CHAIN_STEP_TAG} />
+
+      {{func2()}}
+    `)
+
+    const func1 = vi.fn().mockReturnValue('1')
+    const func2 = vi.fn().mockReturnValue('2')
+
+    const chain = new Chain({
+      prompt,
+      parameters: {
+        func1,
+        func2,
+      },
+    })
+
+    const conversation = await complete({ chain })
+    expect(conversation.messages[0]!.content[0]!.value).toBe('1')
+    expect(conversation.messages[1]!.content[0]!.value).toBe('')
+    expect(conversation.messages[2]!.content[0]!.value).toBe('2')
+    expect(func1).toHaveBeenCalledTimes(1)
+    expect(func2).toHaveBeenCalledTimes(1)
+  })
+
+  it('maintains the scope on simple structures', async () => {
+    const prompt = removeCommonIndent(`
+      {{foo = 5}}
+
+      <${CHAIN_STEP_TAG} />
+
+      {{foo += 1}}
+
+      <${CHAIN_STEP_TAG} />
+
+      {{foo}}
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const conversation = await complete({ chain })
+    expect(
+      conversation.messages[conversation.messages.length - 1]!.content[0]!
+        .value,
+    ).toBe('6')
+  })
+
+  it('maintains the scope in if statements', async () => {
+    const correctPrompt = removeCommonIndent(`
+      {{foo = 5}}
+
+      {{#if true}}
+        <${CHAIN_STEP_TAG} />
+        {{foo += 1}}
+      {{/if}}
+
+      {{foo}}
+    `)
+
+    const incorrectPrompt = removeCommonIndent(`
+      {{foo = 5}}
+
+      {{#if true}}
+        {{bar = 1}}
+        <${CHAIN_STEP_TAG} />
+      {{/if}}
+
+      {{bar}}
+    `)
+
+    const correctChain = new Chain({
+      prompt: correctPrompt,
+      parameters: {},
+    })
+
+    const conversation = await complete({ chain: correctChain })
+    expect(
+      conversation.messages[conversation.messages.length - 1]!.content[0]!
+        .value,
+    ).toBe('6')
+
+    const incorrectChain = new Chain({
+      prompt: incorrectPrompt,
+      parameters: {},
+    })
+
+    const action = () => complete({ chain: incorrectChain })
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('variable-not-declared')
+  })
+
+  it('maintains the scope in each blocks', async () => {
+    const prompt = removeCommonIndent(`
+      {{ foo = 0 }}
+
+      {{#each [1, 2, 3] as element}}
+        <user>
+          {{foo}}
+        </user>
+
+        <${CHAIN_STEP_TAG} />
+
+        {{foo = element}}
+      {{/each}}
+
+      {{foo}}
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const conversation = await complete({ chain, maxSteps: 5 })
+    expect(conversation.messages.length).toBe(7)
+    expect(conversation.messages[0]!.content[0]!.value).toBe('0')
+    expect(conversation.messages[2]!.content[0]!.value).toBe('1')
+    expect(conversation.messages[4]!.content[0]!.value).toBe('2')
+    expect(conversation.messages[6]!.content[0]!.value).toBe('3')
+  })
+
+  it('cannot access variables created in a loop outside its scope', async () => {
+    const prompt = removeCommonIndent(`
+      {{#each [1, 2, 3] as i}}
+        {{foo = i}}
+        <${CHAIN_STEP_TAG} />
+      {{/each}}
+
+      {{foo}}
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const action = () => complete({ chain })
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('variable-not-declared')
+  })
+
+  it('maintains the scope in nested loops', async () => {
+    const prompt = removeCommonIndent(`
+      {{ foo = 0 }}
+
+      {{#each [1, 2, 3] as i}}
+
+        {{#each [1, 2, 3] as j}}
+          <user>
+            {{i}}.{{j}}
+          </user>
+
+          <${CHAIN_STEP_TAG} />
+
+          {{foo = i * j}}
+        {{/each}}
+
+        {{ foo }}
+      {{/each}}
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const conversation = await complete({ chain })
+    const userMessages = conversation.messages.filter(
+      (m) => m.role === MessageRole.user,
+    )
+    const userMessageText = userMessages
+      .map((m) => m.content.map((c) => c.value).join(' '))
+      .join('\n')
+    expect(userMessageText).toBe(
+      removeCommonIndent(`
+      1.1
+      1.2
+      1.3
+      2.1
+      2.2
+      2.3
+      3.1
+      3.2
+      3.3
+    `),
+    )
+    expect(
+      conversation.messages[conversation.messages.length - 1]!.content[0]!
+        .value,
+    ).toBe('9')
+  })
+
+  it('saves the response in a variable', async () => {
+    const prompt = removeCommonIndent(`
+      <${CHAIN_STEP_TAG} as="response" />
+      
+      {{response}}
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const response = {
+      role: MessageRole.assistant,
+      content: [
+        {
+          type: ContentType.text,
+          value: 'foo',
+        },
+      ],
+    } as AssistantMessage
+
+    await chain.step()
+    const { conversation } = await chain.step(response)
+
+    expect(conversation.messages.length).toBe(2)
+    expect(conversation.messages[0]!.content[0]!.value).toBe('foo')
+    expect(conversation.messages[1]!.content[0]!.value).toBe('foo')
+  })
+
+  it('returns the correct configuration in all steps', async () => {
+    const prompt = removeCommonIndent(`
+      ---
+      model: foo-1
+      temperature: 0.5
+      ---
+      <step />                /* step1 */
+      <step model="foo-2" />  /* step2 */
+      <step temperature=1 />  /* step3 */
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    const { conversation: step1 } = await chain.step()
+    expect(step1.config.model).toBe('foo-1')
+    expect(step1.config.temperature).toBe(0.5)
+
+    const { conversation: step2 } = await chain.step(assistantMessage())
+    expect(step2.config.model).toBe('foo-2')
+    expect(step2.config.temperature).toBe(0.5)
+
+    const { conversation: step3 } = await chain.step(assistantMessage())
+    expect(step3.config.model).toBe('foo-1')
+    expect(step3.config.temperature).toBe('1')
+
+    const { conversation: finalConversation } =
+      await chain.step(assistantMessage())
+    expect(finalConversation.config.model).toBe('foo-1')
+    expect(finalConversation.config.temperature).toBe(0.5)
+  })
+})

--- a/packages/compiler/src/compiler/chain.ts
+++ b/packages/compiler/src/compiler/chain.ts
@@ -1,0 +1,81 @@
+import parse from '$compiler/parser'
+import { Fragment } from '$compiler/parser/interfaces'
+import {
+  AssistantMessage,
+  Config,
+  Conversation,
+  Message,
+} from '$compiler/types'
+
+import { Compile } from './compile'
+import Scope from './scope'
+
+type ChainStep = {
+  conversation: Conversation
+  completed: boolean
+}
+
+export class Chain {
+  private rawText: string
+  private ast: Fragment
+  private scope: Scope
+  private didStart: boolean = false
+  private completed: boolean = false
+
+  private messages: Message[] = []
+  private config: Config | undefined
+
+  constructor({
+    prompt,
+    parameters,
+  }: {
+    prompt: string
+    parameters: Record<string, unknown>
+  }) {
+    this.rawText = prompt
+    this.ast = parse(prompt)
+    this.scope = new Scope(parameters)
+  }
+
+  async step(response?: AssistantMessage): Promise<ChainStep> {
+    if (this.completed) {
+      throw new Error('The chain has already completed')
+    }
+    if (!this.didStart && response !== undefined) {
+      throw new Error('A response is not allowed before the chain has started')
+    }
+    if (this.didStart && response === undefined) {
+      throw new Error('A response is required to continue a chain')
+    }
+    this.didStart = true
+
+    const compile = new Compile({
+      ast: this.ast,
+      rawText: this.rawText,
+      globalScope: this.scope,
+      stepResponse: response,
+    })
+
+    const { completed, scopeStash, ast, messages, globalConfig, stepConfig } =
+      await compile.run()
+
+    this.scope = Scope.withStash(scopeStash).copy(this.scope.getPointers())
+    this.ast = ast
+    this.messages.push(...messages)
+    this.config = globalConfig ?? this.config
+    this.completed = completed || this.completed
+
+    const config = {
+      ...this.config,
+      ...stepConfig,
+    }
+
+    return {
+      conversation: {
+        messages: this.messages,
+        config,
+      },
+      completed: this.completed,
+    }
+  }
+}

--- a/packages/compiler/src/compiler/compile.test.ts
+++ b/packages/compiler/src/compiler/compile.test.ts
@@ -3,7 +3,7 @@ import CompileError from '$compiler/error/error'
 import { Message } from '$compiler/types'
 import { describe, expect, it, vi } from 'vitest'
 
-import { compile } from '.'
+import { render } from '.'
 import { removeCommonIndent } from './utils'
 
 const getExpectedError = async <T>(
@@ -23,7 +23,7 @@ async function getCompiledText(
   prompt: string,
   parameters: Record<string, any> = {},
 ) {
-  const result = await compile({
+  const result = await render({
     prompt: removeCommonIndent(prompt),
     parameters,
   })
@@ -43,7 +43,7 @@ describe('config section', async () => {
        - quux
       ---
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -64,7 +64,7 @@ describe('config section', async () => {
        - quux
       ---
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -81,7 +81,7 @@ describe('comments', async () => {
       /* comment */
       charlie
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -103,7 +103,7 @@ describe('comments', async () => {
         Test message
       </system>
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -125,7 +125,7 @@ describe('messages', async () => {
       <assistant>assistant message</assistant>
       <tool id="123">tool message</tool>
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -154,7 +154,7 @@ describe('messages', async () => {
       <foo>message</foo>
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -166,13 +166,13 @@ describe('messages', async () => {
     const prompt = `
       <message role=${CUSTOM_TAG_START}role${CUSTOM_TAG_END}>message</message>
     `
-    const result1 = await compile({
+    const result1 = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         role: 'system',
       },
     })
-    const result2 = await compile({
+    const result2 = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         role: 'user',
@@ -195,7 +195,7 @@ describe('messages', async () => {
       <message role="foo">message</message>
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -210,7 +210,7 @@ describe('messages', async () => {
       </system>
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -223,7 +223,7 @@ describe('messages', async () => {
       Test message
       <user>user message</user>
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -249,7 +249,7 @@ describe('message contents', async () => {
         <text>another text content</text>
       </system>
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -275,7 +275,7 @@ describe('message contents', async () => {
       </system>
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -289,7 +289,7 @@ describe('message contents', async () => {
         Test message
       </system>
     `
-    const result = await compile({
+    const result = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })
@@ -322,7 +322,7 @@ describe('reference tags', async () => {
     } as Record<string, string>
 
     const action = () =>
-      compile({
+      render({
         prompt: prompts['main']!,
         parameters: {},
       })
@@ -346,7 +346,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -378,7 +378,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}foo += 2${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -394,7 +394,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -432,7 +432,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}foo.c${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -446,7 +446,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}foo?.a = 2${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -483,7 +483,7 @@ describe('variable assignment', async () => {
       ${CUSTOM_TAG_START}++foo${CUSTOM_TAG_END}
     `
     const action = () =>
-      compile({
+      render({
         prompt: removeCommonIndent(prompt),
         parameters: {},
       })
@@ -504,7 +504,7 @@ describe('conditional expressions', async () => {
     const whenTrue = vi.fn()
     const whenFalse = vi.fn()
 
-    await compile({
+    await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         foo: true,
@@ -519,7 +519,7 @@ describe('conditional expressions', async () => {
     whenTrue.mockClear()
     whenFalse.mockClear()
 
-    await compile({
+    await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         foo: false,
@@ -540,13 +540,13 @@ describe('conditional expressions', async () => {
         <assistant>Bar!</assistant>
       ${CUSTOM_TAG_START}/if${CUSTOM_TAG_END}
     `
-    const result1 = await compile({
+    const result1 = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         foo: true,
       },
     })
-    const result2 = await compile({
+    const result2 = await render({
       prompt: removeCommonIndent(prompt),
       parameters: {
         foo: false,
@@ -621,7 +621,7 @@ describe('each loops', async () => {
 
   it('does not do anything when the iterable object is not iterable and there is no else block', async () => {
     const prompt = `${CUSTOM_TAG_START}#each 5 as element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}/each${CUSTOM_TAG_END}`
-    expect(compile({ prompt, parameters: {} })).resolves
+    expect(render({ prompt, parameters: {} })).resolves
   })
 
   it('gives access to the index of the element', async () => {
@@ -634,7 +634,7 @@ describe('each loops', async () => {
     const prompt1 = `${CUSTOM_TAG_START}#each ['a', 'b', 'c'] as element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo = 5${CUSTOM_TAG_END} ${CUSTOM_TAG_START}/each${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}`
     const prompt2 = `${CUSTOM_TAG_START}foo = 5${CUSTOM_TAG_END} ${CUSTOM_TAG_START}#each ['a', 'b', 'c'] as element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo = 7${CUSTOM_TAG_END} ${CUSTOM_TAG_START}/each${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}`
     const prompt3 = `${CUSTOM_TAG_START}foo = 5${CUSTOM_TAG_END} ${CUSTOM_TAG_START}#each [1, 2, 3] as element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo += element${CUSTOM_TAG_END} ${CUSTOM_TAG_START}/each${CUSTOM_TAG_END} ${CUSTOM_TAG_START}foo${CUSTOM_TAG_END}`
-    const action1 = () => compile({ prompt: prompt1, parameters: {} })
+    const action1 = () => render({ prompt: prompt1, parameters: {} })
     const error1 = await getExpectedError(action1, CompileError)
     const result2 = await getCompiledText(prompt2)
     const result3 = await getCompiledText(prompt3)

--- a/packages/compiler/src/compiler/errors.test.ts
+++ b/packages/compiler/src/compiler/errors.test.ts
@@ -1,7 +1,7 @@
 import CompileError from '$compiler/error/error'
 import { describe, expect, it } from 'vitest'
 
-import { compile, readMetadata } from '.'
+import { readMetadata, render } from '.'
 import { removeCommonIndent } from './utils'
 
 const getExpectedError = async (
@@ -25,7 +25,7 @@ const expectBothErrors = async ({
   prompt: string
 }) => {
   const compileError = await getExpectedError(async () => {
-    await compile({
+    await render({
       prompt: removeCommonIndent(prompt),
       parameters: {},
     })

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -1,16 +1,22 @@
 import { Conversation, ConversationMetadata } from '$compiler/types'
 
-import { Compile, type ReferencePromptFn } from './compile'
+import { Chain } from './chain'
+import { type ReferencePromptFn } from './compile'
 import { ReadMetadata } from './readMetadata'
 
-export function compile({
+export async function render({
   prompt,
   parameters,
 }: {
   prompt: string
   parameters: Record<string, unknown>
 }): Promise<Conversation> {
-  return new Compile({ prompt, parameters }).run()
+  const iterator = new Chain({ prompt, parameters })
+  const { conversation, completed } = await iterator.step()
+  if (!completed) {
+    throw new Error('Use a Chain to render prompts with multiple steps')
+  }
+  return conversation
 }
 
 export function readMetadata({

--- a/packages/compiler/src/compiler/scope.ts
+++ b/packages/compiler/src/compiler/scope.ts
@@ -1,3 +1,6 @@
+export type ScopePointers = { [key: string]: number }
+export type ScopeStash = unknown[]
+
 export default class Scope {
   /**
    * Global stash
@@ -19,8 +22,8 @@ export default class Scope {
    * Local pointers
    * Every scope has its own local pointers that contains the indexes of the variables in the global stash.
    */
-  private globalStash: unknown[] = [] // Stash of every variable value in the global scope
-  private localPointers: Record<string, number> = {} // Index of every variable in the stash in the current scope
+  private globalStash: ScopeStash = [] // Stash of every variable value in the global scope
+  private localPointers: ScopePointers = {} // Index of every variable in the stash in the current scope
 
   constructor(initialState: Record<string, unknown> = {}) {
     for (const [key, value] of Object.entries(initialState)) {
@@ -28,9 +31,16 @@ export default class Scope {
     }
   }
 
+  static withStash(stash: ScopeStash): Scope {
+    const scope = new Scope()
+    scope.globalStash = stash
+    return scope
+  }
+
   private readFromStash(index: number): unknown {
     return this.globalStash[index]
   }
+
   private addToStash(value: unknown): number {
     this.globalStash.push(value)
     return this.globalStash.length - 1
@@ -60,11 +70,23 @@ export default class Scope {
     this.modifyStash(index, value)
   }
 
-  copy(): Scope {
+  copy(localPointers?: ScopePointers): Scope {
     const scope = new Scope()
     scope.globalStash = this.globalStash
-    scope.localPointers = { ...this.localPointers }
+    scope.localPointers = { ...(localPointers ?? this.localPointers) }
     return scope
+  }
+
+  getStash(): ScopeStash {
+    return this.globalStash
+  }
+
+  getPointers(): ScopePointers {
+    return this.localPointers
+  }
+
+  setPointers(pointers: ScopePointers): void {
+    this.localPointers = pointers
   }
 }
 

--- a/packages/compiler/src/compiler/types.ts
+++ b/packages/compiler/src/compiler/types.ts
@@ -8,6 +8,7 @@ export type ResolveBaseNodeProps<N extends TemplateNode> = {
   scope: Scope
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
+  completedValue?: unknown
 }
 
 export type ToolCallReference = { node: ToolCallTag; value: ToolCall }

--- a/packages/compiler/src/compiler/utils.ts
+++ b/packages/compiler/src/compiler/utils.ts
@@ -1,9 +1,11 @@
 import {
+  CHAIN_STEP_TAG,
   CUSTOM_MESSAGE_TAG,
   REFERENCE_PROMPT_TAG,
   TOOL_CALL_TAG,
 } from '$compiler/constants'
 import {
+  ChainStepTag,
   ContentTag,
   ElementTag,
   MessageTag,
@@ -53,6 +55,17 @@ export function isRefTag(tag: ElementTag): tag is ReferenceTag {
   return tag.name === REFERENCE_PROMPT_TAG
 }
 
+export function isChainStepTag(tag: ElementTag): tag is ChainStepTag {
+  return tag.name === CHAIN_STEP_TAG
+}
+
 export function isToolCallTag(tag: ElementTag): tag is ToolCallTag {
   return tag.name === TOOL_CALL_TAG
+}
+
+export function tagAttributeIsLiteral(tag: ElementTag, name: string): boolean {
+  const attr = tag.attributes.find((attr) => attr.name === name)
+  if (!attr) return false
+  if (attr.value === true) return true
+  return attr.value.every((v) => v.type === 'Text')
 }

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -11,3 +11,5 @@ export const REFERENCE_PROMPT_ATTR = 'prompt' as const
 
 // <tool_call id="…" name="…">{ content }</tool_call>
 export const TOOL_CALL_TAG = 'tool-call' as const
+
+export const CHAIN_STEP_TAG = 'step' as const

--- a/packages/compiler/src/error/errors.ts
+++ b/packages/compiler/src/error/errors.ts
@@ -229,4 +229,8 @@ export default {
       message: `Error calling function: \n${errorKlassName} ${error.message}`,
     }
   },
+  invalidStepConfig: {
+    code: 'invalid-step-config',
+    message: 'Step config must be an object',
+  },
 }

--- a/packages/compiler/src/parser/interfaces.ts
+++ b/packages/compiler/src/parser/interfaces.ts
@@ -1,4 +1,5 @@
 import {
+  CHAIN_STEP_TAG,
   CUSTOM_MESSAGE_TAG,
   REFERENCE_PROMPT_TAG,
   TOOL_CALL_TAG,
@@ -47,6 +48,7 @@ export type MessageTag =
   | IElementTag<MessageRole>
   | IElementTag<typeof CUSTOM_MESSAGE_TAG>
 export type ReferenceTag = IElementTag<typeof REFERENCE_PROMPT_TAG>
+export type ChainStepTag = IElementTag<typeof CHAIN_STEP_TAG>
 export type ToolCallTag = IElementTag<typeof TOOL_CALL_TAG>
 export type ElementTag =
   | ContentTag

--- a/packages/compiler/src/serializer/serialize.test.ts
+++ b/packages/compiler/src/serializer/serialize.test.ts
@@ -1,4 +1,4 @@
-import { compile } from '$compiler/compiler'
+import { render } from '$compiler/compiler'
 import { removeCommonIndent } from '$compiler/compiler/utils'
 import { describe, expect, it } from 'vitest'
 
@@ -12,7 +12,7 @@ describe('serialize', async () => {
       </system>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: {},
     })
@@ -40,7 +40,7 @@ describe('serialize', async () => {
       </system>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: {},
     })
@@ -80,7 +80,7 @@ describe('serialize', async () => {
       </assistant>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: {},
     })
@@ -123,7 +123,7 @@ describe('serialize', async () => {
       </tool>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: {},
     })
@@ -163,7 +163,7 @@ describe('serialize', async () => {
       </assistant>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: {},
     })
@@ -197,7 +197,7 @@ describe('serialize', async () => {
       </user>
     `)
 
-    const conversation = await compile({
+    const conversation = await render({
       prompt,
       parameters: { param: 'value' },
     })


### PR DESCRIPTION
## Overview
A new tag, provisionally named `step`, has been introduced. This tag pauses the compilation process until a new message is generated with the current messages. Once this new message is generated, it is added to the conversation, allowing the compilation to proceed.

### Compile Method:

- The compile method is now an `Iterator` instead of a simple function, which has a single `next` method.
- Each call to `next` returns an object `{ completed, conversation }`, informing wether it has finished or not, and the current compiled conversation up to this point.
- If `completed` is false, the next call to next expects an `AssistantMessage` as an argument, which is added to the conversation replacing the `step` tag, to continue the compilation from where it paused.

### Step-by-Step Execution:

- The compilation process is repeatedly called for each step.
- To avoid recompiling every node at each step, the status of nodes is saved in the AST, which is updated in the `Iterator`
- A node marks its `status.completed` property as `true` once its execution is complete.
- In subsequent steps, completed nodes are skipped to optimize performance.

### Handling Interrupted Nodes

- If a node's execution is interrupted, it sets `status.completed` to `false` and saves the current scope values in `status.scopePointers`.
- This approach ensures that variable changes from skipped nodes do not cause incorrect scopes in subsequent nodes.