### PR TITLE
Commits selector list display

### DIFF
--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -28,7 +28,7 @@ serve(
   {
     fetch: app.fetch,
     overrideGlobalObjects: undefined,
-    port: parseInt(process.env.GATEWAY_PORT || '4000', 10),
+    port: parseInt(process.env.GATEWAY_PORT || '8787', 10),
     hostname: process.env.GATEWAY_HOSTNAME || 'localhost',
   },
   (info) => {

--- a/apps/gateway/src/index.ts
+++ b/apps/gateway/src/index.ts
@@ -28,7 +28,7 @@ serve(
   {
     fetch: app.fetch,
     overrideGlobalObjects: undefined,
-    port: parseInt(process.env.GATEWAY_PORT || '8787', 10),
+    port: parseInt(process.env.GATEWAY_PORT || '4000', 10),
     hostname: process.env.GATEWAY_HOSTNAME || 'localhost',
   },
   (info) => {

--- a/apps/web/src/actions/commits/deleteDraftCommit.test.ts
+++ b/apps/web/src/actions/commits/deleteDraftCommit.test.ts
@@ -1,0 +1,129 @@
+import { database, factories } from '@latitude-data/core'
+import type {
+  Commit,
+  Project,
+  SafeUser,
+  Workspace,
+} from '@latitude-data/core/browser'
+import { deleteDraftCommitAction } from '$/actions/commits/deleteDraftCommitAction'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+  }
+})
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+
+let workspace: Workspace
+let project: Project
+let user: SafeUser
+let commit: Commit
+
+describe('getUsersAction', () => {
+  beforeEach(async () => {
+    const {
+      commit: cmt,
+      workspace: wp,
+      user: usr,
+      project: prj,
+    } = await factories.createProject()
+    user = usr
+    workspace = wp
+    project = prj
+    commit = cmt
+  })
+
+  describe('unauthorized', () => {
+    it('errors when the user is not authenticated', async () => {
+      const [_, error] = await deleteDraftCommitAction({
+        projectId: project.id,
+        id: commit.id,
+      })
+
+      expect(error!.name).toEqual('UnauthorizedError')
+    })
+  })
+
+  describe('authorized', () => {
+    beforeEach(async () => {
+      mocks.getSession.mockReturnValue({
+        user,
+        workspace: { id: workspace.id, name: workspace.name },
+      })
+    })
+
+    it('returns error when project is not found', async () => {
+      const [_, error] = await deleteDraftCommitAction({
+        projectId: 33,
+        id: commit.id,
+      })
+
+      expect(error!.name).toEqual('NotFoundError')
+    })
+
+    it('returns error when commit does not belongs to project', async () => {
+      const { user: unrelatedUser, project: urelatedProject } =
+        await factories.createProject()
+      const { commit: unrelatedCommit } = await factories.createDraft({
+        project: urelatedProject,
+        user: unrelatedUser,
+      })
+      const [_, error] = await deleteDraftCommitAction({
+        projectId: project.id,
+        id: unrelatedCommit.id,
+      })
+
+      expect(error!.name).toEqual('NotFoundError')
+    })
+
+    it('returns error when the commit is merged', async () => {
+      const [_, error] = await deleteDraftCommitAction({
+        projectId: project.id,
+        id: commit.id,
+      })
+      expect(error!.name).toEqual('BadRequestError')
+    })
+
+    it('returns all draft commits', async () => {
+      const { commit: draft } = await factories.createDraft({
+        project,
+        user,
+      })
+      const [data] = await deleteDraftCommitAction({
+        projectId: project.id,
+        id: draft.id,
+      })
+
+      expect(data).toEqual(draft)
+    })
+
+    it('deletes associated documents with draft commit', async () => {
+      const { commit: draft } = await factories.createDraft({
+        project,
+        user,
+      })
+      const { commit: anotherDraf } = await factories.createDraft({
+        project,
+        user,
+      })
+      await factories.createDocumentVersion({
+        commit: draft,
+        path: 'patata/doc1',
+      })
+      await factories.createDocumentVersion({
+        commit: anotherDraf,
+        path: 'patata/doc2',
+      })
+      await deleteDraftCommitAction({
+        projectId: project.id,
+        id: draft.id,
+      })
+
+      const result = await database.query.documentVersions.findMany()
+      expect(result.length).toEqual(1)
+    })
+  })
+})

--- a/apps/web/src/actions/commits/deleteDraftCommitAction.ts
+++ b/apps/web/src/actions/commits/deleteDraftCommitAction.ts
@@ -1,0 +1,22 @@
+'use server'
+
+import { CommitsRepository } from '@latitude-data/core'
+import { deleteCommitDraft } from '$core/services/commits/delete'
+import { z } from 'zod'
+
+import { withProject } from '../procedures'
+
+export const deleteDraftCommitAction = withProject
+  .createServerAction()
+  .input(
+    z.object({
+      id: z.number(),
+    }),
+  )
+  .handler(async ({ input, ctx }) => {
+    const commitScope = new CommitsRepository(ctx.workspace.id)
+    const commit = await commitScope
+      .getCommitById(input.id)
+      .then((r) => r.unwrap())
+    return deleteCommitDraft(commit).then((r) => r.unwrap())
+  })

--- a/apps/web/src/actions/commits/fetchCommitsByProjectAction.test.ts
+++ b/apps/web/src/actions/commits/fetchCommitsByProjectAction.test.ts
@@ -1,6 +1,5 @@
 import { CommitStatus, factories } from '@latitude-data/core'
 import type { Workspace } from '@latitude-data/core/browser'
-import useTestDatabase from '$core/tests/useTestDatabase'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { fetchCommitsByProjectAction } from './fetchCommitsByProjectAction'
@@ -16,8 +15,6 @@ vi.mock('$/services/auth/getSession', () => ({
 
 let workspace: Workspace
 describe('getUsersAction', () => {
-  useTestDatabase()
-
   describe('unauthorized', () => {
     it('errors when the user is not authenticated', async () => {
       const [_, error] = await fetchCommitsByProjectAction({

--- a/apps/web/src/actions/commits/fetchCommitsByProjectAction.ts
+++ b/apps/web/src/actions/commits/fetchCommitsByProjectAction.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { CommitsRepository, CommitStatus } from '@latitude-data/core'
-import commitPresenter from '$/presenters/commitPresenter'
 import { z } from 'zod'
 
 import { withProject } from '../procedures'
@@ -20,7 +19,7 @@ export const fetchCommitsByProjectAction = withProject
     { type: 'json' },
   )
   .handler(async ({ input, ctx }) => {
-    const commits = await new CommitsRepository(ctx.workspace.id)
+    return new CommitsRepository(ctx.workspace.id)
       .getCommitsByProject({
         project: ctx.project,
         filterByStatus: input.status,
@@ -28,7 +27,4 @@ export const fetchCommitsByProjectAction = withProject
         pageSize: input.pageSize ?? ULTRA_LARGE_PAGE_SIZE,
       })
       .then((r) => r.unwrap())
-      .then((r) => r.map(commitPresenter))
-
-    return commits
   })

--- a/apps/web/src/actions/users/fetch.ts
+++ b/apps/web/src/actions/users/fetch.ts
@@ -7,7 +7,7 @@ import { authProcedure } from '../procedures'
 
 export const getUsersActions = authProcedure
   .createServerAction()
-  .handler(async ({ ctx }) => {
+  .handler(({ ctx }) => {
     const usersScope = new UsersRepository(ctx.workspace.id)
 
     return usersScope

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CreateDraftCommitModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CreateDraftCommitModal/index.tsx
@@ -13,7 +13,7 @@ import useCommits from '$/stores/commitsStore'
 import { useRouter } from 'next/navigation'
 import { useServerAction } from 'zsa-react'
 
-export default function NewDraftCommitModal({
+export default function DraftCommitModal({
   open,
   setOpen,
 }: {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/DeleteDraftCommitModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/DeleteDraftCommitModal/index.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+
+import {
+  ConfirmModal,
+  useCurrentProject,
+  useToast,
+} from '@latitude-data/web-ui'
+import { deleteDraftCommitAction } from '$/actions/commits/deleteDraftCommitAction'
+import { ROUTES } from '$/services/routes'
+import useCommits from '$/stores/commitsStore'
+import { ReactStateDispatch } from '$ui/lib/commonTypes'
+import { useRouter } from 'next/navigation'
+import { useServerAction } from 'zsa-react'
+
+export default function DeleteDraftCommitModal({
+  commitId,
+  onClose,
+}: {
+  commitId: number | null
+  onClose: ReactStateDispatch<number | null>
+}) {
+  const { data, mutate } = useCommits()
+  const { toast } = useToast()
+  const commit = useMemo(() => data.find((c) => c.id === commitId), [commitId])
+  const { project } = useCurrentProject()
+  const router = useRouter()
+  const { execute, isPending } = useServerAction(deleteDraftCommitAction, {
+    persistErrorWhilePending: true,
+    persistDataWhilePending: true,
+    onSuccess: (result) => {
+      const deletedDraft = result.data
+      mutate(data.filter((item) => item.id !== deletedDraft.id))
+      router.push(ROUTES.projects.detail({ id: project.id }).commits.latest)
+      onClose(null)
+    },
+    onError: ({ err }) => {
+      toast({
+        title: 'Error',
+        description: err.message,
+        variant: 'destructive',
+      })
+    },
+  })
+  return (
+    <ConfirmModal
+      open={!!commit}
+      title={`Delete ${commit?.title} version`}
+      type='destructive'
+      onOpenChange={() => onClose(null)}
+      onConfirm={() => execute({ projectId: project.id, id: commitId! })}
+      confirm={{
+        label: 'Delete version',
+        description:
+          'Deleting this version means you will lose all modified, deleted, or created prompts. This action cannot be undone.',
+        isConfirming: isPending,
+      }}
+    />
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
@@ -23,6 +23,26 @@ enum BadgeType {
   Merged = 'merged',
 }
 
+function useObserveSelectWidth(ref: React.RefObject<HTMLButtonElement>) {
+  const [width, setWidth] = useState(MIN_WIDTH_SELECTOR_PX)
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      const { width: triggerWidth } = entries[0]?.contentRect ?? { width: 0 }
+      setWidth(
+        Math.max(triggerWidth + TRIGGER_X_PADDING_PX, MIN_WIDTH_SELECTOR_PX),
+      )
+    })
+    if (ref.current) {
+      resizeObserver.observe(ref.current)
+    }
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [ref])
+
+  return width
+}
+
 function CommitSelectorHeader() {
   const [open, setOpen] = useState(false)
   return (
@@ -66,7 +86,7 @@ export default function CommitSelector({
   draftCommits: Commit[]
 }) {
   const ref = useRef<HTMLButtonElement>(null)
-  const [width, setWidth] = useState(MIN_WIDTH_SELECTOR_PX)
+  const width = useObserveSelectWidth(ref)
   const { data: commits } = useCommits({ fallbackData: draftCommits })
   const selected = useMemo(() => {
     const foundCommit = commits.find((commit) => commit.id === currentCommit.id)
@@ -82,20 +102,6 @@ export default function CommitSelector({
             : BadgeType.Merged,
     }
   }, [commits, currentCommit.id, headCommitId])
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver((entries) => {
-      const { width: triggerWidth } = entries[0]?.contentRect ?? { width: 0 }
-      setWidth(
-        Math.max(triggerWidth + TRIGGER_X_PADDING_PX, MIN_WIDTH_SELECTOR_PX),
-      )
-    })
-    if (ref.current) {
-      resizeObserver.observe(ref.current)
-    }
-    return () => {
-      resizeObserver.disconnect()
-    }
-  }, [ref])
 
   return (
     <SelectRoot value={String(currentCommit.id)}>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
 
-import { HELP_CENTER, type Commit } from '@latitude-data/core/browser'
+import {
+  HEAD_COMMIT,
+  HELP_CENTER,
+  User,
+  type Commit,
+} from '@latitude-data/core/browser'
 import {
   Badge,
   Button,
@@ -11,9 +16,17 @@ import {
   SelectTrigger,
   SelectValueWithIcon,
   Text,
+  useCurrentProject,
 } from '@latitude-data/web-ui'
-import NewDraftCommitModal from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/NewDraftCommitModal'
+import PublishDraftCommitModal from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal'
+import { ROUTES } from '$/services/routes'
 import useCommits from '$/stores/commitsStore'
+import useUsers from '$/stores/users'
+import { ReactStateDispatch } from '$ui/lib/commonTypes'
+import { useRouter } from 'next/navigation'
+
+import CreateDraftCommitModal from './CreateDraftCommitModal'
+import DeleteDraftCommitModal from './DeleteDraftCommitModal'
 
 const MIN_WIDTH_SELECTOR_PX = 380
 const TRIGGER_X_PADDING_PX = 26
@@ -23,7 +36,7 @@ enum BadgeType {
   Merged = 'merged',
 }
 
-function useObserveSelectWidth(ref: React.RefObject<HTMLButtonElement>) {
+function useObserveSelectWidth(ref: RefObject<HTMLButtonElement>) {
   const [width, setWidth] = useState(MIN_WIDTH_SELECTOR_PX)
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
@@ -43,8 +56,11 @@ function useObserveSelectWidth(ref: React.RefObject<HTMLButtonElement>) {
   return width
 }
 
-function CommitSelectorHeader() {
-  const [open, setOpen] = useState(false)
+function CommitSelectorHeader({
+  setOpen,
+}: {
+  setOpen: ReactStateDispatch<boolean>
+}) {
   return (
     <>
       <div className='flex flex-col gap-y-4'>
@@ -65,7 +81,6 @@ function CommitSelectorHeader() {
           .
         </Text.H6>
       </div>
-      <NewDraftCommitModal open={open} setOpen={setOpen} />
     </>
   )
 }
@@ -76,17 +91,94 @@ function BadgeCommit({ badgeType }: { badgeType: BadgeType }) {
   return <Badge variant={isLive ? 'accent' : 'muted'}>{text}</Badge>
 }
 
-export default function CommitSelector({
+type SimpleUser = Omit<User, 'encryptedPassword'>
+
+function CommitItem({
+  commit,
   headCommitId,
+  user,
+  onCommitPublish,
+  onCommitDelete,
+}: {
+  commit: Commit
+  headCommitId: number
+  user: SimpleUser | undefined
+  onCommitPublish: ReactStateDispatch<number | null>
+  onCommitDelete: ReactStateDispatch<number | null>
+}) {
+  const isHead = commit.id === headCommitId
+  const isDraft = !commit.mergedAt
+  const { project } = useCurrentProject()
+  const router = useRouter()
+  const badgeType =
+    commit.id === headCommitId ? BadgeType.Head : BadgeType.Draft
+  const commitPath = ROUTES.projects
+    .detail({ id: project.id })
+    .commits.detail({ uuid: isHead ? HEAD_COMMIT : commit.uuid }).root
+  return (
+    <div className='flex flex-col p-4 gap-y-2'>
+      <div className='flex flex-col gap-y-1'>
+        <div className='flex items-center justify-between'>
+          <Text.H5>{commit.title}</Text.H5>
+          <BadgeCommit badgeType={badgeType} />
+        </div>
+        <Text.H6 color='foregroundMuted'>
+          {user ? user.name : 'Unknown user'}
+        </Text.H6>
+      </div>
+      <div className='flex gap-x-4'>
+        <Button
+          variant='link'
+          size='none'
+          onClick={() => router.push(commitPath)}
+        >
+          View
+        </Button>
+        {isDraft ? (
+          <>
+            <Button
+              variant='link'
+              size='none'
+              onClick={() => onCommitPublish(commit.id)}
+            >
+              Publish
+            </Button>
+            <Button
+              variant='link'
+              size='none'
+              onClick={() => onCommitDelete(commit.id)}
+            >
+              Delete
+            </Button>
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default function CommitSelector({
+  headCommit,
   currentCommit,
   draftCommits,
 }: {
-  headCommitId: number
+  headCommit: Commit
   currentCommit: Commit
   draftCommits: Commit[]
 }) {
+  const [open, setOpen] = useState(false)
   const ref = useRef<HTMLButtonElement>(null)
   const width = useObserveSelectWidth(ref)
+  const { data: users } = useUsers()
+  const usersById = useMemo(() => {
+    return users.reduce(
+      (acc, user) => {
+        acc[user.id] = user
+        return acc
+      },
+      {} as Record<string, SimpleUser>,
+    )
+  }, [users])
   const { data: commits } = useCommits({ fallbackData: draftCommits })
   const selected = useMemo(() => {
     const foundCommit = commits.find((commit) => commit.id === currentCommit.id)
@@ -95,30 +187,64 @@ export default function CommitSelector({
       commit,
       title: commit.title ?? commit.uuid,
       badgeType:
-        currentCommit?.id === headCommitId
+        currentCommit?.id === headCommit.id
           ? BadgeType.Head
           : foundCommit
             ? BadgeType.Draft
             : BadgeType.Merged,
     }
-  }, [commits, currentCommit.id, headCommitId])
-
+  }, [commits, currentCommit.id, headCommit.id])
+  const [publishCommit, setPublishCommit] = useState<number | null>(null)
+  const [deleteCommit, setDeleteCommit] = useState<number | null>(null)
   return (
-    <SelectRoot value={String(currentCommit.id)}>
-      <SelectTrigger ref={ref}>
-        <SelectValueWithIcon
-          icon={<BadgeCommit badgeType={selected.badgeType} />}
-        >
-          <Text.H5M ellipsis noWrap userSelect={false}>
-            {selected.title}
-          </Text.H5M>
-        </SelectValueWithIcon>
-      </SelectTrigger>
-      <SelectContent>
-        <div className='p-2' style={{ width, minWidth: MIN_WIDTH_SELECTOR_PX }}>
-          <CommitSelectorHeader />
-        </div>
-      </SelectContent>
-    </SelectRoot>
+    <>
+      <SelectRoot value={String(currentCommit.id)}>
+        <SelectTrigger ref={ref}>
+          <SelectValueWithIcon
+            icon={<BadgeCommit badgeType={selected.badgeType} />}
+          >
+            <Text.H5M ellipsis noWrap userSelect={false}>
+              {selected.title}
+            </Text.H5M>
+          </SelectValueWithIcon>
+        </SelectTrigger>
+        <SelectContent autoScroll={false}>
+          <div className='flex flex-col gap-y-4 p-4'>
+            <div style={{ width, minWidth: MIN_WIDTH_SELECTOR_PX }}>
+              <CommitSelectorHeader setOpen={setOpen} />
+            </div>
+            <ul className='custom-scrollbar max-h-60 border border-border rounded-md divide-y divide-border'>
+              <CommitItem
+                commit={headCommit}
+                headCommitId={headCommit.id}
+                user={usersById[headCommit.userId]}
+                onCommitPublish={setPublishCommit}
+                onCommitDelete={setDeleteCommit}
+              />
+              {commits.map((commit) => (
+                <li key={commit.id}>
+                  <CommitItem
+                    commit={commit}
+                    headCommitId={headCommit.id}
+                    user={usersById[commit.userId]}
+                    onCommitPublish={setPublishCommit}
+                    onCommitDelete={setDeleteCommit}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </SelectContent>
+      </SelectRoot>
+      <CreateDraftCommitModal open={open} setOpen={setOpen} />
+      <DeleteDraftCommitModal
+        commitId={deleteCommit}
+        onClose={setDeleteCommit}
+      />
+      <PublishDraftCommitModal
+        commitId={publishCommit}
+        onClose={setPublishCommit}
+      />
+    </>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/index.tsx
@@ -103,7 +103,9 @@ export default function CommitSelector({
         <SelectValueWithIcon
           icon={<BadgeCommit badgeType={selected.badgeType} />}
         >
-          <Text.H5M>{selected.title}</Text.H5M>
+          <Text.H5M ellipsis noWrap userSelect={false}>
+            {selected.title}
+          </Text.H5M>
         </SelectValueWithIcon>
       </SelectTrigger>
       <SelectContent>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
@@ -1,0 +1,60 @@
+import { useMemo } from 'react'
+
+import {
+  ConfirmModal,
+  useCurrentProject,
+  useToast,
+} from '@latitude-data/web-ui'
+import { deleteDraftCommitAction } from '$/actions/commits/deleteDraftCommitAction'
+import { ROUTES } from '$/services/routes'
+import useCommits from '$/stores/commitsStore'
+import { ReactStateDispatch } from '$ui/lib/commonTypes'
+import { useRouter } from 'next/navigation'
+import { useServerAction } from 'zsa-react'
+
+export default function PublishDraftCommitModal({
+  commitId,
+  onClose,
+}: {
+  commitId: number | null
+  onClose: ReactStateDispatch<number | null>
+}) {
+  const { data, mutate } = useCommits()
+  const { toast } = useToast()
+  const commit = useMemo(() => data.find((c) => c.id === commitId), [commitId])
+  const { project } = useCurrentProject()
+  const router = useRouter()
+  const { execute, isPending } = useServerAction(deleteDraftCommitAction, {
+    persistErrorWhilePending: true,
+    persistDataWhilePending: true,
+    onSuccess: (result) => {
+      const deletedDraft = result.data
+      mutate(data.filter((item) => item.id !== deletedDraft.id))
+      router.push(ROUTES.projects.detail({ id: project.id }).commits.latest)
+      onClose(null)
+    },
+    onError: ({ err }) => {
+      toast({
+        title: 'Error',
+        description: err.message,
+        variant: 'destructive',
+      })
+    },
+  })
+  return (
+    <ConfirmModal
+      type='primary'
+      open={!!commit}
+      title={`Publishing ${commit?.title}`}
+      description='Publishing the version will publish all changes in your prompts to production. Review the changes carefully before publishing.'
+      onOpenChange={() => onClose(null)}
+      onConfirm={() => execute({ projectId: project.id, id: commitId! })}
+      confirm={{
+        label: 'Publish to production',
+        description:
+          'Publishing a new version will update all your prompts in production.',
+        isConfirming: isPending,
+      }}
+    />
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/index.tsx
@@ -40,7 +40,7 @@ export default async function Sidebar({
     <DocumentSidebar
       header={
         <CommitSelector
-          headCommitId={headCommit.id}
+          headCommit={headCommit}
           currentCommit={commit}
           draftCommits={draftCommits}
         />

--- a/packages/core/drizzle/0017_blushing_radioactive_man.sql
+++ b/packages/core/drizzle/0017_blushing_radioactive_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "latitude"."commits" ALTER COLUMN "title" SET NOT NULL;

--- a/packages/core/drizzle/0018_wealthy_dragon_man.sql
+++ b/packages/core/drizzle/0018_wealthy_dragon_man.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "latitude"."document_versions" DROP CONSTRAINT "document_versions_commit_id_commits_id_fk";
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "latitude"."document_versions" ADD CONSTRAINT "document_versions_commit_id_commits_id_fk" FOREIGN KEY ("commit_id") REFERENCES "latitude"."commits"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/core/drizzle/meta/0017_snapshot.json
+++ b/packages/core/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,821 @@
+{
+  "id": "b44b7a5d-af51-4675-9a13-ea46b08f0bc2",
+  "prevId": "32d113cb-1d1f-489e-af0d-86ded2971602",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "latitude.users": {
+      "name": "users",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "latitude.sessions": {
+      "name": "sessions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.workspaces": {
+      "name": "workspaces",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_creator_id_users_id_fk": {
+          "name": "workspaces_creator_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.memberships": {
+      "name": "memberships",
+      "schema": "latitude",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_workspace_id_user_id_pk": {
+          "name": "memberships_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "latitude.api_keys": {
+      "name": "api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_id_idx": {
+          "name": "workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_unique": {
+          "name": "api_keys_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "latitude.projects": {
+      "name": "projects",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_idx": {
+          "name": "workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.commits": {
+      "name": "commits",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_commit_order_idx": {
+          "name": "project_commit_order_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commits_user_id_users_id_fk": {
+          "name": "commits_user_id_users_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commits_uuid_unique": {
+          "name": "commits_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "latitude.document_versions": {
+      "name": "document_versions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved_content": {
+          "name": "resolved_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_uuid_commit_id_idx": {
+          "name": "document_uuid_commit_id_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_commit_id_commits_id_fk": {
+          "name": "document_versions_commit_id_commits_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_uuid_commit_id": {
+          "name": "unique_document_uuid_commit_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_uuid",
+            "commit_id"
+          ]
+        },
+        "unique_path_commit_id_deleted_at": {
+          "name": "unique_path_commit_id_deleted_at",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path",
+            "commit_id",
+            "deleted_at"
+          ]
+        }
+      }
+    },
+    "latitude.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_apikeys_workspace_id_idx": {
+          "name": "provider_apikeys_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_apikeys_user_id_idx": {
+          "name": "provider_apikeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_api_keys_author_id_users_id_fk": {
+          "name": "provider_api_keys_author_id_users_id_fk",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_api_keys_workspace_id_workspaces_id_fk": {
+          "name": "provider_api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_apikeys_token_provider_unique": {
+          "name": "provider_apikeys_token_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token",
+            "provider"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic"
+      ]
+    }
+  },
+  "schemas": {
+    "latitude": "latitude"
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/drizzle/meta/0018_snapshot.json
+++ b/packages/core/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,821 @@
+{
+  "id": "e4e67e08-d220-4bf9-aa69-334417087702",
+  "prevId": "b44b7a5d-af51-4675-9a13-ea46b08f0bc2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "latitude.users": {
+      "name": "users",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_password": {
+          "name": "encrypted_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "latitude.sessions": {
+      "name": "sessions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.workspaces": {
+      "name": "workspaces",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_creator_id_users_id_fk": {
+          "name": "workspaces_creator_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.memberships": {
+      "name": "memberships",
+      "schema": "latitude",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_workspace_id_user_id_pk": {
+          "name": "memberships_workspace_id_user_id_pk",
+          "columns": [
+            "workspace_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "latitude.api_keys": {
+      "name": "api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_id_idx": {
+          "name": "workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_unique": {
+          "name": "api_keys_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "latitude.projects": {
+      "name": "projects",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_idx": {
+          "name": "workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "latitude.commits": {
+      "name": "commits",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_commit_order_idx": {
+          "name": "project_commit_order_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commits_user_id_users_id_fk": {
+          "name": "commits_user_id_users_id_fk",
+          "tableFrom": "commits",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commits_uuid_unique": {
+          "name": "commits_uuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uuid"
+          ]
+        }
+      }
+    },
+    "latitude.document_versions": {
+      "name": "document_versions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved_content": {
+          "name": "resolved_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_uuid_commit_id_idx": {
+          "name": "document_uuid_commit_id_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_versions_commit_id_commits_id_fk": {
+          "name": "document_versions_commit_id_commits_id_fk",
+          "tableFrom": "document_versions",
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_document_uuid_commit_id": {
+          "name": "unique_document_uuid_commit_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "document_uuid",
+            "commit_id"
+          ]
+        },
+        "unique_path_commit_id_deleted_at": {
+          "name": "unique_path_commit_id_deleted_at",
+          "nullsNotDistinct": false,
+          "columns": [
+            "path",
+            "commit_id",
+            "deleted_at"
+          ]
+        }
+      }
+    },
+    "latitude.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_apikeys_workspace_id_idx": {
+          "name": "provider_apikeys_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_apikeys_user_id_idx": {
+          "name": "provider_apikeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_api_keys_author_id_users_id_fk": {
+          "name": "provider_api_keys_author_id_users_id_fk",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "provider_api_keys_workspace_id_workspaces_id_fk": {
+          "name": "provider_api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_api_keys",
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_apikeys_token_provider_unique": {
+          "name": "provider_apikeys_token_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token",
+            "provider"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "openai",
+        "anthropic"
+      ]
+    }
+  },
+  "schemas": {
+    "latitude": "latitude"
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -120,6 +120,20 @@
       "when": 1722439006092,
       "tag": "0016_nifty_the_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1722498737906,
+      "tag": "0017_blushing_radioactive_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1722510508496,
+      "tag": "0018_wealthy_dragon_man",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,7 +3,7 @@ export const LATITUDE_EMAIL = ''
 export const LATITUDE_HELP_URL = ''
 export const LATITUDE_SLACK_URL =
   'https://join.slack.com/t/trylatitude/shared_invite/zt-17dyj4elt-rwM~h2OorAA3NtgmibhnLA'
-export const HEAD_COMMIT = 'latest'
+export const HEAD_COMMIT = 'live'
 export const LATITUDE_CHANGELOG_URL = ''
 export enum CommitStatus {
   All = 'all',

--- a/packages/core/src/repositories/commitsRepository/index.ts
+++ b/packages/core/src/repositories/commitsRepository/index.ts
@@ -142,6 +142,7 @@ export class CommitsRepository extends Repository {
       })
       .from(this.scope)
       .where(and(eq(this.scope.projectId, project.id), filter))
+      .orderBy(desc(this.scope.createdAt))
 
     const result = await Repository.paginateQuery({
       query: query.$dynamic(),

--- a/packages/core/src/repositories/documentVersionsRepository/getDocumentsAtCommit.test.ts
+++ b/packages/core/src/repositories/documentVersionsRepository/getDocumentsAtCommit.test.ts
@@ -2,7 +2,7 @@ import type { Commit, DocumentVersion, Project } from '$core/browser'
 import { HEAD_COMMIT } from '$core/constants'
 import { mergeCommit, updateDocument } from '$core/services'
 import * as factories from '$core/tests/factories'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 import { CommitsRepository } from '../commitsRepository'
 import { DocumentVersionsRepository } from './index'
@@ -54,7 +54,7 @@ describe('getDocumentsAtCommit', () => {
   })
 
   describe('documents for each commit', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       const { project, user } = await factories.createProject()
       const documentsScope = new DocumentVersionsRepository(project.workspaceId)
       const { commit: commit1 } = await factories.createDraft({ project, user })
@@ -148,7 +148,7 @@ describe('getDocumentsAtCommit', () => {
   })
 
   describe('documents from previous commits', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       const { project, user } = await factories.createProject()
       const documentsScope = new DocumentVersionsRepository(project.workspaceId)
 

--- a/packages/core/src/schema/models/commits.ts
+++ b/packages/core/src/schema/models/commits.ts
@@ -20,7 +20,7 @@ export const commits = latitudeSchema.table(
       .notNull()
       .unique()
       .default(sql`gen_random_uuid()`),
-    title: varchar('title', { length: 256 }),
+    title: varchar('title', { length: 256 }).notNull(),
     description: text('description'),
     projectId: bigint('project_id', { mode: 'number' })
       .notNull()

--- a/packages/core/src/schema/models/documentVersions.ts
+++ b/packages/core/src/schema/models/documentVersions.ts
@@ -24,7 +24,7 @@ export const documentVersions = latitudeSchema.table(
     resolvedContent: text('resolved_content'),
     commitId: bigint('commit_id', { mode: 'number' })
       .notNull()
-      .references(() => commits.id),
+      .references(() => commits.id, { onDelete: 'cascade' }),
     deletedAt: timestamp('deleted_at'),
     ...timestamps(),
   },

--- a/packages/core/src/services/commits/create.ts
+++ b/packages/core/src/services/commits/create.ts
@@ -16,7 +16,7 @@ export async function createCommit({
   project: Project
   user: SafeUser
   data: {
-    title?: string
+    title: string
     description?: string
     mergedAt?: Date
   }

--- a/packages/core/src/services/commits/delete.ts
+++ b/packages/core/src/services/commits/delete.ts
@@ -1,0 +1,18 @@
+import { commits, database, Result, Transaction } from '@latitude-data/core'
+import { Commit } from '$core/browser'
+import { assertCommitIsDraft } from '$core/services/documents/utils'
+import { eq } from 'drizzle-orm'
+
+export async function deleteCommitDraft(commit: Commit, db = database) {
+  assertCommitIsDraft(commit).unwrap()
+
+  return Transaction.call<Commit>(async (tx) => {
+    const deleted = await tx
+      .delete(commits)
+      .where(eq(commits.id, commit.id))
+      .returning()
+
+    const deletedCommit = deleted[0]
+    return Result.ok(deletedCommit!)
+  }, db)
+}

--- a/packages/core/src/tests/factories/commits.ts
+++ b/packages/core/src/tests/factories/commits.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { Project, SafeUser } from '$core/browser'
 import { hasOwnProperty } from '$core/lib'
 import { createCommit as createCommitFn } from '$core/services/commits/create'
@@ -13,7 +14,13 @@ export async function createDraft({ project, user }: ICreateDraft) {
     ? (project as unknown as Project)
     : (await createProject(project)).project
 
-  const result = await createCommitFn({ project: projectModel, user, data: {} })
+  const result = await createCommitFn({
+    project: projectModel,
+    user,
+    data: {
+      title: faker.lorem.sentence(4),
+    },
+  })
   const commit = result.unwrap()
 
   return { commit }

--- a/packages/core/src/tests/useTestDatabase.ts
+++ b/packages/core/src/tests/useTestDatabase.ts
@@ -10,12 +10,10 @@ import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest'
 export default function useTestDatabase() {
   beforeAll(async () => {
     patchPgForTransactions()
-    await startTransaction()
   })
   beforeEach(startTransaction)
   afterEach(rollbackTransaction)
   afterAll(async () => {
-    await rollbackTransaction()
     unpatchPgForTransactions()
     await close()
   })

--- a/packages/web-ui/src/ds/atoms/Alert/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Alert/Primitives/index.tsx
@@ -9,6 +9,8 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: 'bg-background text-foreground',
+        primary:
+          'border-primary text-primary dark:border-primary [&>svg]:text-primary',
         destructive:
           'border-destructive text-destructive dark:border-destructive [&>svg]:text-destructive',
       },

--- a/packages/web-ui/src/ds/atoms/Button/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Button/index.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
           'border border-input hover:bg-accent hover:text-accent-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'shadow-none bg-transparent',
+        ghost: 'shadow-none bg-transparent text-muted-foreground',
         link: 'shadow-none underline-offset-4 hover:underline text-primary',
         linkDestructive:
           'shadow-none underline-offset-4 hover:underline text-destructive',
@@ -30,6 +30,7 @@ const buttonVariants = cva(
       size: {
         default: 'py-1.5 px-3',
         small: 'py-1 px-1.5',
+        none: 'py-0 px-0',
       },
     },
     defaultVariants: {
@@ -41,7 +42,7 @@ const buttonVariants = cva(
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants> & {
-    children: ReactNode
+    children?: ReactNode
     iconProps?: IconProps
     fullWidth?: boolean
     asChild?: boolean
@@ -63,6 +64,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   ref,
 ) {
   const Comp = asChild ? Slot : 'button'
+
+  if (!children && !iconProps) {
+    throw new Error('Button must have children or iconProps')
+  }
+
   return (
     <Comp
       disabled={isLoading}

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -7,8 +7,10 @@ import {
   Ellipsis,
   EllipsisVertical,
   File,
+  FilePlus,
   FolderClosed,
   FolderOpen,
+  FolderPlus,
   ListOrdered,
   LoaderCircle,
   Trash,
@@ -28,8 +30,10 @@ export const Icons = {
   ellipsis: Ellipsis,
   ellipsisVertical: EllipsisVertical,
   file: File,
+  filePlus: FilePlus,
   folderClose: FolderClosed,
   folderOpen: FolderOpen,
+  folderPlus: FolderPlus,
   listOrdered: ListOrdered,
   loader: LoaderCircle,
   logo: LatitudeLogo,
@@ -43,6 +47,7 @@ export type IconProps = {
   name: IconName
   color?: TextColor
   spin?: boolean
+  size?: string | number
   widthClass?: string
   heightClass?: string
 }

--- a/packages/web-ui/src/ds/atoms/Modal/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Modal/index.tsx
@@ -57,12 +57,12 @@ export function Modal({
 }
 
 type ConfirmModalProps = Omit<ModalProps, 'footer' | 'children'> & {
-  type?: 'default' | 'destructive'
+  type?: 'default' | 'primary' | 'destructive'
   confirm: {
     label: string
     title?: string
-    isConfirming?: boolean
     description?: string
+    isConfirming?: boolean
   }
   cancel?: { label?: string }
   onConfirm: () => void
@@ -90,7 +90,7 @@ export function ConfirmModal({
           </DialogClose>
           <Button
             isLoading={confirm.isConfirming}
-            variant={type}
+            variant={type === 'primary' ? 'default' : type}
             onClick={onConfirm}
           >
             {confirm.label}

--- a/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
@@ -145,34 +145,47 @@ SelectScrollDownButton.displayName =
 
 const SelectContent = forwardRef<
   ElementRef<typeof SelectPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className,
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    autoScroll?: boolean
+  }
+>(
+  (
+    { className, children, autoScroll = true, position = 'popper', ...props },
+    ref,
+  ) => (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-))
+        {autoScroll ? (
+          <>
+            <SelectScrollUpButton />
+            <SelectPrimitive.Viewport
+              className={cn(
+                'p-1',
+                position === 'popper' &&
+                  'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+              )}
+            >
+              {children}
+            </SelectPrimitive.Viewport>
+            <SelectScrollDownButton />
+          </>
+        ) : (
+          children
+        )}
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  ),
+)
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
 const SelectLabel = forwardRef<

--- a/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
@@ -34,7 +34,7 @@ function SelectValueWithIcon({
   children: ReactNode
 }) {
   return (
-    <div className='flex flex-row items-center gap-x-2'>
+    <div className='w-full flex flex-row items-center gap-x-2'>
       {icon}
       {children}
     </div>

--- a/packages/web-ui/src/ds/atoms/TextArea/index.tsx
+++ b/packages/web-ui/src/ds/atoms/TextArea/index.tsx
@@ -19,6 +19,7 @@ const inputVariants = cva(cn(INPUT_BASE_CLASSES), {
     size: 'normal',
   },
 })
+
 export type TextAreaProps = TextareaAutosizeProps &
   Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'height'> &
   VariantProps<typeof inputVariants> &

--- a/packages/web-ui/src/sections/Document/DetailWrapper/index.tsx
+++ b/packages/web-ui/src/sections/Document/DetailWrapper/index.tsx
@@ -50,13 +50,20 @@ export default function DocumentDetailWrapper({
     if (!panelGroup || !resizeHandles.length) return
 
     const observer = new ResizeObserver(() => {
-      let width = panelGroup.offsetWidth
+      const totalResizeHandlesWidth = Array.from(resizeHandles).reduce(
+        (sum, handle) => sum + handle.offsetWidth,
+        0,
+      )
+      const availableWidthAfterHandles =
+        panelGroup.offsetWidth - totalResizeHandlesWidth
 
-      resizeHandles.forEach((resizeHandle) => {
-        width -= resizeHandle.offsetWidth
-      })
-
-      setMinSize((MIN_SIDEBAR_WIDTH_PX / width) * 100)
+      const otherPanelsMinWidth = Math.max(
+        panelGroup.offsetWidth - MIN_SIDEBAR_WIDTH_PX,
+        0,
+      )
+      if (otherPanelsMinWidth > MIN_SIDEBAR_WIDTH_PX) {
+        setMinSize((MIN_SIDEBAR_WIDTH_PX / availableWidthAfterHandles) * 100)
+      }
     })
     observer.observe(panelGroup)
     resizeHandles.forEach((resizeHandle) => {
@@ -89,7 +96,7 @@ export default function DocumentDetailWrapper({
       onLayout={debouncedLayoutUpdate}
     >
       <ResizablePanel
-        className='w-72'
+        style={{ minWidth: MIN_SIDEBAR_WIDTH_PX }}
         defaultSize={resizableSizes?.[0] ?? DEFAULT_SIDEBAR_PERCENTAGE}
         minSize={minSize}
         maxSize={40}

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/DocumentHeader/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/DocumentHeader/index.tsx
@@ -12,6 +12,18 @@ import { useTempNodes } from '$ui/sections/Document/Sidebar/Files/useTempNodes'
 
 import { Node } from '../useTree'
 
+export function DocumentIcon(
+  { selected }: { selected?: boolean } = { selected: false },
+) {
+  return (
+    <Icons.file
+      className={cn(ICON_CLASS, {
+        'text-accent-foreground': selected,
+      })}
+    />
+  )
+}
+
 export default function DocumentHeader({
   open,
   selected,
@@ -48,6 +60,7 @@ export default function DocumentHeader({
       {
         label: 'Delete file',
         type: 'destructive',
+        iconProps: { name: 'trash' },
         onClick: () => {
           onDeleteFile({ node, documentUuid: node.doc!.documentUuid })
         },
@@ -57,21 +70,17 @@ export default function DocumentHeader({
   )
   return (
     <NodeHeaderWrapper
+      isFile
       open={open}
-      node={node}
+      name={node.name}
+      hasChildren={false}
       actions={actions}
       selected={selected}
       indentation={indentation}
       onClick={handleClick}
       onSaveValue={onSaveValue}
-      onLeaveWithoutSave={deleteTmpFolder}
-      icons={
-        <Icons.file
-          className={cn(ICON_CLASS, {
-            'text-accent-foreground': selected,
-          })}
-        />
-      }
+      onLeaveWithoutSave={() => deleteTmpFolder({ id: node.id })}
+      icons={<DocumentIcon selected={selected} />}
     />
   )
 }

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/FolderHeader/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/FolderHeader/index.tsx
@@ -13,6 +13,19 @@ import { useTempNodes } from '$ui/sections/Document/Sidebar/Files/useTempNodes'
 
 import { Node } from '../useTree'
 
+export function FolderIcons({ open }: { open: boolean }) {
+  const FolderIcon = open ? Icons.folderOpen : Icons.folderClose
+  const ChevronIcon = open ? Icons.chevronDown : Icons.chevronRight
+  return (
+    <>
+      <div className='min-w-6 h-6 flex items-center justify-center'>
+        <ChevronIcon className={cn(ICON_CLASS, 'h-4 w-4')} />
+      </div>
+      <FolderIcon className={ICON_CLASS} />
+    </>
+  )
+}
+
 export default function FolderHeader({
   node,
   open,
@@ -59,15 +72,22 @@ export default function FolderHeader({
       },
     [node.path, togglePath, open],
   )
-  const FolderIcon = open ? Icons.folderOpen : Icons.folderClose
-  const ChevronIcon = open ? Icons.chevronDown : Icons.chevronRight
   const actions = useMemo<MenuOption[]>(
     () => [
-      { label: 'New folder', onClick: onAddNode({ isFile: false }) },
-      { label: 'New Prompt', onClick: onAddNode({ isFile: true }) },
+      {
+        label: 'New folder',
+        iconProps: { name: 'folderPlus' },
+        onClick: onAddNode({ isFile: false }),
+      },
+      {
+        label: 'New Prompt',
+        iconProps: { name: 'filePlus' },
+        onClick: onAddNode({ isFile: true }),
+      },
       {
         label: 'Delete folder',
         type: 'destructive',
+        iconProps: { name: 'trash' },
         onClick: () => {
           if (node.isPersisted) {
             onDeleteFolder({ node, path: node.path })
@@ -89,22 +109,18 @@ export default function FolderHeader({
   )
   return (
     <NodeHeaderWrapper
+      name={node.name}
+      hasChildren={node.children.length > 0}
       onClick={onToggleOpen}
-      onSaveValue={updateFolder}
-      onSaveValueAndTab={onUpdateFolderAndAddOther}
-      onLeaveWithoutSave={deleteTmpFolder}
-      node={node}
+      onSaveValue={({ path }) => updateFolder({ id: node.id, path })}
+      onSaveValueAndTab={({ path }) =>
+        onUpdateFolderAndAddOther({ id: node.id, path })
+      }
+      onLeaveWithoutSave={() => deleteTmpFolder({ id: node.id })}
       open={open}
       actions={actions}
       indentation={indentation}
-      icons={
-        <>
-          <div className='min-w-6 h-6 flex items-center justify-center'>
-            <ChevronIcon className={cn(ICON_CLASS, 'h-4 w-4')} />
-          </div>
-          <FolderIcon className={ICON_CLASS} />
-        </>
-      }
+      icons={<FolderIcons open={open} />}
     />
   )
 }

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/NodeHeaderWrapper/useNodeValidator/index.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/NodeHeaderWrapper/useNodeValidator/index.ts
@@ -52,7 +52,7 @@ export function useNodeValidator({
   name: string | undefined
   inputRef: RefObject<HTMLInputElement>
   nodeRef: RefObject<HTMLDivElement>
-  saveValue: (args: { path: string }) => Promise<void>
+  saveValue: (args: { path: string }) => Promise<void> | void
   saveAndAddOther?: (args: { path: string }) => void
   leaveWithoutSave?: () => void
 }) {

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/TreeToolbar/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/TreeToolbar/index.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+
+import { Button, Text } from '$ui/ds/atoms'
+import { DocumentIcon } from '$ui/sections/Document/Sidebar/Files/DocumentHeader'
+import { useFileTreeContext } from '$ui/sections/Document/Sidebar/Files/FilesProvider'
+import { FolderIcons } from '$ui/sections/Document/Sidebar/Files/FolderHeader'
+import NodeHeaderWrapper from '$ui/sections/Document/Sidebar/Files/NodeHeaderWrapper'
+import { useTempNodes } from '$ui/sections/Document/Sidebar/Files/useTempNodes'
+
+export function TreeToolbar() {
+  const { addToRootFolder } = useTempNodes((s) => ({
+    addToRootFolder: s.addToRootFolder,
+  }))
+  const { onCreateFile } = useFileTreeContext()
+  const [nodeInput, setNodeInput] = useState<'file' | 'folder' | undefined>()
+  const isFile = nodeInput === 'file'
+  return (
+    <>
+      <div className='flex flex-row items-center justify-between px-4 mb-2'>
+        <Text.H5M>Files</Text.H5M>
+        <div className='flex flex-row space-x-2'>
+          <Button
+            variant='ghost'
+            size='none'
+            iconProps={{
+              name: 'folderPlus',
+              size: 16,
+              widthClass: 'w-6',
+              heightClass: 'h-6',
+            }}
+            onClick={() => setNodeInput('folder')}
+          />
+          <Button
+            variant='ghost'
+            size='none'
+            iconProps={{
+              name: 'filePlus',
+              size: 16,
+              widthClass: 'w-6',
+              heightClass: 'h-6',
+            }}
+            onClick={() => setNodeInput('file')}
+          />
+        </div>
+      </div>
+      {nodeInput ? (
+        <NodeHeaderWrapper
+          open={false}
+          hasChildren={false}
+          isFile={isFile}
+          name=' '
+          icons={isFile ? <DocumentIcon /> : <FolderIcons open={false} />}
+          indentation={[{ isLast: true }]}
+          onSaveValue={async ({ path }) => {
+            if (isFile) {
+              await onCreateFile(path)
+            } else {
+              addToRootFolder({ path })
+            }
+
+            setNodeInput(undefined)
+          }}
+          onLeaveWithoutSave={() => setNodeInput(undefined)}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/index.tsx
@@ -6,6 +6,7 @@ import { ConfirmModal } from '$ui/ds/atoms'
 import { cn } from '$ui/lib/utils'
 import DocumentHeader from '$ui/sections/Document/Sidebar/Files/DocumentHeader'
 import FolderHeader from '$ui/sections/Document/Sidebar/Files/FolderHeader'
+import { TreeToolbar } from '$ui/sections/Document/Sidebar/Files/TreeToolbar'
 
 import { FileTreeProvider, useFileTreeContext } from './FilesProvider'
 import { type IndentType } from './NodeHeaderWrapper'
@@ -83,7 +84,7 @@ function FileNode({
   }, [currentPath])
 
   return (
-    <div className='w-full'>
+    <div className='flex-1 w-full custom-scroll max-h-full'>
       <NodeHeader
         indentation={indentation}
         node={node}
@@ -190,12 +191,14 @@ export function FilesTree({
           setDeletable({ type: DeletableType.Folder, path, name: node.name })
         }}
       >
+        <TreeToolbar />
         <FileNode node={rootNode} />
       </FileTreeProvider>
+
       {deletableNode ? (
         <ConfirmModal
           type='destructive'
-          open
+          open={!!deletableNode}
           onConfirm={() => onConfirmDelete(deletableNode)}
           onOpenChange={(open) => {
             if (!open) {

--- a/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.test.ts
+++ b/packages/web-ui/src/sections/Document/Sidebar/Files/useTempNodes/index.test.ts
@@ -9,6 +9,24 @@ describe('useTempNodes', () => {
     useTempNodes.getState().reset()
   })
 
+  it('add a root folder', async () => {
+    const { result } = renderHook(() => useTempNodes((state) => state))
+
+    act(() => result.current.addToRootFolder({ path: 'some-folder' }))
+
+    expect(result.current.tmpFolders).toEqual({
+      '': [
+        new Node({
+          id: expect.any(String),
+          path: 'some-folder',
+          name: 'some-folder',
+          isFile: false,
+          isPersisted: false,
+        }),
+      ],
+    })
+  })
+
   it('should add a folder', async () => {
     const { result } = renderHook(() => useTempNodes((state) => state))
     act(() =>

--- a/packages/web-ui/src/sections/Document/Sidebar/index.tsx
+++ b/packages/web-ui/src/sections/Document/Sidebar/index.tsx
@@ -10,7 +10,7 @@ export default function DocumentSidebar({
   tree: ReactNode
 }) {
   return (
-    <aside className='flex flex-col gap-y-2 w-full'>
+    <aside className='flex flex-col gap-y-2 w-full h-full'>
       <div className='p-4 gap-y-2'>{header}</div>
       <div className='flex-1'>{tree}</div>
     </aside>

--- a/packages/web-ui/styles.css
+++ b/packages/web-ui/styles.css
@@ -2,68 +2,107 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  /* Chrome, Safari and Opera */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+    overflow: -moz-scrollbars-none; /* Firefox */
+  }
+
+  .custom-scrollbar {
+    /** Make scrollbar to not take space **/
+    overflow: overlay !important;
+  }
+  .custom-scrollbar::-webkit-scrollbar {
+    @apply w-5 h-5;
+  }
+
+  .custom-scrollbar.screenshot {
+    overflow: hidden !important;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    @apply bg-gray-400;
+    @apply rounded-full bg-clip-padding border-solid;
+    @apply border-transparent border-[6px];
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
+}
+
 @layer base {
   :root {
-    --background: #FFFFFF;
+    --background: #ffffff;
     --foreground: #030711;
 
-    --card: #FFFFFF;
+    --card: #ffffff;
     --card-foreground: #030711;
 
-    --popover: #FFF;
+    --popover: #fff;
     --popover-foreground: #030711;
 
-    --primary: #076AD5;
-    --primary-foreground: #F9FAFB;
+    --primary: #076ad5;
+    --primary-foreground: #f9fafb;
 
-    --secondary: #F9FAFB;
+    --secondary: #f9fafb;
     --secondary-foreground: #111827;
 
-    --muted: #F3F4F6;
-    --muted-foreground: #66727F;
+    --muted: #f3f4f6;
+    --muted-foreground: #66727f;
 
-    --accent: #EFF7FF;
-    --accent-foreground: #0356B0;
+    --accent: #eff7ff;
+    --accent-foreground: #0356b0;
 
-    --destructive: #DC2828;
-    --destructive-foreground: #FAFAFA;
+    --destructive: #dc2828;
+    --destructive-foreground: #fafafa;
 
-    --border: #E5E7EB;
-    --input: #E5E7EB;
-    --ring: #076AD5;
+    --border: #e5e7eb;
+    --input: #e5e7eb;
+    --ring: #076ad5;
 
     --radius: 0.5rem;
   }
 
   .dark {
-    --background: #0C0C12;
-    --foreground: #F3F4F6;
+    --background: #0c0c12;
+    --foreground: #f3f4f6;
 
     --card: #030711;
-    --card-foreground: #F3F4F6;
+    --card-foreground: #f3f4f6;
 
     --popover: #030711;
-    --popover-foreground: #F3F4F6;
+    --popover-foreground: #f3f4f6;
 
-    --primary: #0A81FF;
+    --primary: #0a81ff;
     --primary-foreground: #031930;
 
     --secondary: #111827;
-    --secondary-foreground: #D1D5DB;
+    --secondary-foreground: #d1d5db;
 
-    --muted: #1F2937;
-    --muted-foreground: #66727F;
+    --muted: #1f2937;
+    --muted-foreground: #66727f;
 
-    --accent: #013D79;
-    --accent-foreground: #8BC4FD;
+    --accent: #013d79;
+    --accent-foreground: #8bc4fd;
 
-    --destructive: #811D1D;
-    --destructive-foreground: #FEF1F1;
+    --destructive: #811d1d;
+    --destructive-foreground: #fef1f1;
 
-    --border: #1F2937;
-    --input: #1F2937;
+    --border: #1f2937;
+    --input: #1f2937;
 
-    --ring: #0A81FF;
+    --ring: #0a81ff;
   }
 }
 

--- a/packages/web-ui/vitest.config.mjs
+++ b/packages/web-ui/vitest.config.mjs
@@ -1,5 +1,6 @@
-import { defineConfig } from 'vitest/config'
 import { resolve } from 'path'
+
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   resolve: {


### PR DESCRIPTION
# What?
Finish working on commits selector from this PR https://github.com/latitude-dev/latitude-llm/pull/78

## TODO
- [x] UI for selector list
- [x] Delete Draft commit modal
- [x] Add icons for adding folder and document

### Next PR
- [ ] Get list of changes `recomputeChanges` method + get documents in main and check diff. Also recompute changes gives me the errors.
- [ ] Do not allow to merge of recompute changes is 0. Put this condition inside `mergeCommit`
- [ ] Publish draft commit modal
- [ ] DISABLE In sidebar actions when a commit is `live`
- [ ] Sidebar documents tree scrollable
- [ ] Mismatch React server and frontend in sidebar
- [ ] Fix sidebar resizable. It does not save the width and when the browser resizes it resizes the sidebar without user intervention
- [ ] Add `v1`, `v2`, `v3`... column to unique and nullable so we can track what version we're working or what version had the best performance.