### PR TITLE
Compiler: detect circular references

### DIFF
--- a/apps/web/src/actions/documents/updateContent.test.ts
+++ b/apps/web/src/actions/documents/updateContent.test.ts
@@ -1,0 +1,110 @@
+import { factories, updateDocument } from '@latitude-data/core'
+import { DocumentVersion, Project, SafeUser } from '$core/browser'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { updateDocumentContentAction } from './updateContent'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+  }
+})
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+
+describe('updateDocumentAction', async () => {
+  describe('unauthorized', () => {
+    let projectId: number
+    let doc1: DocumentVersion
+
+    beforeEach(async () => {
+      const { workspace } = await factories.createWorkspace()
+      const { documents, project } = await factories.createProject({
+        workspace,
+        documents: {
+          doc1: 'foo',
+        },
+      })
+      doc1 = documents.filter((d) => d.path === 'doc1')[0]!
+      projectId = project.id
+    })
+
+    it('errors when the user is not authenticated', async () => {
+      const [_, error] = await updateDocumentContentAction({
+        projectId,
+        documentUuid: doc1.documentUuid,
+        commitId: doc1.commitId,
+        content: 'foo2',
+      })
+
+      expect(error!.name).toEqual('UnauthorizedError')
+    })
+  })
+
+  describe('authorized', () => {
+    let project: Project
+    let doc1: DocumentVersion
+    let user: SafeUser
+
+    beforeEach(async () => {
+      const { workspace, userData } = await factories.createWorkspace()
+      const { documents, project: projectData } = await factories.createProject(
+        {
+          workspace,
+          documents: {
+            doc1: 'foo',
+          },
+        },
+      )
+      doc1 = documents.filter((d) => d.path === 'doc1')[0]!
+      project = projectData
+      user = userData
+
+      mocks.getSession.mockReturnValue({
+        user: userData,
+      })
+    })
+
+    it('modifies the document version when it already exists in the draft', async () => {
+      const { commit: draft } = await factories.createDraft({ project, user })
+      await updateDocument({
+        commit: draft,
+        document: doc1,
+        content: 'foo2',
+      })
+
+      const [data, error] = await updateDocumentContentAction({
+        projectId: project.id,
+        documentUuid: doc1.documentUuid,
+        commitId: draft.id,
+        content: 'foo3',
+      })
+
+      expect(error).toBeNull()
+      expect(data).toMatchObject({
+        documentUuid: doc1.documentUuid,
+        commitId: draft.id,
+        content: 'foo3',
+      })
+    })
+
+    it('creates a new document version when it does not exist in the draft', async () => {
+      const { commit: draft } = await factories.createDraft({ project, user })
+
+      const [data, error] = await updateDocumentContentAction({
+        projectId: project.id,
+        documentUuid: doc1.documentUuid,
+        commitId: draft.id,
+        content: 'foo2',
+      })
+
+      expect(error).toBeNull()
+      expect(data).toMatchObject({
+        documentUuid: doc1.documentUuid,
+        commitId: draft.id,
+        content: 'foo2',
+      })
+    })
+  })
+})

--- a/apps/web/src/actions/documents/updateContent.ts
+++ b/apps/web/src/actions/documents/updateContent.ts
@@ -26,7 +26,7 @@ export const updateDocumentContentAction = withProject
       .then((r) => r.unwrap())
     const docsScope = new DocumentVersionsRepository(ctx.project.workspaceId)
     const document = await docsScope
-      .getDocumentByUuid({
+      .getDocumentAtCommit({
         commit,
         documentUuid: input.documentUuid,
       })

--- a/packages/compiler/src/compiler/compile.ts
+++ b/packages/compiler/src/compiler/compile.ts
@@ -47,8 +47,6 @@ class StopIteration extends Error {
   }
 }
 
-export type ReferencePromptFn = (prompt: string) => Promise<string>
-
 export class Compile {
   private ast: Fragment
   private rawText: string

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -1,8 +1,11 @@
 import { Conversation, ConversationMetadata } from '$compiler/types'
 
 import { Chain } from './chain'
-import { type ReferencePromptFn } from './compile'
-import { ReadMetadata } from './readMetadata'
+import {
+  ReadMetadata,
+  type Document,
+  type ReferencePromptFn,
+} from './readMetadata'
 
 export async function render({
   prompt,
@@ -31,12 +34,17 @@ export function createChain({
 
 export function readMetadata({
   prompt,
+  fullPath,
   referenceFn,
 }: {
   prompt: string
+  fullPath?: string
   referenceFn?: ReferencePromptFn
 }): Promise<ConversationMetadata> {
-  return new ReadMetadata({ prompt, referenceFn }).run()
+  return new ReadMetadata({
+    document: { path: fullPath ?? '', content: prompt },
+    referenceFn,
+  }).run()
 }
 
-export { Chain }
+export { Chain, type Document, type ReferencePromptFn }

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -8,6 +8,7 @@ export const CUSTOM_MESSAGE_ROLE_ATTR = 'role' as const
 // <ref prompt="…">
 export const REFERENCE_PROMPT_TAG = 'ref' as const
 export const REFERENCE_PROMPT_ATTR = 'prompt' as const
+export const REFERENCE_DEPTH_LIMIT = 50
 
 // <tool_call id="…" name="…">{ content }</tool_call>
 export const TOOL_CALL_TAG = 'tool-call' as const

--- a/packages/compiler/src/error/errors.ts
+++ b/packages/compiler/src/error/errors.ts
@@ -1,5 +1,7 @@
 import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$compiler/constants'
 
+import CompileError from './error'
+
 function getKlassName(error: unknown): string {
   const errorKlass = error as Error
   return errorKlass.constructor ? errorKlass.constructor.name : 'Error'
@@ -158,10 +160,6 @@ export default {
     code: 'message-tag-without-role',
     message: 'Message tags must have a role attribute',
   },
-  invalidReferencePromptPlacement: {
-    code: 'invalid-reference-prompt-placement',
-    message: 'Reference tags must not be inside of other tags',
-  },
   referenceTagWithoutPrompt: {
     code: 'reference-tag-without-prompt',
     message: 'Reference tags must have a prompt attribute',
@@ -170,17 +168,32 @@ export default {
     code: 'missing-reference-function',
     message: 'A reference function was not provided',
   },
+  circularReference: {
+    code: 'circular-reference',
+    message: 'There is a circular reference',
+  },
   didNotResolveReferences: {
     code: 'did-not-resolve-references',
     message:
       'Cannot compile reference tags. Make sure you have resolved the references before compiling.',
+  },
+  referenceNotFound: {
+    code: 'reference-not-found',
+    message: 'The referenced document does not exist',
+  },
+  referenceDepthLimit: {
+    code: 'reference-depth-limit',
+    message: 'The reference depth limit has been reached',
   },
   referenceError: (err: unknown) => {
     const error = err as Error
     const errorKlassName = getKlassName(error)
     return {
       code: 'reference-error',
-      message: `There was an error referencing the prompt: \n${errorKlassName} ${error.message}`,
+      message:
+        error instanceof CompileError
+          ? `The referenced prompt contains an error: \n${error.message}`
+          : `There was an error referencing the prompt: \n${errorKlassName}: ${error.message}`,
     }
   },
   referenceTagHasContent: {

--- a/packages/core/src/services/documents/update.test.ts
+++ b/packages/core/src/services/documents/update.test.ts
@@ -74,18 +74,18 @@ describe('updateDocument', () => {
 
     const docsScope = new DocumentVersionsRepository(project.workspaceId)
     const referencedDoc = documents.find((d) => d.path === 'referenced/doc')!
-    const { commit } = await ctx.factories.createDraft({ project, user })
+    const { commit: draft } = await ctx.factories.createDraft({ project, user })
 
     await updateDocument({
-      commit,
+      commit: draft,
       document: referencedDoc,
       content: 'The document that is being referenced v2',
     }).then((r) => r.unwrap())
 
-    await recomputeChanges(commit)
+    await recomputeChanges(draft)
 
     const changedDocuments = await docsScope
-      .listCommitChanges(commit)
+      .listCommitChanges(draft)
       .then((r) => r.unwrap())
 
     expect(changedDocuments.length).toBe(2)


### PR DESCRIPTION
1. Detect circular references on prompts and display them as an error.
2. Errors raised from referenced prompts are also shown in the prompt that references it.
3. We now use UNIX-like relative references.

https://github.com/user-attachments/assets/0a51e6a1-dd17-4b2a-883c-5e5169ab60d7

Note: There's a bug in the video where the circular dependency is not shown until reloading the file. This is fixed.