### PR TITLE
Chain: do not add response as message when storing it as a variable

### DIFF
--- a/packages/compiler/src/compiler/base/nodes/tags/chainStep.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/chainStep.ts
@@ -23,6 +23,7 @@ export async function compile(
   }: CompileNodeContext<ChainStepTag>,
   attributes: Record<string, unknown>,
 ) {
+  groupContent()
   const stepResponse = popStepResponse()
 
   const { as: varName, ...config } = attributes
@@ -46,8 +47,7 @@ export async function compile(
       .join(' ')
 
     scope.set(String(varName), responseText)
+  } else {
+    addMessage(stepResponse!)
   }
-
-  groupContent()
-  addMessage(stepResponse!)
 }

--- a/packages/compiler/src/compiler/chain.test.ts
+++ b/packages/compiler/src/compiler/chain.test.ts
@@ -407,8 +407,26 @@ describe('chain', async () => {
   it('saves the response in a variable', async () => {
     const prompt = removeCommonIndent(`
       <${CHAIN_STEP_TAG} as="response" />
-      
-      {{response}}
+      <user>{{response}}</user>
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: {},
+    })
+
+    await chain.step()
+    const { conversation } = await chain.step('foo')
+
+    expect(conversation.messages.length).toBe(1)
+    expect(conversation.messages[0]!.content[0]!.value).toBe('foo')
+  })
+
+  it('does not add messages using the as attribute', async () => {
+    const prompt = removeCommonIndent(`
+      <user>msg1</user>
+      <${CHAIN_STEP_TAG} as="response" />
+      <user>msg2</user>
     `)
 
     const chain = new Chain({
@@ -420,8 +438,8 @@ describe('chain', async () => {
     const { conversation } = await chain.step('foo')
 
     expect(conversation.messages.length).toBe(2)
-    expect(conversation.messages[0]!.content[0]!.value).toBe('foo')
-    expect(conversation.messages[1]!.content[0]!.value).toBe('foo')
+    expect(conversation.messages[0]!.content[0]!.value).toBe('msg1')
+    expect(conversation.messages[1]!.content[0]!.value).toBe('msg2')
   })
 
   it('returns the correct configuration in all steps', async () => {

--- a/packages/compiler/src/compiler/readMetadata.ts
+++ b/packages/compiler/src/compiler/readMetadata.ts
@@ -514,11 +514,11 @@ export class ReadMetadata {
 
         if (attributes.has('as')) {
           const asAttribute = node.attributes.find((a) => a.name === 'as')!
-          const asValue = (asAttribute.value as TemplateNode[])
-            .map((n) => n.value)
-            .join('')
+          if (asAttribute.value !== true) {
+            const asValue = asAttribute.value.map((n) => n.data).join('')
 
-          scopeContext.definedVariables.add(asValue)
+            scopeContext.definedVariables.add(asValue)
+          }
         }
 
         return


### PR DESCRIPTION
## Without `as` attribute:
(See the `Assistant` message between `Foo` and `Bar`)
<img width="873" alt="image" src="https://github.com/user-attachments/assets/0dfa35f8-dc39-4ef0-a9b8-27ccccc7bdd8">

## With `as` attribute:
(See the lack of `Assistant` message between `Foo` and `Bar`)
<img width="873" alt="image" src="https://github.com/user-attachments/assets/9471ef1f-edba-4052-8a8f-708885851688">
