### PR TITLE
Fix: edit document

### DIFF
--- a/apps/web/src/actions/commits/publishDraftCommit.test.ts
+++ b/apps/web/src/actions/commits/publishDraftCommit.test.ts
@@ -62,7 +62,7 @@ describe('publishDraftCommitAction', () => {
 
     it('returns error when project is not found', async () => {
       const [_, error] = await publishDraftCommitAction({
-        projectId: 33,
+        projectId: 999992,
         id: commit.id,
       })
 

--- a/apps/web/src/actions/documents/create.ts
+++ b/apps/web/src/actions/documents/create.ts
@@ -10,13 +10,14 @@ export const createDocumentVersionAction = withProject
   .input(
     z.object({
       path: z.string(),
-      commitUuid: z.string(),
+      commitId: z.number(),
     }),
     { type: 'json' },
   )
   .handler(async ({ input, ctx }) => {
-    const commit = await new CommitsRepository(ctx.project.workspaceId)
-      .getCommitByUuid({ uuid: input.commitUuid, project: ctx.project })
+    const commitsScope = new CommitsRepository(ctx.project.workspaceId)
+    const commit = await commitsScope
+      .getCommitById(input.commitId)
       .then((r) => r.unwrap())
 
     const result = await createNewDocument({

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -21,7 +21,6 @@ import {
   DocumentTextEditorFallback,
   DropdownMenu,
   useCurrentCommit,
-  useCurrentProject,
   useLocalStorage,
 } from '@latitude-data/web-ui'
 import useDocumentVersions from '$/stores/documentVersions'
@@ -67,15 +66,12 @@ export default function DocumentEditor({
   })
 
   const { commit } = useCurrentCommit()
-  const { project } = useCurrentProject()
 
   const debouncedSave = useDebouncedCallback(
     (val: string) => {
       updateContent({
         documentUuid: document.documentUuid,
         content: val,
-        projectId: project.id,
-        commitId: document.commitId,
       })
       setIsSaved(true)
     },


### PR DESCRIPTION
Editing documents from a new draft was always failing because it tried to perform the update on the HEAD commit instead.