### PR TITLE
Rename document tags

### DIFF
--- a/packages/compiler/src/compiler/chain.test.ts
+++ b/packages/compiler/src/compiler/chain.test.ts
@@ -445,9 +445,9 @@ describe('chain', async () => {
       model: foo-1
       temperature: 0.5
       ---
-      <step />                /* step1 */
-      <step model="foo-2" />  /* step2 */
-      <step temperature=1 />  /* step3 */
+      <response />                /* step1 */
+      <response model="foo-2" />  /* step2 */
+      <response temperature=1 />  /* step3 */
     `)
 
     const chain = new Chain({

--- a/packages/compiler/src/compiler/compile.test.ts
+++ b/packages/compiler/src/compiler/compile.test.ts
@@ -319,7 +319,7 @@ describe('reference tags', async () => {
     const prompts = {
       main: removeCommonIndent(`
         This is the main prompt.
-        <ref prompt="user_messages" />
+        <prompt path="user_messages" />
         The end.
       `),
       user_messages: removeCommonIndent(`

--- a/packages/compiler/src/compiler/readMetadata.test.ts
+++ b/packages/compiler/src/compiler/readMetadata.test.ts
@@ -25,7 +25,7 @@ describe('resolvedPrompt', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         This is the parent prompt.
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent('Lorem ipsum'),
@@ -53,7 +53,7 @@ describe('resolvedPrompt', async () => {
         <user name={{ username }}>
           Test
         </user>
-        <ref prompt="child" />
+        <prompt path="child" />
         <foo>
           This tag does not even exist
         </foo>
@@ -89,11 +89,11 @@ describe('resolvedPrompt', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         Parent:
-        <ref prompt="child" />
+        <prompt path="child" />
       `),
       child: removeCommonIndent(`
         Child:
-        <ref prompt="grandchild" />
+        <prompt path="grandchild" />
       `),
       grandchild: removeCommonIndent(`
         Grandchild.
@@ -118,9 +118,9 @@ describe('resolvedPrompt', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         {{#if foo}}
-          <ref prompt="child1" />
+          <prompt path="child1" />
         {{:else}}
-          <ref prompt="child2" />
+          <prompt path="child2" />
         {{/if}}
       `),
       child1: removeCommonIndent(`
@@ -151,7 +151,7 @@ describe('resolvedPrompt', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         This is the parent prompt.
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
     }
@@ -164,7 +164,7 @@ describe('resolvedPrompt', async () => {
     expect(cleanParentMetadata.resolvedPrompt).toBe(
       removeCommonIndent(`
       This is the parent prompt.
-      /* <ref prompt="child" /> */
+      /* <prompt path="child" /> */
       The end.
     `),
     )
@@ -177,7 +177,7 @@ describe('resolvedPrompt', async () => {
         config: parent
         ---
         Parent.
-        <ref prompt="child" />
+        <prompt path="child" />
       `),
       child: removeCommonIndent(`
         ---
@@ -208,7 +208,7 @@ describe('resolvedPrompt', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         Parent. /* This is the parent document */
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent(`
@@ -319,7 +319,7 @@ describe('referenced prompts', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         This is the parent prompt.
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent('Lorem ipsum'),
@@ -346,7 +346,7 @@ describe('referenced prompts', async () => {
         This is the parent prompt.
         ${CUSTOM_TAG_START}parentParam${CUSTOM_TAG_END}
         ${CUSTOM_TAG_START}parentDefinedVar = 5${CUSTOM_TAG_END}
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent(`
@@ -386,12 +386,12 @@ describe('syntax errors', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         This is the parent prompt.
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent(`
         This is the child prompt.
-        <ref prompt="parent" />
+        <prompt path="parent" />
       `),
     }
 
@@ -409,7 +409,7 @@ describe('syntax errors', async () => {
     const prompts = {
       parent: removeCommonIndent(`
         This is the parent prompt.
-        <ref prompt="child" />
+        <prompt path="child" />
         The end.
       `),
       child: removeCommonIndent(`

--- a/packages/compiler/src/constants.ts
+++ b/packages/compiler/src/constants.ts
@@ -5,12 +5,13 @@ export const CUSTOM_TAG_END = '}}'
 export const CUSTOM_MESSAGE_TAG = 'message' as const
 export const CUSTOM_MESSAGE_ROLE_ATTR = 'role' as const
 
-// <ref prompt="…">
-export const REFERENCE_PROMPT_TAG = 'ref' as const
-export const REFERENCE_PROMPT_ATTR = 'prompt' as const
+// <prompt path="…" />
+export const REFERENCE_PROMPT_TAG = 'prompt' as const
+export const REFERENCE_PROMPT_ATTR = 'path' as const
 export const REFERENCE_DEPTH_LIMIT = 50
 
 // <tool_call id="…" name="…">{ content }</tool_call>
 export const TOOL_CALL_TAG = 'tool-call' as const
 
-export const CHAIN_STEP_TAG = 'step' as const
+// <response as="…" />
+export const CHAIN_STEP_TAG = 'response' as const

--- a/packages/core/src/repositories/documentLogsRepository/getDocumentLogsWithMetadata.test.ts
+++ b/packages/core/src/repositories/documentLogsRepository/getDocumentLogsWithMetadata.test.ts
@@ -180,7 +180,7 @@ describe('getDocumentLogsWithMetadata', () => {
     const { commit } = await factories.createDraft({ project, user })
     const { documentVersion: doc } = await factories.createDocumentVersion({
       commit,
-      content: documentContent('<step/>\n<step/>'),
+      content: documentContent('<response/>\n<response/>'),
     })
     await mergeCommit(commit).then((r) => r.unwrap())
 

--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -119,7 +119,7 @@ model: gpt-4o
 
 
 This is a test document
-<step />`)
+<response />`)
     })
 
     it('pass params to AI', async () => {
@@ -281,7 +281,7 @@ model: gpt-4o
 ---
 
 This is a test document
-<step />
+<response />
 `
 
 async function buildData({ doc1Content = '' }: { doc1Content?: string } = {}) {

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -66,7 +66,7 @@ model: gpt-4o
 ---
 
 This is a test document
-<step />
+<response />
 `
 
 let document: DocumentVersion

--- a/packages/core/src/services/documents/update.test.ts
+++ b/packages/core/src/services/documents/update.test.ts
@@ -70,7 +70,7 @@ describe('updateDocument', () => {
           referenced: {
             doc: 'The document that is being referenced',
           },
-          unmodified: '<ref prompt="referenced/doc" />',
+          unmodified: '<prompt path="referenced/doc" />',
         },
       })
 
@@ -104,7 +104,7 @@ describe('updateDocument', () => {
           referenced: {
             doc: 'The document that is being referenced',
           },
-          main: '<ref prompt="referenced/doc" />',
+          main: '<prompt path="referenced/doc" />',
         },
       })
     const docsScope = new DocumentVersionsRepository(project.workspaceId)
@@ -138,7 +138,7 @@ describe('updateDocument', () => {
           referenced: {
             doc: 'The document that is being referenced',
           },
-          unmodified: '<ref prompt="referenced/doc" />',
+          unmodified: '<prompt path="referenced/doc" />',
         },
       })
     const docsScope = new DocumentVersionsRepository(project.workspaceId)

--- a/packages/core/src/tests/factories/helpers.ts
+++ b/packages/core/src/tests/factories/helpers.ts
@@ -31,7 +31,7 @@ model: ${model ?? faker.internet.domainName()}
 ---
 ${Array.from({ length: steps ?? 1 })
   .map(() => randomSentence())
-  .join('\n<step />\n')}
+  .join('\n<response />\n')}
 `.trim()
 
   return prompt


### PR DESCRIPTION
Renamed the following tags:
- `<step/>` → `<response/>`
- `<ref prompt="…" />` → `<prompt path="…" />`