### PR TITLE
Fix batch range line selector and also allow to create logs on draft commits

### DIFF
--- a/apps/web/src/actions/evaluations/runBatch.ts
+++ b/apps/web/src/actions/evaluations/runBatch.ts
@@ -102,6 +102,8 @@ export const runBatchEvaluationAction = withDataset
         evaluation,
         dataset: ctx.dataset,
         document: ctx.document,
+        projectId: ctx.project.id,
+        commitUuid: ctx.currentCommitUuid,
         fromLine: input.fromLine,
         toLine: input.toLine,
         parametersMap: input.parameters,

--- a/apps/web/src/actions/procedures/index.ts
+++ b/apps/web/src/actions/procedures/index.ts
@@ -54,5 +54,5 @@ export const widthDocument = createServerActionProcedure(withProject)
       })
       .then((r) => r.unwrap())
 
-    return { ...ctx, document }
+    return { ...ctx, document, currentCommitUuid: input.commitUuid }
   })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -120,6 +120,7 @@ export default function DocumentEditor({
     }).then(setMetadata)
   }, [readDocument])
 
+  const isMerged = commit.mergedAt !== null
   return (
     <DocumentEditorContext.Provider
       value={{
@@ -130,6 +131,7 @@ export default function DocumentEditor({
       <div className='flex flex-row w-full h-full gap-8 p-6'>
         <div className='flex flex-col flex-1 flex-grow flex-shrink gap-2 min-w-0'>
           <EditorHeader
+            disabledMetadataSelectors={isMerged}
             title='Prompt editor'
             metadata={metadata}
             prompt={value}
@@ -141,9 +143,7 @@ export default function DocumentEditor({
               metadata={metadata}
               onChange={onChange}
               readOnlyMessage={
-                commit.mergedAt
-                  ? 'Create a draft to edit documents.'
-                  : undefined
+                isMerged ? 'Create a draft to edit documents.' : undefined
               }
               isSaved={isSaved}
             />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/index.tsx
@@ -165,7 +165,7 @@ export function BigNumberPanels({
     <div className='flex flex-wrap gap-6'>
       <Panel label='Total logs' value={String(evaluationResults.length)} />
       <Panel label='Total cost' value={formatCostInMillicents(totalCost)} />
-      <Panel label='Total cost' value={String(totalTokens)} />
+      <Panel label='Total tokens' value={String(totalTokens)} />
       <TypeSpecificPanel
         evaluation={evaluation}
         evaluationResults={evaluationResults}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/DatasetForm/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/DatasetForm/index.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 
 import { Dataset } from '@latitude-data/core/browser'
 import {
   FormFieldGroup,
   Input,
   NumeredList,
+  ReactStateDispatch,
   Select,
   SelectOption,
   SwitchInput,
@@ -14,14 +15,15 @@ function LineRangeInputs({
   disabled,
   fromDefaultValue,
   toDefaultValue,
+  onChangeToLine,
   max,
 }: {
   disabled: boolean
   fromDefaultValue: number | undefined
   toDefaultValue: number | undefined
+  onChangeToLine: ReactStateDispatch<number | undefined>
   max: number | undefined
 }) {
-  const [to, setTo] = useState(toDefaultValue)
   return (
     <FormFieldGroup>
       <Input
@@ -31,8 +33,8 @@ function LineRangeInputs({
         label='From line'
         defaultValue={fromDefaultValue}
         placeholder='Starting line'
-        min={0}
-        max={to}
+        min={1}
+        max={toDefaultValue}
       />
       <Input
         disabled={disabled}
@@ -41,8 +43,10 @@ function LineRangeInputs({
         label='To line'
         placeholder='Ending line'
         defaultValue={toDefaultValue}
-        onChange={(e) => setTo(Number(e.target.value))}
-        min={0}
+        onChange={(e) => {
+          onChangeToLine(Number(e.target.value))
+        }}
+        min={fromDefaultValue}
         max={max}
       />
     </FormFieldGroup>
@@ -56,6 +60,7 @@ export default function DatasetForm({
   wantAllLines,
   fromLine,
   toLine,
+  onChangeToLine,
   datasets,
   isLoadingDatasets,
   parametersList,
@@ -68,6 +73,7 @@ export default function DatasetForm({
   wantAllLines: boolean
   fromLine: number | undefined
   toLine: number | undefined
+  onChangeToLine: ReactStateDispatch<number | undefined>
   headers: SelectOption[]
   selectedDataset: Dataset | null
   datasets: Dataset[]
@@ -122,6 +128,7 @@ export default function DatasetForm({
                 disabled={wantAllLines}
                 fromDefaultValue={fromLine}
                 toDefaultValue={toLine}
+                onChangeToLine={onChangeToLine}
                 max={selectedDataset?.fileMetadata?.rowCount}
               />
               <SwitchInput

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/index.tsx
@@ -94,6 +94,7 @@ export default function CreateBatchEvaluationModal({
         wantAllLines={form.wantAllLines}
         fromLine={form.fromLine}
         toLine={form.toLine}
+        onChangeToLine={form.setToLine}
         headers={form.headers}
         parametersList={form.parametersList}
         onParametersChange={form.onParameterChange}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/useRunBatchForm.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/useRunBatchForm.ts
@@ -50,7 +50,7 @@ export function useRunBatchForm({
 
       setSelectedDataset(ds)
       setParameters(buildEmptyParameters(parametersList))
-      setFromLine(0)
+      setFromLine(1)
       setToLine(ds.fileMetadata.rowCount)
       setHeaders([
         { value: '-1', label: '-- Leave this parameter empty' },

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { computeEvaluationResultsWithMetadata } from '@latitude-data/core/services/evaluationResults/computeEvaluationResultsWithMetadata'
 import { TableWithHeader, Text } from '@latitude-data/web-ui'
+import { findCommitCached } from '$/app/(private)/_data-access'
 import BreadcrumpLink from '$/components/BreadcrumpLink'
 import { Breadcrump } from '$/components/layouts/AppLayout/Header'
 import { getCurrentUser } from '$/services/auth/getCurrentUser'
@@ -30,10 +31,15 @@ export default async function ConnectedEvaluationLayout({
     .find(params.evaluationId)
     .then((r) => r.unwrap())
 
+  const commit = await findCommitCached({
+    projectId: Number(params.projectId),
+    uuid: params.commitUuid,
+  })
   const evaluationResults = await computeEvaluationResultsWithMetadata({
     workspaceId: evaluation.workspaceId,
     evaluation,
     documentUuid: params.documentUuid,
+    draft: commit,
   }).then((r) => r.unwrap())
 
   return (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -30,8 +30,8 @@ export default function RootLayout({
         <NextTopLoader showSpinner={false} />
         <ThemeProvider
           attribute='class'
-          defaultTheme='system'
-          enableSystem
+          defaultTheme='light'
+          enableSystem={false}
           disableTransitionOnChange
         >
           <TooltipProvider>{children}</TooltipProvider>

--- a/apps/web/src/components/EditorHeader/index.tsx
+++ b/apps/web/src/components/EditorHeader/index.tsx
@@ -53,12 +53,14 @@ export default function EditorHeader({
   metadata,
   onChangePrompt,
   rightActions,
+  disabledMetadataSelectors = false,
 }: {
   title: string
   metadata: ConversationMetadata | undefined
   prompt: string
   onChangePrompt: (prompt: string) => void
   rightActions?: ReactNode
+  disabledMetadataSelectors?: boolean
 }) {
   const promptMetadata = useMemo<PromptMeta>(() => {
     const config = metadata?.config
@@ -204,13 +206,16 @@ export default function EditorHeader({
         <Select
           name='provider'
           label='Provider'
-          placeholder='Select a provider'
+          placeholder='Using default provider'
           options={providerOptions}
           value={selectedProvider}
+          disabled={
+            disabledMetadataSelectors || isLoading || !providerOptions.length
+          }
           onChange={onSelectProvider}
         />
         <Select
-          disabled={!selectedProvider}
+          disabled={disabledMetadataSelectors || !selectedProvider}
           name='model'
           label='Model'
           placeholder='Select a model'

--- a/apps/web/src/components/layouts/AppLayout/Header/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/Header/index.tsx
@@ -9,7 +9,8 @@ import {
   SessionUser,
   Text,
 } from '@latitude-data/web-ui'
-import { ThemeButton } from '$/components/ThemeButton'
+// TODO: Review dark mode before enabling
+// import { ThemeButton } from '$/components/ThemeButton'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Fragment } from 'react/jsx-runtime'
@@ -123,7 +124,7 @@ export default function AppHeader({
             ))}
           </nav>
           <AvatarDropdown currentUser={currentUser} />
-          <ThemeButton />
+          {/* <ThemeButton /> Not good enough for Cesar */}
         </div>
       </div>
       {sectionLinks.length > 0 ? (

--- a/packages/core/src/lib/readCsv.ts
+++ b/packages/core/src/lib/readCsv.ts
@@ -1,3 +1,5 @@
+import { isNumber } from 'lodash-es'
+
 import { CsvError, parse, type Options as CsvOptions } from 'csv-parse/sync'
 
 import { Result } from './Result'
@@ -40,12 +42,14 @@ export async function syncReadCsv(
       info: true,
     }
 
-    if (toLine) {
-      opts = { ...opts, toLine }
+    if (isNumber(fromLine)) {
+      // from: https://csv.js.org/parse/options/from/
+      opts = { ...opts, from: fromLine }
     }
 
-    if (fromLine) {
-      opts = { ...opts, fromLine }
+    if (toLine) {
+      // to: https://csv.js.org/parse/options/to/
+      opts = { ...opts, to: toLine }
     }
 
     const records = parse(data, opts) as ParseResult[]

--- a/packages/core/src/services/datasets/preview.ts
+++ b/packages/core/src/services/datasets/preview.ts
@@ -10,7 +10,7 @@ export async function previewDataset({
   dataset,
   disk = diskFactory(),
   prependIndex,
-  fromLine = 0,
+  fromLine = 1,
   toLine = 100,
 }: {
   dataset: Dataset

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -37,7 +37,7 @@ if (environment !== 'production') {
       WEBSOCKET_REFRESH_SECRET_TOKEN_KEY: 'refresh-refresh-token-key',
       WORKERS_WEBSOCKET_SECRET_TOKEN: 'workers-secret-token',
       DRIVE_DISK: 'local',
-      DEFAULT_PROVIDER_ID: '1',
+      DEFAULT_PROVIDER_ID: '-1', // Crazy number to avoid conflicts
       DEFAULT_PROVIDER_MODEL: 'gpt-4o',
       FILE_PUBLIC_PATH,
       FILES_STORAGE_PATH,

--- a/packages/jobs/src/job-definitions/batchEvaluations/runBatchEvaluationJob.test.ts
+++ b/packages/jobs/src/job-definitions/batchEvaluations/runBatchEvaluationJob.test.ts
@@ -28,12 +28,13 @@ vi.mock('@latitude-data/core/data-access', () => ({
   findWorkspaceFromDocument: vi.fn(),
 }))
 
+const commitReo = vi.hoisted(() => ({
+  getCommitByUuid: vi.fn().mockResolvedValue({
+    unwrap: () => ({ id: 'commit-1' }),
+  }),
+}))
 vi.mock('@latitude-data/core/repositories', () => ({
-  CommitsRepository: vi.fn().mockImplementation(() => ({
-    find: vi.fn().mockResolvedValue({
-      unwrap: () => ({ id: 'commit-1' }),
-    }),
-  })),
+  CommitsRepository: vi.fn().mockImplementation(() => commitReo),
 }))
 
 vi.mock('@latitude-data/core/services/datasets/preview', () => ({
@@ -70,6 +71,8 @@ describe('runBatchEvaluationJob', () => {
         evaluation: { id: 1 },
         dataset: { fileMetadata: { rowCount: 3 } },
         document: { documentUuid: 'fake-document-uuid', commitId: 'commit-1' },
+        commitUuid: 'commit-uuid-1',
+        projectId: 1,
         parametersMap: { param1: 0, param2: 1 },
       },
       attemptsMade: 0,
@@ -115,6 +118,15 @@ describe('runBatchEvaluationJob', () => {
         completed: 1,
         total: 3,
       },
+    })
+  })
+
+  it('find commit by uuid and project Id', async () => {
+    await runBatchEvaluationJob(mockJob)
+
+    expect(commitReo.getCommitByUuid).toHaveBeenCalledWith({
+      projectId: 1,
+      uuid: 'commit-uuid-1',
     })
   })
 

--- a/packages/jobs/src/job-definitions/batchEvaluations/runBatchEvaluationJob.ts
+++ b/packages/jobs/src/job-definitions/batchEvaluations/runBatchEvaluationJob.ts
@@ -20,6 +20,8 @@ type RunBatchEvaluationJobParams = {
   evaluation: EvaluationDto
   dataset: Dataset
   document: DocumentVersion
+  commitUuid: string
+  projectId: number
   fromLine?: number
   toLine?: number
   parametersMap?: Record<string, number>
@@ -33,7 +35,9 @@ export const runBatchEvaluationJob = async (
     evaluation,
     dataset,
     document,
-    fromLine = 0,
+    projectId,
+    commitUuid,
+    fromLine,
     toLine,
     parametersMap,
     batchId = randomUUID(),
@@ -43,7 +47,7 @@ export const runBatchEvaluationJob = async (
   if (!workspace) throw new NotFoundError('Workspace not found')
 
   const commit = await new CommitsRepository(workspace.id)
-    .find(document.commitId)
+    .getCommitByUuid({ projectId, uuid: commitUuid })
     .then((r) => r.unwrap())
   const fileMetadata = dataset.fileMetadata
   // TODO: use streaming instead of this service in order to avoid loading the


### PR DESCRIPTION
# What?
Line picker selector was not working properly
Issue: https://github.com/latitude-dev/latitude-llm/issues/180

### 🐛 Evaluation logs not created on DRAFT commits
While fixing the batch line range selector we saw that evaluation logs where not created when in a draft commit. The reason is that we were enqueueing jobs with `document.commitId` instead of draft commit id. Now we pass `commitUuid` that is in the URL of the draft commit.

## What?
- [x] Fix draft commits not creating evaluation logs
- [x] Fix batch range line selector 