### PR TITLE
Fix: Run batch modal

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/index.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
-import { ConversationMetadata } from '@latitude-data/compiler'
+import { ConversationMetadata, readMetadata } from '@latitude-data/compiler'
 import { DocumentVersion, EvaluationDto } from '@latitude-data/core/browser'
 import { Button, CloseTrigger, Modal } from '@latitude-data/web-ui'
 import { useNavigate } from '$/hooks/useNavigate'
@@ -15,7 +15,6 @@ import { useRunBatchForm } from './useRunBatchForm'
 export default function CreateBatchEvaluationModal({
   document,
   evaluation,
-  documentMetadata,
   projectId,
   commitUuid,
 }: {
@@ -23,7 +22,6 @@ export default function CreateBatchEvaluationModal({
   commitUuid: string
   document: DocumentVersion
   evaluation: EvaluationDto
-  documentMetadata: ConversationMetadata
 }) {
   const navigate = useNavigate()
   const documentUuid = document.documentUuid
@@ -44,7 +42,15 @@ export default function CreateBatchEvaluationModal({
       goToDetail()
     },
   })
-  const form = useRunBatchForm({ documentMetadata })
+  const [metadata, setMetadata] = useState<ConversationMetadata>()
+  useEffect(() => {
+    readMetadata({
+      prompt: document.content ?? '',
+      fullPath: document.path,
+    }).then(setMetadata)
+  }, [document])
+
+  const form = useRunBatchForm({ documentMetadata: metadata })
   const onRunBatch = useCallback(() => {
     runBatch({
       datasetId: form.selectedDataset?.id,

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/useRunBatchForm.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/_components/CreateBatchEvaluationModal/useRunBatchForm.ts
@@ -17,11 +17,11 @@ function buildEmptyParameters(parameters: string[]) {
 export function useRunBatchForm({
   documentMetadata,
 }: {
-  documentMetadata: ConversationMetadata
+  documentMetadata?: ConversationMetadata
 }) {
   const parametersList = useMemo(
-    () => Array.from(documentMetadata.parameters),
-    [documentMetadata.parameters],
+    () => Array.from(documentMetadata?.parameters ?? []),
+    [documentMetadata?.parameters],
   )
   const { data: datasets, isLoading: isLoadingDatasets } = useDatasets()
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/create-batch/page.tsx
@@ -1,4 +1,3 @@
-import { readMetadata } from '@latitude-data/compiler'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { getDocumentByUuidCached } from '$/app/(private)/_data-access'
 import { getCurrentUser } from '$/services/auth/getCurrentUser'
@@ -28,15 +27,10 @@ export default async function ConnectionEvaluationModal({
     commitUuid,
     documentUuid,
   })
-  const metadata = await readMetadata({
-    prompt: document.content ?? '',
-    fullPath: document.path,
-  })
   return (
     <CreateBatchEvaluationModal
       evaluation={evaluation}
       document={document}
-      documentMetadata={metadata}
       projectId={params.projectId}
       commitUuid={commitUuid}
     />


### PR DESCRIPTION
Run batch modal was calculating metadata from the document in server-side, then sending it back to the client component. Now that `ConversationMetadata` contains a function, it is no longer serializable