### PR TITLE
Realtime evaluation result table update

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/index.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import {
+  Commit,
+  EvaluationAggregationTotals,
+  EvaluationDto,
+  EvaluationMeanValue,
+  EvaluationModalValue,
+} from '@latitude-data/core/browser'
+import { EvaluationResultWithMetadata } from '@latitude-data/core/repositories'
+
+import { EvaluationResults } from '../EvaluationResults'
+import { MetricsSummary } from '../MetricsSummary'
+import { useEvaluationStatus } from './useEvaluationStatus'
+
+export default function Content<T extends boolean>({
+  commit,
+  evaluation,
+  evaluationResults,
+  documentUuid,
+  aggregationTotals,
+  isNumeric,
+  meanOrModal,
+}: {
+  commit: Commit
+  evaluation: EvaluationDto
+  documentUuid: string
+  evaluationResults: EvaluationResultWithMetadata[]
+  aggregationTotals: EvaluationAggregationTotals
+  isNumeric: T
+  meanOrModal: T extends true ? EvaluationMeanValue : EvaluationModalValue
+}) {
+  const { jobs } = useEvaluationStatus({ evaluation })
+  return (
+    <>
+      <MetricsSummary
+        commit={commit}
+        evaluation={evaluation}
+        documentUuid={documentUuid}
+        aggregationTotals={aggregationTotals}
+        isNumeric={isNumeric}
+        meanOrModal={meanOrModal}
+      />
+      <EvaluationResults
+        evaluation={evaluation}
+        evaluationResults={evaluationResults}
+        jobs={jobs}
+      />
+    </>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/useEvaluationStatus.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/useEvaluationStatus.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Evaluation } from '@latitude-data/core/browser'
+import { useCurrentDocument } from '@latitude-data/web-ui'
+import {
+  useSockets,
+  type EventArgs,
+} from '$/components/Providers/WebsocketsProvider/useSockets'
+
+import { isEvaluationRunDone } from '../../_lib/isEvaluationRunDone'
+import { useRefetchStats } from './useRefetchStats'
+
+const DISAPERING_IN_MS = 5000
+
+export function useEvaluationStatus({
+  evaluation,
+}: {
+  evaluation: Evaluation
+}) {
+  const timeoutRef = useRef<number | null>(null)
+  const [jobs, setJobs] = useState<EventArgs<'evaluationStatus'>[]>([])
+  const document = useCurrentDocument()
+  const { refetchStats } = useRefetchStats({ evaluation, document })
+  const onMessage = useCallback(
+    (args: EventArgs<'evaluationStatus'>) => {
+      if (evaluation.id !== args.evaluationId) return
+      if (document.documentUuid !== args.documentUuid) return
+
+      const done = isEvaluationRunDone(args)
+
+      if (done) {
+        refetchStats()
+      }
+
+      setJobs((prevJobs) => {
+        const jobIndex = prevJobs.findIndex(
+          (job) => job.batchId === args.batchId,
+        )
+
+        if (jobIndex === -1) {
+          return [...prevJobs, args]
+        } else {
+          const newJobs = [...prevJobs]
+          newJobs[jobIndex] = args
+
+          if (done) {
+            setTimeout(() => {
+              setJobs((currentJobs) =>
+                currentJobs.filter((job) => job.batchId !== args.batchId),
+              )
+            }, DISAPERING_IN_MS)
+          }
+
+          return newJobs
+        }
+      })
+    },
+    [evaluation.id, document.documentUuid, refetchStats],
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  useSockets({ event: 'evaluationStatus', onMessage })
+
+  return { jobs }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/useRefetchStats.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Content/useRefetchStats.ts
@@ -1,0 +1,79 @@
+import { useCallback } from 'react'
+
+import {
+  DocumentVersion,
+  Evaluation,
+  EvaluationResultableType,
+} from '@latitude-data/core/browser'
+import { useCurrentCommit } from '@latitude-data/web-ui'
+import useEvaluationResultsCounters from '$/stores/evaluationResultCharts/evaluationResultsCounters'
+import useEvaluationResultsMeanValue from '$/stores/evaluationResultCharts/evaluationResultsMeanValue'
+import useEvaluationResultsModalValue from '$/stores/evaluationResultCharts/evaluationResultsModalValue'
+import useAverageResultsAndCostOverCommit from '$/stores/evaluationResultCharts/numericalResults/averageResultAndCostOverCommitStore'
+import useAverageResultOverTime from '$/stores/evaluationResultCharts/numericalResults/averageResultOverTimeStore'
+
+export function useRefetchStats({
+  evaluation,
+  document,
+}: {
+  evaluation: Evaluation
+  document: DocumentVersion
+}) {
+  const { commit } = useCurrentCommit()
+  const evaluationId = evaluation.id
+  const commitUuid = commit.uuid
+  const documentUuid = document.documentUuid
+  const isNumeric =
+    evaluation.configuration.type === EvaluationResultableType.Number
+
+  const { refetch: refetchAverageResulstAndCostsOverCommit } =
+    useAverageResultsAndCostOverCommit({
+      evaluation,
+      documentUuid,
+    })
+  const { refetch: refetchAverageResultOverTime } = useAverageResultOverTime({
+    evaluation,
+    documentUuid,
+  })
+  const { refetch: refetchMean } = useEvaluationResultsMeanValue({
+    commitUuid,
+    documentUuid,
+    evaluationId,
+  })
+  const { refetch: refetchModal } = useEvaluationResultsModalValue({
+    commitUuid,
+    documentUuid,
+    evaluationId,
+  })
+  const { refetch: refetchTotals } = useEvaluationResultsCounters({
+    commitUuid,
+    documentUuid,
+    evaluationId,
+  })
+
+  const refetchStats = useCallback(() => {
+    console.log('refetchStats')
+
+    Promise.all([
+      refetchTotals(),
+      ...(isNumeric
+        ? [
+            refetchMean(),
+            refetchAverageResulstAndCostsOverCommit(),
+            refetchAverageResultOverTime(),
+          ]
+        : [refetchModal()]),
+    ])
+  }, [
+    isNumeric,
+    refetchMean,
+    refetchModal,
+    refetchTotals,
+    refetchAverageResulstAndCostsOverCommit,
+    refetchAverageResultOverTime,
+  ])
+
+  return {
+    refetchStats,
+  }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultsTable.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultsTable.tsx
@@ -48,6 +48,9 @@ export const ResultCellContent = ({
   return <Text.H4 noWrap>{value as string}</Text.H4>
 }
 
+type EvaluationResultRow = EvaluationResultWithMetadata & {
+  realtimeAdded?: boolean
+}
 export const EvaluationResultsTable = ({
   evaluation,
   evaluationResults,
@@ -55,8 +58,8 @@ export const EvaluationResultsTable = ({
   setSelectedResult,
 }: {
   evaluation: EvaluationDto
-  evaluationResults: EvaluationResultWithMetadata[]
-  selectedResult: EvaluationResultWithMetadata | undefined
+  evaluationResults: EvaluationResultRow[]
+  selectedResult: EvaluationResultRow | undefined
   setSelectedResult: (log: EvaluationResultWithMetadata | undefined) => void
 }) => {
   return (
@@ -71,9 +74,9 @@ export const EvaluationResultsTable = ({
         </TableRow>
       </TableHeader>
       <TableBody className='max-h-full overflow-y-auto'>
-        {evaluationResults.map((evaluationResult, idx) => (
+        {evaluationResults.map((evaluationResult) => (
           <TableRow
-            key={idx}
+            key={evaluationResult.id}
             onClick={() =>
               setSelectedResult(
                 selectedResult?.id === evaluationResult.id
@@ -85,12 +88,18 @@ export const EvaluationResultsTable = ({
               'cursor-pointer border-b-[0.5px] h-12 max-h-12 border-border',
               {
                 'bg-secondary': selectedResult?.id === evaluationResult.id,
+                'animate-flash': evaluationResult.realtimeAdded,
               },
             )}
           >
             <TableCell>
               <Text.H4 noWrap>
-                {relativeTime(evaluationResult.createdAt)}
+                <time
+                  dateTime={evaluationResult.createdAt.toISOString()}
+                  suppressHydrationWarning
+                >
+                  {relativeTime(evaluationResult.createdAt)}
+                </time>
               </Text.H4>
             </TableCell>
             <TableCell>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationStatusBanner/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationStatusBanner/index.tsx
@@ -1,82 +1,31 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { ProgressIndicator } from '@latitude-data/web-ui'
+import { isEvaluationRunDone } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_lib/isEvaluationRunDone'
+import { type EventArgs } from '$/components/Providers/WebsocketsProvider/useSockets'
 
-import { EvaluationDto } from '@latitude-data/core/browser'
-import { ProgressIndicator, useCurrentDocument } from '@latitude-data/web-ui'
-import {
-  useSockets,
-  type EventArgs,
-} from '$/components/Providers/WebsocketsProvider/useSockets'
-
-const DISAPERING_IN_MS = 5000
 export function EvaluationStatusBanner({
-  evaluation,
+  jobs,
 }: {
-  evaluation: EvaluationDto
+  jobs: EventArgs<'evaluationStatus'>[]
 }) {
-  const timeoutRef = useRef<number | null>(null)
-  const [jobs, setJobs] = useState<EventArgs<'evaluationStatus'>[]>([])
-  const document = useCurrentDocument()
-
-  const onMessage = useCallback(
-    (args: EventArgs<'evaluationStatus'>) => {
-      if (evaluation.id !== args.evaluationId) return
-      if (document.documentUuid !== args.documentUuid) return
-
-      setJobs((prevJobs) => {
-        const jobIndex = prevJobs.findIndex(
-          (job) => job.batchId === args.batchId,
-        )
-
-        if (jobIndex === -1) {
-          return [...prevJobs, args]
-        } else {
-          const newJobs = [...prevJobs]
-          newJobs[jobIndex] = args
-
-          if (isDone(args)) {
-            setTimeout(() => {
-              setJobs((currentJobs) =>
-                currentJobs.filter((job) => job.batchId !== args.batchId),
-              )
-            }, DISAPERING_IN_MS)
-          }
-
-          return newJobs
-        }
-      })
-    },
-    [evaluation.id, document.documentUuid],
-  )
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
-    }
-  }, [])
-
-  useSockets({ event: 'evaluationStatus', onMessage })
-
   return (
     <>
       {jobs.map((job) => (
         <div key={job.batchId} className='flex flex-col gap-4'>
-          {!isDone(job) && (
+          {!isEvaluationRunDone(job) && (
             <ProgressIndicator state='running'>
               {`Running batch evaluation ${job.completed}/${job.total}`}
             </ProgressIndicator>
           )}
-          {job.errors > 0 && !isDone(job) && (
+          {job.errors > 0 && (
             <ProgressIndicator state='error'>
               Some evaluations failed to run. We won't retry them automatically
               to avoid increasing provider costs. Total errors:{' '}
               <strong>{job.errors}</strong>
             </ProgressIndicator>
           )}
-          {isDone(job) && (
+          {isEvaluationRunDone(job) && (
             <ProgressIndicator state='completed'>
               Batch evaluation completed! Total evaluations:{' '}
               <strong>{job.total}</strong> · Total errors:{' '}
@@ -88,8 +37,4 @@ export function EvaluationStatusBanner({
       ))}
     </>
   )
-}
-
-function isDone(job: EventArgs<'evaluationStatus'>) {
-  return job.total === job.completed + job.errors
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/MeanValuePanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/MeanValuePanel/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Evaluation, EvaluationMeanValue } from '@latitude-data/core/browser'
+import { EvaluationDto, EvaluationMeanValue } from '@latitude-data/core/browser'
 import { RangeBadge } from '@latitude-data/web-ui'
 import useEvaluationResultsMeanValue from '$/stores/evaluationResultCharts/evaluationResultsMeanValue'
 
@@ -14,7 +14,7 @@ export default function MeanValuePanel({
 }: {
   commitUuid: string
   documentUuid: string
-  evaluation: Evaluation
+  evaluation: EvaluationDto
   mean: EvaluationMeanValue
 }) {
   const { data } = useEvaluationResultsMeanValue(

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/index.tsx
@@ -1,93 +1,30 @@
 import {
   Commit,
-  Evaluation,
-  EvaluationResultableType,
-  Workspace,
+  EvaluationAggregationTotals,
+  EvaluationDto,
+  EvaluationMeanValue,
+  EvaluationModalValue,
 } from '@latitude-data/core/browser'
-import {
-  getEvaluationMeanValueQuery,
-  getEvaluationModalValueQuery,
-  getEvaluationTotalsQuery,
-} from '@latitude-data/core/services/evaluationResults/index'
 
 import MeanValuePanel from './MeanValuePanel'
 import ModalValuePanel from './ModalValuePanel'
 import TotalsPanels from './TotalsPanels'
 
-async function MeanPanel({
-  workspaceId,
-  evaluation,
-  documentUuid,
-  commit,
-}: {
-  workspaceId: number
-  evaluation: Evaluation
-  documentUuid: string
-  commit: Commit
-}) {
-  const mean = await getEvaluationMeanValueQuery({
-    workspaceId,
-    evaluation,
-    documentUuid,
-    commit,
-  })
-
-  return (
-    <MeanValuePanel
-      mean={mean}
-      evaluation={evaluation}
-      commitUuid={commit.uuid}
-      documentUuid={documentUuid}
-    />
-  )
-}
-
-async function ModalPanel({
-  workspaceId,
-  evaluation,
-  documentUuid,
-  commit,
-}: {
-  workspaceId: number
-  evaluation: Evaluation
-  documentUuid: string
-  commit: Commit
-}) {
-  const modal = await getEvaluationModalValueQuery({
-    workspaceId,
-    evaluation,
-    documentUuid,
-    commit,
-  })
-  return (
-    <ModalValuePanel
-      modal={modal}
-      evaluationId={evaluation.id}
-      commitUuid={commit.uuid}
-      documentUuid={documentUuid}
-    />
-  )
-}
-
-export async function BigNumberPanels({
-  workspace,
+export function BigNumberPanels<T extends boolean>({
   commit,
   evaluation,
   documentUuid,
+  aggregationTotals,
+  isNumeric,
+  meanOrModal,
 }: {
-  workspace: Workspace
+  isNumeric: T
   commit: Commit
-  evaluation: Evaluation
+  evaluation: EvaluationDto
   documentUuid: string
+  aggregationTotals: EvaluationAggregationTotals
+  meanOrModal: T extends true ? EvaluationMeanValue : EvaluationModalValue
 }) {
-  const aggregationTotals = await getEvaluationTotalsQuery({
-    workspaceId: workspace.id,
-    commit,
-    evaluation,
-    documentUuid,
-  })
-  const isNumeric =
-    evaluation.configuration.type == EvaluationResultableType.Number
   return (
     <div className='flex flex-wrap gap-6'>
       <TotalsPanels
@@ -98,19 +35,19 @@ export async function BigNumberPanels({
       />
 
       {isNumeric && (
-        <MeanPanel
-          commit={commit}
+        <MeanValuePanel
+          mean={meanOrModal as EvaluationMeanValue}
           evaluation={evaluation}
-          workspaceId={workspace.id}
+          commitUuid={commit.uuid}
           documentUuid={documentUuid}
         />
       )}
 
       {!isNumeric && (
-        <ModalPanel
-          commit={commit}
-          evaluation={evaluation}
-          workspaceId={workspace.id}
+        <ModalValuePanel
+          modal={meanOrModal as EvaluationModalValue}
+          evaluationId={evaluation.id}
+          commitUuid={commit.uuid}
           documentUuid={documentUuid}
         />
       )}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Evaluation } from '@latitude-data/core/browser'
 
 import { CostOverResultsChart } from './CostOverResults'

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/index.tsx
@@ -1,7 +1,5 @@
-'use client'
-
 import {
-  Evaluation,
+  EvaluationDto,
   EvaluationResultableType,
 } from '@latitude-data/core/browser'
 
@@ -11,7 +9,7 @@ export function EvaluationResultsCharts({
   evaluation,
   documentUuid,
 }: {
-  evaluation: Evaluation
+  evaluation: EvaluationDto
   documentUuid: string
 }) {
   const isNumerical =

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/index.tsx
@@ -1,18 +1,30 @@
-import { Commit, Evaluation, Workspace } from '@latitude-data/core/browser'
+'use client'
+
+import {
+  Commit,
+  EvaluationAggregationTotals,
+  EvaluationDto,
+  EvaluationMeanValue,
+  EvaluationModalValue,
+} from '@latitude-data/core/browser'
 
 import { BigNumberPanels } from './BigNumberPanels'
 import { EvaluationResultsCharts } from './Charts'
 
-export function MetricsSummary({
-  workspace,
+export function MetricsSummary<T extends boolean>({
   commit,
   evaluation,
   documentUuid,
+  aggregationTotals,
+  meanOrModal,
+  isNumeric,
 }: {
-  workspace: Workspace
   commit: Commit
-  evaluation: Evaluation
+  evaluation: EvaluationDto
   documentUuid: string
+  aggregationTotals: EvaluationAggregationTotals
+  isNumeric: T
+  meanOrModal: T extends true ? EvaluationMeanValue : EvaluationModalValue
 }) {
   return (
     <div className='flex gap-6 flex-wrap'>
@@ -22,10 +34,12 @@ export function MetricsSummary({
       />
       <div className='min-w-[400px] flex-1 flex flex-col gap-y-6'>
         <BigNumberPanels
-          workspace={workspace}
           commit={commit}
           evaluation={evaluation}
           documentUuid={documentUuid}
+          aggregationTotals={aggregationTotals}
+          isNumeric={isNumeric}
+          meanOrModal={meanOrModal}
         />
       </div>
     </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_lib/isEvaluationRunDone.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_lib/isEvaluationRunDone.ts
@@ -1,0 +1,5 @@
+import { type EventArgs } from '$/components/Providers/WebsocketsProvider/useSockets'
+
+export function isEvaluationRunDone(job: EventArgs<'evaluationStatus'>) {
+  return job.total === job.completed + job.errors
+}

--- a/apps/web/src/stores/evaluationResultCharts/evaluationResultsCounters.ts
+++ b/apps/web/src/stores/evaluationResultCharts/evaluationResultsCounters.ts
@@ -1,4 +1,6 @@
-import { useCurrentProject } from '@latitude-data/web-ui'
+import { useCallback } from 'react'
+
+import { useCurrentProject, useToast } from '@latitude-data/web-ui'
 import { computeEvaluationResultsCountersAction } from '$/actions/evaluationResults/computeEvaluationResultsCountersAction'
 import useSWR, { SWRConfiguration } from 'swr'
 
@@ -12,23 +14,32 @@ export default function useEvaluationResultsCounters(
     documentUuid: string
     evaluationId: number
   },
-  opts: SWRConfiguration = {},
+  { fallbackData }: SWRConfiguration = {},
 ) {
   const { project } = useCurrentProject()
+  const { toast } = useToast()
+  const fetcher = useCallback(async () => {
+    const [data, error] = await computeEvaluationResultsCountersAction({
+      projectId: project.id,
+      commitUuid,
+      documentUuid,
+      evaluationId,
+    })
+
+    if (error) {
+      toast({
+        title: 'Error fetching evaluation stats',
+        description: error.formErrors?.[0] || error.message,
+        variant: 'destructive',
+      })
+      return null
+    }
+    return data
+  }, [commitUuid, documentUuid, evaluationId, project.id])
   const { data, isLoading, error, mutate } = useSWR(
     ['evaluationResultsCounters', commitUuid, documentUuid, evaluationId],
-    async () => {
-      const [data, error] = await computeEvaluationResultsCountersAction({
-        projectId: project.id,
-        commitUuid,
-        documentUuid,
-        evaluationId,
-      })
-
-      if (error) return null
-      return data
-    },
-    opts,
+    fetcher,
+    { fallbackData },
   )
 
   return {

--- a/apps/web/src/stores/evaluationResultCharts/evaluationResultsModalValue.ts
+++ b/apps/web/src/stores/evaluationResultCharts/evaluationResultsModalValue.ts
@@ -1,4 +1,6 @@
-import { useCurrentProject } from '@latitude-data/web-ui'
+import { useCallback } from 'react'
+
+import { useCurrentProject, useToast } from '@latitude-data/web-ui'
 import { computeEvaluationResultsModalValueAction } from '$/actions/evaluationResults/computeEvaluationResultsModalValueAction'
 import useSWR, { SWRConfiguration } from 'swr'
 
@@ -12,24 +14,33 @@ export default function useEvaluationResultsModalValue(
     documentUuid: string
     evaluationId: number
   },
-  opts: SWRConfiguration = {},
+  { fallbackData }: SWRConfiguration = {},
 ) {
   const { project } = useCurrentProject()
+  const { toast } = useToast()
+  const fetcher = useCallback(async () => {
+    const [data, error] = await computeEvaluationResultsModalValueAction({
+      projectId: project.id,
+      commitUuid,
+      documentUuid,
+      evaluationId,
+    })
+
+    if (error) {
+      toast({
+        title: 'Error fetching evaluation modal value',
+        description: error.formErrors?.[0] || error.message,
+        variant: 'destructive',
+      })
+      return null
+    }
+
+    return data
+  }, [commitUuid, documentUuid, evaluationId, project.id])
   const { data, isLoading, error, mutate } = useSWR(
     ['evaluationResultsModalQuery', commitUuid, documentUuid, evaluationId],
-    async () => {
-      const [data, error] = await computeEvaluationResultsModalValueAction({
-        projectId: project.id,
-        commitUuid,
-        documentUuid,
-        evaluationId,
-      })
-
-      if (error) null
-
-      return data
-    },
-    opts,
+    fetcher,
+    { fallbackData },
   )
 
   return {

--- a/apps/web/src/stores/evaluationResultCharts/numericalResults/averageResultAndCostOverCommitStore.ts
+++ b/apps/web/src/stores/evaluationResultCharts/numericalResults/averageResultAndCostOverCommitStore.ts
@@ -1,29 +1,28 @@
+import { useCallback } from 'react'
+
 import { Evaluation } from '@latitude-data/core/browser'
 import { computeAverageResultAndCostOverCommitAction } from '$/actions/evaluationResults/computeAggregatedResults'
-import useSWR, { SWRConfiguration } from 'swr'
+import useSWR from 'swr'
 
-export default function useAverageResultsAndCostOverCommit(
-  {
-    evaluation,
-    documentUuid,
-  }: {
-    evaluation: Evaluation
-    documentUuid: string
-  },
-  opts: SWRConfiguration = {},
-) {
-  const { data, isValidating, isLoading, error } = useSWR(
+export default function useAverageResultsAndCostOverCommit({
+  evaluation,
+  documentUuid,
+}: {
+  evaluation: Evaluation
+  documentUuid: string
+}) {
+  const fetcher = useCallback(async () => {
+    const [data, error] = await computeAverageResultAndCostOverCommitAction({
+      documentUuid,
+      evaluationId: evaluation.id,
+    })
+
+    if (error) return []
+    return data
+  }, [documentUuid, evaluation.id])
+  const { data, isValidating, isLoading, error, mutate } = useSWR(
     ['averageResultAndCostOverCommit', evaluation.id, documentUuid],
-    async () => {
-      const [data, error] = await computeAverageResultAndCostOverCommitAction({
-        documentUuid,
-        evaluationId: evaluation.id,
-      })
-
-      if (error) return []
-      return data
-    },
-    opts,
+    fetcher,
   )
 
   return {
@@ -31,5 +30,6 @@ export default function useAverageResultsAndCostOverCommit(
     isLoading,
     isValidating,
     error,
+    refetch: mutate,
   }
 }

--- a/apps/web/src/stores/evaluationResultCharts/numericalResults/averageResultOverTimeStore.ts
+++ b/apps/web/src/stores/evaluationResultCharts/numericalResults/averageResultOverTimeStore.ts
@@ -1,29 +1,28 @@
+import { useCallback } from 'react'
+
 import { Evaluation } from '@latitude-data/core/browser'
 import { computeAverageResultOverTimeAction } from '$/actions/evaluationResults/computeAggregatedResults'
-import useSWR, { SWRConfiguration } from 'swr'
+import useSWR from 'swr'
 
-export default function useAverageResultOverTime(
-  {
-    evaluation,
-    documentUuid,
-  }: {
-    evaluation: Evaluation
-    documentUuid: string
-  },
-  opts: SWRConfiguration = {},
-) {
-  const { data, isValidating, isLoading, error } = useSWR(
+export default function useAverageResultOverTime({
+  evaluation,
+  documentUuid,
+}: {
+  evaluation: Evaluation
+  documentUuid: string
+}) {
+  const fetcher = useCallback(async () => {
+    const [data, error] = await computeAverageResultOverTimeAction({
+      documentUuid,
+      evaluationId: evaluation.id,
+    })
+
+    if (error) return []
+    return data
+  }, [documentUuid, evaluation.id])
+  const { data, isValidating, isLoading, error, mutate } = useSWR(
     ['averageResultOverTime', evaluation.id, documentUuid],
-    async () => {
-      const [data, error] = await computeAverageResultOverTimeAction({
-        documentUuid,
-        evaluationId: evaluation.id,
-      })
-
-      if (error) return []
-      return data
-    },
-    opts,
+    fetcher,
   )
 
   return {
@@ -31,5 +30,6 @@ export default function useAverageResultOverTime(
     isLoading,
     isValidating,
     error,
+    refetch: mutate,
   }
 }

--- a/apps/web/src/stores/projects.ts
+++ b/apps/web/src/stores/projects.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import { Project } from '@latitude-data/core/browser'
 import { useToast } from '@latitude-data/web-ui'
 import { createProjectAction } from '$/actions/projects/create'
@@ -5,11 +7,11 @@ import { destroyProjectAction } from '$/actions/projects/destroy'
 import { fetchProjectsAction } from '$/actions/projects/fetch'
 import { updateProjectAction } from '$/actions/projects/update'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
-import useSWR, { SWRConfiguration } from 'swr'
+import useSWR from 'swr'
 
-export default function useProjects(opts?: SWRConfiguration) {
+export default function useProjects() {
   const { toast } = useToast()
-  const fetcher = async () => {
+  const fetcher = useCallback(async () => {
     const [data, error] = await fetchProjectsAction()
     if (error) {
       toast({
@@ -21,13 +23,13 @@ export default function useProjects(opts?: SWRConfiguration) {
     if (!data) return []
 
     return data
-  }
+  }, [])
 
   const {
     data = [],
     mutate,
     ...rest
-  } = useSWR<Project[]>('api/projects', fetcher, opts)
+  } = useSWR<Project[]>('api/projects', fetcher)
   const { execute: create } = useLatitudeAction(createProjectAction, {
     onSuccess: ({ data: project }) => {
       toast({

--- a/apps/websockets/src/server.ts
+++ b/apps/websockets/src/server.ts
@@ -47,9 +47,7 @@ const io = new Server(server, {
 })
 
 io.on('connection', (socket: Socket) => {
-  console.log(
-    'Main namespace is not enabled. Connect to /web or /workers instead.',
-  )
+  // Main namespace is not enabled. Connect to /web or /workers instead.
   socket.disconnect()
 })
 
@@ -111,14 +109,12 @@ workers.use(async (socket, next) => {
   try {
     const token = socket.handshake.auth?.token
     if (!token) {
-      console.log('DEBUG: No token provided')
       return next(new Error('Authentication error: No token provided'))
     }
 
     const result = await verifyWorkerWebsocketToken(token)
 
     if (result.error) {
-      console.log('DEBUG: JWT verification failed for worker:', result.error)
       return next(new Error(`Authentication error: ${result.error.message}`))
     }
 
@@ -130,21 +126,15 @@ workers.use(async (socket, next) => {
 })
 
 workers.on('connection', (socket) => {
-  console.log('DEBUG: Worker connected')
-
-  socket.on('pingFromWorkers', () => {
-    console.log('DEBUG: Ping from workers')
-  })
-
   socket.on('evaluationStatus', (args) => {
-    console.log('DEBUG: Evaluation STATUS %s', JSON.stringify(args))
     const { workspaceId, data } = args
     const workspace = buildWorkspaceRoom({ workspaceId })
     web.to(workspace).emit('evaluationStatus', data)
   })
-
-  socket.on('disconnect', () => {
-    console.log('Worker disconnected')
+  socket.on('evaluationResultCreated', (args) => {
+    const { workspaceId, data } = args
+    const workspace = buildWorkspaceRoom({ workspaceId })
+    web.to(workspace).emit('evaluationResultCreated', data)
   })
 })
 

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -1,7 +1,5 @@
 import http from 'http'
 
-import { WebsocketClient } from '@latitude-data/core/websockets/workers'
-
 import { captureException, captureMessage } from './utils/sentry'
 import startWorkers from './workers'
 
@@ -11,12 +9,7 @@ console.log('Workers started')
 
 const port = process.env.WORKERS_PORT || 3002
 const server = http.createServer(async (req, res) => {
-  const websockets = await WebsocketClient.getSocket()
-
-  if (req.url === '/ping' && req.method === 'GET') {
-    websockets.emit('pingFromWorkers')
-    res.end(JSON.stringify({ status: 'OK', message: 'Pong' }))
-  } else if (req.url === '/health' && req.method === 'GET') {
+  if (req.url === '/health' && req.method === 'GET') {
     res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ status: 'OK', message: 'Workers are healthy' }))
   } else {

--- a/packages/core/src/events/handlers/createEvaluationResultJob.test.ts
+++ b/packages/core/src/events/handlers/createEvaluationResultJob.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { EvaluationRunEvent } from '.'
+import {
+  Commit,
+  DocumentLog,
+  DocumentVersion,
+  Project,
+  ProviderApiKey,
+  ProviderLog,
+  User,
+  Workspace,
+} from '../../browser'
+import { EvaluationResultableType, Providers } from '../../constants'
+import { NotFoundError } from '../../lib'
+import { mergeCommit } from '../../services/commits'
+import * as factories from '../../tests/factories'
+
+const mocks = vi.hoisted(() => {
+  const mockEmit = vi.fn()
+  return {
+    getSocket: vi.fn().mockResolvedValue({ emit: mockEmit }),
+    mockEmit,
+  }
+})
+
+vi.mock('../../websockets/workers', async (importOriginal) => {
+  const mod =
+    (await importOriginal()) as typeof import('../../websockets/workers')
+  return {
+    ...mod,
+    WebsocketClient: {
+      getSocket: mocks.getSocket,
+    },
+  }
+})
+
+let event: EvaluationRunEvent
+let workspace: Workspace
+let user: User
+let project: Project
+let provider: ProviderApiKey
+let evaluation: Awaited<ReturnType<typeof factories.createLlmAsJudgeEvaluation>>
+let commit: Commit
+let documentVersion: DocumentVersion
+let documentLog: DocumentLog
+let providerLog: ProviderLog
+
+describe('createEvaluationResultJob', () => {
+  beforeEach(async () => {
+    vi.resetModules()
+
+    const basic = await factories.createProject()
+    workspace = basic.workspace
+    user = basic.user
+    project = basic.project
+    provider = basic.providers[0]!
+    const { commit: draft } = await factories.createDraft({ project, user })
+    const doc = await factories.createDocumentVersion({
+      commit: draft,
+      path: 'folder1/doc1',
+      content: factories.helpers.createPrompt({ provider }),
+    })
+    documentVersion = doc.documentVersion
+    commit = await mergeCommit(draft).then((r) => r.unwrap())
+
+    evaluation = await factories.createLlmAsJudgeEvaluation({
+      workspace,
+      prompt: factories.helpers.createPrompt({ provider }),
+      configuration: {
+        type: EvaluationResultableType.Number,
+        detail: {
+          range: { from: 0, to: 100 },
+        },
+      },
+    })
+    const { documentLog: log } = await factories.createDocumentLog({
+      document: documentVersion,
+      commit,
+    })
+    documentLog = log
+
+    providerLog = await factories.createProviderLog({
+      documentLogUuid: documentLog.uuid,
+      providerId: provider.id,
+      providerType: Providers.OpenAI,
+    })
+    event = {
+      type: 'evaluationRun',
+      data: {
+        evaluationId: evaluation.id,
+        documentUuid: documentVersion.documentUuid,
+        documentLogUuid: documentLog.uuid,
+        providerLogUuid: providerLog.uuid,
+        response: {
+          object: { result: 33 },
+        },
+      },
+    } as unknown as EvaluationRunEvent
+  })
+
+  it('send websocket event for "evaluationResultCreated"', async () => {
+    const mod = await import('./createEvaluationResultJob')
+    const { createEvaluationResultJob } = mod
+    await createEvaluationResultJob({ data: event })
+
+    expect(mocks.mockEmit).toHaveBeenCalledWith('evaluationResultCreated', {
+      workspaceId: workspace.id,
+      data: {
+        documentUuid: documentVersion.documentUuid,
+        workspaceId: workspace.id,
+        evaluationId: evaluation.id,
+        evaluationResultId: expect.any(Number),
+        row: {
+          commit,
+          id: expect.any(Number),
+          evaluationId: evaluation.id,
+          documentLogId: documentLog.id,
+          providerLogId: providerLog.id,
+          resultableType: EvaluationResultableType.Number,
+          resultableId: expect.any(Number),
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          tokens: expect.any(Number),
+          costInMillicents: expect.any(Number),
+          result: '33',
+        },
+      },
+    })
+  })
+
+  it('should throw NotFoundError when evaluation is not found', async () => {
+    const mod = await import('./createEvaluationResultJob')
+    const { createEvaluationResultJob } = mod
+    const data = {
+      ...event,
+      data: { ...event.data, evaluationId: 999 },
+    }
+    await expect(createEvaluationResultJob({ data })).rejects.toThrow(
+      new NotFoundError('Evaluation not found'),
+    )
+  })
+
+  it('should throw NotFoundError when documentLogs is not found', async () => {
+    const mod = await import('./createEvaluationResultJob')
+    const { createEvaluationResultJob } = mod
+    const fakeUuid = '00000000-0000-0000-0000-000000000000'
+    const data = {
+      ...event,
+      data: { ...event.data, documentLogUuid: fakeUuid },
+    }
+    await expect(createEvaluationResultJob({ data })).rejects.toThrow(
+      new NotFoundError('Document log not found'),
+    )
+  })
+
+  it('should throw NotFoundError when providerLog is not found', async () => {
+    const mod = await import('./createEvaluationResultJob')
+    const { createEvaluationResultJob } = mod
+    const fakeUuid = '00000000-0000-0000-0000-000000000000'
+    const data = {
+      ...event,
+      data: { ...event.data, providerLogUuid: fakeUuid },
+    }
+    await expect(createEvaluationResultJob({ data })).rejects.toThrow(
+      new NotFoundError('Provider log not found'),
+    )
+  })
+})

--- a/packages/core/src/events/handlers/index.ts
+++ b/packages/core/src/events/handlers/index.ts
@@ -39,6 +39,7 @@ export type MembershipCreatedEvent = LatitudeEventGeneric<
 export type EvaluationRunEvent = LatitudeEventGeneric<
   'evaluationRun',
   {
+    documentUuid: string
     evaluationId: number
     documentLogUuid: string
     providerLogUuid: string

--- a/packages/core/src/services/evaluationResults/aggregations/countersQuery.test.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/countersQuery.test.ts
@@ -193,7 +193,7 @@ describe('evaluation results aggregations', () => {
         expect(result.mostCommon).toBe('apple')
         // Funcky test because of floating point math issues
         // in Mac OS and CI Linux
-        expect(result.percentage).toBeGreaterThan(65)
+        expect(result.percentage).toBeGreaterThan(64)
         expect(result.percentage).toBeLessThan(67)
       })
     })

--- a/packages/core/src/services/evaluations/run.ts
+++ b/packages/core/src/services/evaluations/run.ts
@@ -36,9 +36,11 @@ const getResultSchema = (type: EvaluationResultableType): JSONSchema7 => {
 export const runEvaluation = async (
   {
     documentLog,
+    documentUuid,
     evaluation,
   }: {
     documentLog: DocumentLog
+    documentUuid: string
     evaluation: EvaluationDto
   },
   db = database,
@@ -105,12 +107,14 @@ export const runEvaluation = async (
       output: 'object',
     },
   })
+
   if (chainResult.error) return chainResult
 
   chainResult.value.response.then((response) => {
     publisher.publish({
       type: 'evaluationRun',
       data: {
+        documentUuid,
         evaluationId: evaluation.id,
         documentLogUuid: documentLog.uuid,
         providerLogUuid: response.providerLog.uuid,

--- a/packages/core/src/websockets/constants.ts
+++ b/packages/core/src/websockets/constants.ts
@@ -3,6 +3,8 @@
 // All this can be seen in the browser. If you want something private
 // put in other place.
 
+import { type EvaluationResultWithMetadata } from '../repositories'
+
 const ONE_HOUR = 60 * 60 * 1000
 const SEVEN_DAYS = 7 * 24 * ONE_HOUR
 
@@ -35,8 +37,18 @@ type EvaluationStatusArgs = {
   errors: number
   enqueued: number
 }
+
+type evaluationResultCreatedArgs = {
+  workspaceId: number
+  evaluationId: number
+  documentUuid: string
+  evaluationResultId: number
+  row: EvaluationResultWithMetadata
+}
+
 export type WebServerToClientEvents = {
   evaluationStatus: (args: EvaluationStatusArgs) => void
+  evaluationResultCreated: (args: evaluationResultCreatedArgs) => void
   joinWorkspace: (args: { workspaceId: number; userId: string }) => void
 }
 export type WebClientToServerEvents = {
@@ -45,8 +57,11 @@ export type WebClientToServerEvents = {
 
 export type WorkersClientToServerEvents = {
   evaluationStatus: (args: {
-    data: EvaluationStatusArgs
     workspaceId: number
+    data: EvaluationStatusArgs
   }) => void
-  pingFromWorkers: () => void
+  evaluationResultCreated: (args: {
+    workspaceId: number
+    data: evaluationResultCreatedArgs
+  }) => void
 }

--- a/packages/core/src/websockets/workers.ts
+++ b/packages/core/src/websockets/workers.ts
@@ -23,15 +23,6 @@ export class WebsocketClient {
     WebsocketClient.instance = instance
     return new Promise<WorkerSocket>((resolve) => {
       websockets.on('connect', () => {
-        console.log('Workers connected to WebSocket server')
-        resolve(websockets)
-      })
-
-      websockets.on('connect_error', (error) => {
-        console.error(
-          'Error connecting to WebSocket server from WORKERS:',
-          error,
-        )
         resolve(websockets)
       })
     })

--- a/packages/jobs/src/job-definitions/batchEvaluations/runEvaluationJob.test.ts
+++ b/packages/jobs/src/job-definitions/batchEvaluations/runEvaluationJob.test.ts
@@ -1,0 +1,152 @@
+import { Job } from 'bullmq'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runEvaluationJob, type RunEvaluationJobData } from './runEvaluationJob'
+
+vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+vi.mock('@latitude-data/core/queues', () => ({
+  queues: vi.fn(() => Promise.resolve({})), // mock queues function
+}))
+
+vi.mock('@latitude-data/core/repositories', () => ({
+  DocumentLogsRepository: vi.fn().mockImplementation(() => ({
+    findByUuid: vi.fn(() =>
+      Promise.resolve({ unwrap: () => Promise.resolve({}) }),
+    ),
+  })),
+  EvaluationsRepository: vi.fn().mockImplementation(() => ({
+    find: vi.fn(() => Promise.resolve({ unwrap: () => Promise.resolve({}) })),
+  })),
+}))
+
+const runEvaluationMock = vi.hoisted(() =>
+  vi.fn(() =>
+    Promise.resolve({
+      unwrap: () =>
+        Promise.resolve({
+          response: new Promise((resolve) => {
+            resolve(null)
+          }),
+        }),
+    }),
+  ),
+)
+vi.mock('@latitude-data/core/services/evaluations/run', () => ({
+  runEvaluation: runEvaluationMock,
+}))
+
+const mockEmit = vi.hoisted(() => vi.fn())
+const mockGetSocket = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ emit: mockEmit }),
+)
+vi.mock('@latitude-data/core/websockets/workers', () => ({
+  WebsocketClient: {
+    getSocket: mockGetSocket,
+  },
+}))
+
+vi.mock('@latitude-data/env', () => ({
+  env: { NODE_ENV: 'test' }, // Mock environment to be 'test'
+}))
+
+const incrementCompletedMock = vi.hoisted(() => vi.fn())
+const incrementErrorsMock = vi.hoisted(() => vi.fn())
+vi.mock('../../utils/progressTracker', () => {
+  return {
+    ProgressTracker: vi.fn().mockImplementation(() => ({
+      incrementCompleted: incrementCompletedMock,
+      incrementErrors: incrementErrorsMock,
+      getProgress: vi.fn(() => Promise.resolve({ completed: 1, total: 1 })),
+    })),
+  }
+})
+
+let jobData: Job<RunEvaluationJobData>
+describe('runEvaluationJob', () => {
+  beforeEach(() => {
+    mockGetSocket.mockClear()
+    jobData = {
+      id: '1',
+      data: {
+        workspaceId: 1,
+        documentUuid: 'doc-uuid',
+        documentLogUuid: 'log-uuid',
+        evaluationId: 2,
+        batchId: 'batch-123',
+        skipProgress: false,
+      },
+    } as Job<RunEvaluationJobData>
+
+    runEvaluationMock.mockClear()
+  })
+
+  it('calls runEvaluation', async () => {
+    await runEvaluationJob(jobData)
+    expect(runEvaluationMock).toHaveBeenCalledWith({
+      documentLog: expect.any(Object),
+      evaluation: expect.any(Object),
+      documentUuid: 'doc-uuid',
+    })
+    incrementCompletedMock.mockClear()
+  })
+
+  it('wait for runEvaluation response to finish', async () => {
+    const responsePromise = new Promise((resolve) =>
+      setTimeout(() => resolve('expected response'), 100),
+    )
+    const mockedResponse = {
+      unwrap: () =>
+        Promise.resolve({
+          response: responsePromise,
+        }),
+    }
+
+    runEvaluationMock.mockResolvedValue(mockedResponse)
+
+    const awaitResponseSpy = vi.fn()
+    responsePromise.then(awaitResponseSpy)
+
+    await runEvaluationJob(jobData)
+    expect(awaitResponseSpy).toHaveBeenCalled()
+    incrementCompletedMock.mockClear()
+  })
+
+  it('increment succesfull counter', async () => {
+    await runEvaluationJob(jobData)
+    expect(mockGetSocket).toHaveBeenCalledTimes(1)
+    expect(incrementCompletedMock).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith('evaluationStatus', {
+      workspaceId: 1,
+      data: {
+        batchId: 'batch-123',
+        evaluationId: 2,
+        documentUuid: 'doc-uuid',
+        completed: 1,
+        total: 1,
+      },
+    })
+    incrementCompletedMock.mockClear()
+  })
+
+  it('increment error counter', async () => {
+    runEvaluationMock.mockImplementationOnce(() => {
+      throw new Error('Some error occurred')
+    })
+
+    await runEvaluationJob(jobData)
+
+    expect(mockGetSocket).toHaveBeenCalledTimes(1)
+    expect(incrementErrorsMock).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledWith('evaluationStatus', {
+      workspaceId: 1,
+      data: {
+        batchId: 'batch-123',
+        evaluationId: 2,
+        documentUuid: 'doc-uuid',
+        completed: 1,
+        total: 1,
+      },
+    })
+  })
+})

--- a/packages/jobs/src/job-definitions/batchEvaluations/runEvaluationJob.ts
+++ b/packages/jobs/src/job-definitions/batchEvaluations/runEvaluationJob.ts
@@ -10,7 +10,7 @@ import { Job } from 'bullmq'
 
 import { ProgressTracker } from '../../utils/progressTracker'
 
-type RunEvaluationJobData = {
+export type RunEvaluationJobData = {
   workspaceId: number
   documentUuid: string
   documentLogUuid: string
@@ -35,10 +35,15 @@ export const runEvaluationJob = async (job: Job<RunEvaluationJobData>) => {
       .find(evaluationId)
       .then((r) => r.unwrap())
 
-    await runEvaluation({
+    const { response } = await runEvaluation({
       documentLog,
       evaluation,
+      documentUuid,
     }).then((r) => r.unwrap())
+
+    // Waiting for the reponse is important. It guarantees that the evaluation
+    // has been created before we notify the client via websockets.
+    await response
 
     await progressTracker.incrementCompleted()
   } catch (error) {

--- a/packages/jobs/src/utils/progressTracker.ts
+++ b/packages/jobs/src/utils/progressTracker.ts
@@ -25,16 +25,8 @@ export class ProgressTracker {
     await this.redis.incr(this.getKey('errors'))
   }
 
-  async decrementTotal() {
-    await this.redis.decr(this.getKey('total'))
-  }
-
   async incrementEnqueued() {
     await this.redis.incr(this.getKey('enqueued'))
-  }
-
-  async decrementEnqueued() {
-    await this.redis.decr(this.getKey('enqueued'))
   }
 
   async getProgress() {

--- a/packages/web-ui/tailwind.config.js
+++ b/packages/web-ui/tailwind.config.js
@@ -83,10 +83,15 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: '0' },
         },
+        'flash-background': {
+          '0%': { backgroundColor: 'transparent' },
+         '100%': { backgroundColor: 'rgb(var(--accent))' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'flash': 'flash-background 1s ease-in-out',
       },
       maxWidth: {
         modal: '580px',


### PR DESCRIPTION
# What?
When a evaluation is run show results in the frontend whenever they're processed


## TODO
- [x] Fix weird jumping of table update when mutating with row from websockets
- [x] On finish run evaluation trigger update stats
- [x] Add test to check websocket is called when evaluation result is created