### PR TITLE
chore: handle errors properly during streaming

### DIFF
--- a/apps/gateway/src/routes/api/v1/projects/:projectId/versions/:versionUuid/documents/handlers/_shared.ts
+++ b/apps/gateway/src/routes/api/v1/projects/:projectId/versions/:versionUuid/documents/handlers/_shared.ts
@@ -87,7 +87,14 @@ function latitudeEventPresenter(event: {
         response: omit(event.data.response, 'providerLog', 'documentLogUuid'),
       }
     case ChainEventTypes.Error:
-      return event.data
+      return {
+        type: ChainEventTypes.Error,
+        error: {
+          name: event.data.error.name,
+          message: event.data.error.message,
+          stack: event.data.error.stack,
+        },
+      }
     default:
       throw new BadRequestError(
         `Unknown event type in chainEventPresenter ${JSON.stringify(event)}`,

--- a/apps/gateway/src/routes/api/v1/projects/:projectId/versions/:versionUuid/documents/handlers/run.ts
+++ b/apps/gateway/src/routes/api/v1/projects/:projectId/versions/:versionUuid/documents/handlers/run.ts
@@ -36,6 +36,7 @@ export const runHandler = factory.createHandlers(
           commitUuid: versionUuid!,
           documentPath: path!,
         }).then((r) => r.unwrap())
+
         const result = await runDocumentAtCommit({
           workspace,
           document,


### PR DESCRIPTION
If the streaming failed for some reason we were just throwing unhandled exceptions. Now we catch them and return a proper error event. Both the chains/run and providerLogs/addMessages services should never throw.