### PR TITLE
Extended and paginated results on refine modal

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,7 @@
       "name": "Debug Web",
       "type": "node-terminal",
       "request": "launch",
-      "command": "cd apps/web && pnpm dev",
-      "serverReadyAction": {
-        "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s",
-        "action": "debugWithChrome"
-      }
+      "command": "cd apps/web && pnpm dev"
     }
   ]
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/RefineModal/steps/2_SelectEvaluationResults/SelectableEvaluationResultsTable.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/RefineModal/steps/2_SelectEvaluationResults/SelectableEvaluationResultsTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Dispatch, SetStateAction, useMemo, useState } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import { capitalize } from 'lodash-es'
 
 import {
@@ -53,37 +53,37 @@ export const ResultCellContent = ({
   return <Text.H4 noWrap>{String(value)}</Text.H4>
 }
 
-const PAGE_SIZE = 10
-
 type EvaluationResultRow = EvaluationResultWithMetadata & {
   realtimeAdded?: boolean
 }
 export const SelectableEvaluationResultsTable = ({
   evaluation,
-  evaluationResults,
+  evaluationResultsRows,
   selectedResults,
   setSelectedResults,
+  totalCount,
+  pageSize,
+  page,
+  setPage,
 }: {
   evaluation: EvaluationDto
-  evaluationResults: EvaluationResultRow[]
+  evaluationResultsRows: EvaluationResultRow[]
   selectedResults: EvaluationResultRow[]
   setSelectedResults: Dispatch<SetStateAction<EvaluationResultRow[]>>
+  totalCount: number
+  pageSize: number
+  page: number
+  setPage: (_: number) => void
 }) => {
-  const [page, setPage] = useState(1)
-  const scopedEvaluationResults = useMemo(
-    () => evaluationResults.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
-    [evaluationResults, page],
-  )
-
   return (
     <Table
       className='table-auto'
       externalFooter={
         <LogicTablePaginationFooter
           page={page}
-          totalCount={evaluationResults.length}
-          totalCountLabel={`${evaluationResults.length} results, ${selectedResults.length} selected`}
-          pageSize={PAGE_SIZE}
+          totalCount={totalCount}
+          totalCountLabel={`${totalCount} results, ${selectedResults.length} selected`}
+          pageSize={pageSize}
           onPageChange={setPage}
         />
       }
@@ -97,7 +97,7 @@ export const SelectableEvaluationResultsTable = ({
         </TableRow>
       </TableHeader>
       <TableBody className='custom-scrollbar'>
-        {scopedEvaluationResults.map((evaluationResult) => {
+        {evaluationResultsRows.map((evaluationResult) => {
           const isSelected = !!selectedResults.find(
             (r) => r.id === evaluationResult.id,
           )

--- a/apps/web/src/app/api/documents/[projectId]/[commitUuid]/[documentUuid]/evaluation-results-by-document-content/[evaluationId]/route.ts
+++ b/apps/web/src/app/api/documents/[projectId]/[commitUuid]/[documentUuid]/evaluation-results-by-document-content/[evaluationId]/route.ts
@@ -11,7 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export const GET = errorHandler(
   authHandler(
     async (
-      _: NextRequest,
+      req: NextRequest,
       {
         params,
         workspace,
@@ -26,6 +26,10 @@ export const GET = errorHandler(
       },
     ) => {
       const { evaluationId, documentUuid, commitUuid, projectId } = params
+      const { searchParams } = new URL(req.url)
+      const page = Number(searchParams.get('page')) || 1
+      const pageSize = Number(searchParams.get('pageSize')) || 10
+
       const commitsScope = new CommitsRepository(workspace.id)
       const commit = await commitsScope
         .getCommitByUuid({ projectId, uuid: commitUuid })
@@ -40,9 +44,12 @@ export const GET = errorHandler(
         evaluation,
         commit,
         documentUuid,
-      }).then((r) => r.unwrap())
+        page,
+        pageSize,
+      })
+      const data = result.unwrap()
 
-      return NextResponse.json(result, { status: 200 })
+      return NextResponse.json(data, { status: 200 })
     },
   ),
 )

--- a/packages/core/src/repositories/evaluationResultsRepository/index.ts
+++ b/packages/core/src/repositories/evaluationResultsRepository/index.ts
@@ -37,6 +37,7 @@ export type EvaluationResultWithMetadata = EvaluationResultDto & {
   commit: Commit
   tokens: number | null
   costInMillicents: number | null
+  documentContentHash: string
 }
 
 export class EvaluationResultsRepository extends Repository<

--- a/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
+++ b/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
@@ -45,6 +45,7 @@ export function createEvaluationResultQuery(
         commit: commits,
         tokens: aggregatedFieldsSubQuery.tokens,
         costInMillicents: aggregatedFieldsSubQuery.costInMillicents,
+        documentContentHash: documentLogsScope.contentHash,
       })
       .from(evaluationResultsScope)
       .innerJoin(


### PR DESCRIPTION
Now `EvaluationResultsWithMetadata` also contain a `documentContentHash` attribute, which can be used to determine whether an evaluation result was made from a log for an exact document content or not.

The list of evaluation results in the Refine modal menu is now fully paginated, and includes all results from logs made either from this commit, or any other commit that has the same contentHash.