### PR TITLE
Fix: Compiler was reading all attributes as strings.

### DIFF
--- a/packages/compiler/src/compiler/base/nodes/tag.ts
+++ b/packages/compiler/src/compiler/base/nodes/tag.ts
@@ -38,10 +38,12 @@ async function resolveTagAttributes({
       continue
     }
 
-    let totalValue: string = ''
+    const accumulatedValue: unknown[] = []
     for await (const node of value) {
       if (node.type === 'Text') {
-        totalValue += node.data
+        if (node.data) {
+          accumulatedValue.push(node.data)
+        }
         continue
       }
 
@@ -49,12 +51,17 @@ async function resolveTagAttributes({
         const expression = node.expression
         const resolvedValue = await resolveExpression(expression, scope)
         if (resolvedValue === undefined) continue
-        totalValue += String(resolvedValue)
+        accumulatedValue.push(resolvedValue)
         continue
       }
     }
 
-    attributes[name] = totalValue
+    const finalValue =
+      accumulatedValue.length > 1
+        ? accumulatedValue.map(String).join('')
+        : accumulatedValue[0]
+
+    attributes[name] = finalValue
   }
 
   return attributes

--- a/packages/compiler/src/compiler/chain.test.ts
+++ b/packages/compiler/src/compiler/chain.test.ts
@@ -447,7 +447,7 @@ describe('chain', async () => {
       ---
       <response />                /* step1 */
       <response model="foo-2" />  /* step2 */
-      <response temperature=1 />  /* step3 */
+      <response temperature={{1}} />  /* step3 */
     `)
 
     const chain = new Chain({
@@ -465,7 +465,7 @@ describe('chain', async () => {
 
     const { conversation: step3 } = await chain.step('')
     expect(step3.config.model).toBe('foo-1')
-    expect(step3.config.temperature).toBe('1')
+    expect(step3.config.temperature).toBe(1)
 
     const { conversation: finalConversation } = await chain.step('')
     expect(finalConversation.config.model).toBe('foo-1')


### PR DESCRIPTION
The compiler treated all HTML-like tag attributes as strings. As a result, our config schema didn’t allow modifying the ⁠temperature in a ⁠response chain step, because it wouldn’t read it as a number.
