### PR TITLE
Optimise real-time compilation

### DIFF
--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/EvaluationEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/EvaluationEditor/Editor/index.tsx
@@ -43,14 +43,11 @@ export default function EvaluationEditor({
     () => promptConfigSchema({ providers: providers ?? [] }),
     [providers],
   )
-  const { metadata } = useMetadata(
-    {
-      prompt: value,
-      withParameters: SERIALIZED_DOCUMENT_LOG_FIELDS,
-      configSchema,
-    },
-    [value, configSchema],
-  )
+  const { metadata } = useMetadata({
+    prompt: value,
+    withParameters: SERIALIZED_DOCUMENT_LOG_FIELDS,
+    configSchema,
+  })
 
   const save = useCallback(
     (val: string) => {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -185,15 +185,12 @@ export default function DocumentEditor({
     [providers],
   )
 
-  const { metadata } = useMetadata(
-    {
-      prompt: value,
-      fullPath: document.path,
-      referenceFn: readDocument,
-      configSchema,
-    },
-    [readDocument, configSchema],
-  )
+  const { metadata } = useMetadata({
+    prompt: value,
+    fullPath: document.path,
+    referenceFn: readDocument,
+    configSchema,
+  })
 
   const isMerged = commit.mergedAt !== null
   return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
@@ -32,13 +32,10 @@ export default function CreateBatchEvaluationModal({
     },
   })
 
-  const { metadata } = useMetadata(
-    {
-      prompt: document.content ?? '',
-      fullPath: document.path,
-    },
-    [document],
-  )
+  const { metadata } = useMetadata({
+    prompt: document.content ?? '',
+    fullPath: document.path,
+  })
 
   const form = useRunBatchForm({ documentMetadata: metadata })
   const onRunBatch = useCallback(() => {


### PR DESCRIPTION
Changes made:

- `readMetadata` won't be executed while another metadata is still being calculated.
- Added a debounce of 500ms to `readMetadata` execution.

This does NOT optimize the execution of `readMetadata`, reduces how often it’s run and removes unnecesary parallel executions.

