### PR TITLE
Auto validate launch-day register reward

### DIFF
--- a/apps/web/src/services/user/setupService.ts
+++ b/apps/web/src/services/user/setupService.ts
@@ -51,6 +51,7 @@ export default function setupService({
           user,
           type: RewardType.SignupLaunchDay,
           reference: LAUNCH_DAY, // not really used for this reward type
+          autoValidated: true,
         },
         tx,
       )

--- a/packages/core/src/services/claimedRewards/claim.ts
+++ b/packages/core/src/services/claimedRewards/claim.ts
@@ -12,11 +12,13 @@ export async function claimReward(
     user,
     type,
     reference,
+    autoValidated,
   }: {
     workspace: Workspace
     user: User
     type: RewardType
     reference: string
+    autoValidated?: boolean
   },
   db = database,
 ) {
@@ -51,6 +53,7 @@ export async function claimReward(
         rewardType: type,
         reference,
         value: REWARD_VALUES[type],
+        isValid: autoValidated ? true : null,
       })
       .returning()
       .then((r) => r[0])


### PR DESCRIPTION
The backoffice is getting filled with tons of rewards that should be auto-validated by default.

![image](https://github.com/user-attachments/assets/21a90f8e-74fc-4124-950e-27dc2a5e8ec7)
