### PR TITLE
feat: retry strategy in sdk

### DIFF
--- a/packages/sdks/typescript/src/chat.test.ts
+++ b/packages/sdks/typescript/src/chat.test.ts
@@ -267,4 +267,22 @@ describe('message', () => {
       },
     })
   })
+
+  it('should retry 3 times if gateway is not available', async () => {
+    const mockFn = vi.fn()
+    server.use(
+      http.post(
+        'http://localhost:8787/api/v1/conversations/fake-document-log-uuid/chat',
+        () => {
+          mockFn('called!')
+          return new HttpResponse(null, {
+            status: 502,
+          })
+        },
+      ),
+    )
+
+    await SDK.chat('fake-document-log-uuid', [])
+    expect(mockFn).toHaveBeenCalledTimes(3)
+  })
 })


### PR DESCRIPTION
In case of a bad gateway response we should retry the request a couple of times before giving up.