### PR TITLE
feature: better evaluation creation ux

### DIFF
--- a/packages/core/src/services/providerApiKeys/destroy.test.ts
+++ b/packages/core/src/services/providerApiKeys/destroy.test.ts
@@ -1,0 +1,58 @@
+import { env } from 'process'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Providers, User, Workspace } from '../../browser'
+import { BadRequestError } from '../../lib'
+import { createProject, createProviderApiKey } from '../../tests/factories'
+import { destroyProviderApiKey } from './destroy'
+
+// Mock environment variable
+vi.mock('@latitude-data/env', () => ({
+  env: {
+    DEFAULT_PROVIDER_API_KEY: 'default-api-key',
+  },
+}))
+
+describe('destroyProviderApiKey', () => {
+  let workspace: Workspace, user: User
+
+  beforeEach(async () => {
+    const { workspace: w, user: u } = await createProject()
+    workspace = w
+    user = u
+  })
+
+  it('should not allow deleting the default provider API key', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      user,
+      name: 'Default Provider',
+      type: Providers.OpenAI,
+      token: env.DEFAULT_PROVIDER_API_KEY,
+    })
+
+    const result = await destroyProviderApiKey(provider)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(BadRequestError)
+    expect(result.error!.message).toBe(
+      'Cannot delete the default provider API key',
+    )
+  })
+
+  it('should allow deleting a non-default provider API key', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      user,
+      name: 'Non-Default Provider',
+      type: Providers.OpenAI,
+      token: 'non-default-api-key',
+    })
+
+    const result = await destroyProviderApiKey(provider)
+
+    expect(result.ok).toBe(true)
+    expect(result.value).toEqual(provider)
+  })
+})

--- a/packages/core/src/services/providerApiKeys/destroy.ts
+++ b/packages/core/src/services/providerApiKeys/destroy.ts
@@ -1,3 +1,4 @@
+import { env } from '@latitude-data/env'
 import { eq } from 'drizzle-orm'
 import { DatabaseError } from 'pg'
 
@@ -11,10 +12,16 @@ import {
 } from '../../lib'
 import { providerApiKeys } from '../../schema'
 
-export function destroyProviderApiKey(
+export async function destroyProviderApiKey(
   providerApiKey: ProviderApiKey,
   db = database,
 ) {
+  if (providerApiKey.token === env.DEFAULT_PROVIDER_API_KEY) {
+    return Result.error(
+      new BadRequestError('Cannot delete the default provider API key'),
+    )
+  }
+
   return Transaction.call(async (tx) => {
     try {
       const result = await tx

--- a/packages/core/src/tests/factories/providerApiKeys.ts
+++ b/packages/core/src/tests/factories/providerApiKeys.ts
@@ -12,18 +12,20 @@ export type ICreateProvider = {
   type: Providers
   name: string
   user: User
+  token?: string
 }
 export async function createProviderApiKey({
   workspace,
   type,
   name,
   user,
+  token = `sk-${faker.string.alphanumeric(48)}`,
 }: ICreateProvider) {
   const providerApiKey = await createFn({
     workspace,
     provider: type,
     name,
-    token: `sk-${faker.string.alphanumeric(48)}`,
+    token,
     author: user,
   }).then((r) => r.unwrap())
 


### PR DESCRIPTION
It allows only to create an evaluation when there's a provider from a supported type (openai or anthropic) or the default provider. If any of those cases is not true, it will return an error (should never happen).