### PR TITLE
Fixes LATITUDE-LLM-APP-4D Invalid state: Controller is already closed

### DIFF
--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/sdks/typescript/src/utils/nodeFetchResponseToReadableStream.ts
+++ b/packages/sdks/typescript/src/utils/nodeFetchResponseToReadableStream.ts
@@ -15,16 +15,26 @@ export function nodeFetchResponseToReadableStream(nodeStream: Readable) {
       })
 
       /**
-       * The 'close' event is emitted when the stream and any of its underlying resources
-       * (like a file descriptor) have been closed.
+       * The 'end' event is emitted when there is no more data to be consumed from the stream.
+       * The 'end' event will not be emitted unless the data is completely consumed.
+       * This can be accomplished by switching the stream into flowing mode, or by calling stream.read() repeatedly until all data has been consumed.
+       */
+      nodeStream.on('end', () => {
+        controller.close()
+      })
+
+      /**
+       * The 'close' event is emitted when the stream and any of its
+       * underlying resources (a file descriptor, for example) have been closed.
        * The event indicates that no more events will be emitted, and no further computation will occur.
        *
-       * Other similar event is `end` event, which is emitted when there is no more data to be consumed from the stream.
-       * But I think is safer to rely on `close` event, because it is emitted when the stream is closed,
-       * and no more events will be emitted.
+       * A Readable stream will always emit the 'close' event if it is created with the emitClose option.
        */
       nodeStream.on('close', () => {
-        controller.close()
+        // Optionally handle the case when the stream closes unexpectedly
+        if (!nodeStream.readableEnded) {
+          controller.close()
+        }
       })
 
       /**


### PR DESCRIPTION
I had to choose between `end` and `close` events and think I picked the wrong one. Let's see if this fixes the issue. By the way, this does not happen all the time. I just tested production and worked for me.

## Sentry issue
https://latitude-l5.sentry.io/issues/5996210933/?alert_rule_id=15461351&alert_type=issue&environment=production&notification_uuid=5e4bbccb-4064-409f-9799-f92cd1868ca6&project=4507922531418112&referrer=slack