### PR TITLE
Fix scrolls and container limits

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
@@ -216,10 +216,10 @@ export default function Chat({
   )
 
   return (
-    <div className='flex flex-col h-full'>
+    <div className='flex flex-col flex-1 gap-2 h-full overflow-hidden'>
       <div
         ref={containerRef}
-        className='flex flex-col gap-3 h-full overflow-y-auto custom-scrollbar pb-12'
+        className='flex flex-col gap-3 flex-grow flex-shrink min-h-0 custom-scrollbar pb-12'
       >
         <Text.H6M>Prompt</Text.H6M>
         <MessageList

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
@@ -63,24 +63,30 @@ export default function Preview({
   }, [metadata, parameters])
 
   return (
-    <div
-      ref={containerRef}
-      className='flex flex-col gap-3 h-full overflow-y-auto'
-    >
-      <div className='flex flex-col gap-2'>
-        <Text.H6M>Preview</Text.H6M>
-        {(conversation?.messages ?? []).map((message, index) => (
-          <Message key={index} role={message.role} content={message.content} />
-        ))}
-      </div>
-      {error !== undefined && <ErrorMessage error={error} />}
-      {!completed && (
-        <div className='w-full py-1 px-4 bg-secondary rounded-lg'>
-          <Text.H6 color='foregroundMuted'>
-            Showing the first step. Other steps will show after running.
-          </Text.H6>
+    <div className='flex flex-col flex-1 gap-2 h-full overflow-hidden'>
+      <div
+        ref={containerRef}
+        className='flex flex-col gap-3 flex-grow flex-shrink min-h-0 custom-scrollbar'
+      >
+        <div className='flex flex-col gap-2'>
+          <Text.H6M>Preview</Text.H6M>
+          {(conversation?.messages ?? []).map((message, index) => (
+            <Message
+              key={index}
+              role={message.role}
+              content={message.content}
+            />
+          ))}
         </div>
-      )}
+        {error !== undefined && <ErrorMessage error={error} />}
+        {!completed && (
+          <div className='w-full py-1 px-4 bg-secondary rounded-lg'>
+            <Text.H6 color='foregroundMuted'>
+              Showing the first step. Other steps will show after running.
+            </Text.H6>
+          </div>
+        )}
+      </div>
 
       <div className='flex flex-row w-full items-center justify-center gap-2'>
         {error || (metadata?.errors.length ?? 0) > 0 ? (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import { ConversationMetadata } from '@latitude-data/compiler'
 import { DocumentVersion } from '@latitude-data/core/browser'
@@ -22,6 +29,44 @@ export function convertParams(inputs: Record<string, string>) {
   )
 }
 
+function InputParams({
+  inputs,
+  setInputs,
+}: {
+  inputs: Record<string, string>
+  setInputs: Dispatch<SetStateAction<Record<string, string>>>
+}) {
+  const setInput = useCallback(
+    (param: string, value: string) => {
+      setInputs({ ...inputs, [param]: value })
+    },
+    [inputs],
+  )
+
+  return (
+    <div className='flex flex-col gap-3 flex-shrink-0 max-h-[33%] custom-scrollbar'>
+      <Text.H6M>Inputs</Text.H6M>
+      {Object.keys(inputs).length > 0 ? (
+        Object.entries(inputs).map(([param, value], idx) => (
+          <div className='flex flex-row gap-4 w-full items-center' key={idx}>
+            <Badge variant='accent'>&#123;&#123;{param}&#125;&#125;</Badge>
+            <div className='flex flex-grow w-full'>
+              <Input
+                value={value}
+                onChange={(e) => setInput(param, e.target.value)}
+              />
+            </div>
+          </div>
+        ))
+      ) : (
+        <Text.H6 color='foregroundMuted'>
+          No inputs. Use &#123;&#123; input_name &#125;&#125; to insert.
+        </Text.H6>
+      )}
+    </div>
+  )
+}
+
 export default function Playground({
   document,
   metadata,
@@ -32,13 +77,6 @@ export default function Playground({
   const [mode, setMode] = useState<'preview' | 'chat'>('preview')
   const [inputs, setInputs] = useState<Record<string, string>>({})
   const parameters = useMemo(() => convertParams(inputs), [inputs])
-
-  const setInput = useCallback(
-    (param: string, value: string) => {
-      setInputs({ ...inputs, [param]: value })
-    },
-    [inputs],
-  )
 
   useEffect(() => {
     if (!metadata) return
@@ -56,50 +94,24 @@ export default function Playground({
   }, [metadata])
 
   return (
-    <>
+    <div className='flex flex-col gap-2 max-h-full h-full'>
       <Header title='Playground' />
-      <div className='flex flex-col gap-6 relative'>
-        <div className='flex flex-col gap-3 max-h-[35vh] overflow-y-auto pr-4 pb-4'>
-          <Text.H6M>Inputs</Text.H6M>
-          {Object.keys(inputs).length > 0 ? (
-            Object.entries(inputs).map(([param, value], idx) => (
-              <div
-                className='flex flex-row gap-4 w-full items-center'
-                key={idx}
-              >
-                <Badge variant='accent'>&#123;&#123;{param}&#125;&#125;</Badge>
-                <div className='flex flex-grow w-full'>
-                  <Input
-                    value={value}
-                    onChange={(e) => setInput(param, e.target.value)}
-                  />
-                </div>
-              </div>
-            ))
-          ) : (
-            <Text.H6 color='foregroundMuted'>
-              No inputs. Use &#123;&#123; input_name &#125;&#125; to insert.
-            </Text.H6>
-          )}
-        </div>
-        <div className='flex flex-col flex-grow gap-3'>
-          <div className='flex flex-col flex-grow flex-shrink relative h-full overflow-y-auto'>
-            {mode === 'preview' ? (
-              <Preview
-                metadata={metadata}
-                parameters={parameters}
-                runPrompt={() => setMode('chat')}
-              />
-            ) : (
-              <Chat
-                clearChat={() => setMode('preview')}
-                document={document}
-                parameters={parameters}
-              />
-            )}
-          </div>
-        </div>
+      <InputParams inputs={inputs} setInputs={setInputs} />
+      <div className='flex-grow flex-shrink min-h-0 flex flex-col gap-2 overflow-hidden'>
+        {mode === 'preview' ? (
+          <Preview
+            metadata={metadata}
+            parameters={parameters}
+            runPrompt={() => setMode('chat')}
+          />
+        ) : (
+          <Chat
+            clearChat={() => setMode('preview')}
+            document={document}
+            parameters={parameters}
+          />
+        )}
       </div>
-    </>
+    </div>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -285,7 +285,7 @@ export default function DocumentEditor({
               />
             </Suspense>
           </div>
-          <div className='flex flex-col flex-1 gap-2 overflow-y-auto custom-scrollbar max-h-[calc(100vh-170px)]'>
+          <div className='flex-1 relative'>
             <Playground document={document} metadata={metadata!} />
           </div>
         </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/index.tsx
@@ -27,7 +27,9 @@ export default function DocumentTabs({
           Deploy this prompt <Icon name='code2' />
         </Button>
       </div>
-      <div className='flex-grow flex flex-col w-full'>{children}</div>
+      <div className='flex-grow min-h-0 flex flex-col w-full relative'>
+        {children}
+      </div>
     </>
   )
 }

--- a/apps/web/src/components/layouts/AppLayout/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/index.tsx
@@ -19,7 +19,7 @@ export default function AppLayout({
 }: AppLayoutProps) {
   return (
     <div
-      className={cn('grid grid-rows-[auto,1fr] h-screen overflow-hidden', {
+      className={cn('flex flex-col h-screen overflow-hidden relative', {
         'overflow-y-auto custom-scrollbar': scrollable,
       })}
     >
@@ -28,7 +28,9 @@ export default function AppLayout({
         navigationLinks={navigationLinks}
         currentUser={currentUser}
       />
-      <main>{children}</main>
+      <main className='w-full flex-grow min-h-0 h-full relative'>
+        {children}
+      </main>
     </div>
   )
 }

--- a/packages/web-ui/src/ds/atoms/SplitPane/index.tsx
+++ b/packages/web-ui/src/ds/atoms/SplitPane/index.tsx
@@ -18,7 +18,6 @@ function Pane({ children }: { children: ReactNode }) {
 }
 
 const PaneWrapper = ({
-  width = 'auto',
   children,
   isResizable = false,
   className,
@@ -30,10 +29,13 @@ const PaneWrapper = ({
 }) => {
   return (
     <div
-      className={cn('h-full overflow-y-auto custom-scrollbar', className)}
-      style={{
-        width: width === 'auto' ? 'auto' : isResizable ? width - 1 : width,
-      }}
+      className={cn(
+        'h-full max-h-full custom-scrollbar w-full relative min-h-0',
+        {
+          'flex-grow min-w-0': !isResizable,
+        },
+        className,
+      )}
     >
       {children}
     </div>
@@ -87,7 +89,7 @@ function ResizablePane({
       axis='x'
       width={paneWidth}
       minConstraints={[minWidth, Infinity]}
-      className='flex relative'
+      className='flex relative flex-shrink-0 flex-grow-0'
       resizeHandles={['e']}
       handle={SplitHandle}
       onResize={onResize}
@@ -114,16 +116,15 @@ function HorizontalSplit({
   cssPanelHeight?: string
 }) {
   const [paneWidth, setPaneWidth] = useState<number>(initialWidth)
-  const width = typeof window !== 'undefined' ? paneWidth : initialWidth
   return (
-    <div className='min-h-full w-full grid grid-cols-[auto,1fr]'>
+    <div className='flex flex-row w-full relative h-full max-h-full min-h-full'>
       <ResizablePane
         minWidth={minWidth}
         paneWidth={paneWidth}
         onResizePane={setPaneWidth}
         onResizeStop={onResizeStop}
       >
-        <PaneWrapper isResizable width={width} className={cssPanelHeight}>
+        <PaneWrapper isResizable className={cssPanelHeight}>
           {leftPane}
         </PaneWrapper>
       </ResizablePane>

--- a/packages/web-ui/src/sections/Document/DetailWrapper/index.tsx
+++ b/packages/web-ui/src/sections/Document/DetailWrapper/index.tsx
@@ -41,7 +41,6 @@ export default function DocumentDetailWrapper({
   )
   return (
     <SplitPane
-      cssPanelHeight='h-[calc(100vh-53px)]'
       initialWidth={sidebarWidth ?? minSidebarWidth}
       minWidth={minSidebarWidth}
       onResizeStop={onResizeStop}


### PR DESCRIPTION
Removed some hardcoded height limitations to containers, and fixed the actual responsiveness and container sizes through CSS attributes (tailwind classes, don't worry). Man, flex containers are so useful and and easy to do wrong :)

Fixed by using `flex-grow` and `flex-shrink` attributes when needed.

Also, now Playground buttons stay always visible at the bottom without having to scroll

https://github.com/user-attachments/assets/f3eb16df-7e4f-4da4-80e6-07b44bc860b5




