### PR TITLE
Remove redundant apk update calls in Dockerfiles

### DIFF
--- a/apps/gateway/docker/Dockerfile
+++ b/apps/gateway/docker/Dockerfile
@@ -5,7 +5,6 @@ ARG SENTRY_AUTH_TOKEN
 FROM node:20-alpine AS alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat curl
 
 FROM alpine as base

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -8,7 +8,6 @@ ARG SENTRY_AUTH_TOKEN
 FROM node:20-alpine AS alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat curl
 
 FROM alpine as base

--- a/apps/websockets/docker/Dockerfile
+++ b/apps/websockets/docker/Dockerfile
@@ -4,7 +4,6 @@ ARG PROJECT_PATH="apps/websockets"
 FROM node:20-alpine AS alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat curl
 
 FROM alpine as base

--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -5,7 +5,6 @@ ARG SENTRY_AUTH_TOKEN
 FROM node:20-alpine AS alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat curl
 
 FROM alpine as base

--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -3,7 +3,6 @@ ARG PROJECT="@latitude-data/core"
 FROM node:20-alpine AS alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat
 
 FROM alpine as base


### PR DESCRIPTION
Removed unnecessary `apk update` commands in all Dockerfiles. The `apk add` commands already utilize the `--no-cache` option, making the update step superfluous and ensuring the latest packages are used without maintaining a local cache. An additional `apk update` in another Docker image layer will just make the image larger with no benefits.