### PR TITLE
Add support for openai o1 models

### DIFF
--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/EvaluationEditor/Editor/Playground/Chat/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/EvaluationEditor/Editor/Playground/Chat/index.tsx
@@ -50,6 +50,7 @@ export default function Chat({
   const [chainLength, setChainLength] = useState<number>(Infinity)
   const [conversation, setConversation] = useState<Conversation | undefined>()
   const [responseStream, setResponseStream] = useState<string | undefined>()
+  const [isStreaming, setIsStreaming] = useState(false)
 
   const addMessageToConversation = useCallback(
     (message: ConversationMessage) => {
@@ -69,7 +70,7 @@ export default function Chat({
   const runEvaluation = useCallback(async () => {
     setError(undefined)
     setResponseStream(undefined)
-
+    setIsStreaming(true)
     let response = ''
     let messagesCount = 0
 
@@ -101,9 +102,11 @@ export default function Chat({
           } else if (data.type === ChainEventTypes.Complete) {
             setResponseStream(undefined)
             setUsage(data.response.usage)
+            setIsStreaming(false)
             setEndTime(performance.now())
           } else if (data.type === ChainEventTypes.Error) {
             setError(new Error(data.error.message))
+            setIsStreaming(false)
           }
           break
         }
@@ -119,6 +122,7 @@ export default function Chat({
           break
       }
     }
+    setIsStreaming(false)
   }, [parameters, runPromptAction])
 
   useEffect(() => {
@@ -168,11 +172,16 @@ export default function Chat({
         <TokenUsage
           isScrolledToBottom={isScrolledToBottom}
           usage={usage}
-          responseStream={responseStream}
+          isStreaming={isStreaming}
         />
       </div>
       <div className='flex items-center justify-center'>
-        <Button fancy variant='outline' onClick={clearChat}>
+        <Button
+          disabled={isStreaming}
+          fancy
+          variant='outline'
+          onClick={clearChat}
+        >
           Clear chat
         </Button>
       </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
@@ -60,6 +60,7 @@ export default function Chat({
   const [chainLength, setChainLength] = useState<number>(Infinity)
   const [conversation, setConversation] = useState<Conversation | undefined>()
   const [responseStream, setResponseStream] = useState<string | undefined>()
+  const [isStreaming, setIsStreaming] = useState(false)
 
   const addMessageToConversation = useCallback(
     (message: ConversationMessage) => {
@@ -80,7 +81,12 @@ export default function Chat({
     const start = performance.now()
     setError(undefined)
     setResponseStream('')
-
+    setIsStreaming(true)
+    setUsage({
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    })
     let response = ''
     let messagesCount = 0
 
@@ -136,6 +142,7 @@ export default function Chat({
     } catch (error) {
       setError(error as Error)
     } finally {
+      setIsStreaming(false)
       setResponseStream(undefined)
     }
   }, [
@@ -258,12 +265,12 @@ export default function Chat({
         <TokenUsage
           isScrolledToBottom={isScrolledToBottom}
           usage={usage}
-          responseStream={responseStream}
+          isStreaming={isStreaming}
         />
         <ChatTextArea
           clearChat={clearChat}
           placeholder='Enter followup message...'
-          disabled={responseStream !== undefined}
+          disabled={isStreaming}
           onSubmit={submitUserMessage}
         />
       </div>
@@ -290,13 +297,13 @@ export function AnimatedDots() {
 export function TokenUsage({
   isScrolledToBottom,
   usage,
-  responseStream,
+  isStreaming,
 }: {
   isScrolledToBottom: boolean
   usage: LanguageModelUsage | undefined
-  responseStream: string | undefined
+  isStreaming: boolean
 }) {
-  if (!usage && responseStream === undefined) return null
+  if (!usage && isStreaming) return null
 
   return (
     <div
@@ -307,7 +314,7 @@ export function TokenUsage({
         },
       )}
     >
-      {responseStream === undefined ? (
+      {!isStreaming && usage ? (
         <Tooltip
           side='top'
           align='center'

--- a/packages/core/src/services/ai/estimateCost/openai.ts
+++ b/packages/core/src/services/ai/estimateCost/openai.ts
@@ -2,12 +2,18 @@ import type { ModelCost } from '.'
 
 // source: https://openai.com/api/pricing/
 const OPENAI_MODEL_COST_PER_1M_TOKENS = {
-  'gpt-4o': { input: 5.0, output: 15.0 },
+  'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-2024-08-06': { input: 2.5, output: 10.0 },
   'gpt-4o-2024-05-13': { input: 5.0, output: 15.0 },
 
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
   'gpt-4o-mini-2024-07-18': { input: 0.15, output: 0.6 },
+
+  'o1-preview': { input: 15.0, output: 60.0 },
+  'o1-preview-2024-09-12': { input: 15.0, output: 60.0 },
+  'o1-mini': { input: 3.0, output: 12.0 },
+  'o1-mini-2024-09-12': { input: 3.0, output: 12.0 },
+
 
   'chatgpt-4o-latest': { input: 5.0, output: 15.0 },
   'gpt-4-turbo': { input: 10.0, output: 30.0 },

--- a/packages/core/src/services/ai/estimateCost/openai.ts
+++ b/packages/core/src/services/ai/estimateCost/openai.ts
@@ -14,7 +14,6 @@ const OPENAI_MODEL_COST_PER_1M_TOKENS = {
   'o1-mini': { input: 3.0, output: 12.0 },
   'o1-mini-2024-09-12': { input: 3.0, output: 12.0 },
 
-
   'chatgpt-4o-latest': { input: 5.0, output: 15.0 },
   'gpt-4-turbo': { input: 10.0, output: 30.0 },
   'gpt-4-turbo-2024-04-09': { input: 10.0, output: 30.0 },

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -106,13 +106,24 @@ export async function ai({
         output: output as any,
       })
 
+      const chunks: StreamChunk[] = [
+        {
+          type: 'object',
+          object: result.object,
+        },
+        {
+          type: 'finish',
+          finishReason: result.finishReason,
+          usage: result.usage,
+          response: result.response,
+        },
+      ]
+
       const fullStream = new ReadableStream<StreamChunk>({
         start(controller: any) {
-          const streamChunk: StreamChunk = {
-            type: 'object',
-            object: result.object,
-          }
-          controller.enqueue(streamChunk)
+          chunks.forEach((chunk) => {
+            controller.enqueue(chunk)
+          })
           controller.close()
         },
       })
@@ -129,13 +140,24 @@ export async function ai({
 
     const result = await generateText(commonOptions)
 
+    const chunks: StreamChunk[] = [
+      {
+        type: 'text-delta',
+        textDelta: result.text,
+      },
+      {
+        type: 'finish',
+        finishReason: result.finishReason,
+        usage: result.usage,
+        response: result.response,
+      },
+    ]
+
     const fullStream = new ReadableStream<StreamChunk>({
       start(controller: any) {
-        const streamChunk: StreamChunk = {
-          type: 'text-delta',
-          textDelta: result.text,
-        }
-        controller.enqueue(streamChunk)
+        chunks.forEach((chunk) => {
+          controller.enqueue(chunk)
+        })
         controller.close()
       },
     })

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -4,17 +4,18 @@ import { Message } from '@latitude-data/compiler'
 import {
   CoreMessage,
   CoreTool,
+  generateObject,
+  generateText,
   jsonSchema,
   ObjectStreamPart,
   streamObject,
   StreamObjectResult,
   streamText,
   StreamTextResult,
-  generateText,
-  generateObject,
   TextStreamPart,
 } from 'ai'
 import { JSONSchema7 } from 'json-schema'
+
 import { ProviderApiKey, RunErrorCodes, StreamType } from '../../browser'
 import { Result, TypedResult } from '../../lib'
 import { ChainError } from '../chains/ChainErrors'
@@ -93,7 +94,6 @@ export async function ai({
   }
 
   if (UNSUPPORTED_STREAM_MODELS.includes(model)) {
-
     if (output && schema) {
       const result = await generateObject({
         ...commonOptions,

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -7,6 +7,7 @@ import {
   generateObject,
   generateText,
   jsonSchema,
+  LanguageModel,
   ObjectStreamPart,
   streamObject,
   StreamObjectResult,
@@ -55,6 +56,7 @@ export async function ai({
   config,
   schema,
   output,
+  customLanguageModel,
 }: {
   provider: ProviderApiKey
   config: PartialConfig
@@ -62,6 +64,7 @@ export async function ai({
   prompt?: string
   schema?: JSONSchema7
   output?: 'object' | 'array' | 'no-schema' | undefined
+  customLanguageModel?: LanguageModel
 }): Promise<
   TypedResult<
     AIReturn<StreamType>,
@@ -81,7 +84,9 @@ export async function ai({
 
   if (languageModelResult.error) return languageModelResult
 
-  const languageModel = languageModelResult.value(model)
+  const languageModel = customLanguageModel
+    ? customLanguageModel
+    : languageModelResult.value(model)
   const toolsResult = buildTools(config.tools)
   if (toolsResult.error) return toolsResult
 

--- a/packages/core/src/services/ai/providers/models/index.ts
+++ b/packages/core/src/services/ai/providers/models/index.ts
@@ -10,6 +10,10 @@ export enum Providers {
 const OPEN_AI_MODELS = {
   'gpt-4o-mini': 'gpt-4o-mini',
   'gpt-4o': 'gpt-4o',
+  'o1-preview': 'o1-preview',
+  'o1-preview-2024-09-12': 'o1-preview-2024-09-12',
+  'o1-mini': 'o1-mini',
+  'o1-mini-2024-09-12	': 'o1-mini-2024-09-12',
   'gpt-4': 'gpt-4',
   'gpt-4-32k': 'gpt-4-32k',
   'gpt-4o-2024-08-06': 'gpt-4o-2024-08-06',
@@ -67,6 +71,13 @@ export const PROVIDER_MODELS: Partial<
   },
   [Providers.Custom]: {},
 }
+
+export const UNSUPPORTED_STREAM_MODELS = [
+  'o1-preview',
+  'o1-preview-2024-09-12',
+  'o1-mini',
+  'o1-mini-2024-09-12',
+]
 
 export function findFirstModelForProvider(provider: Providers) {
   return Object.keys(PROVIDER_MODELS[provider] ?? {})[0]


### PR DESCRIPTION
- Since o1 models doesn't support streaming, I simulated a stream, as it's much easier because all the latitude pipeline seems to be stream only.
- Adapted the playground to display correct loading animation.