### PR TITLE
fix: cannot remove providers

### DIFF
--- a/packages/core/src/services/providerApiKeys/destroy.ts
+++ b/packages/core/src/services/providerApiKeys/destroy.ts
@@ -19,7 +19,7 @@ export async function destroyProviderApiKey(
   return Transaction.call(async (tx) => {
     const result = await tx
       .update(providerApiKeys)
-      .set({ deletedAt: new Date(), token: '<removed>' })
+      .set({ deletedAt: new Date(), token: `<removed-${providerApiKey.id}>` })
       .where(eq(providerApiKeys.id, providerApiKey.id))
       .returning()
     const deleted = result[0]


### PR DESCRIPTION
Soft-deleting a provider would change the token key to `<removed>`. Trying to remove a second provider of the same type in the same workspace failed because of the unique workspace-type-token constraint since both providers would have the `<removed>` token.