### PR TITLE
refactor(repositories): update repository inheritance to use RepositoryLegacy and RepositoryV2

### DIFF
--- a/apps/web/src/presenters/providerLogPresenter.ts
+++ b/apps/web/src/presenters/providerLogPresenter.ts
@@ -8,6 +8,7 @@ export default function providerLogPresenter(
 ): ProviderLogDto {
   return {
     ...omit(providerLog, 'responseText', 'responseObject'),
+
     response: buildProviderLogResponse(providerLog),
   }
 }

--- a/packages/core/src/repositories/apiKeysRepository.ts
+++ b/packages/core/src/repositories/apiKeysRepository.ts
@@ -3,11 +3,11 @@ import { eq, getTableColumns } from 'drizzle-orm'
 import { ApiKey } from '../browser'
 import { NotFoundError, Result } from '../lib'
 import { apiKeys } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = getTableColumns(apiKeys)
 
-export class ApiKeysRepository extends Repository<typeof tt, ApiKey> {
+export class ApiKeysRepository extends RepositoryLegacy<typeof tt, ApiKey> {
   get scope() {
     return this.db
       .select(tt)

--- a/packages/core/src/repositories/claimedRewardsRepository.ts
+++ b/packages/core/src/repositories/claimedRewardsRepository.ts
@@ -3,11 +3,11 @@ import { and, eq, getTableColumns, isNull, not, or, sum } from 'drizzle-orm'
 import { ClaimedReward, RewardType } from '../browser'
 import { Result } from '../lib'
 import { claimedRewards } from '../schema/models/claimedRewards'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = getTableColumns(claimedRewards)
 
-export class ClaimedRewardsRepository extends Repository<
+export class ClaimedRewardsRepository extends RepositoryLegacy<
   typeof tt,
   ClaimedReward
 > {

--- a/packages/core/src/repositories/commitsRepository/index.ts
+++ b/packages/core/src/repositories/commitsRepository/index.ts
@@ -13,7 +13,7 @@ import {
   recomputeChanges,
   RecomputedChanges,
 } from '../../services/documents/recomputeChanges'
-import Repository from '../repository'
+import RepositoryLegacy from '../repository'
 import { buildCommitsScope, columnSelection } from './utils/buildCommitsScope'
 import { getHeadCommitForProject } from './utils/getHeadCommit'
 
@@ -47,7 +47,7 @@ function filterByStatusQuery({
   }
 }
 
-export class CommitsRepository extends Repository<
+export class CommitsRepository extends RepositoryLegacy<
   typeof columnSelection,
   Commit
 > {

--- a/packages/core/src/repositories/datasetsRepository.ts
+++ b/packages/core/src/repositories/datasetsRepository.ts
@@ -2,7 +2,7 @@ import { eq, sql } from 'drizzle-orm'
 
 import { Dataset } from '../browser'
 import { datasets, users } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 export const datasetColumns = {
   id: datasets.id,
@@ -19,7 +19,7 @@ export const datasetColumns = {
     name: sql`${users.name}`.as('users_name'),
   },
 }
-export class DatasetsRepository extends Repository<
+export class DatasetsRepository extends RepositoryLegacy<
   typeof datasetColumns,
   Dataset
 > {

--- a/packages/core/src/repositories/documentLogsRepository/index.ts
+++ b/packages/core/src/repositories/documentLogsRepository/index.ts
@@ -9,7 +9,7 @@ import {
   runErrors,
   workspaces,
 } from '../../schema'
-import Repository from '../repository'
+import Repository from '../repositoryV2'
 
 export type DocumentLogWithMetadata = DocumentLog & {
   commit: Commit
@@ -20,7 +20,7 @@ export type DocumentLogWithMetadata = DocumentLog & {
 
 const tt = getTableColumns(documentLogs)
 
-export class DocumentLogsRepository extends Repository<typeof tt, DocumentLog> {
+export class DocumentLogsRepository extends Repository<DocumentLog> {
   get scope() {
     return this.db
       .select(tt)
@@ -39,14 +39,11 @@ export class DocumentLogsRepository extends Repository<typeof tt, DocumentLog> {
         ),
       )
       .where(and(isNull(runErrors.id), eq(workspaces.id, this.workspaceId)))
-      .as('documentLogsScope')
+      .$dynamic()
   }
 
   async findByUuid(uuid: string) {
-    const result = await this.db
-      .select()
-      .from(this.scope)
-      .where(eq(this.scope.uuid, uuid))
+    const result = await this.scope.where(eq(documentLogs.uuid, uuid))
 
     if (!result.length) {
       return Result.error(

--- a/packages/core/src/repositories/documentVersionsRepository/index.ts
+++ b/packages/core/src/repositories/documentVersionsRepository/index.ts
@@ -14,7 +14,7 @@ import { Commit, DocumentVersion } from '../../browser'
 import { NotFoundError, Result } from '../../lib'
 import { commits, documentVersions, projects } from '../../schema'
 import { CommitsRepository } from '../commitsRepository'
-import Repository from '../repository'
+import RepositoryLegacy from '../repository'
 
 function mergeDocuments(
   ...documentsArr: DocumentVersion[][]
@@ -46,7 +46,7 @@ const tt = {
   projectId: sql<number>`${projects.id}::int`.as('projectId'),
 }
 
-export class DocumentVersionsRepository extends Repository<
+export class DocumentVersionsRepository extends RepositoryLegacy<
   typeof tt,
   DocumentVersion & { mergedAt: Date | null; projectId: number }
 > {

--- a/packages/core/src/repositories/evaluationsRepository.ts
+++ b/packages/core/src/repositories/evaluationsRepository.ts
@@ -10,7 +10,7 @@ import {
   evaluations,
   llmAsJudgeEvaluationMetadatas,
 } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = {
   ...getTableColumns(evaluations),
@@ -27,7 +27,7 @@ const tt = {
   },
 }
 
-export class EvaluationsRepository extends Repository<
+export class EvaluationsRepository extends RepositoryLegacy<
   typeof tt,
   EvaluationDto
 > {

--- a/packages/core/src/repositories/latitudeApiKeysRepository.ts
+++ b/packages/core/src/repositories/latitudeApiKeysRepository.ts
@@ -2,11 +2,14 @@ import { eq, getTableColumns } from 'drizzle-orm'
 
 import { ApiKey } from '../browser'
 import { apiKeys } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = getTableColumns(apiKeys)
 
-export class LatitudeApiKeysRepository extends Repository<typeof tt, ApiKey> {
+export class LatitudeApiKeysRepository extends RepositoryLegacy<
+  typeof tt,
+  ApiKey
+> {
   get scope() {
     return this.db
       .select(tt)

--- a/packages/core/src/repositories/membershipsRepository.ts
+++ b/packages/core/src/repositories/membershipsRepository.ts
@@ -3,11 +3,14 @@ import { eq, getTableColumns } from 'drizzle-orm'
 import { Membership } from '../browser'
 import { NotFoundError, Result } from '../lib'
 import { memberships } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = getTableColumns(memberships)
 
-export class MembershipsRepository extends Repository<typeof tt, Membership> {
+export class MembershipsRepository extends RepositoryLegacy<
+  typeof tt,
+  Membership
+> {
   get scope() {
     return this.db
       .select()

--- a/packages/core/src/repositories/projectsRepository.ts
+++ b/packages/core/src/repositories/projectsRepository.ts
@@ -12,13 +12,13 @@ import {
 import { Project } from '../browser'
 import { NotFoundError, Result } from '../lib'
 import { commits, documentVersions, projects } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const NOT_FOUND_MSG = 'Project not found'
 
 const tt = getTableColumns(projects)
 
-export class ProjectsRepository extends Repository<typeof tt, Project> {
+export class ProjectsRepository extends RepositoryLegacy<typeof tt, Project> {
   get scope() {
     return this.db
       .select(tt)

--- a/packages/core/src/repositories/providerApiKeysRepository.ts
+++ b/packages/core/src/repositories/providerApiKeysRepository.ts
@@ -3,11 +3,11 @@ import { and, eq, getTableColumns, isNull } from 'drizzle-orm'
 import { ProviderApiKey } from '../browser'
 import { NotFoundError, Result } from '../lib'
 import { providerApiKeys } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = getTableColumns(providerApiKeys)
 
-export class ProviderApiKeysRepository extends Repository<
+export class ProviderApiKeysRepository extends RepositoryLegacy<
   typeof tt,
   ProviderApiKey
 > {

--- a/packages/core/src/repositories/repositoryV2.ts
+++ b/packages/core/src/repositories/repositoryV2.ts
@@ -1,0 +1,60 @@
+import { eq, inArray } from 'drizzle-orm'
+import { PgSelect } from 'drizzle-orm/pg-core'
+
+import { database } from '../client'
+import { NotFoundError, Result } from '../lib'
+
+export type QueryOptions = {
+  limit?: number
+  offset?: number
+}
+
+export default abstract class Repository<T extends Record<string, unknown>> {
+  protected workspaceId: number
+  protected db = database
+
+  constructor(workspaceId: number, db = database) {
+    this.workspaceId = workspaceId
+    this.db = db
+  }
+
+  abstract get scope(): PgSelect<string>
+
+  async findAll(opts: QueryOptions = {}) {
+    let query = this.scope
+    if (opts.limit !== undefined) {
+      query = this.scope.limit(opts.limit)
+    }
+
+    if (opts.offset !== undefined) {
+      query = this.scope.offset(opts.offset)
+    }
+
+    return Result.ok((await query) as T[])
+  }
+
+  async find(id: string | number | undefined | null) {
+    const result = await this.scope
+      .where(eq(this.scope._.selectedFields.id, id))
+      .limit(1)
+    if (!result[0]) {
+      return Result.error(new NotFoundError(`Record with id ${id} not found`))
+    }
+
+    return Result.ok(result[0]! as T)
+  }
+
+  async findMany(ids: (string | number)[]) {
+    const result = await this.scope
+      .where(inArray(this.scope._.selectedFields.id, ids))
+      .limit(ids.length)
+
+    return Result.ok(result as T[])
+  }
+
+  async findFirst() {
+    const result = await this.scope.limit(1)
+
+    return Result.ok(result[0] as T | undefined)
+  }
+}

--- a/packages/core/src/repositories/runErrors/documentLogsRepository/index.ts
+++ b/packages/core/src/repositories/runErrors/documentLogsRepository/index.ts
@@ -10,7 +10,7 @@ import {
   workspaces,
 } from '../../../schema'
 import { DocumentLogWithMetadata } from '../../documentLogsRepository'
-import Repository from '../../repository'
+import Repository from '../../repositoryV2'
 import { RunErrorField } from '../evaluationResultsRepository'
 
 const tt = {
@@ -27,10 +27,7 @@ export type DocumentLogWithMetadataAndError = DocumentLogWithMetadata & {
 export type DocumentLogWithErrorScope =
   typeof DocumentLogsWithErrorsRepository.prototype.scope
 
-export class DocumentLogsWithErrorsRepository extends Repository<
-  typeof tt,
-  DocumentLogWithMetadataAndError
-> {
+export class DocumentLogsWithErrorsRepository extends Repository<DocumentLogWithMetadataAndError> {
   get scope() {
     return this.db
       .select(tt)
@@ -49,14 +46,11 @@ export class DocumentLogsWithErrorsRepository extends Repository<
         ),
       )
       .where(eq(workspaces.id, this.workspaceId))
-      .as('documentLogsWithErrorsScope')
+      .$dynamic()
   }
 
   async findByUuid(uuid: string) {
-    const result = await this.db
-      .select()
-      .from(this.scope)
-      .where(eq(this.scope.uuid, uuid))
+    const result = await this.scope.where(eq(documentLogs.uuid, uuid))
 
     if (!result.length) {
       return Result.error(

--- a/packages/core/src/repositories/runErrors/evaluationResultsRepository/index.ts
+++ b/packages/core/src/repositories/runErrors/evaluationResultsRepository/index.ts
@@ -13,7 +13,7 @@ import {
   evaluationResultDto,
   EvaluationResultWithMetadata,
 } from '../../evaluationResultsRepository'
-import Repository from '../../repository'
+import RepositoryLegacy from '../../repository'
 
 const evaluationResultDtoWithErrors = {
   ...evaluationResultDto,
@@ -38,7 +38,7 @@ export type EvaluationResultWithMetadataAndErrors =
     error: RunErrorField
   }
 
-export class EvaluationResultsWithErrorsRepository extends Repository<
+export class EvaluationResultsWithErrorsRepository extends RepositoryLegacy<
   typeof evaluationResultDtoWithErrors,
   EvaluationResultWithMetadataAndErrors
 > {

--- a/packages/core/src/repositories/usersRepository.ts
+++ b/packages/core/src/repositories/usersRepository.ts
@@ -2,14 +2,14 @@ import { and, eq, getTableColumns } from 'drizzle-orm'
 
 import { User } from '../browser'
 import { memberships, users } from '../schema'
-import Repository from './repository'
+import RepositoryLegacy from './repository'
 
 const tt = {
   ...getTableColumns(users),
   confirmedAt: memberships.confirmedAt,
 }
 
-export class UsersRepository extends Repository<typeof tt, User> {
+export class UsersRepository extends RepositoryLegacy<typeof tt, User> {
   get scope() {
     return this.db
       .select(tt)

--- a/packages/core/src/services/documentLogs/computeDocumentLogWithMetadata.ts
+++ b/packages/core/src/services/documentLogs/computeDocumentLogWithMetadata.ts
@@ -5,6 +5,7 @@ import { database } from '../../client'
 import { findWorkspaceFromDocumentLog } from '../../data-access'
 import { NotFoundError, Result, TypedResult } from '../../lib'
 import { DocumentLogWithMetadataAndError } from '../../repositories'
+import { documentLogs } from '../../schema'
 import { computeDocumentLogsWithMetadataQuery } from './computeDocumentLogsWithMetadata'
 
 export async function computeDocumentLogWithMetadata(
@@ -14,7 +15,7 @@ export async function computeDocumentLogWithMetadata(
   const workspace = await findWorkspaceFromDocumentLog(documentLog, db)
   if (!workspace) return Result.error(new NotFoundError('Workspace not found'))
 
-  const { scope, baseQuery } = computeDocumentLogsWithMetadataQuery(
+  const { baseQuery } = computeDocumentLogsWithMetadataQuery(
     {
       workspaceId: workspace.id,
       documentUuid: documentLog.documentUuid,
@@ -23,7 +24,9 @@ export async function computeDocumentLogWithMetadata(
     db,
   )
 
-  const result = await baseQuery.where(eq(scope.id, documentLog.id)).limit(1)
+  const result = await baseQuery
+    .where(eq(documentLogs.id, documentLog.id))
+    .limit(1)
 
   if (result.length === 0) {
     return Result.error(new NotFoundError('Document log not found'))

--- a/packages/core/src/services/documentLogs/fetchDocumentLogWithMetadata.ts
+++ b/packages/core/src/services/documentLogs/fetchDocumentLogWithMetadata.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm'
 import { database } from '../../client'
 import { NotFoundError, Result, TypedResult } from '../../lib'
 import { DocumentLogWithMetadataAndError } from '../../repositories'
+import { documentLogs } from '../../schema'
 import { computeDocumentLogsWithMetadataQuery } from './computeDocumentLogsWithMetadata'
 
 function throwNotFound({
@@ -34,7 +35,7 @@ export async function fetchDocumentLogWithMetadata(
 
   if (identifier === undefined) return throwNotFound({ identifier, type })
 
-  const { scope, baseQuery } = computeDocumentLogsWithMetadataQuery(
+  const { baseQuery } = computeDocumentLogsWithMetadataQuery(
     {
       workspaceId,
       allowAnyDraft: true,
@@ -44,9 +45,11 @@ export async function fetchDocumentLogWithMetadata(
   let logs: DocumentLogWithMetadataAndError[] = []
 
   if (documentLogUuid) {
-    logs = await baseQuery.where(eq(scope.uuid, documentLogUuid)).limit(1)
+    logs = await baseQuery
+      .where(eq(documentLogs.uuid, documentLogUuid))
+      .limit(1)
   } else if (documentLogId) {
-    logs = await baseQuery.where(eq(scope.id, documentLogId)).limit(1)
+    logs = await baseQuery.where(eq(documentLogs.id, documentLogId)).limit(1)
   }
 
   const documentLog = logs[0]

--- a/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
+++ b/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
@@ -4,16 +4,14 @@ import { Commit } from '../../browser'
 import { database } from '../../client'
 import { DocumentLogsRepository } from '../../repositories/documentLogsRepository'
 import { EvaluationResultsRepository } from '../../repositories/evaluationResultsRepository'
-import { commits, providerLogs } from '../../schema'
+import { commits, documentLogs, providerLogs } from '../../schema'
 
 export function createEvaluationResultQuery(
   workspaceId: number,
   db = database,
 ) {
-  const { scope: evaluationResultsScope } = new EvaluationResultsRepository(
-    workspaceId,
-    db,
-  )
+  const { scope } = new EvaluationResultsRepository(workspaceId, db)
+  const evaluationResultsScope = scope.as('evaluation_results_scope')
   const { scope: documentLogsScope } = new DocumentLogsRepository(
     workspaceId,
     db,
@@ -45,14 +43,14 @@ export function createEvaluationResultQuery(
         commit: commits,
         tokens: aggregatedFieldsSubQuery.tokens,
         costInMillicents: aggregatedFieldsSubQuery.costInMillicents,
-        documentContentHash: documentLogsScope.contentHash,
+        documentContentHash: documentLogs.contentHash,
       })
       .from(evaluationResultsScope)
       .innerJoin(
-        documentLogsScope,
-        eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+        documentLogs,
+        eq(documentLogs.id, evaluationResultsScope.documentLogId),
       )
-      .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+      .innerJoin(commits, eq(commits.id, documentLogs.commitId))
       .innerJoin(
         aggregatedFieldsSubQuery,
         eq(aggregatedFieldsSubQuery.id, evaluationResultsScope.id),

--- a/packages/core/src/services/evaluationResults/_createEvaluationResultQueryWithErrors.ts
+++ b/packages/core/src/services/evaluationResults/_createEvaluationResultQueryWithErrors.ts
@@ -5,7 +5,7 @@ import {
   DocumentLogsWithErrorsRepository,
   EvaluationResultsWithErrorsRepository,
 } from '../../repositories'
-import { commits, providerLogs } from '../../schema'
+import { commits, documentLogs, providerLogs } from '../../schema'
 
 export function createEvaluationResultQueryWithErrors(
   workspaceId: number,
@@ -44,14 +44,14 @@ export function createEvaluationResultQueryWithErrors(
         commit: commits,
         tokens: aggregatedFieldsSubQuery.tokens,
         costInMillicents: aggregatedFieldsSubQuery.costInMillicents,
-        documentContentHash: documentLogsScope.contentHash,
+        documentContentHash: documentLogs.contentHash,
       })
       .from(evaluationResultsScope)
       .innerJoin(
-        documentLogsScope,
-        eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+        documentLogs,
+        eq(documentLogs.id, evaluationResultsScope.documentLogId),
       )
-      .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+      .innerJoin(commits, eq(commits.id, documentLogs.commitId))
       .innerJoin(
         aggregatedFieldsSubQuery,
         eq(aggregatedFieldsSubQuery.id, evaluationResultsScope.id),

--- a/packages/core/src/services/evaluationResults/aggregations/countersQuery.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/countersQuery.ts
@@ -4,8 +4,7 @@ import { getCommitFilter } from '../_createEvaluationResultQuery'
 import { Commit, Evaluation } from '../../../browser'
 import { database } from '../../../client'
 import { EvaluationResultsRepository } from '../../../repositories'
-import { DocumentLogsRepository } from '../../../repositories/documentLogsRepository'
-import { commits, providerLogs } from '../../../schema'
+import { commits, documentLogs, providerLogs } from '../../../schema'
 
 export async function getEvaluationTotalsQuery(
   {
@@ -21,13 +20,8 @@ export async function getEvaluationTotalsQuery(
   },
   db = database,
 ) {
-  const { scope: evaluationResultsScope } = new EvaluationResultsRepository(
-    workspaceId,
-    db,
-  )
-
-  const documentLogsRepo = new DocumentLogsRepository(workspaceId, db)
-  const documentLogsScope = documentLogsRepo.scope
+  const { scope } = new EvaluationResultsRepository(workspaceId, db)
+  const evaluationResultsScope = scope.as('evaluation_results_scope')
 
   const result = await db
     .select({
@@ -38,8 +32,8 @@ export async function getEvaluationTotalsQuery(
     })
     .from(evaluationResultsScope)
     .innerJoin(
-      documentLogsScope,
-      eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+      documentLogs,
+      eq(documentLogs.id, evaluationResultsScope.documentLogId),
     )
     .innerJoin(
       providerLogs,
@@ -48,7 +42,7 @@ export async function getEvaluationTotalsQuery(
     .where(
       and(
         eq(evaluationResultsScope.evaluationId, evaluation.id),
-        eq(documentLogsScope.documentUuid, documentUuid),
+        eq(documentLogs.documentUuid, documentUuid),
       ),
     )
     .limit(1)
@@ -59,14 +53,14 @@ export async function getEvaluationTotalsQuery(
     })
     .from(evaluationResultsScope)
     .innerJoin(
-      documentLogsScope,
-      eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+      documentLogs,
+      eq(documentLogs.id, evaluationResultsScope.documentLogId),
     )
-    .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+    .innerJoin(commits, eq(commits.id, documentLogs.commitId))
     .where(
       and(
         eq(evaluationResultsScope.evaluationId, evaluation.id),
-        eq(documentLogsScope.documentUuid, documentUuid),
+        eq(documentLogs.documentUuid, documentUuid),
         getCommitFilter(commit),
       ),
     )

--- a/packages/core/src/services/evaluationResults/aggregations/meanValueQuery.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/meanValueQuery.ts
@@ -8,8 +8,7 @@ import {
 } from '../../../browser'
 import { database } from '../../../client'
 import { EvaluationResultsRepository } from '../../../repositories'
-import { DocumentLogsRepository } from '../../../repositories/documentLogsRepository'
-import { commits } from '../../../schema'
+import { commits, documentLogs } from '../../../schema'
 
 export async function getEvaluationMeanValueQuery(
   {
@@ -25,12 +24,8 @@ export async function getEvaluationMeanValueQuery(
   },
   db = database,
 ) {
-  const { scope: evaluationResultsScope } = new EvaluationResultsRepository(
-    workspaceId,
-    db,
-  )
-  const documentLogsRepo = new DocumentLogsRepository(workspaceId, db)
-  const documentLogsScope = documentLogsRepo.scope
+  const { scope } = new EvaluationResultsRepository(workspaceId, db)
+  const evaluationResultsScope = scope.as('evaluation_results_scope')
 
   const results = await db
     .select({
@@ -40,14 +35,14 @@ export async function getEvaluationMeanValueQuery(
     })
     .from(evaluationResultsScope)
     .innerJoin(
-      documentLogsScope,
-      eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+      documentLogs,
+      eq(documentLogs.id, evaluationResultsScope.documentLogId),
     )
-    .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+    .innerJoin(commits, eq(commits.id, documentLogs.commitId))
     .where(
       and(
         eq(evaluationResultsScope.evaluationId, evaluation.id),
-        eq(documentLogsScope.documentUuid, documentUuid),
+        eq(documentLogs.documentUuid, documentUuid),
         getCommitFilter(commit),
       ),
     )

--- a/packages/core/src/services/evaluationResults/aggregations/modalValueQuery.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/modalValueQuery.ts
@@ -4,8 +4,7 @@ import { getCommitFilter } from '../_createEvaluationResultQuery'
 import { Commit, Evaluation } from '../../../browser'
 import { database } from '../../../client'
 import { EvaluationResultsRepository } from '../../../repositories'
-import { DocumentLogsRepository } from '../../../repositories/documentLogsRepository'
-import { commits } from '../../../schema'
+import { commits, documentLogs } from '../../../schema'
 
 export async function getEvaluationModalValueQuery(
   {
@@ -21,15 +20,8 @@ export async function getEvaluationModalValueQuery(
   },
   db = database,
 ) {
-  const { scope: evaluationResultsScope } = new EvaluationResultsRepository(
-    workspaceId,
-    db,
-  )
-  const { scope: documentLogsScope } = new DocumentLogsRepository(
-    workspaceId,
-    db,
-  )
-
+  const repo = new EvaluationResultsRepository(workspaceId, db)
+  const evaluationResultsScope = repo.scope.as('evaluation_results_scope')
   const totalQuery = await db
     .select({
       totalCount: sum(evaluationResultsScope.id)
@@ -38,14 +30,14 @@ export async function getEvaluationModalValueQuery(
     })
     .from(evaluationResultsScope)
     .innerJoin(
-      documentLogsScope,
-      eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+      documentLogs,
+      eq(documentLogs.id, evaluationResultsScope.documentLogId),
     )
-    .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+    .innerJoin(commits, eq(commits.id, documentLogs.commitId))
     .where(
       and(
         eq(evaluationResultsScope.evaluationId, evaluation.id),
-        eq(documentLogsScope.documentUuid, documentUuid),
+        eq(documentLogs.documentUuid, documentUuid),
         getCommitFilter(commit),
       ),
     )
@@ -61,14 +53,14 @@ export async function getEvaluationModalValueQuery(
     })
     .from(evaluationResultsScope)
     .innerJoin(
-      documentLogsScope,
-      eq(documentLogsScope.id, evaluationResultsScope.documentLogId),
+      documentLogs,
+      eq(documentLogs.id, evaluationResultsScope.documentLogId),
     )
-    .innerJoin(commits, eq(commits.id, documentLogsScope.commitId))
+    .innerJoin(commits, eq(commits.id, documentLogs.commitId))
     .where(
       and(
         eq(evaluationResultsScope.evaluationId, evaluation.id),
-        eq(documentLogsScope.documentUuid, documentUuid),
+        eq(documentLogs.documentUuid, documentUuid),
         getCommitFilter(commit),
       ),
     )


### PR DESCRIPTION
This commit refactors the repository classes to inherit from either RepositoryLegacy or RepositoryV2 instead of the original Repository class. The changes are made to improve the baseline performance of the repository classes. Legacy repositories make use of subqueries which can often be slow. New repository uses drizzle's dynamic queries which are much faster. This change should improve the performance of the document logs section.

- Updated various repository classes to extend RepositoryLegacy.
- Introduced RepositoryV2 for new repository implementations.
- Adjusted method calls and query scopes to align with the new repository structure.
- Ensured that all references to the old Repository class are replaced with the appropriate new classes.

This refactor aims to streamline the transition to the new repository structure while maintaining backward compatibility with legacy code.