### PR TITLE
Simpler evaluations part 1.5

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/RefineModal/steps/2_SelectEvaluationResults/SelectableEvaluationResultsTable.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/RefineModal/steps/2_SelectEvaluationResults/SelectableEvaluationResultsTable.tsx
@@ -30,8 +30,7 @@ export const ResultCellContent = ({
   value: unknown
 }) => {
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Boolean
+    evaluation.metadata.configuration.type === EvaluationResultableType.Boolean
   ) {
     return (
       <Text.H4 color={(value as boolean) ? 'success' : 'destructive'}>
@@ -41,15 +40,10 @@ export const ResultCellContent = ({
   }
 
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Number
+    evaluation.metadata.configuration.type === EvaluationResultableType.Number
   ) {
-    const minValue =
-      (evaluation.configuration ?? evaluation.metadata.configuration)!.detail
-        ?.range.from ?? 0
-    const maxValue =
-      (evaluation.configuration ?? evaluation.metadata.configuration)!.detail
-        ?.range.to ?? 10
+    const minValue = evaluation.metadata.configuration.detail?.range.from ?? 0
+    const maxValue = evaluation.metadata.configuration.detail?.range.to ?? 10
 
     return (
       <RangeBadge

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultsTable.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultsTable.tsx
@@ -40,8 +40,7 @@ export const ResultCellContent = ({
   value: unknown
 }) => {
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Boolean
+    evaluation.metadata.configuration.type === EvaluationResultableType.Boolean
   ) {
     return (
       <Badge variant={value === 'true' ? 'success' : 'destructive'}>
@@ -51,15 +50,10 @@ export const ResultCellContent = ({
   }
 
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Number
+    evaluation.metadata.configuration.type === EvaluationResultableType.Number
   ) {
-    const minValue =
-      (evaluation.configuration ?? evaluation.metadata.configuration)!.detail
-        ?.range.from ?? 0
-    const maxValue =
-      (evaluation.configuration ?? evaluation.metadata.configuration)!.detail
-        ?.range.to ?? 10
+    const minValue = evaluation.metadata.configuration.detail?.range.from ?? 0
+    const maxValue = evaluation.metadata.configuration.detail?.range.to ?? 10
 
     return (
       <RangeBadge

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/MeanValuePanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/BigNumberPanels/MeanValuePanel/index.tsx
@@ -41,8 +41,7 @@ export default function MeanValuePanel({
     documentUuid,
     onStatusChange,
   })
-  const config = (evaluation.configuration ??
-    evaluation.metadata.configuration)!.detail!
+  const config = evaluation.metadata.configuration.detail!
   const defaultMinValue = config.range.from
   const defaultMaxValue = config.range.to
   return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/CostOverResults.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/CostOverResults.tsx
@@ -75,10 +75,8 @@ export function CostOverResultsChart({
             xAxis: {
               label: 'Average result',
               type: 'number',
-              min: (evaluation.configuration ??
-                evaluation.metadata.configuration)!.detail!.range.from,
-              max: (evaluation.configuration ??
-                evaluation.metadata.configuration)!.detail!.range.to,
+              min: evaluation.metadata.configuration.detail!.range.from,
+              max: evaluation.metadata.configuration.detail!.range.to,
             },
             yAxis: {
               label: 'Average cost',

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/ResultsOverTime.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/ResultsOverTime.tsx
@@ -97,10 +97,8 @@ export function ResultOverTimeChart({
             yAxis: {
               label: 'Average result',
               type: 'number',
-              min: (evaluation.configuration ??
-                evaluation.metadata.configuration)!.detail!.range.from,
-              max: (evaluation.configuration ??
-                evaluation.metadata.configuration)!.detail!.range.to,
+              min: evaluation.metadata.configuration.detail!.range.from,
+              max: evaluation.metadata.configuration.detail!.range.to,
             },
             data: parsedData,
             tooltipLabel: (item) => {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/index.tsx
@@ -13,8 +13,7 @@ export function EvaluationResultsCharts({
   documentUuid: string
 }) {
   const isNumerical =
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Number
+    evaluation.metadata.configuration.type === EvaluationResultableType.Number
 
   if (!isNumerical) return null
 

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
@@ -48,8 +48,7 @@ export default async function ConnectedEvaluationLayout({
     uuid: params.commitUuid,
   })
   const isNumeric =
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ==
-    EvaluationResultableType.Number
+    evaluation.metadata.configuration.type == EvaluationResultableType.Number
 
   let provider
   if (evaluation.metadata.prompt) {
@@ -93,12 +92,7 @@ export default async function ConnectedEvaluationLayout({
                 {evaluation.name}
               </Text.H4M>
               <Text.H4M color='foregroundMuted'>
-                {
-                  TYPE_TEXT[
-                    (evaluation.configuration ??
-                      evaluation.metadata.configuration)!.type
-                  ]
-                }
+                {TYPE_TEXT[evaluation.metadata.configuration.type]}
               </Text.H4M>
               <Tooltip
                 asChild

--- a/apps/web/src/components/EvaluationAggregatedResult/index.tsx
+++ b/apps/web/src/components/EvaluationAggregatedResult/index.tsx
@@ -137,8 +137,7 @@ export default function EvaluationAggregatedResult({
   commitUuid: string
 }) {
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Number
+    evaluation.metadata.configuration.type === EvaluationResultableType.Number
   ) {
     return (
       <EvaluationMeanValue
@@ -150,8 +149,7 @@ export default function EvaluationAggregatedResult({
   }
 
   if (
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type ===
-    EvaluationResultableType.Boolean
+    evaluation.metadata.configuration.type === EvaluationResultableType.Boolean
   ) {
     return (
       <EvaluationBooleanValue

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -58,7 +58,6 @@ export type LlmAsJudgeEvaluationMetadata = InferSelectModel<
 export type Subscription = InferSelectModel<typeof subscriptions>
 
 export type EvaluationDto = Evaluation & {
-  configuration?: LlmAsJudgeEvaluationMetadata['configuration'] | null // Added for backward compatibility while the schema transition is being processed. Will be removed on next PR
   metadata: Omit<
     LlmAsJudgeEvaluationMetadata,
     'metadataType' | 'createdAt' | 'updatedAt'

--- a/packages/core/src/services/evaluationResults/aggregations/meanValueQuery.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/meanValueQuery.ts
@@ -1,11 +1,7 @@
 import { and, eq, sql } from 'drizzle-orm'
 
 import { getCommitFilter } from '../_createEvaluationResultQuery'
-import {
-  Commit,
-  EvaluationDto,
-  EvaluationResultConfiguration,
-} from '../../../browser'
+import { Commit, EvaluationDto } from '../../../browser'
 import { database } from '../../../client'
 import { EvaluationResultsRepository } from '../../../repositories'
 import { commits, documentLogs } from '../../../schema'
@@ -47,8 +43,7 @@ export async function getEvaluationMeanValueQuery(
       ),
     )
   const value = results[0]
-  const config = (evaluation.configuration ??
-    evaluation.metadata.configuration)! as EvaluationResultConfiguration
+  const config = evaluation.metadata.configuration
   const { from: minValue, to: maxValue } = config.detail!.range
   return {
     minValue,

--- a/packages/core/src/services/evaluationResults/create.ts
+++ b/packages/core/src/services/evaluationResults/create.ts
@@ -51,15 +51,13 @@ export async function createEvaluationResult(
   }: CreateEvaluationResultProps,
   db = database,
 ) {
-  const resultableTable = getResultable(
-    (evaluation.configuration ?? evaluation.metadata.configuration)!.type,
-  )
+  const resultableTable = getResultable(evaluation.metadata.configuration.type)
   let resultableId: number | undefined
 
   if (!resultableTable && result) {
     return Result.error(
       new BadRequestError(
-        `Unsupported result type: ${(evaluation.configuration ?? evaluation.metadata.configuration)!.type}`,
+        `Unsupported result type: ${evaluation.metadata.configuration.type}`,
       ),
     )
   }
@@ -82,10 +80,7 @@ export async function createEvaluationResult(
         evaluationId: evaluation.id,
         documentLogId: documentLog.id,
         providerLogId: providerLog?.id,
-        resultableType: result
-          ? (evaluation.configuration ?? evaluation.metadata.configuration)!
-              .type
-          : null,
+        resultableType: result ? evaluation.metadata.configuration.type : null,
         resultableId,
         source: documentLog.source,
       })

--- a/packages/core/src/services/evaluations/EvaluationRunChecker/index.ts
+++ b/packages/core/src/services/evaluations/EvaluationRunChecker/index.ts
@@ -85,8 +85,7 @@ export class EvaluationRunChecker {
 
   private async buildSchema() {
     const resultSchema = getResultSchema(
-      (this.evaluation.configuration ?? this.evaluation.metadata.configuration)!
-        .type,
+      this.evaluation.metadata.configuration.type,
     )
 
     if (resultSchema.error) {

--- a/packages/core/src/services/evaluations/create.test.ts
+++ b/packages/core/src/services/evaluations/create.test.ts
@@ -236,9 +236,9 @@ ${metadata.prompt}
       const evaluation = await repo
         .find(result.value!.id)
         .then((r) => r.unwrap())
-      expect(
-        (evaluation.configuration ?? evaluation.metadata.configuration)!.type,
-      ).toBe(EvaluationResultableType.Text)
+      expect(evaluation.metadata.configuration.type).toBe(
+        EvaluationResultableType.Text,
+      )
     })
 
     it('creates an LLM as Judge evaluation with boolean configuration', async () => {
@@ -264,9 +264,9 @@ ${metadata.prompt}
         .find(result.value!.id)
         .then((r) => r.unwrap())
 
-      expect(
-        (evaluation.configuration ?? evaluation.metadata.configuration)!.type,
-      ).toBe(EvaluationResultableType.Boolean)
+      expect(evaluation.metadata.configuration.type).toBe(
+        EvaluationResultableType.Boolean,
+      )
     })
 
     it('returns an error for invalid evaluation type', async () => {


### PR DESCRIPTION
[Part 1.5](https://github.com/latitude-dev/latitude-llm/issues/420)
Remove the (evaluation.configuration ?? evaluation.metadata.configuration) safenet to only use evaluation.metadata.configuration from now on.