### PR TITLE
feat(commits): add caching for document responses

### DIFF
--- a/packages/core/src/services/commits/promptCache.test.ts
+++ b/packages/core/src/services/commits/promptCache.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as cacheModule from '../../cache'
+import { createProject } from '../../tests/factories'
+import { getCachedResponse, setCachedResponse } from './promptCache'
+
+describe('promptCache', async () => {
+  const mockCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+  }
+
+  beforeEach(() => {
+    // @ts-expect-error - mock
+    vi.spyOn(cacheModule, 'cache').mockResolvedValue(mockCache)
+    vi.clearAllMocks()
+  })
+
+  const { workspace } = await createProject()
+  const config = { temperature: 0 }
+  const conversation = { messages: [], config }
+  const response = {
+    streamType: 'text',
+    text: 'cached response',
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+    toolCalls: [],
+  }
+
+  describe('getCachedResponse', () => {
+    it('returns undefined when temperature is not 0', async () => {
+      const result = await getCachedResponse({
+        workspace,
+        config: { temperature: 0.5 },
+        conversation,
+      })
+
+      expect(result).toBeUndefined()
+      expect(mockCache.get).not.toHaveBeenCalled()
+    })
+
+    it('returns cached response when available', async () => {
+      mockCache.get.mockResolvedValueOnce(JSON.stringify(response))
+
+      const result = await getCachedResponse({
+        workspace,
+        config,
+        conversation,
+      })
+
+      expect(result).toEqual(response)
+      expect(mockCache.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns undefined when cache throws error', async () => {
+      mockCache.get.mockRejectedValueOnce(new Error('Cache error'))
+
+      const result = await getCachedResponse({
+        workspace,
+        config,
+        conversation,
+      })
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('setCachedResponse', () => {
+    it('does not cache when temperature is not 0', async () => {
+      await setCachedResponse({
+        workspace,
+        config: { temperature: 0.5 },
+        conversation,
+        // @ts-expect-error - mock
+        response,
+      })
+
+      expect(mockCache.set).not.toHaveBeenCalled()
+    })
+
+    it('caches response when temperature is 0', async () => {
+      await setCachedResponse({
+        workspace,
+        config,
+        conversation,
+        // @ts-expect-error - mock
+        response,
+      })
+
+      expect(mockCache.set).toHaveBeenCalledTimes(1)
+      expect(mockCache.set).toHaveBeenCalledWith(
+        expect.stringContaining(`workspace:${workspace.id}:prompt:`),
+        JSON.stringify(response),
+      )
+    })
+
+    it('silently fails when cache throws error', async () => {
+      mockCache.set.mockRejectedValueOnce(new Error('Cache error'))
+
+      await expect(
+        setCachedResponse({
+          workspace,
+          config,
+          conversation,
+          // @ts-expect-error - mock
+          response,
+        }),
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/packages/core/src/services/commits/promptCache.ts
+++ b/packages/core/src/services/commits/promptCache.ts
@@ -1,0 +1,80 @@
+import { hash } from 'crypto'
+
+import { Config, Conversation } from '@latitude-data/compiler'
+
+import { ChainStepResponse, StreamType, type Workspace } from '../../browser'
+import { cache } from '../../cache'
+
+function generateCacheKey(
+  workspace: Workspace,
+  config: Config,
+  conversation: Conversation,
+): string {
+  const k = hash(
+    'sha256',
+    `${JSON.stringify(conversation)}:${JSON.stringify(config)}`,
+  )
+
+  return `workspace:${workspace.id}:prompt:${k}`
+}
+
+function shouldCache(config: Config): boolean {
+  const temp = parseFloat(config.temperature as any)
+  return isNaN(temp) || temp === 0
+}
+
+async function getFromCache(
+  key: string,
+): Promise<ChainStepResponse<StreamType> | undefined> {
+  try {
+    const c = await cache()
+    const cachedResponseStr = await c.get(key)
+    return cachedResponseStr ? JSON.parse(cachedResponseStr) : undefined
+  } catch (e) {
+    return undefined
+  }
+}
+
+async function setToCache(
+  key: string,
+  response: ChainStepResponse<StreamType>,
+): Promise<void> {
+  try {
+    const c = await cache()
+    await c.set(key, JSON.stringify(response))
+  } catch (e) {
+    // Silently fail cache writes
+  }
+}
+
+export async function getCachedResponse({
+  workspace,
+  config,
+  conversation,
+}: {
+  workspace: Workspace
+  config: Config
+  conversation: Conversation
+}) {
+  if (!shouldCache(config)) return undefined
+
+  const key = generateCacheKey(workspace, config, conversation)
+  return await getFromCache(key)
+}
+
+export async function setCachedResponse({
+  workspace,
+  config,
+  conversation,
+  response,
+}: {
+  workspace: Workspace
+  config: Config
+  conversation: Conversation
+  response: ChainStepResponse<StreamType>
+}) {
+  if (!shouldCache(config)) return
+
+  const key = generateCacheKey(workspace, config, conversation)
+  await setToCache(key, response)
+}


### PR DESCRIPTION
[feat(commits): Implement cached response for chain responses](https://github.com/latitude-dev/latitude-llm/pull/530/commits/9b8a969715bdf0513a4041af4f52918821d3600f)
- Added `DocumentCache` class to handle caching of chain step responses based on workspace, config, and conversation.
- Introduced `getCachedResponse` and `setCachedResponse` functions to retrieve and store cached responses.
- Updated `runChain` function to utilize cached responses if available, reducing redundant calls to the AI module.
- Added tests to verify the caching behavior and ensure correct functionality with various configurations and scenarios.

This change improves performance by avoiding repeated AI calls for the same conversation and configuration, leveraging cached responses when appropriate.