### PR TITLE
Start docker compose in dev without menu

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -2,5 +2,5 @@ name: latitude-llm
 windows:
   - web: cd apps/web
   - apps: pnpm dev --filter='./apps/*' --filter='./packages/sdks/typescript' --filter='./packages/compiler'
-  - docker: docker compose up
+  - docker: docker compose up --menu=false
   - studio: cd packages/core && pnpm db:studio


### PR DESCRIPTION
This change will facilitate scrolling through the docker compose logs. The new docker compose menu (default) makes the scrolling buggy, even unusable.