### PR TITLE
Evaluations: Remove configuration from create service

### DIFF
--- a/packages/core/src/schema/models/evaluationMetadataLlmAsJudgeAdvanced.ts
+++ b/packages/core/src/schema/models/evaluationMetadataLlmAsJudgeAdvanced.ts
@@ -1,8 +1,7 @@
-import { bigint, bigserial, index, jsonb, text } from 'drizzle-orm/pg-core'
+import { bigint, bigserial, index, text } from 'drizzle-orm/pg-core'
 
 import { latitudeSchema } from '../db-schema'
 import { timestamps } from '../schemaHelpers'
-import { EvaluationResultConfiguration } from '../types'
 import { evaluationAdvancedTemplates } from './evaluationAdvancedTemplates'
 
 export const evaluationMetadataLlmAsJudgeAdvanced = latitudeSchema.table(
@@ -10,8 +9,6 @@ export const evaluationMetadataLlmAsJudgeAdvanced = latitudeSchema.table(
   {
     id: bigserial('id', { mode: 'number' }).notNull().primaryKey(),
     prompt: text('prompt').notNull(),
-    configuration: jsonb('configuration') // TODO: Will be removed on next PR
-      .$type<EvaluationResultConfiguration>(),
     templateId: bigint('template_id', { mode: 'number' }).references(
       () => evaluationAdvancedTemplates.id,
     ),

--- a/packages/core/src/services/evaluations/create.test.ts
+++ b/packages/core/src/services/evaluations/create.test.ts
@@ -106,7 +106,6 @@ describe('createAdvancedEvaluation', () => {
         user,
         name: 'Test Evaluation',
         description: 'Test Description',
-
         configuration: {
           type: EvaluationResultableType.Text,
           detail: {
@@ -143,7 +142,6 @@ describe('createAdvancedEvaluation', () => {
         user,
         name: 'Test Evaluation',
         description: 'Test Description',
-
         configuration: {
           type: EvaluationResultableType.Number,
           detail: {
@@ -184,7 +182,6 @@ describe('createAdvancedEvaluation', () => {
         user,
         name,
         description,
-
         configuration: {
           type: EvaluationResultableType.Number,
           detail: {
@@ -204,15 +201,6 @@ describe('createAdvancedEvaluation', () => {
         description,
         metadata: {
           ...evaluation.metadata,
-          configuration: {
-            type: EvaluationResultableType.Number,
-            detail: {
-              range: {
-                from: 0,
-                to: 100,
-              },
-            },
-          },
           prompt: `
 ---
 provider: ${provider!.name}
@@ -551,9 +539,6 @@ describe('createEvaluation', () => {
       expect(evaluation.metadata).toMatchObject({
         prompt: 'Test Prompt',
         templateId: null,
-        configuration: {
-          type: EvaluationResultableType.Text,
-        },
       })
 
       expect(evaluation.resultConfiguration).toMatchObject({
@@ -589,15 +574,6 @@ describe('createEvaluation', () => {
       expect(evaluation.metadata).toMatchObject({
         prompt: 'Test Prompt',
         templateId: null,
-        configuration: {
-          type: EvaluationResultableType.Number,
-          detail: {
-            range: {
-              from: 0,
-              to: 100,
-            },
-          },
-        },
       })
 
       expect(evaluation.resultConfiguration).toMatchObject({
@@ -634,9 +610,6 @@ describe('createEvaluation', () => {
       expect(evaluation.metadata).toMatchObject({
         prompt: 'Test Prompt',
         templateId: null,
-        configuration: {
-          type: EvaluationResultableType.Boolean,
-        },
       })
 
       expect(evaluation.resultConfiguration).toMatchObject({

--- a/packages/core/src/services/evaluations/create.ts
+++ b/packages/core/src/services/evaluations/create.ts
@@ -102,31 +102,10 @@ export async function createEvaluation<
     )
   }
 
-  const legacyConfiguration =
-    metadataType === EvaluationMetadataType.LlmAsJudgeAdvanced
-      ? {
-          configuration: {
-            type: resultType,
-            ...(resultType === EvaluationResultableType.Number && {
-              detail: {
-                range: {
-                  from: (
-                    resultConfiguration as EvaluationConfigurationNumerical
-                  ).minValue,
-                  to: (resultConfiguration as EvaluationConfigurationNumerical)
-                    .maxValue,
-                },
-              },
-            }),
-          },
-        }
-      : undefined
-
   return await Transaction.call(async (tx) => {
     const metadataRow = (await tx
       .insert(metadataTables[metadataType])
-      // @ts-expect-error — The configuration type is being manually added here, although drizzle does not like it. It will be removed in the next PR.
-      .values([{ ...metadata, ...legacyConfiguration }])
+      .values([metadata])
       .returning()
       .then((r) => r[0]!)) as IEvaluationMetadata
 


### PR DESCRIPTION
The configuration attribute is no longer used in code.
The create service is the only part of the code where this attribute is referenced. We need to remove it before removing the attribute itself from the schema.