### PR TITLE
Fix github social link

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -94,7 +94,7 @@
   ],
   "footerSocials": {
     "twitter": "https://twitter.com/trylatitude",
-    "github": "https://github.com/latitude-dev/latitude",
+    "github": "https://github.com/latitude-dev/latitude-llm",
     "linkedin": "https://www.linkedin.com/company/trylatitude/"
   }
 }


### PR DESCRIPTION
# What?

The link of github in the docs took to the wrong repo.

> I just kept forgoting about it and clicking on it and it triggered me so made the quick PR 😅 