### PR TITLE
No stream mode in v2 chat

### DIFF
--- a/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/handlers/chat.test.ts
+++ b/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/handlers/chat.test.ts
@@ -1,0 +1,546 @@
+import { MessageRole } from '@latitude-data/compiler'
+import { RunErrorCodes } from '@latitude-data/constants/errors'
+import {
+  ChainEventTypes,
+  ChainStepResponse,
+  LogSources,
+  ProviderLog,
+  StreamEventTypes,
+  Workspace,
+} from '@latitude-data/core/browser'
+import { unsafelyGetFirstApiKeyByWorkspaceId } from '@latitude-data/core/data-access'
+import { createProject } from '@latitude-data/core/factories'
+import { LatitudeError } from '@latitude-data/core/lib/errors'
+import { Result } from '@latitude-data/core/lib/Result'
+import { ChainError } from '@latitude-data/core/services/chains/ChainErrors/index'
+import { parseSSEvent } from '$/common/parseSSEEvent'
+import app from '$/routes/app'
+import { testConsumeStream } from 'test/helpers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  addMessages: vi.fn(),
+  captureException: vi.fn(),
+  queues: {
+    defaultQueue: {
+      jobs: {},
+    },
+  },
+}))
+
+vi.mock(
+  '@latitude-data/core/services/documentLogs/index',
+  async (importOriginal) => {
+    const original = (await importOriginal()) as typeof importOriginal
+
+    return {
+      ...original,
+      addMessages: mocks.addMessages,
+    }
+  },
+)
+
+vi.mock('$/common/sentry', async (importOriginal) => {
+  const original = (await importOriginal()) as typeof importOriginal
+
+  return {
+    ...original,
+    captureException: mocks.captureException,
+  }
+})
+
+vi.mock('$/jobs', () => ({
+  queues: mocks.queues,
+}))
+
+let token: string
+let route: string
+let body: Record<string, any>
+let headers: Record<string, string>
+let workspace: Workspace
+const step: ChainStepResponse<'text'> = {
+  streamType: 'text',
+  text: 'fake-response-text',
+  usage: { promptTokens: 4, completionTokens: 6, totalTokens: 10 },
+  toolCalls: [],
+  documentLogUuid: 'fake-document-log-uuid',
+  providerLog: {
+    messages: [
+      {
+        role: MessageRole.assistant,
+        toolCalls: [],
+        content: 'fake-assistant-content',
+      },
+    ],
+  } as unknown as ProviderLog,
+}
+
+describe('POST /chat', () => {
+  describe('unauthorized', () => {
+    it('fails', async () => {
+      const res = await app.request(
+        `/api/v2/conversations/${step.documentLogUuid}/chat`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            stream: true,
+            messages: [
+              {
+                role: MessageRole.user,
+                content: 'fake-user-content',
+              },
+            ],
+          }),
+        },
+      )
+
+      expect(res.status).toBe(401)
+      expect(res.headers.get('www-authenticate')).toBe('Bearer realm=""')
+    })
+  })
+
+  describe('authorized with stream', () => {
+    beforeEach(async () => {
+      mocks.addMessages.mockClear()
+
+      const project = await createProject()
+      workspace = project.workspace
+      const apikey = (
+        await unsafelyGetFirstApiKeyByWorkspaceId({
+          workspaceId: workspace.id,
+        })
+      ).unwrap()
+
+      token = apikey.token
+      route = `/api/v2/conversations/${step.documentLogUuid}/chat`
+      body = {
+        stream: true,
+        messages: [
+          {
+            role: MessageRole.user,
+            content: 'fake-user-content',
+          },
+        ],
+      }
+      headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      }
+    })
+
+    it('stream succeeds', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({
+                    event: StreamEventTypes.Latitude,
+                    data: {
+                      type: ChainEventTypes.Complete,
+                      response: step,
+                      messages: step.providerLog?.messages,
+                    },
+                  })
+                  controller.close()
+                },
+              }),
+              response: new Promise((resolve) => resolve(Result.ok({}))),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      let { done, value } = await testConsumeStream(res.body as ReadableStream)
+      const event = parseSSEvent(value!)
+
+      expect(mocks.queues)
+      expect(res.status).toBe(200)
+      expect(res.body).toBeInstanceOf(ReadableStream)
+      expect(done).toBe(true)
+      expect(event).toEqual({
+        id: 0,
+        event: StreamEventTypes.Latitude,
+        data: {
+          type: ChainEventTypes.Complete,
+          uuid: step.documentLogUuid,
+          response: {
+            streamType: step.streamType,
+            text: step.text,
+            usage: step.usage,
+            toolCalls: step.toolCalls,
+          },
+          messages: step.providerLog?.messages,
+        },
+      })
+    })
+
+    it('calls chat provider', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({
+                    event: StreamEventTypes.Latitude,
+                    data: {
+                      type: ChainEventTypes.Complete,
+                      response: step,
+                      messages: step.providerLog?.messages,
+                    },
+                  })
+                  controller.close()
+                },
+              }),
+              response: new Promise((resolve) => resolve(Result.ok({}))),
+            }),
+          )
+        }),
+      )
+
+      await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.addMessages).toHaveBeenCalledWith({
+        workspace,
+        documentLogUuid: step.documentLogUuid,
+        messages: body.messages,
+        source: LogSources.API,
+      })
+    })
+
+    it('uses source from __internal', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({
+                    event: StreamEventTypes.Latitude,
+                    data: {
+                      type: ChainEventTypes.Complete,
+                      response: step,
+                      messages: step.providerLog?.messages,
+                    },
+                  })
+                  controller.close()
+                },
+              }),
+              response: new Promise((resolve) => resolve(Result.ok({}))),
+            }),
+          )
+        }),
+      )
+
+      await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify({
+          __internal: { source: LogSources.Playground },
+          ...body,
+        }),
+        headers,
+      })
+
+      expect(mocks.addMessages).toHaveBeenCalledWith({
+        workspace,
+        documentLogUuid: step.documentLogUuid,
+        messages: body.messages,
+        source: LogSources.Playground,
+      })
+    })
+
+    it('returns error when addMessages has an error', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue({
+                    event: StreamEventTypes.Latitude,
+                    data: {
+                      type: ChainEventTypes.Error,
+                      error: new ChainError({
+                        code: RunErrorCodes.AIRunError,
+                        message: 'API call error',
+                      }),
+                    },
+                  })
+                  controller.close()
+                },
+              }),
+              response: new Promise((resolve) => resolve(Result.ok({}))),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      let { done, value } = await testConsumeStream(res.body as ReadableStream)
+      const event = parseSSEvent(value!)
+
+      expect(mocks.queues)
+      expect(res.status).toBe(200)
+      expect(res.body).toBeInstanceOf(ReadableStream)
+      expect(done).toBe(true)
+      expect(event).toEqual({
+        id: 0,
+        event: StreamEventTypes.Latitude,
+        data: {
+          type: ChainEventTypes.Error,
+          error: {
+            name: 'UnprocessableEntityError',
+            message: 'API call error',
+          },
+        },
+      })
+      expect(mocks.captureException).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('authorized without stream', () => {
+    beforeEach(async () => {
+      mocks.addMessages.mockClear()
+
+      const project = await createProject()
+      workspace = project.workspace
+      const apikey = (
+        await unsafelyGetFirstApiKeyByWorkspaceId({
+          workspaceId: workspace.id,
+        })
+      ).unwrap()
+
+      token = apikey.token
+      route = `/api/v2/conversations/${step.documentLogUuid}/chat`
+      body = {
+        stream: false,
+        messages: [
+          {
+            role: MessageRole.user,
+            content: 'fake-user-content',
+          },
+        ],
+      }
+      headers = {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      }
+    })
+
+    it('returns response', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(Result.ok(step))
+              }),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.queues)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        uuid: step.documentLogUuid,
+        conversation: step.providerLog?.messages,
+        response: {
+          streamType: step.streamType,
+          text: step.text,
+          usage: step.usage,
+          toolCalls: step.toolCalls,
+        },
+      })
+    })
+
+    it('calls chat provider', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(Result.ok(step))
+              }),
+            }),
+          )
+        }),
+      )
+
+      await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.addMessages).toHaveBeenCalledWith({
+        workspace,
+        documentLogUuid: step.documentLogUuid,
+        messages: body.messages,
+        source: LogSources.API,
+      })
+    })
+
+    it('uses source from __internal', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(Result.ok(step))
+              }),
+            }),
+          )
+        }),
+      )
+
+      await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify({
+          __internal: { source: LogSources.Playground },
+          ...body,
+        }),
+        headers,
+      })
+
+      expect(mocks.addMessages).toHaveBeenCalledWith({
+        workspace,
+        documentLogUuid: step.documentLogUuid,
+        messages: body.messages,
+        source: LogSources.Playground,
+      })
+    })
+
+    it('returns error when addMessages has an error', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(
+                  Result.error(
+                    new ChainError({
+                      code: RunErrorCodes.AIRunError,
+                      message: 'API call error',
+                    }),
+                  ),
+                )
+              }),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.queues)
+      expect(res.status).toBe(422)
+      expect(await res.json()).toEqual({
+        name: 'DocumentRunError',
+        errorCode: RunErrorCodes.AIRunError,
+        message: 'API call error',
+        details: {
+          errorCode: RunErrorCodes.AIRunError,
+        },
+      })
+      expect(mocks.captureException).not.toHaveBeenCalled()
+    })
+
+    it('returns error when no documentLogUuid in documentRunPresenter', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(Result.ok({ ...step, documentLogUuid: undefined }))
+              }),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.queues)
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({
+        name: 'LatitudeError',
+        errorCode: 'LatitudeError',
+        message: 'Document Log uuid not found in response',
+        details: {},
+      })
+      expect(mocks.captureException).toHaveBeenCalledWith(
+        new LatitudeError('Document Log uuid not found in response'),
+      )
+    })
+
+    it('returns error when no providerLog in documentRunPresenter', async () => {
+      mocks.addMessages.mockReturnValue(
+        new Promise((resolve) => {
+          resolve(
+            Result.ok({
+              stream: new ReadableStream({}),
+              response: new Promise((resolve) => {
+                resolve(Result.ok({ ...step, providerLog: undefined }))
+              }),
+            }),
+          )
+        }),
+      )
+
+      const res = await app.request(route, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers,
+      })
+
+      expect(mocks.queues)
+      expect(res.status).toBe(500)
+      expect(await res.json()).toEqual({
+        name: 'LatitudeError',
+        errorCode: 'LatitudeError',
+        message: 'Conversation messages not found in response',
+        details: {},
+      })
+      expect(mocks.captureException).toHaveBeenCalledWith(
+        new LatitudeError('Conversation messages not found in response'),
+      )
+    })
+  })
+})

--- a/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/handlers/chat.ts
+++ b/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/handlers/chat.ts
@@ -1,0 +1,73 @@
+import { zValidator } from '@hono/zod-validator'
+import { LogSources, messagesSchema } from '@latitude-data/core/browser'
+import { getUnknownError } from '@latitude-data/core/lib/getUnknownError'
+import { streamToGenerator } from '@latitude-data/core/lib/streamToGenerator'
+import { addMessages } from '@latitude-data/core/services/documentLogs/index'
+import { captureException } from '@sentry/node'
+import { Factory } from 'hono/factory'
+import { streamSSE } from 'hono/streaming'
+import { z } from 'zod'
+
+import { chainEventPresenter } from '../../../../v1/projects/[projectId]/versions/[versionUuid]/documents/handlers/_shared'
+import { documentRunPresenter } from '../../../projects/[projectId]/versions/[versionUuid]/documents/handlers/documentPresenter'
+
+const factory = new Factory()
+
+const schema = z.object({
+  messages: messagesSchema,
+  stream: z.boolean().default(false),
+  __internal: z
+    .object({
+      source: z.nativeEnum(LogSources).optional(),
+    })
+    .optional(),
+})
+
+export const chatHandler = factory.createHandlers(
+  zValidator('json', schema),
+  async (c) => {
+    const { conversationUuid } = c.req.param()
+    const { messages, stream: useSSE, __internal } = c.req.valid('json')
+    const workspace = c.get('workspace')
+
+    const result = (
+      await addMessages({
+        workspace,
+        documentLogUuid: conversationUuid,
+        messages,
+        source: __internal?.source ?? LogSources.API,
+      })
+    ).unwrap()
+
+    if (useSSE) {
+      return streamSSE(
+        c,
+        async (stream) => {
+          let id = 0
+          for await (const event of streamToGenerator(result.stream)) {
+            const data = chainEventPresenter(event)
+
+            stream.writeSSE({
+              id: String(id++),
+              event: event.event,
+              data: typeof data === 'string' ? data : JSON.stringify(data),
+            })
+          }
+        },
+        (error: Error) => {
+          const unknownError = getUnknownError(error)
+
+          if (unknownError) {
+            captureException(error)
+          }
+
+          return Promise.resolve()
+        },
+      )
+    }
+
+    const response = (await result.response).unwrap()
+    const body = documentRunPresenter(response).unwrap()
+    return c.json(body)
+  },
+)

--- a/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/index.ts
+++ b/apps/gateway/src/routes/api/v2/conversations/[conversationUuid]/index.ts
@@ -1,6 +1,6 @@
-import { chatHandler } from '$/routes/api/v1/conversations/[conversationUuid]/handlers/chat'
 import { Hono } from 'hono'
 
+import { chatHandler } from './handlers/chat'
 import { evaluateHandler } from './handlers/evaluate'
 
 export const conversationsRouter = new Hono()

--- a/docs/guides/prompt-manager/api-access.mdx
+++ b/docs/guides/prompt-manager/api-access.mdx
@@ -158,12 +158,15 @@ The previously described `POST /projects/{projectId}/versions/{versionUuid}/docu
       "role": "user" | "system" | "assistant",
       "content": string
     }
-  ]
+  ],
+  "stream": true
 }
 ```
 
+- `stream`: Optional boolean parameter (defaults to `false`). When set to true, the response will be a stream of Server-Sent Events (SSE). If false, a single JSON response containing the last event is returned.
+
 **Response:**
-The response is a stream of Server-Sent Events (SSE), similar to the "Run a Document" endpoint.
+The response is a stream of Server-Sent Events (SSE) or a single JSON response containing the final event, similar to the "Run a Document" endpoint.
 
 #### 3. Get a Prompt
 

--- a/docs/guides/prompt-manager/api-access.mdx
+++ b/docs/guides/prompt-manager/api-access.mdx
@@ -165,6 +165,10 @@ The previously described `POST /projects/{projectId}/versions/{versionUuid}/docu
 
 - `stream`: Optional boolean parameter (defaults to `false`). When set to true, the response will be a stream of Server-Sent Events (SSE). If false, a single JSON response containing the last event is returned.
 
+<Note>
+  Message follows [OpenAI's format](https://platform.openai.com/docs/guides/text-generation/building-prompts).
+</Note>
+
 **Response:**
 The response is a stream of Server-Sent Events (SSE) or a single JSON response containing the final event, similar to the "Run a Document" endpoint.
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -211,6 +211,9 @@ export type RunSyncAPIResponse = {
   response: ChainCallResponseDto
 }
 
+// FIXME: Move to @latitude-data/constants
+export type ChatSyncAPIResponse = RunSyncAPIResponse
+
 export type ChainEventDto =
   | ProviderData
   | {

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -190,7 +190,7 @@ describe('addMessages', () => {
     )
   })
 
-  it('send documentLogUuid when chain is completed', async () => {
+  it('returns chain stream', async () => {
     const { addMessages } = await import('./index')
     const { stream } = await addMessages({
       workspace,
@@ -249,5 +249,40 @@ describe('addMessages', () => {
         },
       },
     ])
+  })
+
+  it('returns chain response', async () => {
+    const { addMessages } = await import('./index')
+    const result = (
+      await addMessages({
+        workspace,
+        documentLogUuid: providerLog.documentLogUuid!,
+        messages: [
+          {
+            role: MessageRole.user,
+            content: [
+              {
+                type: ContentType.text,
+                text: 'This is a user message',
+              },
+            ],
+          },
+        ],
+        source: LogSources.API,
+      })
+    ).unwrap()
+
+    const response = (await result.response).unwrap()
+    const repo = new ProviderLogsRepository(workspace.id)
+    const logs = (await repo.findAll()).unwrap()
+
+    expect(response).toEqual({
+      streamType: 'text',
+      text: 'Fake AI generated text',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      toolCalls: [],
+      documentLogUuid: providerLog.documentLogUuid,
+      providerLog: logs[logs.length - 1],
+    })
   })
 })

--- a/packages/core/src/services/providerLogs/addMessages.ts
+++ b/packages/core/src/services/providerLogs/addMessages.ts
@@ -4,6 +4,7 @@ import {
   Message,
   MessageRole,
 } from '@latitude-data/compiler'
+import { RunErrorCodes } from '@latitude-data/constants/errors'
 
 import {
   ChainEvent,
@@ -16,9 +17,9 @@ import {
   Workspace,
 } from '../../browser'
 import { unsafelyFindProviderApiKey } from '../../data-access'
-import { NotFoundError, Result } from '../../lib'
-import debug from '../../lib/debug'
+import { NotFoundError, Result, TypedResult } from '../../lib'
 import { ai, PartialConfig } from '../ai'
+import { ChainError } from '../chains/ChainErrors'
 import {
   ChainStreamConsumer,
   parseResponseText,
@@ -26,6 +27,11 @@ import {
 import { consumeStream } from '../chains/ChainStreamConsumer/consumeStream'
 import { checkFreeProviderQuota } from '../chains/checkFreeProviderQuota'
 import { ProviderProcessor } from '../chains/ProviderProcessor'
+
+export type ChainResponse<T extends StreamType> = TypedResult<
+  ChainStepResponse<T>,
+  ChainError<RunErrorCodes>
+>
 
 export async function addMessages({
   workspace,
@@ -62,13 +68,11 @@ export async function addMessages({
     )
   }
 
-  let responseResolve: (value?: ChainStepResponse<StreamType>) => void
+  let responseResolve: (value: ChainResponse<StreamType>) => void
 
-  const response = new Promise<ChainStepResponse<StreamType> | undefined>(
-    (resolve) => {
-      responseResolve = resolve
-    },
-  )
+  const response = new Promise<ChainResponse<StreamType>>((resolve) => {
+    responseResolve = resolve
+  })
 
   const fmessages = [
     ...providerLog.messages,
@@ -99,11 +103,12 @@ export async function addMessages({
         documentLogUuid: providerLog.documentLogUuid!,
         messages: fmessages,
       })
-        .then(responseResolve)
-        .catch((e) => {
-          debug(`Error in addMessages: ${e}`)
-
-          responseResolve()
+        .then((res) => {
+          responseResolve(Result.ok(res))
+        })
+        .catch((err) => {
+          // TODO: createRunError in DB?
+          responseResolve(Result.error(err))
         })
     },
   })

--- a/packages/core/src/services/providerLogs/addMessages.ts
+++ b/packages/core/src/services/providerLogs/addMessages.ts
@@ -107,7 +107,6 @@ export async function addMessages({
           responseResolve(Result.ok(res))
         })
         .catch((err) => {
-          // TODO: createRunError in DB?
           responseResolve(Result.error(err))
         })
     },

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/sdks/typescript/src/tests/chat.test.ts
+++ b/packages/sdks/typescript/src/tests/chat.test.ts
@@ -1,5 +1,6 @@
 import { LogSources } from '@latitude-data/core/browser'
 import { Latitude } from '$sdk/index'
+import { ApiErrorCodes, LatitudeApiError } from '$sdk/utils/errors'
 import { parseSSE } from '$sdk/utils/parseSSE'
 import { setupServer } from 'msw/node'
 import {
@@ -35,65 +36,86 @@ describe('/chat', () => {
     })
   })
 
-  it(
-    'sends auth header',
-    server.boundary(async () => {
-      const mockFn = mockAuthHeader({ server, apiVersion: 'v2' })
-      await sdk.chat('fake-document-log-uuid', [])
-      expect(mockFn).toHaveBeenCalledWith('Bearer fake-api-key')
-    }),
-  )
+  describe('with streaming', () => {
+    it(
+      'sends auth header',
+      server.boundary(async () => {
+        const mockFn = mockAuthHeader({ server, apiVersion: 'v2' })
 
-  it(
-    'send data onMessage callback',
-    server.boundary(async () => {
-      const onMessageMock = vi.fn()
-      const { chunks, docPath } = mockChatMessage({
-        server,
-        docPath: 'fake-document-log-uuid',
-        apiVersion: 'v2',
-      })
+        await sdk.chat('fake-document-log-uuid', [], { stream: true })
 
-      await sdk.chat(docPath, [], { onEvent: onMessageMock })
+        expect(mockFn).toHaveBeenCalledWith('Bearer fake-api-key')
+      }),
+    )
 
-      chunks.forEach((chunk, index) => {
-        // @ts-expect-error
-        const { event, data } = parseSSE(chunk)
-        expect(onMessageMock).toHaveBeenNthCalledWith(index + 1, {
-          event,
-          data: JSON.parse(data),
+    it(
+      'send data onMessage callback',
+      server.boundary(async () => {
+        const onMessageMock = vi.fn()
+        const { chunks, docPath } = mockChatMessage({
+          server,
+          docPath: 'fake-document-log-uuid',
+          apiVersion: 'v2',
         })
-      })
-    }),
-  )
 
-  it(
-    'calls endpoint with body and headers',
-    server.boundary(async () => {
-      const { mockBody, docPath } = mockBodyResponse({
+        await sdk.chat(docPath, [], { stream: true, onEvent: onMessageMock })
+
+        chunks.forEach((chunk, index) => {
+          // @ts-expect-error
+          const { event, data } = parseSSE(chunk)
+          expect(onMessageMock).toHaveBeenNthCalledWith(index + 1, {
+            event,
+            data: JSON.parse(data),
+          })
+        })
+      }),
+    )
+
+    it(
+      'calls endpoint with body and headers',
+      server.boundary(async () => {
+        const { mockBody, docPath } = mockBodyResponse({
+          server,
+          apiVersion: 'v2',
+          docPath: 'fake-document-log-uuid',
+        })
+
+        await sdk.chat(docPath, [], { stream: true })
+
+        expect(mockBody).toHaveBeenCalledWith({
+          body: {
+            __internal: { source: LogSources.API },
+            messages: [],
+            stream: true,
+          },
+        })
+      }),
+    )
+
+    it('should retry 3 times if gateway is not available', async () => {
+      const onErrorMock = vi.fn()
+      const { mockFn, docPath } = mock502Response({
         server,
         apiVersion: 'v2',
         docPath: 'fake-document-log-uuid',
       })
-      await sdk.chat(docPath, [])
 
-      expect(mockBody).toHaveBeenCalledWith({
-        body: {
-          __internal: { source: LogSources.API },
-          messages: [],
-        },
-      })
-    }),
-  )
+      await sdk.chat(docPath, [], { stream: true, onError: onErrorMock })
 
-  it('should retry 3 times if gateway is not available', async () => {
-    const { mockFn, docPath } = mock502Response({
-      server,
-      apiVersion: 'v2',
-      docPath: 'fake-document-log-uuid',
+      expect(mockFn).toHaveBeenCalledTimes(3)
+      expect(onErrorMock).toHaveBeenCalledWith(
+        new LatitudeApiError({
+          status: 502,
+          serverResponse: JSON.stringify({
+            name: 'LatitudeError',
+            message: 'Something bad happened',
+            errorCode: 'LatitudeError',
+          }),
+          message: 'Something bad happened',
+          errorCode: ApiErrorCodes.InternalServerError,
+          dbErrorRef: undefined,
+        }),
+      )
     })
-
-    await sdk.chat(docPath, [])
-    expect(mockFn).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/sdks/typescript/src/tests/chat.test.ts
+++ b/packages/sdks/typescript/src/tests/chat.test.ts
@@ -41,14 +41,15 @@ describe('/chat', () => {
     it(
       'makes request',
       server.boundary(async () => {
-        const { mockAuthHeader, mockUrl, mockBody, docPath } = mockRequest({
-          server,
-          apiVersion: 'v2',
-          docPath: 'fake-document-log-uuid',
-        })
+        const { mockAuthHeader, mockUrl, mockBody, conversationUuid } =
+          mockRequest({
+            server,
+            apiVersion: 'v2',
+            conversationUuid: 'fake-document-log-uuid',
+          })
 
         await sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,
@@ -65,7 +66,7 @@ describe('/chat', () => {
 
         expect(mockAuthHeader).toHaveBeenCalledWith('Bearer fake-api-key')
         expect(mockUrl).toHaveBeenCalledWith(
-          `http://localhost:8787/api/v2/conversations/${docPath}/chat`,
+          `http://localhost:8787/api/v2/conversations/${conversationUuid}/chat`,
         )
         expect(mockBody).toHaveBeenCalledWith({
           body: {
@@ -93,14 +94,14 @@ describe('/chat', () => {
         const onMessageMock = vi.fn()
         const onFinishMock = vi.fn()
         const onErrorMock = vi.fn()
-        const { chunks, finalResponse, docPath } = mockStreamResponse({
+        const { chunks, finalResponse, conversationUuid } = mockStreamResponse({
           server,
-          docPath: 'fake-document-log-uuid',
+          conversationUuid: 'fake-document-log-uuid',
           apiVersion: 'v2',
         })
 
         const response = await sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,
@@ -136,14 +137,14 @@ describe('/chat', () => {
 
     it('retries 3 times if gateway is not available', async () => {
       const onErrorMock = vi.fn()
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await sdk.chat(
-        docPath,
+        conversationUuid,
         [
           {
             role: MessageRole.user,
@@ -176,14 +177,14 @@ describe('/chat', () => {
 
     it('does not throw error if onError option is present', async () => {
       const onErrorMock = vi.fn()
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await sdk.chat(
-        docPath,
+        conversationUuid,
         [
           {
             role: MessageRole.user,
@@ -215,15 +216,15 @@ describe('/chat', () => {
     })
 
     it('throws error if onError option is not present', async () => {
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await expect(
         sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,
@@ -258,14 +259,15 @@ describe('/chat', () => {
     it(
       'makes request',
       server.boundary(async () => {
-        const { mockAuthHeader, mockUrl, mockBody, docPath } = mockRequest({
-          server,
-          apiVersion: 'v2',
-          docPath: 'fake-document-log-uuid',
-        })
+        const { mockAuthHeader, mockUrl, mockBody, conversationUuid } =
+          mockRequest({
+            server,
+            apiVersion: 'v2',
+            conversationUuid: 'fake-document-log-uuid',
+          })
 
         await sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,
@@ -282,7 +284,7 @@ describe('/chat', () => {
 
         expect(mockAuthHeader).toHaveBeenCalledWith('Bearer fake-api-key')
         expect(mockUrl).toHaveBeenCalledWith(
-          `http://localhost:8787/api/v2/conversations/${docPath}/chat`,
+          `http://localhost:8787/api/v2/conversations/${conversationUuid}/chat`,
         )
         expect(mockBody).toHaveBeenCalledWith({
           body: {
@@ -309,14 +311,14 @@ describe('/chat', () => {
       server.boundary(async () => {
         const onFinishMock = vi.fn()
         const onErrorMock = vi.fn()
-        const { finalResponse, docPath } = mockNonStreamResponse({
+        const { finalResponse, conversationUuid } = mockNonStreamResponse({
           server,
-          docPath: 'fake-document-log-uuid',
+          conversationUuid: 'fake-document-log-uuid',
           apiVersion: 'v2',
         })
 
         const response = await sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,
@@ -343,14 +345,14 @@ describe('/chat', () => {
 
     it('retries 3 times if gateway is not available', async () => {
       const onErrorMock = vi.fn()
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await sdk.chat(
-        docPath,
+        conversationUuid,
         [
           {
             role: MessageRole.user,
@@ -383,14 +385,14 @@ describe('/chat', () => {
 
     it('does not throw error if onError option is present', async () => {
       const onErrorMock = vi.fn()
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await sdk.chat(
-        docPath,
+        conversationUuid,
         [
           {
             role: MessageRole.user,
@@ -422,15 +424,15 @@ describe('/chat', () => {
     })
 
     it('throws error if onError option is not present', async () => {
-      const { mockFn, docPath } = mock502Response({
+      const { mockFn, conversationUuid } = mock502Response({
         server,
         apiVersion: 'v2',
-        docPath: 'fake-document-log-uuid',
+        conversationUuid: 'fake-document-log-uuid',
       })
 
       await expect(
         sdk.chat(
-          docPath,
+          conversationUuid,
           [
             {
               role: MessageRole.user,

--- a/packages/sdks/typescript/src/tests/helpers/chat.ts
+++ b/packages/sdks/typescript/src/tests/helpers/chat.ts
@@ -1,4 +1,5 @@
 import { CHUNKS } from '$sdk/test/chunks-example'
+import { ApiErrorCodes } from '$sdk/utils/errors'
 import { parseSSE } from '$sdk/utils/parseSSE'
 import { SdkApiVersion } from '$sdk/utils/types'
 import { http, HttpResponse } from 'msw'
@@ -116,7 +117,8 @@ export function mock502Response({
         return HttpResponse.json(
           {
             name: 'LatitudeError',
-            errorCode: 'LatitudeError',
+            message: 'Something bad happened',
+            errorCode: ApiErrorCodes.InternalServerError,
           },
           { status: 502 },
         )

--- a/packages/sdks/typescript/src/tests/helpers/chat.ts
+++ b/packages/sdks/typescript/src/tests/helpers/chat.ts
@@ -12,11 +12,11 @@ const encoder = new TextEncoder()
 export function mockRequest({
   server,
   apiVersion,
-  docPath,
+  conversationUuid,
 }: {
   server: Server
   apiVersion: SdkApiVersion
-  docPath: string
+  conversationUuid: string
 }) {
   const mockAuthHeader = vi.fn()
   const mockUrl = vi.fn()
@@ -24,7 +24,7 @@ export function mockRequest({
   let body = {}
   server.use(
     http.post(
-      `http://localhost:8787/api/${apiVersion}/conversations/${docPath}/chat`,
+      `http://localhost:8787/api/${apiVersion}/conversations/${conversationUuid}/chat`,
       async (info) => {
         mockAuthHeader(info.request.headers.get('Authorization'))
         mockUrl(info.request.url)
@@ -42,22 +42,22 @@ export function mockRequest({
       },
     ),
   )
-  return { mockAuthHeader, mockUrl, mockBody, docPath }
+  return { mockAuthHeader, mockUrl, mockBody, conversationUuid }
 }
 
 export function mockStreamResponse({
   server,
   apiVersion,
-  docPath,
+  conversationUuid,
 }: {
   server: Server
-  docPath: string
+  conversationUuid: string
   apiVersion: SdkApiVersion
 }) {
   let stream: ReadableStream
   server.use(
     http.post(
-      `http://localhost:8787/api/${apiVersion}/conversations/${docPath}/chat`,
+      `http://localhost:8787/api/${apiVersion}/conversations/${conversationUuid}/chat`,
       async () => {
         stream = new ReadableStream({
           start(controller) {
@@ -81,40 +81,40 @@ export function mockStreamResponse({
       },
     ),
   )
-  return { chunks: CHUNKS, finalResponse: FINAL_RESPONSE, docPath }
+  return { chunks: CHUNKS, finalResponse: FINAL_RESPONSE, conversationUuid }
 }
 
 export function mockNonStreamResponse({
   server,
   apiVersion,
-  docPath,
+  conversationUuid,
 }: {
   server: Server
-  docPath: string
+  conversationUuid: string
   apiVersion: SdkApiVersion
 }) {
   server.use(
     http.post(
-      `http://localhost:8787/api/${apiVersion}/conversations/${docPath}/chat`,
+      `http://localhost:8787/api/${apiVersion}/conversations/${conversationUuid}/chat`,
       () => HttpResponse.json(FINAL_RESPONSE),
     ),
   )
-  return { finalResponse: FINAL_RESPONSE, docPath }
+  return { finalResponse: FINAL_RESPONSE, conversationUuid }
 }
 
 export function mock502Response({
   server,
   apiVersion,
-  docPath,
+  conversationUuid,
 }: {
   server: Server
   apiVersion: SdkApiVersion
-  docPath: string
+  conversationUuid: string
 }) {
   const mockFn = vi.fn()
   server.use(
     http.post(
-      `http://localhost:8787/api/${apiVersion}/conversations/${docPath}/chat`,
+      `http://localhost:8787/api/${apiVersion}/conversations/${conversationUuid}/chat`,
       () => {
         mockFn('called!')
         return HttpResponse.json(
@@ -128,5 +128,5 @@ export function mock502Response({
       },
     ),
   )
-  return { mockFn, docPath }
+  return { mockFn, conversationUuid }
 }

--- a/packages/sdks/typescript/src/utils/streamChat.ts
+++ b/packages/sdks/typescript/src/utils/streamChat.ts
@@ -1,0 +1,65 @@
+import { Readable } from 'stream'
+
+import {
+  ApiErrorCodes,
+  ApiErrorJsonResponse,
+} from '@latitude-data/constants/errors'
+import { LatitudeApiError } from '$sdk/utils/errors'
+import { handleStream } from '$sdk/utils/handleStream'
+import { makeRequest } from '$sdk/utils/request'
+import { ChatOptions, HandlerType, SDKOptions } from '$sdk/utils/types'
+
+export async function streamChat(
+  uuid: string,
+  {
+    messages,
+    onEvent,
+    onFinished,
+    onError,
+    options,
+  }: ChatOptions & {
+    options: SDKOptions
+  },
+) {
+  try {
+    const response = await makeRequest({
+      method: 'POST',
+      handler: HandlerType.Chat,
+      params: { conversationUuid: uuid },
+      options: options,
+      body: { messages, stream: true },
+    })
+
+    if (!response.ok) {
+      const json = (await response.json()) as ApiErrorJsonResponse
+      const error = new LatitudeApiError({
+        status: response.status,
+        serverResponse: JSON.stringify(json),
+        message: json.message,
+        errorCode: json.errorCode,
+        dbErrorRef: json.dbErrorRef,
+      })
+
+      onError?.(error)
+      return !onError ? Promise.reject(error) : Promise.resolve(undefined)
+    }
+
+    return handleStream({
+      body: response.body! as Readable,
+      onEvent,
+      onFinished,
+      onError,
+    })
+  } catch (e) {
+    const err = e as Error
+    const error = new LatitudeApiError({
+      status: 500,
+      message: err.message,
+      serverResponse: err.message,
+      errorCode: ApiErrorCodes.InternalServerError,
+    })
+
+    onError?.(error)
+    return !onError ? Promise.reject(error) : Promise.resolve(undefined)
+  }
+}

--- a/packages/sdks/typescript/src/utils/syncChat.ts
+++ b/packages/sdks/typescript/src/utils/syncChat.ts
@@ -1,0 +1,64 @@
+import {
+  ApiErrorCodes,
+  ApiErrorJsonResponse,
+} from '@latitude-data/constants/errors'
+import { LatitudeApiError } from '$sdk/utils/errors'
+import { makeRequest } from '$sdk/utils/request'
+import {
+  ChatOptions,
+  ChatSyncAPIResponse,
+  HandlerType,
+  SDKOptions,
+} from '$sdk/utils/types'
+
+export async function syncChat(
+  uuid: string,
+  {
+    messages,
+    onFinished,
+    onError,
+    options,
+  }: ChatOptions & {
+    options: SDKOptions
+  },
+) {
+  try {
+    const response = await makeRequest({
+      method: 'POST',
+      handler: HandlerType.Chat,
+      params: { conversationUuid: uuid },
+      options: options,
+      body: { messages, stream: false },
+    })
+
+    if (!response.ok) {
+      const json = (await response.json()) as ApiErrorJsonResponse
+      const error = new LatitudeApiError({
+        status: response.status,
+        serverResponse: JSON.stringify(json),
+        message: json.message,
+        errorCode: json.errorCode,
+        dbErrorRef: json.dbErrorRef,
+      })
+
+      onError?.(error)
+      return !onError ? Promise.reject(error) : Promise.resolve(undefined)
+    }
+
+    const json = (await response.json()) as ChatSyncAPIResponse
+    onFinished?.(json)
+
+    return Promise.resolve(json)
+  } catch (e) {
+    const err = e as Error
+    const error = new LatitudeApiError({
+      status: 500,
+      message: err.message,
+      serverResponse: err.message,
+      errorCode: ApiErrorCodes.InternalServerError,
+    })
+
+    onError?.(error)
+    return !onError ? Promise.reject(error) : Promise.resolve(undefined)
+  }
+}

--- a/packages/sdks/typescript/src/utils/types.ts
+++ b/packages/sdks/typescript/src/utils/types.ts
@@ -4,6 +4,7 @@ import {
   type ChainEvent,
   type ChainEventDto,
   type ChainEventTypes,
+  type ChatSyncAPIResponse,
   type RunSyncAPIResponse,
   type StreamEventTypes,
 } from '@latitude-data/core/browser'
@@ -26,6 +27,7 @@ type RunDocumentBodyParam = {
 }
 type ChatBodyParams = {
   messages: Message[]
+  stream?: boolean
 }
 export type LogUrlParams = RunUrlParams
 type LogBodyParams = {
@@ -100,6 +102,7 @@ export type {
   ChainEvent,
   StreamEventTypes,
   ChainEventTypes,
+  ChatSyncAPIResponse,
   RunSyncAPIResponse,
 }
 
@@ -108,6 +111,11 @@ export type RunOptions = StreamResponseCallbacks & {
   versionUuid?: string
   customIdentifier?: string
   parameters?: Record<string, unknown>
+  stream?: boolean
+}
+
+export type ChatOptions = StreamResponseCallbacks & {
+  messages: Message[]
   stream?: boolean
 }
 


### PR DESCRIPTION
Closes: https://github.com/latitude-dev/latitude-llm/issues/535

Implements:
- `stream: false` option in `/chat` v2 endpoint that returns the last chain event as a JSON response.
- `chat` sdk function now accepts `stream` as a parameter

Notice that as `stream` option is now `false` by default, this is a breaking change for both API and SDK. But as discussed by the team this is ok,