### PR TITLE
feature: migrate provider log id to evaluation provider log id

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/index.tsx
@@ -88,7 +88,9 @@ export function EvaluationResults({
     EvaluationResultWithMetadataAndErrors | undefined
   >(undefined)
   const { open, onClose, onOpen } = useToggleModal()
-  const { data: providerLog } = useProviderLog(selectedResult?.providerLogId)
+  const { data: providerLog } = useProviderLog(
+    selectedResult?.evaluationProviderLogId,
+  )
   const searchParams = useSearchParams()
   const page = searchParams.get('page')
   const pageSize = searchParams.get('pageSize')

--- a/packages/core/src/data-access/evaluationResults.ts
+++ b/packages/core/src/data-access/evaluationResults.ts
@@ -1,8 +1,7 @@
 import { eq } from 'drizzle-orm'
 
-import { EvaluationResult } from '../browser'
 import { database } from '../client'
-import { workspacesDtoColumns } from '../repositories'
+import { EvaluationResultDto, workspacesDtoColumns } from '../repositories'
 import {
   evaluationResults,
   evaluations,
@@ -11,7 +10,7 @@ import {
 } from '../schema'
 
 export const findWorkspaceFromEvaluationResult = async (
-  evaluationResult: EvaluationResult,
+  evaluationResult: EvaluationResultDto,
   db = database,
 ) => {
   const result = await db

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentJob.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentJob.ts
@@ -64,6 +64,7 @@ export const runDocumentJob = async (job: Job<RunDocumentJobData>) => {
     const commit = await commitsScope
       .getCommitByUuid({ projectId, uuid: commitUuid })
       .then((r) => r.unwrap())
+
     await runDocumentAtCommit({
       workspace,
       document,
@@ -73,6 +74,7 @@ export const runDocumentJob = async (job: Job<RunDocumentJobData>) => {
     }).then((r) => r.unwrap())
 
     await progressTracker.incrementCompleted()
+
     await emitDocumentBatchRunStatus(
       websockets,
       workspaceId,

--- a/packages/core/src/repositories/connectedEvaluationsRepository/index.ts
+++ b/packages/core/src/repositories/connectedEvaluationsRepository/index.ts
@@ -146,7 +146,7 @@ export class ConnectedEvaluationsRepository extends RepositoryLegacy<
           )
           .innerJoin(
             providerLogs,
-            eq(providerLogs.id, evaluationResultsScope.providerLogId),
+            eq(providerLogs.id, evaluationResultsScope.evaluationProviderLogId),
           )
           .where(eq(evaluationResultsScope.evaluationId, evaluationId)),
       )

--- a/packages/core/src/repositories/evaluationResultsRepository/index.ts
+++ b/packages/core/src/repositories/evaluationResultsRepository/index.ts
@@ -28,8 +28,11 @@ import {
 } from '../../schema'
 import Repository from '../repositoryV2'
 
+const { providerLogId: _providerLogId, ...tt } =
+  getTableColumns(evaluationResults)
+
 export const evaluationResultDto = {
-  ...getTableColumns(evaluationResults),
+  ...tt,
   result: sql<string>`
     CASE
       WHEN ${evaluationResults.resultableType} = ${EvaluationResultableType.Boolean} THEN ${evaluationResultableBooleans.result}::text
@@ -39,7 +42,7 @@ export const evaluationResultDto = {
   `.as('result'),
 }
 
-export type EvaluationResultDto = EvaluationResult & {
+export type EvaluationResultDto = Omit<EvaluationResult, 'providerLogId'> & {
   result: string | number | boolean | undefined
 }
 
@@ -154,7 +157,7 @@ export class EvaluationResultsRepository extends Repository<EvaluationResultDto>
     return result[0]?.count ?? 0
   }
 
-  private parseResult(row: EvaluationResult & { result: string }) {
+  private parseResult(row: EvaluationResultDto & { result: string }) {
     const { result, resultableType, ...rest } = row
 
     let parsedResult

--- a/packages/core/src/services/chains/ChainStreamConsumer/index.ts
+++ b/packages/core/src/services/chains/ChainStreamConsumer/index.ts
@@ -67,6 +67,7 @@ export class ChainStreamConsumer {
     config: Config
   }) {
     const content = parseResponseText(response)
+
     enqueueChainEvent(controller, {
       event: StreamEventTypes.Latitude,
       data: {
@@ -96,6 +97,7 @@ export class ChainStreamConsumer {
     e: unknown
   }) {
     const error = parseError(e)
+
     enqueueChainEvent(controller, {
       event: StreamEventTypes.Latitude,
       data: {
@@ -108,6 +110,7 @@ export class ChainStreamConsumer {
       },
     })
     controller.close()
+
     return error
   }
 
@@ -128,6 +131,7 @@ export class ChainStreamConsumer {
   setup(step: ValidatedStep) {
     const newMessages = step.conversation.messages.slice(this.previousCount)
     const messageCount = this.previousCount + newMessages.length
+
     enqueueChainEvent(this.controller, {
       data: {
         type: ChainEventTypes.Step,
@@ -138,6 +142,7 @@ export class ChainStreamConsumer {
       },
       event: StreamEventTypes.Latitude,
     })
+
     return { messageCount, stepStartTime: Date.now() }
   }
 

--- a/packages/core/src/services/chains/ChainValidator/index.ts
+++ b/packages/core/src/services/chains/ChainValidator/index.ts
@@ -23,169 +23,156 @@ export type ValidatedStep = {
 type JSONOverride = { schema: JSONSchema7; output: 'object' | 'array' }
 export type ConfigOverrides = JSONOverride | { output: 'no-schema' }
 
-export class ChainValidator {
-  private workspace: Workspace
-  private prevText: string | undefined
-  private chain: Chain
-  private providersMap: CachedApiKeys
-  private configOverrides?: ConfigOverrides
+type ValidatorContext = {
+  workspace: Workspace
+  prevText: string | undefined
+  chain: Chain
+  providersMap: CachedApiKeys
+  configOverrides?: ConfigOverrides
+}
 
-  constructor({
-    workspace,
-    prevText,
-    chain,
-    providersMap,
-    configOverrides,
-  }: {
-    workspace: Workspace
-    prevText: string | undefined
-    chain: Chain
-    providersMap: CachedApiKeys
-    configOverrides?: ConfigOverrides
-  }) {
-    this.workspace = workspace
-    this.prevText = prevText
-    this.chain = chain
-    this.providersMap = providersMap
-    this.configOverrides = configOverrides
-  }
+const getInputSchema = (
+  chainCompleted: boolean,
+  config: Config,
+  configOverrides?: ConfigOverrides,
+): JSONSchema7 | undefined => {
+  if (!chainCompleted) return undefined
+  const overrideSchema =
+    configOverrides && 'schema' in configOverrides
+      ? configOverrides.schema
+      : undefined
+  return overrideSchema || config.schema
+}
 
-  async call() {
-    const chainResult = await this.safeChain()
-    if (chainResult.error) return chainResult
+const getOutputType = (
+  chainCompleted: boolean,
+  config: Config,
+  configOverrides?: ConfigOverrides,
+): 'object' | 'array' | 'no-schema' | undefined => {
+  if (!chainCompleted) return undefined
 
-    const { chainCompleted, conversation } = chainResult.value
-    const configResult = this.validateConfig(conversation.config)
-    if (configResult.error) return configResult
+  if (configOverrides?.output) return configOverrides.output
 
-    const config = configResult.unwrap()
-    const providerResult = this.findProvider(config.provider)
-    if (providerResult.error) return providerResult
+  const configSchema = config.schema
 
-    const provider = providerResult.value
-    const freeQuota = await checkFreeProviderQuota({
-      workspace: this.workspace,
-      provider,
-      model: config.model,
-    })
-    if (freeQuota.error) return freeQuota
+  if (!configSchema) return 'no-schema'
 
-    const rule = applyCustomRules({
-      providerType: provider.provider,
-      messages: conversation.messages,
-      config,
-    })
+  return configSchema.type === 'array' ? 'array' : 'object'
+}
 
-    return Result.ok({
-      provider,
-      config: rule.config as Config,
-      chainCompleted,
-      conversation: {
-        ...conversation,
-        messages: rule?.messages ?? conversation.messages,
-      },
-      schema: this.getInputSchema(chainCompleted, config),
-      output: this.getOutputType(chainCompleted, config),
-    })
-  }
-
-  private getInputSchema(
-    chainCompleted: boolean,
-    config: Config,
-  ): JSONSchema7 | undefined {
-    if (!chainCompleted) return undefined
-    const override = this.configOverrides
-    const overrideSchema =
-      override && 'schema' in override ? override.schema : undefined
-    return overrideSchema || config.schema
-  }
-
-  private getOutputType(
-    chainCompleted: boolean,
-    config: Config,
-  ): 'object' | 'array' | 'no-schema' | undefined {
-    if (!chainCompleted) return undefined
-
-    if (this.configOverrides?.output) return this.configOverrides.output
-
-    const configSchema = config.schema
-
-    if (!configSchema) return 'no-schema'
-
-    return configSchema.type === 'array' ? 'array' : 'object'
-  }
-
-  private async safeChain() {
-    try {
-      const { completed, conversation } = await this.chain.step(this.prevText)
-      return Result.ok({ chainCompleted: completed, conversation })
-    } catch (e) {
-      const error = e as CompileError
-      return Result.error(
-        new ChainError({
-          message: 'Error validating chain',
-          code: RunErrorCodes.ChainCompileError,
-          details: {
-            compileCode: error.code ?? 'unknown_compile_error',
-            message: error.message,
-          },
-        }),
-      )
-    }
-  }
-
-  private findProvider(name: string) {
-    const provider = this.providersMap.get(name)
-    if (provider) return Result.ok(provider)
-
-    const settingUrl = 'https://app.latitude.so/settings'
+const safeChain = async (chain: Chain, prevText: string | undefined) => {
+  try {
+    const { completed, conversation } = await chain.step(prevText)
+    return Result.ok({ chainCompleted: completed, conversation })
+  } catch (e) {
+    const error = e as CompileError
     return Result.error(
       new ChainError({
-        message: `Provider API Key with name ${name} not found. Go to ${settingUrl} to add a new provider if there is not one already with that name.`,
-        code: RunErrorCodes.MissingProvider,
+        message: 'Error validating chain',
+        code: RunErrorCodes.ChainCompileError,
+        details: {
+          compileCode: error.code ?? 'unknown_compile_error',
+          message: error.message,
+        },
+      }),
+    )
+  }
+}
+
+const findProvider = (name: string, providersMap: CachedApiKeys) => {
+  const provider = providersMap.get(name)
+  if (provider) return Result.ok(provider)
+
+  const settingUrl = 'https://app.latitude.so/settings'
+  return Result.error(
+    new ChainError({
+      message: `Provider API Key with name ${name} not found. Go to ${settingUrl} to add a new provider if there is not one already with that name.`,
+      code: RunErrorCodes.MissingProvider,
+    }),
+  )
+}
+
+const validateConfig = (
+  config: Record<string, unknown>,
+): TypedResult<Config, ChainError<RunErrorCodes.DocumentConfigError>> => {
+  const doc =
+    'https://docs.latitude.so/guides/getting-started/providers#using-providers-in-prompts'
+  const schema = z
+    .object({
+      model: z.string({
+        message: `"model" attribute is required. Read more here: ${doc}`,
+      }),
+      provider: z.string({
+        message: `"provider" attribute is required. Read more here: ${doc}`,
+      }),
+      google: googleConfig,
+      azure: z
+        .object({
+          resourceName: z.string({
+            message: 'Azure resourceName is required',
+          }),
+        })
+        .optional(),
+    })
+    .catchall(z.unknown())
+
+  const result = schema.safeParse(config)
+
+  if (!result.success) {
+    const validationError = result.error.errors[0]
+    const message = validationError
+      ? validationError.message
+      : 'Error validating document configuration'
+    return Result.error(
+      new ChainError({
+        message,
+        code: RunErrorCodes.DocumentConfigError,
       }),
     )
   }
 
-  validateConfig(
-    config: Record<string, unknown>,
-  ): TypedResult<Config, ChainError<RunErrorCodes.DocumentConfigError>> {
-    const doc =
-      'https://docs.latitude.so/guides/getting-started/providers#using-providers-in-prompts'
-    const schema = z
-      .object({
-        model: z.string({
-          message: `"model" attribute is required. Read more here: ${doc}`,
-        }),
-        provider: z.string({
-          message: `"provider" attribute is required. Read more here: ${doc}`,
-        }),
-        google: googleConfig,
-        azure: z
-          .object({
-            resourceName: z.string({
-              message: 'Azure resourceName is required',
-            }),
-          })
-          .optional(),
-      })
-      .catchall(z.unknown())
+  return Result.ok(result.data)
+}
 
-    const result = schema.safeParse(config)
+export const validateChain = async (
+  context: ValidatorContext,
+): Promise<TypedResult<ValidatedStep, ChainError<RunErrorCodes>>> => {
+  const { workspace, prevText, chain, providersMap, configOverrides } = context
 
-    if (!result.success) {
-      const validationError = result.error.errors[0]
-      const message = validationError
-        ? validationError.message
-        : 'Error validating document configuration'
-      return Result.error(
-        new ChainError({
-          message,
-          code: RunErrorCodes.DocumentConfigError,
-        }),
-      )
-    }
+  const chainResult = await safeChain(chain, prevText)
+  if (chainResult.error) return chainResult
 
-    return Result.ok(result.data)
-  }
+  const { chainCompleted, conversation } = chainResult.value
+  const configResult = validateConfig(conversation.config)
+  if (configResult.error) return configResult
+
+  const config = configResult.unwrap()
+  const providerResult = findProvider(config.provider, providersMap)
+  if (providerResult.error) return providerResult
+
+  const provider = providerResult.value
+  const freeQuota = await checkFreeProviderQuota({
+    workspace,
+    provider,
+    model: config.model,
+  })
+  if (freeQuota.error) return freeQuota
+
+  const rule = applyCustomRules({
+    providerType: provider.provider,
+    messages: conversation.messages,
+    config,
+  })
+
+  return Result.ok({
+    provider,
+    config: rule.config as Config,
+    chainCompleted,
+    conversation: {
+      ...conversation,
+      messages: rule?.messages ?? conversation.messages,
+    },
+    schema: getInputSchema(chainCompleted, config, configOverrides),
+    output: getOutputType(chainCompleted, config, configOverrides),
+  })
 }

--- a/packages/core/src/services/chains/ProviderProcessor/index.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/index.ts
@@ -1,148 +1,97 @@
 import { Message } from '@latitude-data/compiler'
-import { RunErrorCodes } from '@latitude-data/constants/errors'
 
 import {
+  ChainStepResponse,
   LogSources,
   ProviderApiKey,
   StreamType,
   Workspace,
 } from '../../../browser'
 import { StreamCommonData } from '../../../events/events'
-import { generateUUIDIdentifier, Result } from '../../../lib'
+import { generateUUIDIdentifier } from '../../../lib'
 import { AIReturn, PartialConfig } from '../../ai'
-import { ChainError } from '../ChainErrors'
-import { StreamConsumeReturn } from '../ChainStreamConsumer/consumeStream'
 import { processStreamObject } from './processStreamObject'
 import { processStreamText } from './processStreamText'
-import { saveOrPublishProviderLogs } from './saveOrPublishProviderLogs'
 
-export class ProviderProcessor {
-  private apiProvider: ProviderApiKey
-  private source: LogSources
-  private workspace: Workspace
-  private config: PartialConfig
-  private messages: Message[]
-  private saveSyncProviderLogs: boolean
-  private errorableUuid: string | undefined
+async function buildCommonData({
+  aiResult,
+  startTime,
+  workspace,
+  source,
+  apiProvider,
+  config,
+  messages,
+  errorableUuid,
+}: {
+  aiResult: Awaited<AIReturn<StreamType>>
+  startTime: number
+  workspace: Workspace
+  source: LogSources
+  apiProvider: ProviderApiKey
+  config: PartialConfig
+  messages: Message[]
+  errorableUuid?: string
+}): Promise<StreamCommonData> {
+  const endTime = Date.now()
+  const duration = endTime - startTime
+  return {
+    uuid: generateUUIDIdentifier(),
 
-  constructor({
+    // AI Provider Data
+    workspaceId: workspace.id,
+    source: source,
+    providerId: apiProvider.id,
+    providerType: apiProvider.provider,
+    // FIXME: This should be polymorphic
+    // https://github.com/latitude-dev/latitude-llm/issues/229
+    documentLogUuid: errorableUuid,
+
+    // AI
+    duration,
+    generatedAt: new Date(),
+    model: config.model,
+    config: config,
+    messages: messages,
+    usage: await aiResult.data.usage,
+  }
+}
+
+/**
+ * This function is responsible for processing the AI response
+ */
+export async function processResponse({
+  aiResult,
+  startTime,
+  workspace,
+  source,
+  apiProvider,
+  config,
+  messages,
+  errorableUuid,
+}: {
+  aiResult: Awaited<AIReturn<StreamType>>
+  startTime: number
+  workspace: Workspace
+  source: LogSources
+  apiProvider: ProviderApiKey
+  config: PartialConfig
+  messages: Message[]
+  errorableUuid?: string
+}): Promise<ChainStepResponse<StreamType>> {
+  const commonData = await buildCommonData({
+    aiResult,
+    startTime,
     workspace,
-    apiProvider,
     source,
+    apiProvider,
     config,
     messages,
-    saveSyncProviderLogs,
     errorableUuid,
-  }: {
-    workspace: Workspace
-    apiProvider: ProviderApiKey
-    source: LogSources
-    config: PartialConfig
-    messages: Message[]
-    saveSyncProviderLogs: boolean
-    errorableUuid?: string
-  }) {
-    this.apiProvider = apiProvider
-    this.workspace = workspace
-    this.source = source
-    this.config = config
-    this.messages = messages
-    this.saveSyncProviderLogs = saveSyncProviderLogs
-    this.errorableUuid = errorableUuid
+  })
+
+  if (aiResult.type === 'text') {
+    return processStreamText({ aiResult, commonData })
   }
 
-  /**
-   * This method is responsible of 2 things
-   * 1. Process the AI response
-   * 2. Create a provider log if necessary (syncronous call or enqueue call)
-   *
-   * Provider log is created with AI error if present in the consumed stream
-   */
-  async call({
-    aiResult,
-    startTime,
-    finishReason,
-  }: {
-    aiResult: Awaited<AIReturn<StreamType>>
-    startTime: number
-    finishReason: StreamConsumeReturn['finishReason']
-  }) {
-    const checkResult = this.checkValidType(aiResult)
-    if (checkResult.error) return checkResult
-
-    const { response, providerLogsData } = await this.processResponse({
-      aiResult,
-      startTime,
-    })
-
-    const providerLog = await saveOrPublishProviderLogs({
-      workspace: this.workspace,
-      streamType: aiResult.type,
-      finishReason,
-      data: providerLogsData,
-      saveSyncProviderLogs: this.saveSyncProviderLogs,
-    })
-
-    return Result.ok({ ...response, providerLog })
-  }
-
-  private async processResponse({
-    aiResult,
-    startTime,
-  }: {
-    aiResult: Awaited<AIReturn<StreamType>>
-    startTime: number
-  }) {
-    const commonData = await this.buildCommonData({ aiResult, startTime })
-
-    if (aiResult.type === 'text') {
-      return processStreamText({ aiResult, commonData })
-    }
-
-    return processStreamObject({ aiResult, commonData })
-  }
-
-  private async buildCommonData({
-    aiResult,
-    startTime,
-  }: {
-    aiResult: Awaited<AIReturn<StreamType>>
-    startTime: number
-  }): Promise<StreamCommonData> {
-    const endTime = Date.now()
-    const duration = endTime - startTime
-    return {
-      uuid: generateUUIDIdentifier(),
-
-      // AI Provider Data
-      workspaceId: this.workspace.id,
-      source: this.source,
-      providerId: this.apiProvider.id,
-      providerType: this.apiProvider.provider,
-      // FIXME: This should be polymorphic
-      // https://github.com/latitude-dev/latitude-llm/issues/229
-      documentLogUuid: this.errorableUuid,
-
-      // AI
-      duration,
-      generatedAt: new Date(),
-      model: this.config.model,
-      config: this.config,
-      messages: this.messages,
-      usage: await aiResult.data.usage,
-    }
-  }
-
-  private checkValidType(aiResult: AIReturn<StreamType>) {
-    const { type } = aiResult
-    const invalidType = type !== 'text' && type !== 'object'
-    if (!invalidType) return Result.nil()
-
-    return Result.error(
-      new ChainError({
-        code: RunErrorCodes.UnsupportedProviderResponseTypeError,
-        message: `Invalid stream type ${type} result is not a textStream or objectStream`,
-      }),
-    )
-  }
+  return processStreamObject({ aiResult, commonData })
 }

--- a/packages/core/src/services/chains/ProviderProcessor/processStreamObject.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/processStreamObject.ts
@@ -1,39 +1,6 @@
-import { ChainStepResponse } from '../../../constants'
 import { StreamCommonData } from '../../../events/events'
 import { objectToString } from '../../../helpers'
 import { AIReturn } from '../../ai'
-
-async function processResponse({
-  aiResult,
-  commonData,
-}: {
-  commonData: StreamCommonData
-  aiResult: Awaited<AIReturn<'object'>>
-}): Promise<ChainStepResponse<'object'>> {
-  const object = await aiResult.data.object
-  return {
-    streamType: aiResult.type,
-    documentLogUuid: commonData.documentLogUuid,
-    usage: await aiResult.data.usage,
-    text: objectToString(object),
-    object,
-  }
-}
-
-async function createProviderLogData({
-  response,
-  commonData,
-}: {
-  response: Awaited<ReturnType<typeof processResponse>>
-  commonData: StreamCommonData
-}) {
-  return {
-    ...commonData,
-    responseObject: response.object,
-  }
-}
-
-export type ObjectProviderLogsData = ReturnType<typeof createProviderLogData>
 
 export async function processStreamObject({
   aiResult,
@@ -42,11 +9,12 @@ export async function processStreamObject({
   commonData: StreamCommonData
   aiResult: Awaited<AIReturn<'object'>>
 }) {
-  const response = await processResponse({ aiResult, commonData })
-  const providerLogsData = await createProviderLogData({
-    response,
-    commonData,
-  })
-
-  return { response, providerLogsData }
+  const object = await aiResult.data.object
+  return {
+    streamType: aiResult.type,
+    documentLogUuid: commonData.documentLogUuid,
+    usage: await aiResult.data.usage,
+    text: objectToString(object),
+    object,
+  }
 }

--- a/packages/core/src/services/chains/ProviderProcessor/processStreamText.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/processStreamText.ts
@@ -1,14 +1,13 @@
-import { ChainStepResponse } from '../../../constants'
 import { StreamCommonData } from '../../../events/events'
 import { AIReturn } from '../../ai'
 
-async function processResponse({
+export async function processStreamText({
   aiResult,
   commonData,
 }: {
   commonData: StreamCommonData
   aiResult: Awaited<AIReturn<'text'>>
-}): Promise<ChainStepResponse<'text'>> {
+}) {
   return {
     streamType: aiResult.type,
     documentLogUuid: commonData.documentLogUuid,
@@ -20,38 +19,4 @@ async function processResponse({
       arguments: t.args,
     })),
   }
-}
-
-async function createProviderLogData({
-  response,
-  aiResult,
-  commonData,
-}: {
-  response: Awaited<ReturnType<typeof processResponse>>
-  aiResult: Awaited<AIReturn<'text'>>
-  commonData: StreamCommonData
-}) {
-  return {
-    ...commonData,
-    responseText: await aiResult.data.text,
-    toolCalls: response.toolCalls,
-  }
-}
-
-export type TextProviderLogsData = ReturnType<typeof createProviderLogData>
-
-export async function processStreamText({
-  aiResult,
-  commonData,
-}: {
-  commonData: StreamCommonData
-  aiResult: Awaited<AIReturn<'text'>>
-}) {
-  const response = await processResponse({ aiResult, commonData })
-  const providerLogsData = await createProviderLogData({
-    response,
-    aiResult,
-    commonData,
-  })
-  return { response, providerLogsData }
 }

--- a/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.test.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.test.ts
@@ -7,7 +7,10 @@ import { publisher } from '../../../events/publisher'
 import * as jobsModule from '../../../jobs'
 import { generateUUIDIdentifier } from '../../../lib'
 import * as createProviderLogService from '../../providerLogs/create'
-import { LogData, saveOrPublishProviderLogs } from './saveOrPublishProviderLogs'
+import {
+  buildProviderLogDto,
+  saveOrPublishProviderLogs,
+} from './saveOrPublishProviderLogs'
 
 const publisherSpy = vi.spyOn(publisher, 'publishLater')
 const createProviderLogSpy = vi.spyOn(
@@ -28,8 +31,9 @@ const setupJobsSpy = vi.spyOn(jobsModule, 'setupJobs')
 // @ts-expect-error - mock implementation
 setupJobsSpy.mockResolvedValue(mocks.queues)
 
-let data: LogData<'text'>
+let data: ReturnType<typeof buildProviderLogDto>
 let workspace: Workspace
+
 describe('saveOrPublishProviderLogs', () => {
   beforeEach(async () => {
     const prompt = factories.helpers.createPrompt({
@@ -54,6 +58,7 @@ describe('saveOrPublishProviderLogs', () => {
       commit,
     })
     workspace = setup.workspace
+    // @ts-expect-error - mock implementation
     data = {
       workspaceId: setup.workspace.id,
       uuid: generateUUIDIdentifier(),

--- a/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
@@ -1,20 +1,16 @@
-import { Workspace } from '../../../browser'
-import { StreamType } from '../../../constants'
+import { Conversation } from '@latitude-data/compiler'
+import { FinishReason } from 'ai'
+
+import { ProviderApiKey, Workspace } from '../../../browser'
+import { ChainStepResponse, LogSources, StreamType } from '../../../constants'
 import { AIProviderCallCompletedData } from '../../../events/events'
 import { publisher } from '../../../events/publisher'
 import { setupJobs } from '../../../jobs'
+import { generateUUIDIdentifier } from '../../../lib'
+import { PartialConfig } from '../../ai'
 import { createProviderLog } from '../../providerLogs'
-import { StreamConsumeReturn } from '../ChainStreamConsumer/consumeStream'
-import { type ObjectProviderLogsData } from './processStreamObject'
-import { type TextProviderLogsData } from './processStreamText'
 
-export type LogData<T extends StreamType> = T extends 'text'
-  ? Awaited<TextProviderLogsData>
-  : T extends 'object'
-    ? Awaited<ObjectProviderLogsData>
-    : unknown
-
-export async function saveOrPublishProviderLogs<T extends StreamType>({
+export async function saveOrPublishProviderLogs({
   workspace,
   data,
   streamType,
@@ -22,14 +18,16 @@ export async function saveOrPublishProviderLogs<T extends StreamType>({
   finishReason,
 }: {
   workspace: Workspace
-  streamType: T
-  data: LogData<T>
+  streamType: StreamType
+  data: ReturnType<typeof buildProviderLogDto>
   saveSyncProviderLogs: boolean
-  finishReason: StreamConsumeReturn['finishReason']
+  finishReason: FinishReason
 }) {
   publisher.publishLater({
     type: 'aiProviderCallCompleted',
-    data: { ...data, streamType } as AIProviderCallCompletedData<T>,
+    data: { ...data, streamType } as AIProviderCallCompletedData<
+      typeof streamType
+    >,
   })
 
   const providerLogsData = {
@@ -50,4 +48,45 @@ export async function saveOrPublishProviderLogs<T extends StreamType>({
     ...providerLogsData,
     generatedAt: data.generatedAt.toISOString(),
   })
+}
+
+export function buildProviderLogDto({
+  workspace,
+  source,
+  provider,
+  conversation,
+  stepStartTime,
+  errorableUuid,
+  response,
+}: {
+  workspace: Workspace
+  source: LogSources
+  provider: ProviderApiKey
+  conversation: Conversation
+  stepStartTime: number
+  errorableUuid?: string
+  response: ChainStepResponse<StreamType>
+}) {
+  return {
+    uuid: generateUUIDIdentifier(),
+
+    // AI Provider Data
+    workspaceId: workspace.id,
+    source: source,
+    providerId: provider.id,
+    providerType: provider.provider,
+    documentLogUuid: errorableUuid,
+
+    // AI
+    duration: Date.now() - stepStartTime,
+    generatedAt: new Date(),
+    model: conversation.config.model as string,
+    config: conversation.config as PartialConfig,
+    messages: conversation.messages,
+    usage: response.usage,
+    responseObject:
+      response.streamType === 'object' ? response.object : undefined,
+    responseText: response.streamType === 'text' ? response.text : undefined,
+    toolCalls: response.streamType === 'text' ? response.toolCalls : [],
+  }
 }

--- a/packages/core/src/services/chains/run-errors.test.ts
+++ b/packages/core/src/services/chains/run-errors.test.ts
@@ -19,7 +19,7 @@ import {
   PARTIAL_FINISH_CHUNK,
   TOOLS,
 } from './ChainStreamConsumer/consumeStream.test'
-import { ChainValidator } from './ChainValidator'
+import * as ChainValidator from './ChainValidator'
 import { runChain } from './run'
 
 let providersMap: Map<string, any>
@@ -81,18 +81,19 @@ describe('run chain error handling', () => {
   })
 
   it('stores error when default provider quota is exceeded', async () => {
-    const chainValidatorCall = vi.spyOn(ChainValidator.prototype, 'call')
-    chainValidatorCall.mockImplementation(() =>
-      Promise.resolve(
-        Result.error(
-          new ChainError({
-            code: RunErrorCodes.DefaultProviderExceededQuota,
-            message:
-              'You have exceeded your maximum number of free runs for today',
-          }),
+    const chainValidatorCall = vi
+      .spyOn(ChainValidator, 'validateChain')
+      .mockImplementation(() =>
+        Promise.resolve(
+          Result.error(
+            new ChainError({
+              code: RunErrorCodes.DefaultProviderExceededQuota,
+              message:
+                'You have exceeded your maximum number of free runs for today',
+            }),
+          ),
         ),
-      ),
-    )
+      )
     const run = await runChain({
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
@@ -124,11 +125,14 @@ describe('run chain error handling', () => {
   })
 
   it('store error as unknown when something undefined happens', async () => {
-    const chainValidatorCall = vi.spyOn(ChainValidator.prototype, 'call')
-    chainValidatorCall.mockImplementation(() =>
-      // @ts-expect-error - Error is not valid here but we fake an unknown error
-      Promise.resolve(Result.error(new Error('Something undefined happened'))),
-    )
+    const chainValidatorCall = vi
+      .spyOn(ChainValidator, 'validateChain')
+      .mockImplementation(() =>
+        // @ts-expect-error - Error is not valid here but we fake an unknown error
+        Promise.resolve(
+          Result.error(new Error('Something undefined happened')),
+        ),
+      )
     const run = await runChain({
       errorableType: ErrorableEntity.DocumentLog,
       workspace,

--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -191,12 +191,14 @@ This is a test document
         parameters: {},
         source: LogSources.API,
       }).then((r) => r.unwrap())
+
       await response
       await duration
 
       const { value } = await testConsumeStream(stream)
       const repo = new ProviderLogsRepository(workspace.id)
       const logs = await repo.findAll().then((r) => r.unwrap())
+
       expect(value).toEqual([
         {
           data: {

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -122,6 +122,7 @@ export async function runDocumentAtCommit({
       source,
       publishEvent: false,
     })
+
     return checkerResult
   }
 

--- a/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
+++ b/packages/core/src/services/evaluationResults/_createEvaluationResultQuery.ts
@@ -28,7 +28,7 @@ export function createEvaluationResultQuery(
     .from(evaluationResultsScope)
     .innerJoin(
       providerLogs,
-      eq(providerLogs.id, evaluationResultsScope.providerLogId),
+      eq(providerLogs.id, evaluationResultsScope.evaluationProviderLogId),
     )
     .groupBy(evaluationResultsScope.id)
     .as('aggregatedFieldsSubQuery')

--- a/packages/core/src/services/evaluationResults/_createEvaluationResultQueryWithErrors.ts
+++ b/packages/core/src/services/evaluationResults/_createEvaluationResultQueryWithErrors.ts
@@ -29,7 +29,7 @@ export function createEvaluationResultQueryWithErrors(
     .from(evaluationResultsScope)
     .leftJoin(
       providerLogs,
-      eq(providerLogs.id, evaluationResultsScope.providerLogId),
+      eq(providerLogs.id, evaluationResultsScope.evaluationProviderLogId),
     )
     .groupBy(evaluationResultsScope.id)
     .as('aggregatedFieldsSubQuery')

--- a/packages/core/src/services/evaluationResults/aggregations/countersQuery.ts
+++ b/packages/core/src/services/evaluationResults/aggregations/countersQuery.ts
@@ -37,7 +37,7 @@ export async function getEvaluationTotalsQuery(
     )
     .innerJoin(
       providerLogs,
-      eq(providerLogs.id, evaluationResultsScope.providerLogId),
+      eq(providerLogs.id, evaluationResultsScope.evaluationProviderLogId),
     )
     .where(
       and(

--- a/packages/core/src/services/evaluationResults/computeEvaluationResultsWithMetadata.ts
+++ b/packages/core/src/services/evaluationResults/computeEvaluationResultsWithMetadata.ts
@@ -54,7 +54,7 @@ export async function computeEvaluationResultsWithMetadata(
   const filteredResultsSubQuery = db
     .select({
       id: evaluationResultsScope.id,
-      providerLogId: evaluationResultsScope.providerLogId,
+      evaluationProviderLogId: evaluationResultsScope.evaluationProviderLogId,
       error: evaluationResultsScope.error,
     })
     .from(evaluationResultsScope)
@@ -92,7 +92,7 @@ export async function computeEvaluationResultsWithMetadata(
     )
     .leftJoin(
       providerLogs,
-      eq(providerLogs.id, filteredResultsSubQuery.providerLogId),
+      eq(providerLogs.id, filteredResultsSubQuery.evaluationProviderLogId),
     )
     .groupBy(evaluationResultsScope.id)
     .as('aggregatedFieldsSubQuery')

--- a/packages/core/src/services/evaluationResults/serialize.ts
+++ b/packages/core/src/services/evaluationResults/serialize.ts
@@ -31,7 +31,7 @@ export async function serialize(
 
   const providerLogsScope = new ProviderLogsRepository(workspace.id, db)
   const providerLogResult = await providerLogsScope.find(
-    evaluationResult.providerLogId,
+    evaluationResult.evaluationProviderLogId,
   )
   if (providerLogResult.error) return Result.error(providerLogResult.error)
   if (!providerLogResult.value) {

--- a/packages/core/src/services/evaluations/run.ts
+++ b/packages/core/src/services/evaluations/run.ts
@@ -91,6 +91,7 @@ export async function runEvaluation(
       message: `Provider with model [${response?.providerLog?.config?.model ?? 'unknown'}] did not return a valid JSON object`,
     })
     await handleEvaluationError(error, errorableUuid)
+
     return Result.error(error)
   }
 

--- a/packages/core/src/services/providerLogs/create.ts
+++ b/packages/core/src/services/providerLogs/create.ts
@@ -1,5 +1,5 @@
 import { Message, ToolCall } from '@latitude-data/compiler'
-import { LanguageModelUsage } from 'ai'
+import { FinishReason, LanguageModelUsage } from 'ai'
 
 import { LogSources, ProviderLog, Providers, Workspace } from '../../browser'
 import { database } from '../../client'
@@ -8,7 +8,6 @@ import { Result, Transaction } from '../../lib'
 import { providerLogs } from '../../schema'
 import { estimateCost, PartialConfig } from '../ai'
 import { touchApiKey } from '../apiKeys'
-import { StreamConsumeReturn } from '../chains/ChainStreamConsumer/consumeStream'
 import { touchProviderApiKey } from '../providerApiKeys/touch'
 
 const TO_MILLICENTS_FACTOR = 100_000
@@ -25,7 +24,7 @@ export type CreateProviderLogProps = {
   usage?: LanguageModelUsage
   duration?: number
   source: LogSources
-  finishReason?: StreamConsumeReturn['finishReason']
+  finishReason?: FinishReason
   apiKeyId?: number
   responseText?: string
   responseObject?: unknown
@@ -97,6 +96,7 @@ export async function createProviderLog(
       .returning()
 
     const log = inserts[0]! as ProviderLog
+
     if (providerId) await touchProviderApiKey(providerId, trx)
     if (apiKeyId) await touchApiKey(apiKeyId, trx)
 


### PR DESCRIPTION
Also fixes bug where provider logs weren't being saved for cached prompts and add tests for this case.