### PR TITLE
feat(compiler): add CommonJS support and update package exports

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -5,11 +5,21 @@
   "license": "LGPL",
   "description": "Compiler for Latitude's custom conversation language",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "src"
-  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": ["src"],
   "scripts": {
     "dev": "rollup -c -w",
     "build": "rollup -c",

--- a/packages/compiler/rollup.config.mjs
+++ b/packages/compiler/rollup.config.mjs
@@ -39,6 +39,11 @@ export default [
         file: 'dist/index.js',
         sourcemap: true,
       },
+      {
+        file: 'dist/index.cjs',
+        format: 'cjs',
+        sourcemap: true,
+      },
     ],
     plugins: [
       typescript({
@@ -54,7 +59,7 @@ export default [
       'node:crypto',
       'yaml',
       'crypto',
-      'zod'
+      'zod',
     ],
   },
   {


### PR DESCRIPTION
- Updated `main` field in package.json to point to CommonJS entry point.
- Added `module` field for ES module entry point.
- Defined `exports` field to specify import and require paths for both types and default exports.
- Modified Rollup configuration to generate both ES module and CommonJS builds.
- Ensured source maps are generated for both build formats.

This change ensures compatibility with both CommonJS and ES module systems, making the package more versatile and easier to integrate into different environments.