### PR TITLE
Use chat streaming in playground

### DIFF
--- a/apps/web/src/actions/sdk/addMessagesAction.ts
+++ b/apps/web/src/actions/sdk/addMessagesAction.ts
@@ -49,6 +49,7 @@ export async function addMessagesAction({
   >()
 
   const response = sdk.chat(documentLogUuid, messages, {
+    stream: true,
     onEvent: (event) => {
       stream.update(event)
     },


### PR DESCRIPTION
As said in https://github.com/latitude-dev/latitude-llm/pull/548 chat endpoint is now non-streaming by default (find more info of why the breaking-change in that PR), so we have to specify streaming in playground's chat.