### PR TITLE
Fix floating points in cost over results chart

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/CostOverResults.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/MetricsSummary/Charts/Numerical/CostOverResults.tsx
@@ -82,12 +82,24 @@ export function CostOverResultsChart({
               type: 'number',
               min: evaluationConfiguration.minValue,
               max: evaluationConfiguration.maxValue,
+              tickFormatter: (value) =>
+                Intl.NumberFormat('en-US', {
+                  style: 'decimal',
+                  maximumFractionDigits: 2,
+                }).format(Number(value)),
             },
             yAxis: {
               label: 'Average cost',
               type: 'number',
               min: 0,
               max: 'auto',
+              tickFormatter: (value) =>
+                Intl.NumberFormat('en-US', {
+                  style: 'currency',
+                  currency: 'USD',
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 6,
+                }).format(Number(value)),
             },
             data: parsedData,
             tooltipLabel: (item) => (


### PR DESCRIPTION
# What?
☝️ That


### Before
![image](https://github.com/user-attachments/assets/acd5f4e6-777b-4eaf-aefa-829722d44a78)


### After
![image](https://github.com/user-attachments/assets/85059f5a-3975-41ac-8b1e-b4b31e8a13cb)
