### PR TITLE
quickfix(editor): correct position in editor errors

### DIFF
--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/index.tsx
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/index.tsx
@@ -84,10 +84,12 @@ export function DocumentTextEditor({
 
   const errorFixFn = useMemo(() => {
     if (!copilot) return undefined
+
     return (errors: DocumentError[]) => {
       const request =
         'Please, fix the following errors from the prompt:\n' +
         errors.map((error) => ` - ${JSON.stringify(error)}`).join('\n')
+
       return copilot.requestSuggestion(request)
     }
   }, [copilot])


### PR DESCRIPTION
Errors passed through web worker's postMessage bus are coerced to regular Error instances (?), so I'm just serializing them before sending them batch to the main thread.