### PR TITLE
Propmtl compiler v1 part 3: Step tags

### DIFF
--- a/packages/promptl/src/compiler/base/nodes/for.ts
+++ b/packages/promptl/src/compiler/base/nodes/for.ts
@@ -13,6 +13,7 @@ type ForNodeWithStatus = TemplateNodeWithStatus & {
 export async function compile({
   node,
   scope,
+  isInsideStepTag,
   isInsideContentTag,
   isInsideMessageTag,
   resolveBaseNode,
@@ -32,6 +33,7 @@ export async function compile({
       await resolveBaseNode({
         node: childNode,
         scope: childScope,
+        isInsideStepTag,
         isInsideMessageTag,
         isInsideContentTag,
       })
@@ -72,6 +74,7 @@ export async function compile({
       await resolveBaseNode({
         node: childNode,
         scope: localScope,
+        isInsideStepTag,
         isInsideMessageTag,
         isInsideContentTag,
         completedValue: `step_${i}`,

--- a/packages/promptl/src/compiler/base/nodes/fragment.ts
+++ b/packages/promptl/src/compiler/base/nodes/fragment.ts
@@ -5,6 +5,7 @@ import { CompileNodeContext } from '../types'
 export async function compile({
   node,
   scope,
+  isInsideStepTag,
   isInsideContentTag,
   isInsideMessageTag,
   resolveBaseNode,
@@ -13,6 +14,7 @@ export async function compile({
     await resolveBaseNode({
       node: childNode,
       scope,
+      isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
     })

--- a/packages/promptl/src/compiler/base/nodes/if.ts
+++ b/packages/promptl/src/compiler/base/nodes/if.ts
@@ -5,6 +5,7 @@ import { CompileNodeContext } from '../types'
 export async function compile({
   node,
   scope,
+  isInsideStepTag,
   isInsideContentTag,
   isInsideMessageTag,
   resolveBaseNode,
@@ -17,6 +18,7 @@ export async function compile({
     await resolveBaseNode({
       node: childNode,
       scope: childScope,
+      isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
     })

--- a/packages/promptl/src/compiler/base/nodes/tag.ts
+++ b/packages/promptl/src/compiler/base/nodes/tag.ts
@@ -14,10 +14,10 @@ import {
 } from '$promptl/parser/interfaces'
 
 import { CompileNodeContext } from '../types'
-import { compile as resolveChainStep } from './tags/chainStep'
 import { compile as resolveContent } from './tags/content'
 import { compile as resolveMessage } from './tags/message'
 import { compile as resolveRef } from './tags/ref'
+import { compile as resolveChainStep } from './tags/step'
 
 async function resolveTagAttributes({
   node: tagNode,
@@ -68,6 +68,7 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
   const {
     node,
     scope,
+    isInsideStepTag,
     isInsideContentTag,
     isInsideMessageTag,
     resolveBaseNode,
@@ -109,6 +110,7 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
     await resolveBaseNode({
       node: childNode,
       scope,
+      isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
     })

--- a/packages/promptl/src/compiler/base/nodes/tags/content.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/content.ts
@@ -13,6 +13,7 @@ export async function compile(
   {
     node,
     scope,
+    isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
     resolveBaseNode,
@@ -30,6 +31,7 @@ export async function compile(
     await resolveBaseNode({
       node: childNode,
       scope,
+      isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag: true,
     })

--- a/packages/promptl/src/compiler/base/nodes/tags/message.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/message.ts
@@ -20,6 +20,7 @@ export async function compile(
   const {
     node,
     scope,
+    isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
     resolveBaseNode,
@@ -49,6 +50,7 @@ export async function compile(
     await resolveBaseNode({
       node: childNode,
       scope,
+      isInsideStepTag,
       isInsideMessageTag: true,
       isInsideContentTag,
     })

--- a/packages/promptl/src/compiler/base/nodes/tags/step.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/step.ts
@@ -15,26 +15,46 @@ export async function compile(
   {
     node,
     scope,
+    isInsideStepTag,
+    isInsideMessageTag,
+    isInsideContentTag,
     popStepResponse,
-    addMessage,
     groupContent,
+    resolveBaseNode,
     baseNodeError,
     stop,
   }: CompileNodeContext<ChainStepTag>,
   attributes: Record<string, unknown>,
 ) {
+  if (isInsideStepTag) {
+    baseNodeError(errors.stepTagInsideStep, node)
+  }
+
   const stepResponse = popStepResponse()
 
   const { as: varName, ...config } = attributes
 
+  // The step must be processed.
   if (stepResponse === undefined) {
     if (!isValidConfig(config)) {
       baseNodeError(errors.invalidStepConfig, node)
     }
 
+    for await (const childNode of node.children ?? []) {
+      await resolveBaseNode({
+        node: childNode,
+        scope,
+        isInsideStepTag: true,
+        isInsideMessageTag,
+        isInsideContentTag,
+      })
+    }
+
+    // Stop the compiling process up to this point.
     stop(config as Config)
   }
 
+  // The step has already been process, this is the continuation of the chain.
   if ('as' in attributes) {
     if (!tagAttributeIsLiteral(node, 'as')) {
       baseNodeError(errors.invalidStaticAttribute('as'), node)
@@ -44,5 +64,4 @@ export async function compile(
   }
 
   groupContent()
-  addMessage(stepResponse!)
 }

--- a/packages/promptl/src/compiler/base/types.ts
+++ b/packages/promptl/src/compiler/base/types.ts
@@ -35,7 +35,7 @@ type RaiseErrorFn<T = void | never, N = TemplateNode | LogicalExpression> = (
 type NodeStatus = {
   completedAs?: unknown
   scopePointers?: ScopePointers | undefined
-  eachIterationIndex?: number
+  loopIterationIndex?: number
 }
 
 export type TemplateNodeWithStatus = TemplateNode & {
@@ -53,11 +53,12 @@ export type CompileNodeContext<N extends TemplateNode> = {
   baseNodeError: RaiseErrorFn<never, TemplateNode>
   expressionError: RaiseErrorFn<never, LogicalExpression>
 
+  isInsideStepTag: boolean
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
 
   setConfig: (config: Config) => void
-  addMessage: (message: Message) => void
+  addMessage: (message: Message, global?: boolean) => void
   addStrayText: (text: string) => void
   popStrayText: () => string
   groupStrayText: () => void

--- a/packages/promptl/src/compiler/compile.ts
+++ b/packages/promptl/src/compiler/compile.ts
@@ -54,7 +54,7 @@ export class Compile {
   private defaultRole: MessageRole
 
   private messages: Message[] = []
-  private config: Config | undefined
+  private globalConfig: Config | undefined
   private stepResponse: MessageContent[] | undefined
 
   private accumulatedText: string = ''
@@ -90,6 +90,7 @@ export class Compile {
       await this.resolveBaseNode({
         node: this.ast,
         scope: this.globalScope,
+        isInsideStepTag: false,
         isInsideMessageTag: false,
         isInsideContentTag: false,
       })
@@ -107,8 +108,8 @@ export class Compile {
     return {
       ast: this.ast,
       scopeStash: this.globalScope.getStash(),
+      globalConfig: this.globalConfig,
       messages: this.messages,
-      globalConfig: this.config,
       stepConfig,
       completed,
     }
@@ -123,8 +124,8 @@ export class Compile {
   }
 
   private setConfig(config: Config): void {
-    if (this.config !== undefined) return
-    this.config = config
+    if (this.globalConfig !== undefined) return
+    this.globalConfig = config
   }
 
   private addStrayText(text: string) {
@@ -204,6 +205,7 @@ export class Compile {
   private async resolveBaseNode({
     node,
     scope,
+    isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
     completedValue = true,
@@ -232,6 +234,7 @@ export class Compile {
     const context: CompileNodeContext<TemplateNode> = {
       node,
       scope,
+      isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
       resolveBaseNode: resolveBaseNodeFn.bind(this),

--- a/packages/promptl/src/compiler/errors.test.ts
+++ b/packages/promptl/src/compiler/errors.test.ts
@@ -123,6 +123,21 @@ describe(`all compilation errors that don't require value resolution are caught 
     })
   })
 
+  it('step-tag-inside-step', async () => {
+    const prompt = `
+      <step>
+        <step>
+          Foo
+        </step>
+      </step>
+    `
+
+    await expectBothErrors({
+      code: 'step-tag-inside-step',
+      prompt,
+    })
+  })
+
   it('message-tag-inside-message', async () => {
     const prompt = `
       <system>

--- a/packages/promptl/src/compiler/index.ts
+++ b/packages/promptl/src/compiler/index.ts
@@ -18,10 +18,7 @@ export async function render({
   parameters?: Record<string, unknown>
 } & CompileOptions): Promise<Conversation> {
   const iterator = new Chain({ prompt, parameters, ...compileOptions })
-  const { conversation, completed } = await iterator.step()
-  if (!completed) {
-    throw new Error('Use a Chain to render prompts with multiple steps')
-  }
+  const { conversation } = await iterator.step()
   return conversation
 }
 

--- a/packages/promptl/src/compiler/types.ts
+++ b/packages/promptl/src/compiler/types.ts
@@ -6,6 +6,7 @@ import type Scope from './scope'
 export type ResolveBaseNodeProps<N extends TemplateNode> = {
   node: N
   scope: Scope
+  isInsideStepTag: boolean
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
   completedValue?: unknown

--- a/packages/promptl/src/constants.ts
+++ b/packages/promptl/src/constants.ts
@@ -14,7 +14,8 @@ export const REFERENCE_PROMPT_ATTR = 'path' as const
 export const REFERENCE_DEPTH_LIMIT = 50
 
 // <response as="…" />
-export const CHAIN_STEP_TAG = 'response' as const
+export const CHAIN_STEP_TAG = 'step' as const
+export const CHAIN_STEP_ISOLATED_ATTR = 'isolated' as const
 
 export enum KEYWORDS {
   if = 'if',

--- a/packages/promptl/src/error/errors.ts
+++ b/packages/promptl/src/error/errors.ts
@@ -145,6 +145,10 @@ export default {
     code: 'invalid-tool-call-placement',
     message: 'Only assistant messages can contain tool calls',
   },
+  stepTagInsideStep: {
+    code: 'step-tag-inside-step',
+    message: 'Step tags cannot be inside of another step tag',
+  },
   messageTagInsideMessage: {
     code: 'message-tag-inside-message',
     message: 'Message tags cannot be inside of another message',


### PR DESCRIPTION
This is the second from a series of PRs to implement [the new spec for the PromptL language](https://latitudedata.notion.site/PromptL-v1-12fa92110b9780d7824ef3c540e4bed2?pvs=4).

**What's in this PR?**

Here, I have changed the `<response>` tag into the "brand new" `<step>`. The `step` tag, although apparently working in a whole different way, it really just adds two changes:
1. The ⁠step tag can now have messages as children. It returns a conversation that includes all previous messages (except in a specific case explained below) and the contents within.
2. If you add an `⁠isolated` attribute, it will return only its contents as the conversation for that step. Moreover, subsequent steps will not include these messages as context.