### PR TITLE
PromptL compiler v1 - Chapter 4: xml support

### DIFF
--- a/packages/promptl/src/compiler/base/nodes/tags/content.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/content.ts
@@ -1,8 +1,5 @@
 import { removeCommonIndent } from '$promptl/compiler/utils'
-import {
-  CUSTOM_CONTENT_TAG,
-  CUSTOM_CONTENT_TYPE_ATTR,
-} from '$promptl/constants'
+import { CUSTOM_CONTENT_TYPE_ATTR, TAG_NAMES } from '$promptl/constants'
 import errors from '$promptl/error/errors'
 import { ContentTag } from '$promptl/parser/interfaces'
 import { ContentType, ContentTypeTagName } from '$promptl/types'
@@ -39,7 +36,7 @@ export async function compile(
   const textContent = removeCommonIndent(popStrayText())
 
   let type: ContentType
-  if (node.name === CUSTOM_CONTENT_TAG) {
+  if (node.name === TAG_NAMES.content) {
     if (attributes[CUSTOM_CONTENT_TYPE_ATTR] === undefined) {
       baseNodeError(errors.messageTagWithoutRole, node)
     }

--- a/packages/promptl/src/compiler/base/nodes/tags/message.test.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/message.test.ts
@@ -49,19 +49,6 @@ describe('messages', async () => {
     ])
   })
 
-  it('fails when using an unknown tag', async () => {
-    const prompt = `
-      <foo>message</foo>
-    `
-    const action = () =>
-      render({
-        prompt: removeCommonIndent(prompt),
-        parameters: {},
-      })
-    const error = await getExpectedError(action, CompileError)
-    expect(error.code).toBe('unknown-tag')
-  })
-
   it('can create messages with the common message tag', async () => {
     const prompt = `
       <message role=${CUSTOM_TAG_START}role${CUSTOM_TAG_END}>message</message>
@@ -213,21 +200,6 @@ describe('message contents', async () => {
     expect((message.content[2]! as TextContent).text).toBe(
       'another text content',
     )
-  })
-
-  it('fails when using an invalid content type', async () => {
-    const prompt = `
-      <system>
-        <foo>text content</foo>
-      </system>
-    `
-    const action = () =>
-      render({
-        prompt: removeCommonIndent(prompt),
-        parameters: {},
-      })
-    const error = await getExpectedError(action, CompileError)
-    expect(error.code).toBe('unknown-tag')
   })
 
   it('creates a text content when no content tag is present', async () => {

--- a/packages/promptl/src/compiler/base/nodes/tags/message.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/message.ts
@@ -1,7 +1,4 @@
-import {
-  CUSTOM_MESSAGE_ROLE_ATTR,
-  CUSTOM_MESSAGE_TAG,
-} from '$promptl/constants'
+import { CUSTOM_MESSAGE_ROLE_ATTR, TAG_NAMES } from '$promptl/constants'
 import errors from '$promptl/error/errors'
 import { MessageTag, TemplateNode } from '$promptl/parser/interfaces'
 import {
@@ -38,7 +35,7 @@ export async function compile(
   groupContent()
 
   let role = node.name as MessageRole
-  if (node.name === CUSTOM_MESSAGE_TAG) {
+  if (node.name === TAG_NAMES.message) {
     if (attributes[CUSTOM_MESSAGE_ROLE_ATTR] === undefined) {
       baseNodeError(errors.messageTagWithoutRole, node)
     }

--- a/packages/promptl/src/compiler/chain.test.ts
+++ b/packages/promptl/src/compiler/chain.test.ts
@@ -1,4 +1,4 @@
-import { CHAIN_STEP_TAG } from '$promptl/constants'
+import { TAG_NAMES } from '$promptl/constants'
 import CompileError from '$promptl/error/error'
 import { getExpectedError } from '$promptl/test/helpers'
 import {
@@ -491,7 +491,7 @@ describe('chain', async () => {
             {{i}}.{{j}}
           </user>
 
-          <${CHAIN_STEP_TAG} />
+          <${TAG_NAMES.step} />
 
           {{foo = i * j}}
         {{endfor}}
@@ -536,7 +536,7 @@ describe('chain', async () => {
 
   it('saves the response in a variable', async () => {
     const prompt = removeCommonIndent(`
-      <${CHAIN_STEP_TAG} as="response" />
+      <${TAG_NAMES.step} as="response" />
       
       {{response}}
     `)

--- a/packages/promptl/src/compiler/errors.test.ts
+++ b/packages/promptl/src/compiler/errors.test.ts
@@ -110,19 +110,6 @@ describe(`all compilation errors that don't require value resolution are caught 
     })
   })
 
-  it('unknown-tag', async () => {
-    const prompt = `
-      <foo>
-        Foo
-      </foo>
-    `
-
-    await expectBothErrors({
-      code: 'unknown-tag',
-      prompt,
-    })
-  })
-
   it('step-tag-inside-step', async () => {
     const prompt = `
       <step>

--- a/packages/promptl/src/compiler/readMetadata.test.ts
+++ b/packages/promptl/src/compiler/readMetadata.test.ts
@@ -1,3 +1,4 @@
+import { TAG_NAMES } from '$promptl/constants'
 import CompileError from '$promptl/error/error'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
@@ -595,8 +596,8 @@ describe('syntax errors', async () => {
       `),
       child: removeCommonIndent(`
         This is the child prompt.
-        Error:
-        <unknownTag />
+        Error: (close unopened tag)
+        </${TAG_NAMES.message}>
       `),
     }
 
@@ -611,6 +612,8 @@ describe('syntax errors', async () => {
     expect(metadata.errors[0]!.message).contains(
       'The referenced prompt contains an error:',
     )
-    expect(metadata.errors[0]!.message).contains(`Unknown tag: 'unknownTag'`)
+    expect(metadata.errors[0]!.message).contains(
+      `Unexpected closing tag for ${TAG_NAMES.message}`,
+    )
   })
 })

--- a/packages/promptl/src/compiler/readMetadata.ts
+++ b/packages/promptl/src/compiler/readMetadata.ts
@@ -1,9 +1,8 @@
 import {
   CUSTOM_MESSAGE_ROLE_ATTR,
-  CUSTOM_MESSAGE_TAG,
   REFERENCE_DEPTH_LIMIT,
   REFERENCE_PROMPT_ATTR,
-  REFERENCE_PROMPT_TAG,
+  TAG_NAMES,
 } from '$promptl/constants'
 import CompileError, { error } from '$promptl/error/error'
 import errors from '$promptl/error/errors'
@@ -462,7 +461,7 @@ export class ReadMetadata {
         })
 
         const role = node.name as MessageRole
-        if (node.name === CUSTOM_MESSAGE_TAG) {
+        if (node.name === TAG_NAMES.message) {
           if (!attributes.has(CUSTOM_MESSAGE_ROLE_ATTR)) {
             this.baseNodeError(errors.messageTagWithoutRole, node)
             return
@@ -542,7 +541,7 @@ export class ReadMetadata {
           .map((node) => node.data)
           .join('')
 
-        let resolvedRefPrompt = `/* <${REFERENCE_PROMPT_TAG} ${REFERENCE_PROMPT_ATTR}="${refPromptPath}" /> */`
+        let resolvedRefPrompt = `/* <${TAG_NAMES.prompt} ${REFERENCE_PROMPT_ATTR}="${refPromptPath}" /> */`
         const currentReferences = this.references[this.fullPath] ?? []
 
         const resolveRef = async () => {
@@ -649,6 +648,7 @@ export class ReadMetadata {
         return
       }
 
+      // Should not be reachable, as non-recognized tags are caught by the parser
       this.baseNodeError(errors.unknownTag(node.name), node)
       return
     }

--- a/packages/promptl/src/compiler/utils.ts
+++ b/packages/promptl/src/compiler/utils.ts
@@ -1,9 +1,4 @@
-import {
-  CHAIN_STEP_TAG,
-  CUSTOM_CONTENT_TAG,
-  CUSTOM_MESSAGE_TAG,
-  REFERENCE_PROMPT_TAG,
-} from '$promptl/constants'
+import { TAG_NAMES } from '$promptl/constants'
 import {
   ChainStepTag,
   ContentTag,
@@ -43,23 +38,23 @@ export function removeCommonIndent(text: string): string {
 }
 
 export function isMessageTag(tag: ElementTag): tag is MessageTag {
-  if (tag.name === CUSTOM_MESSAGE_TAG) return true
+  if (tag.name === TAG_NAMES.message) return true
   return Object.values(MessageRole).includes(tag.name as MessageRole)
 }
 
 export function isContentTag(tag: ElementTag): tag is ContentTag {
-  if (tag.name === CUSTOM_CONTENT_TAG) return true
+  if (tag.name === TAG_NAMES.content) return true
   return Object.values(ContentTypeTagName).includes(
     tag.name as ContentTypeTagName,
   )
 }
 
 export function isRefTag(tag: ElementTag): tag is ReferenceTag {
-  return tag.name === REFERENCE_PROMPT_TAG
+  return tag.name === TAG_NAMES.prompt
 }
 
 export function isChainStepTag(tag: ElementTag): tag is ChainStepTag {
-  return tag.name === CHAIN_STEP_TAG
+  return tag.name === TAG_NAMES.step
 }
 
 export function tagAttributeIsLiteral(tag: ElementTag, name: string): boolean {

--- a/packages/promptl/src/constants.ts
+++ b/packages/promptl/src/constants.ts
@@ -1,20 +1,26 @@
+import { ContentTypeTagName, MessageRole } from './types'
+
 export const CUSTOM_TAG_START = '{{'
 export const CUSTOM_TAG_END = '}}'
 
-// <message role="…">
-export const CUSTOM_MESSAGE_TAG = 'message' as const
+export enum TAG_NAMES {
+  message = 'message',
+  system = MessageRole.system,
+  user = MessageRole.user,
+  assistant = MessageRole.assistant,
+  tool = MessageRole.tool,
+  content = 'content',
+  text = ContentTypeTagName.text,
+  image = ContentTypeTagName.image,
+  toolCall = ContentTypeTagName.toolCall,
+  prompt = 'prompt',
+  step = 'step',
+}
+
 export const CUSTOM_MESSAGE_ROLE_ATTR = 'role' as const
-
-export const CUSTOM_CONTENT_TAG = 'content' as const
 export const CUSTOM_CONTENT_TYPE_ATTR = 'type' as const
-
-// <prompt path="…" />
-export const REFERENCE_PROMPT_TAG = 'prompt' as const
 export const REFERENCE_PROMPT_ATTR = 'path' as const
 export const REFERENCE_DEPTH_LIMIT = 50
-
-// <response as="…" />
-export const CHAIN_STEP_TAG = 'step' as const
 export const CHAIN_STEP_ISOLATED_ATTR = 'isolated' as const
 
 export enum KEYWORDS {
@@ -31,3 +37,4 @@ export enum KEYWORDS {
 }
 
 export const RESERVED_KEYWORDS = Object.values(KEYWORDS)
+export const RESERVED_TAGS = Object.values(TAG_NAMES)

--- a/packages/promptl/src/parser/interfaces.ts
+++ b/packages/promptl/src/parser/interfaces.ts
@@ -1,9 +1,4 @@
-import {
-  CHAIN_STEP_TAG,
-  CUSTOM_CONTENT_TAG,
-  CUSTOM_MESSAGE_TAG,
-  REFERENCE_PROMPT_TAG,
-} from '$promptl/constants'
+import { TAG_NAMES } from '$promptl/constants'
 import { ContentTypeTagName, MessageRole } from '$promptl/types'
 import { Identifier, type Node as LogicalExpression } from 'estree'
 
@@ -45,13 +40,13 @@ type IElementTag<T extends string> = BaseNode & {
 
 export type MessageTag =
   | IElementTag<MessageRole>
-  | IElementTag<typeof CUSTOM_MESSAGE_TAG>
+  | IElementTag<typeof TAG_NAMES.message>
 export type ContentTag =
   | IElementTag<ContentTypeTagName>
-  | IElementTag<typeof CUSTOM_CONTENT_TAG>
+  | IElementTag<typeof TAG_NAMES.content>
 
-export type ReferenceTag = IElementTag<typeof REFERENCE_PROMPT_TAG>
-export type ChainStepTag = IElementTag<typeof CHAIN_STEP_TAG>
+export type ReferenceTag = IElementTag<typeof TAG_NAMES.prompt>
+export type ChainStepTag = IElementTag<typeof TAG_NAMES.step>
 export type ElementTag =
   | ContentTag
   | MessageTag

--- a/packages/promptl/src/parser/state/fragment.ts
+++ b/packages/promptl/src/parser/state/fragment.ts
@@ -1,4 +1,8 @@
-import { CUSTOM_TAG_END, CUSTOM_TAG_START } from '$promptl/constants'
+import {
+  CUSTOM_TAG_END,
+  CUSTOM_TAG_START,
+  RESERVED_TAGS,
+} from '$promptl/constants'
 
 import { Parser } from '..'
 import { config } from './config'
@@ -8,7 +12,10 @@ import { tag } from './tag'
 import { text } from './text'
 
 export default function fragment(parser: Parser): (parser: Parser) => void {
-  if (parser.match('<')) {
+  if (
+    parser.matchRegex(new RegExp(`^</?(${RESERVED_TAGS.join('|')})`)) ||
+    parser.match('<!--')
+  ) {
     return tag
   }
   if (parser.match(CUSTOM_TAG_START) || parser.match(CUSTOM_TAG_END)) {


### PR DESCRIPTION
Recognized tags are the only ones evaluated. Tags with unreserved names are treated as plain text.

```xml
<hell-yeah>
```