### PR TITLE
PromptL compiler v1 - Chapter 5: Scoped references

### DIFF
--- a/packages/promptl/src/compiler/base/nodes/for.ts
+++ b/packages/promptl/src/compiler/base/nodes/for.ts
@@ -19,6 +19,7 @@ export async function compile({
   resolveBaseNode,
   resolveExpression,
   expressionError,
+  fullPath,
 }: CompileNodeContext<ForBlock>) {
   const nodeWithStatus = node as ForNodeWithStatus
   nodeWithStatus.status = {
@@ -36,6 +37,7 @@ export async function compile({
         isInsideStepTag,
         isInsideMessageTag,
         isInsideContentTag,
+        fullPath,
       })
     }
     return
@@ -77,6 +79,7 @@ export async function compile({
         isInsideStepTag,
         isInsideMessageTag,
         isInsideContentTag,
+        fullPath,
         completedValue: `step_${i}`,
       })
     }

--- a/packages/promptl/src/compiler/base/nodes/fragment.ts
+++ b/packages/promptl/src/compiler/base/nodes/fragment.ts
@@ -8,6 +8,7 @@ export async function compile({
   isInsideStepTag,
   isInsideContentTag,
   isInsideMessageTag,
+  fullPath,
   resolveBaseNode,
 }: CompileNodeContext<Fragment>) {
   for await (const childNode of node.children ?? []) {
@@ -17,6 +18,7 @@ export async function compile({
       isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
+      fullPath,
     })
   }
 }

--- a/packages/promptl/src/compiler/base/nodes/if.ts
+++ b/packages/promptl/src/compiler/base/nodes/if.ts
@@ -8,6 +8,7 @@ export async function compile({
   isInsideStepTag,
   isInsideContentTag,
   isInsideMessageTag,
+  fullPath,
   resolveBaseNode,
   resolveExpression,
 }: CompileNodeContext<IfBlock>) {
@@ -21,6 +22,7 @@ export async function compile({
       isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
+      fullPath,
     })
   }
 }

--- a/packages/promptl/src/compiler/base/nodes/tag.ts
+++ b/packages/promptl/src/compiler/base/nodes/tag.ts
@@ -71,6 +71,7 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
     isInsideStepTag,
     isInsideContentTag,
     isInsideMessageTag,
+    fullPath,
     resolveBaseNode,
     baseNodeError,
     groupStrayText,
@@ -113,6 +114,7 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
       isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag,
+      fullPath,
     })
   }
 }

--- a/packages/promptl/src/compiler/base/nodes/tags/content.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/content.ts
@@ -13,6 +13,7 @@ export async function compile(
     isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
+    fullPath,
     resolveBaseNode,
     baseNodeError,
     popStrayText,
@@ -31,6 +32,7 @@ export async function compile(
       isInsideStepTag,
       isInsideMessageTag,
       isInsideContentTag: true,
+      fullPath,
     })
   }
   const textContent = removeCommonIndent(popStrayText())

--- a/packages/promptl/src/compiler/base/nodes/tags/message.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/message.ts
@@ -20,6 +20,7 @@ export async function compile(
     isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
+    fullPath,
     resolveBaseNode,
     baseNodeError,
     groupContent,
@@ -50,6 +51,7 @@ export async function compile(
       isInsideStepTag,
       isInsideMessageTag: true,
       isInsideContentTag,
+      fullPath,
     })
   }
 

--- a/packages/promptl/src/compiler/base/nodes/tags/ref.test.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/ref.test.ts
@@ -1,0 +1,279 @@
+import path from 'path'
+
+import { Chain, render } from '$promptl/compiler'
+import { complete } from '$promptl/compiler/test/helpers'
+import { removeCommonIndent } from '$promptl/compiler/utils'
+import CompileError from '$promptl/error/error'
+import { getExpectedError } from '$promptl/test/helpers'
+import {
+  MessageRole,
+  SystemMessage,
+  TextContent,
+  UserMessage,
+} from '$promptl/types'
+import { describe, expect, it, vi } from 'vitest'
+
+const buildReferenceFn =
+  (prompts: Record<string, string>) =>
+  async (refPath: string, sourcePath?: string) => {
+    const fullPath = sourcePath
+      ? path.resolve(path.dirname(sourcePath), refPath)
+      : refPath
+
+    if (!prompts[fullPath]) return undefined
+    return {
+      content: prompts[fullPath],
+      path: fullPath,
+    }
+  }
+
+describe('ref tags', async () => {
+  it('allows referencing other prompts', async () => {
+    const prompts = {
+      parent: '<prompt path="child" />',
+      child: 'child message',
+    }
+
+    const result = await render({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+    })
+
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'child message',
+      },
+    ])
+  })
+
+  it('throws an error if the referenced function was not included', async () => {
+    const prompts = {
+      parent: '<prompt path="child" />',
+      child: 'child message',
+    }
+
+    const action = () => render({ prompt: prompts['parent'] })
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('missing-reference-function')
+  })
+
+  it('throws an error if the referenced prompt does not exist', async () => {
+    const prompts = {
+      parent: '<prompt path="child" />',
+    }
+
+    const action = () =>
+      render({
+        prompt: prompts['parent'],
+        referenceFn: buildReferenceFn(prompts),
+      })
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('reference-not-found')
+  })
+
+  it('referenced prompts do not inherit variables or parameters from parents', async () => {
+    const prompts = {
+      child: 'Child message: {{foo}}',
+      parent: '<prompt path="child" />',
+    }
+
+    const action = () =>
+      render({
+        prompt: prompts['parent'],
+        parameters: { foo: 'bar' },
+        referenceFn: buildReferenceFn(prompts),
+      })
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('variable-not-declared')
+  })
+
+  it('referenced prompts can receive parameters as tag attributes', async () => {
+    const prompts = {
+      child: 'Child message: {{foo}}',
+      parent: '<prompt path="child" foo="bar" />',
+    }
+
+    const result = await render({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+    })
+
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'Child message: bar',
+      },
+    ])
+  })
+
+  it('referenced prompts cannot modify parameters from parents', async () => {
+    const prompts = {
+      child: '{{ foo = foo + 1 }}',
+      parent: '<prompt path="child" foo={{foo}} /> {{ foo }}',
+    }
+
+    const result = await render({
+      prompt: prompts['parent'],
+      parameters: { foo: 1 },
+      referenceFn: buildReferenceFn(prompts),
+    })
+
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: '1',
+      },
+    ])
+  })
+
+  it('referenced prompts can include messages and contents', async () => {
+    const prompts = {
+      child: removeCommonIndent(`
+        <user>User message</user>
+        <content-text>This is a text content!</content-text>
+      `),
+      parent: '<prompt path="child" />',
+    }
+
+    const result = await render({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+    })
+
+    expect(result.messages.length).toBe(2)
+    const userMessage = result.messages[0]! as UserMessage
+    expect(userMessage.content).toEqual([
+      {
+        type: 'text',
+        text: 'User message',
+      },
+    ])
+    const systemMessage = result.messages[1]! as SystemMessage
+    expect(systemMessage.content).toEqual([
+      {
+        type: 'text',
+        text: 'This is a text content!',
+      },
+    ])
+  })
+
+  it('prompts can be referenced inside messages', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        <user>
+          <prompt path="child" />
+        </user>
+      `),
+      child: 'Child message',
+    }
+
+    const result = await render({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+    })
+
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'Child message',
+      },
+    ])
+  })
+
+  it('wrong tags combinations can raise errors even between references', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        <user>
+          <prompt path="child" />
+        </user>
+      `),
+      child: '<system>Foo</system>',
+    }
+
+    const action = () =>
+      render({
+        prompt: prompts['parent'],
+        referenceFn: buildReferenceFn(prompts),
+      })
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('message-tag-inside-message')
+  })
+
+  it('can run steps from inside references', async () => {
+    const prompts = {
+      parent: removeCommonIndent(`
+        <step>
+          Step 1
+        </step>
+
+        <prompt path="child" />
+
+        <step>
+          Step 2
+        </step>
+      `),
+      child: removeCommonIndent(`
+        <step>
+          <user>Substep 1</user>
+        </step>
+        <step>
+          <user>Substep 2</user>
+        </step>
+      `),
+    }
+
+    const chain = new Chain({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+    })
+    const { steps, conversation } = await complete({ chain })
+    expect(steps).toBe(4)
+    expect(conversation.messages.length).toBe(8) // 4 steps + 4 assistant responses
+    const stepsContent = conversation.messages
+      .filter((m) => m.role != MessageRole.assistant)
+      .map((m) => (m.content[0] as TextContent).text)
+    expect(stepsContent).toEqual(['Step 1', 'Substep 1', 'Substep 2', 'Step 2'])
+  })
+
+  it('node state from references correctly cached during steps', async () => {
+    const func = vi.fn()
+
+    const prompts = {
+      parent: removeCommonIndent(`
+        <prompt path="child" func={{func}} />
+      `),
+      child: removeCommonIndent(`
+        <step>
+          {{ func() }}
+        </step>
+        {{ for i in [1, 2] }}
+          <step>
+            {{ func() }}
+          </step>
+        {{ endfor }}
+      `),
+    }
+
+    const chain = new Chain({
+      prompt: prompts['parent'],
+      referenceFn: buildReferenceFn(prompts),
+      parameters: { func },
+    })
+
+    await complete({ chain })
+
+    expect(func).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/promptl/src/compiler/base/nodes/tags/ref.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/ref.ts
@@ -1,11 +1,55 @@
+import Scope from '$promptl/compiler/scope'
 import errors from '$promptl/error/errors'
-import { ReferenceTag } from '$promptl/parser/interfaces'
+import parse from '$promptl/parser'
+import { Fragment, ReferenceTag } from '$promptl/parser/interfaces'
 
-import { CompileNodeContext } from '../../types'
+import { CompileNodeContext, TemplateNodeWithStatus } from '../../types'
+
+type ForNodeWithStatus = TemplateNodeWithStatus & {
+  status: TemplateNodeWithStatus['status'] & {
+    refAst: Fragment
+    refFullPath: string
+  }
+}
 
 export async function compile(
-  { node, baseNodeError }: CompileNodeContext<ReferenceTag>,
-  _: Record<string, unknown>,
+  props: CompileNodeContext<ReferenceTag>,
+  attributes: Record<string, unknown>,
 ) {
-  baseNodeError(errors.didNotResolveReferences, node)
+  const {
+    node,
+    scope,
+    fullPath,
+    referencePromptFn,
+    baseNodeError,
+    resolveBaseNode,
+  } = props
+
+  const nodeWithStatus = node as ForNodeWithStatus
+  nodeWithStatus.status = {
+    ...nodeWithStatus.status,
+    scopePointers: scope.getPointers(),
+  }
+
+  const { path, ...refParameters } = attributes
+  if (!path) baseNodeError(errors.referenceTagWithoutPrompt, node)
+  if (typeof path !== 'string') baseNodeError(errors.invalidReferencePath, node)
+
+  if (!nodeWithStatus.status.refAst || !nodeWithStatus.status.refFullPath) {
+    if (!referencePromptFn) baseNodeError(errors.missingReferenceFunction, node)
+
+    const prompt = await referencePromptFn!(path as string, fullPath)
+    if (!prompt) baseNodeError(errors.referenceNotFound, node)
+    const ast = parse(prompt!.content)
+    nodeWithStatus.status.refAst = ast
+    nodeWithStatus.status.refFullPath = prompt!.path
+  }
+
+  const refScope = new Scope(refParameters)
+  await resolveBaseNode({
+    ...props,
+    node: nodeWithStatus.status.refAst,
+    scope: refScope,
+    fullPath: nodeWithStatus.status.refFullPath,
+  })
 }

--- a/packages/promptl/src/compiler/base/nodes/tags/step.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/step.ts
@@ -18,6 +18,7 @@ export async function compile(
     isInsideStepTag,
     isInsideMessageTag,
     isInsideContentTag,
+    fullPath,
     popStepResponse,
     groupContent,
     resolveBaseNode,
@@ -47,6 +48,7 @@ export async function compile(
         isInsideStepTag: true,
         isInsideMessageTag,
         isInsideContentTag,
+        fullPath,
       })
     }
 

--- a/packages/promptl/src/compiler/base/types.ts
+++ b/packages/promptl/src/compiler/base/types.ts
@@ -8,7 +8,7 @@ import {
 } from '$promptl/types'
 import type { Node as LogicalExpression } from 'estree'
 
-import { ResolveBaseNodeProps } from '../types'
+import { ReferencePromptFn, ResolveBaseNodeProps } from '../types'
 
 export enum NodeType {
   Literal = 'Literal',
@@ -56,6 +56,9 @@ export type CompileNodeContext<N extends TemplateNode> = {
   isInsideStepTag: boolean
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
+
+  fullPath: string | undefined
+  referencePromptFn: ReferencePromptFn | undefined
 
   setConfig: (config: Config) => void
   addMessage: (message: Message, global?: boolean) => void

--- a/packages/promptl/src/compiler/chain.test.ts
+++ b/packages/promptl/src/compiler/chain.test.ts
@@ -1,53 +1,12 @@
 import { TAG_NAMES } from '$promptl/constants'
 import CompileError from '$promptl/error/error'
 import { getExpectedError } from '$promptl/test/helpers'
-import {
-  Conversation,
-  MessageContent,
-  MessageRole,
-  TextContent,
-} from '$promptl/types'
+import { MessageRole, TextContent } from '$promptl/types'
 import { describe, expect, it, vi } from 'vitest'
 
-import { buildStepResponseContent, Chain } from './chain'
+import { Chain } from './chain'
+import { complete } from './test/helpers'
 import { removeCommonIndent } from './utils'
-
-async function defaultCallback(): Promise<string> {
-  return 'RESPONSE'
-}
-
-async function complete({
-  chain,
-  callback,
-  maxSteps = 50,
-}: {
-  chain: Chain
-  callback?: (convo: Conversation) => Promise<string>
-  maxSteps?: number
-}): Promise<{
-  response: MessageContent[]
-  conversation: Conversation
-  steps: number
-}> {
-  let steps = 0
-  let conversation: Conversation
-
-  let responseContent: MessageContent[] | undefined
-  while (true) {
-    const { completed, conversation: _conversation } =
-      await chain.step(responseContent)
-
-    conversation = _conversation
-
-    if (completed) return { conversation, steps, response: responseContent! }
-
-    const response = await (callback ?? defaultCallback)(conversation)
-    responseContent = buildStepResponseContent(response)
-    steps++
-
-    if (steps > maxSteps) throw new Error('too many chain steps')
-  }
-}
 
 describe('chain', async () => {
   it('does not return "completed" in the first iteration', async () => {

--- a/packages/promptl/src/compiler/compile.test.ts
+++ b/packages/promptl/src/compiler/compile.test.ts
@@ -148,34 +148,6 @@ describe('comments', async () => {
   })
 })
 
-describe('reference tags', async () => {
-  it('always fails', async () => {
-    const prompts = {
-      main: removeCommonIndent(`
-        This is the main prompt.
-        <prompt path="user_messages" />
-        The end.
-      `),
-      user_messages: removeCommonIndent(`
-        <user>
-          User 1
-        </user>
-        <user>
-          User 2
-        </user>
-      `),
-    } as Record<string, string>
-
-    const action = () =>
-      render({
-        prompt: prompts['main']!,
-        parameters: {},
-      })
-    const error = await getExpectedError(action, CompileError)
-    expect(error.code).toBe('did-not-resolve-references')
-  })
-})
-
 describe('variable assignment', async () => {
   it('can define variables', async () => {
     const prompt = `

--- a/packages/promptl/src/compiler/index.ts
+++ b/packages/promptl/src/compiler/index.ts
@@ -2,12 +2,8 @@ import { Conversation, ConversationMetadata } from '$promptl/types'
 import { z } from 'zod'
 
 import { Chain } from './chain'
-import {
-  ReadMetadata,
-  type Document,
-  type ReferencePromptFn,
-} from './readMetadata'
-import { CompileOptions } from './types'
+import { ReadMetadata } from './readMetadata'
+import type { CompileOptions, Document, ReferencePromptFn } from './types'
 
 export async function render({
   prompt,

--- a/packages/promptl/src/compiler/test/helpers.ts
+++ b/packages/promptl/src/compiler/test/helpers.ts
@@ -1,4 +1,7 @@
+import { Conversation, MessageContent } from '$promptl/types'
 import { expect } from 'vitest'
+
+import { buildStepResponseContent, Chain } from '../chain'
 
 export async function getExpectedError<T>(
   action: () => Promise<unknown>,
@@ -11,4 +14,37 @@ export async function getExpectedError<T>(
     return err as T
   }
   throw new Error('Expected an error to be thrown')
+}
+
+export async function complete({
+  chain,
+  callback,
+  maxSteps = 50,
+}: {
+  chain: Chain
+  callback?: (convo: Conversation) => Promise<string>
+  maxSteps?: number
+}): Promise<{
+  response: MessageContent[]
+  conversation: Conversation
+  steps: number
+}> {
+  let steps = 0
+  let conversation: Conversation
+
+  let responseContent: MessageContent[] | undefined
+  while (true) {
+    const { completed, conversation: _conversation } =
+      await chain.step(responseContent)
+
+    conversation = _conversation
+
+    if (completed) return { conversation, steps, response: responseContent! }
+
+    const response = callback ? await callback(conversation) : 'RESPONSE'
+    responseContent = buildStepResponseContent(response)
+    steps++
+
+    if (steps > maxSteps) throw new Error('too many chain steps')
+  }
 }

--- a/packages/promptl/src/compiler/types.ts
+++ b/packages/promptl/src/compiler/types.ts
@@ -3,6 +3,15 @@ import { MessageRole } from '$promptl/types'
 
 import type Scope from './scope'
 
+export type Document = {
+  path: string
+  content: string
+}
+export type ReferencePromptFn = (
+  path: string,
+  from?: string,
+) => Promise<Document | undefined>
+
 export type ResolveBaseNodeProps<N extends TemplateNode> = {
   node: N
   scope: Scope
@@ -10,8 +19,11 @@ export type ResolveBaseNodeProps<N extends TemplateNode> = {
   isInsideMessageTag: boolean
   isInsideContentTag: boolean
   completedValue?: unknown
+  fullPath?: string | undefined
 }
 
 export type CompileOptions = {
+  referenceFn?: ReferencePromptFn
+  fullPath?: string
   defaultRole?: MessageRole
 }

--- a/packages/promptl/src/error/errors.ts
+++ b/packages/promptl/src/error/errors.ts
@@ -189,15 +189,14 @@ export default {
     code: 'circular-reference',
     message: 'There is a circular reference',
   },
-  didNotResolveReferences: {
-    code: 'did-not-resolve-references',
-    message:
-      'Cannot compile reference tags. Make sure you have resolved the references before compiling.',
-  },
   referenceNotFound: {
     code: 'reference-not-found',
     message: 'The referenced document does not exist',
   },
+  referenceMissingParameter: (name: string) => ({
+    code: 'reference-missing-parameter',
+    message: `The referenced prompt requires a '${name}' parameter. Add it as an attribute to the tag.`,
+  }),
   referenceDepthLimit: {
     code: 'reference-depth-limit',
     message: 'The reference depth limit has been reached',
@@ -231,6 +230,10 @@ export default {
     code: 'invalid-content-type',
     message: `Invalid content type: ${name}`,
   }),
+  invalidReferencePath: {
+    code: 'invalid-reference-path',
+    message: 'Reference path must be a string',
+  },
   variableNotDeclared: (name: string) => ({
     code: 'variable-not-declared',
     message: `Variable '${name}' is not declared`,

--- a/packages/promptl/src/types/index.ts
+++ b/packages/promptl/src/types/index.ts
@@ -10,7 +10,7 @@ export type Conversation = {
 }
 
 export type ConversationMetadata = {
-  resolvedPrompt: string
+  hash: string
   config: Config
   errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime


### PR DESCRIPTION
Implemented the new behaviour for the `<prompt path="…" />` tag.

**Changes in language:**
- Referenced prompts do not have access to the parent's variables. The parent can pass variables to the referenced prompts as attributes in the `prompt` tag.
- In the same line, parameters from referenced prompts are not shown as parameters from the parent.
- Reference tags will now display an error if the parent is not passing a parameter used in the referenced prompt.

**Changes in code:**
- `readMetadata` will no longer return a `resolvedPrompt` string. Instead, it will return a `hash` which can be used to identify changes in the prompt content or any of its references.
- Both `render` and `Chain` will now require passing an optional `referenceFn` parameter to compile prompts with reference tags, which contains the logic to obtain a prompt's content given a path. An optional `fullPath` parameter is also available to enable local paths. Not providing the `referenceFn` will result in a compile error if (and only if) the prompt contains a reference tag.
