### PR TITLE
Promptl compiler v1 part 6 – Provider adapters

### DIFF
--- a/packages/promptl/src/compiler/base/nodes/tags/content.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/content.ts
@@ -83,6 +83,16 @@ export async function compile(
     if (!id) baseNodeError(errors.toolCallTagWithoutId, node)
     if (!name) baseNodeError(errors.toolCallWithoutName, node)
 
+    let toolArguments = rest['arguments']
+    delete rest['arguments']
+    if (toolArguments && typeof toolArguments === 'string') {
+      try {
+        rest['arguments'] = JSON.parse(toolArguments)
+      } catch (e) {
+        baseNodeError(errors.invalidToolCallArguments, node)
+      }
+    }
+
     addContent({
       node,
       content: {
@@ -90,7 +100,7 @@ export async function compile(
         type: ContentType.toolCall,
         toolCallId: String(id),
         toolName: String(name),
-        toolArguments: {}, // TODO: Issue for a future PR
+        toolArguments: (toolArguments ?? {}) as Record<string, unknown>,
       },
     })
     return

--- a/packages/promptl/src/compiler/base/nodes/tags/message.ts
+++ b/packages/promptl/src/compiler/base/nodes/tags/message.ts
@@ -104,6 +104,7 @@ function buildMessage<R extends MessageRole>(
     }
 
     message.toolId = String(attributes.id)
+    delete message['id']
   }
 
   return message

--- a/packages/promptl/src/compiler/index.ts
+++ b/packages/promptl/src/compiler/index.ts
@@ -1,19 +1,27 @@
-import { Conversation, ConversationMetadata } from '$promptl/types'
+import {
+  AdapterMessageType,
+  Adapters,
+  ProviderAdapter,
+} from '$promptl/providers'
+import { ProviderConversation } from '$promptl/providers/adapter'
+import { ConversationMetadata, Message } from '$promptl/types'
 import { z } from 'zod'
 
 import { Chain } from './chain'
 import { ReadMetadata } from './readMetadata'
 import type { CompileOptions, Document, ReferencePromptFn } from './types'
 
-export async function render({
+export async function render<M extends AdapterMessageType = Message>({
   prompt,
   parameters = {},
+  adapter = Adapters.default as ProviderAdapter<M>,
   ...compileOptions
 }: {
   prompt: string
   parameters?: Record<string, unknown>
-} & CompileOptions): Promise<Conversation> {
-  const iterator = new Chain({ prompt, parameters, ...compileOptions })
+  adapter?: ProviderAdapter<M>
+} & CompileOptions): Promise<ProviderConversation<M>> {
+  const iterator = new Chain({ prompt, parameters, adapter, ...compileOptions })
   const { conversation } = await iterator.step()
   return conversation
 }

--- a/packages/promptl/src/providers/adapter.ts
+++ b/packages/promptl/src/providers/adapter.ts
@@ -1,0 +1,16 @@
+import { Message, Conversation as PromptlConversation } from '$promptl/types'
+
+export type ProviderConversation<M extends object> = {
+  config: PromptlConversation['config']
+  messages: M[]
+}
+
+export type ProviderAdapter<M extends object> = {
+  toPromptl(conversation: ProviderConversation<M>): PromptlConversation
+  fromPromptl(conversation: PromptlConversation): ProviderConversation<M>
+}
+
+export const defaultAdapter: ProviderAdapter<Message> = {
+  toPromptl: (c) => c,
+  fromPromptl: (c) => c,
+}

--- a/packages/promptl/src/providers/anthropic/adapter.test.ts
+++ b/packages/promptl/src/providers/anthropic/adapter.test.ts
@@ -1,0 +1,102 @@
+import { render } from '$promptl/compiler'
+import { removeCommonIndent } from '$promptl/compiler/utils'
+import { MessageRole } from '$promptl/types'
+import { describe, expect, it } from 'vitest'
+
+import { Adapters } from '..'
+
+describe('Anthropic adapter', async () => {
+  it('moves top system messages to config', async () => {
+    const prompt = `Hello <system>World</system>`
+    const { config, messages } = await render({
+      prompt,
+      adapter: Adapters.anthropic,
+    })
+    expect(messages).toEqual([])
+
+    expect(config.system).toEqual([
+      {
+        type: 'text',
+        text: 'Hello',
+      },
+      {
+        type: 'text',
+        text: 'World',
+      },
+    ])
+  })
+
+  it('adapts user messages', async () => {
+    const prompt = removeCommonIndent(`
+      <user>
+        Hello world!
+        <content-image>https://image.source/</content-image>
+      </user>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.anthropic })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.user,
+        content: [
+          { type: 'text', text: 'Hello world!' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'https://image.source/',
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('adapts assistant messages', async () => {
+    const prompt = removeCommonIndent(`
+      <assistant>
+        Hello world!
+        <tool-call id="1234" name="get_weather" arguments={{ { location: "Barcelona" } }} />
+      </assistant>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.anthropic })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.assistant,
+        content: [
+          { type: 'text', text: 'Hello world!' },
+          {
+            type: 'tool_use',
+            id: '1234',
+            name: 'get_weather',
+            input: { location: 'Barcelona' },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('adapts tool messages', async () => {
+    const prompt = removeCommonIndent(`
+      <tool id="1234">
+        17ºC
+      </tool>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.anthropic })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.user,
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: '1234',
+            content: [{ type: 'text', text: '17ºC' }],
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/promptl/src/providers/anthropic/adapter.ts
+++ b/packages/promptl/src/providers/anthropic/adapter.ts
@@ -1,0 +1,286 @@
+import {
+  ContentType,
+  MessageRole,
+  Conversation as PromptlConversation,
+  ImageContent as PromptlImageContent,
+  Message as PromptlMessage,
+  MessageContent as PromptlMessageContent,
+  SystemMessage as PromptlSystemMessage,
+  TextContent as PromptlTextContent,
+  ToolCallContent as PromptlToolCallContent,
+  ToolMessage as PromptlToolMessage,
+  UserMessage as PromptlUserMessage,
+} from '$promptl/types'
+
+import { ProviderAdapter, type ProviderConversation } from '../adapter'
+import {
+  AssistantMessage as AnthropicAssistantMessage,
+  ContentType as AnthropicContentType,
+  ImageContent as AnthropicImageContent,
+  Message as AnthropicMessage,
+  MessageContent as AnthropicMessageContent,
+  TextContent as AnthropicTextContent,
+  UserMessage as AnthropicUserMessage,
+} from './types'
+
+export const AnthropicAdapter: ProviderAdapter<AnthropicMessage> = {
+  fromPromptl(
+    promptlConversation: PromptlConversation,
+  ): ProviderConversation<AnthropicMessage> {
+    // Initialize system messages
+    const systemPrompt: AnthropicMessageContent[] = []
+    const systemConfig = promptlConversation.config.system as
+      | undefined
+      | string
+      | AnthropicMessageContent[]
+    if (Array.isArray(systemConfig)) systemPrompt.push(...systemConfig)
+    if (typeof systemConfig === 'string') {
+      systemPrompt.push({ type: AnthropicContentType.text, text: systemConfig })
+    }
+
+    const [systemMessagesOnTop, restMessages] =
+      promptlConversation.messages.reduce(
+        (acc: [PromptlMessage[], PromptlMessage[]], message) => {
+          if (message.role === MessageRole.system) {
+            acc[0].push(message)
+          } else {
+            acc[1].push(message)
+          }
+          return acc
+        },
+        [[], []],
+      )
+
+    systemPrompt.push(
+      ...systemMessagesOnTop
+        .map((m) => {
+          const messageToAnthropic = promptlToAnthropic({
+            ...m,
+            role: MessageRole.user,
+          })
+          const content = messageToAnthropic.content
+          if (typeof content === 'string') {
+            return [
+              { type: AnthropicContentType.text, text: content },
+            ] as AnthropicTextContent[]
+          }
+          return content
+        })
+        .flat(),
+    )
+
+    return {
+      config: {
+        ...promptlConversation.config,
+        system: systemPrompt,
+      },
+      messages: restMessages.map(promptlToAnthropic),
+    }
+  },
+
+  toPromptl(
+    anthropicConversation: ProviderConversation<AnthropicMessage>,
+  ): PromptlConversation {
+    const { system: systemPrompt, ...restConfig } =
+      anthropicConversation.config as {
+        system:
+          | undefined
+          | string
+          | (AnthropicImageContent | AnthropicTextContent)[]
+        [key: string]: unknown
+      }
+
+    const systemMessages: PromptlSystemMessage[] = systemPrompt
+      ? [
+          {
+            role: MessageRole.system,
+            content: Array.isArray(systemPrompt)
+              ? systemPrompt.map((c) => {
+                  if (c.type === AnthropicContentType.image) {
+                    return toPromptlImage(c)
+                  }
+                  return c as unknown as PromptlMessageContent
+                })
+              : [{ type: ContentType.text, text: systemPrompt }],
+          },
+        ]
+      : []
+
+    return {
+      config: restConfig,
+      messages: [
+        ...systemMessages,
+        ...anthropicConversation.messages.map(anthropicToPromptl).flat(),
+      ],
+    }
+  },
+}
+
+function toAnthropicImage(
+  imageContent: PromptlImageContent,
+): AnthropicImageContent {
+  const { image, ...rest } = imageContent
+  return {
+    ...rest,
+    type: AnthropicContentType.image,
+    source: {
+      type: 'base64', // only available type for now
+      media_type: 'image/png',
+      data: image.toString('base64'),
+    },
+  }
+}
+
+function toPromptlImage(
+  imageContent: AnthropicImageContent,
+): PromptlImageContent {
+  const { source, ...rest } = imageContent
+  return {
+    ...rest,
+    type: ContentType.image,
+    image: source.data,
+  }
+}
+
+function promptlToAnthropic(message: PromptlMessage): AnthropicMessage {
+  if (message.role === MessageRole.system) {
+    throw new Error(
+      'Anthropic only supports system messages at the top of the conversation',
+    )
+  }
+
+  if (message.role === MessageRole.user) {
+    const { content, ...rest } = message
+    const adaptedContent = content.map((c) => {
+      if (c.type === ContentType.image) return toAnthropicImage(c)
+      return c
+    })
+
+    return {
+      ...rest,
+      content: adaptedContent,
+    } as AnthropicUserMessage
+  }
+
+  if (message.role === MessageRole.assistant) {
+    const { content, ...rest } = message
+
+    const adaptedContent = content.map((c) => {
+      if (c.type === ContentType.image) return toAnthropicImage(c)
+      if (c.type === ContentType.toolCall) {
+        return {
+          type: AnthropicContentType.tool_use,
+          id: c.toolCallId,
+          name: c.toolName,
+          input: c.toolArguments,
+        }
+      }
+      return c
+    })
+
+    return {
+      ...rest,
+      content: adaptedContent,
+    } as AnthropicAssistantMessage
+  }
+
+  if (message.role === MessageRole.tool) {
+    const { toolId, content, ...rest } = message
+    const adaptedContent = content.map((c) => {
+      if (c.type === ContentType.image) return toAnthropicImage(c)
+      return c
+    })
+    return {
+      ...rest,
+      role: MessageRole.user,
+      content: [
+        {
+          type: AnthropicContentType.tool_result,
+          tool_use_id: toolId,
+          ...(content.length ? { content: adaptedContent } : {}),
+        },
+      ],
+    } as AnthropicUserMessage
+  }
+
+  //@ts-expect-error — There are no more supported roles. Typescript knows it and is yelling me back
+  throw new Error(`Unsupported message role: ${message.role}`)
+}
+
+function anthropicToPromptl(message: AnthropicMessage): PromptlMessage[] {
+  const messageContent: AnthropicMessageContent[] =
+    typeof message.content === 'string'
+      ? [{ type: AnthropicContentType.text, text: message.content }]
+      : message.content
+
+  if (message.role === MessageRole.assistant) {
+    return [
+      {
+        ...message,
+        content: messageContent.map((c) => {
+          if (c.type === AnthropicContentType.image) return toPromptlImage(c)
+          if (c.type === AnthropicContentType.tool_use) {
+            return {
+              type: ContentType.toolCall,
+              toolCallId: c.id,
+              toolName: c.name,
+              toolArguments: c.input,
+            } as PromptlToolCallContent
+          }
+          return c as unknown as PromptlMessageContent
+        }),
+      },
+    ]
+  }
+
+  if (message.role === MessageRole.user) {
+    const { userMessage, toolMessages } = messageContent.reduce(
+      (
+        acc: {
+          userMessage: PromptlUserMessage
+          toolMessages: PromptlToolMessage[]
+        },
+        c,
+      ) => {
+        if (c.type === AnthropicContentType.tool_result) {
+          const toolResponseContent = c.content
+            ? Array.isArray(c.content)
+              ? c.content.map((cc) => {
+                  if (cc.type === AnthropicContentType.image)
+                    return toPromptlImage(cc)
+                  return cc as unknown as PromptlMessageContent
+                })
+              : [
+                  {
+                    type: ContentType.text,
+                    text: c.content!,
+                  } as PromptlTextContent,
+                ]
+            : []
+
+          acc.toolMessages.push({
+            ...message,
+            role: MessageRole.tool,
+            toolId: c.tool_use_id,
+            content: toolResponseContent,
+          })
+        } else {
+          acc.userMessage.content.push(c as unknown as PromptlMessageContent)
+        }
+        return acc
+      },
+      {
+        userMessage: { ...message, role: MessageRole.user, content: [] },
+        toolMessages: [],
+      },
+    )
+
+    return [
+      ...toolMessages,
+      ...(userMessage.content.length ? [userMessage] : []),
+    ]
+  }
+
+  //@ts-expect-error — There are no more supported roles. Typescript knows it and is yelling me back
+  throw new Error(`Unsupported message role: ${message.role}`)
+}

--- a/packages/promptl/src/providers/anthropic/types.ts
+++ b/packages/promptl/src/providers/anthropic/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Anthropic API reference for messages
+ * Reference for https://api.anthropic.com/v1/messages
+ * Source: https://docs.anthropic.com/en/api/messages
+ */
+
+import { MessageRole as PromptlMessageRole } from '$promptl/types'
+
+export enum MessageRole {
+  user = PromptlMessageRole.user,
+  assistant = PromptlMessageRole.assistant,
+}
+
+export enum ContentType {
+  text = 'text',
+  image = 'image',
+  tool_use = 'tool_use',
+  tool_result = 'tool_result',
+  document = 'document',
+}
+
+interface IMessageContent {
+  type: ContentType
+  cache_control?: {
+    type: string
+  }
+  [key: string]: unknown
+}
+
+export type TextContent = IMessageContent & {
+  type: ContentType.text
+  text: string
+}
+
+export type ImageContent = IMessageContent & {
+  type: ContentType.image
+  source: {
+    type: string
+    media_type: string
+    data: string
+  }
+}
+
+export type ToolUseContent = IMessageContent & {
+  type: ContentType.tool_use
+  id: string
+  name: string
+  input: object
+}
+
+export type ToolResultContent = IMessageContent & {
+  type: ContentType.tool_result
+  tool_use_id: string
+  is_error?: boolean
+  content?: string | (TextContent | ImageContent)[]
+}
+
+export type DocumentContent = IMessageContent & {
+  type: ContentType.document
+  source: {
+    type: string
+    media_type: string
+    data: string
+  }
+}
+
+export type MessageContent =
+  | TextContent
+  | ImageContent
+  | DocumentContent
+  | ToolUseContent
+  | ToolResultContent
+
+interface IMessage {
+  role: MessageRole
+  content: string | MessageContent[]
+}
+
+export type UserMessage = IMessage & {
+  role: MessageRole.user
+}
+
+export type AssistantMessage = IMessage & {
+  role: MessageRole.assistant
+}
+
+export type Message = UserMessage | AssistantMessage

--- a/packages/promptl/src/providers/index.ts
+++ b/packages/promptl/src/providers/index.ts
@@ -1,0 +1,15 @@
+import { defaultAdapter } from './adapter'
+import { AnthropicAdapter } from './anthropic/adapter'
+import { OpenAIAdapter } from './openai/adapter'
+
+export type { ProviderAdapter } from './adapter'
+
+export const Adapters = {
+  default: defaultAdapter,
+  openai: OpenAIAdapter,
+  anthropic: AnthropicAdapter,
+} as const
+
+export type AdapterMessageType<
+  T extends keyof typeof Adapters = keyof typeof Adapters,
+> = ReturnType<(typeof Adapters)[T]['fromPromptl']>['messages'][number]

--- a/packages/promptl/src/providers/openai/adapter.test.ts
+++ b/packages/promptl/src/providers/openai/adapter.test.ts
@@ -1,0 +1,101 @@
+import { render } from '$promptl/compiler'
+import { removeCommonIndent } from '$promptl/compiler/utils'
+import { MessageRole } from '$promptl/types'
+import { describe, expect, it } from 'vitest'
+
+import { Adapters } from '..'
+import { AssistantMessage as OpenAiAssistantMessage } from './types'
+
+describe('OpenAI adapter', async () => {
+  it('adapts system messages', async () => {
+    const prompt = `Hello world!`
+    const { messages } = await render({ prompt, adapter: Adapters.openai })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.system,
+        content: 'Hello world!', // System messages are defined as a string in OpenAI
+      },
+    ])
+  })
+
+  it('adapts user messages', async () => {
+    const prompt = removeCommonIndent(`
+      <user name="Image master">
+        Hello world!
+        <content-image>https://image.source/</content-image>
+      </user>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.openai })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.user,
+        name: 'Image master',
+        content: [
+          { type: 'text', text: 'Hello world!' },
+          { type: 'image', image: 'https://image.source/' },
+        ],
+      },
+    ])
+  })
+
+  it('adapts assistant messages', async () => {
+    const prompt = removeCommonIndent(`
+      <assistant>
+        Hello world!
+        <tool-call id="1234" name="get_weather" arguments={{ { location: "Barcelona" } }} />
+      </assistant>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.openai })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.assistant,
+        content: [{ type: 'text', text: 'Hello world!' }],
+        tool_calls: [
+          {
+            id: '1234',
+            type: 'function',
+            function: {
+              name: 'get_weather',
+              arguments: JSON.stringify({ location: 'Barcelona' }),
+            },
+          },
+        ],
+      },
+    ])
+
+    const promptWithoutToolCalls = removeCommonIndent(`
+      <assistant>
+        Hello world!
+      </assistant>
+    `)
+
+    const { messages: messagesWithoutToolCalls } = await render({
+      prompt: promptWithoutToolCalls,
+      adapter: Adapters.openai,
+    })
+
+    expect(messagesWithoutToolCalls[0]!.role).toBe(MessageRole.assistant)
+    expect(
+      (messagesWithoutToolCalls[0] as OpenAiAssistantMessage).tool_calls,
+    ).not.toBeDefined()
+  })
+
+  it('adapts tool messages', async () => {
+    const prompt = removeCommonIndent(`
+      <tool id="1234">
+        17ºC
+      </tool>
+    `)
+
+    const { messages } = await render({ prompt, adapter: Adapters.openai })
+    expect(messages).toEqual([
+      {
+        role: MessageRole.tool,
+        tool_call_id: '1234',
+        content: [{ type: 'text', text: '17ºC' }],
+      },
+    ])
+  })
+})

--- a/packages/promptl/src/providers/openai/adapter.ts
+++ b/packages/promptl/src/providers/openai/adapter.ts
@@ -1,0 +1,156 @@
+import {
+  ContentType,
+  MessageContent,
+  MessageRole,
+  Conversation as PromptlConversation,
+  Message as PromptlMessage,
+  TextContent,
+  ToolCallContent,
+} from '$promptl/types'
+
+import { ProviderAdapter, type ProviderConversation } from '../adapter'
+import {
+  AssistantMessage as OpenAIAssistantMessage,
+  Message as OpenAIMessage,
+  SystemMessage as OpenAISystemMessage,
+  TextContent as OpenAITextContent,
+  ToolCall as OpenAIToolCall,
+  ToolMessage as OpenAIToolMessage,
+} from './types'
+
+export const OpenAIAdapter: ProviderAdapter<OpenAIMessage> = {
+  fromPromptl(
+    promptlConversation: PromptlConversation,
+  ): ProviderConversation<OpenAIMessage> {
+    return {
+      config: promptlConversation.config,
+      messages: promptlConversation.messages.map(promptlToOpenAi),
+    }
+  },
+
+  toPromptl(
+    openAiConversation: ProviderConversation<OpenAIMessage>,
+  ): PromptlConversation {
+    return {
+      config: openAiConversation.config,
+      messages: openAiConversation.messages.map(openAiToPromptl),
+    }
+  },
+}
+
+function promptlToOpenAi(message: PromptlMessage): OpenAIMessage {
+  if (message.role === MessageRole.system) {
+    const { content, ...rest } = message
+    if (content.some((c) => c.type !== ContentType.text)) {
+      throw new Error(
+        `Unsupported content type for system message: ${content.map((c) => c.type).join(', ')}`,
+      )
+    }
+    const textContent = content
+    if (textContent.length === 1) {
+      return {
+        ...rest,
+        content: (content[0] as TextContent).text,
+      } as OpenAISystemMessage
+    }
+
+    return { ...rest, content: textContent as unknown as OpenAITextContent[] }
+  }
+
+  if (message.role === MessageRole.user) {
+    const { content, ...rest } = message
+    if (content.some((c) => !Object.values(ContentType).includes(c.type))) {
+      throw new Error(
+        `Unsupported content type for user message: ${content.map((c) => c.type).join(', ')}`,
+      )
+    }
+
+    return { ...rest, content: content as unknown as OpenAITextContent[] }
+  }
+
+  if (message.role === MessageRole.assistant) {
+    const { content, ...rest } = message
+
+    const { toolCalls, textContent } = content.reduce(
+      (
+        acc: { toolCalls: OpenAIToolCall[]; textContent: OpenAITextContent[] },
+        c,
+      ) => {
+        if (c.type === ContentType.text) {
+          acc.textContent.push(c as unknown as OpenAITextContent)
+          return acc
+        }
+
+        if (c.type === ContentType.toolCall) {
+          acc.toolCalls.push({
+            id: c.toolCallId,
+            type: 'function',
+            function: {
+              name: c.toolName,
+              arguments: JSON.stringify(c.toolArguments),
+            },
+          })
+          return acc
+        }
+
+        throw new Error(
+          `Unsupported content type for assistant message: ${c.type}`,
+        )
+      },
+      { toolCalls: [], textContent: [] },
+    )
+
+    return {
+      ...rest,
+      content: textContent,
+      tool_calls: toolCalls.length ? toolCalls : undefined,
+    } as OpenAIAssistantMessage
+  }
+
+  if (message.role === MessageRole.tool) {
+    const { toolId, ...rest } = message
+    return {
+      ...rest,
+      tool_call_id: toolId,
+    } as unknown as OpenAIToolMessage
+  }
+
+  //@ts-expect-error — There are no more supported roles. Typescript knows it and is yelling me back
+  throw new Error(`Unsupported message role: ${message.role}`)
+}
+
+function openAiToPromptl(message: OpenAIMessage): PromptlMessage {
+  const content: MessageContent[] =
+    typeof message.content === 'string'
+      ? [{ type: ContentType.text, text: message.content as string }]
+      : (message.content as unknown as MessageContent[])
+
+  if (message.role === MessageRole.assistant) {
+    const toolCalls: OpenAIToolCall[] = message.tool_calls || []
+    content.push(
+      ...toolCalls.map(
+        (tc) =>
+          ({
+            type: ContentType.toolCall,
+            toolCallId: tc.id,
+            toolName: tc.function.name,
+            toolArguments: JSON.parse(tc.function.arguments),
+          }) as ToolCallContent,
+      ),
+    )
+  }
+
+  if (message.role === MessageRole.tool) {
+    const { tool_call_id, content: _, ...rest } = message
+    return {
+      toolId: tool_call_id,
+      content,
+      ...rest,
+    }
+  }
+
+  return {
+    ...message,
+    content,
+  }
+}

--- a/packages/promptl/src/providers/openai/types.ts
+++ b/packages/promptl/src/providers/openai/types.ts
@@ -1,0 +1,83 @@
+/**
+ * OpenAI API reference for messages
+ * Reference for https://api.openai.com/v1/chat/completions
+ * Source: https://platform.openai.com/docs/api-reference/chat/create#chat-create-messages
+ */
+
+import { MessageRole } from '$promptl/types'
+
+export enum ContentType {
+  text = 'text',
+  image = 'image',
+  input_audio = 'input_audio',
+}
+
+interface IMessageContent {
+  type: ContentType
+  [key: string]: unknown
+}
+
+export type TextContent = IMessageContent & {
+  type: ContentType.text
+  text: string
+}
+
+export type ImageContent = IMessageContent & {
+  type: ContentType.image
+  image: string | Uint8Array | Buffer | ArrayBuffer | URL
+}
+
+export type AudioContent = IMessageContent & {
+  type: ContentType.input_audio
+  data: string
+  format: string
+}
+
+export type MessageContent = TextContent | ImageContent | AudioContent
+
+export type ToolCall = {
+  id: string
+  type: 'function'
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+interface IMessage {
+  role: MessageRole
+  content: MessageContent[]
+}
+
+export type SystemMessage = IMessage & {
+  role: MessageRole.system
+  name?: string
+  content: string | TextContent[]
+}
+
+export type UserMessage = IMessage & {
+  role: MessageRole.user
+  name?: string
+  content: string | MessageContent[]
+}
+
+export type AssistantMessage = IMessage & {
+  role: MessageRole.assistant
+  content: string
+  refusal?: string
+  name?: string
+  audio?: { id: string }
+  tool_calls?: ToolCall[]
+}
+
+export type ToolMessage = IMessage & {
+  role: MessageRole.tool
+  tool_call_id: string
+  content: string | MessageContent[]
+}
+
+export type Message =
+  | SystemMessage
+  | UserMessage
+  | AssistantMessage
+  | ToolMessage


### PR DESCRIPTION
PromptL will come with several adapters, allowing it to automatically receive inputs and export outputs in the expected structure of the most common providers, making it plug-and-play.

By default, it will be using OpenAI's schema.

WIP: Typescript really does not like PromptL defining types and then passing them to another package with their own types, even if they're actually compatible.