### PR TITLE
Some more fixes in document parameters and logs

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { DocumentLogWithMetadataAndError } from '@latitude-data/core/repositories'
 import {
@@ -13,9 +13,7 @@ import {
   EventArgs,
   useSockets,
 } from '$/components/Providers/WebsocketsProvider/useSockets'
-import { useGenerateDocumentLogDetailUrl } from '$/hooks/useGenerateDocumentLogDetailUrl'
 import useDocumentLogs, { documentLogPresenter } from '$/stores/documentLogs'
-import useDocumentLogWithPaginationPosition from '$/stores/documentLogWithPaginationPosition'
 import useProviderLogs from '$/stores/providerLogs'
 import { useSearchParams } from 'next/navigation'
 
@@ -68,48 +66,12 @@ const useDocumentLogSocket = (
   useSockets({ event: 'documentLogCreated', onMessage })
 }
 
-/**
- * When this page receive ?logUuid=some-uuid it can happen 2 things
- *
- *   1. The `page=NUMBER` is correct and `selectedLog` is there.
- *   2. There is no `page` param or is incorrect `selectedLog` is not there.
- *
- * We handle (2) here by looking the right page for the `logUuid` in the URL
- */
-function useRedirectToLogDetail({
-  selectedLog,
-  documentLogUuid,
-}: {
-  selectedLog: DocumentLogWithMetadataAndError | undefined
-  documentLogUuid: string | undefined
-}) {
-  const mounted = useRef(false)
-  const { data: position, isLoading } = useDocumentLogWithPaginationPosition({
-    documentLogUuid: selectedLog ? undefined : documentLogUuid,
-  })
-  const { url } = useGenerateDocumentLogDetailUrl({
-    documentLogUuid,
-    page: position?.page,
-  })
-  useEffect(() => {
-    if (selectedLog) return
-    if (mounted.current) return
-    if (isLoading || !url) return
-
-    mounted.current = true
-
-    window.location.href = url
-  }, [url, isLoading, selectedLog])
-}
-
 export function DocumentLogs({
   documentLogs: serverDocumentLogs,
   selectedLog: serverSelectedLog,
-  documentLogUuid,
 }: {
   documentLogs: DocumentLogWithMetadataAndError[]
   selectedLog: DocumentLogWithMetadataAndError | undefined
-  documentLogUuid: string | undefined
 }) {
   const tableRef = useRef<HTMLTableElement>(null)
   const sidebarWrapperRef = useRef<HTMLDivElement>(null)
@@ -140,7 +102,6 @@ export function DocumentLogs({
   )
 
   useDocumentLogSocket(document.documentUuid, mutate)
-  useRedirectToLogDetail({ selectedLog, documentLogUuid })
 
   if (!documentLogs.length) {
     return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/page.tsx
@@ -1,12 +1,34 @@
+import { Workspace } from '@latitude-data/core/browser'
 import { QueryParams } from '@latitude-data/core/lib/pagination/buildPaginatedUrl'
 import { computeDocumentLogsWithMetadataQuery } from '@latitude-data/core/services/documentLogs/computeDocumentLogsWithMetadata'
+import { fetchDocumentLogWithPosition } from '@latitude-data/core/services/documentLogs/fetchDocumentLogWithPosition'
 import { Button, TableWithHeader } from '@latitude-data/web-ui'
 import { findCommitCached } from '$/app/(private)/_data-access'
 import { getCurrentUser } from '$/services/auth/getCurrentUser'
 import { ROUTES } from '$/services/routes'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 
 import { DocumentLogs } from './_components/DocumentLogs'
+
+async function fetchDocumentLogPage({
+  workspace,
+  documentLogUuid,
+}: {
+  workspace: Workspace
+  documentLogUuid: string | undefined
+}) {
+  if (!documentLogUuid) return undefined
+
+  const result = await fetchDocumentLogWithPosition({
+    workspace,
+    documentLogUuid,
+  })
+
+  if (result.error) return undefined
+
+  return result.value.page.toString()
+}
 
 export default async function DocumentPage({
   params,
@@ -18,27 +40,42 @@ export default async function DocumentPage({
   const { workspace } = await getCurrentUser()
   const projectId = Number(params.projectId)
   const commitUuid = params.commitUuid
+  const documentUuid = params.documentUuid
   const commit = await findCommitCached({ projectId, uuid: commitUuid })
+  const documentLogUuid = searchParams.logUuid?.toString()
+  const page = searchParams.page?.toString?.()
+  const currentLogPage = await fetchDocumentLogPage({
+    workspace,
+    documentLogUuid,
+  })
+
+  if (currentLogPage && currentLogPage !== page) {
+    const route = ROUTES.projects
+      .detail({ id: projectId })
+      .commits.detail({ uuid: commit.uuid })
+      .documents.detail({ uuid: documentUuid }).logs.root
+    return redirect(
+      `${route}?page=${currentLogPage}&logUuid=${documentLogUuid}`,
+    )
+  }
+
+  // Paginated logs
   const rows = await computeDocumentLogsWithMetadataQuery({
     workspaceId: workspace.id,
-    documentUuid: params.documentUuid,
+    documentUuid,
     draft: commit,
-    page: searchParams.page as string | undefined,
+    page,
     pageSize: searchParams.pageSize as string | undefined,
   })
-  const documentLogUuid = searchParams.logUuid?.toString()
+
+  // Current log in that page
   const selectedLog = rows.find((r) => r.uuid === documentLogUuid)
+
   return (
     <div className='flex flex-grow min-h-0 flex-col w-full p-6 gap-2 min-w-0'>
       <TableWithHeader
         title='Logs'
-        table={
-          <DocumentLogs
-            documentLogs={rows}
-            documentLogUuid={documentLogUuid}
-            selectedLog={selectedLog}
-          />
-        }
+        table={<DocumentLogs documentLogs={rows} selectedLog={selectedLog} />}
         actions={
           <Link
             href={


### PR DESCRIPTION
# What?
Yesterday we deployed new document parameters in the document playground. Is under the feature flag and before opening I want to fix some issues I saw at the end of the day. Plus some of Cesar's qa fixes. 

## TODO
- [x] Redirect to current log detail in the backend
- [ ] Fix multi-line history log navigation on the small screen
- [ ] Debounce clicking on history log navigation.

We were doing a shitty version of this in the client with a useEffect and I realize that we have a backend. So I just moved to it