### PR TITLE
feat(evaluations): add eject functionality for evaluations

### DIFF
--- a/apps/web/src/actions/evaluations/eject.test.ts
+++ b/apps/web/src/actions/evaluations/eject.test.ts
@@ -1,0 +1,127 @@
+import {
+  EvaluationMetadataType,
+  EvaluationResultableType,
+  ProviderApiKey,
+  Providers,
+} from '@latitude-data/core/browser'
+import * as factories from '@latitude-data/core/factories'
+import { Result } from '@latitude-data/core/lib/Result'
+import { EvaluationsRepository } from '@latitude-data/core/repositories'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ejectEvaluationAction } from './eject'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+  }
+})
+
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+
+vi.mock('@latitude-data/core/repositories/evaluationsRepository')
+
+describe('ejectEvaluationAction', () => {
+  describe('unauthorized', () => {
+    let evaluationId: number
+
+    beforeEach(async () => {
+      const { workspace, userData } = await factories.createWorkspace()
+      const provider = await factories.createProviderApiKey({
+        workspace,
+        type: Providers.OpenAI,
+        name: 'Test Provider',
+        user: userData,
+      })
+      const evaluation = await factories.createLlmAsJudgeEvaluation({
+        workspace,
+        user: userData,
+        prompt: factories.helpers.createPrompt({ provider }),
+      })
+      evaluationId = evaluation.id
+    })
+
+    it('errors when the user is not authenticated', async () => {
+      mocks.getSession.mockReturnValue(null)
+
+      const [_, error] = await ejectEvaluationAction({
+        id: evaluationId,
+      })
+
+      expect(error!.name).toEqual('UnauthorizedError')
+    })
+  })
+
+  describe('authorized', () => {
+    let evaluation: any
+    let user: any
+    let workspace: any
+    let provider: ProviderApiKey
+
+    beforeEach(async () => {
+      const { workspace: createdWorkspace, userData } =
+        await factories.createWorkspace()
+
+      workspace = createdWorkspace
+      user = userData
+      provider = await factories.createProviderApiKey({
+        workspace,
+        type: Providers.OpenAI,
+        name: 'Test Provider',
+        user,
+      })
+      evaluation = await factories.createEvaluation({
+        workspace,
+        user,
+        metadataType: EvaluationMetadataType.LlmAsJudgeSimple,
+        metadata: {
+          providerApiKeyId: provider.id,
+          model: 'gpt-4o',
+          objective: 'Test objective',
+          additionalInstructions: 'Test additional instructions',
+        },
+        resultType: EvaluationResultableType.Boolean,
+        resultConfiguration: {
+          trueValueDescription: 'Test true value description',
+          falseValueDescription: 'Test false value description',
+        },
+      })
+
+      mocks.getSession.mockReturnValue({
+        user: userData,
+      })
+    })
+
+    it('successfully ejects an evaluation', async () => {
+      // @ts-expect-error - Mocking the repository
+      vi.mocked(EvaluationsRepository).mockImplementation(() => ({
+        find: vi.fn().mockResolvedValue(Result.ok(evaluation)),
+      }))
+
+      const [data, error] = await ejectEvaluationAction({
+        id: evaluation.id,
+      })
+
+      expect(error).toBeNull()
+      expect(data).toEqual(expect.objectContaining({ id: evaluation.id }))
+    })
+
+    it('throws an error if evaluation is not found', async () => {
+      // @ts-expect-error - Mocking the repository
+      vi.mocked(EvaluationsRepository).mockImplementation(() => ({
+        find: vi
+          .fn()
+          .mockResolvedValue(Result.error(new Error('Evaluation not found'))),
+      }))
+
+      const [_, error] = await ejectEvaluationAction({
+        id: 999,
+      })
+
+      expect(error).not.toBeNull()
+      expect(error!.message).toEqual('Evaluation not found')
+    })
+  })
+})

--- a/apps/web/src/actions/evaluations/eject.ts
+++ b/apps/web/src/actions/evaluations/eject.ts
@@ -1,0 +1,18 @@
+'use server'
+
+import { EvaluationsRepository } from '@latitude-data/core/repositories'
+import { ejectEvaluation } from '@latitude-data/core/services/evaluations/eject'
+import { z } from 'zod'
+
+import { authProcedure } from '../procedures'
+
+export const ejectEvaluationAction = authProcedure
+  .createServerAction()
+  .input(z.object({ id: z.coerce.number() }))
+  .handler(async ({ input, ctx }) => {
+    const scope = new EvaluationsRepository(ctx.workspace.id)
+    const evaluation = await scope.find(input.id).then((r) => r.unwrap())
+    const result = await ejectEvaluation(evaluation)
+
+    return result.unwrap()
+  })

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/BooleanEvaluationEditor/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/BooleanEvaluationEditor/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent } from 'react'
 
 import {
   EvaluationConfigurationBoolean,
@@ -8,25 +8,19 @@ import {
   EvaluationMetadataLlmAsJudgeSimple,
   EvaluationMetadataType,
   EvaluationResultableType,
-  findFirstModelForProvider,
 } from '@latitude-data/core/browser'
 import {
-  Button,
   FormField,
   FormFieldGroup,
   Input,
   Label,
-  Text,
   useToast,
 } from '@latitude-data/web-ui'
-import {
-  IProviderByName,
-  ProviderModelSelector,
-} from '$/components/EditorHeader'
-import { envClient } from '$/envClient'
-import useModelOptions from '$/hooks/useModelOptions'
+import { ProviderModelSelector } from '$/components/EditorHeader'
 import useEvaluations from '$/stores/evaluations'
-import useProviderApiKeys from '$/stores/providerApiKeys'
+
+import { EvaluationEditorLayout } from '../components/EvaluationEditorLayout'
+import { useProviderModel } from '../hooks/useProviderModel'
 
 export default function BooleanEvaluationEditor({
   evaluation,
@@ -34,66 +28,23 @@ export default function BooleanEvaluationEditor({
   evaluation: EvaluationDto
 }) {
   const { toast } = useToast()
-  const { data: providerApiKeys } = useProviderApiKeys()
   const metadata = evaluation.metadata as EvaluationMetadataLlmAsJudgeSimple
   const resultConfiguration =
     evaluation.resultConfiguration as EvaluationConfigurationBoolean
-  const [selectedProvider, setSelectedProvider] = useState<string | undefined>()
-  const [selectedModel, setSelectedModel] = useState<
-    string | undefined | null
-  >()
-  useEffect(() => {
-    const provider = providerApiKeys.find(
-      (pk) => pk.id === metadata.providerApiKeyId,
-    )
-    if (!provider) return
-
-    setSelectedProvider(provider.name)
-    setSelectedModel(metadata.model)
-  }, [providerApiKeys])
-
   const { update } = useEvaluations()
 
-  const providerOptions = useMemo(() => {
-    return providerApiKeys.map((apiKey) => ({
-      label: apiKey.name,
-      value: apiKey.name,
-    }))
-  }, [providerApiKeys])
-  const providersByName = useMemo(() => {
-    return providerApiKeys.reduce((acc, data) => {
-      acc[data.name] = data
-      return acc
-    }, {} as IProviderByName)
-  }, [providerApiKeys])
-  const provider = selectedProvider
-    ? providersByName[selectedProvider]
-    : undefined
-  const modelOptions = useModelOptions({
-    provider: provider?.provider,
-    name: provider?.name,
-  })
-  const onProviderChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedProvider) return
+  const {
+    provider,
+    selectedProvider,
+    selectedModel,
+    providerOptions,
+    modelOptions,
+    onProviderChange,
+    onModelChange,
+  } = useProviderModel(metadata)
 
-    const firstModel = findFirstModelForProvider({
-      provider: providersByName[value],
-      latitudeProvider: envClient.NEXT_PUBLIC_DEFAULT_PROJECT_ID,
-    })
-
-    setSelectedProvider(value)
-    setSelectedModel(firstModel)
-  }
-  const onModelChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedModel) return
-
-    setSelectedModel(value)
-  }
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-
     const formData = new FormData(e.currentTarget)
 
     const [_, error] = await update({
@@ -123,63 +74,56 @@ export default function BooleanEvaluationEditor({
   }
 
   return (
-    <div className='flex flex-col gap-y-2 h-full'>
-      <div className='flex flex-row items-center justify-between'>
-        <Text.H4M>{evaluation.name}</Text.H4M>
-        <Button fancy form='simple-boolean-evaluation-editor' type='submit'>
-          Save changes
-        </Button>
-      </div>
-      <form
-        className='bg-backgroundCode flex flex-grow flex-col gap-y-4 p-4 rounded-lg border'
-        id='simple-boolean-evaluation-editor'
-        onSubmit={onSubmit}
-      >
-        <FormField>
-          <ProviderModelSelector
-            modelDisabled={!modelOptions.length || !selectedProvider}
-            modelOptions={modelOptions}
-            onModelChange={onModelChange}
-            onProviderChange={onProviderChange}
-            providerDisabled={!providerOptions.length}
-            providerOptions={providerOptions}
-            selectedModel={selectedModel}
-            selectedProvider={selectedProvider}
-          />
-        </FormField>
-        <FormField label='Evaluation objective'>
+    <EvaluationEditorLayout
+      name={evaluation.name}
+      evaluationId={evaluation.id}
+      formId='simple-boolean-evaluation-editor'
+      onSubmit={onSubmit}
+    >
+      <FormField>
+        <ProviderModelSelector
+          modelDisabled={!modelOptions.length || !selectedProvider}
+          modelOptions={modelOptions}
+          onModelChange={onModelChange}
+          onProviderChange={onProviderChange}
+          providerDisabled={!providerOptions.length}
+          providerOptions={providerOptions}
+          selectedModel={selectedModel}
+          selectedProvider={selectedProvider}
+        />
+      </FormField>
+      <FormField label='Evaluation objective'>
+        <Input
+          name='objective'
+          defaultValue={metadata.objective}
+          placeholder='The main objective of the evaluation'
+        />
+      </FormField>
+      <FormFieldGroup>
+        <FormField label='True value description'>
           <Input
-            name='objective'
-            defaultValue={metadata.objective}
-            placeholder='The main objective of the evaluation'
+            name='trueValueDescription'
+            defaultValue={resultConfiguration.trueValueDescription ?? ''}
+            placeholder='Description of the true value'
           />
         </FormField>
-        <FormFieldGroup>
-          <FormField label='True value description'>
-            <Input
-              name='trueValueDescription'
-              defaultValue={resultConfiguration.trueValueDescription ?? ''}
-              placeholder='Description of the true value'
-            />
-          </FormField>
-          <FormField label='False value description'>
-            <Input
-              name='falseValueDescription'
-              defaultValue={resultConfiguration.falseValueDescription ?? ''}
-              placeholder='Description of the false value'
-            />
-          </FormField>
-        </FormFieldGroup>
-        <div className='flex flex-col gap-2 flex-grow'>
-          <Label>Additional instructions</Label>
-          <textarea
-            name='additionalInstructions'
-            className='w-full h-full border rounded-lg p-2 text-sm text-foreground'
-            defaultValue={metadata.additionalInstructions ?? ''}
-            placeholder='Additional instructions the eval should take into account...'
+        <FormField label='False value description'>
+          <Input
+            name='falseValueDescription'
+            defaultValue={resultConfiguration.falseValueDescription ?? ''}
+            placeholder='Description of the false value'
           />
-        </div>
-      </form>
-    </div>
+        </FormField>
+      </FormFieldGroup>
+      <div className='flex flex-col gap-2 flex-grow'>
+        <Label>Additional instructions</Label>
+        <textarea
+          name='additionalInstructions'
+          className='w-full h-full border rounded-lg p-2 text-sm text-foreground'
+          defaultValue={metadata.additionalInstructions ?? ''}
+          placeholder='Additional instructions the eval should take into account...'
+        />
+      </div>
+    </EvaluationEditorLayout>
   )
 }

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/NumberEvaluationEditor/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/NumberEvaluationEditor/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent } from 'react'
 
 import {
   EvaluationConfigurationNumerical,
@@ -8,24 +8,18 @@ import {
   EvaluationMetadataLlmAsJudgeSimple,
   EvaluationMetadataType,
   EvaluationResultableType,
-  findFirstModelForProvider,
 } from '@latitude-data/core/browser'
 import {
-  Button,
   FormFieldGroup,
   Input,
-  Text,
   TextArea,
   useToast,
 } from '@latitude-data/web-ui'
-import {
-  IProviderByName,
-  ProviderModelSelector,
-} from '$/components/EditorHeader'
-import { envClient } from '$/envClient'
-import useModelOptions from '$/hooks/useModelOptions'
+import { ProviderModelSelector } from '$/components/EditorHeader'
 import useEvaluations from '$/stores/evaluations'
-import useProviderApiKeys from '$/stores/providerApiKeys'
+
+import { EvaluationEditorLayout } from '../components/EvaluationEditorLayout'
+import { useProviderModel } from '../hooks/useProviderModel'
 
 export default function NumberEvaluationEditor({
   evaluation,
@@ -33,66 +27,23 @@ export default function NumberEvaluationEditor({
   evaluation: EvaluationDto
 }) {
   const { toast } = useToast()
-  const { data: providerApiKeys } = useProviderApiKeys()
   const metadata = evaluation.metadata as EvaluationMetadataLlmAsJudgeSimple
   const resultConfiguration =
     evaluation.resultConfiguration as EvaluationConfigurationNumerical
-  const [selectedProvider, setSelectedProvider] = useState<string | undefined>()
-  const [selectedModel, setSelectedModel] = useState<
-    string | undefined | null
-  >()
-  useEffect(() => {
-    const provider = providerApiKeys.find(
-      (pk) => pk.id === metadata.providerApiKeyId,
-    )
-    if (!provider) return
-
-    setSelectedProvider(provider.name)
-    setSelectedModel(metadata.model)
-  }, [providerApiKeys])
-
   const { update } = useEvaluations()
 
-  const providerOptions = useMemo(() => {
-    return providerApiKeys.map((apiKey) => ({
-      label: apiKey.name,
-      value: apiKey.name,
-    }))
-  }, [providerApiKeys])
-  const providersByName = useMemo(() => {
-    return providerApiKeys.reduce((acc, data) => {
-      acc[data.name] = data
-      return acc
-    }, {} as IProviderByName)
-  }, [providerApiKeys])
-  const provider = selectedProvider
-    ? providersByName[selectedProvider]
-    : undefined
-  const modelOptions = useModelOptions({
-    provider: provider?.provider,
-    name: provider?.name,
-  })
-  const onProviderChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedProvider) return
+  const {
+    provider,
+    selectedProvider,
+    selectedModel,
+    providerOptions,
+    modelOptions,
+    onProviderChange,
+    onModelChange,
+  } = useProviderModel(metadata)
 
-    const firstModel = findFirstModelForProvider({
-      provider: providersByName[value],
-      latitudeProvider: envClient.NEXT_PUBLIC_DEFAULT_PROJECT_ID,
-    })
-
-    setSelectedProvider(value)
-    setSelectedModel(firstModel)
-  }
-  const onModelChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedModel) return
-
-    setSelectedModel(value)
-  }
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-
     const formData = new FormData(e.currentTarget)
 
     const [_, error] = await update({
@@ -124,70 +75,63 @@ export default function NumberEvaluationEditor({
   }
 
   return (
-    <div className='flex flex-col gap-y-2 h-full'>
-      <div className='flex flex-row items-center justify-between'>
-        <Text.H4M>{evaluation.name}</Text.H4M>
-        <Button fancy form='simple-number-evaluation-editor' type='submit'>
-          Save changes
-        </Button>
-      </div>
-      <form
-        className='bg-backgroundCode flex flex-grow flex-col gap-y-4 p-4 rounded-lg border'
-        id='simple-number-evaluation-editor'
-        onSubmit={onSubmit}
-      >
-        <ProviderModelSelector
-          modelDisabled={!modelOptions.length || !selectedProvider}
-          modelOptions={modelOptions}
-          onModelChange={onModelChange}
-          onProviderChange={onProviderChange}
-          providerDisabled={!providerOptions.length}
-          providerOptions={providerOptions}
-          selectedModel={selectedModel}
-          selectedProvider={selectedProvider}
+    <EvaluationEditorLayout
+      name={evaluation.name}
+      evaluationId={evaluation.id}
+      formId='simple-number-evaluation-editor'
+      onSubmit={onSubmit}
+    >
+      <ProviderModelSelector
+        modelDisabled={!modelOptions.length || !selectedProvider}
+        modelOptions={modelOptions}
+        onModelChange={onModelChange}
+        onProviderChange={onProviderChange}
+        providerDisabled={!providerOptions.length}
+        providerOptions={providerOptions}
+        selectedModel={selectedModel}
+        selectedProvider={selectedProvider}
+      />
+      <Input
+        name='objective'
+        label='Evaluation objective'
+        defaultValue={metadata.objective}
+        placeholder='The main objective of the evaluation'
+      />
+      <FormFieldGroup>
+        <Input
+          label='Min Value'
+          type='number'
+          name='minValue'
+          defaultValue={resultConfiguration.minValue}
         />
         <Input
-          name='objective'
-          label='Evaluation objective'
-          defaultValue={metadata.objective}
-          placeholder='The main objective of the evaluation'
+          label='Min value description'
+          name='minValueDescription'
+          defaultValue={resultConfiguration.minValueDescription ?? ''}
+          placeholder='Description of the min value'
         />
-        <FormFieldGroup>
-          <Input
-            label='Min Value'
-            type='number'
-            name='minValue'
-            defaultValue={resultConfiguration.minValue}
-          />
-          <Input
-            label='Min value description'
-            name='minValueDescription'
-            defaultValue={resultConfiguration.minValueDescription ?? ''}
-            placeholder='Description of the min value'
-          />
-        </FormFieldGroup>
-        <FormFieldGroup>
-          <Input
-            label='Max Value'
-            type='number'
-            name='maxValue'
-            defaultValue={resultConfiguration.maxValue}
-          />
-          <Input
-            label='Max value description'
-            name='maxValueDescription'
-            defaultValue={resultConfiguration.maxValueDescription ?? ''}
-            placeholder='Description of the max value'
-          />
-        </FormFieldGroup>
-        <TextArea
-          autoGrow
-          label='Additional instructions'
-          name='additionalInstructions'
-          placeholder='Additional instructions the eval should take into account...'
-          defaultValue={metadata.additionalInstructions ?? ''}
+      </FormFieldGroup>
+      <FormFieldGroup>
+        <Input
+          label='Max Value'
+          type='number'
+          name='maxValue'
+          defaultValue={resultConfiguration.maxValue}
         />
-      </form>
-    </div>
+        <Input
+          label='Max value description'
+          name='maxValueDescription'
+          defaultValue={resultConfiguration.maxValueDescription ?? ''}
+          placeholder='Description of the max value'
+        />
+      </FormFieldGroup>
+      <TextArea
+        autoGrow
+        label='Additional instructions'
+        name='additionalInstructions'
+        placeholder='Additional instructions the eval should take into account...'
+        defaultValue={metadata.additionalInstructions ?? ''}
+      />
+    </EvaluationEditorLayout>
   )
 }

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/TextEvaluationEditor/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/TextEvaluationEditor/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { FormEvent } from 'react'
 
 import {
   EvaluationConfigurationText,
@@ -8,24 +8,13 @@ import {
   EvaluationMetadataLlmAsJudgeSimple,
   EvaluationMetadataType,
   EvaluationResultableType,
-  findFirstModelForProvider,
 } from '@latitude-data/core/browser'
-import {
-  Button,
-  FormField,
-  Input,
-  Label,
-  Text,
-  useToast,
-} from '@latitude-data/web-ui'
-import {
-  IProviderByName,
-  ProviderModelSelector,
-} from '$/components/EditorHeader'
-import { envClient } from '$/envClient'
-import useModelOptions from '$/hooks/useModelOptions'
+import { FormField, Input, Label, useToast } from '@latitude-data/web-ui'
+import { ProviderModelSelector } from '$/components/EditorHeader'
 import useEvaluations from '$/stores/evaluations'
-import useProviderApiKeys from '$/stores/providerApiKeys'
+
+import { EvaluationEditorLayout } from '../components/EvaluationEditorLayout'
+import { useProviderModel } from '../hooks/useProviderModel'
 
 export default function TextEvaluationEditor({
   evaluation,
@@ -33,66 +22,23 @@ export default function TextEvaluationEditor({
   evaluation: EvaluationDto
 }) {
   const { toast } = useToast()
-  const { data: providerApiKeys } = useProviderApiKeys()
   const metadata = evaluation.metadata as EvaluationMetadataLlmAsJudgeSimple
   const resultConfiguration =
     evaluation.resultConfiguration as EvaluationConfigurationText
-  const [selectedProvider, setSelectedProvider] = useState<string | undefined>()
-  const [selectedModel, setSelectedModel] = useState<
-    string | undefined | null
-  >()
-  useEffect(() => {
-    const provider = providerApiKeys.find(
-      (pk) => pk.id === metadata.providerApiKeyId,
-    )
-    if (!provider) return
-
-    setSelectedProvider(provider.name)
-    setSelectedModel(metadata.model)
-  }, [providerApiKeys])
-
   const { update } = useEvaluations()
 
-  const providerOptions = useMemo(() => {
-    return providerApiKeys.map((apiKey) => ({
-      label: apiKey.name,
-      value: apiKey.name,
-    }))
-  }, [providerApiKeys])
-  const providersByName = useMemo(() => {
-    return providerApiKeys.reduce((acc, data) => {
-      acc[data.name] = data
-      return acc
-    }, {} as IProviderByName)
-  }, [providerApiKeys])
-  const provider = selectedProvider
-    ? providersByName[selectedProvider]
-    : undefined
-  const modelOptions = useModelOptions({
-    provider: provider?.provider,
-    name: provider?.name,
-  })
-  const onProviderChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedProvider) return
+  const {
+    provider,
+    selectedProvider,
+    selectedModel,
+    providerOptions,
+    modelOptions,
+    onProviderChange,
+    onModelChange,
+  } = useProviderModel(metadata)
 
-    const firstModel = findFirstModelForProvider({
-      provider: providersByName[value],
-      latitudeProvider: envClient.NEXT_PUBLIC_DEFAULT_PROJECT_ID,
-    })
-
-    setSelectedProvider(value)
-    setSelectedModel(firstModel)
-  }
-  const onModelChange = async (value: string) => {
-    if (!value) return
-    if (value === selectedModel) return
-
-    setSelectedModel(value)
-  }
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-
     const formData = new FormData(e.currentTarget)
 
     const [_, error] = await update({
@@ -121,54 +67,47 @@ export default function TextEvaluationEditor({
   }
 
   return (
-    <div className='flex flex-col gap-y-2 h-full'>
-      <div className='flex flex-row items-center justify-between'>
-        <Text.H4M>{evaluation.name}</Text.H4M>
-        <Button fancy form='simple-text-evaluation-editor' type='submit'>
-          Save changes
-        </Button>
+    <EvaluationEditorLayout
+      evaluationId={evaluation.id}
+      name={evaluation.name}
+      formId='simple-text-evaluation-editor'
+      onSubmit={onSubmit}
+    >
+      <FormField>
+        <ProviderModelSelector
+          modelDisabled={!modelOptions.length || !selectedProvider}
+          modelOptions={modelOptions}
+          onModelChange={onModelChange}
+          onProviderChange={onProviderChange}
+          providerDisabled={!providerOptions.length}
+          providerOptions={providerOptions}
+          selectedModel={selectedModel}
+          selectedProvider={selectedProvider}
+        />
+      </FormField>
+      <FormField label='Evaluation objective'>
+        <Input
+          name='objective'
+          defaultValue={metadata.objective}
+          placeholder='The main objective of the evaluation'
+        />
+      </FormField>
+      <FormField label='Value description'>
+        <Input
+          name='valueDescription'
+          defaultValue={resultConfiguration.valueDescription ?? ''}
+          placeholder='Description of the evaluation output value'
+        />
+      </FormField>
+      <div className='flex flex-col gap-2 flex-grow'>
+        <Label>Additional instructions</Label>
+        <textarea
+          name='additionalInstructions'
+          className='w-full h-full border rounded-lg p-2 text-sm text-foreground'
+          defaultValue={metadata.additionalInstructions ?? ''}
+          placeholder='Additional instructions the eval should take into account...'
+        />
       </div>
-      <form
-        className='bg-backgroundCode flex flex-grow flex-col gap-y-4 p-4 rounded-lg border'
-        id='simple-text-evaluation-editor'
-        onSubmit={onSubmit}
-      >
-        <FormField>
-          <ProviderModelSelector
-            modelDisabled={!modelOptions.length || !selectedProvider}
-            modelOptions={modelOptions}
-            onModelChange={onModelChange}
-            onProviderChange={onProviderChange}
-            providerDisabled={!providerOptions.length}
-            providerOptions={providerOptions}
-            selectedModel={selectedModel}
-            selectedProvider={selectedProvider}
-          />
-        </FormField>
-        <FormField label='Evaluation objective'>
-          <Input
-            name='objective'
-            defaultValue={metadata.objective}
-            placeholder='The main objective of the evaluation'
-          />
-        </FormField>
-        <FormField label='Value description'>
-          <Input
-            name='valueDescription'
-            defaultValue={resultConfiguration.valueDescription ?? ''}
-            placeholder='Description of the evaluation output value'
-          />
-        </FormField>
-        <div className='flex flex-col gap-2 flex-grow'>
-          <Label>Additional instructions</Label>
-          <textarea
-            name='additionalInstructions'
-            className='w-full h-full border rounded-lg p-2 text-sm text-foreground'
-            defaultValue={metadata.additionalInstructions ?? ''}
-            placeholder='Additional instructions the eval should take into account...'
-          />
-        </div>
-      </form>
-    </div>
+    </EvaluationEditorLayout>
   )
 }

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/components/EvaluationEditorLayout.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/components/EvaluationEditorLayout.tsx
@@ -1,0 +1,92 @@
+import { FormEvent, ReactNode, useState } from 'react'
+
+import {
+  Button,
+  ConfirmModal,
+  Icon,
+  Text,
+  useToast,
+} from '@latitude-data/web-ui'
+import { ejectEvaluationAction } from '$/actions/evaluations/eject'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { useRouter } from 'next/navigation'
+
+interface EvaluationEditorLayoutProps {
+  name: string
+  formId: string
+  evaluationId: number
+  children: ReactNode
+  onSubmit: (e: FormEvent<HTMLFormElement>) => Promise<void>
+}
+
+export function EvaluationEditorLayout({
+  name,
+  formId,
+  evaluationId,
+  children,
+  onSubmit,
+}: EvaluationEditorLayoutProps) {
+  const [showEjectModal, setShowEjectModal] = useState(false)
+  const router = useRouter()
+  const { execute: eject, isPending } = useLatitudeAction(
+    ejectEvaluationAction,
+    {
+      onSuccess: () => {
+        router.refresh()
+      },
+      onError: ({ err }) => {
+        toast({
+          title: 'Error',
+          description: err.message,
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+  const { toast } = useToast()
+
+  const handleEject = () => eject({ id: evaluationId })
+
+  return (
+    <div className='flex flex-col gap-y-2 h-full'>
+      <div className='flex flex-row items-center justify-between'>
+        <Text.H4M>{name}</Text.H4M>
+        <div className='flex gap-2'>
+          <Button
+            fancy
+            variant='outline'
+            onClick={() => setShowEjectModal(true)}
+          >
+            <div className='flex flex-row items-center gap-x-2'>
+              Eject <Icon name='pencil' />
+            </div>
+          </Button>
+          <Button fancy form={formId} type='submit'>
+            Save changes
+          </Button>
+        </div>
+      </div>
+      <form
+        className='bg-backgroundCode flex flex-grow flex-col gap-y-4 p-4 rounded-lg border'
+        id={formId}
+        onSubmit={onSubmit}
+      >
+        {children}
+      </form>
+
+      <ConfirmModal
+        open={showEjectModal}
+        onOpenChange={setShowEjectModal}
+        title='Eject to Advanced Mode'
+        description='This action will convert this evaluation into an advanced evaluation with a custom prompt that you can further edit.'
+        confirm={{
+          label: 'Eject',
+          isConfirming: isPending,
+          description:
+            'The evaluation will be converted to advanced mode with a custom prompt. This action cannot be undone.',
+        }}
+        onConfirm={handleEject}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/hooks/useProviderModel.ts
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Simple/hooks/useProviderModel.ts
@@ -1,0 +1,81 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  EvaluationMetadataLlmAsJudgeSimple,
+  findFirstModelForProvider,
+} from '@latitude-data/core/browser'
+import { IProviderByName } from '$/components/EditorHeader'
+import { envClient } from '$/envClient'
+import useModelOptions from '$/hooks/useModelOptions'
+import useProviderApiKeys from '$/stores/providerApiKeys'
+
+export function useProviderModel(metadata: EvaluationMetadataLlmAsJudgeSimple) {
+  const { data: providerApiKeys } = useProviderApiKeys()
+  const [selectedProvider, setSelectedProvider] = useState<string | undefined>()
+  const [selectedModel, setSelectedModel] = useState<
+    string | undefined | null
+  >()
+
+  useEffect(() => {
+    const provider = providerApiKeys.find(
+      (pk) => pk.id === metadata.providerApiKeyId,
+    )
+    if (!provider) return
+
+    setSelectedProvider(provider.name)
+    setSelectedModel(metadata.model)
+  }, [providerApiKeys, metadata])
+
+  const providerOptions = useMemo(() => {
+    return providerApiKeys.map((apiKey) => ({
+      label: apiKey.name,
+      value: apiKey.name,
+    }))
+  }, [providerApiKeys])
+
+  const providersByName = useMemo(() => {
+    return providerApiKeys.reduce((acc, data) => {
+      acc[data.name] = data
+      return acc
+    }, {} as IProviderByName)
+  }, [providerApiKeys])
+
+  const provider = selectedProvider
+    ? providersByName[selectedProvider]
+    : undefined
+
+  const modelOptions = useModelOptions({
+    provider: provider?.provider,
+    name: provider?.name,
+  })
+
+  const onProviderChange = async (value: string) => {
+    if (!value) return
+    if (value === selectedProvider) return
+
+    const firstModel = findFirstModelForProvider({
+      provider: providersByName[value],
+      latitudeProvider: envClient.NEXT_PUBLIC_DEFAULT_PROJECT_ID,
+    })
+
+    setSelectedProvider(value)
+    setSelectedModel(firstModel)
+  }
+
+  const onModelChange = async (value: string) => {
+    if (!value) return
+    if (value === selectedModel) return
+
+    setSelectedModel(value)
+  }
+
+  return {
+    provider,
+    selectedProvider,
+    selectedModel,
+    providerOptions,
+    modelOptions,
+    onProviderChange,
+    onModelChange,
+  }
+}

--- a/packages/core/src/services/evaluations/create.ts
+++ b/packages/core/src/services/evaluations/create.ts
@@ -78,6 +78,12 @@ type CreateEvaluationResultConfiguration<R extends EvaluationResultableType> =
         ? EvaluationResultConfigurationText
         : never
 
+export const configurationTables = {
+  [EvaluationResultableType.Boolean]: evaluationConfigurationBoolean,
+  [EvaluationResultableType.Number]: evaluationConfigurationNumerical,
+  [EvaluationResultableType.Text]: evaluationConfigurationText,
+} as const
+
 export async function createEvaluation<
   M extends EvaluationMetadataType,
   R extends EvaluationResultableType,
@@ -127,12 +133,6 @@ export async function createEvaluation<
       new BadRequestError(`Invalid metadata type ${metadataType}`),
     )
   }
-
-  const configurationTables = {
-    [EvaluationResultableType.Boolean]: evaluationConfigurationBoolean,
-    [EvaluationResultableType.Number]: evaluationConfigurationNumerical,
-    [EvaluationResultableType.Text]: evaluationConfigurationText,
-  } as const
 
   if (!configurationTables[resultType]) {
     return Result.error(

--- a/packages/core/src/services/evaluations/eject.ts
+++ b/packages/core/src/services/evaluations/eject.ts
@@ -1,0 +1,68 @@
+import { eq } from 'drizzle-orm'
+
+import { EvaluationDto, EvaluationMetadataType } from '../../browser'
+import { database } from '../../client'
+import { unsafelyFindWorkspace } from '../../data-access'
+import { BadRequestError, NotFoundError, Result, Transaction } from '../../lib'
+import {
+  evaluationMetadataLlmAsJudgeAdvanced,
+  evaluationMetadataLlmAsJudgeSimple,
+  evaluations,
+} from '../../schema'
+import { configurationTables } from './create'
+import { getEvaluationPrompt } from './prompt'
+
+export async function ejectEvaluation(
+  evaluation: EvaluationDto,
+  db = database,
+) {
+  if (evaluation.metadataType !== EvaluationMetadataType.LlmAsJudgeSimple) {
+    return Result.error(
+      new BadRequestError('You cannot eject this evaluation type'),
+    )
+  }
+
+  const workspace = await unsafelyFindWorkspace(evaluation.workspaceId)
+  if (!workspace) return Result.error(new NotFoundError('Workspace not found'))
+
+  const promptResult = await getEvaluationPrompt({
+    workspace,
+    evaluation,
+  })
+  if (promptResult.error) return promptResult
+
+  return Transaction.call(async (tx) => {
+    const metadatas = await tx
+      .insert(evaluationMetadataLlmAsJudgeAdvanced)
+      .values([{ prompt: promptResult.value }])
+      .returning()
+    const metadata = metadatas[0]!
+
+    const updateResult = await tx
+      .update(evaluations)
+      .set({
+        metadataType: EvaluationMetadataType.LlmAsJudgeAdvanced,
+        metadataId: metadata.id,
+      })
+      .where(eq(evaluations.id, evaluation.id))
+      .returning()
+    const updatedEvaluation = updateResult[0]!
+
+    const table = configurationTables[evaluation.resultType]
+    const resultConfigurations = await tx
+      .select()
+      .from(table)
+      .where(eq(table.id, evaluation.resultConfigurationId!))
+    const resultConfiguration = resultConfigurations[0]!
+
+    await tx
+      .delete(evaluationMetadataLlmAsJudgeSimple)
+      .where(eq(evaluationMetadataLlmAsJudgeSimple.id, evaluation.metadataId!))
+
+    return Result.ok({
+      ...updatedEvaluation,
+      metadata,
+      resultConfiguration,
+    } as unknown as EvaluationDto)
+  }, db)
+}

--- a/packages/web-ui/src/ds/atoms/Alert/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Alert/index.tsx
@@ -35,6 +35,7 @@ export function Alert({
     <AlertRoot variant={variant}>
       {showIcon && (
         <Icon
+          className='mt-0.5' // To align with the Title leading
           name='alert'
           color={variant ? IconColor[variant] || 'foreground' : 'foreground'}
         />


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/632079b8-5cf3-4eae-9c85-96c3cd484149)
![image](https://github.com/user-attachments/assets/9a73a5b1-37e2-4a70-a417-de4fd2ce6665)


- Implement `ejectEvaluationAction` to handle the ejection of evaluations to advanced mode.
- Create `ejectEvaluation` service to manage the ejection process, including updating metadata and result configurations.
- Add unit tests for `ejectEvaluationAction` to ensure proper handling of authorized and unauthorized scenarios.
- Refactor evaluation editors to use a common `EvaluationEditorLayout` component for consistent UI and functionality.
- Introduce `useProviderModel` hook to manage provider and model selection logic across different evaluation editors.

This change allows users to convert simple evaluations into advanced evaluations with custom prompts, enhancing the flexibility and customization of the evaluation process.