### PR TITLE
Order project list by edited at

### DIFF
--- a/apps/web/src/app/(private)/_data-access/index.ts
+++ b/apps/web/src/app/(private)/_data-access/index.ts
@@ -30,8 +30,7 @@ export const getFirstProjectCached = cache(
 export const getActiveProjectsCached = cache(
   async ({ workspaceId }: { workspaceId: number }) => {
     const projectsScope = new ProjectsRepository(workspaceId)
-    const result =
-      await projectsScope.findAllActiveDocumentsWithAgreggatedData()
+    const result = await projectsScope.findAllActiveWithAgreggatedData()
     const projects = result.unwrap()
 
     return projects

--- a/apps/web/src/app/(private)/dashboard/_components/ProjectsTable/index.tsx
+++ b/apps/web/src/app/(private)/dashboard/_components/ProjectsTable/index.tsx
@@ -17,8 +17,7 @@ import { ROUTES } from '$/services/routes'
 import Link from 'next/link'
 
 type ProjectWithAgreggatedData = Project & {
-  documentCount: number
-  lastCreatedAtDocument: Date | null
+  lastEditedAt: Date | null
 }
 export function ProjectsTable({
   projects,
@@ -31,7 +30,6 @@ export function ProjectsTable({
       <TableHeader>
         <TableRow verticalPadding>
           <TableHead>Name</TableHead>
-          <TableHead>Prompts</TableHead>
           <TableHead>Edited</TableHead>
           <TableHead>Created</TableHead>
           <TableHead />
@@ -52,12 +50,7 @@ export function ProjectsTable({
             </TableCell>
             <TableCell>
               <Text.H5 color='foregroundMuted'>
-                {project.documentCount || '-'}
-              </Text.H5>
-            </TableCell>
-            <TableCell>
-              <Text.H5 color='foregroundMuted'>
-                {relativeTime(project.lastCreatedAtDocument)}
+                {relativeTime(project.lastEditedAt)}
               </Text.H5>
             </TableCell>
             <TableCell>

--- a/packages/core/src/repositories/projectsRepository.ts
+++ b/packages/core/src/repositories/projectsRepository.ts
@@ -1,4 +1,4 @@
-import { desc, eq, getTableColumns, isNull, max, sql } from 'drizzle-orm'
+import { and, desc, eq, getTableColumns, isNull, max, sql } from 'drizzle-orm'
 
 import { Project } from '../browser'
 import { NotFoundError, Result } from '../lib'
@@ -58,8 +58,8 @@ export class ProjectsRepository extends RepositoryLegacy<typeof tt, Project> {
         })
         .from(this.scope)
         .innerJoin(commits, eq(commits.projectId, this.scope.id))
-        .where(isNull(this.scope.deletedAt))
         .innerJoin(documentVersions, eq(documentVersions.commitId, commits.id))
+        .where(and(isNull(this.scope.deletedAt), isNull(commits.deletedAt)))
         .groupBy(this.scope.id),
     )
 
@@ -76,6 +76,7 @@ export class ProjectsRepository extends RepositoryLegacy<typeof tt, Project> {
         desc(
           sql`COALESCE(${aggredatedData.lastEditedAt}, ${this.scope.createdAt})`,
         ),
+        desc(this.scope.id),
       )
 
     return Result.ok(result)

--- a/packages/core/src/tests/factories/documents.ts
+++ b/packages/core/src/tests/factories/documents.ts
@@ -1,8 +1,9 @@
 import { and, eq } from 'drizzle-orm'
 
-import { User, Workspace, type Commit } from '../../browser'
+import { DocumentVersion, User, Workspace, type Commit } from '../../browser'
 import { database } from '../../client'
 import { documentVersions } from '../../schema'
+import { destroyDocument } from '../../services/documents'
 import { createNewDocument } from '../../services/documents/create'
 import { updateDocument } from '../../services/documents/update'
 
@@ -30,6 +31,7 @@ export async function markAsSoftDelete(
 
 export async function createDocumentVersion(
   data: IDocumentVersionData & { workspace: Workspace; user: User },
+  tx = database,
 ) {
   let result = await createNewDocument({
     workspace: data.workspace,
@@ -47,7 +49,80 @@ export async function createDocumentVersion(
     })
   }
 
-  const documentVersion = result.unwrap()
+  // Fetch created or updated document from db because createNewDocument and
+  // updateDocument perform 2 updates but return the state of the first one
+  const document = (
+    await tx
+      .select()
+      .from(documentVersions)
+      .where(
+        and(
+          eq(documentVersions.documentUuid, result.unwrap().documentUuid),
+          eq(documentVersions.commitId, data.commit.id),
+        ),
+      )
+  )[0]!
 
-  return { documentVersion }
+  return { documentVersion: document }
+}
+
+export async function updateDocumentVersion(
+  {
+    document,
+    commit,
+    path,
+    content,
+  }: {
+    document: DocumentVersion
+    commit: Commit
+    path?: string
+    content?: string
+  },
+  tx = database,
+) {
+  await updateDocument({
+    commit,
+    document,
+    path,
+    content,
+  }).then((result) => result.unwrap())
+
+  // Fetch updated document from db because updateDocument performs
+  // 2 updates but returns the state of the first one
+  const updatedDocument = (
+    await tx
+      .select()
+      .from(documentVersions)
+      .where(
+        and(
+          eq(documentVersions.documentUuid, document.documentUuid),
+          eq(documentVersions.commitId, commit.id),
+        ),
+      )
+  )[0]!
+
+  return updatedDocument
+}
+
+export async function destroyDocumentVersion(
+  { document, commit }: { document: DocumentVersion; commit: Commit },
+  tx = database,
+) {
+  await destroyDocument({ document, commit }).then((result) => result.unwrap())
+
+  // Fetch destroyed document from db because destroyDocument does
+  // not return it. Note, it can be undefined when hard deleted
+  const destroyedDocument = (
+    await tx
+      .select()
+      .from(documentVersions)
+      .where(
+        and(
+          eq(documentVersions.documentUuid, document.documentUuid),
+          eq(documentVersions.commitId, commit.id),
+        ),
+      )
+  )[0]
+
+  return destroyedDocument
 }


### PR DESCRIPTION
Closes:  https://github.com/latitude-dev/latitude-llm/issues/607

This feature orders the project list shown in the main dashboard by a computed project edited at descendingly. It also removes the prompt count, because (as discussed) it is not important, and the value shown is not consistent with the actual number of prompts the user sees in its draft (and it is difficult to compute because we would have to traverse all the commits to know).