### PR TITLE
Redirect to log correct page in paginated logs list

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
@@ -61,7 +61,7 @@ export function HistoryLogParams({
       <div className='flex flex-row gap-x-4 justify-between items-center border-border border-b pb-4'>
         {data.isLoading || hasLogs ? (
           <>
-            <div className='flex-grow'>
+            <div className='flex flex-grow min-w-0'>
               {data.isLoadingLog ? (
                 <div className='flex flex-row gap-x-2 w-full'>
                   <Skeleton height='h3' className='w-2/3' />
@@ -69,38 +69,41 @@ export function HistoryLogParams({
                 </div>
               ) : null}
               {!data.isLoadingLog && urlData ? (
-                <Link href={urlData.url}>
-                  <div className='flex flex-row items-center gap-x-2'>
-                    <Text.H5>{urlData.createdAt}</Text.H5>
-                    {urlData.hasError ? (
-                      <Tooltip
-                        variant='destructive'
-                        trigger={
-                          <Badge variant='destructive'>
-                            {urlData.shortCode}
-                          </Badge>
-                        }
-                      >
-                        This log has an error
-                      </Tooltip>
-                    ) : (
-                      <Badge variant='accent'>{urlData.shortCode}</Badge>
-                    )}
-                    <Icon name='externalLink' color='foregroundMuted' />
-                  </div>
+                <Link
+                  href={urlData.url}
+                  className='flex-grow min-w-0 flex flex-row items-center gap-x-2'
+                >
+                  <Text.H5 ellipsis noWrap>
+                    {urlData.createdAt}
+                  </Text.H5>
+                  {urlData.hasError ? (
+                    <Tooltip
+                      variant='destructive'
+                      trigger={
+                        <Badge variant='destructive'>{urlData.shortCode}</Badge>
+                      }
+                    >
+                      This log has an error
+                    </Tooltip>
+                  ) : (
+                    <Badge variant='accent'>{urlData.shortCode}</Badge>
+                  )}
+                  <Icon
+                    name='externalLink'
+                    color='foregroundMuted'
+                    className='flex-none'
+                  />
                 </Link>
               ) : null}
             </div>
-            <div>
-              <ParametersPaginationNav
-                disabled={data.isLoadingLog}
-                label='history logs'
-                currentIndex={data.position}
-                totalCount={data.count}
-                onPrevPage={data.onPrevPage}
-                onNextPage={data.onNextPage}
-              />
-            </div>
+            <ParametersPaginationNav
+              disabled={data.isLoadingLog}
+              label='history logs'
+              currentIndex={data.position}
+              totalCount={data.count}
+              onPrevPage={data.onPrevPage}
+              onNextPage={data.onNextPage}
+            />
           </>
         ) : (
           <div className='w-full flex justify-center'>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/useLogHistoryParams.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/useLogHistoryParams.ts
@@ -98,11 +98,16 @@ export function useLogHistoryParams({
     },
   })
 
-  const updatePosition = useCallback((position: number) => {
-    setPosition((prev) =>
-      prev ? { ...prev, position } : { position, page: 1 },
-    )
-  }, [])
+  const updatePosition = useCallback(
+    (position: number) => {
+      if (isLoadingLog) return
+
+      setPosition((prev) =>
+        prev ? { ...prev, position } : { position, page: 1 },
+      )
+    },
+    [isLoadingLog],
+  )
 
   const onNextPage = useCallback(
     (position: number) => updatePosition(position + 1),

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/PaginationNav/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/PaginationNav/index.tsx
@@ -21,7 +21,7 @@ export function ParametersPaginationNav({
   if (currentIndex === undefined || totalCount === undefined) return null
 
   return (
-    <div className='flex items-center'>
+    <div className='flex items-center min-w-0'>
       <Button
         size='default'
         variant='ghost'
@@ -31,13 +31,10 @@ export function ParametersPaginationNav({
         }}
         onClick={() => onPrevPage(currentIndex)}
       />
-      <div className='flex flex-row items-center gap-x-1'>
-        <Text.H5M color='foregroundMuted'>
-          {zeroIndex ? currentIndex + INDEX_ZERO_LIST : currentIndex}
-        </Text.H5M>
-        <div className='max-w-14' />
-        <Text.H5M color='foregroundMuted'>
-          of {totalCount} {label}
+      <div className='flex flex-row justify-center items-center flex-grow min-w-0'>
+        <Text.H5M color='foregroundMuted' ellipsis noWrap>
+          {zeroIndex ? currentIndex + INDEX_ZERO_LIST : currentIndex} of{' '}
+          {totalCount} {label}
         </Text.H5M>
       </div>
       <Button

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -17,6 +17,7 @@ import {
   Button,
   DocumentTextEditor,
   DocumentTextEditorFallback,
+  SplitPane,
   Text,
   useCurrentCommit,
   useCurrentProject,
@@ -244,53 +245,64 @@ export default function DocumentEditor({
           addMessagesAction: addMessagesAction as AddMessagesActionFn,
         }}
       >
-        <div className='flex flex-row w-full h-full gap-8 p-6'>
-          <div className='flex flex-col flex-1 flex-grow flex-shrink gap-2 min-w-0'>
-            <EditorHeader
-              providers={providers}
-              disabledMetadataSelectors={isMerged}
-              title='Prompt editor'
-              metadata={metadata}
-              prompt={value}
-              onChangePrompt={onChange}
-              freeRunsCount={freeRunsCount}
-              showCopilotSetting
-            />
-            <Suspense fallback={<DocumentTextEditorFallback />}>
-              <DocumentTextEditor
-                value={value}
-                metadata={metadata}
-                onChange={onChange}
-                diff={diff}
-                readOnlyMessage={
-                  isMerged ? 'Create a draft to edit documents.' : undefined
-                }
-                isSaved={isSaved}
-                actionButtons={
-                  <Button
-                    className='bg-background'
-                    variant='outline'
-                    size='small'
-                    iconProps={{
-                      name: 'sparkles',
-                      size: 'small',
+        <SplitPane
+          className='p-6'
+          initialPercentage={55}
+          minWidth={300}
+          leftPane={
+            <SplitPane.Pane>
+              <div className='pr-4 flex flex-col flex-1 flex-grow flex-shrink gap-2 min-w-0'>
+                <EditorHeader
+                  providers={providers}
+                  disabledMetadataSelectors={isMerged}
+                  title='Prompt editor'
+                  metadata={metadata}
+                  prompt={value}
+                  onChangePrompt={onChange}
+                  freeRunsCount={freeRunsCount}
+                  showCopilotSetting
+                />
+                <Suspense fallback={<DocumentTextEditorFallback />}>
+                  <DocumentTextEditor
+                    value={value}
+                    metadata={metadata}
+                    onChange={onChange}
+                    diff={diff}
+                    readOnlyMessage={
+                      isMerged ? 'Create a draft to edit documents.' : undefined
+                    }
+                    isSaved={isSaved}
+                    actionButtons={
+                      <Button
+                        className='bg-background'
+                        variant='outline'
+                        size='small'
+                        iconProps={{
+                          name: 'sparkles',
+                          size: 'small',
+                        }}
+                        onClick={() => setRefineDocumentModalOpen(true)}
+                      >
+                        <Text.H6>Refine</Text.H6>
+                      </Button>
+                    }
+                    copilot={{
+                      isLoading: isCopilotLoading,
+                      requestSuggestion,
                     }}
-                    onClick={() => setRefineDocumentModalOpen(true)}
-                  >
-                    <Text.H6>Refine</Text.H6>
-                  </Button>
-                }
-                copilot={{
-                  isLoading: isCopilotLoading,
-                  requestSuggestion,
-                }}
-              />
-            </Suspense>
-          </div>
-          <div className='flex-1 relative'>
-            <Playground document={document} metadata={metadata!} />
-          </div>
-        </div>
+                  />
+                </Suspense>
+              </div>
+            </SplitPane.Pane>
+          }
+          rightPane={
+            <SplitPane.Pane>
+              <div className='pl-4 flex-1 relative max-h-full'>
+                <Playground document={document} metadata={metadata!} />
+              </div>
+            </SplitPane.Pane>
+          }
+        />
       </DocumentEditorContext.Provider>
     </>
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogBlankSlate/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogBlankSlate/index.tsx
@@ -1,0 +1,61 @@
+import { Commit } from '@latitude-data/core/browser'
+import { Button, Text } from '@latitude-data/web-ui'
+import { getDocumentByUuidCached } from '$/app/(private)/_data-access'
+import { ROUTES } from '$/services/routes'
+import Link from 'next/link'
+
+import { DocumentBlankSlateLayout } from '../../../../../_components/DocumentBlankSlateLayout'
+import { DocumentsClient } from '../../../../../_components/DocumentsClient'
+
+export async function DocumentLogBlankSlate({
+  commit,
+  projectId,
+  documentUuid,
+}: {
+  commit: Commit
+  documentUuid: string
+  projectId: number
+}) {
+  const document = await getDocumentByUuidCached({
+    documentUuid,
+    projectId,
+    commitUuid: commit.uuid,
+  })
+  return (
+    <DocumentBlankSlateLayout>
+      <div className='flex flex-col gap-4 items-center'>
+        <Text.H5>
+          To get started, please choose one of the following options:
+        </Text.H5>
+      </div>
+      <Link
+        href={
+          ROUTES.projects
+            .detail({ id: projectId })
+            .commits.detail({ uuid: commit.uuid })
+            .documents.detail({ uuid: documentUuid }).logs.upload
+        }
+      >
+        <Button fullWidth variant='outline'>
+          <div className='flex flex-col gap-1 p-4'>
+            <Text.H4M>Import logs from UI</Text.H4M>
+            <Text.H5 color='foregroundMuted'>
+              If you run prompts outside of Latitude, you can upload your logs
+              in order to evaluate them.
+            </Text.H5>
+          </div>
+        </Button>
+      </Link>
+      <Text.H5 color='foregroundMuted'>Or</Text.H5>
+      <div className='p-6 bg-background border rounded-lg flex flex-col gap-4 max-w-3xl'>
+        <Text.H4M>Import logs from code</Text.H4M>
+        <Text.H5 color='foregroundMuted'>
+          Run this code snippet to start importing logs into Latitude. Once
+          done, come back to this page, and you'll be able to evaluate both
+          existing and incoming logs.
+        </Text.H5>
+        <DocumentsClient document={document} />
+      </div>
+    </DocumentBlankSlateLayout>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { DocumentLogWithMetadataAndError } from '@latitude-data/core/repositories'
 import {
@@ -13,9 +13,7 @@ import {
   EventArgs,
   useSockets,
 } from '$/components/Providers/WebsocketsProvider/useSockets'
-import { useGenerateDocumentLogDetailUrl } from '$/hooks/useGenerateDocumentLogDetailUrl'
 import useDocumentLogs, { documentLogPresenter } from '$/stores/documentLogs'
-import useDocumentLogWithPaginationPosition from '$/stores/documentLogWithPaginationPosition'
 import useProviderLogs from '$/stores/providerLogs'
 import { useSearchParams } from 'next/navigation'
 
@@ -68,48 +66,12 @@ const useDocumentLogSocket = (
   useSockets({ event: 'documentLogCreated', onMessage })
 }
 
-/**
- * When this page receive ?logUuid=some-uuid it can happen 2 things
- *
- *   1. The `page=NUMBER` is correct and `selectedLog` is there.
- *   2. There is no `page` param or is incorrect `selectedLog` is not there.
- *
- * We handle (2) here by looking the right page for the `logUuid` in the URL
- */
-function useRedirectToLogDetail({
-  selectedLog,
-  documentLogUuid,
-}: {
-  selectedLog: DocumentLogWithMetadataAndError | undefined
-  documentLogUuid: string | undefined
-}) {
-  const mounted = useRef(false)
-  const { data: position, isLoading } = useDocumentLogWithPaginationPosition({
-    documentLogUuid: selectedLog ? undefined : documentLogUuid,
-  })
-  const { url } = useGenerateDocumentLogDetailUrl({
-    documentLogUuid,
-    page: position?.page,
-  })
-  useEffect(() => {
-    if (selectedLog) return
-    if (mounted.current) return
-    if (isLoading || !url) return
-
-    mounted.current = true
-
-    window.location.href = url
-  }, [url, isLoading, selectedLog])
-}
-
 export function DocumentLogs({
   documentLogs: serverDocumentLogs,
   selectedLog: serverSelectedLog,
-  documentLogUuid,
 }: {
   documentLogs: DocumentLogWithMetadataAndError[]
   selectedLog: DocumentLogWithMetadataAndError | undefined
-  documentLogUuid: string | undefined
 }) {
   const tableRef = useRef<HTMLTableElement>(null)
   const sidebarWrapperRef = useRef<HTMLDivElement>(null)
@@ -140,7 +102,6 @@ export function DocumentLogs({
   )
 
   useDocumentLogSocket(document.documentUuid, mutate)
-  useRedirectToLogDetail({ selectedLog, documentLogUuid })
 
   if (!documentLogs.length) {
     return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/page.tsx
@@ -1,17 +1,38 @@
+import { Commit, Workspace } from '@latitude-data/core/browser'
 import { QueryParams } from '@latitude-data/core/lib/pagination/buildPaginatedUrl'
 import { computeDocumentLogsWithMetadataQuery } from '@latitude-data/core/services/documentLogs/computeDocumentLogsWithMetadata'
-import { Button, TableWithHeader, Text } from '@latitude-data/web-ui'
-import {
-  findCommitCached,
-  getDocumentByUuidCached,
-} from '$/app/(private)/_data-access'
+import { fetchDocumentLogWithPosition } from '@latitude-data/core/services/documentLogs/fetchDocumentLogWithPosition'
+import { Button, TableWithHeader } from '@latitude-data/web-ui'
+import { findCommitCached } from '$/app/(private)/_data-access'
+import { DocumentLogBlankSlate } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogBlankSlate'
 import { getCurrentUser } from '$/services/auth/getCurrentUser'
 import { ROUTES } from '$/services/routes'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 
-import { DocumentBlankSlateLayout } from '../../_components/DocumentBlankSlateLayout'
-import { DocumentsClient } from '../../_components/DocumentsClient'
 import { DocumentLogs } from './_components/DocumentLogs'
+
+async function fetchDocumentLogPage({
+  workspace,
+  commit: _c, // TODO: Add when other PRs are merged
+  documentLogUuid,
+}: {
+  commit: Commit
+  workspace: Workspace
+  documentLogUuid: string | undefined
+}) {
+  if (!documentLogUuid) return undefined
+
+  const result = await fetchDocumentLogWithPosition({
+    workspace,
+    // commit, TODO: Add when other PRs are merged
+    documentLogUuid,
+  })
+
+  if (result.error) return undefined
+
+  return result.value.page.toString()
+}
 
 export default async function DocumentPage({
   params,
@@ -23,71 +44,48 @@ export default async function DocumentPage({
   const { workspace } = await getCurrentUser()
   const projectId = Number(params.projectId)
   const commitUuid = params.commitUuid
+  const documentUuid = params.documentUuid
   const commit = await findCommitCached({ projectId, uuid: commitUuid })
+  const documentLogUuid = searchParams.logUuid?.toString()
+  const page = searchParams.page?.toString?.()
+  const currentLogPage = await fetchDocumentLogPage({
+    workspace,
+    commit,
+    documentLogUuid,
+  })
+
+  if (currentLogPage && currentLogPage !== page) {
+    const route = ROUTES.projects
+      .detail({ id: projectId })
+      .commits.detail({ uuid: commit.uuid })
+      .documents.detail({ uuid: documentUuid }).logs.root
+    return redirect(
+      `${route}?page=${currentLogPage}&logUuid=${documentLogUuid}`,
+    )
+  }
+
   const rows = await computeDocumentLogsWithMetadataQuery({
     workspaceId: workspace.id,
     documentUuid: params.documentUuid,
     draft: commit,
-    page: searchParams.page as string | undefined,
+    page,
     pageSize: searchParams.pageSize as string | undefined,
   })
-  const documentLogUuid = searchParams.logUuid?.toString()
-  const selectedLog = rows.find((r) => r.uuid === documentLogUuid)
-  const document = await getDocumentByUuidCached({
-    documentUuid: params.documentUuid,
-    projectId,
-    commitUuid,
-  })
 
+  const selectedLog = rows.find((r) => r.uuid === documentLogUuid)
   return (
     <div className='flex flex-grow min-h-0 flex-col w-full p-6 gap-2 min-w-0'>
-      {!rows.length && (
-        <DocumentBlankSlateLayout>
-          <div className='flex flex-col gap-4 items-center'>
-            <Text.H5>
-              To get started, please choose one of the following options:
-            </Text.H5>
-          </div>
-          <Link
-            href={
-              ROUTES.projects
-                .detail({ id: projectId })
-                .commits.detail({ uuid: params.commitUuid })
-                .documents.detail({ uuid: params.documentUuid }).logs.upload
-            }
-          >
-            <Button fullWidth variant='outline'>
-              <div className='flex flex-col gap-1 p-4'>
-                <Text.H4M>Import logs from UI</Text.H4M>
-                <Text.H5 color='foregroundMuted'>
-                  If you run prompts outside of Latitude, you can upload your
-                  logs in order to evaluate them.
-                </Text.H5>
-              </div>
-            </Button>
-          </Link>
-          <Text.H5 color='foregroundMuted'>Or</Text.H5>
-          <div className='p-6 bg-background border rounded-lg flex flex-col gap-4 max-w-3xl'>
-            <Text.H4M>Import logs from code</Text.H4M>
-            <Text.H5 color='foregroundMuted'>
-              Run this code snippet to start importing logs into Latitude. Once
-              done, come back to this page, and you'll be able to evaluate both
-              existing and incoming logs.
-            </Text.H5>
-            <DocumentsClient document={document} />
-          </div>
-        </DocumentBlankSlateLayout>
-      )}
-      {rows.length && (
+      {!rows.length ? (
+        <DocumentLogBlankSlate
+          commit={commit}
+          projectId={projectId}
+          documentUuid={documentUuid}
+        />
+      ) : null}
+      {rows.length ? (
         <TableWithHeader
           title='Logs'
-          table={
-            <DocumentLogs
-              documentLogs={rows}
-              documentLogUuid={documentLogUuid}
-              selectedLog={selectedLog}
-            />
-          }
+          table={<DocumentLogs documentLogs={rows} selectedLog={selectedLog} />}
           actions={
             <Link
               href={
@@ -103,7 +101,7 @@ export default async function DocumentPage({
             </Link>
           }
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/web-ui/src/ds/atoms/SplitPane/index.tsx
+++ b/packages/web-ui/src/ds/atoms/SplitPane/index.tsx
@@ -12,6 +12,7 @@ import {
 
 import { ResizableBox, ResizeCallbackData, ResizeHandle } from 'react-resizable'
 
+import { useMeasure } from '../../../browser'
 import { cn } from '../../../lib/utils'
 
 const JS_PANEL_CLASS = 'js-pane'
@@ -88,7 +89,7 @@ function ResizablePane({
   children: ReactNode
   paneWidth: number
   onResizePane: (width: number) => void
-  onResizeStop: (width: number) => void
+  onResizeStop?: (width: number) => void
 }) {
   const onResize = (_: SyntheticEvent, data: ResizeCallbackData) => {
     const lessThanMinWidth = minWidth ? data.size.width < minWidth : false
@@ -100,7 +101,7 @@ function ResizablePane({
   }
   const onStop = useCallback(
     (_e: SyntheticEvent, data: ResizeCallbackData) => {
-      onResizeStop(data.size.width)
+      onResizeStop?.(data.size.width)
     },
     [onResizeStop],
   )
@@ -125,20 +126,40 @@ function HorizontalSplit({
   leftPane,
   rightPane,
   initialWidth,
+  initialPercentage,
   minWidth,
   onResizeStop,
   cssPanelHeight,
+  className,
 }: {
   leftPane: ReactNode
   rightPane: ReactNode
-  initialWidth: number
+  initialWidth?: number
+  initialPercentage?: number
   minWidth: number
-  onResizeStop: (width: number) => void
+  onResizeStop?: (width: number) => void
   cssPanelHeight?: string
+  className?: string
 }) {
-  const [paneWidth, setPaneWidth] = useState<number>(initialWidth)
+  const [ref, { width: initialWidthFromRef }] = useMeasure<HTMLDivElement>()
+  const [paneWidth, setPaneWidth] = useState<number>(initialWidth ?? 0)
+  useEffect(() => {
+    if (paneWidth > 0) return
+
+    if (!initialPercentage) return
+
+    const percentage = initialPercentage / 100
+    setPaneWidth(initialWidthFromRef * percentage)
+  }, [initialWidth, initialWidthFromRef, initialPercentage])
+
   return (
-    <div className='flex flex-row w-full relative h-full max-h-full min-h-full'>
+    <div
+      ref={ref}
+      className={cn(
+        'flex flex-row w-full relative h-full max-h-full min-h-full',
+        className,
+      )}
+    >
       <ResizablePane
         minWidth={minWidth}
         paneWidth={paneWidth}
@@ -158,23 +179,29 @@ const SplitPane = ({
   leftPane,
   rightPane,
   initialWidth,
+  initialPercentage,
   minWidth,
   onResizeStop,
   cssPanelHeight,
+  className,
 }: {
   leftPane: ReactNode
   rightPane: ReactNode
-  initialWidth: number
+  initialWidth?: number
+  initialPercentage?: number
   minWidth: number
-  onResizeStop: (width: number) => void
+  onResizeStop?: (width: number) => void
   cssPanelHeight?: string
+  className?: string
 }) => {
   return (
     <HorizontalSplit
+      className={className}
       cssPanelHeight={cssPanelHeight}
       leftPane={leftPane}
       rightPane={rightPane}
       initialWidth={initialWidth}
+      initialPercentage={initialPercentage}
       minWidth={minWidth}
       onResizeStop={onResizeStop}
     />


### PR DESCRIPTION
# What?
We were doing a shitty version of this in the client with a useEffect and I realize that we have a backend. So I just moved to it. Also: Make the playground resizable and avoid requesting a log when one is in flight

## TODO
- [x] Redirect to log detail and correct `page` if `?logUuid=some-uuid` is found
- [x] Enable resize of document editor and playground