### PR TITLE
Properly fix web api by respecting request/response argument on NextJS API handlers

### DIFF
--- a/apps/web/src/app/api/apiKeys/route.ts
+++ b/apps/web/src/app/api/apiKeys/route.ts
@@ -1,23 +1,13 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { ApiKeysRepository } from '@latitude-data/core/repositories/apiKeysRepository'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        workspace,
-      }: {
-        workspace: Workspace
-      },
-    ) => {
-      const apiKeysScope = new ApiKeysRepository(workspace.id)
-      const rows = await apiKeysScope.findAll().then((r) => r.unwrap())
+  authHandler(async (_req: NextRequest, _res: NextResponse, { workspace }) => {
+    const apiKeysScope = new ApiKeysRepository(workspace.id)
+    const rows = await apiKeysScope.findAll().then((r) => r.unwrap())
 
-      return NextResponse.json(rows, { status: 200 })
-    },
-  ),
+    return NextResponse.json(rows, { status: 200 })
+  }),
 )

--- a/apps/web/src/app/api/claimedRewards/route.ts
+++ b/apps/web/src/app/api/claimedRewards/route.ts
@@ -1,24 +1,14 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { ClaimedRewardsRepository } from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        workspace,
-      }: {
-        workspace: Workspace
-      },
-    ) => {
-      const claimedRewardsScope = new ClaimedRewardsRepository(workspace.id)
-      const result = await claimedRewardsScope.findAllValidOptimistic()
-      const rows = result.unwrap()
+  authHandler(async (_req: NextRequest, _res: NextResponse, { workspace }) => {
+    const claimedRewardsScope = new ClaimedRewardsRepository(workspace.id)
+    const result = await claimedRewardsScope.findAllValidOptimistic()
+    const rows = result.unwrap()
 
-      return NextResponse.json(rows, { status: 200 })
-    },
-  ),
+    return NextResponse.json(rows, { status: 200 })
+  }),
 )

--- a/apps/web/src/app/api/datasets/[datasetId]/preview/route.ts
+++ b/apps/web/src/app/api/datasets/[datasetId]/preview/route.ts
@@ -1,22 +1,17 @@
-import { Workspace } from '@latitude-data/core/browser'
+import { Ok } from '@latitude-data/core/lib/Result'
 import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { previewDataset } from '@latitude-data/core/services/datasets/preview'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: { datasetId: number }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = { datasetId: string }
+type ResponseResult = Awaited<ReturnType<typeof previewDataset>>
+type PreviewResponse = ResponseResult extends Ok<infer T> ? T : never
+
+export const GET = errorHandler<IParam, PreviewResponse>(
+  authHandler<IParam, PreviewResponse>(
+    async (_req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { datasetId } = params
       const repo = new DatasetsRepository(workspace.id)
       const dataset = await repo.find(datasetId).then((r) => r.unwrap())

--- a/apps/web/src/app/api/datasets/route.ts
+++ b/apps/web/src/app/api/datasets/route.ts
@@ -1,23 +1,13 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        workspace,
-      }: {
-        workspace: Workspace
-      },
-    ) => {
-      const scope = new DatasetsRepository(workspace.id)
-      const rows = await scope.findAll().then((r) => r.unwrap())
+  authHandler(async (_req: NextRequest, _res: NextResponse, { workspace }) => {
+    const scope = new DatasetsRepository(workspace.id)
+    const rows = await scope.findAll().then((r) => r.unwrap())
 
-      return NextResponse.json(rows, { status: 200 })
-    },
-  ),
+    return NextResponse.json(rows, { status: 200 })
+  }),
 )

--- a/apps/web/src/app/api/documentLogs/[id]/route.ts
+++ b/apps/web/src/app/api/documentLogs/[id]/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 type Params = { id: string }
 export const GET = errorHandler<Params, DocumentLogWithMetadataAndError>(
   authHandler<Params, DocumentLogWithMetadataAndError>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const id = params.id
       const log = await fetchDocumentLogWithMetadata({
         workspaceId: workspace.id,

--- a/apps/web/src/app/api/documentLogs/uuids/[uuid]/route.ts
+++ b/apps/web/src/app/api/documentLogs/uuids/[uuid]/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 type IParam = { uuid: string }
 export const GET = errorHandler<IParam, DocumentLogWithMetadataAndError>(
   authHandler<IParam, DocumentLogWithMetadataAndError>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const uuid = params.uuid
       const log = await fetchDocumentLogWithMetadata({
         workspaceId: workspace.id,

--- a/apps/web/src/app/api/evaluations/[evaluationId]/connected-documents/route.ts
+++ b/apps/web/src/app/api/evaluations/[evaluationId]/connected-documents/route.ts
@@ -1,33 +1,26 @@
-import { Workspace } from '@latitude-data/core/browser'
-import { ConnectedEvaluationsRepository } from '@latitude-data/core/repositories'
+import {
+  ConnectedDocumentWithMetadata,
+  ConnectedEvaluationsRepository,
+} from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = { evaluationId: string }
+
+export const GET = errorHandler<IParam, ConnectedDocumentWithMetadata[]>(
+  authHandler<IParam, ConnectedDocumentWithMetadata[]>(
+    async (_req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId } = params
       const connectedEvaluationsScope = new ConnectedEvaluationsRepository(
         workspace.id,
       )
-      const connectedDocuments =
+      const result =
         await connectedEvaluationsScope.getConnectedDocumentsWithMetadata(
-          evaluationId,
+          Number(evaluationId),
         )
-
-      return NextResponse.json(connectedDocuments.unwrap(), { status: 200 })
+      const data = result.unwrap()
+      return NextResponse.json(data, { status: 200 })
     },
   ),
 )

--- a/apps/web/src/app/api/evaluations/route.ts
+++ b/apps/web/src/app/api/evaluations/route.ts
@@ -1,26 +1,16 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        workspace,
-      }: {
-        workspace: Workspace
-      },
-    ) => {
-      const documentUuid = req.nextUrl.searchParams.get('documentUuid')
-      const evaluationsScope = new EvaluationsRepository(workspace.id)
-      const result = documentUuid
-        ? await evaluationsScope.findByDocumentUuid(documentUuid)
-        : await evaluationsScope.findAll()
+  authHandler(async (req: NextRequest, _res: NextResponse, { workspace }) => {
+    const documentUuid = req.nextUrl.searchParams.get('documentUuid')
+    const evaluationsScope = new EvaluationsRepository(workspace.id)
+    const result = documentUuid
+      ? await evaluationsScope.findByDocumentUuid(documentUuid)
+      : await evaluationsScope.findAll()
 
-      return NextResponse.json(result.unwrap(), { status: 200 })
-    },
-  ),
+    return NextResponse.json(result.unwrap(), { status: 200 })
+  }),
 )

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/[documentLogUuid]/position/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/[documentLogUuid]/position/route.ts
@@ -12,7 +12,7 @@ type Position = ResponseResult extends Ok<infer T> ? T : never
 
 export const GET = errorHandler<IParam, Position>(
   authHandler<IParam, Position>(
-    async (req: NextRequest, { params, workspace }) => {
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId, commitUuid, documentLogUuid } = params
       const commitsScope = new CommitsRepository(workspace.id)
       const searchParams = req.nextUrl.searchParams

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/aggregations/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/aggregations/route.ts
@@ -1,26 +1,20 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { computeDocumentLogsAggregations } from '@latitude-data/core/services/documentLogs/computeDocumentLogsAggregations'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          projectId: string
-          commitUuid: string
-          documentUuid: string
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  projectId: string
+  commitUuid: string
+  documentUuid: string
+}
+type ResponseResult = Awaited<
+  ReturnType<typeof computeDocumentLogsAggregations>
+>
+export const GET = errorHandler<IParam, ResponseResult>(
+  authHandler<IParam, ResponseResult>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId, commitUuid, documentUuid } = params
       const commitsScope = new CommitsRepository(workspace.id)
       const commit = await commitsScope

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/daily-count/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/daily-count/route.ts
@@ -1,26 +1,15 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { computeDocumentLogsDailyCount } from '@latitude-data/core/services/documentLogs/computeDocumentLogsDailyCount'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          projectId: string
-          commitUuid: string
-          documentUuid: string
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = { projectId: string; commitUuid: string; documentUuid: string }
+type ResponseResult = Awaited<ReturnType<typeof computeDocumentLogsDailyCount>>
+
+export const GET = errorHandler<IParam, ResponseResult>(
+  authHandler<IParam, ResponseResult>(
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId, commitUuid, documentUuid } = params
       const searchParams = req.nextUrl.searchParams
       const days = searchParams.get('days')

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/pagination/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/pagination/route.ts
@@ -27,7 +27,7 @@ type IParam = {
 type IPagination = ReturnType<typeof buildPagination>
 export const GET = errorHandler<IParam, IPagination>(
   authHandler<IParam, IPagination>(
-    async (req: NextRequest, { params, workspace }) => {
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const searchParams = req.nextUrl.searchParams
       const commitsScope = new CommitsRepository(workspace.id)
       const excludeErrors = searchParams.get('excludeErrors') === 'true'

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/route.test.ts
@@ -10,10 +10,12 @@ import {
 } from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
 import { createRunError } from '@latitude-data/core/services/runErrors/create'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GET } from './route'
+import { GET, type ResponseResult } from './route'
+
+type GetResponse = NextResponse<ResponseResult<true>>
 
 const mocks = vi.hoisted(() => {
   return {
@@ -29,6 +31,7 @@ describe('GET logs', () => {
   let commit: Commit
   let document: DocumentVersion
   let workspace: WorkspaceDto
+  let mockResponse: GetResponse = {} as unknown as GetResponse
   let mockRequest: NextRequest
   let user: User
 
@@ -69,7 +72,7 @@ describe('GET logs', () => {
 
   describe('unauthorized', () => {
     it('should return 401 if user is not authenticated', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         workspace,
       } as any)
 
@@ -87,7 +90,7 @@ describe('GET logs', () => {
     })
 
     it('should return all logs', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: String(project.id),
           commitUuid: commit.uuid,
@@ -112,7 +115,7 @@ describe('GET logs', () => {
 
     it('should should not fail with page=0', async () => {
       mockRequest = new NextRequest('http://localhost:3000?page=0')
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: String(project.id),
           commitUuid: commit.uuid,
@@ -145,7 +148,7 @@ describe('GET logs', () => {
         commit: commit2,
       })
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: String(project.id),
           commitUuid: commit.uuid,
@@ -162,7 +165,7 @@ describe('GET logs', () => {
 
     it('should exclude logs with errors', async () => {
       mockRequest = new NextRequest('http://localhost:3000?excludeErrors=true')
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: String(project.id),
           commitUuid: commit.uuid,

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/documentLogs/route.ts
@@ -21,7 +21,7 @@ function parsePage(page: string | null): string {
   return parsed < 1 ? '1' : parsed.toString()
 }
 
-type ResponseResult<T extends boolean> = T extends true
+export type ResponseResult<T extends boolean> = T extends true
   ? DocumentLogWithMetadataAndError[]
   : DocumentLog[]
 
@@ -33,7 +33,7 @@ type IParams = {
 
 export const GET = errorHandler<IParams, ResponseResult<boolean>>(
   authHandler<IParams, ResponseResult<boolean>>(
-    async (req: NextRequest, { params, workspace }) => {
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId, commitUuid, documentUuid } = params
       const searchParams = req.nextUrl.searchParams
       const excludeErrors = searchParams.get('excludeErrors') === 'true'

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/average-and-cost/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/average-and-cost/route.ts
@@ -1,30 +1,26 @@
-import { Workspace } from '@latitude-data/core/browser'
+import { ExtractOk } from '@latitude-data/core/lib/Result'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { computeAverageResultAndCostOverCommit } from '@latitude-data/core/services/evaluationResults/index'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-          page: string | null
-          pageSize: string | null
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: number
+  documentUuid: string
+  commitUuid: string
+  projectId: number
+  page: string | null
+  pageSize: string | null
+}
+type ResponseResult = Awaited<
+  ReturnType<typeof computeAverageResultAndCostOverCommit>
+>
+type AverageResultAndCost = ExtractOk<ResponseResult>
+
+export const GET = errorHandler<IParam, AverageResultAndCost>(
+  authHandler<IParam, AverageResultAndCost>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId, documentUuid } = params
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const evaluation = await evaluationScope

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/average/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/average/route.ts
@@ -1,30 +1,24 @@
-import { Workspace } from '@latitude-data/core/browser'
+import { ExtractOk } from '@latitude-data/core/lib/Result'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { computeAverageResultOverTime } from '@latitude-data/core/services/evaluationResults/index'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-          page: string | null
-          pageSize: string | null
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: number
+  documentUuid: string
+  commitUuid: string
+  projectId: number
+  page: string | null
+  pageSize: string | null
+}
+type ResponseResult = Awaited<ReturnType<typeof computeAverageResultOverTime>>
+type AverageResultOverTime = ExtractOk<ResponseResult>
+
+export const GET = errorHandler<IParam, AverageResultOverTime>(
+  authHandler<IParam, AverageResultOverTime>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId, documentUuid } = params
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const evaluation = await evaluationScope

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/counters/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/counters/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   EvaluationsRepository,
@@ -8,26 +7,19 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-          page: string | null
-          pageSize: string | null
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: number
+  documentUuid: string
+  commitUuid: string
+  projectId: number
+  page: string | null
+  pageSize: string | null
+}
+type EvaluationTotals = Awaited<ReturnType<typeof getEvaluationTotalsQuery>>
+
+export const GET = errorHandler<IParam, EvaluationTotals>(
+  authHandler<IParam, EvaluationTotals>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId, projectId, commitUuid, documentUuid } = params
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const commitsScope = new CommitsRepository(workspace.id)

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/mean/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/mean/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   EvaluationsRepository,
@@ -8,26 +7,20 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-          page: string | null
-          pageSize: string | null
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: string
+  documentUuid: string
+  commitUuid: string
+  projectId: string
+  page: string | null
+  pageSize: string | null
+}
+
+type ResponseResult = Awaited<ReturnType<typeof getEvaluationMeanValueQuery>>
+
+export const GET = errorHandler<IParam, ResponseResult>(
+  authHandler<IParam, ResponseResult>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId, documentUuid } = params
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const commitsScope = new CommitsRepository(workspace.id)

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/modal/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/modal/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   EvaluationsRepository,
@@ -8,26 +7,18 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-          page: string | null
-          pageSize: string | null
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: number
+  documentUuid: string
+  commitUuid: string
+  projectId: number
+  page: string | null
+  pageSize: string | null
+}
+type ResponseResult = Awaited<ReturnType<typeof getEvaluationModalValueQuery>>
+export const GET = errorHandler<IParam, ResponseResult>(
+  authHandler<IParam, ResponseResult>(
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { evaluationId, projectId, commitUuid, documentUuid } = params
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const commitsScope = new CommitsRepository(workspace.id)

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/pagination/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/pagination/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { buildPagination } from '@latitude-data/core/lib/pagination/buildPagination'
 import {
   CommitsRepository,
@@ -23,24 +22,17 @@ function pageUrl(params: {
     .evaluations.detail(Number(params.evaluationId)).root
 }
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: string
+  documentUuid: string
+  commitUuid: string
+  projectId: string
+}
+
+type IPagination = ReturnType<typeof buildPagination>
+export const GET = errorHandler<IParam, IPagination>(
+  authHandler<IParam, IPagination>(
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const searchParams = req.nextUrl.searchParams
       const evaluationsScope = new EvaluationsRepository(workspace.id)
       const evaluation = await evaluationsScope
@@ -50,7 +42,7 @@ export const GET = errorHandler(
       const commit = await commitsScope
         .getCommitByUuid({
           uuid: params.commitUuid,
-          projectId: params.projectId,
+          projectId: Number(params.projectId),
         })
         .then((r) => r.unwrap())
       const countResult = await computeEvaluationResultsWithMetadataCount({

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/evaluation-results/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   EvaluationsRepository,
@@ -8,24 +7,16 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: string
+  documentUuid: string
+  commitUuid: string
+  projectId: string
+}
+type IResult = Awaited<ReturnType<typeof computeEvaluationResultsWithMetadata>>
+export const GET = errorHandler<IParam, IResult>(
+  authHandler<IParam, IResult>(
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { documentUuid, commitUuid, evaluationId, projectId } = params
 
       const searchParams = req.nextUrl.searchParams
@@ -34,10 +25,10 @@ export const GET = errorHandler(
       const commitsScope = new CommitsRepository(workspace.id)
       const evaluationScope = new EvaluationsRepository(workspace.id)
       const evaluation = await evaluationScope
-        .find(evaluationId)
+        .find(Number(evaluationId))
         .then((r) => r.unwrap())
       const commit = await commitsScope
-        .getCommitByUuid({ projectId, uuid: commitUuid })
+        .getCommitByUuid({ projectId: Number(projectId), uuid: commitUuid })
         .then((r) => r.unwrap())
 
       const rows = await computeEvaluationResultsWithMetadata({

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/logs/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/logs/route.ts
@@ -1,4 +1,3 @@
-import { Workspace } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   EvaluationsRepository,
@@ -8,23 +7,19 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          evaluationId: number
-          documentUuid: string
-          commitUuid: string
-          projectId: number
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  evaluationId: string
+  documentUuid: string
+  commitUuid: string
+  projectId: string
+}
+type IResult = Awaited<
+  ReturnType<typeof fetchDocumentLogsWithEvaluationResults>
+>
+
+export const GET = errorHandler<IParam, IResult>(
+  authHandler<IParam, IResult>(
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const searchParams = new URL(req.url).searchParams
       const page = searchParams.get('page') ?? '1'
       const pageSize = searchParams.get('pageSize') ?? '25'

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/route.test.ts
@@ -1,4 +1,8 @@
-import { Providers, User } from '@latitude-data/core/browser'
+import {
+  ConnectedEvaluation,
+  Providers,
+  User,
+} from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
 import { Result } from '@latitude-data/core/lib/Result'
 import { ConnectedEvaluationsRepository } from '@latitude-data/core/repositories'
@@ -6,6 +10,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { GET } from './route'
+
+type Response = NextResponse<ConnectedEvaluation[]>
 
 vi.mock('@latitude-data/core/repositories', async (importOriginal) => {
   const original = await importOriginal()
@@ -23,6 +29,7 @@ describe('GET /api/documents/[projectId]/[commitUuid]/[documentUuid]/evaluations
   let workspace: any
   let documents: any
   let mockEvaluations: any
+  let mockResponse: Response = {} as Response
 
   beforeEach(async () => {
     vi.resetAllMocks()
@@ -72,7 +79,7 @@ describe('GET /api/documents/[projectId]/[commitUuid]/[documentUuid]/evaluations
     const request = new NextRequest(
       'http://localhost/api/documents/test-project/test-commit/test-document-uuid/evaluations',
     )
-    const response = await GET(request, {
+    const response = await GET(request, mockResponse, {
       params: { documentUuid: documents[0]?.documentUuid },
       user: { id: 'test-user-id' } as unknown as User,
       workspace,
@@ -106,7 +113,7 @@ describe('GET /api/documents/[projectId]/[commitUuid]/[documentUuid]/evaluations
     const request = new NextRequest(
       'http://localhost/api/documents/test-project/test-commit/test-document-uuid/evaluations',
     )
-    const response = await GET(request, {
+    const response = await GET(request, mockResponse, {
       params: { documentUuid: documents[0]!.documentUuid },
       user: { id: 'test-user-id' } as unknown as User,
       workspace,

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 type IParam = { documentUuid: string }
 export const GET = errorHandler<IParam, ConnectedEvaluation[]>(
   authHandler<IParam, ConnectedEvaluation[]>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { documentUuid } = params
       const scope = new ConnectedEvaluationsRepository(workspace.id)
       const connectedEvaluations = await scope

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/route.ts
@@ -1,4 +1,4 @@
-import { DocumentVersion, Workspace } from '@latitude-data/core/browser'
+import { DocumentVersion } from '@latitude-data/core/browser'
 import {
   CommitsRepository,
   DocumentVersionsRepository,
@@ -7,25 +7,14 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-type IParam = { projectId: number; commitUuid: string }
+type IParam = { projectId: string; commitUuid: string }
+
 export const GET = errorHandler<IParam, DocumentVersion[]>(
   authHandler<IParam, DocumentVersion[]>(
-    async (
-      _: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          projectId: number
-          commitUuid: string
-        }
-        workspace: Workspace
-      },
-    ) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId, commitUuid } = params
       const commit = await new CommitsRepository(workspace.id)
-        .getCommitByUuid({ uuid: commitUuid, projectId })
+        .getCommitByUuid({ uuid: commitUuid, projectId: Number(projectId) })
         .then((r) => r.unwrap())
       const docsScope = new DocumentVersionsRepository(workspace.id)
       const result = await docsScope.getDocumentsAtCommit(commit)

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/route.ts
@@ -13,7 +13,7 @@ import { NextRequest, NextResponse } from 'next/server'
 type IParam = { projectId: string; commitUuid: string }
 export const GET = errorHandler<IParam, DocumentVersion[]>(
   authHandler<IParam, DocumentVersion[]>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const projectId = params.projectId
       const commitUuid = params.commitUuid
 

--- a/apps/web/src/app/api/projects/[projectId]/commits/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/route.test.ts
@@ -1,9 +1,11 @@
 import { CommitStatus, User, Workspace } from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GET } from './route'
+import { GET, IResult } from './route'
+
+type Response = NextResponse<IResult>
 
 const mocks = vi.hoisted(() => {
   return {
@@ -16,6 +18,7 @@ vi.mock('$/services/auth/getSession', () => ({
 
 describe('GET handler for commits', () => {
   let mockRequest: NextRequest
+  let mockResponse: Response = {} as Response
   let mockWorkspace: Workspace
   let mockUser: User
 
@@ -34,7 +37,7 @@ describe('GET handler for commits', () => {
     it('should return 401 if user is not authenticated', async () => {
       mocks.getSession.mockReturnValue(null)
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: { projectId: '1', status: CommitStatus.Draft },
         workspace: mockWorkspace,
       } as any)
@@ -53,7 +56,7 @@ describe('GET handler for commits', () => {
     })
 
     it('should return 404 when project is not found', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: { projectId: '999', status: CommitStatus.Draft },
         workspace: mockWorkspace,
       } as any)
@@ -74,7 +77,7 @@ describe('GET handler for commits', () => {
         workspace: otherWorkspace,
       })
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: project.id.toString(),
           status: CommitStatus.Draft,
@@ -99,7 +102,7 @@ describe('GET handler for commits', () => {
         user: mockUser,
       })
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {
           projectId: project.id.toString(),
           status: CommitStatus.Draft,

--- a/apps/web/src/app/api/projects/[projectId]/commits/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/route.ts
@@ -1,7 +1,6 @@
 import {
   CommitStatus,
   ULTRA_LARGE_PAGE_SIZE,
-  Workspace,
 } from '@latitude-data/core/browser'
 import {
   BadRequestError,
@@ -16,24 +15,19 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-// FIXME: Use generic types. Check other routes for examples.
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        params,
-        workspace,
-      }: {
-        params: {
-          projectId: number
-          page?: number
-          pageSize?: number
-        }
-        workspace: Workspace
-      },
-    ) => {
+type IParam = {
+  projectId: number
+  page?: number
+  pageSize?: number
+}
+export type IResult = Awaited<
+  ReturnType<typeof CommitsRepository.prototype.getCommitsByProjectQuery>
+>
+export const GET = errorHandler<IParam, IResult>(
+  authHandler<IParam, IResult>(
+    async (req: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId } = params
+
       if (!projectId) {
         throw new BadRequestError('Project ID is required')
       }

--- a/apps/web/src/app/api/projects/[projectId]/documents-for-import/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/documents-for-import/route.test.ts
@@ -5,11 +5,13 @@ import {
   WorkspaceDto,
 } from '@latitude-data/core/browser'
 import { createProject, helpers } from '@latitude-data/core/factories'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { SubscriptionPlan } from 'node_modules/@latitude-data/core/src/plans'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GET } from './route'
+import { DocumentsImported, GET } from './route'
+
+type Response = NextResponse<DocumentsImported>
 
 const mocks = vi.hoisted(() => {
   return {
@@ -23,6 +25,7 @@ vi.mock('$/services/auth/getSession', () => ({
 describe('GET handler for documents/[projectId]/for-import', () => {
   let mockRequest: NextRequest
   let mockParams: { projectId: string }
+  let mockedResponse: Response = {} as Response
   let mockWorkspace: WorkspaceDto
   let mockDocuments: DocumentVersion[]
   let user: User
@@ -60,7 +63,7 @@ describe('GET handler for documents/[projectId]/for-import', () => {
 
   describe('unauthorized', () => {
     it('should return 401 if user is not authenticated', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockedResponse, {
         params: mockParams,
         workspace: mockWorkspace,
         user: {
@@ -88,7 +91,7 @@ describe('GET handler for documents/[projectId]/for-import', () => {
     })
 
     it('should return 400 if projectId is missing', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockedResponse, {
         params: {},
         workspace: mockWorkspace,
         user,
@@ -102,7 +105,7 @@ describe('GET handler for documents/[projectId]/for-import', () => {
     })
 
     it('should return documents for import when valid params are provided', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockedResponse, {
         params: mockParams,
         user,
         workspace: mockWorkspace,

--- a/apps/web/src/app/api/projects/[projectId]/documents-for-import/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/documents-for-import/route.ts
@@ -1,5 +1,5 @@
 import { BadRequestError } from '@latitude-data/core/lib/errors'
-import { Ok } from '@latitude-data/core/lib/Result'
+import { ExtractOk } from '@latitude-data/core/lib/Result'
 import { DocumentVersionsRepository } from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
@@ -10,11 +10,11 @@ type IParam = { projectId?: string }
 type ResponseResult = Awaited<
   ReturnType<typeof DocumentVersionsRepository.prototype.getDocumentsForImport>
 >
-type DocumentsImported = ResponseResult extends Ok<infer T> ? T : never
+export type DocumentsImported = ExtractOk<ResponseResult>
 
 export const GET = errorHandler<IParam, DocumentsImported>(
   authHandler<IParam, DocumentsImported>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { projectId } = params
 
       if (!projectId) {

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,13 +1,16 @@
+import { Project } from '@latitude-data/core/browser'
 import { ProjectsRepository } from '@latitude-data/core/repositories'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(async (_: NextRequest, { workspace }) => {
-    const scope = new ProjectsRepository(workspace.id)
-    const projects = await scope.findAllActive().then((r) => r.unwrap())
+export const GET = errorHandler<{}, Project[]>(
+  authHandler<{}, Project[]>(
+    async (_: NextRequest, _res: NextResponse, { workspace }) => {
+      const scope = new ProjectsRepository(workspace.id)
+      const projects = await scope.findAllActive().then((r) => r.unwrap())
 
-    return NextResponse.json(projects, { status: 200 })
-  }),
+      return NextResponse.json(projects, { status: 200 })
+    },
+  ),
 )

--- a/apps/web/src/app/api/providerApiKeys/fetch.test.ts
+++ b/apps/web/src/app/api/providerApiKeys/fetch.test.ts
@@ -1,10 +1,17 @@
-import { Providers, User, Workspace } from '@latitude-data/core/browser'
+import {
+  ProviderApiKey,
+  Providers,
+  User,
+  Workspace,
+} from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
 import { createProviderApiKey } from '@latitude-data/core/services/providerApiKeys/create'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { GET } from './route'
+
+type Response = NextResponse<ProviderApiKey[]>
 
 const mocks = vi.hoisted(() => {
   return {
@@ -17,6 +24,7 @@ vi.mock('$/services/auth/getSession', () => ({
 
 describe('GET handler for provider API keys', () => {
   let mockRequest: NextRequest
+  let mockResponse: Response = {} as Response
   let mockWorkspace: Workspace
   let mockUser: User
 
@@ -33,7 +41,7 @@ describe('GET handler for provider API keys', () => {
     it('should return 401 if user is not authenticated', async () => {
       mocks.getSession.mockReturnValue(null)
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         workspace: mockWorkspace,
       } as any)
 
@@ -51,7 +59,7 @@ describe('GET handler for provider API keys', () => {
     })
 
     it('should return empty array when no provider API keys exist', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         workspace: mockWorkspace,
       } as any)
 
@@ -69,7 +77,7 @@ describe('GET handler for provider API keys', () => {
         name: 'foo',
       })
 
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         workspace: mockWorkspace,
       } as any)
 

--- a/apps/web/src/app/api/providerApiKeys/route.ts
+++ b/apps/web/src/app/api/providerApiKeys/route.ts
@@ -5,7 +5,7 @@ import providerApiKeyPresenter from '$/presenters/providerApiKeyPresenter'
 import { NextRequest, NextResponse } from 'next/server'
 
 export const GET = errorHandler(
-  authHandler(async (_: NextRequest, { workspace }) => {
+  authHandler(async (_: NextRequest, _res: NextResponse, { workspace }) => {
     const providerApiKeysScope = new ProviderApiKeysRepository(workspace.id)
     const rows = await providerApiKeysScope
       .findAll()

--- a/apps/web/src/app/api/providerLogs/[providerLogId]/route.ts
+++ b/apps/web/src/app/api/providerLogs/[providerLogId]/route.ts
@@ -6,10 +6,11 @@ import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 type IParam = { providerLogId: string }
-type ReturnResponse = ReturnType<typeof providerLogPresenter>
+type ReturnResponse = ReturnType<typeof serializeProviderLog>
+
 export const GET = errorHandler<IParam, ReturnResponse>(
   authHandler<IParam, ReturnResponse>(
-    async (_: NextRequest, { params, workspace }) => {
+    async (_: NextRequest, _res: NextResponse, { params, workspace }) => {
       const { providerLogId } = params
 
       if (!providerLogId) {

--- a/apps/web/src/app/api/providerLogs/route.ts
+++ b/apps/web/src/app/api/providerLogs/route.ts
@@ -1,20 +1,14 @@
-import { Workspace } from '@latitude-data/core/browser'
 import { ProviderLogsRepository } from '@latitude-data/core/repositories'
 import serializeProviderLog from '@latitude-data/core/services/providerLogs/serialize'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
-  authHandler(
-    async (
-      req: NextRequest,
-      {
-        workspace,
-      }: {
-        workspace: Workspace
-      },
-    ) => {
+type IResult = ReturnType<typeof serializeProviderLog>
+
+export const GET = errorHandler<{}, IResult[]>(
+  authHandler<{}, IResult[]>(
+    async (req: NextRequest, _res: NextResponse, { workspace }) => {
       const searchParams = req.nextUrl.searchParams
       const documentUuid = searchParams.get('documentUuid')
       const documentLogUuid = searchParams.get('documentLogUuid')

--- a/apps/web/src/app/api/users/route.test.ts
+++ b/apps/web/src/app/api/users/route.test.ts
@@ -1,10 +1,11 @@
 import { User, WorkspaceDto } from '@latitude-data/core/browser'
 import { createWorkspace } from '@latitude-data/core/factories'
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { GET } from './route'
 
+type Response = NextResponse<User[]>
 const mocks = vi.hoisted(() => {
   return {
     getSession: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock('$/services/auth/getSession', () => ({
 
 describe('GET handler for users', () => {
   let mockRequest: NextRequest
+  let mockResponse: Response = {} as Response
   let mockWorkspace: WorkspaceDto
   let mockUser: User
 
@@ -30,7 +32,7 @@ describe('GET handler for users', () => {
 
   describe('unauthorized', () => {
     it('should return 401 if user is not authenticated', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         workspace: mockWorkspace,
       } as any)
 
@@ -48,7 +50,7 @@ describe('GET handler for users', () => {
     })
 
     it('should return all users when authenticated', async () => {
-      const response = await GET(mockRequest, {
+      const response = await GET(mockRequest, mockResponse, {
         params: {},
         workspace: mockWorkspace,
         user: mockUser,

--- a/apps/web/src/app/api/users/route.ts
+++ b/apps/web/src/app/api/users/route.ts
@@ -6,10 +6,12 @@ import { NextRequest, NextResponse } from 'next/server'
 
 type IParams = {}
 export const GET = errorHandler<IParams, User[]>(
-  authHandler<IParams, User[]>(async (_: NextRequest, { workspace }) => {
-    const usersScope = new UsersRepository(workspace.id)
-    const rows = await usersScope.findAll().then((r) => r.unwrap())
+  authHandler<IParams, User[]>(
+    async (_: NextRequest, _res: NextResponse, { workspace }) => {
+      const usersScope = new UsersRepository(workspace.id)
+      const rows = await usersScope.findAll().then((r) => r.unwrap())
 
-    return NextResponse.json(rows, { status: 200 })
-  }),
+      return NextResponse.json(rows, { status: 200 })
+    },
+  ),
 )

--- a/apps/web/src/app/api/workspaces/current/route.ts
+++ b/apps/web/src/app/api/workspaces/current/route.ts
@@ -5,7 +5,9 @@ import { NextRequest, NextResponse } from 'next/server'
 
 type IParam = {}
 export const GET = errorHandler<IParam, WorkspaceDto>(
-  authHandler<IParam, WorkspaceDto>(async (_: NextRequest, { workspace }) => {
-    return NextResponse.json(workspace, { status: 200 })
-  }),
+  authHandler<IParam, WorkspaceDto>(
+    async (_: NextRequest, _res: NextResponse, { workspace }) => {
+      return NextResponse.json(workspace, { status: 200 })
+    },
+  ),
 )

--- a/apps/web/src/app/api/workspaces/usage/route.ts
+++ b/apps/web/src/app/api/workspaces/usage/route.ts
@@ -7,9 +7,12 @@ import { NextRequest, NextResponse } from 'next/server'
 type IParam = {}
 
 export const GET = errorHandler<IParam, WorkspaceUsage>(
-  authHandler<IParam, WorkspaceUsage>(async (_: NextRequest, { workspace }) => {
-    const usage = await computeWorkspaceUsage(workspace).then((r) => r.unwrap())
-
-    return NextResponse.json(usage, { status: 200 })
-  }),
+  authHandler<IParam, WorkspaceUsage>(
+    async (_: NextRequest, _res: NextResponse, { workspace }) => {
+      const usage = await computeWorkspaceUsage(workspace).then((r) =>
+        r.unwrap(),
+      )
+      return NextResponse.json(usage, { status: 200 })
+    },
+  ),
 )

--- a/apps/web/src/middlewares/errorHandler.ts
+++ b/apps/web/src/middlewares/errorHandler.ts
@@ -3,20 +3,20 @@ import { debuglog } from 'util'
 import { LatitudeError } from '@latitude-data/core/lib/errors'
 import env from '$/env'
 import { captureException } from '$/helpers/captureException'
-import {
-  AuthContext,
-  DefaultParams,
-  HandlerFn,
-} from '$/middlewares/authHandler'
+import { Context, DefaultParams, HandlerFn } from '$/middlewares/authHandler'
 import { NextRequest, NextResponse } from 'next/server'
 
 export function errorHandler<
   IReq extends DefaultParams,
   IResp extends object = {},
 >(handler: HandlerFn<IReq, IResp>) {
-  return async (req: NextRequest, context: AuthContext<IReq>) => {
+  return async (
+    req: NextRequest,
+    res: NextResponse<IResp>,
+    context: Context<IReq>,
+  ) => {
     try {
-      return await handler(req, context)
+      return await handler(req, res, context)
     } catch (error) {
       if (env.NODE_ENV === 'development') {
         debuglog((error as Error).message)

--- a/packages/core/src/lib/Result.ts
+++ b/packages/core/src/lib/Result.ts
@@ -15,6 +15,7 @@ export class Ok<V> {
     return true
   }
 }
+export type ExtractOk<T> = T extends Ok<infer V> ? V : never
 
 export class ErrorResult<E extends Error> {
   public readonly value: undefined = undefined


### PR DESCRIPTION
# ⚠️ DO NOT MERGE
This is not the right approach 

---
# What?
This PR is open for [reverting the types in web api](https://github.com/latitude-dev/latitude-llm/pull/645) but is a shame. So I took a look and I think the error was that when building nextjs app it didn't recognize our NextJS API handlers as valid

What I did was to take the second argument of the handler to pass the context (user, workspace)
But this is wrong:

❌ Wrong:
```javascript
const GET =  (req: NextRequest, context: LatitudeAPIContext) => Promise<NextResponse>
```

What nextjs expect is req/res

✅ Ok:
```javascript
const GET =  (req: NextRequest, res: NextResponse, context: LatitudeAPIContext) => Promise<NextResponse>
```

## What was the problem?
NextJS's build when deploying was failing. 

Now I did this:
```bash
docker compose --profile building build web
```

And it finishes 🎉 Successfully 
![image](https://github.com/user-attachments/assets/34ebfafa-e717-4cf4-b230-8f5ac88c5604)

