### PR TITLE
Fixes LATITUDE-LLM-APP-8A ?

### DIFF
--- a/apps/web/src/app/(private)/datasets/preview/[datasetId]/page.tsx
+++ b/apps/web/src/app/(private)/datasets/preview/[datasetId]/page.tsx
@@ -14,6 +14,9 @@ export async function generateMetadata(
   },
   parent: ResolvingMetadata,
 ) {
+  // Wait for parent metadata to resolve to ensure auth middleware is executed
+  const parentMetadata = await parent
+
   const { datasetId } = await params
 
   try {
@@ -21,7 +24,7 @@ export async function generateMetadata(
 
     return buildMetatags({
       title: `${dataset.name} (preview)`,
-      parent: await parent,
+      parent: parentMetadata,
     })
   } catch (error) {
     if (error instanceof NotFoundError) return notFound()

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/layout.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/layout.tsx
@@ -14,6 +14,9 @@ export async function generateMetadata(
   },
   parent: ResolvingMetadata,
 ) {
+  // Wait for parent metadata to resolve to ensure auth middleware is executed
+  const parentMetadata = await parent
+
   const { evaluationUuid } = await params
 
   try {
@@ -21,7 +24,7 @@ export async function generateMetadata(
 
     return buildMetatags({
       title: evaluation.name,
-      parent: await parent,
+      parent: parentMetadata,
     })
   } catch (error) {
     if (error instanceof NotFoundError) return notFound()

--- a/apps/web/src/app/(private)/projects/[projectId]/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/layout.tsx
@@ -15,6 +15,9 @@ export async function generateMetadata(
   },
   parent: ResolvingMetadata,
 ) {
+  // Wait for parent metadata to resolve to ensure auth middleware is executed
+  const parentMetadata = await parent
+
   const { projectId } = await params
 
   try {
@@ -26,7 +29,7 @@ export async function generateMetadata(
 
     return buildMetatags({
       title: project.name,
-      parent: await parent,
+      parent: parentMetadata,
     })
   } catch (error) {
     if (error instanceof NotFoundError) return notFound()


### PR DESCRIPTION
I don't know how the related sentry error is possible. If the user is not authenticated should have been redirected before going into the project.

I am not sure if this fix fixes anything, I don't know if when generating metadata the middleware executes or not. If it is not synchronous the metadata from the parent could be resolved and then go into the child metadata resolution without waiting for the middleware.

Let's try.