### PR TITLE
Latitude PromptL implementation

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -22,7 +22,7 @@
     "@latitude-data/constants": "workspace:^",
     "@latitude-data/core": "workspace:^",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/promptl": "^0.0.3",
+    "@latitude-data/promptl": "^0.1.0",
     "@sentry/cli": "^2.37.0",
     "@sentry/node": "^8.30.0",
     "@t3-oss/env-core": "^0.10.1",

--- a/apps/gateway/src/presenters/documentPresenter.ts
+++ b/apps/gateway/src/presenters/documentPresenter.ts
@@ -1,10 +1,15 @@
 import { readMetadata } from '@latitude-data/compiler'
 import { DocumentVersion } from '@latitude-data/core/browser'
+import { scan } from '@latitude-data/promptl'
 
 export async function documentPresenter(document: DocumentVersion) {
   let metadata
   try {
-    metadata = await readMetadata({ prompt: document.content })
+    if (document.promptlVersion === 0) {
+      metadata = await readMetadata({ prompt: document.content })
+    } else {
+      metadata = await scan({ prompt: document.content })
+    }
   } catch (err) {
     // do nothing, prompt could have invalid content
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "@latitude-data/compiler": "workspace:^",
     "@latitude-data/core": "workspace:*",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/promptl": "^0.0.3",
+    "@latitude-data/promptl": "^0.1.0",
     "@latitude-data/sdk": "workspace:*",
     "@latitude-data/web-ui": "workspace:*",
     "@lucia-auth/adapter-drizzle": "^1.0.7",

--- a/apps/web/src/actions/documents/runDocumentInBatchAction.ts
+++ b/apps/web/src/actions/documents/runDocumentInBatchAction.ts
@@ -4,6 +4,7 @@ import { readMetadata } from '@latitude-data/compiler'
 import { publisher } from '@latitude-data/core/events/publisher'
 import { setupJobs } from '@latitude-data/core/jobs'
 import { CommitsRepository } from '@latitude-data/core/repositories'
+import { scan } from '@latitude-data/promptl'
 import { z } from 'zod'
 
 import {
@@ -22,10 +23,14 @@ export const runDocumentInBatchAction = withDataset
         .record(z.number().optional())
         .optional()
         .superRefine(async (parameters = {}, refineCtx) => {
-          const metadata = await readMetadata({
-            prompt: ctx.document.content ?? '',
-            fullPath: ctx.document.path,
-          })
+          const metadata =
+            ctx.document.promptlVersion === 0
+              ? await readMetadata({
+                  prompt: ctx.document.content,
+                })
+              : await scan({
+                  prompt: ctx.document.content,
+                })
           const docParams = metadata.parameters
           const headers = ctx.dataset.fileMetadata.headers
           const paramKeys = Object.keys(parameters)

--- a/apps/web/src/actions/evaluations/runBatch.ts
+++ b/apps/web/src/actions/evaluations/runBatch.ts
@@ -4,6 +4,7 @@ import { readMetadata } from '@latitude-data/compiler'
 import { publisher } from '@latitude-data/core/events/publisher'
 import { setupJobs } from '@latitude-data/core/jobs'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
+import { scan } from '@latitude-data/promptl'
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
 
@@ -24,10 +25,10 @@ export const runBatchEvaluationAction = withDataset
         .record(z.number().optional())
         .optional()
         .superRefine(async (parameters = {}, refineCtx) => {
-          const metadata = await readMetadata({
-            prompt: ctx.document.content ?? '',
-            fullPath: ctx.document.path,
-          })
+          const metadata =
+            ctx.document.promptlVersion === 0
+              ? await readMetadata({ prompt: ctx.document.content })
+              : await scan({ prompt: ctx.document.content })
           const docParams = metadata.parameters
           const headers = ctx.dataset.fileMetadata.headers
           const paramKeys = Object.keys(parameters)

--- a/apps/web/src/actions/prompts/run.ts
+++ b/apps/web/src/actions/prompts/run.ts
@@ -15,16 +15,18 @@ export const runPromptAction = authProcedure
     z.object({
       prompt: z.string(),
       parameters: z.record(z.any()),
+      promptlVersion: z.number(),
     }),
   )
   .handler(async ({ ctx, input }) => {
-    const { prompt, parameters } = input
+    const { prompt, parameters, promptlVersion } = input
     const stream = createStreamableValue()
     try {
       const run = await runPrompt({
         workspace: ctx.workspace,
         source: LogSources.Evaluation,
         prompt,
+        promptlVersion,
         parameters,
         providersMap: await buildProvidersMap({
           workspaceId: ctx.workspace.id,

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/dashboard/_components/EvaluationStats.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/dashboard/_components/EvaluationStats.tsx
@@ -8,6 +8,7 @@ import {
   EvaluationMetadataType,
 } from '@latitude-data/core/browser'
 import { ConnectedDocumentWithMetadata } from '@latitude-data/core/repositories'
+import { scan } from '@latitude-data/promptl'
 import { Skeleton, Text } from '@latitude-data/web-ui'
 import { formatCostInMillicents } from '$/app/_lib/formatUtils'
 import useConnectedDocuments from '$/stores/connectedDocuments'
@@ -38,10 +39,21 @@ export default function EvaluationStats({
 
   useEffect(() => {
     if (evaluation.metadataType === EvaluationMetadataType.LlmAsJudgeAdvanced) {
-      readMetadata({ prompt: evaluation.metadata.prompt }).then((metadata) => {
-        const metadataModel = (metadata.config['model'] as string) ?? 'Unknown'
-        setModel(metadataModel)
-      })
+      if (evaluation.metadata.promptlVersion === 0) {
+        readMetadata({ prompt: evaluation.metadata.prompt }).then(
+          (metadata) => {
+            const metadataModel =
+              (metadata.config['model'] as string) ?? 'Unknown'
+            setModel(metadataModel)
+          },
+        )
+      } else {
+        scan({ prompt: evaluation.metadata.prompt }).then((metadata) => {
+          const metadataModel =
+            (metadata.config['model'] as string) ?? 'Unknown'
+          setModel(metadataModel)
+        })
+      }
     } else if (
       evaluation.metadataType === EvaluationMetadataType.LlmAsJudgeSimple
     ) {

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Advanced/index.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Editor/Advanced/index.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 
 import {
+  EvaluationDto,
   EvaluationMetadataLlmAsJudgeAdvanced,
   EvaluationMetadataType,
   ProviderApiKey,
@@ -17,6 +18,17 @@ import EditorHeader from '$/components/EditorHeader'
 import { useMetadata } from '$/hooks/useMetadata'
 import useEvaluations from '$/stores/evaluations'
 import useProviderApiKeys from '$/stores/providerApiKeys'
+
+const promptlVersion = (evaluation?: EvaluationDto) => {
+  if (
+    evaluation?.metadataType === EvaluationMetadataType.LlmAsJudgeAdvanced &&
+    evaluation?.metadata.promptlVersion !== 0
+  ) {
+    return 0
+  }
+
+  return 1
+}
 
 export default function AdvancedEvaluationEditor({
   evaluationUuid,
@@ -45,6 +57,7 @@ export default function AdvancedEvaluationEditor({
     runReadMetadata({
       prompt: value,
       withParameters: SERIALIZED_DOCUMENT_LOG_FIELDS,
+      promptlVersion: promptlVersion(evaluation),
     })
   }, [providers, runReadMetadata])
 
@@ -67,6 +80,7 @@ export default function AdvancedEvaluationEditor({
       runReadMetadata({
         prompt: value,
         withParameters: SERIALIZED_DOCUMENT_LOG_FIELDS,
+        promptlVersion: promptlVersion(evaluation),
       })
     },
     [setValue, runReadMetadata, providers],

--- a/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Playground/Variables/hooks/useVariablesData.tsx
+++ b/apps/web/src/app/(private)/evaluations/(evaluation)/[evaluationUuid]/editor/_components/Playground/Variables/hooks/useVariablesData.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-import { Config, readMetadata } from '@latitude-data/compiler'
 import { ProviderLogDto } from '@latitude-data/core/browser'
 import {
   formatContext,
@@ -12,25 +11,11 @@ import useDocumentLogWithMetadata from '$/stores/documentLogWithMetadata'
 import { PinnedDocumentation } from '../components/PinnedDocumentation'
 
 export const useVariablesData = (providerLog: ProviderLogDto) => {
-  const [config, setConfig] = useState<Config>()
   const { data: documentLogWithMetadata } = useDocumentLogWithMetadata({
     documentLogUuid: providerLog.documentLogUuid,
   })
   const [isMessagesPinned, setIsMessagesPinned] = useState(false)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-
-  useEffect(() => {
-    const fn = async () => {
-      if (!documentLogWithMetadata) return
-
-      const metadata = await readMetadata({
-        prompt: documentLogWithMetadata!.resolvedContent,
-      })
-      setConfig(metadata.config)
-    }
-
-    fn()
-  }, [documentLogWithMetadata])
 
   const variableSections = [
     {
@@ -83,7 +68,7 @@ export const useVariablesData = (providerLog: ProviderLogDto) => {
     },
     {
       title: 'config',
-      content: config ? JSON.stringify(config, null, 2) : '',
+      content: JSON.stringify(providerLog.config, null, 2),
       tooltip: 'The prompt configuration used to generate the prompt',
       height: '24',
     },

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -172,6 +172,7 @@ export default function DocumentEditor({
       documents: _documents,
       document,
       fullPath: document.path,
+      promptlVersion: document.promptlVersion,
     })
   }, [])
 
@@ -185,6 +186,7 @@ export default function DocumentEditor({
         documents: _documents,
         document,
         fullPath: document.path,
+        promptlVersion: document.promptlVersion,
       })
     },
     [runReadMetadata, document.path],

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentationModal/index.tsx
@@ -11,6 +11,7 @@ import {
 
 import { ConversationMetadata, readMetadata } from '@latitude-data/compiler'
 import { ApiKey } from '@latitude-data/core/browser'
+import { scan } from '@latitude-data/promptl'
 import { Modal } from '@latitude-data/web-ui'
 import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import useDocumentVersions from '$/stores/documentVersions'
@@ -50,11 +51,19 @@ export default function DocumentationModal({
     const doit = async () => {
       if (!document) return
 
-      const metadata = await readMetadata({
-        prompt: document.content ?? '',
-        fullPath: document.path,
-      })
-      setMetadata(metadata)
+      // TODO: Include referenceFn, otherwise it will fail if the prompt contains references
+      const metadata =
+        document.promptlVersion === 0
+          ? await readMetadata({
+              prompt: document.content ?? '',
+              fullPath: document.path,
+            })
+          : await scan({
+              prompt: document.content ?? '',
+              fullPath: document.path,
+            })
+
+      setMetadata(metadata as ConversationMetadata)
     }
 
     doit()

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { ConversationMetadata, readMetadata } from '@latitude-data/compiler'
 import { Dataset, DocumentVersion } from '@latitude-data/core/browser'
+import { scan } from '@latitude-data/promptl'
 import {
   Button,
   CloseTrigger,
@@ -87,11 +88,15 @@ function useRunDocumentInBatchForm({
     const fn = async () => {
       if (!document || !document.content) return
 
-      const metadata = await readMetadata({
-        prompt: document.content,
-      })
+      // TODO: Include referenceFn, otherwise it will fail if the prompt contains references
+      const metadata =
+        document.promptlVersion === 0
+          ? await readMetadata({
+              prompt: document.content,
+            })
+          : await scan({ prompt: document.content })
 
-      setMetadata(metadata)
+      setMetadata(metadata as ConversationMetadata)
 
       // Only choose the dataset if it's not already selected
       const ds = selectedDataset

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
@@ -36,6 +36,7 @@ export default function CreateBatchEvaluationModal({
     runReadMetadata({
       prompt: document.content ?? '',
       fullPath: document.path,
+      promptlVersion: document.promptlVersion,
     })
   }, [])
 

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/layout.tsx
@@ -6,6 +6,7 @@ import {
   EvaluationResultableType,
 } from '@latitude-data/core/browser'
 import { env } from '@latitude-data/env'
+import { scan } from '@latitude-data/promptl'
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -56,9 +57,14 @@ export default async function ConnectedEvaluationLayout({
 
   let provider
   if (evaluation.metadataType == EvaluationMetadataType.LlmAsJudgeAdvanced) {
-    const metadata = await readMetadata({
-      prompt: evaluation.metadata.prompt,
-    })
+    const metadata =
+      evaluation.metadata.promptlVersion === 0
+        ? await readMetadata({
+            prompt: evaluation.metadata.prompt,
+          })
+        : await scan({
+            prompt: evaluation.metadata.prompt,
+          })
 
     if (
       metadata.config.provider &&

--- a/apps/web/src/app/api/evaluations/[evaluationId]/prompt/route.ts
+++ b/apps/web/src/app/api/evaluations/[evaluationId]/prompt/route.ts
@@ -1,0 +1,41 @@
+import { EvaluationMetadataType, Workspace } from '@latitude-data/core/browser'
+import { EvaluationsRepository } from '@latitude-data/core/repositories'
+import { getEvaluationPrompt } from '@latitude-data/core/services/evaluations/index'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      _: NextRequest,
+      {
+        params,
+        workspace,
+      }: {
+        params: {
+          evaluationId: number
+        }
+        workspace: Workspace
+      },
+    ) => {
+      const { evaluationId } = params
+      const evaluationsScope = new EvaluationsRepository(workspace.id)
+      const evaluation = await evaluationsScope
+        .find(evaluationId)
+        .then((r) => r.unwrap())
+
+      if (
+        ![
+          EvaluationMetadataType.LlmAsJudgeAdvanced,
+          EvaluationMetadataType.LlmAsJudgeSimple,
+        ].includes(evaluation.metadataType)
+      ) {
+        throw new Error('Only LLM as judge evaluations are supported')
+      }
+
+      const prompt = await getEvaluationPrompt({ workspace, evaluation })
+      return NextResponse.json(prompt.unwrap(), { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -107,6 +107,9 @@ export const _API_ROUTES = {
       connectedDocuments: {
         root: `/api/evaluations/${id}/connected-documents`,
       },
+      prompt: {
+        root: `/api/evaluations/${id}/prompt`,
+      },
     }),
   },
 }

--- a/apps/web/src/stores/evaluationPrompt.ts
+++ b/apps/web/src/stores/evaluationPrompt.ts
@@ -1,0 +1,26 @@
+import useFetcher from '$/hooks/useFetcher'
+import { ROUTES } from '$/services/routes'
+import useSWR, { SWRConfiguration } from 'swr'
+
+export default function useEvaluationPrompt(
+  {
+    evaluationId,
+  }: {
+    evaluationId: number
+  },
+  opts: SWRConfiguration = {},
+) {
+  const fetcher = useFetcher(
+    ROUTES.api.evaluations.detail(evaluationId).prompt.root,
+  )
+  const { data, ...rest } = useSWR<string>(
+    ['evaluationPrompt', evaluationId],
+    fetcher,
+    opts,
+  )
+
+  return {
+    data,
+    ...rest,
+  }
+}

--- a/apps/web/src/workers/readMetadata.ts
+++ b/apps/web/src/workers/readMetadata.ts
@@ -1,20 +1,26 @@
 import { readMetadata } from '@latitude-data/compiler'
 import { type DocumentVersion } from '@latitude-data/core/browser'
+import { scan } from '@latitude-data/promptl'
 
 export type ReadMetadataWorkerProps = Parameters<typeof readMetadata>[0] & {
+  promptlVersion: number
   document?: DocumentVersion
   documents?: DocumentVersion[]
 }
 
 self.onmessage = async function (event: { data: ReadMetadataWorkerProps }) {
-  const { document, documents, prompt, ...rest } = event.data
+  const { document, documents, prompt, promptlVersion, ...rest } = event.data
 
   const referenceFn = readDocument(document, documents, prompt)
-  const metadata = await readMetadata({
+
+  const props = {
     ...rest,
     prompt,
-    referenceFn: referenceFn ?? undefined,
-  })
+    referenceFn,
+  }
+
+  const metadata =
+    promptlVersion === 0 ? await readMetadata(props) : await scan(props)
 
   const { setConfig: _, errors: errors, ...returnedMetadata } = metadata
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,6 +141,6 @@
     "zod": "^3.23.8"
   },
   "dependencies": {
-    "@latitude-data/promptl": "^0.0.3"
+    "@latitude-data/promptl": "^0.1.0"
   }
 }

--- a/packages/core/src/services/chains/run-errors.test.ts
+++ b/packages/core/src/services/chains/run-errors.test.ts
@@ -99,6 +99,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain: mockChain as Chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -138,6 +139,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain: mockChain as Chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -167,6 +169,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -201,6 +204,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -236,6 +240,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -271,6 +276,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -312,6 +318,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })
@@ -353,6 +360,7 @@ describe('run chain error handling', () => {
       errorableType: ErrorableEntity.DocumentLog,
       workspace,
       chain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
     })

--- a/packages/core/src/services/chains/run.test.ts
+++ b/packages/core/src/services/chains/run.test.ts
@@ -1,7 +1,7 @@
 import {
-  Chain,
   ContentType,
   Conversation,
+  Chain as LegacyChain,
   MessageRole,
 } from '@latitude-data/compiler'
 import { v4 as uuid } from 'uuid'
@@ -22,7 +22,7 @@ vi.mock('@latitude-data/compiler')
 vi.mock('uuid')
 
 describe('runChain', () => {
-  const mockChain: Partial<Chain> = {
+  const mockChain: Partial<LegacyChain> = {
     step: vi.fn(),
     rawText: 'Test raw text',
   }
@@ -83,7 +83,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -155,7 +156,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -229,7 +231,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -271,7 +274,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -347,7 +351,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -437,7 +442,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -493,7 +499,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -564,7 +571,8 @@ describe('runChain', () => {
 
     const run = await runChain({
       workspace,
-      chain: mockChain as Chain,
+      chain: mockChain as LegacyChain,
+      promptlVersion: 0,
       providersMap,
       source: LogSources.API,
       errorableType: ErrorableEntity.DocumentLog,
@@ -634,7 +642,8 @@ describe('runChain', () => {
       })
       const run = await runChain({
         workspace,
-        chain: mockChain as Chain,
+        chain: mockChain as LegacyChain,
+        promptlVersion: 0,
         providersMap,
         source: LogSources.API,
         errorableType: ErrorableEntity.DocumentLog,
@@ -686,7 +695,8 @@ describe('runChain', () => {
 
         const run = await runChain({
           workspace,
-          chain: mockChain as Chain,
+          chain: mockChain as LegacyChain,
+          promptlVersion: 0,
           providersMap,
           source: LogSources.API,
           errorableType: ErrorableEntity.DocumentLog,
@@ -744,7 +754,8 @@ describe('runChain', () => {
 
         const run = await runChain({
           workspace,
-          chain: mockChain as Chain,
+          chain: mockChain as LegacyChain,
+          promptlVersion: 0,
           providersMap,
           source: LogSources.API,
           errorableType: ErrorableEntity.DocumentLog,

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -131,6 +131,7 @@ export async function runDocumentAtCommit({
     errorableType,
     workspace,
     chain: checkerResult.value.chain,
+    promptlVersion: document.promptlVersion,
     providersMap,
     source,
   })

--- a/packages/core/src/services/documents/getResolvedContent.ts
+++ b/packages/core/src/services/documents/getResolvedContent.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 
 import { readMetadata, Document as RefDocument } from '@latitude-data/compiler'
+import { scan } from '@latitude-data/promptl'
 
 import { Commit, DocumentVersion, Workspace } from '../../browser'
 import {
@@ -59,11 +60,18 @@ export async function getResolvedContent({
     }
   }
 
-  const metadata = await readMetadata({
-    prompt: document.content,
-    fullPath: document.path,
-    referenceFn,
-  })
+  const metadata =
+    document.promptlVersion === 0
+      ? await readMetadata({
+          prompt: document.content,
+          fullPath: document.path,
+          referenceFn,
+        })
+      : await scan({
+          prompt: document.content,
+          fullPath: document.path,
+          referenceFn,
+        })
 
   return Result.ok(metadata.resolvedPrompt)
 }

--- a/packages/core/src/services/evaluations/eject.ts
+++ b/packages/core/src/services/evaluations/eject.ts
@@ -34,7 +34,7 @@ export async function ejectEvaluation(
   return Transaction.call(async (tx) => {
     const metadatas = await tx
       .insert(evaluationMetadataLlmAsJudgeAdvanced)
-      .values([{ prompt: promptResult.value }])
+      .values([{ prompt: promptResult.value, promptlVersion: 1 }])
       .returning()
     const metadata = metadatas[0]!
 

--- a/packages/core/src/services/evaluations/prompt/index.test.ts
+++ b/packages/core/src/services/evaluations/prompt/index.test.ts
@@ -1,4 +1,4 @@
-import { readMetadata } from '@latitude-data/compiler'
+import { scan } from '@latitude-data/promptl'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { getEvaluationPrompt } from '.'
@@ -61,7 +61,7 @@ describe('getEvaluationPrompt', () => {
     expect(obtainedPrompt).toBe(evaluation.metadata.prompt)
   })
 
-  it('Creates a compilable prompt for a simple evaluation', async () => {
+  it('Creates a compilable promptl prompt for a simple evaluation', async () => {
     const model = 'custom-model'
 
     const evaluation = await createEvaluation({
@@ -90,7 +90,7 @@ describe('getEvaluationPrompt', () => {
       evaluation,
     }).then((r) => r.unwrap())
 
-    const metadata = await readMetadata({
+    const metadata = await scan({
       prompt: evaluationPrompt,
       withParameters: SERIALIZED_DOCUMENT_LOG_FIELDS,
     })

--- a/packages/core/src/services/evaluations/prompt/index.ts
+++ b/packages/core/src/services/evaluations/prompt/index.ts
@@ -107,11 +107,11 @@ Now, evaluate the assistant response for the following conversation, based on yo
 
 {{ messages.all }}
 
-{{#if cost || duration }}
+{{if cost || duration }}
   Also, here is some aditional metadata about the LLM response. It may or may not be relevant to your objective.
-  {{#if cost }} - Cost: {{ cost }} cents. {{/if}}
-  {{#if duration }} - Duration: {{ duration }} milliseconds. {{/if}}
-{{/if}}
+  {{if cost }} - Cost: {{ cost }} cents. {{endif}}
+  {{if duration }} - Duration: {{ duration }} milliseconds. {{endif}}
+{{endif}}
 
 You must respond with a JSON object with the following properties:
  - value: ${valueInformation(evaluation)}

--- a/packages/core/src/services/evaluations/run.test.ts
+++ b/packages/core/src/services/evaluations/run.test.ts
@@ -174,6 +174,7 @@ describe('run', () => {
         errorableType: ErrorableEntity.EvaluationResult,
         workspace,
         chain,
+        promptlVersion: 0,
         source: LogSources.Evaluation,
         providersMap: new Map().set(provider.name, providerUsed),
         configOverrides: {

--- a/packages/core/src/services/evaluations/run.ts
+++ b/packages/core/src/services/evaluations/run.ts
@@ -4,6 +4,7 @@ import {
   DocumentLog,
   ErrorableEntity,
   EvaluationDto,
+  EvaluationMetadataType,
   LogSources,
   ProviderLog,
 } from '../../browser'
@@ -72,11 +73,16 @@ export async function runEvaluation(
     workspaceId: evaluation.workspaceId,
   })
 
+  const usePromptl =
+    evaluation.metadataType !== EvaluationMetadataType.LlmAsJudgeAdvanced ||
+    evaluation.metadata.promptlVersion !== 0
+
   const run = await runChain({
     generateUUID: () => errorableUuid,
     errorableType: ErrorableEntity.EvaluationResult,
     workspace,
     chain,
+    promptlVersion: usePromptl ? 1 : 0,
     source: LogSources.Evaluation,
     providersMap,
     configOverrides: { schema, output: 'object' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
       '@sentry/cli':
         specifier: ^2.37.0
         version: 2.38.0(encoding@0.1.13)
@@ -331,8 +331,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
       '@latitude-data/sdk':
         specifier: workspace:*
         version: link:../../packages/sdks/typescript
@@ -660,8 +660,8 @@ importers:
   packages/core:
     dependencies:
       '@latitude-data/promptl':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^0.0.48
@@ -2599,8 +2599,8 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@latitude-data/promptl@0.0.3':
-    resolution: {integrity: sha512-7ScPc0q2nd8rJiQvulej7HExjQbLOiMMuygtiDss4wP0MJ2/FWG3CZbbLVavjefnqP5xK47uogO8db2PhsI1Rg==}
+  '@latitude-data/promptl@0.1.0':
+    resolution: {integrity: sha512-WhEdkI/alyRaPL4HF1np1p+JGPtYWq4of7CQ2iUNySwkoRU8r38EnihLtxOlvFZbwMa8caTN2fWdEORBI+hY6g==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -12799,7 +12799,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@latitude-data/promptl@0.0.3':
+  '@latitude-data/promptl@0.1.0':
     dependencies:
       acorn: 8.14.0
       code-red: 1.0.4


### PR DESCRIPTION
Latitude will now use the right compiler (legacy or ✨PromptL✨) depending on the version of the document and advanced evaluations, both to run prompts and to evaluate syntax.

Note: All LLM as Judge Simple evaluations will always be treated as PromptL evaluations, and evacuating them will create them accordingly. Until the UI is setup, this is the only way to create a promptl document for now.
