### PR TITLE
Change checkbox color to align with design system for form elements

### DIFF
--- a/packages/web-ui/src/ds/atoms/Button/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Button/index.tsx
@@ -36,7 +36,7 @@ const buttonContainerVariants = cva(
       {
         variant: 'outline',
         fanciness: 'fancy',
-        className: 'shadow-[inset_0px_0px_0px_1px_hsl(var(--border))]',
+        className: 'shadow-[inset_0px_0px_0px_1px_hsl(var(--input))]',
       },
     ],
     defaultVariants: {
@@ -98,7 +98,7 @@ const buttonVariants = cva(
       {
         variant: 'outline',
         fanciness: 'fancy',
-        className: 'shadow-[inset_0px_0px_0px_1px_hsl(var(--border))]',
+        className: 'shadow-[inset_0px_0px_0px_1px_hsl(var(--input))]',
       },
       {
         size: 'default',

--- a/packages/web-ui/src/ds/atoms/Checkbox/Primitive/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Checkbox/Primitive/index.tsx
@@ -18,14 +18,21 @@ const CheckboxAtom = forwardRef<
     ref={ref}
     className={cn(
       'peer h-4 w-4 shrink-0 rounded-sm',
-      'border border-primary focus-visible:outline-none',
+      'border border-input focus-visible:outline-none',
       'focus-visible:ring-1 focus-visible:ring-ring ',
-      'data-[state=checked]:bg-primary',
+
+      // Checked
+      'data-[state=checked]:bg-primary data-[state=checked]:border-primary',
       'data-[state=checked]:text-primary-foreground',
-      'data-[state=indeterminate]:text-primary',
-      'dark:border-foreground data-[state=checked]:dark:bg-foreground',
-      'dark:data-[state=checked]:text-background',
+      'data-[state=indeterminate]:text-primary data-[state=indeterminate]:border-primary',
+      'data-[state=indeterminate]:text-primary focus-visible:border-primary',
+
+      // Dark mode
+      'dark:border-foreground dark:data-[state=checked]:bg-background',
+      'dark:data-[state=checked]:text-foreground dark:focus-visible:ring-foreground',
       'dark:data-[state=indeterminate]:text-foreground',
+
+      // Disabled
       'disabled:cursor-not-allowed disabled:opacity-20',
       'disabled:border-foreground disabled:bg-gray-200 dark:disabled:bg-gray-900',
       className,

--- a/packages/web-ui/styles.css
+++ b/packages/web-ui/styles.css
@@ -81,7 +81,7 @@
     --success-foreground: 120 87% 97%;
 
     --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
+    --input: 0 0% 84.8%;
     --ring: 211 94% 43%;
 
     --chart-1: 12 76% 61%;


### PR DESCRIPTION
# What?
While doing the best pick on what colors should have the checkbox I realized that default `--input` color for borders doesn't have a good contrast. So I increased a bit to make it look a bit sharp.

## Before
Always blue (too much for some people)
<img width="275" alt="image" src="https://github.com/user-attachments/assets/7c055032-048d-443b-aa3b-3fba1c0658d8">

## After 
Only blue when the occasion lo merece
<img width="236" alt="image" src="https://github.com/user-attachments/assets/aa04a595-00a4-4ea3-9d92-cc99a1696736">
