### PR TITLE
Bugfix: Non-stream API run requests failing with PromptL documents

### DIFF
--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -227,6 +227,7 @@ model: gpt-4o
             response: {
               streamType: 'text',
               documentLogUuid: expect.any(String),
+              providerLog: expect.any(Object),
               text: 'Fake AI generated text',
               toolCalls: [],
               usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
@@ -261,6 +262,7 @@ model: gpt-4o
             documentLogUuid: expect.any(String),
             response: {
               documentLogUuid: expect.any(String),
+              providerLog: expect.any(Object),
               streamType: 'text',
               text: 'Fake AI generated text',
               toolCalls: [],


### PR DESCRIPTION
Bug: Running a promptl document through the API with `stream: false` returned a "Conversation messages not found in response" error.

Explanation:
When running a prompt through the gateway, we store the provider logs asyncronously through workers to not add any delay to our response. However, since we always need the latest provider log, this one WAS created syncronously.

We used the ⁠`completed` attribute from the `chain.step` response to determine which step’s provider log had to be created synchronously. This attribute indicated which step was the last one. However, with PromptL, the meaning of `⁠completed` has changed. Now, it is true when the last step has already been run and there are no more steps ahead.