### PR TITLE
WIP / Fix actions overlap tabs in document log detail when screen is small

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/MetadataInfoTabs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/MetadataInfoTabs/index.tsx
@@ -25,22 +25,21 @@ export const MetadataInfoTabs = forwardRef<HTMLDivElement, Props>(
       <div
         ref={ref}
         className={cn(
-          'flex flex-col flex-grow min-h-0 bg-background overflow-hidden',
+          'flex flex-col flex-grow flex-shrink-0 min-h-0 bg-background w-auto',
           'border border-border rounded-lg items-center relative',
           className,
         )}
       >
-        <div className='pt-6 pb-2 relative flex justify-center w-full'>
+        <div className='pt-6 pb-2 flex flex-row w-full px-4'>
+          <div className='flex-1 flex justify-end'>{/* Left spacer */}</div>
           <TabSelector
             options={tabs}
             selected={selectedTab}
             onSelect={setSelectedTab}
           />
-          {tabsActions ? (
-            <div className='absolute right-4 top-6 flex items-center justify-end w-full min-h-11 pointer-events-none'>
-              {tabsActions}
-            </div>
-          ) : null}
+          <div className='flex-1 flex justify-end min-h-11 pl-4 pointer-events-none'>
+            {tabsActions && <>{tabsActions}</>}
+          </div>
         </div>
         <div className='w-full custom-scrollbar overflow-y-auto'>
           <div className='flex px-4 py-5 flex-col gap-4 w-full overflow-x-auto'>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultInfo/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/EvaluationResults/EvaluationResultInfo/index.tsx
@@ -92,7 +92,7 @@ function DocumentLogInfoModal({
       <DocumentLogInfo
         documentLog={documentLog!}
         providerLogs={providerLogs}
-        evaluationResults={evaluationResults[documentLogId]}
+        evaluationResults={evaluationResults[documentLogId] || []}
         isLoading={isLoading}
         error={errorDocumentLog}
       />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/index.tsx
@@ -158,7 +158,7 @@ export function DocumentLogs({
             <DocumentLogInfo
               documentLog={selectedLog}
               providerLogs={providerLogs}
-              evaluationResults={evaluationResults[selectedLog.id]}
+              evaluationResults={evaluationResults[selectedLog.id] || []}
               isLoading={isProviderLogsLoading || isEvaluationResultsLoading}
               stickyRef={stickyRef}
               sidebarWrapperRef={sidebarWrapperRef}

--- a/apps/web/src/hooks/useStickyNested.ts
+++ b/apps/web/src/hooks/useStickyNested.ts
@@ -84,5 +84,5 @@ export function useStickyNested({
     }
   }, [scrollableArea, beacon, target, offset])
 
-  useUpdateWidthOnTargetContainerChange({ target, targetContainer })
+  // useUpdateWidthOnTargetContainerChange({ target, targetContainer })
 }


### PR DESCRIPTION
Fix actions overlaps tabs in document log detail when screen is small

It still breaks when scrolling.... I don't know how to solve it...

https://github.com/user-attachments/assets/4427f688-35fd-4888-b65d-cb0ec1dfbbc1

