### PR TITLE
Fix Refine from evaluation results

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -13,9 +13,9 @@ import {
   Commit,
   DocumentVersion,
   EvaluationDto,
+  EvaluationResult,
   ProviderApiKey,
 } from '@latitude-data/core/browser'
-import { type EvaluationResultByDocument } from '@latitude-data/core/repositories'
 import {
   Button,
   DocumentTextEditor,
@@ -72,7 +72,7 @@ export default function DocumentEditor({
   providerApiKeys?: ProviderApiKey[]
   freeRunsCount?: number
   evaluation: EvaluationDto | undefined
-  evaluationResults: EvaluationResultByDocument[]
+  evaluationResults: EvaluationResult[]
 }) {
   const { execute: publishEvent } = useLatitudeAction(publishEventAction)
   const { commit } = useCurrentCommit()

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/useRefinement.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/useRefinement.ts
@@ -1,6 +1,10 @@
 import { useCallback, useState } from 'react'
 
-import { DocumentVersion, EvaluationDto } from '@latitude-data/core/browser'
+import {
+  DocumentVersion,
+  EvaluationDto,
+  EvaluationResult,
+} from '@latitude-data/core/browser'
 import { type EvaluationResultByDocument } from '@latitude-data/core/repositories'
 import { useToggleModal } from '$/hooks/useToogleModal'
 import { ROUTES } from '$/services/routes'
@@ -24,7 +28,7 @@ export function useRefinement({
   commitUuid: string
   document: DocumentVersion
   serverEvaluation: EvaluationDto | undefined
-  serverEvaluationResults: EvaluationResultByDocument[]
+  serverEvaluationResults: EvaluationResult[]
 }) {
   const navigate = useRouter()
   const openRefinementFromServer =
@@ -34,7 +38,12 @@ export function useRefinement({
   )
   const [evaluationResults, setEvaluationResults] = useState<
     EvaluationResultByDocument[]
-  >(serverEvaluationResults)
+    // NOTE: We lie here. From server we receive EvaluationResult[],
+    // but we need EvaluationResultByDocument[] for the second step.
+    // The thing is that when a refine comes from a evaluation we jump to step
+    // 3 directly and we don't need `evaluationResult.result` field which is
+    // not present in basic EvaluationResult.
+  >(serverEvaluationResults as unknown as EvaluationResultByDocument[])
   const modal = useToggleModal({ initialState: openRefinementFromServer })
 
   const cleanServer = useCallback(() => {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/page.tsx
@@ -50,8 +50,8 @@ export default async function DocumentPage({
     ids: query.reval,
     workspace,
     documentUuid,
-    commit,
   })
+
   const document = await getDocumentByUuidCached({
     documentUuid: documentUuid,
     projectId,

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -48,7 +48,10 @@ export type RunError = InferSelectModel<typeof runErrors>
 export type RunErrorInsert = InferInsertModel<typeof runErrors>
 export type Evaluation = InferSelectModel<typeof evaluations>
 export type ConnectedEvaluation = InferSelectModel<typeof connectedEvaluations>
-export type EvaluationResult = InferSelectModel<typeof evaluationResults>
+export type EvaluationResult = Omit<
+  InferSelectModel<typeof evaluationResults>,
+  'providerLogId'
+>
 export type EvaluationTemplate = InferSelectModel<
   typeof evaluationAdvancedTemplates
 >

--- a/packages/core/src/services/evaluationResults/findManyByIdAndEvaluation.test.ts
+++ b/packages/core/src/services/evaluationResults/findManyByIdAndEvaluation.test.ts
@@ -50,7 +50,6 @@ describe('findManyByIdAndEvaluation', () => {
       const result = await findManyByIdAndEvaluation({
         workspace,
         documentUuid: document.documentUuid,
-        commit,
         ids: undefined,
       })
       expect(result).toEqual({
@@ -60,7 +59,7 @@ describe('findManyByIdAndEvaluation', () => {
     })
   })
 
-  describe('when an string or array of strings', () => {
+  describe('With evaluation results', () => {
     beforeAll(async () => {
       const ev = await factories.createLlmAsJudgeEvaluation({
         workspace,
@@ -91,87 +90,108 @@ describe('findManyByIdAndEvaluation', () => {
         .then((r) => r.unwrap())
     })
 
-    it('finds evaluation when passed id as string', async () => {
-      const result = await findManyByIdAndEvaluation({
-        workspace,
-        documentUuid: document.documentUuid,
-        commit,
-        ids: String(evaluationResult.id),
-      })
-      expect(result).toEqual({
-        evaluation,
-        evaluationResults: [
-          {
-            id: evaluationResult.id,
-            source: evaluationResult.source,
-            result: evaluationResult.result,
-            createdAt: evaluationResult.createdAt,
-            sameContent: true,
-          },
-        ],
+    describe('When evaluation is not connected to document', () => {
+      it('finds nothing', async () => {
+        const result = await findManyByIdAndEvaluation({
+          workspace,
+          documentUuid: document.documentUuid,
+          ids: [String(evaluationResult.id)],
+        })
+        expect(result).toEqual({
+          evaluation: undefined,
+          evaluationResults: undefined,
+        })
       })
     })
 
-    it('finds evaluation when passed id as array of string', async () => {
-      const result = await findManyByIdAndEvaluation({
-        workspace,
-        documentUuid: document.documentUuid,
-        commit,
-        ids: [String(evaluationResult.id)],
+    describe('With connected evaluations', () => {
+      beforeAll(async () => {
+        await factories.createConnectedEvaluation({
+          workspace,
+          user,
+          documentUuid: document.documentUuid,
+          evaluationUuid: evaluation.uuid,
+        })
       })
-      expect(result).toEqual({
-        evaluation,
-        evaluationResults: [
+
+      it('finds evaluation when passed id as string', async () => {
+        const result = await findManyByIdAndEvaluation({
+          workspace,
+          documentUuid: document.documentUuid,
+          ids: String(evaluationResult.id),
+        })
+        expect(result).toEqual({
+          evaluation,
+          evaluationResults: [
+            expect.objectContaining({
+              id: evaluationResult.id,
+              source: evaluationResult.source,
+              createdAt: evaluationResult.createdAt,
+            }),
+          ],
+        })
+      })
+
+      it('finds evaluation when passed id as array of string', async () => {
+        const result = await findManyByIdAndEvaluation({
+          workspace,
+          documentUuid: document.documentUuid,
+          ids: [String(evaluationResult.id)],
+        })
+        expect(result).toEqual({
+          evaluation,
+          evaluationResults: [
+            expect.objectContaining({
+              id: evaluationResult.id,
+              source: evaluationResult.source,
+              result: evaluationResult.result,
+              createdAt: evaluationResult.createdAt,
+            }),
+          ],
+        })
+      })
+
+      it('returns nothing if results from different evaluations', async () => {
+        const { documentLog } = await factories.createDocumentLog({
+          document,
+          commit,
+        })
+        const ev = await factories.createLlmAsJudgeEvaluation({
+          workspace,
+          user,
+        })
+        const evaluationRepo = new EvaluationsRepository(workspace.id)
+        const evaluation2 = await evaluationRepo
+          .find(ev.id)
+          .then((r) => r.unwrap())
+        const evaluatedProviderLog = await factories.createProviderLog({
+          workspace,
+          documentLogUuid: documentLog.uuid,
+          providerId: provider.id,
+          providerType: provider.provider,
+        })
+        const { evaluationResult: er } = await factories.createEvaluationResult(
           {
-            id: evaluationResult.id,
-            source: evaluationResult.source,
-            result: evaluationResult.result,
-            createdAt: evaluationResult.createdAt,
-            sameContent: true,
+            evaluation: evaluation2,
+            documentLog,
+            evaluatedProviderLog,
+            result: 'yes',
           },
-        ],
-      })
-    })
+        )
+        const evaluationResRepo = new EvaluationResultsRepository(workspace.id)
+        const evaluationResult2 = await evaluationResRepo
+          .find(er.id)
+          .then((r) => r.unwrap())
 
-    it('returns nothing if results from different evaluations', async () => {
-      const { documentLog } = await factories.createDocumentLog({
-        document,
-        commit,
-      })
-      const ev = await factories.createLlmAsJudgeEvaluation({
-        workspace,
-        user,
-      })
-      const evaluationRepo = new EvaluationsRepository(workspace.id)
-      const evaluation2 = await evaluationRepo
-        .find(ev.id)
-        .then((r) => r.unwrap())
-      const evaluatedProviderLog = await factories.createProviderLog({
-        workspace,
-        documentLogUuid: documentLog.uuid,
-        providerId: provider.id,
-        providerType: provider.provider,
-      })
-      const { evaluationResult: er } = await factories.createEvaluationResult({
-        evaluation: evaluation2,
-        documentLog,
-        evaluatedProviderLog,
-        result: 'yes',
-      })
-      const evaluationResRepo = new EvaluationResultsRepository(workspace.id)
-      const evaluationResult2 = await evaluationResRepo
-        .find(er.id)
-        .then((r) => r.unwrap())
-
-      const result = await findManyByIdAndEvaluation({
-        workspace,
-        documentUuid: document.documentUuid,
-        commit,
-        ids: [String(evaluationResult.id), String(evaluationResult2.id)],
-      })
-      expect(result).toEqual({
-        evaluation: undefined,
-        evaluationResults: undefined,
+        const result = await findManyByIdAndEvaluation({
+          workspace,
+          documentUuid: document.documentUuid,
+          ids: [String(evaluationResult.id), String(evaluationResult2.id)],
+        })
+        expect(result).toEqual({
+          evaluation: undefined,
+          evaluationResults: undefined,
+        })
       })
     })
   })


### PR DESCRIPTION
# What?
In the first iteration of refine from evaluations I used `computeEvaluationResultsByDocumentContent` service which does a lot of things and pick a lot of evaluation results. This is wrong for the task of selecting only results comming from evaluation results table. The fix simplifies the query by just using evaluation results repository and checking the evaluation is connected to the document where the refinement happens.