### PR TITLE
Fork document from one workspace to another

### DIFF
--- a/apps/web/src/services/user/setupService.ts
+++ b/apps/web/src/services/user/setupService.ts
@@ -1,21 +1,6 @@
-import { Providers, RewardType } from '@latitude-data/core/browser'
-import { SessionData } from '@latitude-data/core/data-access'
-import { publisher } from '@latitude-data/core/events/publisher'
-import { Result } from '@latitude-data/core/lib/Result'
-import Transaction, {
-  PromisedResult,
-} from '@latitude-data/core/lib/Transaction'
-import { createApiKey } from '@latitude-data/core/services/apiKeys/create'
-import { claimReward } from '@latitude-data/core/services/claimedRewards/claim'
-import { createMembership } from '@latitude-data/core/services/memberships/create'
-import { importDefaultProject } from '@latitude-data/core/services/projects/import'
-import { createProviderApiKey } from '@latitude-data/core/services/providerApiKeys/create'
-import { createUser } from '@latitude-data/core/services/users/createUser'
-import { createWorkspace } from '@latitude-data/core/services/workspaces/create'
+import setupServiceFn from '@latitude-data/core/services/users/setupService'
 import { env } from '@latitude-data/env'
 import { captureException } from '$/helpers/captureException'
-
-const LAUNCH_DAY = '2024-10-10'
 
 export default function setupService({
   email,
@@ -25,83 +10,13 @@ export default function setupService({
   email: string
   name: string
   companyName: string
-}): PromisedResult<SessionData> {
-  return Transaction.call(async (tx) => {
-    const userResult = await createUser(
-      { email, name, confirmedAt: new Date() },
-      tx,
-    )
-
-    if (userResult.error) return userResult
-
-    const user = userResult.value
-    const resultWorkspace = await createWorkspace(
-      {
-        name: companyName,
-        user,
-      },
-      tx,
-    )
-    if (resultWorkspace.error) return resultWorkspace
-    const workspace = resultWorkspace.value
-
-    if (new Date().toISOString().split('T')[0] === LAUNCH_DAY) {
-      await claimReward(
-        {
-          workspace,
-          user,
-          type: RewardType.SignupLaunchDay,
-          reference: LAUNCH_DAY, // not really used for this reward type
-          autoValidated: true,
-        },
-        tx,
-      )
-    }
-
-    const firstProvider = await createProviderApiKey(
-      {
-        workspace,
-        provider: Providers.OpenAI,
-        name: env.DEFAULT_PROVIDER_ID,
-        token: env.DEFAULT_PROVIDER_API_KEY,
-        author: user,
-      },
-      tx,
-    )
-
-    if (firstProvider.error) {
-      captureException(firstProvider.error)
-    }
-
-    const resultImportingDefaultProject = await importDefaultProject(
-      { workspace, user },
-      tx,
-    )
-
-    if (resultImportingDefaultProject.error) {
-      captureException(resultImportingDefaultProject.error)
-    }
-
-    const results = await Promise.all([
-      createMembership({ confirmedAt: new Date(), user, workspace }, tx),
-      createApiKey({ workspace }, tx),
-    ])
-
-    const result = Result.findError(results)
-    if (result) return result
-
-    publisher.publishLater({
-      type: 'userCreated',
-      data: {
-        ...user,
-        workspaceId: workspace.id,
-        userEmail: user.email,
-      },
-    })
-
-    return Result.ok({
-      user,
-      workspace,
-    })
+}) {
+  return setupServiceFn({
+    email,
+    name,
+    companyName,
+    defaultProviderId: env.DEFAULT_PROVIDER_ID,
+    defaultProviderApiKey: env.DEFAULT_PROVIDER_API_KEY,
+    captureException,
   })
 }

--- a/packages/compiler/src/types/index.ts
+++ b/packages/compiler/src/types/index.ts
@@ -15,6 +15,7 @@ export type ConversationMetadata = {
   errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime
   setConfig: (config: Config) => string
+  includedPromptPaths: Set<string>
 }
 
 export * from './message'

--- a/packages/core/src/services/documents/create.ts
+++ b/packages/core/src/services/documents/create.ts
@@ -23,12 +23,14 @@ export async function createNewDocument(
     commit,
     path,
     content,
+    promptlVersion = 1,
   }: {
     workspace: Workspace
     user?: User
     commit: Commit
     path: string
     content?: string
+    promptlVersion?: number
   },
   db = database,
 ): Promise<TypedResult<DocumentVersion, Error>> {
@@ -70,7 +72,7 @@ export async function createNewDocument(
         commitId: commit.id,
         path,
         content: content ?? defaultContent,
-        promptlVersion: 1,
+        promptlVersion,
       })
       .returning()
 

--- a/packages/core/src/services/documents/forkDocument/buildDocuments.ts
+++ b/packages/core/src/services/documents/forkDocument/buildDocuments.ts
@@ -1,0 +1,45 @@
+import { Commit, DocumentVersion } from '../../../browser'
+import { getDocumentMetadata } from '../scan'
+
+export async function buildDocuments({
+  destination,
+  origin,
+}: {
+  destination: {
+    commit: Commit
+    providerData: {
+      providerName: string | undefined
+      modelName: string | undefined
+    }
+  }
+  origin: { documents: DocumentVersion[] }
+}) {
+  return Promise.all(
+    origin.documents.map(async (doc) => {
+      const { config, setConfig } = await getDocumentMetadata({
+        document: doc,
+        getDocumentByPath: (path) =>
+          origin.documents.find((d) => d.path === path),
+      })
+      delete config.model
+      delete config.provider
+      let newConfig = config
+      const providerData = destination.providerData
+
+      if (providerData.providerName) {
+        newConfig = { ...newConfig, provider: providerData.providerName }
+      }
+
+      if (providerData.modelName) {
+        newConfig = { ...newConfig, model: providerData.modelName }
+      }
+
+      return {
+        path: doc.path,
+        content: setConfig(newConfig),
+        commitId: destination.commit.id,
+        promtlVersion: doc.promptlVersion,
+      }
+    }),
+  )
+}

--- a/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
+++ b/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
@@ -1,0 +1,29 @@
+import { Commit, DocumentVersion, Workspace } from '../../../browser'
+import { Result } from '../../../lib'
+import { DocumentVersionsRepository } from '../../../repositories'
+import { scanDocumentContent } from '../scan'
+
+export async function getIncludedDocuments({
+  workspace,
+  commit,
+  document,
+}: {
+  workspace: Workspace
+  commit: Commit
+  document: DocumentVersion
+}) {
+  const metadata = await scanDocumentContent({
+    workspaceId: workspace.id,
+    document,
+    commit,
+  }).then((r) => r.unwrap())
+  const includedPaths = Array.from(metadata.includedPromptPaths)
+  const documentScope = new DocumentVersionsRepository(workspace.id)
+  const allDocs = await documentScope
+    .getDocumentsAtCommit(commit)
+    .then((r) => r.unwrap())
+
+  const includedDocs = allDocs.filter((doc) => includedPaths.includes(doc.path))
+
+  return Result.ok(includedDocs)
+}

--- a/packages/core/src/services/documents/forkDocument/index.test.ts
+++ b/packages/core/src/services/documents/forkDocument/index.test.ts
@@ -1,0 +1,266 @@
+import { eq } from 'drizzle-orm'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  Commit,
+  DocumentVersion,
+  ProviderApiKey,
+  Providers,
+  User,
+  Workspace,
+} from '../../../browser'
+import { database } from '../../../client'
+import { providerApiKeys } from '../../../schema'
+import * as factories from '../../../tests/factories'
+import setupService from '../../users/setupService'
+import { forkDocument } from './index'
+import { buildProjects } from './testHelpers/buildProjects'
+import { generateDocumentsOutput } from './testHelpers/generateDocumentsOutput'
+
+let fromWorkspace: Workspace
+let toWorkspace: Workspace
+let commit: Commit
+let user: User
+let originDocuments: DocumentVersion[]
+let document: DocumentVersion
+let destProviders: ProviderApiKey[]
+
+describe('forkDocument', () => {
+  beforeAll(async () => {
+    const {
+      workspace: wsp,
+      document: doc,
+      commit: cmt,
+      documents,
+    } = await buildProjects()
+    fromWorkspace = wsp
+    originDocuments = documents
+    document = doc
+    commit = cmt
+  })
+
+  describe('Existing workspace', () => {
+    beforeAll(async () => {
+      const { workspace: tWp, userData } = await factories.createWorkspace()
+      toWorkspace = tWp
+      user = userData
+    })
+
+    describe('With providers', () => {
+      beforeAll(async () => {
+        // Another provider
+        destProviders = await Promise.all([
+          await factories.createProviderApiKey({
+            workspace: toWorkspace,
+            type: Providers.OpenAI,
+            name: 'openAI',
+            user,
+          }),
+          await factories.createProviderApiKey({
+            workspace: toWorkspace,
+            type: Providers.Google,
+            name: 'google',
+            user,
+          }),
+        ])
+      })
+
+      describe('With default provider', () => {
+        beforeAll(async () => {
+          const [_, provider] = destProviders
+          toWorkspace = await factories
+            .setProviderAsDefault(toWorkspace, provider!)
+            .then((r) => r.unwrap())
+        })
+
+        it('fork document with default provider', async () => {
+          const targetProject = await forkDocument({
+            origin: { workspace: fromWorkspace, commit, document },
+            destination: { workspace: toWorkspace, user },
+          })
+          const { commitCount, documents } = await generateDocumentsOutput({
+            project: targetProject,
+          })
+
+          expect(targetProject.name).toBe('Copy of some-folder/parent')
+          expect(commitCount).toBe(1)
+          expect(documents).toEqual([
+            {
+              path: 'some-folder/parent',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'siblingParent/sibling',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/child1',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/child2',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/childSibling',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grandchild1',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grandchild2',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grand-grand-grandChildren/deepestGrandChild',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+          ])
+        })
+
+        it('fork document with default model', async () => {
+          const [_, provider] = destProviders
+          await database
+            .update(providerApiKeys)
+            .set({
+              defaultModel: 'gemini-1.0-pro',
+            })
+            .where(eq(providerApiKeys.id, provider!.id))
+          const targetProject = await forkDocument({
+            origin: { workspace: fromWorkspace, commit, document },
+            destination: { workspace: toWorkspace, user },
+          })
+          const { commitCount, documents } = await generateDocumentsOutput({
+            project: targetProject,
+          })
+
+          expect(commitCount).toBe(1)
+          expect(documents[0]).toEqual({
+            path: 'some-folder/parent',
+            provider: 'google',
+            model: 'gemini-1.0-pro',
+          })
+        })
+
+        it('fork a nested document', async () => {
+          const anotherDoc = originDocuments.find(
+            (d) => d.path === 'some-folder/children/child1',
+          )!
+          const targetProject = await forkDocument({
+            origin: { workspace: fromWorkspace, commit, document: anotherDoc },
+            destination: { workspace: toWorkspace, user },
+          })
+          const { documents } = await generateDocumentsOutput({
+            project: targetProject,
+          })
+          expect(documents).toEqual([
+            {
+              path: 'some-folder/children/child1',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/childSibling',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grandchild1',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grandchild2',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+            {
+              path: 'some-folder/children/grandchildren/grand-grand-grandChildren/deepestGrandChild',
+              provider: 'google',
+              model: 'gemini-1.5-flash',
+            },
+          ])
+        })
+      })
+    })
+  })
+
+  describe('New workspace', () => {
+    beforeAll(async () => {
+      const { user: usr, workspace: wsp } = await setupService({
+        name: 'Alice',
+        email: 'alice@example.com',
+        companyName: 'Alice Company',
+        defaultProviderId: 'Latitude',
+        defaultProviderApiKey: 'some-key',
+      }).then((r) => r.unwrap())
+      user = usr
+      toWorkspace = wsp
+    })
+
+    it('fork document with Latitude provider', async () => {
+      const targetProject = await forkDocument({
+        origin: { workspace: fromWorkspace, commit, document },
+        destination: { workspace: toWorkspace, user },
+      })
+      const { commitCount, documents } = await generateDocumentsOutput({
+        project: targetProject,
+      })
+
+      expect(targetProject.name).toBe('Copy of some-folder/parent')
+      expect(commitCount).toBe(1)
+      expect(documents).toEqual([
+        {
+          path: 'some-folder/parent',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'siblingParent/sibling',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/child1',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/child2',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/childSibling',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/grandchildren/grandchild1',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/grandchildren/grandchild2',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+        {
+          path: 'some-folder/children/grandchildren/grand-grand-grandChildren/deepestGrandChild',
+          provider: 'Latitude',
+          model: 'gpt-4o-mini',
+        },
+      ])
+    })
+  })
+})

--- a/packages/core/src/services/documents/forkDocument/index.ts
+++ b/packages/core/src/services/documents/forkDocument/index.ts
@@ -1,0 +1,125 @@
+import {
+  Commit,
+  DocumentVersion,
+  findFirstModelForProvider,
+  User,
+  Workspace,
+} from '../../../browser'
+import { Result } from '../../../lib'
+import { createProject } from '../../projects/create'
+import { findDefaultProvider } from '../../providerApiKeys/findDefaultProvider'
+import { createNewDocument } from '../create'
+import { buildDocuments } from './buildDocuments'
+import { getIncludedDocuments } from './getIncludedDocuments'
+
+type ForkProps = {
+  origin: {
+    workspace: Workspace
+    commit: Commit
+    document: DocumentVersion
+  }
+  destination: {
+    workspace: Workspace
+    user: User
+  }
+  defaultProviderId?: string
+}
+
+async function createProjectFromDocument({
+  workspace,
+  user,
+  document,
+}: {
+  document: DocumentVersion
+  workspace: Workspace
+  user: User
+}) {
+  const name = `Copy of ${document.path}`
+  return createProject({ name, workspace, user })
+}
+
+async function createDocuments({
+  origin,
+  destination,
+}: {
+  origin: ForkProps['origin']
+  destination: {
+    workspace: Workspace
+    user: User
+    commit: Commit
+    providerData: {
+      providerName: string | undefined
+      modelName: string | undefined
+    }
+  }
+}) {
+  const documents = await getIncludedDocuments({
+    workspace: origin.workspace,
+    commit: origin.commit,
+    document: origin.document,
+  }).then((r) => r.unwrap())
+
+  const docsData = await buildDocuments({
+    origin: { documents },
+    destination: {
+      commit: destination.commit,
+      providerData: destination.providerData,
+    },
+  })
+
+  const newDocs = await Promise.all(
+    docsData.map(async (docData) =>
+      createNewDocument({
+        workspace: destination.workspace,
+        ...docData,
+        user: destination.user,
+        commit: destination.commit,
+      }),
+    ),
+  )
+
+  if (newDocs.some((r) => r.error)) {
+    const result = newDocs.find((r) => r.error)
+    const error = result!.error!
+    return Result.error(
+      new Error(`Failed to create documents: ${error.message}`),
+    )
+  }
+
+  return Result.ok(newDocs.map((r) => r.unwrap()))
+}
+
+export async function forkDocument({
+  origin,
+  destination,
+  defaultProviderId,
+}: ForkProps) {
+  const { commit, project } = await createProjectFromDocument({
+    document: origin.document,
+    workspace: destination.workspace,
+    user: destination.user,
+  }).then((r) => r.unwrap())
+
+  const provider = await findDefaultProvider(destination.workspace).then((r) =>
+    r.unwrap(),
+  )
+  const model = findFirstModelForProvider({
+    provider,
+    latitudeProvider: defaultProviderId,
+  })
+
+  await createDocuments({
+    origin,
+    destination: {
+      workspace: destination.workspace,
+      user: destination.user,
+      commit,
+      providerData: {
+        providerName: provider?.name,
+        modelName: model,
+      },
+    },
+  }).then((r) => r.unwrap())
+
+  return project
+}

--- a/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
+++ b/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
@@ -1,0 +1,88 @@
+import { Providers } from '../../../../constants'
+import * as factories from '../../../../tests/factories'
+
+export async function buildProjects() {
+  const { workspace, user, documents, project, commit } =
+    await factories.createProject({
+      providers: [
+        { name: 'openai', type: Providers.OpenAI },
+        { name: 'myAnthropic', type: Providers.Anthropic },
+      ],
+      documents: {
+        rootFile: factories.helpers.createPrompt({
+          provider: 'myAnthropic',
+          content: 'foo',
+        }),
+        siblingParent: {
+          sibling: factories.helpers.createPrompt({
+            provider: 'myAnthropic',
+            content: 'Sibling Parent',
+          }),
+        },
+        'some-folder': {
+          parent: factories.helpers.createPrompt({
+            provider: 'openai',
+            model: 'gpt-3.5-turbo',
+            content: `
+            Parent:
+            <prompt path="./children/child1" />
+            <prompt path="../siblingParent/sibling" />
+            <prompt path="./children/child2" />
+          `,
+          }),
+          children: {
+            child1: factories.helpers.createPrompt({
+              provider: 'myAnthropic',
+              content: `
+            Child 1:
+            <prompt path="./grandchildren/grandchild1" />
+            <prompt path="./childSibling" />
+          `,
+            }),
+            child2: factories.helpers.createPrompt({
+              provider: 'myAnthropic',
+              content: `
+            Child 2:
+            <prompt path="./grandchildren/grandchild2" />
+            <prompt path="./childSibling" />
+          `,
+            }),
+            childSibling: factories.helpers.createPrompt({
+              provider: 'myAnthropic',
+              content: `
+            Link to grand grand child 2:
+            <prompt path="./grandchildren/grandchild2" />
+          `,
+            }),
+            grandchildren: {
+              grandchild1: factories.helpers.createPrompt({
+                provider: 'myAnthropic',
+                content: `
+            Grandchild 1:
+            <prompt path="./grand-grand-grandChildren/deepestGrandChild" />
+          `,
+              }),
+              grandchild2: factories.helpers.createPrompt({
+                provider: 'myAnthropic',
+                content: 'Grandchild 2',
+              }),
+              'grand-grand-grandChildren': {
+                deepestGrandChild: factories.helpers.createPrompt({
+                  provider: 'myAnthropic',
+                  content: 'Grandchild 2',
+                }),
+              },
+            },
+          },
+        },
+      },
+    })
+  return {
+    commit,
+    workspace,
+    user,
+    project,
+    document: documents.find((doc) => doc.path === 'some-folder/parent')!,
+    documents,
+  }
+}

--- a/packages/core/src/services/documents/forkDocument/testHelpers/generateDocumentsOutput.ts
+++ b/packages/core/src/services/documents/forkDocument/testHelpers/generateDocumentsOutput.ts
@@ -1,0 +1,41 @@
+import { eq } from 'drizzle-orm'
+
+import { Project } from '../../../../browser'
+import { database } from '../../../../client'
+import { commits, documentVersions } from '../../../../schema'
+import { getDocumentMetadata } from '../../scan'
+
+export async function generateDocumentsOutput({
+  project,
+}: {
+  project: Project
+}) {
+  const allCommits = await database.query.commits.findMany({
+    where: eq(commits.projectId, project.id),
+  })
+  const firstCommit = allCommits[0]!
+  const allDocs = await database.query.documentVersions.findMany({
+    where: eq(documentVersions.commitId, firstCommit.id),
+  })
+
+  const documents = await Promise.all(
+    allDocs.map(async (doc) => {
+      const meta = await getDocumentMetadata({
+        document: doc,
+        getDocumentByPath: (path) => allDocs.find((d) => d.path === path),
+      })
+      return {
+        path: doc.path,
+        provider: meta.config.provider,
+        model: meta.config.model,
+      }
+    }),
+  )
+
+  return {
+    commitCount: allCommits.length,
+    documents: documents.sort(
+      (a, b) => a.path.length - b.path.length || a.path.localeCompare(b.path),
+    ),
+  }
+}

--- a/packages/core/src/services/users/index.ts
+++ b/packages/core/src/services/users/index.ts
@@ -1,3 +1,4 @@
 export * from './createUser'
 export * from './invite'
 export * from './update'
+export * from './setupService'

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -1,0 +1,108 @@
+import { Providers, RewardType } from '../../constants'
+import { SessionData } from '../../data-access'
+import { publisher } from '../../events/publisher'
+import { PromisedResult, Result, Transaction } from '../../lib'
+import { createApiKey } from '../apiKeys'
+import { claimReward } from '../claimedRewards'
+import { createMembership } from '../memberships/create'
+import { importDefaultProject } from '../projects/import'
+import { createProviderApiKey } from '../providerApiKeys'
+import { createWorkspace } from '../workspaces'
+import { createUser } from './createUser'
+
+const LAUNCH_DAY = '2024-10-10'
+
+export default function setupService({
+  email,
+  name,
+  companyName,
+  defaultProviderId,
+  defaultProviderApiKey,
+  captureException,
+}: {
+  email: string
+  name: string
+  companyName: string
+  defaultProviderId: string
+  defaultProviderApiKey: string
+  captureException?: (error: Error) => void
+}): PromisedResult<SessionData> {
+  return Transaction.call(async (tx) => {
+    const userResult = await createUser(
+      { email, name, confirmedAt: new Date() },
+      tx,
+    )
+
+    if (userResult.error) return userResult
+
+    const user = userResult.value
+    const resultWorkspace = await createWorkspace(
+      {
+        name: companyName,
+        user,
+      },
+      tx,
+    )
+    if (resultWorkspace.error) return resultWorkspace
+    const workspace = resultWorkspace.value
+
+    if (new Date().toISOString().split('T')[0] === LAUNCH_DAY) {
+      await claimReward(
+        {
+          workspace,
+          user,
+          type: RewardType.SignupLaunchDay,
+          reference: LAUNCH_DAY, // not really used for this reward type
+          autoValidated: true,
+        },
+        tx,
+      )
+    }
+
+    const firstProvider = await createProviderApiKey(
+      {
+        workspace,
+        provider: Providers.OpenAI,
+        name: defaultProviderId,
+        token: defaultProviderApiKey,
+        author: user,
+      },
+      tx,
+    )
+
+    if (firstProvider.error) {
+      captureException?.(firstProvider.error)
+    }
+
+    const resultImportingDefaultProject = await importDefaultProject(
+      { workspace, user },
+      tx,
+    )
+
+    if (resultImportingDefaultProject.error) {
+      captureException?.(resultImportingDefaultProject.error)
+    }
+
+    const results = await Promise.all([
+      createMembership({ confirmedAt: new Date(), user, workspace }, tx),
+      createApiKey({ workspace }, tx),
+    ])
+
+    const result = Result.findError(results)
+    if (result) return result
+
+    publisher.publishLater({
+      type: 'userCreated',
+      data: {
+        ...user,
+        workspaceId: workspace.id,
+        userEmail: user.email,
+      },
+    })
+
+    return Result.ok({
+      user,
+      workspace,
+    })
+  })
+}

--- a/packages/core/src/tests/factories/providerApiKeys.ts
+++ b/packages/core/src/tests/factories/providerApiKeys.ts
@@ -54,5 +54,5 @@ export async function setProviderAsDefault(
   workspace: Workspace,
   provider: ProviderApiKey,
 ) {
-  await updateWorkspace(workspace, { defaultProviderId: provider.id })
+  return await updateWorkspace(workspace, { defaultProviderId: provider.id })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.2
       '@sentry/cli':
         specifier: ^2.37.0
         version: 2.38.0(encoding@0.1.13)
@@ -331,8 +331,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.2
       '@latitude-data/sdk':
         specifier: workspace:*
         version: link:../../packages/sdks/typescript
@@ -347,7 +347,7 @@ importers:
         version: 4.6.0(monaco-editor@0.50.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)
       '@sentry/nextjs':
         specifier: ^8.34.0
-        version: 8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.0.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)(webpack@5.95.0)
+        version: 8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.0.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)(webpack@5.95.0(esbuild@0.19.12))
       '@sentry/utils':
         specifier: ^8.30.0
         version: 8.35.0
@@ -660,8 +660,8 @@ importers:
   packages/core:
     dependencies:
       '@latitude-data/promptl':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.2
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^0.0.48
@@ -853,8 +853,8 @@ importers:
   packages/sdks/typescript:
     dependencies:
       '@latitude-data/promptl':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.2
       '@t3-oss/env-core':
         specifier: ^0.10.1
         version: 0.10.1(typescript@5.6.3)(zod@3.23.8)
@@ -951,8 +951,8 @@ importers:
         specifier: workspace:*
         version: link:../../tools/eslint
       '@latitude-data/promptl':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.2
       '@latitude-data/typescript-config':
         specifier: workspace:*
         version: link:../../tools/typescript
@@ -2608,8 +2608,8 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@latitude-data/promptl@0.3.0':
-    resolution: {integrity: sha512-lTEIuzl+CK5B/Zs6303ZdqjG3j12zra1Z0TVDTILaDzEnCUtdAuaKTT8UVoST6yrAcMe9gG5ZF0wG7HP/3nneQ==}
+  '@latitude-data/promptl@0.3.2':
+    resolution: {integrity: sha512-yk6PCCsf8Nwf81gIwIMupF5bbZWdwN9txWEjHSGpd8P1r/A+YblmyM/fIwG9h9RnSFT/stjtfAjb+TNMLqBGmQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -2692,8 +2692,8 @@ packages:
     resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=18.x
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=18.x
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -3550,8 +3550,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3647,8 +3647,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3664,7 +3664,7 @@ packages:
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3713,8 +3713,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3860,7 +3860,7 @@ packages:
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3915,8 +3915,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3959,7 +3959,7 @@ packages:
     resolution: {integrity: sha512-RcBoffx2IZG6quLBXo5sj3fF47rKmmkiMhG1ZBua4nFjHYlmW8j1uUMyO5HNglxIF9E52NYq4sF7XeZRp9jYjg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^18.0 || ^19.0 || ^19.0.0-rc || >=18.x
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/container@0.0.14':
     resolution: {integrity: sha512-NgoaJJd9tTtsrveL86Ocr/AYLkGyN3prdXKd/zm5fQpfDhy/NXezyT3iF6VlwAOEUIu64ErHpAJd+P6ygR+vjg==}
@@ -12821,7 +12821,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@latitude-data/promptl@0.3.0':
+  '@latitude-data/promptl@0.3.2':
     dependencies:
       acorn: 8.14.0
       code-red: 1.0.4
@@ -15228,7 +15228,7 @@ snapshots:
       '@sentry/types': 8.35.0
       '@sentry/utils': 8.35.0
 
-  '@sentry/nextjs@8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.0.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)(webpack@5.95.0)':
+  '@sentry/nextjs@8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.0.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)(webpack@5.95.0(esbuild@0.19.12))':
     dependencies:
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.27.0
@@ -15241,14 +15241,14 @@ snapshots:
       '@sentry/types': 8.35.0
       '@sentry/utils': 8.35.0
       '@sentry/vercel-edge': 8.35.0
-      '@sentry/webpack-plugin': 2.22.3(encoding@0.1.13)(webpack@5.95.0)
+      '@sentry/webpack-plugin': 2.22.3(encoding@0.1.13)(webpack@5.95.0(esbuild@0.19.12))
       chalk: 3.0.0
       next: 15.0.3(@opentelemetry/api@1.9.0)(react-dom@19.0.0-rc-5d19e1c8-20240923(react@19.0.0-rc-5d19e1c8-20240923))(react@19.0.0-rc-5d19e1c8-20240923)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
     optionalDependencies:
-      webpack: 5.95.0
+      webpack: 5.95.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/core'
@@ -15330,12 +15330,12 @@ snapshots:
       '@sentry/types': 8.35.0
       '@sentry/utils': 8.35.0
 
-  '@sentry/webpack-plugin@2.22.3(encoding@0.1.13)(webpack@5.95.0)':
+  '@sentry/webpack-plugin@2.22.3(encoding@0.1.13)(webpack@5.95.0(esbuild@0.19.12))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.3(encoding@0.1.13)
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.95.0
+      webpack: 5.95.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -23098,14 +23098,16 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.10(webpack@5.95.0):
+  terser-webpack-plugin@5.3.10(esbuild@0.19.12)(webpack@5.95.0(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.95.0
+      webpack: 5.95.0(esbuild@0.19.12)
+    optionalDependencies:
+      esbuild: 0.19.12
 
   terser@5.36.0:
     dependencies:
@@ -24000,7 +24002,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.95.0:
+  webpack@5.95.0(esbuild@0.19.12):
     dependencies:
       '@types/estree': 1.0.6
       '@webassemblyjs/ast': 1.14.1
@@ -24022,7 +24024,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.95.0)
+      terser-webpack-plugin: 5.3.10(esbuild@0.19.12)(webpack@5.95.0(esbuild@0.19.12))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
# What?
This PR only focuses on the actual service that does the forking. The authorization layer will be added later. I want to make this ready for use

![image](https://github.com/user-attachments/assets/488687f6-a68b-478e-81e8-97674562a7f9)


## TODO
- [x] Add tests 
- [x] Implement fork
- [x] Choose a provider to use in copied documents
- [x] Fork to a new workspace (one after signup)
- [x] Fork to an existing workspace with default provider
- [x] Fork to an existing workspace without default provider
- [x] ~~Fork to an existing workspace without providers. It's possible? 💥~~ . Nothing happens it sets to nothing so they have to create one provider and set in the forked document
- [x] QA Signup flow