### PR TITLE
Feature/597 collapse messages and parameters

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -22,7 +22,7 @@
     "@latitude-data/constants": "workspace:^",
     "@latitude-data/core": "workspace:^",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/promptl": "^0.3.1",
+    "@latitude-data/promptl": "^0.3.2",
     "@sentry/cli": "^2.37.0",
     "@sentry/node": "^8.30.0",
     "@t3-oss/env-core": "^0.10.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "@latitude-data/compiler": "workspace:^",
     "@latitude-data/core": "workspace:*",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/promptl": "^0.3.1",
+    "@latitude-data/promptl": "^0.3.2",
     "@latitude-data/sdk": "workspace:*",
     "@latitude-data/web-ui": "workspace:*",
     "@lucia-auth/adapter-drizzle": "^1.0.7",

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Actions.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Actions.tsx
@@ -1,0 +1,18 @@
+import { SwitchToogle, Text } from '@latitude-data/web-ui'
+
+export type ActionsState = {
+  expandParameters: boolean
+  setExpandParameters: (expand: boolean) => void
+}
+
+export default function Actions(state: ActionsState) {
+  return (
+    <div className='flex flex-row gap-2 items-center'>
+      <Text.H6M>Expand parameters</Text.H6M>
+      <SwitchToogle
+        checked={state.expandParameters}
+        onCheckedChange={state.setExpandParameters}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
@@ -29,16 +29,19 @@ import { LanguageModelUsage } from 'ai'
 import { readStreamableValue } from 'ai/rsc'
 
 import { DocumentEditorContext } from '..'
+import Actions, { ActionsState } from './Actions'
 
 export default function Chat({
   document,
   parameters,
   clearChat,
+  expandParameters,
+  setExpandParameters,
 }: {
   document: DocumentVersion
   parameters: Record<string, unknown>
   clearChat: () => void
-}) {
+} & ActionsState) {
   const [documentLogUuid, setDocumentLogUuid] = useState<string>()
   const { commit } = useCurrentCommit()
   const { project } = useCurrentProject()
@@ -231,9 +234,17 @@ export default function Chat({
         ref={containerRef}
         className='flex flex-col gap-3 flex-grow flex-shrink min-h-0 custom-scrollbar pb-12'
       >
-        <Text.H6M>Prompt</Text.H6M>
+        <div className='flex flex-row items-center justify-between w-full'>
+          <Text.H6M>Prompt</Text.H6M>
+          <Actions
+            expandParameters={expandParameters}
+            setExpandParameters={setExpandParameters}
+          />
+        </div>
         <MessageList
           messages={conversation?.messages.slice(0, chainLength - 1) ?? []}
+          parameters={parameters}
+          collapseParameters={!expandParameters}
         />
         {(conversation?.messages.length ?? 0) >= chainLength && (
           <>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/Input/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/Input/index.tsx
@@ -15,9 +15,11 @@ import {
 export function InputParams({
   inputs,
   setInput,
+  disabled = false,
 }: {
   inputs: Inputs<InputSource>
-  setInput: (param: string, value: PlaygroundInput<InputSource>) => void
+  setInput?: (param: string, value: PlaygroundInput<InputSource>) => void
+  disabled?: boolean
 }) {
   return (
     <ClientOnly>
@@ -51,8 +53,9 @@ export function InputParams({
                       value={value ?? ''}
                       minRows={1}
                       maxRows={6}
+                      disabled={disabled}
                       onChange={(e) => {
-                        setInput(param, { ...input, value: e.target.value })
+                        setInput?.(param, { ...input, value: e.target.value })
                       }}
                     />
                   </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
@@ -29,6 +29,8 @@ export default function Playground({
     documentVersionUuid: document.documentUuid,
   })
   const [forcedSize, setForcedSize] = useState<number | undefined>()
+  const [expandParameters, setExpandParameters] = useState(false)
+
   return (
     <SplitPane
       direction='vertical'
@@ -54,12 +56,16 @@ export default function Playground({
               metadata={metadata}
               parameters={parameters}
               runPrompt={() => setMode('chat')}
+              expandParameters={expandParameters}
+              setExpandParameters={setExpandParameters}
             />
           ) : (
             <Chat
-              clearChat={() => setMode('preview')}
               document={document}
               parameters={parameters}
+              clearChat={() => setMode('preview')}
+              expandParameters={expandParameters}
+              setExpandParameters={setExpandParameters}
             />
           )}
         </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/Metadata.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/Metadata.tsx
@@ -6,9 +6,11 @@ import { DocumentLogWithMetadataAndError } from '@latitude-data/core/repositorie
 import { ClickToCopy, Message, Text } from '@latitude-data/web-ui'
 import { formatCostInMillicents, formatDuration } from '$/app/_lib/formatUtils'
 import { RunErrorMessage } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/RunErrorMessage'
+import { Inputs } from '$/hooks/useDocumentParameters'
 import useProviderApiKeys from '$/stores/providerApiKeys'
 import { format } from 'date-fns'
 
+import { InputParams } from '../../../../_components/DocumentEditor/Editor/Playground/DocumentParams/Input/index'
 import {
   FinishReasonItem,
   MetadataItem,
@@ -156,6 +158,32 @@ function ProviderLogsMetadata({
   )
 }
 
+function DocumentLogParameters({
+  documentLog,
+}: {
+  documentLog: DocumentLogWithMetadataAndError
+}) {
+  const parameters = useMemo(() => {
+    return Object.entries(documentLog.parameters).reduce(
+      (acc, [key, value]) => {
+        acc[key] = {
+          value: String(value),
+          metadata: { includeInPrompt: true },
+        }
+        return acc
+      },
+      {} as Inputs<'manual'>,
+    )
+  }, [documentLog.uuid, documentLog.parameters])
+
+  return (
+    <>
+      <Text.H5M color='foreground'>Parameters</Text.H5M>
+      <InputParams inputs={parameters} disabled />
+    </>
+  )
+}
+
 export function DocumentLogMetadata({
   documentLog,
   providerLogs = [],
@@ -198,6 +226,9 @@ export function DocumentLogMetadata({
           documentLog={documentLog}
         />
       ) : null}
+      {Object.keys(documentLog.parameters).length > 0 && (
+        <DocumentLogParameters documentLog={documentLog} />
+      )}
       {lastResponse ? (
         <div className='flex flex-col gap-y-2'>
           <Text.H5M color='foreground'>Last Response</Text.H5M>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/index.tsx
@@ -184,7 +184,10 @@ export function DocumentLogInfo({
                   />
                 )}
                 {selectedTab === 'messages' && (
-                  <DocumentLogMessages messages={messages} />
+                  <DocumentLogMessages
+                    documentLog={documentLog}
+                    messages={messages}
+                  />
                 )}
                 {selectedTab === 'evaluations' && (
                   <DocumentLogEvaluations

--- a/apps/web/src/hooks/useDocumentParameters/index.ts
+++ b/apps/web/src/hooks/useDocumentParameters/index.ts
@@ -16,7 +16,10 @@ export type PlaygroundInput<S extends InputSource> = S extends 'dataset'
       value: string
       metadata: { includeInPrompt: boolean }
     }
-  : { value: string; metadata: { includeInPrompt?: boolean } }
+  : {
+      value: string
+      metadata: { includeInPrompt?: boolean }
+    }
 
 type ManualInput = PlaygroundInput<'manual'>
 type DatasetInput = PlaygroundInput<'dataset'>

--- a/packages/compiler/src/compiler/base/nodes/tags/content.ts
+++ b/packages/compiler/src/compiler/base/nodes/tags/content.ts
@@ -1,4 +1,3 @@
-import { removeCommonIndent } from '$compiler/compiler/utils'
 import errors from '$compiler/error/errors'
 import { ContentTag } from '$compiler/parser/interfaces'
 import { ContentType } from '$compiler/types'
@@ -30,21 +29,28 @@ export async function compile(
       isInsideContentTag: true,
     })
   }
-  const textContent = removeCommonIndent(popStrayText().text)
+
+  const stray = popStrayText()
 
   // TODO: This if else is probably not required but the types enforce it.
   // Improve types.
-  if (node.name === 'text') {
+  if (node.name === 'text' && stray.text.length > 0) {
     addContent({
       ...attributes,
       type: ContentType.text,
-      text: textContent,
+      text: stray.text,
+      _promptlSourceMap: stray.sourceMap,
     })
-  } else {
+    return
+  }
+
+  if (node.name === 'image' && stray.text.length > 0) {
     addContent({
       ...attributes,
       type: ContentType.image,
-      image: textContent,
+      image: stray.text,
+      _promptlSourceMap: stray.sourceMap,
     })
+    return
   }
 }

--- a/packages/compiler/src/compiler/base/nodes/text.ts
+++ b/packages/compiler/src/compiler/base/nodes/text.ts
@@ -6,5 +6,5 @@ export async function compile({
   node,
   addStrayText,
 }: CompileNodeContext<Text>) {
-  addStrayText(node.data, node)
+  addStrayText(node.data)
 }

--- a/packages/compiler/src/compiler/base/types.ts
+++ b/packages/compiler/src/compiler/base/types.ts
@@ -59,7 +59,7 @@ export type CompileNodeContext<N extends TemplateNode> = {
 
   setConfig: (config: Config) => void
   addMessage: (message: Message) => void
-  addStrayText: (text: string, node: TemplateNode) => void
+  addStrayText: (text: string, node?: TemplateNode) => void
   popStrayText: () => { text: string; sourceMap: PromptlSourceRef[] }
   groupStrayText: () => void
   addContent: (content: MessageContent) => void

--- a/packages/compiler/src/compiler/compile.test.ts
+++ b/packages/compiler/src/compiler/compile.test.ts
@@ -652,9 +652,9 @@ Given a context, answer questions succintly yet complete.
   describe('includes source map when specified', async () => {
     it('returns empty source map when no identifiers', async () => {
       const prompt = `
-  Given a context, answer questions succintly yet complete.
-  <system>context</system>
-  <user>Please, help me with question!</user>
+Given a context, answer questions succintly yet complete.
+<system>context</system>
+<user>Please, help me with question!</user>
       `
       const { messages } = await render({
         prompt,
@@ -696,9 +696,9 @@ Given a context, answer questions succintly yet complete.
 
     it('returns source map when single identifiers per content', async () => {
       const prompt = `
-  Given a context, answer questions succintly yet complete.
-  <system>{{ context }}</system>
-  <user>Please, help me with {{ question }}!</user>
+Given a context, answer questions succintly yet complete.
+<system>{{ context }}</system>
+<user>Please, help me with {{ question }}!</user>
       `
       const { messages } = await render({
         prompt,
@@ -756,9 +756,9 @@ Given a context, answer questions succintly yet complete.
 
     it('returns source map when multiple identifiers per content', async () => {
       const prompt = `
-  Given some context, answer questions succintly yet complete.
-  <system>{{ context_1 }} and {{ context_2 }}</system>
-  <user>Please, help me with {{ question_1 }} and {{ question_2 }}!</user>
+Given some context, answer questions succintly yet complete.
+<system>{{ context_1 }} and {{ context_2 }}</system>
+<user>Please, help me with {{ question_1 }} and {{ question_2 }}!</user>
       `
       const { messages } = await render({
         prompt,
@@ -818,6 +818,194 @@ Given a context, answer questions succintly yet complete.
                   start: 36,
                   end: 46,
                   identifier: 'question_2',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns source map when duplicated identifiers', async () => {
+      const prompt = `
+Given a context, answer questions succintly yet complete.
+<system>{{ context }} and {{ context }}</system>
+<user>Please, help me with {{ question }} and {{ question }}!</user>
+      `
+      const { messages } = await render({
+        prompt,
+        parameters: {
+          context: 'context',
+          question: 'question',
+        },
+        includeSourceMap: true,
+      })
+      expect(messages).toEqual([
+        {
+          role: MessageRole.system,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'Given a context, answer questions succintly yet complete.',
+              _promptlSourceMap: [],
+            },
+          ],
+        },
+        {
+          role: MessageRole.system,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'context and context',
+              _promptlSourceMap: [
+                {
+                  start: 0,
+                  end: 7,
+                  identifier: 'context',
+                },
+                {
+                  start: 12,
+                  end: 19,
+                  identifier: 'context',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          role: MessageRole.user,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'Please, help me with question and question!',
+              _promptlSourceMap: [
+                {
+                  start: 21,
+                  end: 29,
+                  identifier: 'question',
+                },
+                {
+                  start: 34,
+                  end: 42,
+                  identifier: 'question',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns source map when multiple new lines and indents', async () => {
+      const prompt = `
+  Given a context, answer questions succintly yet complete.
+  <system>
+
+
+    {{ context }}
+
+
+  </system>
+      <user>
+
+  Please, help me
+    with {{ question }}!
+  </user>
+<user>
+  Is this the real life?
+  
+  <text>
+    Is this just fantasy?
+      {{ lyrics }}
+      
+      
+  </text>
+<image>{{image}}</image>
+</user>
+
+    {{empty}}{{empty}}
+      `
+      const { messages } = await render({
+        prompt,
+        parameters: {
+          context: 'context',
+          question: 'question',
+          lyrics: 'lyrics',
+          image: 'image',
+          empty: '   ',
+        },
+        includeSourceMap: true,
+      })
+      expect(messages).toEqual([
+        {
+          role: MessageRole.system,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'Given a context, answer questions succintly yet complete.',
+              _promptlSourceMap: [],
+            },
+          ],
+        },
+        {
+          role: MessageRole.system,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'context',
+              _promptlSourceMap: [
+                {
+                  start: 0,
+                  end: 7,
+                  identifier: 'context',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          role: MessageRole.user,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'Please, help me\n  with question!',
+              _promptlSourceMap: [
+                {
+                  start: 23,
+                  end: 31,
+                  identifier: 'question',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          role: MessageRole.user,
+          content: [
+            {
+              type: ContentType.text,
+              text: 'Is this the real life?',
+              _promptlSourceMap: [],
+            },
+            {
+              type: ContentType.text,
+              text: 'Is this just fantasy?\n  lyrics',
+              _promptlSourceMap: [
+                {
+                  start: 24,
+                  end: 30,
+                  identifier: 'lyrics',
+                },
+              ],
+            },
+            {
+              type: ContentType.image,
+              image: 'image',
+              _promptlSourceMap: [
+                {
+                  start: 0,
+                  end: 5,
+                  identifier: 'image',
                 },
               ],
             },

--- a/packages/compiler/src/compiler/index.ts
+++ b/packages/compiler/src/compiler/index.ts
@@ -28,11 +28,12 @@ export async function render({
 export function createChain({
   prompt,
   parameters,
+  ...options
 }: {
   prompt: string
   parameters: Record<string, unknown>
-}): Chain {
-  return new Chain({ prompt, parameters })
+} & CompileOptions): Chain {
+  return new Chain({ prompt, parameters, ...options })
 }
 
 export function readMetadata({

--- a/packages/compiler/src/compiler/utils.ts
+++ b/packages/compiler/src/compiler/utils.ts
@@ -26,19 +26,22 @@ export async function hasContent(iterable: Iterable<unknown>) {
   return false
 }
 
-export function removeCommonIndent(text: string): string {
-  const lines = text.split('\n')
-  const commonIndent =
-    lines.reduce((acc: number | null, line: string) => {
+export function getCommonIndent(text: string): number {
+  return (
+    text.split('\n').reduce((acc: number | null, line: string) => {
       if (line.trim() === '') return acc
       const indent = line.match(/^\s*/)![0]
       if (acc === null) return indent.length
       return indent.length < acc ? indent.length : acc
     }, null) ?? 0
-  return lines
-    .map((line) => {
-      return line.slice(commonIndent)
-    })
+  )
+}
+
+export function removeCommonIndent(text: string): string {
+  const indent = getCommonIndent(text)
+  return text
+    .split('\n')
+    .map((line) => line.slice(indent))
     .join('\n')
     .trim()
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -141,6 +141,6 @@
     "zod": "^3.23.8"
   },
   "dependencies": {
-    "@latitude-data/promptl": "^0.3.1"
+    "@latitude-data/promptl": "^0.3.2"
   }
 }

--- a/packages/core/src/services/ai/providers/rules/anthropic.test.ts
+++ b/packages/core/src/services/ai/providers/rules/anthropic.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest'
 
 import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
-import { applyCustomRules, ProviderRules } from './index'
+import { applyProviderRules, ProviderRules } from './index'
 
 const providerType = Providers.Anthropic
 
@@ -50,7 +50,7 @@ describe('applyAnthropicRules', () => {
     })
 
     it('only modifies system messages that are not at the beggining', () => {
-      const rules = applyCustomRules({ providerType, messages, config })
+      const rules = applyProviderRules({ providerType, messages, config })
 
       const appliedMessages = rules.messages
 
@@ -58,21 +58,11 @@ describe('applyAnthropicRules', () => {
       expect(appliedMessages[0]).toEqual(messages[0])
       expect(appliedMessages[1]).toEqual(messages[1])
       expect(appliedMessages[2]).toEqual(messages[2])
-      expect(appliedMessages[4]).toEqual({
-        role: MessageRole.assistant,
-        content: [{ type: 'text', text: messages[4]!.content }],
-      })
-
       expect(appliedMessages[3]).toEqual({
         role: MessageRole.user,
         content: [{ type: 'text', text: messages[3]!.content }],
       })
-
-      expect(appliedMessages[3]).toEqual({
-        role: MessageRole.user,
-        content: [{ type: 'text', text: messages[3]!.content }],
-      })
-
+      expect(appliedMessages[4]).toEqual(messages[4])
       expect(appliedMessages[5]).toEqual({
         role: MessageRole.user,
         content: [
@@ -83,7 +73,7 @@ describe('applyAnthropicRules', () => {
     })
 
     it('generates warning when system messages are not at the beggining', () => {
-      const rules = applyCustomRules({ providerType, messages, config })
+      const rules = applyProviderRules({ providerType, messages, config })
 
       expect(rules.rules).toEqual([
         {
@@ -106,7 +96,7 @@ describe('applyAnthropicRules', () => {
         content: [{ type: 'text', text: 'Respond to the user' }],
       },
     ] as Message[]
-    const rules = applyCustomRules({
+    const rules = applyProviderRules({
       providerType,
       messages: theMessages,
       config,

--- a/packages/core/src/services/ai/providers/rules/custom.test.ts
+++ b/packages/core/src/services/ai/providers/rules/custom.test.ts
@@ -1,0 +1,262 @@
+import type { Message } from '@latitude-data/compiler'
+import { describe, expect, it } from 'vitest'
+
+import { ProviderRules } from '.'
+import { applyCustomRules } from './custom'
+
+describe('applyCustomRules', () => {
+  it('not warns when no rules are violated', () => {
+    const messages = [
+      {
+        role: 'system',
+        content: 'You are a helpful chatbot',
+      },
+      {
+        role: 'system',
+        content: 'Respond to the user',
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'system',
+        content: 'Use a short response',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'text',
+            text: 'The image is a lie',
+          },
+        ],
+      },
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'text',
+            text: 'The image is a lie',
+          },
+        ],
+      },
+    ] as Message[]
+
+    const rules = applyCustomRules({
+      config: {},
+      messages: messages,
+      rules: [],
+    })
+
+    expect(rules).toEqual({
+      config: {},
+      messages: messages,
+      rules: [],
+    })
+  })
+
+  it('warns when system messages have non-text content', () => {
+    const messages = [
+      {
+        role: 'system',
+        content: 'You are a helpful chatbot',
+      },
+      {
+        role: 'system',
+        content: 'Respond to the user',
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'system',
+        content: 'Use a short response',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'text',
+            text: 'The image is a lie',
+          },
+        ],
+      },
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      },
+    ] as Message[]
+
+    const rules = applyCustomRules({
+      rules: [],
+      messages,
+      config: {},
+    })
+
+    expect(rules).toEqual({
+      config: {},
+      messages: messages,
+      rules: [
+        {
+          rule: ProviderRules.Custom,
+          ruleMessage: 'System messages can only have text content.',
+        },
+      ],
+    })
+  })
+
+  it('warns when assistant messages have images', () => {
+    const messages = [
+      {
+        role: 'system',
+        content: 'You are a helpful chatbot',
+      },
+      {
+        role: 'system',
+        content: 'Respond to the user',
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'system',
+        content: 'Use a short response',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      },
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'text',
+            text: 'The image is a lie',
+          },
+        ],
+      },
+    ] as Message[]
+
+    const rules = applyCustomRules({
+      rules: [],
+      messages,
+      config: {},
+    })
+
+    expect(rules).toEqual({
+      config: {},
+      messages: messages,
+      rules: [
+        {
+          rule: ProviderRules.Custom,
+          ruleMessage: 'Assistant messages cannot have images.',
+        },
+      ],
+    })
+  })
+
+  it('warns when multiple rules are violated', () => {
+    const messages = [
+      {
+        role: 'system',
+        content: 'You are a helpful chatbot',
+      },
+      {
+        role: 'system',
+        content: 'Respond to the user',
+      },
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello' }],
+      },
+      {
+        role: 'system',
+        content: 'Use a short response',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      },
+      {
+        role: 'system',
+        content: [
+          {
+            type: 'text',
+            text: 'Also here is an image',
+          },
+          {
+            type: 'image',
+            image: 'https://example.com/image.png',
+          },
+        ],
+      },
+    ] as Message[]
+
+    const rules = applyCustomRules({
+      rules: [],
+      messages,
+      config: {},
+    })
+
+    expect(rules).toEqual({
+      config: {},
+      messages: messages,
+      rules: [
+        {
+          rule: ProviderRules.Custom,
+          ruleMessage: 'System messages can only have text content.',
+        },
+        {
+          rule: ProviderRules.Custom,
+          ruleMessage: 'Assistant messages cannot have images.',
+        },
+      ],
+    })
+  })
+})

--- a/packages/core/src/services/ai/providers/rules/custom.ts
+++ b/packages/core/src/services/ai/providers/rules/custom.ts
@@ -1,0 +1,41 @@
+import { ContentType, MessageRole } from '@latitude-data/compiler'
+
+import { AppliedRules, ProviderRules } from '.'
+
+export function applyCustomRules(rules: AppliedRules): AppliedRules {
+  const hasNonTextSystemMessage = rules.messages.some(
+    (message) =>
+      message.role === MessageRole.system &&
+      Array.isArray(message.content) &&
+      message.content.some((content) => content.type !== ContentType.text),
+  )
+
+  if (hasNonTextSystemMessage) {
+    rules.rules = [
+      ...rules.rules,
+      {
+        rule: ProviderRules.Custom,
+        ruleMessage: 'System messages can only have text content.',
+      },
+    ]
+  }
+
+  const hasAssistantMessageWithImage = rules.messages.some(
+    (message) =>
+      message.role === MessageRole.assistant &&
+      Array.isArray(message.content) &&
+      message.content.some((content) => content.type === ContentType.image),
+  )
+
+  if (hasAssistantMessageWithImage) {
+    rules.rules = [
+      ...rules.rules,
+      {
+        rule: ProviderRules.Custom,
+        ruleMessage: 'Assistant messages cannot have images.',
+      },
+    ]
+  }
+
+  return rules
+}

--- a/packages/core/src/services/ai/providers/rules/google.test.ts
+++ b/packages/core/src/services/ai/providers/rules/google.test.ts
@@ -1,7 +1,7 @@
 import type { Message } from '@latitude-data/compiler'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { applyCustomRules, ProviderRules } from '.'
+import { applyProviderRules, ProviderRules } from '.'
 import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
 
@@ -50,7 +50,7 @@ describe('applyGoogleRules', () => {
     })
 
     it('only modifies system messages that are not at the beggining', () => {
-      const rules = applyCustomRules({ providerType, messages, config })
+      const rules = applyProviderRules({ providerType, messages, config })
 
       const appliedMessages = rules.messages
 
@@ -58,21 +58,11 @@ describe('applyGoogleRules', () => {
       expect(appliedMessages[0]).toEqual(messages[0])
       expect(appliedMessages[1]).toEqual(messages[1])
       expect(appliedMessages[2]).toEqual(messages[2])
-      expect(appliedMessages[4]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'text', text: messages[4]!.content }],
-      })
-
       expect(appliedMessages[3]).toEqual({
         role: 'user',
         content: [{ type: 'text', text: messages[3]!.content }],
       })
-
-      expect(appliedMessages[3]).toEqual({
-        role: 'user',
-        content: [{ type: 'text', text: messages[3]!.content }],
-      })
-
+      expect(appliedMessages[4]).toEqual(messages[4])
       expect(appliedMessages[5]).toEqual({
         role: 'user',
         content: [
@@ -83,7 +73,7 @@ describe('applyGoogleRules', () => {
     })
 
     it('generates warning when system messages are not at the beggining', () => {
-      const rules = applyCustomRules({ providerType, messages, config })
+      const rules = applyProviderRules({ providerType, messages, config })
 
       expect(rules.rules).toEqual([
         {

--- a/packages/core/src/services/ai/providers/rules/index.ts
+++ b/packages/core/src/services/ai/providers/rules/index.ts
@@ -3,6 +3,7 @@ import type { Config, Message } from '@latitude-data/compiler'
 import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
 import { applyAnthropicRules } from './anthropic'
+import { applyCustomRules } from './custom'
 import { applyGoogleRules } from './google'
 import { vercelSdkRules } from './vercel'
 
@@ -10,6 +11,7 @@ export enum ProviderRules {
   Anthropic = 'anthropic',
   Google = 'google',
   VercelSDK = 'latitude',
+  Custom = 'custom',
 }
 
 type ProviderRule = { rule: ProviderRules; ruleMessage: string }
@@ -26,7 +28,7 @@ type Props = {
   config: Config | PartialConfig
 }
 
-export function applyCustomRules({
+export function applyProviderRules({
   providerType,
   messages,
   config,
@@ -36,6 +38,7 @@ export function applyCustomRules({
     messages,
     config,
   }
+
   if (providerType === Providers.Anthropic) {
     rules = applyAnthropicRules(rules)
   }
@@ -44,5 +47,24 @@ export function applyCustomRules({
     rules = applyGoogleRules(rules)
   }
 
-  return vercelSdkRules(rules, providerType)
+  rules = applyCustomRules(rules)
+
+  return rules
+}
+
+export function applyAllRules({
+  providerType,
+  messages,
+  config,
+}: Props): AppliedRules {
+  let rules: AppliedRules = {
+    rules: [],
+    messages,
+    config,
+  }
+
+  rules = applyProviderRules({ providerType, messages, config })
+  rules = vercelSdkRules(rules, providerType)
+
+  return rules
 }

--- a/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
+++ b/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
@@ -63,8 +63,6 @@ export function extractContentMetadata({
   content: Record<string, unknown>
   provider: Providers
 }) {
-  delete content._promptlSourceMap
-
   const definedAttributes = Object.keys(content).filter((key) =>
     CONTENT_DEFINED_ATTRIBUTES.includes(
       key as (typeof CONTENT_DEFINED_ATTRIBUTES)[number],

--- a/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
+++ b/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
@@ -63,6 +63,8 @@ export function extractContentMetadata({
   content: Record<string, unknown>
   provider: Providers
 }) {
+  delete content._promptlSourceMap
+
   const definedAttributes = Object.keys(content).filter((key) =>
     CONTENT_DEFINED_ATTRIBUTES.includes(
       key as (typeof CONTENT_DEFINED_ATTRIBUTES)[number],

--- a/packages/core/src/services/ai/providers/rules/vercel.ts
+++ b/packages/core/src/services/ai/providers/rules/vercel.ts
@@ -23,7 +23,7 @@ function flattenSystemMessage({
 }): Message[] {
   const content = message.content as TextContent[] | string
 
-  // NOTO: `applyCustomRules` can be invoked multiple times
+  // NOTE: `applyAllRules` can be invoked multiple times
   // during a chain. if system message.content is already
   // a string we consider it already processed.
   if (typeof content === 'string') return [message]

--- a/packages/core/src/services/chains/ChainValidator/index.ts
+++ b/packages/core/src/services/chains/ChainValidator/index.ts
@@ -9,7 +9,7 @@ import { Chain as PromptlChain } from '@latitude-data/promptl'
 import { JSONSchema7 } from 'json-schema'
 import { z } from 'zod'
 
-import { applyCustomRules, ProviderApiKey, Workspace } from '../../../browser'
+import { applyProviderRules, ProviderApiKey, Workspace } from '../../../browser'
 import { Result, TypedResult } from '../../../lib'
 import { Config } from '../../ai'
 import { googleConfig } from '../../ai/helpers'
@@ -199,7 +199,7 @@ export const validateChain = async (
   })
   if (freeQuota.error) return freeQuota
 
-  const rule = applyCustomRules({
+  const rule = applyProviderRules({
     providerType: provider.provider,
     messages: conversation.messages as Message[],
     config,

--- a/packages/core/src/services/chains/run.test.ts
+++ b/packages/core/src/services/chains/run.test.ts
@@ -294,7 +294,10 @@ describe('runChain', () => {
     expect(aiModule.ai).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [
-          { role: MessageRole.system, content: 'System instruction' },
+          {
+            role: MessageRole.system,
+            content: [{ type: ContentType.text, text: 'System instruction' }],
+          },
           {
             role: MessageRole.user,
             content: [{ type: ContentType.text, text: 'User message' }],

--- a/packages/core/src/services/commits/RunDocumentChecker/index.ts
+++ b/packages/core/src/services/commits/RunDocumentChecker/index.ts
@@ -62,6 +62,7 @@ export class RunDocumentChecker {
           createLegacyChain({
             prompt: metadata.resolvedPrompt,
             parameters: this.parameters,
+            includeSourceMap: true,
           }),
         )
       } else {
@@ -76,6 +77,7 @@ export class RunDocumentChecker {
             prompt: metadata.resolvedPrompt,
             parameters: this.processParameters(this.parameters),
             adapter: Adapters.default,
+            includeSourceMap: true,
           }),
         )
       }

--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -181,8 +181,6 @@ model: gpt-4o
                 {
                   type: 'text',
                   text: 'This is a test document',
-                  // The source map is deleted after applying
-                  // the vercel rules inside the ai service
                   _promptlSourceMap: [],
                 },
               ],
@@ -230,8 +228,6 @@ model: gpt-4o
                   {
                     type: 'text',
                     text: 'This is a test document',
-                    // The source map is deleted after applying
-                    // the vercel rules inside the ai service
                     _promptlSourceMap: [],
                   },
                 ],
@@ -275,8 +271,6 @@ model: gpt-4o
                   {
                     type: 'text',
                     text: 'With two steps',
-                    // The source map is deleted after applying
-                    // the vercel rules inside the ai service
                     _promptlSourceMap: [],
                   },
                 ],

--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -174,7 +174,20 @@ model: gpt-4o
 
       expect(aiSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          messages: [{ role: 'system', content: 'This is a test document' }],
+          messages: [
+            {
+              role: 'system',
+              content: [
+                {
+                  type: 'text',
+                  text: 'This is a test document',
+                  // The source map is deleted after applying
+                  // the vercel rules inside the ai service
+                  _promptlSourceMap: [],
+                },
+              ],
+            },
+          ],
           config: { model: 'gpt-4o', provider: 'openai' },
           provider,
         }),
@@ -213,7 +226,15 @@ model: gpt-4o
             messages: [
               {
                 role: 'system',
-                content: 'This is a test document',
+                content: [
+                  {
+                    type: 'text',
+                    text: 'This is a test document',
+                    // The source map is deleted after applying
+                    // the vercel rules inside the ai service
+                    _promptlSourceMap: [],
+                  },
+                ],
               },
             ],
           },
@@ -250,7 +271,15 @@ model: gpt-4o
               },
               {
                 role: 'system',
-                content: 'With two steps',
+                content: [
+                  {
+                    type: 'text',
+                    text: 'With two steps',
+                    // The source map is deleted after applying
+                    // the vercel rules inside the ai service
+                    _promptlSourceMap: [],
+                  },
+                ],
               },
             ],
           },

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -19,7 +19,9 @@
     "prettier": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "exports": {
@@ -42,7 +44,7 @@
     "eventsource-parser": "^2.0.1",
     "node-fetch": "3.3.2",
     "zod": "^3.23.8",
-    "@latitude-data/promptl": "^0.3.1"
+    "@latitude-data/promptl": "^0.3.2"
   },
   "devDependencies": {
     "@latitude-data/constants": "workspace:*",

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@latitude-data/eslint-config": "workspace:*",
-    "@latitude-data/promptl": "^0.3.1",
+    "@latitude-data/promptl": "^0.3.2",
     "@latitude-data/typescript-config": "workspace:*",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-avatar": "^1.1.0",

--- a/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
@@ -1,14 +1,18 @@
+'use client'
+
+import { ReactNode, useState } from 'react'
+
 import {
   ContentType,
   MessageContent,
-  TextContent,
+  PromptlSourceRef,
   ToolContent,
   ToolRequestContent,
 } from '@latitude-data/compiler'
 
 import { cn } from '../../../../lib/utils'
-import { Badge, CodeBlock, Skeleton, Text } from '../../../atoms'
-import { TextColor } from '../../../tokens'
+import { Badge, CodeBlock, Skeleton, Text, Tooltip } from '../../../atoms'
+import { colors, TextColor } from '../../../tokens'
 import { roleVariant } from './helpers'
 
 export { roleVariant } from './helpers'
@@ -19,6 +23,8 @@ export type MessageProps = {
   className?: string
   size?: 'default' | 'small'
   animatePulse?: boolean
+  parameters?: Record<string, unknown>
+  collapseParameters?: boolean
 }
 
 export function Message({
@@ -26,7 +32,10 @@ export function Message({
   content,
   animatePulse,
   size = 'default',
+  parameters = {},
+  collapseParameters = false,
 }: MessageProps) {
+  const [collapseMessage, setCollapseMessage] = useState(false)
   return (
     <div
       className={cn('flex flex-col gap-1 w-full items-start', {
@@ -39,18 +48,26 @@ export function Message({
         </Badge>
       </div>
       <div className='flex w-full flex-row items-stretch gap-4 pl-4'>
-        <div className='flex-shrink-0 bg-muted w-1 rounded-lg' />
+        <div
+          className='flex-shrink-0 bg-muted w-1 rounded-lg cursor-pointer hover:bg-primary transition-colors'
+          onClick={() => setCollapseMessage(!collapseMessage)}
+        />
         <div className={cn('flex flex-1 flex-col gap-1')}>
-          {typeof content === 'string' ? (
-            <ContentValue value={content} color='foregroundMuted' size={size} />
+          {collapseMessage ? (
+            <Content value='...' color='foregroundMuted' size={size} />
+          ) : typeof content === 'string' ? (
+            <Content value={content} color='foregroundMuted' size={size} />
           ) : (
             content.map((c, idx) => (
-              <ContentValue
+              <Content
                 key={idx}
                 index={idx}
                 color='foregroundMuted'
                 value={c}
                 size={size}
+                parameters={parameters}
+                collapseParameters={collapseParameters}
+                sourceMap={(c as any)?._promptlSourceMap}
               />
             ))
           )}
@@ -79,47 +96,60 @@ export function MessageSkeleton({ role }: { role: string }) {
   )
 }
 
-const ContentValue = ({
+const Content = ({
   index = 0,
   color,
   value,
   size,
+  parameters = {},
+  collapseParameters = false,
+  sourceMap = [],
 }: {
   index?: number
   color: TextColor
-  value: MessageContent | string
+  value: string | MessageContent
   size?: 'default' | 'small'
+  parameters?: Record<string, unknown>
+  collapseParameters?: boolean
+  sourceMap?: PromptlSourceRef[]
 }) => {
-  const TextComponent = size === 'small' ? Text.H6 : Text.H5
-
   if (typeof value === 'string') {
-    return value.split('\n').map((line, lineIndex) => (
-      <TextComponent
+    return (
+      <ContentText
+        index={index}
         color={color}
-        whiteSpace='preWrap'
-        wordBreak='normal'
-        key={`${index}-${lineIndex}`}
-      >
-        {line || '\n'}
-      </TextComponent>
-    ))
+        message={value}
+        size={size}
+        parameters={parameters}
+        collapseParameters={collapseParameters}
+        sourceMap={sourceMap}
+      />
+    )
   }
 
   switch (value.type) {
     case ContentType.text:
-      return (value as TextContent).text.split('\n').map((line, lineIndex) => (
-        <TextComponent
+      return (
+        <ContentText
+          index={index}
           color={color}
-          whiteSpace='preWrap'
-          wordBreak='breakAll'
-          key={`${index}-${lineIndex}`}
-        >
-          {line || '\n'}
-        </TextComponent>
-      ))
+          message={value.text}
+          size={size}
+          parameters={parameters}
+          collapseParameters={collapseParameters}
+          sourceMap={sourceMap}
+        />
+      )
 
     case ContentType.image:
-      return <div>Image content not implemented yet</div>
+      return (
+        <ContentText
+          index={index}
+          color={color}
+          message={'<Image content not implemented yet>'}
+          size={size}
+        />
+      )
 
     case ContentType.toolCall:
       return (
@@ -146,4 +176,183 @@ const ContentValue = ({
     default:
       return null
   }
+}
+
+const ContentText = ({
+  index = 0,
+  color,
+  message,
+  size,
+  parameters = {},
+  collapseParameters = false,
+  sourceMap = [],
+}: {
+  index?: number
+  color: TextColor
+  message: string
+  size?: 'default' | 'small'
+  parameters?: Record<string, unknown>
+  collapseParameters?: boolean
+  sourceMap?: PromptlSourceRef[]
+}) => {
+  const TextComponent = size === 'small' ? Text.H6 : Text.H5
+
+  // Filter source map references without value
+  sourceMap = sourceMap.filter(
+    (ref) => message.slice(ref.start, ref.end).trim().length > 0,
+  )
+
+  // Sort source map to ensure references are ordered
+  sourceMap = sourceMap.sort((a, b) => a.start - b.start)
+
+  const segments = segmentMessage(
+    message,
+    sourceMap,
+    parameters,
+    collapseParameters,
+  )
+  const groups = groupSegmentsByNewLine(segments)
+
+  return groups.map((group, groupIndex) => (
+    <TextComponent
+      color={color}
+      whiteSpace='preWrap'
+      wordBreak='breakAll'
+      key={`${index}-group-${groupIndex}`}
+    >
+      {group.length > 0
+        ? group.map((segment, segmentIndex) => (
+            <span key={`${index}-group-${groupIndex}-segment-${segmentIndex}`}>
+              {segment}
+            </span>
+          ))
+        : '\n'}
+    </TextComponent>
+  ))
+}
+
+type Segment = string | ReactNode
+
+function identifierSegment(
+  message: string,
+  sourceRef: PromptlSourceRef,
+  collapseParameters: boolean,
+) {
+  if (collapseParameters) {
+    return (
+      <Tooltip
+        asChild
+        trigger={
+          <Badge variant='accent'>
+            &#123;&#123;{sourceRef.identifier}&#125;&#125;
+          </Badge>
+        }
+      >
+        <div className='line-clamp-6'>
+          {message.slice(sourceRef.start, sourceRef.end)}
+        </div>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <span className={colors.textColors.accentForeground}>
+          {message.slice(sourceRef.start, sourceRef.end)}
+        </span>
+      }
+    >
+      <div className='line-clamp-6'>{sourceRef.identifier}</div>
+    </Tooltip>
+  )
+}
+
+function dynamicSegment(
+  message: string,
+  sourceRef: PromptlSourceRef,
+  collapseParameters: boolean,
+) {
+  if (collapseParameters) {
+    return (
+      <Tooltip
+        asChild
+        trigger={
+          <Badge variant='yellow'>&#123;&#123;dynamic&#125;&#125;</Badge>
+        }
+      >
+        <div className='line-clamp-6'>
+          {message.slice(sourceRef.start, sourceRef.end)}
+        </div>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <Tooltip
+      asChild
+      trigger={
+        <span className={colors.textColors.warningMutedForeground}>
+          {message.slice(sourceRef.start, sourceRef.end)}
+        </span>
+      }
+    >
+      <div className='line-clamp-6'>dynamic</div>
+    </Tooltip>
+  )
+}
+
+function segmentMessage(
+  message: string,
+  sourceMap: PromptlSourceRef[],
+  parameters: Record<string, unknown>,
+  collapseParameters: boolean,
+): Segment[] {
+  let segments: Segment[] = []
+
+  const firstSegment = message.slice(0, sourceMap[0]?.start ?? message.length)
+  if (firstSegment.length > 0) segments.push(firstSegment)
+
+  for (let i = 0; i < sourceMap.length; i++) {
+    if (sourceMap[i]!.identifier && !!parameters[sourceMap[i]!.identifier!]) {
+      segments.push(
+        identifierSegment(message, sourceMap[i]!, collapseParameters),
+      )
+    } else {
+      segments.push(dynamicSegment(message, sourceMap[i]!, collapseParameters))
+    }
+
+    const nextSegment = message.slice(
+      sourceMap[i]!.end,
+      sourceMap[i + 1]?.start ?? message.length,
+    )
+    if (nextSegment.length > 0) segments.push(nextSegment)
+  }
+
+  return segments
+}
+
+function groupSegmentsByNewLine(segments: Segment[]) {
+  let groups: Segment[][] = []
+  let currentGroup: Segment[] = []
+
+  for (const segment of segments) {
+    if (typeof segment === 'string') {
+      const subsegments = segment.split('\n')
+      for (let i = 0; i < subsegments.length; i++) {
+        if (subsegments[i]!.length > 0) currentGroup.push(subsegments[i])
+        if (i < subsegments.length - 1) {
+          groups.push(currentGroup)
+          currentGroup = []
+        }
+      }
+    } else {
+      currentGroup.push(segment)
+    }
+  }
+
+  if (currentGroup.length > 0) groups.push(currentGroup)
+
+  return groups
 }

--- a/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
@@ -224,7 +224,10 @@ const ContentText = ({
       {group.length > 0
         ? group.map((segment, segmentIndex) => (
             <span key={`${index}-group-${groupIndex}-segment-${segmentIndex}`}>
-              {RenderSegment(segment, collapseParameters)}
+              <SegmentComponent
+                segment={segment}
+                collapseParameters={collapseParameters}
+              />
             </span>
           ))
         : '\n'}
@@ -232,7 +235,13 @@ const ContentText = ({
   ))
 }
 
-function RenderSegment(segment: Segment, collapseParameters: boolean) {
+function SegmentComponent({
+  segment,
+  collapseParameters,
+}: {
+  segment: Segment
+  collapseParameters: boolean
+}) {
   if (typeof segment === 'string') {
     return segment
   }

--- a/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import {
   ContentType,
@@ -211,8 +211,11 @@ const ContentText = ({
   // Sort source map to ensure references are ordered
   sourceMap = sourceMap.sort((a, b) => a.start - b.start)
 
-  const segments = segmentMessage(message, sourceMap, parameters)
-  const groups = groupSegmentsByNewLine(segments)
+  const segments = useMemo(
+    () => segmentMessage(message, sourceMap, parameters),
+    [message, sourceMap, parameters],
+  )
+  const groups = useMemo(() => groupSegmentsByNewLine(segments), [segments])
 
   return groups.map((group, groupIndex) => (
     <TextComponent

--- a/packages/web-ui/src/ds/molecules/Chat/MessageList/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/MessageList/index.tsx
@@ -6,12 +6,25 @@ import { Message as ConversationMessage } from '@latitude-data/compiler'
 
 import { Message } from '../Message'
 
-export function MessageList({ messages }: { messages: ConversationMessage[] }) {
+export function MessageList({
+  messages,
+  parameters,
+  collapseParameters,
+}: {
+  messages: ConversationMessage[]
+  parameters?: Record<string, unknown>
+  collapseParameters?: boolean
+}) {
   return (
     <div className='flex flex-col gap-4'>
       {messages.map((message, index) => (
         <Fragment key={index}>
-          <Message role={message.role} content={message.content} />
+          <Message
+            role={message.role}
+            content={message.content}
+            parameters={parameters}
+            collapseParameters={collapseParameters}
+          />
         </Fragment>
       ))}
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,7 +236,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.3.1
+        specifier: ^0.3.2
         version: 0.3.2
       '@sentry/cli':
         specifier: ^2.37.0
@@ -331,7 +331,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/promptl':
-        specifier: ^0.3.1
+        specifier: ^0.3.2
         version: 0.3.2
       '@latitude-data/sdk':
         specifier: workspace:*
@@ -660,7 +660,7 @@ importers:
   packages/core:
     dependencies:
       '@latitude-data/promptl':
-        specifier: ^0.3.1
+        specifier: ^0.3.2
         version: 0.3.2
     devDependencies:
       '@ai-sdk/anthropic':
@@ -853,7 +853,7 @@ importers:
   packages/sdks/typescript:
     dependencies:
       '@latitude-data/promptl':
-        specifier: ^0.3.1
+        specifier: ^0.3.2
         version: 0.3.2
       '@t3-oss/env-core':
         specifier: ^0.10.1
@@ -951,7 +951,7 @@ importers:
         specifier: workspace:*
         version: link:../../tools/eslint
       '@latitude-data/promptl':
-        specifier: ^0.3.1
+        specifier: ^0.3.2
         version: 0.3.2
       '@latitude-data/typescript-config':
         specifier: workspace:*
@@ -16330,7 +16330,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1))
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
@@ -18018,7 +18018,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-turbo: 2.2.3(eslint@8.57.1)
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)
 
@@ -18036,7 +18036,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -18049,7 +18049,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:


### PR DESCRIPTION
Related: https://github.com/latitude-dev/latitude-llm/issues/597

- In the playground preview, chat and document log info you now can collapse parameters and individual messages.
- In the document log info parameters used for that run are now shown.
- Bring the fixes for the PromptL compiler to the legacy one, so everyone can enjoy collapsing their parameters :) . https://github.com/latitude-dev/promptl/pull/6
- Fixes bug that crashed the document editor page when putting a non text content in system messages or an image content in an assistant message.