### PR TITLE
Fork for not logged users or new users

### DIFF
--- a/apps/web/src/actions/magicLinkTokens/confirm.ts
+++ b/apps/web/src/actions/magicLinkTokens/confirm.ts
@@ -14,6 +14,7 @@ export const confirmMagicLinkTokenAction = createServerAction()
   .input(
     z.object({
       token: z.string(),
+      returnTo: z.string().optional(),
     }),
   )
   .handler(async ({ input }) => {
@@ -35,5 +36,5 @@ export const confirmMagicLinkTokenAction = createServerAction()
       },
     })
 
-    redirect(ROUTES.root)
+    redirect(input.returnTo ? input.returnTo : ROUTES.root)
   })

--- a/apps/web/src/actions/user/loginAction.ts
+++ b/apps/web/src/actions/user/loginAction.ts
@@ -13,12 +13,15 @@ export const loginAction = errorHandlingProcedure
   .input(
     z.object({
       email: z.string().email(),
+      returnTo: z.string().optional(),
     }),
     { type: 'formData' },
   )
   .handler(async ({ input }) => {
     const { user } = await getUserFromCredentials(input).then((r) => r.unwrap())
-    await createMagicLinkToken({ user }).then((r) => r.unwrap())
+    await createMagicLinkToken({ user, returnTo: input.returnTo }).then((r) =>
+      r.unwrap(),
+    )
 
     redirect(ROUTES.auth.magicLinkSent(user.email))
   })

--- a/apps/web/src/actions/user/setupAction.ts
+++ b/apps/web/src/actions/user/setupAction.ts
@@ -14,6 +14,7 @@ export const setupAction = errorHandlingProcedure
   .input(
     async () => {
       return z.object({
+        returnTo: z.string().optional(),
         name: z.string().min(1, { message: 'Name is a required field' }),
         email: z
           .string()
@@ -49,5 +50,5 @@ export const setupAction = errorHandlingProcedure
       },
     })
 
-    redirect(ROUTES.root)
+    redirect(input.returnTo ? input.returnTo : ROUTES.root)
   })

--- a/apps/web/src/app/(public)/login/LoginForm/index.tsx
+++ b/apps/web/src/app/(public)/login/LoginForm/index.tsx
@@ -6,7 +6,13 @@ import { Button, FormWrapper, Input, useToast } from '@latitude-data/web-ui'
 import { loginAction } from '$/actions/user/loginAction'
 import { useServerAction } from 'zsa-react'
 
-export default function LoginForm({ footer }: { footer: ReactNode }) {
+export default function LoginForm({
+  footer,
+  returnTo,
+}: {
+  footer: ReactNode
+  returnTo?: string
+}) {
   const { toast } = useToast()
   const { isPending, error, executeFormAction } = useServerAction(loginAction, {
     onError: ({ err }) => {
@@ -22,6 +28,7 @@ export default function LoginForm({ footer }: { footer: ReactNode }) {
   const errors = error?.fieldErrors
   return (
     <form action={executeFormAction}>
+      <input type='hidden' name='returnTo' value={returnTo} />
       <FormWrapper>
         <Input
           autoFocus

--- a/apps/web/src/app/(public)/login/_components/LoginFooter/index.tsx
+++ b/apps/web/src/app/(public)/login/_components/LoginFooter/index.tsx
@@ -1,13 +1,18 @@
 import { Button, Icon, Text } from '@latitude-data/web-ui'
 import { ROUTES } from '$/services/routes'
 import Link from 'next/link'
+import { MouseEvent } from 'react'
 
-export default function LoginFooter() {
+export default function LoginFooter({
+  onClickSignup,
+}: {
+  onClickSignup?: (event: MouseEvent<HTMLAnchorElement>) => void
+}) {
   return (
     <div>
       <Text.H5 color='foregroundMuted'>
         Don't have an account yet?{' '}
-        <Link href={ROUTES.auth.setup}>
+        <Link href={ROUTES.auth.setup} onClick={onClickSignup}>
           <Button variant='link' className='p-0'>
             Sign up
             <Icon name='arrowRight' />

--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -24,7 +24,7 @@ export default async function LoginPage() {
       header={<FocusHeader title='Welcome to Latitude' />}
       footer={<LoginFooter />}
     >
-      <Card>
+      <Card background='light'>
         <CardContent standalone>
           <LoginForm footer={<AuthFooter />} />
         </CardContent>

--- a/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
+++ b/apps/web/src/app/(public)/magic-links/confirm/[token]/page.tsx
@@ -9,17 +9,20 @@ import useLatitudeAction from '$/hooks/useLatitudeAction'
 
 export default function ConfirmMagicLink({
   params,
+  searchParams,
 }: {
   params: Promise<{ token: string }>
+  searchParams: Promise<{ returnTo?: string }>
 }) {
   const { token } = use(params)
+  const { returnTo } = use(searchParams)
   const { execute } = useLatitudeAction(confirmMagicLinkTokenAction, {
     onSuccess: () => {}, // We don't want the default toast message in this case
   })
 
   useEffect(() => {
-    setTimeout(() => execute({ token }), 1000)
-  }, [execute])
+    setTimeout(() => execute({ token, returnTo }), 1000)
+  }, [execute, returnTo, token])
 
   return (
     <FocusLayout

--- a/apps/web/src/app/(public)/setup/SetupForm/index.tsx
+++ b/apps/web/src/app/(public)/setup/SetupForm/index.tsx
@@ -12,11 +12,13 @@ export default function SetupForm({
   name,
   companyName,
   footer,
+  returnTo,
 }: {
+  footer: ReactNode
   email?: string
   name?: string
   companyName?: string
-  footer: ReactNode
+  returnTo?: string
 }) {
   const { toast } = useToast()
   const { execute, isPending } = useLatitudeAction(setupAction)
@@ -34,6 +36,7 @@ export default function SetupForm({
   const errors = error?.fieldErrors
   return (
     <form action={action}>
+      <input type='hidden' name='returnTo' value={returnTo} />
       <FormWrapper>
         <Input
           autoFocus

--- a/apps/web/src/app/(public)/setup/_components/SignupFooter/index.tsx
+++ b/apps/web/src/app/(public)/setup/_components/SignupFooter/index.tsx
@@ -1,0 +1,22 @@
+import { Button, Icon, Text } from '@latitude-data/web-ui'
+import { ROUTES } from '$/services/routes'
+import Link from 'next/link'
+import { MouseEvent } from 'react'
+
+export default function SignupFooter({
+  onClickLogin,
+}: {
+  onClickLogin?: (event: MouseEvent<HTMLAnchorElement>) => void
+}) {
+  return (
+    <Text.H5 color='foregroundMuted' display='block'>
+      Already have an account?{' '}
+      <Link href={ROUTES.auth.login} onClick={onClickLogin}>
+        <Button variant='link' className='p-0'>
+          Log in
+          <Icon name='arrowRight' />
+        </Button>
+      </Link>
+    </Text.H5>
+  )
+}

--- a/apps/web/src/app/(public)/setup/page.tsx
+++ b/apps/web/src/app/(public)/setup/page.tsx
@@ -4,6 +4,7 @@ import AuthFooter from '$/app/(public)/_components/Footer'
 import { FocusLayout } from '$/components/layouts'
 
 import SetupForm from './SetupForm'
+import SignupFooter from '$/app/(public)/setup/_components/SignupFooter'
 
 export const dynamic = 'force-dynamic'
 
@@ -29,8 +30,9 @@ export default async function SetupPage({
           description='Join us today and start improve the way you work with LLMs!'
         />
       }
+      footer={<SignupFooter />}
     >
-      <Card>
+      <Card background='light'>
         <CardContent standalone>
           <SetupForm
             email={email}

--- a/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/_components/ForkButton/index.tsx
+++ b/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/_components/ForkButton/index.tsx
@@ -1,15 +1,33 @@
 import { forkDocumentAction } from '$/actions/documents/sharing/forkDocumentAction'
+import LoginFooter from '$/app/(public)/login/_components/LoginFooter'
+import LoginForm from '$/app/(public)/login/LoginForm'
+import SignupFooter from '$/app/(public)/setup/_components/SignupFooter'
+import SetupForm from '$/app/(public)/setup/SetupForm'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 import { useNavigate } from '$/hooks/useNavigate'
+import { useToggleModal } from '$/hooks/useToogleModal'
 import { ROUTES } from '$/services/routes'
 import { PublishedDocument } from '@latitude-data/core/browser'
-import { Button } from '@latitude-data/web-ui'
+import {
+  Button,
+  ButtonProps,
+  Modal,
+  useMaybeSession,
+} from '@latitude-data/web-ui'
+import { MouseEvent, useCallback, useState } from 'react'
 
-// TODO: Implement fork action + job or go to fork page
-// Show login modal if not currentUser
-// const { currentUser } = useMaybeSession()
-
-export function ForkButton({ shared }: { shared: PublishedDocument }) {
+export function ForkButton({
+  shared,
+  variant = 'outline',
+  fullWidth = false,
+}: {
+  shared: PublishedDocument
+  variant?: ButtonProps['variant']
+  fullWidth?: ButtonProps['fullWidth']
+}) {
+  const { currentUser } = useMaybeSession()
+  const [form, setForm] = useState<'login' | 'signup'>('signup')
+  const { open, onOpen, onOpenChange } = useToggleModal()
   const router = useNavigate()
   const { execute: fork, isPending: isForking } = useLatitudeAction(
     forkDocumentAction,
@@ -24,23 +42,72 @@ export function ForkButton({ shared }: { shared: PublishedDocument }) {
       },
     },
   )
+  const onForkClick = useCallback(() => {
+    if (!currentUser) {
+      onOpen()
+      return
+    }
+
+    fork({ publishedDocumentUuid: shared.uuid! })
+  }, [currentUser, fork, shared.uuid!])
+  const onClickSignup = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    setForm('signup')
+  }, [])
+  const onClickLogin = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    setForm('login')
+  }, [])
+  const returnTo = ROUTES.share.document(shared.uuid!).fork
   return (
-    <Button
-      fancy
-      variant='outline'
-      disabled={isForking}
-      onClick={() => fork({ publishedDocumentUuid: shared.uuid! })}
-      iconProps={
-        isForking
-          ? {
-              name: 'loader',
-              color: 'foreground',
-              className: 'animate-spin',
-            }
-          : undefined
-      }
-    >
-      {`${isForking ? 'Copying this prompt...' : 'Copy this prompt'}`}
-    </Button>
+    <>
+      <Button
+        fancy
+        variant={variant}
+        disabled={isForking}
+        fullWidth={fullWidth}
+        onClick={onForkClick}
+        iconProps={
+          isForking
+            ? {
+                name: 'loader',
+                color: 'foreground',
+                className: 'animate-spin',
+              }
+            : undefined
+        }
+      >
+        {`${isForking ? 'Copying this prompt...' : 'Copy this prompt'}`}
+      </Button>
+      <Modal
+        dismissible
+        open={open}
+        onOpenChange={onOpenChange}
+        size='small'
+        title={form === 'signup' ? 'Sign up' : 'Log in'}
+        description={
+          form === 'signup'
+            ? 'Sign up to copy this prompt'
+            : 'Log in to copy this prompt'
+        }
+      >
+        {form === 'signup' ? (
+          <SetupForm
+            returnTo={returnTo}
+            footer={<SignupFooter onClickLogin={onClickLogin} />}
+          />
+        ) : null}
+        {form === 'login' ? (
+          <LoginForm
+            returnTo={returnTo}
+            footer={<LoginFooter onClickSignup={onClickSignup} />}
+          />
+        ) : null}
+      </Modal>
+    </>
   )
 }

--- a/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/_components/Header/index.tsx
+++ b/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/_components/Header/index.tsx
@@ -1,5 +1,7 @@
+'use client'
+
 import { PublishedDocument } from '@latitude-data/core/browser'
-import { Icon, Text } from '@latitude-data/web-ui'
+import { Icon, Text, TripleThemeToggle } from '@latitude-data/web-ui'
 import { AppHeaderWrapper } from '$/components/layouts/AppLayout/Header'
 import { ROUTES } from '$/services/routes'
 import Link from 'next/link'
@@ -22,20 +24,26 @@ export function PromptHeader({
       <AppHeaderWrapper xPadding='none'>
         <Container>
           <div className='w-full flex flex-row items-center justify-between'>
-            <div>{showShare && <ForkButton shared={shared} />}</div>
             <Link
               href={ROUTES.dashboard.root}
-              className='flex flex-row items-center gap-x-4'
+              className='flex flex-row items-center gap-x-2'
             >
-              <div className='hidden sm:block'>
-                <Text.H5 color='foregroundMuted'>Made with Latitude</Text.H5>
-              </div>
               <Icon name='logo' size='large' />
+              <div className='hidden sm:flex flex-col'>
+                <Text.H6M>AI tools</Text.H6M>
+                <Text.H7 color='foregroundMuted'>by Latitude</Text.H7>
+              </div>
             </Link>
+            {showShare && <ForkButton shared={shared} />}
+            <div className='min-w-20'>
+              <TripleThemeToggle />
+            </div>
           </div>
         </Container>
       </AppHeaderWrapper>
+
       {beforeShareInfo}
+
       <Container className='flex flex-col gap-y-8'>
         <div className='w-full flex flex-row justify-center'>
           <div className='flex flex-col gap-y-1 sm:w-modal'>

--- a/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/fork/_components/ForkDocument/index.tsx
+++ b/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/fork/_components/ForkDocument/index.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { PromptHeader } from '$/app/(public)/share/d/[publishedDocumentUuid]/_components/Header'
+import { PublishedDocument } from '@latitude-data/core/browser'
+import { Container } from '$/app/(public)/share/d/[publishedDocumentUuid]/_components/Container'
+import {
+  Card,
+  CardDescription,
+  CardTitle,
+  CardContent,
+  CardHeader,
+  Button,
+  Icon,
+} from '@latitude-data/web-ui'
+import { ForkButton } from '$/app/(public)/share/d/[publishedDocumentUuid]/_components/ForkButton'
+import { ROUTES } from '$/services/routes'
+import Link from 'next/link'
+
+export function ForkDocument({ shared }: { shared: PublishedDocument }) {
+  const back = ROUTES.share.document(shared.uuid!).root
+  return (
+    <div className='h-screen bg-background-gray flex flex-col pb-4 sm:pb-8 gap-y-4 sm:gap-y-8 custom-scrollbar'>
+      <PromptHeader
+        shared={shared}
+        beforeShareInfo={
+          <Container className='flex justify-center'>
+            <Card shadow='sm' background='light' className='w-modal'>
+              <CardHeader>
+                <CardTitle>Copy this prompt</CardTitle>
+                <CardDescription>
+                  This prompt will be copied to your Latitude account
+                </CardDescription>
+              </CardHeader>
+              <CardContent className='flex flex-row gap-x-4'>
+                <Button variant='outline' fullWidth asChild>
+                  <Link
+                    href={back}
+                    className='flex flex-row items-center gap-x-2'
+                  >
+                    <Icon name='chevronLeft' />
+                    <span>Back to Prompt</span>
+                  </Link>
+                </Button>
+                <ForkButton fullWidth variant='default' shared={shared} />
+              </CardContent>
+            </Card>
+          </Container>
+        }
+      />
+    </div>
+  )
+}

--- a/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/fork/page.tsx
+++ b/apps/web/src/app/(public)/share/d/[publishedDocumentUuid]/fork/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation'
+import { findSharedDocumentCached } from '$/app/(public)/_data_access'
+import { getCurrentUser } from '$/services/auth/getCurrentUser'
+import { ForkDocument } from './_components/ForkDocument'
+
+export default async function ForkedDocumentPage({
+  params,
+}: {
+  params: Promise<{ publishedDocumentUuid: string }>
+  searchParams: Promise<{ commitUuid: string; documentUuid: string }>
+}) {
+  const { publishedDocumentUuid } = await params
+  const { workspace, user } = await getCurrentUser()
+
+  const result = await findSharedDocumentCached(publishedDocumentUuid)
+
+  if (result.error || !user || !workspace) return notFound()
+
+  return <ForkDocument shared={result.value.shared} />
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import '@latitude-data/web-ui/styles.css'
 
 import {
   ThemeProvider,
+  THEMES,
   ToastProvider,
   TooltipProvider,
 } from '@latitude-data/web-ui'
@@ -33,6 +34,7 @@ export default function RootLayout({
         <ThemeProvider
           attribute='class'
           defaultTheme='light'
+          themes={THEMES as unknown as string[]}
           enableSystem
           disableTransitionOnChange
         >

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -10,14 +10,18 @@ export const metadata = buildMetatags({
 
 export default async function GlobalNoFound() {
   return (
-    <ErrorComponent
-      type='gray'
-      message="We couldn't find what you are looking for. Please make sure that the page exists and try again."
-      submit={
-        <Link href={ROUTES.root}>
-          <Button>Go to Homepage</Button>
-        </Link>
-      }
-    />
+    <div className='h-screen flex items-center justify-center'>
+      <ErrorComponent
+        type='gray'
+        message="We couldn't find what you are looking for. Please make sure that the page exists and try again."
+        submit={
+          <Link href={ROUTES.root}>
+            <Button fancy variant='outline'>
+              Go to Homepage
+            </Button>
+          </Link>
+        }
+      />
+    </div>
   )
 }

--- a/apps/web/src/hooks/useToogleModal.ts
+++ b/apps/web/src/hooks/useToogleModal.ts
@@ -6,6 +6,10 @@ export function useToggleModal({
   const [open, setOpen] = useState(initialState)
   const onClose = useCallback(() => setOpen(false), [])
   const onOpen = useCallback(() => setOpen(true), [])
+  const onOpenChange = useCallback(
+    (newOpen?: boolean) => setOpen((prev) => newOpen ?? !prev),
+    [],
+  )
 
-  return { open, onClose, onOpen }
+  return { open, onClose, onOpen, onOpenChange }
 }

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -75,7 +75,7 @@ export type EventHandler<E extends LatitudeEvent> = ({
 
 export type MagicLinkTokenCreated = LatitudeEventGeneric<
   'magicLinkTokenCreated',
-  MagicLinkToken & { userEmail: string }
+  MagicLinkToken & { userEmail: string; returnTo?: string }
 >
 export type UserCreatedEvent = LatitudeEventGeneric<
   'userCreated',

--- a/packages/core/src/events/handlers/sendMagicLinkHandler.ts
+++ b/packages/core/src/events/handlers/sendMagicLinkHandler.ts
@@ -10,6 +10,7 @@ export async function sendMagicLinkJob({
 }) {
   const user = await unsafelyGetUser(event.data.userId)
   if (!user) throw new NotFoundError('User not found')
+  event.data.returnTo
 
   const mailer = new MagicLinkMailer(
     {
@@ -18,6 +19,7 @@ export async function sendMagicLinkJob({
     {
       user: user.name!,
       magicLinkToken: event.data.token,
+      returnTo: event.data.returnTo,
     },
   )
 

--- a/packages/core/src/mailers/emails/magicLinks/magicLinkMail.tsx
+++ b/packages/core/src/mailers/emails/magicLinks/magicLinkMail.tsx
@@ -5,12 +5,15 @@ import { Link, Text } from '@react-email/components'
 
 import Layout from '../_components/Layout'
 
-type Props = {
+export default function MagicLinkMail({
+  user,
+  magicLinkToken,
+  returnTo,
+}: {
   user: string
   magicLinkToken: string
-}
-
-export default function MagicLinkMail({ user, magicLinkToken }: Props) {
+  returnTo?: string
+}) {
   return (
     <Layout title='Login' previewText='Log in with this magic link'>
       <Text>Hi {user},</Text>
@@ -19,7 +22,7 @@ export default function MagicLinkMail({ user, magicLinkToken }: Props) {
         in.
       </Text>
       <Link
-        href={createMagicLink(magicLinkToken)}
+        href={createMagicLink(magicLinkToken, returnTo)}
         target='_blank'
         className='text-blue-500 font-medium text-base mb-4'
       >
@@ -29,8 +32,9 @@ export default function MagicLinkMail({ user, magicLinkToken }: Props) {
   )
 }
 
-const createMagicLink = (token: string) => {
-  return `${env.LATITUDE_URL}/magic-links/confirm/${token}`
+const createMagicLink = (token: string, returnTo?: string) => {
+  const goTo = returnTo ? `?returnTo=${returnTo}` : ''
+  return `${env.LATITUDE_URL}/magic-links/confirm/${token}${goTo}`
 }
 
 MagicLinkMail.PreviewProps = {

--- a/packages/core/src/mailers/mailers/mailers/magicLinks/MagicLinkMailer.ts
+++ b/packages/core/src/mailers/mailers/mailers/magicLinks/MagicLinkMailer.ts
@@ -9,15 +9,21 @@ import Mailer from '../../Mailer'
 export class MagicLinkMailer extends Mailer {
   user: string
   magicLinkToken: string
+  returnTo?: string
 
   constructor(
     options: Mail.Options,
-    { user, magicLinkToken }: { user: string; magicLinkToken: string },
+    {
+      user,
+      magicLinkToken,
+      returnTo,
+    }: { user: string; magicLinkToken: string; returnTo?: string },
   ) {
     super(options)
 
     this.user = user
     this.magicLinkToken = magicLinkToken
+    this.returnTo = returnTo
   }
 
   async send(): Promise<TypedResult<SMTPTransport.SentMessageInfo, Error>> {
@@ -29,6 +35,7 @@ export class MagicLinkMailer extends Mailer {
         MagicLinkMail({
           user: this.user,
           magicLinkToken: this.magicLinkToken,
+          returnTo: this.returnTo,
         }),
       ),
     })

--- a/packages/core/src/services/magicLinkTokens/create.ts
+++ b/packages/core/src/services/magicLinkTokens/create.ts
@@ -5,7 +5,7 @@ import { Result, Transaction } from '../../lib'
 import { magicLinkTokens } from '../../schema/models/magicLinkTokens'
 
 export async function createMagicLinkToken(
-  { user }: { user: User },
+  { user, returnTo }: { user: User; returnTo?: string },
   db = database,
 ) {
   return Transaction.call(async (tx) => {
@@ -19,6 +19,7 @@ export async function createMagicLinkToken(
       data: {
         ...magicLinkToken[0]!,
         userEmail: user.email,
+        returnTo,
       },
     })
 

--- a/packages/web-ui/src/ds/atoms/Button/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Button/index.tsx
@@ -79,7 +79,7 @@ const buttonVariants = cva(
         default: 'py-1.5 px-3',
         small: 'py-1 px-1.5',
         none: 'py-0 px-0',
-        icon: 'h-10 w-10',
+        icon: 'h-6 w-6',
       },
       fanciness: {
         default: '',

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -33,6 +33,7 @@ import {
   LoaderCircle,
   Lock,
   MinusIcon,
+  MonitorIcon,
   Moon,
   Pencil,
   Pin,
@@ -54,7 +55,7 @@ import {
 } from 'lucide-react'
 
 import { cn } from '../../../lib/utils'
-import { colors, type TextColor } from '../../tokens'
+import { colors, DarkTextColor, type TextColor } from '../../tokens'
 import { LatitudeLogo, LatitudeLogoMonochrome } from './custom-icons'
 
 const Icons = {
@@ -97,6 +98,7 @@ const Icons = {
   logoMonochrome: LatitudeLogoMonochrome,
   modification: SquareDot,
   moon: Moon,
+  monitor: MonitorIcon,
   pencil: Pencil,
   pin: Pin,
   pinOff: PinOff,
@@ -119,6 +121,7 @@ export type IconName = keyof typeof Icons
 export type IconProps = {
   name: IconName
   color?: TextColor
+  darkColor?: DarkTextColor
   spin?: boolean
   size?: Size
   widthClass?: string
@@ -131,6 +134,7 @@ type Size = 'small' | 'normal' | 'large' | 'xlarge' | 'xxxlarge'
 export function Icon({
   name,
   color,
+  darkColor,
   spin,
   size = 'normal',
   className,
@@ -141,6 +145,7 @@ export function Icon({
       className={cn(
         {
           [colors.textColors[color!]]: color,
+          [colors.darkTextColors[darkColor!]]: darkColor,
           'w-3 h-3': size === 'small',
           'w-4 h-4': size === 'normal',
           'w-6 h-6': size === 'large',

--- a/packages/web-ui/src/ds/atoms/Modal/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Modal/Primitives/index.tsx
@@ -81,7 +81,7 @@ const DialogContent = forwardRef<
           ref={ref}
           forceMount={forceMount}
           className={cn(
-            'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 max-h-[90%] border dark:border bg-background shadow duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+            'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 max-h-[90%] border dark:border bg-background shadow duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg',
             _cn,
           )}
           onEscapeKeyDown={onEscapeKeyDown}

--- a/packages/web-ui/src/ds/atoms/Modal/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Modal/index.tsx
@@ -44,7 +44,7 @@ export type ModalProps = {
   description?: string
   children?: ReactNode
   footer?: ReactNode
-  size?: 'regular' | 'large'
+  size?: 'small' | 'regular' | 'large'
   steps?: {
     total: number
     current: number
@@ -69,11 +69,12 @@ export function Modal({
       <DialogContent
         dismissible={dismissible}
         className={cn('flex flex-col', {
+          'max-w-modal-sm': size === 'small',
           'max-w-modal': size === 'regular',
           'max-w-modal-lg': size === 'large',
         })}
       >
-        <div className='flex flex-col relative max-h-full sm:rounded-lg overflow-hidden'>
+        <div className='flex flex-col relative max-h-full overflow-hidden'>
           {steps || title || description ? (
             <div className='flex flex-col gap-y-4 pb-6'>
               {steps && (

--- a/packages/web-ui/src/ds/molecules/TrippleThemeToggle/index.tsx
+++ b/packages/web-ui/src/ds/molecules/TrippleThemeToggle/index.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useCallback, useState } from 'react'
+import { Button, ClientOnly } from '../../atoms'
+import { cn } from '../../../lib/utils'
+
+export const THEMES = ['light', 'dark', 'system'] as const
+export type ThemeValue = (typeof THEMES)[number]
+
+export function TripleThemeToggle() {
+  const { theme: initialTheme, setTheme } = useTheme()
+  const [theme, setLocalTheme] = useState<ThemeValue>(
+    initialTheme as unknown as ThemeValue,
+  )
+  const onClick = useCallback(
+    (t: ThemeValue) => () => {
+      setLocalTheme(t)
+      setTimeout(() => {
+        setTheme(() => t)
+      }, 200) // Css transition duration
+    },
+    [setTheme],
+  )
+  return (
+    <ClientOnly>
+      <div className='p-1 bg-gray-100 dark:bg-background-gray rounded-full flex items-center'>
+        <div className='relative flex'>
+          {THEMES.map((t) => (
+            <Button
+              key={t}
+              variant='nope'
+              size='icon'
+              onClick={onClick(t)}
+              aria-label={`Switch to ${t} theme`}
+              className='rounded-full relative z-10'
+              iconProps={{
+                name: t === 'light' ? 'sun' : t === 'dark' ? 'moon' : 'monitor',
+                color: 'foreground',
+                darkColor: theme === t ? 'background' : 'foregroundMuted',
+              }}
+            />
+          ))}
+          <div
+            className={cn(
+              'absolute top-0 left-0 w-6 h-full',
+              'bg-background dark:bg-foreground/70 rounded-full',
+              'transition-transform duration-200 ease-in-out',
+              {
+                'translate-x-0': theme === 'light',
+                'translate-x-6': theme === 'dark',
+                'translate-x-12': theme === 'system',
+              },
+            )}
+          />
+        </div>
+      </div>
+    </ClientOnly>
+  )
+}

--- a/packages/web-ui/src/ds/molecules/index.ts
+++ b/packages/web-ui/src/ds/molecules/index.ts
@@ -1,4 +1,5 @@
 export { default as FocusHeader } from './FocusHeader'
+
 export * from './DocumentTextEditor'
 export * from './Chat'
 export * from './ClicktoCopy'
@@ -21,3 +22,4 @@ export * from './ThemeButton'
 export * from './Breadcrumb'
 export * from './BlankSlate'
 export * from './Tabs'
+export * from './TrippleThemeToggle'

--- a/packages/web-ui/src/ds/tokens/colors.ts
+++ b/packages/web-ui/src/ds/tokens/colors.ts
@@ -20,6 +20,23 @@ export const colors = {
     warningForeground: 'text-warning-foreground',
     warningMutedForeground: 'text-warning-muted-foreground',
   },
+  darkTextColors: {
+    white: 'dark:text-white',
+    primary: 'dark:text-primary',
+    foreground: 'dark:text-foreground',
+    background: 'dark:text-background',
+    foregroundMuted: 'dark:text-muted-foreground',
+    accent: 'dark:text-accent',
+    destructive: 'dark:text-destructive',
+    destructiveForeground: 'dark:text-destructive-foreground',
+    destructiveMutedForeground: 'dark:text-destructive-muted-foreground',
+    success: 'dark:text-success',
+    successForeground: 'dark:text-success-foreground',
+    accentForeground: 'dark:text-accent-foreground',
+    secondaryForeground: 'dark:text-secondary-foreground',
+    warningForeground: 'dark:text-warning-foreground',
+    warningMutedForeground: 'dark:text-warning-muted-foreground',
+  },
   borderColors: {
     transparent: 'border-transparent',
     white: 'border-white',
@@ -27,5 +44,6 @@ export const colors = {
   },
 }
 export type TextColor = keyof typeof colors.textColors
+export type DarkTextColor = keyof typeof colors.darkTextColors
 export type BorderColor = keyof typeof colors.borderColors
 export type BackgroundColor = keyof typeof colors.backgrounds

--- a/packages/web-ui/tailwind.config.js
+++ b/packages/web-ui/tailwind.config.js
@@ -123,9 +123,10 @@ export default {
         'modal-lg': '720px',
       },
       maxWidth: {
+        'modal-sm': '360px',
         modal: '580px',
         'modal-lg': '720px',
-        chat: '1024px'
+        chat: '1024px',
       },
       transitionDelay: {
         250: '250ms',


### PR DESCRIPTION
# What?
Implement auth flow on public shared prompts.

### TODO 
- [x] If user is not logged in show login modal
- [x] When user put the email send a magic link with a `returnTo` path to `shared/d/:uuid/fork` so they can finish forking that prompt
- [x] Implement `share/d/:uuid/fork` page
- [x] When user does not have an account show signup modal
- [x] When user do workspace setup redirect to `returnTo` path

## Theme toggle
I like more this one that the selector we have inside the app. What do you think?
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/d1cfcc21-8fdb-4583-8e15-ad09d4a9448e">
