### PR TITLE
Do not store in cached AI response the data model attributes like `providerLog` or `documentLogUuid`

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -51,22 +51,21 @@ export const HELP_CENTER = {
 }
 
 export type StreamType = 'object' | 'text'
-export type ChainStepTextResponse = {
-  streamType: 'text'
+type BaseResponse = {
   text: string
   usage: LanguageModelUsage
-  toolCalls: ToolCall[]
   documentLogUuid?: string
   providerLog?: ProviderLog
 }
 
-export type ChainStepObjectResponse = {
+export type ChainStepTextResponse = BaseResponse & {
+  streamType: 'text'
+  toolCalls: ToolCall[]
+}
+
+export type ChainStepObjectResponse = BaseResponse & {
   streamType: 'object'
   object: any
-  text: string
-  usage: LanguageModelUsage
-  documentLogUuid?: string
-  providerLog?: ProviderLog
 }
 
 export type ChainStepResponse<T extends StreamType> = T extends 'text'

--- a/packages/core/src/services/chains/run.test.ts
+++ b/packages/core/src/services/chains/run.test.ts
@@ -650,6 +650,7 @@ describe('runChain', () => {
         providersMap,
         source: LogSources.API,
         errorableType: ErrorableEntity.DocumentLog,
+        generateUUID: () => 'new-document-log-uuid',
       })
       const spy = vi.spyOn(aiModule, 'ai')
       const saveOrPublishProviderLogSpy = vi
@@ -666,6 +667,7 @@ describe('runChain', () => {
           providerLog: { id: 'fake-provider-log-id' },
         }),
       )
+      expect(res.value?.documentLogUuid).toEqual('new-document-log-uuid')
     })
 
     describe('with config having temperature != 0', () => {

--- a/packages/core/src/services/chains/run.ts
+++ b/packages/core/src/services/chains/run.ts
@@ -205,12 +205,16 @@ async function runStep({
           conversation: step.conversation,
           stepStartTime,
           errorableUuid,
-          response: cachedResponse,
+          response: cachedResponse as ChainStepResponse<StreamType>,
         }),
         saveSyncProviderLogs: true, // TODO: temp bugfix, it should only save last one syncronously
       })
 
-      const response = { ...cachedResponse, providerLog }
+      const response = {
+        ...cachedResponse,
+        providerLog,
+        documentLogUuid: errorableUuid,
+      } as ChainStepResponse<StreamType>
 
       if (step.chainCompleted) {
         streamConsumer.chainCompleted({


### PR DESCRIPTION
# What?
We were storing these attributes and we had a bug where follow up conversations were linked to the original document log UUID because that's what was returned from running a chain that was cached