### PR TITLE
chore(release): bump versions for @latitude-data/sdk to 1.0.0-beta.10…

### DIFF
--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "OpenTelemetry exporters for Latitude",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",


### PR DESCRIPTION
… and @latitude-data/telemetry to 0.0.3