### PR TITLE
feat(telemetry): handle non-oai vercel calls in some scenarios

### DIFF
--- a/examples/chat-app/handlers/openai.ts
+++ b/examples/chat-app/handlers/openai.ts
@@ -1,26 +1,8 @@
 import { Request, Response } from 'express'
 import OpenAI from 'openai'
-import { zodResponseFormat } from 'openai/helpers/zod'
-import z from 'zod'
 
+import { latitude } from '../instrumentation'
 import { getWeather } from '../services/weather'
-import { Latitude } from '@latitude-data/sdk'
-
-const latitude = new Latitude('9d5a427b-f4db-42c4-ac03-41e30675bac2', {
-  __internal: {
-    gateway: {
-      host: 'localhost',
-      port: 8787,
-      ssl: false,
-    },
-  },
-  telemetry: {
-    modules: {
-      // @ts-ignore
-      openAI: OpenAI,
-    },
-  },
-})
 
 // Initialize OpenAI client
 export const openai = new OpenAI({

--- a/examples/chat-app/instrumentation.ts
+++ b/examples/chat-app/instrumentation.ts
@@ -1,33 +1,14 @@
 import dotenv from 'dotenv'
 import { Latitude } from '@latitude-data/sdk'
-import { Anthropic } from '@anthropic-ai/sdk'
-import OpenAI from 'openai'
+import { VercelSpanProcessor } from '@latitude-data/telemetry'
 
 // Load environment variables first
 dotenv.config()
 
-export const latitude = new Latitude(process.env.LATITUDE_API_KEY, {
+export const latitude = new Latitude('9d5a427b-f4db-42c4-ac03-41e30675bac2', {
   projectId: 21,
   telemetry: {
     disableBatch: true,
-    //processors: [VercelSpanProcessor],
-    modules: {
-      // @ts-ignore
-      openAI: OpenAI,
-      // @ts-ignore
-      anthropic: Anthropic,
-    },
+    processors: [VercelSpanProcessor],
   },
 })
-
-const secondLatitudeProject = new Latitude(
-  '9d5a427b-f4db-42c4-ac03-41e30675bac2',
-  {
-    projectId: 23,
-    telemetry: {
-      modules: {
-        openAI: OpenAI, // Check the documentation to get a list of supported modules
-      },
-    },
-  },
-)

--- a/packages/core/src/jobs/job-definitions/traces/processOtlpTracesJob.ts
+++ b/packages/core/src/jobs/job-definitions/traces/processOtlpTracesJob.ts
@@ -63,11 +63,13 @@ export const processOtlpTracesJob = async (
     }),
   )
 
+  const processedSpans = spans.map(({ span }) => processSpan({ span }))
+
   // Create all traces and spans in a single transaction, skipping existing traces
   await bulkCreateTracesAndSpans({
     workspace,
     traces: tracesToCreate,
     // @ts-expect-error - Fix when we fix types in compiler
-    spans: spans.map(({ span }) => processSpan({ span })),
+    spans: processedSpans,
   })
 }

--- a/packages/core/src/services/traces/bulkCreateTracesAndSpans.ts
+++ b/packages/core/src/services/traces/bulkCreateTracesAndSpans.ts
@@ -1,7 +1,7 @@
-import { eq, inArray } from 'drizzle-orm'
+import { eq, inArray, sql } from 'drizzle-orm'
 
 import { Workspace } from '../../browser'
-import { database } from '../../client'
+import { Database, database } from '../../client'
 import { SpanKind, SpanMetadataTypes } from '../../constants'
 import { publisher } from '../../events/publisher'
 import { Result, Transaction } from '../../lib'
@@ -11,53 +11,8 @@ import { Message, ToolCall } from '@latitude-data/compiler'
 
 export type BulkCreateTracesAndSpansProps = {
   workspace: Workspace
-  traces: Array<{
-    traceId: string
-    name?: string
-    startTime: Date
-    endTime?: Date
-    attributes?: Record<string, string | number | boolean>
-    status?: string
-  }>
-  spans: Array<{
-    traceId: string
-    spanId: string
-    parentSpanId?: string | null
-    name: string
-    kind: SpanKind
-    startTime: Date
-    endTime?: Date | null
-    attributes?: Record<string, string | number | boolean> | null
-    status?: string | null
-    statusMessage?: string | null
-    tools?: Array<ToolCall> | null
-    events?: Array<{
-      name: string
-      timestamp: string
-      attributes?: Record<string, string | number | boolean>
-    }> | null
-    links?: Array<{
-      traceId: string
-      spanId: string
-      attributes?: Record<string, string | number | boolean>
-    }> | null
-    internalType?: SpanMetadataTypes | null
-    model?: string | null
-    modelParameters?: unknown | null
-    input?: Message[] | null
-    output?: Message[] | null
-    inputTokens?: number | null
-    outputTokens?: number | null
-    totalTokens?: number | null
-    inputCostInMillicents?: number | null
-    outputCostInMillicents?: number | null
-    totalCostInMillicents?: number | null
-    metadata?: Record<string, string | number | boolean> | null
-    documentUuid?: string | null
-    parameters?: Record<string, string | number | boolean> | null
-    distinctId?: string | null
-    commitUuid?: string | null
-  }>
+  traces: TraceInput[]
+  spans: SpanInput[]
 }
 
 export async function bulkCreateTracesAndSpans(
@@ -68,134 +23,252 @@ export async function bulkCreateTracesAndSpans(
   }: BulkCreateTracesAndSpansProps,
   db = database,
 ) {
-  // First, find existing traces outside the transaction
-  let existingTraceIds = new Set<string>()
-  if (tracesToCreate.length > 0) {
-    const existingTraces = await db.query.traces.findMany({
-      where: inArray(
-        traces.traceId,
-        tracesToCreate.map((t) => t.traceId),
-      ),
-    })
-    existingTraceIds = new Set(existingTraces.map((t) => t.traceId))
-  }
+  // Find existing traces and spans outside the transaction
+  const [existingTraceIds, existingSpanIds] = await Promise.all([
+    findExistingTraces(tracesToCreate, db),
+    findExistingSpans(spansToCreate, db),
+  ])
 
-  // Filter out traces that already exist if skipExistingTraces is true
+  // Split items into create and update operations
   const tracesToInsert = tracesToCreate.filter(
-    (trace) => !existingTraceIds.has(trace.traceId),
+    (t) => !existingTraceIds.has(t.traceId),
   )
-  const tracesToUpdate = tracesToCreate.filter((trace) =>
-    existingTraceIds.has(trace.traceId),
+  const tracesToUpdate = tracesToCreate.filter((t) =>
+    existingTraceIds.has(t.traceId),
   )
 
   return Transaction.call(async (tx) => {
-    // Create new traces if any
-    let createdTraces: (typeof traces.$inferSelect)[] = []
-    let updatedTraces: (typeof traces.$inferSelect)[] = []
+    // Handle traces
+    const [createdTraces, updatedTraces] = await Promise.all([
+      createTraces({ workspace, tracesToInsert }, tx),
+      updateTraces(tracesToUpdate, tx),
+    ])
 
-    if (tracesToUpdate.length > 0) {
-      tracesToUpdate.forEach(async (trace) => {
-        const updatedTrace = await tx
-          .update(traces)
-          .set({
-            startTime: trace.startTime,
-            endTime: trace.endTime,
-            attributes: trace.attributes,
-            status: trace.status,
-          })
-          .where(eq(traces.traceId, trace.traceId))
-          .returning()
-
-        updatedTraces.push(updatedTrace[0]!)
-      })
-    }
-    if (tracesToInsert.length > 0) {
-      createdTraces = await tx
-        .insert(traces)
-        .values(
-          tracesToInsert.map((trace) => ({
-            workspaceId: workspace.id,
-            traceId: trace.traceId,
-            name: trace.name,
-            startTime: trace.startTime,
-            endTime: trace.endTime,
-            attributes: trace.attributes,
-            status: trace.status,
-          })),
-        )
-        // If the trace already exists we do a noop. This can happen as
-        // atomicity is not guaranteed (two traces can try to get created at the
-        // same time).
-        .onConflictDoUpdate({
-          target: [traces.traceId],
-          set: {
-            updatedAt: new Date(),
-          },
-        })
-        .returning()
-    }
-
-    // Get all valid trace IDs (both existing and newly created)
+    // Get all valid trace IDs
     const validTraceIds = new Set([
       ...existingTraceIds,
       ...createdTraces.map((t) => t.traceId),
     ])
 
-    // Filter spans to only include those associated with valid traces
+    // Filter and split spans
     const validSpans = spansToCreate.filter((span) =>
       validTraceIds.has(span.traceId),
     )
+    const spansToInsert = validSpans.filter(
+      (s) => !existingSpanIds.has(s.spanId),
+    )
+    const spansToUpdate = validSpans.filter((s) =>
+      existingSpanIds.has(s.spanId),
+    )
 
-    // Create all valid spans
-    const createdSpans = await tx
-      .insert(spans)
-      .values(
-        validSpans.map((span) => ({
-          traceId: span.traceId,
-          spanId: span.spanId,
-          parentSpanId: span.parentSpanId,
-          name: span.name,
-          kind: span.kind,
-          startTime: span.startTime,
-          endTime: span.endTime,
-          attributes: span.attributes,
-          status: span.status,
-          statusMessage: span.statusMessage,
-          events: span.events,
-          links: span.links,
-          internalType: span.internalType,
-          model: span.model,
-          modelParameters: span.modelParameters,
-          input: span.input,
-          output: span.output,
-          inputTokens: span.inputTokens,
-          outputTokens: span.outputTokens,
-          totalTokens: span.totalTokens,
-          inputCostInMillicents: span.inputCostInMillicents,
-          outputCostInMillicents: span.outputCostInMillicents,
-          totalCostInMillicents: span.totalCostInMillicents,
-          tools: span.tools,
-          metadata: span.metadata,
-          documentUuid: span.documentUuid,
-          parameters: span.parameters,
-          distinctId: span.distinctId,
-          commitUuid: span.commitUuid,
-        })),
-      )
-      .returning()
+    // Handle spans
+    const [createdSpans, updatedSpans] = await Promise.all([
+      createSpans(spansToInsert, tx),
+      updateSpans(spansToUpdate, tx),
+    ])
+
+    const allTraces = [...createdTraces, ...updatedTraces]
+    const allSpans = [...createdSpans, ...updatedSpans]
 
     publisher.publishLater({
       type: 'bulkCreateTracesAndSpans',
       data: {
         workspaceId: workspace.id,
-        traces: createdTraces,
-        spans: createdSpans,
+        traces: allTraces,
+        spans: allSpans,
       },
     })
 
     return Result.ok({
-      traces: createdTraces,
-      spans: createdSpans,
+      traces: allTraces,
+      spans: allSpans,
     })
   }, db)
+}
+
+type SpanInput = {
+  traceId: string
+  spanId: string
+  parentSpanId?: string | null
+  name: string
+  kind: SpanKind
+  startTime: Date
+  endTime?: Date | null
+  attributes?: Record<string, string | number | boolean> | null
+  status?: string | null
+  statusMessage?: string | null
+  tools?: Array<ToolCall> | null
+  events?: Array<{
+    name: string
+    timestamp: string
+    attributes?: Record<string, string | number | boolean>
+  }> | null
+  links?: Array<{
+    traceId: string
+    spanId: string
+    attributes?: Record<string, string | number | boolean>
+  }> | null
+  internalType?: SpanMetadataTypes | null
+  model?: string | null
+  modelParameters?: unknown | null
+  input?: Message[] | null
+  output?: Message[] | null
+  inputTokens?: number | null
+  outputTokens?: number | null
+  totalTokens?: number | null
+  inputCostInMillicents?: number | null
+  outputCostInMillicents?: number | null
+  totalCostInMillicents?: number | null
+  metadata?: Record<string, string | number | boolean> | null
+  documentUuid?: string | null
+  parameters?: Record<string, string | number | boolean> | null
+  distinctId?: string | null
+  commitUuid?: string | null
+}
+
+type TraceInput = {
+  traceId: string
+  name?: string
+  startTime: Date
+  endTime?: Date
+  attributes?: Record<string, string | number | boolean>
+  status?: string
+}
+
+async function findExistingTraces(tracez: TraceInput[], db: Database) {
+  if (tracez.length === 0) return new Set<string>()
+
+  const existingTraces = await db.query.traces.findMany({
+    where: inArray(
+      traces.traceId,
+      tracez.map((t) => t.traceId),
+    ),
+  })
+
+  return new Set(existingTraces.map((t) => t.traceId))
+}
+
+async function findExistingSpans(spanz: SpanInput[], db: Database) {
+  if (spanz.length === 0) return new Set<string>()
+
+  const existingSpans = await db.query.spans.findMany({
+    where: inArray(
+      spans.spanId,
+      spanz.map((s) => s.spanId),
+    ),
+  })
+
+  return new Set(existingSpans.map((s) => s.spanId))
+}
+
+async function updateTraces(tracesToUpdate: TraceInput[], tx: Database) {
+  const updatedTraces: (typeof traces.$inferSelect)[] = []
+
+  for (const trace of tracesToUpdate) {
+    const updated = await tx
+      .update(traces)
+      .set({
+        startTime: trace.startTime,
+        endTime: trace.endTime,
+        attributes: trace.attributes,
+        status: trace.status,
+      })
+      .where(eq(traces.traceId, trace.traceId))
+      .returning()
+    updatedTraces.push(updated[0]!)
+  }
+
+  return updatedTraces
+}
+
+async function createTraces(
+  {
+    workspace,
+    tracesToInsert,
+  }: {
+    workspace: Workspace
+    tracesToInsert: TraceInput[]
+  },
+  tx: Database,
+) {
+  if (tracesToInsert.length === 0) return []
+
+  return tx
+    .insert(traces)
+    .values(
+      tracesToInsert.map((trace) => ({
+        workspaceId: workspace.id,
+        traceId: trace.traceId,
+        name: trace.name,
+        startTime: trace.startTime,
+        endTime: trace.endTime,
+        attributes: trace.attributes,
+        status: trace.status,
+      })),
+    )
+    .onConflictDoUpdate({
+      target: [traces.traceId],
+      set: {
+        updatedAt: new Date(),
+      },
+    })
+    .returning()
+}
+
+async function updateSpans(spansToUpdate: SpanInput[], tx: Database) {
+  const updatedSpans: (typeof spans.$inferSelect)[] = []
+
+  for (const span of spansToUpdate) {
+    const updated = await tx
+      .update(spans)
+      .set({
+        ...span,
+        // Exclude traceId and spanId as they're part of the primary key
+        traceId: undefined,
+        spanId: undefined,
+      })
+      .where(eq(spans.spanId, span.spanId))
+      .returning()
+    updatedSpans.push(updated[0]!)
+  }
+
+  return updatedSpans
+}
+
+async function createSpans(spansToInsert: SpanInput[], tx: Database) {
+  if (spansToInsert.length === 0) return []
+
+  const updateSet: Record<string, unknown> = {
+    parentSpanId: sql`EXCLUDED.parent_span_id`,
+    name: sql`EXCLUDED.name`,
+    kind: sql`EXCLUDED.kind`,
+    startTime: sql`EXCLUDED.start_time`,
+    endTime: sql`EXCLUDED.end_time`,
+    attributes: sql`EXCLUDED.attributes`,
+    status: sql`EXCLUDED.status`,
+    statusMessage: sql`EXCLUDED.status_message`,
+    events: sql`EXCLUDED.events`,
+    links: sql`EXCLUDED.links`,
+    internalType: sql`EXCLUDED.internal_type`,
+    model: sql`EXCLUDED.model`,
+    modelParameters: sql`EXCLUDED.model_parameters`,
+    input: sql`EXCLUDED.input`,
+    output: sql`EXCLUDED.output`,
+    tools: sql`EXCLUDED.tools`,
+    metadata: sql`EXCLUDED.metadata`,
+    documentUuid: sql`EXCLUDED.document_uuid`,
+    parameters: sql`EXCLUDED.parameters`,
+    distinctId: sql`EXCLUDED.distinct_id`,
+    commitUuid: sql`EXCLUDED.commit_uuid`,
+    updatedAt: new Date(),
+  }
+
+  return tx
+    .insert(spans)
+    .values(spansToInsert)
+    .onConflictDoUpdate({
+      target: [spans.spanId],
+      set: updateSet,
+    })
+    .returning()
 }

--- a/packages/core/src/services/traces/extractInputOutput.ts
+++ b/packages/core/src/services/traces/extractInputOutput.ts
@@ -164,7 +164,6 @@ function extractOpenAIToolCalls(
   while (true) {
     const toolCallKey = `gen_ai.completion.${completionIndex}.tool_calls.${toolCallIndex}`
     const toolName = attrs[`${toolCallKey}.name`] as string
-
     if (!toolName) break
 
     const args = tryParseJSON(attrs[`${toolCallKey}.arguments`] as string)

--- a/packages/core/src/services/traces/otlp.ts
+++ b/packages/core/src/services/traces/otlp.ts
@@ -177,16 +177,16 @@ function processGenerationSpan(
   span: OtlpSpan,
 ): Partial<typeof spans.$inferInsert> {
   const attrs = convertOtlpAttributes({ attributes: span.attributes })
-  if (!attrs['gen_ai.system']) return {}
-
-  const provider = extractProvider(attrs)
-  if (!provider) return {}
-
-  const model = extractModel(attrs)
   const { input, output } = extractInputOutput(attrs)
+  if (!input.length || !output.length) return {}
+
   const modelParameters = extractModelParameters(attrs)
+  const provider = extractProvider(attrs)
+  const model = extractModel(attrs)
   const usage = extractUsage(attrs)
-  const costs = calculateCosts({ usage, provider, model: model as string })
+  const costs = provider
+    ? calculateCosts({ usage, provider, model: model as string })
+    : {}
   const toolCalls = extractFunctions(attrs)
 
   return {


### PR DESCRIPTION
Generating objects with non-oai models via vercel produced some unexpected spans. Adapted code to handle those. Also implemented upsert of spans in case they already exist.