### PR TITLE
refactor(traces): simplify traces pagination and realtime updates

### DIFF
--- a/apps/web/src/app/(private)/traces/_components/TracesTable/index.tsx
+++ b/apps/web/src/app/(private)/traces/_components/TracesTable/index.tsx
@@ -55,12 +55,7 @@ export function TracesTable({ traces: serverTraces }: Props) {
     },
   )
 
-  useRealtimeTraces({
-    page: Number(page),
-    pageSize: Number(pageSize),
-    filters,
-    fallbackData: serverTraces,
-  })
+  useRealtimeTraces()
 
   const handleSearch = (completedSearches: CompletedSearch[]) => {
     const params = new URLSearchParams(searchParams)

--- a/apps/web/src/app/(private)/traces/_components/TracesTable/useRealtimeTraces.ts
+++ b/apps/web/src/app/(private)/traces/_components/TracesTable/useRealtimeTraces.ts
@@ -6,36 +6,16 @@ import {
   EventArgs,
   useSockets,
 } from '$/components/Providers/WebsocketsProvider/useSockets'
-import {
-  SearchFilter,
-  Span,
-  Trace,
-  TraceWithSpans,
-} from '@latitude-data/core/browser'
+import { Span, Trace, TraceWithSpans } from '@latitude-data/core/browser'
 import { reverse, sortBy } from 'lodash-es'
 import { ListTracesResponse } from '@latitude-data/core/services/traces/list'
 
-export function useRealtimeTraces({
-  page,
-  pageSize,
-  filters,
-  fallbackData,
-}: {
-  page: number
-  pageSize: number
-  filters: SearchFilter[]
-  fallbackData: ListTracesResponse
-}) {
-  const { mutate } = useTracesPagination(
-    {
-      page: Number(page),
-      pageSize: Number(pageSize),
-      filters,
-    },
-    {
-      fallbackData,
-    },
-  )
+export function useRealtimeTraces() {
+  const { mutate } = useTracesPagination({
+    page: 1,
+    pageSize: 25,
+    filters: [],
+  })
 
   const onMessage = useCallback(
     (args: EventArgs<'tracesAndSpansCreated'>) => {
@@ -78,8 +58,8 @@ export function useRealtimeTraces({
             return {
               items: newData,
               count: newData.length,
-              page,
-              pageSize,
+              page: 1,
+              pageSize: 25,
             }
           } else {
             return {

--- a/apps/web/src/components/TablePaginationFooter/GoToPageInput/index.tsx
+++ b/apps/web/src/components/TablePaginationFooter/GoToPageInput/index.tsx
@@ -24,7 +24,10 @@ export function GoToPageInput({
     event.preventDefault()
 
     const targetPage = Number(new FormData(event.currentTarget).get('page'))
-    const queryParams = window.location.search
+    const urlParams = new URLSearchParams(window.location.search)
+
+    // Replace or add the page parameter
+    urlParams.set('page', targetPage.toString())
 
     if (baseUrl) {
       router.push(
@@ -32,7 +35,7 @@ export function GoToPageInput({
           baseUrl,
           page: targetPage,
           pageSize,
-          queryParams,
+          queryParams: urlParams.toString(),
           encodeQueryParams: false,
         }),
       )

--- a/docs/guides/sdk/typescript.mdx
+++ b/docs/guides/sdk/typescript.mdx
@@ -137,6 +137,11 @@ sdk.prompts.renderChain({
 })
 ```
 
+<Note>
+  `render` and `renderChain` only work with the latest iteration of Latitude's
+  open source prompt syntax: [PromptL](https://promptl.ai/)
+</Note>
+
 ### Run a prompt through Latitude Gateway
 
 Latitude's Gateway is a high-performing gateway that proxies your LLM calls

--- a/examples/chat-app/handlers/vercel.ts
+++ b/examples/chat-app/handlers/vercel.ts
@@ -24,8 +24,8 @@ export async function handleVercelChat(req: Request, res: Response) {
 
     const completion = await latitude.telemetry.span({}, () =>
       generateObject({
-        //model: openai('gpt-4o-mini'),
-        model: google('gemini-1.5-flash-latest'),
+        model: openai('gpt-4o-mini'),
+        //model: google('gemini-1.5-flash-latest'),
         // model: anthropic('claude-3-5-sonnet-latest'),
         max_tokens: 1000,
         // @ts-ignore

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "1.0.0-beta.11",
+  "version": "1.0.0-beta.12",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -1,8 +1,13 @@
-import type { ContentType, Message, MessageRole } from '@latitude-data/compiler'
-import type {
-  ChainEventDto,
-  DocumentLog,
-  EvaluationResultDto,
+import {
+  type ContentType,
+  type Message,
+  type MessageRole,
+} from '@latitude-data/compiler'
+import {
+  Providers,
+  type ChainEventDto,
+  type DocumentLog,
+  type EvaluationResultDto,
 } from '@latitude-data/constants'
 
 import {
@@ -312,15 +317,9 @@ class Latitude {
     parameters,
     adapter: _adapter,
   }: RenderPromptOptions<M>) {
-    if (prompt.promptlVersion !== 1) {
-      throw new Error(
-        'The prompt is defined with the Legacy syntax. Please update it to the new syntax. Learn more: https://docs.latitude.so/guides/prompt-manager/migrate-to-promptl',
-      )
-    }
-    const content = prompt.resolvedContent ?? prompt.content
-    const adapter = _adapter ?? getPromptlAdapterFromProvider(prompt.provider)
+    const adapter = _adapter ?? getPromptlAdapterFromProvider(Providers.OpenAI)
     const { config, messages } = await render({
-      prompt: content,
+      prompt: prompt.content,
       parameters,
       adapter,
     })

--- a/packages/sdks/typescript/src/utils/types.ts
+++ b/packages/sdks/typescript/src/utils/types.ts
@@ -168,7 +168,9 @@ export type RunPromptOptions = StreamResponseCallbacks & {
 
 export type RenderPromptOptions<M extends AdapterMessageType = PromptlMessage> =
   {
-    prompt: Prompt
+    prompt: {
+      content: string
+    }
     parameters: Record<string, unknown>
     adapter?: ProviderAdapter<M>
   }


### PR DESCRIPTION
- Remove pagination params from useRealtimeTraces hook
- Set default values for page size and filters
- Improve URL parameter handling in pagination component (was a bit broken)
- Made Typescript SDK render method not depend on latitude-specific prompt abstractions such as resolvedContent or provider