### PR TITLE
Reset to document version UI

### DIFF
--- a/apps/web/src/actions/history/resetDocumentVersion/resetDocumentVersionAction.ts
+++ b/apps/web/src/actions/history/resetDocumentVersion/resetDocumentVersionAction.ts
@@ -1,0 +1,91 @@
+'use server'
+
+import {
+  CommitsRepository,
+  DocumentVersionsRepository,
+} from '@latitude-data/core/repositories'
+import { z } from 'zod'
+
+import { withProject } from '../../procedures'
+import { computeDocumentRevertChanges } from '@latitude-data/core/services/documents/computeRevertChanges'
+import { createCommit } from '@latitude-data/core/services/commits/create'
+import { updateDocument } from '@latitude-data/core/services/documents/update'
+
+export const resetDocumentVersionAction = withProject
+  .createServerAction()
+  .input(
+    z.object({
+      targetDraftUuid: z.string().optional(),
+      documentCommitUuid: z.string(),
+      documentUuid: z.string(),
+    }),
+  )
+  .handler(async ({ input, ctx }) => {
+    const { workspace, project } = ctx
+    const { targetDraftUuid, documentCommitUuid, documentUuid } = input
+
+    const docsScope = new DocumentVersionsRepository(workspace.id)
+
+    const originalDocument = await docsScope
+      .getDocumentAtCommit({
+        projectId: project.id,
+        commitUuid: documentCommitUuid,
+        documentUuid,
+      })
+      .then((r) => r.value)
+
+    const commitScope = new CommitsRepository(workspace.id)
+    const headCommit = await commitScope
+      .getHeadCommit(ctx.project.id)
+      .then((r) => r.unwrap()!)
+
+    const targetCommit = targetDraftUuid
+      ? await commitScope
+          .getCommitByUuid({ uuid: targetDraftUuid, projectId: project.id })
+          .then((r) => r.unwrap())
+      : headCommit
+
+    const targetDocument = await docsScope
+      .getDocumentAtCommit({
+        commitUuid: targetCommit.uuid,
+        documentUuid: input.documentUuid,
+      })
+      .then((r) => r.value)
+
+    const documentVersionChanges = await computeDocumentRevertChanges({
+      workspace: ctx.workspace,
+      draft: targetCommit,
+      changedDocument: targetDocument,
+      originalDocument,
+    }).then((r) => r.unwrap())
+
+    const oldDocumentPath =
+      targetDocument?.path ??
+      originalDocument?.path ??
+      documentVersionChanges.path
+
+    const targetDraft = targetDraftUuid
+      ? targetCommit
+      : await createCommit({
+          project: ctx.project,
+          user: ctx.user,
+          data: {
+            title: `Reset "${oldDocumentPath}"`,
+            description: `Reset document "${oldDocumentPath}" to version "${targetCommit.title}"`,
+          },
+        }).then((r) => r.unwrap())
+
+    await updateDocument({
+      commit: targetDraft,
+      document: targetDocument ?? originalDocument!,
+      path: documentVersionChanges.path,
+      content: documentVersionChanges.content,
+      deletedAt: documentVersionChanges.deletedAt,
+    }).then((r) => r.unwrap())
+
+    return {
+      commitUuid: targetDraft.uuid,
+      documentUuid:
+        documentVersionChanges.deletedAt != null ? undefined : documentUuid,
+    }
+  })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/CommitChangesList/documentActions.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/_components/CommitChangesList/documentActions.ts
@@ -1,0 +1,125 @@
+import { Commit } from '@latitude-data/core/browser'
+import { ChangedDocument } from '@latitude-data/core/repositories'
+import { useCurrentCommit } from '@latitude-data/web-ui/browser'
+import { useRouter } from 'next/navigation'
+import { ROUTES } from '$/services/routes'
+import { useHistoryActionModalContext } from '../ActionModal'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { getChangesToRevertDocumentAction } from '$/actions/history/revertDocumentVersion/getChangesToRevertDocumentAction'
+import { revertDocumentChangesAction } from '$/actions/history/revertDocumentVersion/revertDocumentAction'
+import { useCallback } from 'react'
+import { getChangesToResetDocumentAction } from '$/actions/history/resetDocumentVersion/getChangesToResetDocumentAction'
+import { resetDocumentVersionAction } from '$/actions/history/resetDocumentVersion/resetDocumentVersionAction'
+
+export function useDocumentActions({
+  commit,
+  change,
+}: {
+  commit: Commit
+  change: ChangedDocument
+}) {
+  const router = useRouter()
+  const { open, setError, setChanges } = useHistoryActionModalContext()
+  const { commit: currentCommit } = useCurrentCommit()
+
+  const { execute: executeGetChangesToRevert } = useLatitudeAction(
+    getChangesToRevertDocumentAction,
+    {
+      onSuccess: ({ data: changes }) => {
+        setChanges(changes)
+      },
+      onError: ({ err: error }) => setError(error.message),
+    },
+  )
+
+  const { execute: executeGetChangesToReset } = useLatitudeAction(
+    getChangesToResetDocumentAction,
+    {
+      onSuccess: ({ data: changes }) => {
+        setChanges(changes)
+      },
+      onError: ({ err: error }) => setError(error.message),
+    },
+  )
+
+  const { execute: executeRevertChanges } = useLatitudeAction(
+    revertDocumentChangesAction,
+    {
+      onSuccess: ({ data: { commitUuid, documentUuid } }) => {
+        const commitBaseRoute = ROUTES.projects
+          .detail({ id: commit.projectId })
+          .commits.detail({ uuid: commitUuid }).documents
+        const route = documentUuid
+          ? commitBaseRoute.detail({ uuid: documentUuid }).root
+          : commitBaseRoute.root
+        router.push(route)
+      },
+      onError: ({ err: error }) => setError(error.message),
+    },
+  )
+
+  const { execute: executeResetChanges } = useLatitudeAction(
+    resetDocumentVersionAction,
+    {
+      onSuccess: ({ data: { commitUuid, documentUuid } }) => {
+        const commitBaseRoute = ROUTES.projects
+          .detail({ id: commit.projectId })
+          .commits.detail({ uuid: commitUuid }).documents
+        const route = documentUuid
+          ? commitBaseRoute.detail({ uuid: documentUuid }).root
+          : commitBaseRoute.root
+        router.push(route)
+      },
+      onError: ({ err: error }) => setError(error.message),
+    },
+  )
+
+  const getChangesToRevert = useCallback(() => {
+    open({
+      title: `Revert changes from ${change.path}`,
+      onConfirm: () =>
+        executeRevertChanges({
+          projectId: commit.projectId,
+          targetDraftUuid: currentCommit.mergedAt
+            ? undefined
+            : currentCommit.uuid,
+          documentUuid: change.documentUuid,
+          documentCommitUuid: commit.uuid,
+        }),
+    })
+
+    executeGetChangesToRevert({
+      projectId: commit.projectId,
+      targetDraftUuid: currentCommit.mergedAt ? undefined : currentCommit.uuid,
+      documentUuid: change.documentUuid,
+      documentCommitUuid: commit.uuid,
+    })
+  }, [commit, change])
+
+  const getChangesToReset = useCallback(() => {
+    open({
+      title: `Reset document to ${change.path}`,
+      onConfirm: () =>
+        executeResetChanges({
+          projectId: commit.projectId,
+          targetDraftUuid: currentCommit.mergedAt
+            ? undefined
+            : currentCommit.uuid,
+          documentUuid: change.documentUuid,
+          documentCommitUuid: commit.uuid,
+        }),
+    })
+
+    executeGetChangesToReset({
+      projectId: commit.projectId,
+      targetDraftUuid: currentCommit.mergedAt ? undefined : currentCommit.uuid,
+      documentUuid: change.documentUuid,
+      documentCommitUuid: commit.uuid,
+    })
+  }, [commit, change])
+
+  return {
+    getChangesToRevert,
+    getChangesToReset,
+  }
+}

--- a/packages/core/src/services/documents/update.ts
+++ b/packages/core/src/services/documents/update.ts
@@ -45,7 +45,9 @@ export async function updateDocument(
     }
 
     const workspace = await findWorkspaceFromCommit(commit, tx)
-    const docsScope = new DocumentVersionsRepository(workspace!.id, tx)
+    const docsScope = new DocumentVersionsRepository(workspace!.id, tx, {
+      includeDeleted: true,
+    })
     const documents = (await docsScope.getDocumentsAtCommit(commit)).unwrap()
     const doc = documents.find((d) => d.documentUuid === document.documentUuid)
 


### PR DESCRIPTION
The second of 4 actions for the History page:
- [x] Revert changes from a specific document
- [x] Reset document to a specific version
- [ ] Revert all changes from a commit
- [ ] Reset project to a commit

In addition to this, increased the complexity on the restrictions to when a document version can be both reverted and/or resetted.

https://github.com/user-attachments/assets/2171aa58-3fed-425f-a129-92d89dcf48cc
