### PR TITLE
Fix drizzle

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,9 +1,9 @@
-import {
-  type AssistantMessage,
-  type Message as CompilerMessage,
-  type SystemMessage,
-  type ToolCall,
-  type UserMessage,
+import type {
+  AssistantMessage,
+  Message as CompilerMessage,
+  SystemMessage,
+  ToolCall,
+  UserMessage,
 } from '@latitude-data/compiler'
 import {
   EvaluationResultableType,

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -2,11 +2,9 @@ import { z } from 'zod'
 import { CsvData, ParameterType } from './constants'
 import { ProviderApiKey, ProviderLogDto } from './schema/types'
 
-import {
-  ContentType,
+import type {
   Message,
   MessageContent,
-  MessageRole,
   ToolRequestContent,
 } from '@latitude-data/compiler'
 
@@ -67,21 +65,21 @@ export function buildConversation(providerLog: ProviderLogDto) {
 
   if (providerLog.response && providerLog.response.length > 0) {
     message = {
-      role: MessageRole.assistant,
+      role: 'assistant',
       content: [
         {
-          type: ContentType.text,
+          type: 'text',
           text: providerLog.response,
         },
       ],
       toolCalls: [],
-    }
+    } as Message
   }
 
   if (providerLog.toolCalls.length > 0) {
     const content = providerLog.toolCalls.map((toolCall) => {
       return {
-        type: ContentType.toolCall,
+        type: 'tool-call',
         toolCallId: toolCall.id,
         toolName: toolCall.name,
         args: toolCall.arguments,
@@ -93,10 +91,10 @@ export function buildConversation(providerLog: ProviderLogDto) {
       message.toolCalls = providerLog.toolCalls
     } else {
       message = {
-        role: MessageRole.assistant,
+        role: 'assistant',
         content: content,
         toolCalls: providerLog.toolCalls,
-      }
+      } as Message
     }
   }
 

--- a/packages/core/src/jobs/job-definitions/documentLogs/createDocumentLogJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentLogs/createDocumentLogJob.ts
@@ -1,4 +1,4 @@
-import { Message } from '@latitude-data/compiler'
+import type { Message } from '@latitude-data/compiler'
 import { Job } from 'bullmq'
 
 import { Commit } from '../../../browser'

--- a/packages/core/src/schema/models/providerLogs.ts
+++ b/packages/core/src/schema/models/providerLogs.ts
@@ -1,4 +1,4 @@
-import { Message, ToolCall } from '@latitude-data/compiler'
+import type { Message, ToolCall } from '@latitude-data/compiler'
 import {
   bigint,
   bigserial,

--- a/packages/core/src/schema/models/spans.ts
+++ b/packages/core/src/schema/models/spans.ts
@@ -15,7 +15,7 @@ import { SpanKind } from '../../constants'
 import { latitudeSchema } from '../db-schema'
 import { timestamps } from '../schemaHelpers'
 import { traces } from './traces'
-import { ToolCall } from '@latitude-data/compiler'
+import type { ToolCall } from '@latitude-data/compiler'
 
 // SpanKind describes the relationship between the Span, its parents, and its children in a Trace
 export const spanKindsEnum = latitudeSchema.enum('span_kinds', [

--- a/packages/core/src/services/ai/helpers.ts
+++ b/packages/core/src/services/ai/helpers.ts
@@ -3,7 +3,7 @@ import { createAzure } from '@ai-sdk/azure'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createMistral } from '@ai-sdk/mistral'
 import { createOpenAI } from '@ai-sdk/openai'
-import { Message, MessageRole } from '@latitude-data/compiler'
+import { type Message, MessageRole } from '@latitude-data/compiler'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 
 import { Providers } from '../../constants'

--- a/packages/core/src/services/ai/index.test.ts
+++ b/packages/core/src/services/ai/index.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, Message, MessageRole } from '@latitude-data/compiler'
+import { ContentType, type Message, MessageRole } from '@latitude-data/compiler'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 import { APICallError, CoreTool, ObjectStreamPart, TextStreamPart } from 'ai'
 import { MockLanguageModelV1 } from 'ai/test'

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -1,6 +1,6 @@
 import { omit } from 'lodash-es'
 
-import { Message } from '@latitude-data/compiler'
+import type { Message } from '@latitude-data/compiler'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 import {
   CoreMessage,

--- a/packages/core/src/services/ai/providers/rules/anthropic.test.ts
+++ b/packages/core/src/services/ai/providers/rules/anthropic.test.ts
@@ -1,4 +1,4 @@
-import { Message, MessageRole } from '@latitude-data/compiler'
+import { type Message, MessageRole } from '@latitude-data/compiler'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import { PartialConfig } from '../../helpers'

--- a/packages/core/src/services/commits/RunDocumentChecker/index.ts
+++ b/packages/core/src/services/commits/RunDocumentChecker/index.ts
@@ -1,7 +1,7 @@
 import {
   createChain as createLegacyChain,
   readMetadata,
-  ReferencePromptFn,
+  type ReferencePromptFn,
 } from '@latitude-data/compiler'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 import { Adapters, Chain as PromptlChain, scan } from 'promptl-ai'

--- a/packages/core/src/services/commits/getChanges.ts
+++ b/packages/core/src/services/commits/getChanges.ts
@@ -6,7 +6,7 @@ import {
 } from '../../browser'
 import { database } from '../../client'
 import { PromisedResult, Result } from '../../lib'
-import { CompileError } from 'promptl-ai'
+import type { CompileError } from 'promptl-ai'
 import { recomputeChanges } from '../documents'
 import {
   ChangedDocument,

--- a/packages/core/src/services/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.ts
@@ -1,4 +1,4 @@
-import { Message } from '@latitude-data/compiler'
+import type { Message } from '@latitude-data/compiler'
 
 import { LogSources, Workspace } from '../../../browser'
 import { ProviderLogsRepository } from '../../../repositories'

--- a/packages/core/src/services/documentLogs/create.ts
+++ b/packages/core/src/services/documentLogs/create.ts
@@ -1,4 +1,4 @@
-import { Message, ToolCall } from '@latitude-data/compiler'
+import type { Message, ToolCall } from '@latitude-data/compiler'
 
 import { Commit, DocumentLog, LogSources } from '../../browser'
 import { database } from '../../client'

--- a/packages/core/src/services/documents/scan.ts
+++ b/packages/core/src/services/documents/scan.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import { readMetadata, Document as RefDocument } from '@latitude-data/compiler'
-import { ConversationMetadata, scan } from 'promptl-ai'
+import { type ConversationMetadata, scan } from 'promptl-ai'
 
 import { Commit, DocumentVersion, Workspace } from '../../browser'
 import {

--- a/packages/core/src/services/providerLogs/addMessages.ts
+++ b/packages/core/src/services/providerLogs/addMessages.ts
@@ -1,4 +1,4 @@
-import { Message } from '@latitude-data/compiler'
+import type { Message } from '@latitude-data/compiler'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 
 import {

--- a/packages/core/src/services/providerLogs/create.ts
+++ b/packages/core/src/services/providerLogs/create.ts
@@ -1,4 +1,4 @@
-import { Message, ToolCall } from '@latitude-data/compiler'
+import type { Message, ToolCall } from '@latitude-data/compiler'
 import { FinishReason, LanguageModelUsage } from 'ai'
 
 import { LogSources, ProviderLog, Providers, Workspace } from '../../browser'

--- a/packages/core/src/services/traces/bulkCreateTracesAndSpans.ts
+++ b/packages/core/src/services/traces/bulkCreateTracesAndSpans.ts
@@ -7,7 +7,7 @@ import { publisher } from '../../events/publisher'
 import { Result, Transaction } from '../../lib'
 import { spans } from '../../schema/models/spans'
 import { traces } from '../../schema/models/traces'
-import { Message, ToolCall } from '@latitude-data/compiler'
+import type { Message, ToolCall } from '@latitude-data/compiler'
 
 export type BulkCreateTracesAndSpansProps = {
   workspace: Workspace

--- a/packages/core/src/tests/factories/evaluationResults.ts
+++ b/packages/core/src/tests/factories/evaluationResults.ts
@@ -1,5 +1,9 @@
 import { faker } from '@faker-js/faker'
-import { ContentType, Conversation, createChain } from '@latitude-data/compiler'
+import {
+  ContentType,
+  type Conversation,
+  createChain,
+} from '@latitude-data/compiler'
 import { Adapters, Chain as PromptlChain } from 'promptl-ai'
 import { LanguageModelUsage } from 'ai'
 import { eq } from 'drizzle-orm'

--- a/packages/core/src/tests/factories/providerLogs.ts
+++ b/packages/core/src/tests/factories/providerLogs.ts
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid'
 
 import { LogSources, ProviderLog, Providers, Workspace } from '../../browser'
 import { createProviderLog as createProviderLogService } from '../../services/providerLogs'
-import { ToolCall } from '@latitude-data/compiler'
+import type { ToolCall } from '@latitude-data/compiler'
 
 export type IProviderLogData = {
   documentLogUuid: string


### PR DESCRIPTION
Fixes Drizzle not able to import `@latitude-data/compiler`, which makes it unable to open the studio or generate migrations