### PR TITLE
Autonomous Agents behaviour prototype

### DIFF
--- a/packages/constants/src/ai.ts
+++ b/packages/constants/src/ai.ts
@@ -154,31 +154,39 @@ export type ChainEvent =
       event: StreamEventTypes.Provider
     }
 
+export type LatitudeStepEventData = {
+  type: ChainEventTypes.Step
+  config: Config
+  isLastStep: boolean
+  messages: Message[]
+  documentLogUuid?: string
+}
+
+export type LatitudeStepCompleteEventData = {
+  type: ChainEventTypes.StepComplete
+  response: ChainStepResponse<StreamType>
+  documentLogUuid?: string
+}
+
+export type LatitudeChainCompleteEventData = {
+  type: ChainEventTypes.Complete
+  config: Config
+  messages?: Message[]
+  object?: any
+  response: ChainStepResponse<StreamType>
+  documentLogUuid?: string
+}
+
+export type LatitudeChainErrorEventData = {
+  type: ChainEventTypes.Error
+  error: Error
+}
+
 export type LatitudeEventData =
-  | {
-      type: ChainEventTypes.Step
-      config: Config
-      isLastStep: boolean
-      messages: Message[]
-      documentLogUuid?: string
-    }
-  | {
-      type: ChainEventTypes.StepComplete
-      response: ChainStepResponse<StreamType>
-      documentLogUuid?: string
-    }
-  | {
-      type: ChainEventTypes.Complete
-      config: Config
-      messages?: Message[]
-      object?: any
-      response: ChainStepResponse<StreamType>
-      documentLogUuid?: string
-    }
-  | {
-      type: ChainEventTypes.Error
-      error: Error
-    }
+  | LatitudeStepEventData
+  | LatitudeStepCompleteEventData
+  | LatitudeChainCompleteEventData
+  | LatitudeChainErrorEventData
 
 // FIXME: Move to @latitude-data/constants
 export type RunSyncAPIResponse = {
@@ -189,3 +197,13 @@ export type RunSyncAPIResponse = {
 
 // FIXME: Move to @latitude-data/constants
 export type ChatSyncAPIResponse = RunSyncAPIResponse
+
+export const toolCallResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  result: z.string().or(z.record(z.any())),
+  isError: z.boolean().optional(),
+  text: z.string().optional(),
+})
+
+export type ToolCallResponse = z.infer<typeof toolCallResponseSchema>

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -446,3 +446,5 @@ export type DraftChange = {
   oldDocumentPath: string
   content: DiffValue
 }
+
+export const AGENT_RETURN_TOOL_NAME = 'agent_finish_task'

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -2,11 +2,22 @@ import { z } from 'zod'
 import { CsvData, ParameterType } from './constants'
 import { ProviderApiKey, ProviderLogDto } from './schema/types'
 
-import type {
+import {
+  ContentType,
   Message,
   MessageContent,
+  MessageRole,
+  ToolCall,
   ToolRequestContent,
+  ToolContent,
+  AssistantMessage,
+  ToolMessage,
 } from '@latitude-data/compiler'
+import {
+  ChainStepResponse,
+  StreamType,
+  ToolCallResponse,
+} from '@latitude-data/constants'
 
 const DEFAULT_OBJECT_TO_STRING_MESSAGE =
   'Error: Provider returned an object that could not be stringified'
@@ -57,6 +68,126 @@ export function buildCsvFile(csvData: CsvData, name: string): File {
   const rows = csvData.data.map((row) => Object.values(row.record).join(','))
   const csv = [headers, ...rows].join('\n')
   return new File([csv], `${name}.csv`, { type: 'text/csv' })
+}
+
+type BuildMessageParams<T extends StreamType> = T extends 'object'
+  ? {
+      type: 'object'
+      data?: {
+        object: any | undefined
+        text: string | undefined
+      }
+    }
+  : {
+      type: 'text'
+      data?: {
+        text: string | undefined
+        toolCalls?: ToolCall[]
+        toolCallResponses?: ToolCallResponse[]
+      }
+    }
+export function buildResponseMessage<T extends StreamType>({
+  type,
+  data,
+}: BuildMessageParams<T>) {
+  if (!data) return undefined
+
+  if (type === 'text' && data.toolCalls && data.toolCallResponses) {
+    throw new Error(
+      'A message cannot have both toolCalls and toolCallResponses',
+    )
+  }
+
+  const toolCallResponses =
+    type === 'text' ? (data.toolCallResponses ?? []) : []
+
+  const text = data.text
+  const object = type === 'object' ? data.object : undefined
+  const toolCalls = type === 'text' ? (data.toolCalls ?? []) : []
+  let content: MessageContent[] = []
+
+  if (text && text.length > 0) {
+    content.push({
+      type: ContentType.text,
+      text: text,
+    })
+  }
+
+  if (object) {
+    content.push({
+      type: ContentType.text,
+      text: objectToString(object),
+    })
+  }
+
+  if (toolCalls.length > 0) {
+    const toolContents = toolCalls.map((toolCall) => {
+      return {
+        type: ContentType.toolCall,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+        args: toolCall.arguments,
+      } as ToolRequestContent
+    })
+
+    content = content.concat(toolContents)
+  }
+
+  if (toolCallResponses.length > 0) {
+    const toolResponseContents = toolCallResponses.map((toolCallResponse) => {
+      return {
+        type: ContentType.toolResult,
+        toolCallId: toolCallResponse.id,
+        toolName: toolCallResponse.name,
+        result:
+          typeof toolCallResponse.result === 'string'
+            ? JSON.parse(toolCallResponse.result)
+            : toolCallResponse.result,
+        isError: toolCallResponse.isError || false,
+      }
+    })
+
+    content = content.concat(toolResponseContents as unknown as ToolContent[])
+  }
+
+  if (!content.length) return undefined
+
+  if (toolCallResponses.length > 0) {
+    return {
+      role: MessageRole.tool,
+      content,
+    } as ToolMessage
+  }
+
+  return { role: MessageRole.assistant, content, toolCalls } as AssistantMessage
+}
+
+export function buildMessagesFromResponse<T extends StreamType>({
+  response,
+}: {
+  response: ChainStepResponse<T>
+}) {
+  const type = response.streamType
+  const message =
+    type === 'object'
+      ? buildResponseMessage<'object'>({
+          type: 'object',
+          data: {
+            object: response.object,
+            text: response.text,
+          },
+        })
+      : type === 'text'
+        ? buildResponseMessage<'text'>({
+            type: 'text',
+            data: { text: response.text, toolCalls: response.toolCalls },
+          })
+        : undefined
+
+  const previousMessages = response.providerLog
+    ? response.providerLog.messages
+    : []
+  return [...previousMessages, ...(message ? [message] : [])]
 }
 
 export function buildConversation(providerLog: ProviderLogDto) {

--- a/packages/core/src/services/chains/ChainStreamConsumer/index.test.ts
+++ b/packages/core/src/services/chains/ChainStreamConsumer/index.test.ts
@@ -15,12 +15,12 @@ import {
 } from '../../../constants'
 import * as factories from '../../../tests/factories'
 import { ChainError } from '../ChainErrors'
-import { ValidatedStep } from '../ChainValidator'
+import { ValidatedChainStep } from '../ChainValidator'
 
 describe('ChainStreamConsumer', () => {
   let controller: ReadableStreamDefaultController
   let consumer: ChainStreamConsumer
-  let step: ValidatedStep
+  let step: ValidatedChainStep
 
   beforeEach(async () => {
     const { workspace, userData: user } = await factories.createWorkspace()

--- a/packages/core/src/services/chains/ChainStreamConsumer/index.ts
+++ b/packages/core/src/services/chains/ChainStreamConsumer/index.ts
@@ -17,7 +17,10 @@ import {
 import { objectToString } from '../../../helpers'
 import { Config } from '../../ai'
 import { ChainError } from '../ChainErrors'
-import { ValidatedStep } from '../ChainValidator'
+import { ValidatedChainStep } from '../ChainValidator'
+import { ValidatedAgentStep } from '../agents/AgentStepValidator'
+
+type ValidatedStep = ValidatedChainStep | ValidatedAgentStep
 
 export function enqueueChainEvent(
   controller: ReadableStreamDefaultController,

--- a/packages/core/src/services/chains/agents/AgentStepValidator/index.ts
+++ b/packages/core/src/services/chains/agents/AgentStepValidator/index.ts
@@ -1,0 +1,164 @@
+import { Conversation, Message, ToolCall } from '@latitude-data/compiler'
+import { RunErrorCodes } from '@latitude-data/constants/errors'
+import { JSONSchema7 } from 'json-schema'
+import { z } from 'zod'
+
+import {
+  AGENT_RETURN_TOOL_NAME,
+  applyProviderRules,
+  ProviderApiKey,
+  Workspace,
+} from '../../../../browser'
+import { Result, TypedResult } from '../../../../lib'
+import { Config } from '../../../ai'
+import { azureConfig, googleConfig } from '../../../ai/helpers'
+import { ChainError } from '../../ChainErrors'
+import { checkFreeProviderQuota } from '../../checkFreeProviderQuota'
+import { CachedApiKeys } from '../../run'
+
+export type ValidatedAgentStep = {
+  config: Config
+  provider: ProviderApiKey
+  conversation: Conversation
+  chainCompleted: boolean
+  schema?: JSONSchema7
+  output?: 'object' | 'array' | 'no-schema'
+}
+
+type JSONOverride = { schema: JSONSchema7; output: 'object' | 'array' }
+export type ConfigOverrides = JSONOverride | { output: 'no-schema' }
+
+type ValidatorContext = {
+  workspace: Workspace
+  prevText: string | undefined
+  conversation: Conversation
+  providersMap: CachedApiKeys
+}
+
+const findProvider = (name: string, providersMap: CachedApiKeys) => {
+  const provider = providersMap.get(name)
+  if (provider) return Result.ok(provider)
+
+  const settingUrl = 'https://app.latitude.so/settings'
+  return Result.error(
+    new ChainError({
+      message: `Provider API Key with name ${name} not found. Go to ${settingUrl} to add a new provider if there is not one already with that name.`,
+      code: RunErrorCodes.MissingProvider,
+    }),
+  )
+}
+
+const validateConfig = (
+  config: Record<string, unknown>,
+): TypedResult<Config, ChainError<RunErrorCodes.DocumentConfigError>> => {
+  const doc =
+    'https://docs.latitude.so/guides/getting-started/providers#using-providers-in-prompts'
+  const schema = z
+    .object({
+      model: z.string({
+        message: `"model" attribute is required. Read more here: ${doc}`,
+      }),
+      provider: z.string({
+        message: `"provider" attribute is required. Read more here: ${doc}`,
+      }),
+      google: googleConfig.optional(),
+      azure: azureConfig.optional(),
+    })
+    .catchall(z.unknown())
+
+  const result = schema.safeParse(config)
+
+  if (!result.success) {
+    const validationError = result.error.errors[0]
+    const message = validationError
+      ? validationError.message
+      : 'Error validating document configuration'
+    return Result.error(
+      new ChainError({
+        message,
+        code: RunErrorCodes.DocumentConfigError,
+      }),
+    )
+  }
+
+  return Result.ok(result.data)
+}
+
+const applyAgentTools = (config: Config): Config => {
+  const { schema, ...rest } = config
+
+  const DEFAULT_SCHEMA: JSONSchema7 = {
+    type: 'object',
+    properties: {
+      response: {
+        type: 'string',
+      },
+    },
+    required: ['response'],
+  }
+
+  return {
+    ...rest,
+    tools: {
+      ...(rest.tools ?? {}),
+      [AGENT_RETURN_TOOL_NAME]: {
+        description:
+          'You are an autonomous agent. You have been assigned a task, and your objective is to send messages autonomously following your instructions, obtaining information, and performing actions, indefinitely.\nWith this tool, you will be able to FINISH this workflow. Only use this tool when you have achieved your task and are ready to return the final results.\nUse this tool all by itself, do not include a response with it. If you need to both give a response and run this tool, do it in two separate messages.\nThis tool can ONLY be called once, and it will define the end of your task. Do not try to call it before finishing your task. Do not try to call it multiple times within the same message.\n',
+        parameters: schema ?? DEFAULT_SCHEMA,
+      },
+    },
+  }
+}
+
+export const validateAgentStep = async (
+  context: ValidatorContext,
+): Promise<TypedResult<ValidatedAgentStep, ChainError<RunErrorCodes>>> => {
+  const { workspace, conversation, providersMap } = context
+
+  const configResult = validateConfig(conversation.config)
+  if (configResult.error) return Result.error(configResult.error)
+
+  const config = configResult.unwrap()
+  const providerResult = findProvider(config.provider, providersMap)
+  if (providerResult.error) return providerResult
+
+  const provider = providerResult.value
+  const freeQuota = await checkFreeProviderQuota({
+    workspace,
+    provider,
+    model: config.model,
+  })
+  if (freeQuota.error) return freeQuota
+
+  const rule = applyProviderRules({
+    providerType: provider.provider,
+    messages: conversation.messages as Message[],
+    config,
+  })
+
+  const assistantResponse =
+    conversation.messages[conversation.messages.length - 1]
+
+  const lastMessageToolCalls: ToolCall[] | undefined =
+    assistantResponse?.toolCalls as ToolCall[]
+
+  const chainCompleted =
+    lastMessageToolCalls?.some(
+      (toolCall) => toolCall.name === AGENT_RETURN_TOOL_NAME,
+    ) ?? false
+
+  return Result.ok({
+    provider,
+    config: applyAgentTools(rule.config as Config),
+    conversation: {
+      ...conversation,
+      config: applyAgentTools(config),
+      messages: rule?.messages ?? conversation.messages,
+    },
+    chainCompleted,
+
+    // Agents' "schema" config will be used for the return function, not for the actual LLM output.
+    schema: undefined,
+    output: 'no-schema',
+  })
+}

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -1,6 +1,7 @@
 import {
   ChainStepResponse,
   Commit,
+  DocumentType,
   ErrorableEntity,
   LogSources,
   StreamType,
@@ -9,6 +10,7 @@ import {
 } from '../../browser'
 import { publisher } from '../../events/publisher'
 import { generateUUIDIdentifier, Result } from '../../lib'
+import { runAgent } from '../chains/agents/run'
 import { runChain } from '../chains/run'
 import { createDocumentLog } from '../documentLogs'
 import { getResolvedContent } from '../documents'
@@ -126,7 +128,7 @@ export async function runDocumentAtCommit({
     return checkerResult
   }
 
-  const run = await runChain({
+  const runArgs = {
     generateUUID: () => errorableUuid,
     errorableType,
     workspace,
@@ -134,7 +136,12 @@ export async function runDocumentAtCommit({
     promptlVersion: document.promptlVersion,
     providersMap,
     source,
-  })
+  }
+
+  const run =
+    document.documentType === DocumentType.Agent
+      ? await runAgent(runArgs)
+      : await runChain(runArgs)
 
   return Result.ok({
     stream: run.stream,


### PR DESCRIPTION
First prototype for Autonomous Agents.

In this PR, the following feature has been added:
- When a prompt has a `type: agent` configuration, a new `agent_finish_workflow` tool will be injected into the prompt, which will run an indefinite amount of steps until this tool has been called.
- The `schema` configuration from the prompt is repurposed in agents, where it only affects to the schema of the finish tool, instead of the response format for each intermediate step.
- If an Agent prompt already contains user-defined steps, all of those are executed without the return tool injected. The tool is only available for the autonomous steps executed by the agent.


https://github.com/user-attachments/assets/5d0bbec0-7ca0-4957-a7df-42045fe89b24

(Note on video: First attempt was blazing fast because of response caching. I removed it by setting a temperature)