### PR TITLE
Fix: Error when last step of a chain responds with a tool call

### DIFF
--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -262,15 +262,6 @@ model: gpt-4o
             },
             messages: [
               {
-                role: 'assistant',
-                content: [
-                  {
-                    type: 'text',
-                    text: 'Fake AI generated text',
-                  },
-                ],
-              },
-              {
                 role: 'system',
                 content: [
                   {

--- a/packages/core/src/services/documentLogs/addMessages/findPausedChain.ts
+++ b/packages/core/src/services/documentLogs/addMessages/findPausedChain.ts
@@ -37,7 +37,7 @@ export async function findPausedChain({
   return Result.ok({
     document: result.value,
     commit,
-    pausedChainMessages: cachedData.messages,
     pausedChain: cachedData.chain,
+    previousResponse: cachedData.previousResponse,
   })
 }

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -446,12 +446,24 @@ describe('addMessages', () => {
 
     expect(value).toEqual([
       {
+        event: 'latitude-event',
+        data: expect.objectContaining({
+          type: 'chain-step',
+        }),
+      },
+      {
         event: 'provider-event',
         data: { type: 'text-delta', textDelta: 'AI gener' },
       },
       {
         event: 'provider-event',
         data: { type: 'text-delta', textDelta: 'ated text' },
+      },
+      {
+        event: 'latitude-event',
+        data: expect.objectContaining({
+          type: 'chain-step-complete',
+        }),
       },
       {
         event: 'latitude-event',
@@ -570,6 +582,12 @@ describe('addMessages', () => {
     expect(stream).toEqual([
       {
         event: StreamEventTypes.Latitude,
+        data: expect.objectContaining({
+          type: ChainEventTypes.Step,
+        }),
+      },
+      {
+        event: StreamEventTypes.Latitude,
         data: {
           type: ChainEventTypes.Error,
           error: {
@@ -637,6 +655,18 @@ describe('addMessages', () => {
       .then((r) => r.at(-1)!)
 
     expect(stream).toEqual([
+      {
+        event: StreamEventTypes.Latitude,
+        data: expect.objectContaining({
+          type: ChainEventTypes.Step,
+        }),
+      },
+      {
+        event: StreamEventTypes.Latitude,
+        data: expect.objectContaining({
+          type: ChainEventTypes.StepComplete,
+        }),
+      },
       {
         event: StreamEventTypes.Latitude,
         data: expect.objectContaining({

--- a/packages/core/src/services/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.ts
@@ -66,10 +66,9 @@ export async function addMessages({
     commit: pausedChainData.commit,
     document: pausedChainData.document,
     pausedChain: pausedChainData.pausedChain,
-    pausedChainMessages:
-      pausedChainData.pausedChainMessages as unknown as Message[],
     documentLogUuid,
     responseMessages: messages,
+    previousResponse: pausedChainData.previousResponse,
     source,
   })
 }

--- a/packages/core/src/services/providerLogs/addMessages.ts
+++ b/packages/core/src/services/providerLogs/addMessages.ts
@@ -14,7 +14,7 @@ import {
 } from '../../browser'
 import { unsafelyFindProviderApiKey } from '../../data-access'
 import { NotFoundError, Result, TypedResult } from '../../lib'
-import { ai, PartialConfig } from '../ai'
+import { ai, Config, PartialConfig } from '../ai'
 import { ChainError } from '../chains/ChainErrors'
 import { ChainStreamConsumer } from '../chains/ChainStreamConsumer'
 import { consumeStream } from '../chains/ChainStreamConsumer/consumeStream'
@@ -124,6 +124,13 @@ async function iterate({
       provider,
     }).then((r) => r.unwrap())
 
+    ChainStreamConsumer.startStep({
+      controller,
+      config: config as Config,
+      messages: [], // No additional messages added between User message and Assistant response
+      documentLogUuid: documentLogUuid!,
+    })
+
     const stepStartTime = Date.now()
 
     const aiResult = await ai({
@@ -172,6 +179,11 @@ async function iterate({
     })
 
     const response = { ..._response, providerLog }
+
+    ChainStreamConsumer.stepCompleted({
+      controller,
+      response,
+    })
 
     const responseMessages = buildMessagesFromResponse({ response })
     ChainStreamConsumer.chainCompleted({


### PR DESCRIPTION
Fixes:
- `lastResponse` not included on `resumeConversation`
- `chain-step-complete` event not being sent for the last chain event
- Playground not updating, or updating incorrectly, the time, token usage and chain length.
- Improved how messages are handled in step events

Before:

https://github.com/user-attachments/assets/d04a5b1c-fe23-4f61-ac03-115126fdd5b2

After:

https://github.com/user-attachments/assets/96ee84e2-1990-4d04-9792-2bd9c8a55290
