### PR TITLE
feat: moved blog to latitude.so/blog route

### DIFF
--- a/apps/infra/src/core/cloudfront.ts
+++ b/apps/infra/src/core/cloudfront.ts
@@ -1,9 +1,14 @@
 import * as aws from '@pulumi/aws'
+import * as pulumi from '@pulumi/pulumi'
 
+// Configure US East provider for ACM certificates and Lambda@Edge
 export const usEastProvider = new aws.Provider('us-east-1', {
   region: 'us-east-1',
 })
 
+// =========================================
+// SSL Certificates
+// =========================================
 const certificate = new aws.acm.Certificate(
   'latitudeCertificate',
   {
@@ -13,6 +18,20 @@ const certificate = new aws.acm.Certificate(
   { provider: usEastProvider },
 )
 
+const mainCertificate = new aws.acm.Certificate(
+  'latitudeMainCertificate',
+  {
+    domainName: 'latitude.so',
+    validationMethod: 'DNS',
+  },
+  { provider: usEastProvider },
+)
+
+// =========================================
+// CloudFront Functions
+// =========================================
+
+// Redirect function for ai.latitude.so -> latitude.so
 const redirectFunction = new aws.cloudfront.Function('redirectFunction', {
   code: `
 function handler(event) {
@@ -30,27 +49,11 @@ function handler(event) {
   runtime: 'cloudfront-js-1.0',
 })
 
-const blogOriginFunction = new aws.cloudfront.Function('blogOriginFunction', {
-  code: `
-  function handler(event) {
-    var request = event.request;
+// =========================================
+// CloudFront Distributions
+// =========================================
 
-    // Extract the path from the original request
-    var originalPath = request.uri;
-
-    // Modify the host and URI to point to the Ghost blog
-    request.headers['host'] = [{ key: 'host', value: 'latitude-blog.ghost.io' }];
-    request.uri = originalPath;
-
-    // Return the modified request
-    return request;
-}
-
-`,
-  name: 'blog-origin',
-  runtime: 'cloudfront-js-1.0',
-})
-
+// Redirect Distribution (ai.latitude.so -> latitude.so)
 const distribution = new aws.cloudfront.Distribution('latitudeRedirect', {
   enabled: true,
   isIpv6Enabled: true,
@@ -77,44 +80,10 @@ const distribution = new aws.cloudfront.Distribution('latitudeRedirect', {
       },
     ],
   },
-  orderedCacheBehaviors: [
-    {
-      pathPattern: '/blog/*',
-      allowedMethods: ['GET', 'HEAD'],
-      cachedMethods: ['GET', 'HEAD'],
-      targetOriginId: 'blog',
-      forwardedValues: {
-        queryString: false,
-        cookies: {
-          forward: 'none',
-        },
-      },
-      viewerProtocolPolicy: 'redirect-to-https',
-      minTtl: 0,
-      functionAssociations: [
-        {
-          eventType: 'viewer-request',
-          functionArn: blogOriginFunction.arn,
-        },
-      ],
-      defaultTtl: 300,
-      maxTtl: 1200,
-    },
-  ],
   origins: [
     {
       domainName: 'latitude.so',
       originId: 'latitudeOrigin',
-      customOriginConfig: {
-        httpPort: 80,
-        httpsPort: 443,
-        originSslProtocols: ['TLSv1.2'],
-        originProtocolPolicy: 'https-only',
-      },
-    },
-    {
-      domainName: 'latitude-blog.ghost.io',
-      originId: 'blog',
       customOriginConfig: {
         httpPort: 80,
         httpsPort: 443,
@@ -135,8 +104,139 @@ const distribution = new aws.cloudfront.Distribution('latitudeRedirect', {
   },
 })
 
-export const distributionUrl = distribution.domainName
+// Main Distribution (latitude.so)
+const mainDistribution = new aws.cloudfront.Distribution('latitudeMain', {
+  enabled: true,
+  isIpv6Enabled: true,
+  httpVersion: 'http2',
+  aliases: ['latitude.so'],
+  // Default behavior for the main site
+  defaultCacheBehavior: {
+    allowedMethods: ['GET', 'HEAD'],
+    cachedMethods: ['GET', 'HEAD'],
+    targetOriginId: 'mainOrigin',
+    forwardedValues: {
+      queryString: false,
+      cookies: {
+        forward: 'none',
+      },
+    },
+    viewerProtocolPolicy: 'redirect-to-https',
+    minTtl: 0,
+    defaultTtl: 300,
+    maxTtl: 1200,
+  },
+  // Additional behaviors for specific paths
+  orderedCacheBehaviors: [
+    {
+      // Blog behavior: directly routes to latitude-blog.ghost.io
+      pathPattern: '/blog*',
+      allowedMethods: ['GET', 'HEAD'],
+      cachedMethods: ['GET', 'HEAD'],
+      targetOriginId: 'blog',
+      forwardedValues: {
+        queryString: false,
+        cookies: {
+          forward: 'none',
+        },
+      },
+      viewerProtocolPolicy: 'redirect-to-https',
+      minTtl: 0,
+      defaultTtl: 300,
+      maxTtl: 1200,
+    },
+    {
+      // Content behavior: also routes to latitude-blog.ghost.io
+      pathPattern: '/content*',
+      allowedMethods: ['GET', 'HEAD'],
+      cachedMethods: ['GET', 'HEAD'],
+      targetOriginId: 'blog',
+      forwardedValues: {
+        queryString: false,
+        cookies: {
+          forward: 'none',
+        },
+      },
+      viewerProtocolPolicy: 'redirect-to-https',
+      minTtl: 0,
+      defaultTtl: 300,
+      maxTtl: 1200,
+    },
+    {
+      // Public assets behavior: routes to latitude-blog.ghost.io
+      pathPattern: '/public*',
+      allowedMethods: ['GET', 'HEAD'],
+      cachedMethods: ['GET', 'HEAD'],
+      targetOriginId: 'blog',
+      forwardedValues: {
+        queryString: false,
+        cookies: {
+          forward: 'none',
+        },
+      },
+      viewerProtocolPolicy: 'redirect-to-https',
+      minTtl: 0,
+      defaultTtl: 300,
+      maxTtl: 1200,
+    },
+    {
+      // Assets behavior: routes to latitude-blog.ghost.io
+      pathPattern: '/assets*',
+      allowedMethods: ['GET', 'HEAD'],
+      cachedMethods: ['GET', 'HEAD'],
+      targetOriginId: 'blog',
+      forwardedValues: {
+        queryString: false,
+        cookies: {
+          forward: 'none',
+        },
+      },
+      viewerProtocolPolicy: 'redirect-to-https',
+      minTtl: 0,
+      defaultTtl: 300,
+      maxTtl: 1200,
+    },
+  ],
+  // Origins configuration
+  origins: [
+    {
+      // Main site origin
+      domainName: 'passionate-hours-147463.framer.app',
+      originId: 'mainOrigin',
+      customOriginConfig: {
+        httpPort: 80,
+        httpsPort: 443,
+        originSslProtocols: ['TLSv1.2'],
+        originProtocolPolicy: 'https-only',
+      },
+    },
+    {
+      // Blog origin (Ghost.io)
+      domainName: 'latitude-blog.ghost.io',
+      originId: 'blog',
+      customOriginConfig: {
+        httpPort: 80,
+        httpsPort: 443,
+        originSslProtocols: ['TLSv1.2'],
+        originProtocolPolicy: 'https-only',
+      },
+    },
+  ],
+  restrictions: {
+    geoRestriction: {
+      restrictionType: 'none',
+    },
+  },
+  viewerCertificate: {
+    acmCertificateArn: mainCertificate.arn,
+    sslSupportMethod: 'sni-only',
+    minimumProtocolVersion: 'TLSv1.2_2021',
+  },
+})
 
+// =========================================
+// DNS Records
+// =========================================
 const record = new aws.route53.Record('latitudeRecord', {
   zoneId: 'Z04918046RTZRA6UX0HY',
   name: 'ai.latitude.so',
@@ -150,4 +250,9 @@ const record = new aws.route53.Record('latitudeRecord', {
   ],
 })
 
+// =========================================
+// Exports
+// =========================================
+export const distributionUrl = distribution.domainName
 export const recordName = record.name
+export const mainDistributionUrl = mainDistribution.domainName


### PR DESCRIPTION
Using cloudfront as a proxe server for latitude.so domain. Routing to framer or blog depending on the request path.