### PR TITLE
Chat with Agents

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Chat.tsx
@@ -63,10 +63,12 @@ export default function Chat<V extends PromptlVersion>({
       parameters,
     })
 
-    const documentLogUuid = new Promise<string>((resolve, reject) => {
+    const documentLogUuid = new Promise<string>((resolve, _reject) => {
       response.then((r) => {
-        if (!r) {
-          reject(new Error('No document log uuid'))
+        if (!r?.uuid) {
+          // TODO: This error is raised when the streaming returns an error
+          // Without the uuid, we can't chat anymore.
+          // reject(new Error('No document log uuid'))
           return
         }
         resolve(r.uuid)
@@ -170,7 +172,7 @@ export default function Chat<V extends PromptlVersion>({
         <ChatTextArea
           clearChat={clearChat}
           placeholder='Enter followup message...'
-          disabled={isLoading}
+          disabled={isLoading || !!error}
           onSubmit={submitUserMessage}
           toolRequests={unresponedToolCalls}
           addMessages={addMessages}

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.test.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.test.ts
@@ -126,11 +126,11 @@ describe('respondToToolCalls', () => {
       // @ts-ignore
       Result.ok(mockResult),
     )
-    const resumeConversationMock = vi.fn()
+    const resumePausedPromptMock = vi.fn()
     vi.doMock(
-      '../../../../services/documentLogs/addMessages/resumeConversation',
+      '../../../../services/documentLogs/addMessages/resumePausedPrompt',
       () => ({
-        resumeConversation: resumeConversationMock,
+        resumePausedPrompt: resumePausedPromptMock,
       }),
     )
 
@@ -192,7 +192,7 @@ describe('respondToToolCalls', () => {
       source: LogSources.Playground,
     })
 
-    expect(resumeConversationMock).toHaveBeenCalledWith({
+    expect(resumePausedPromptMock).toHaveBeenCalledWith({
       workspace,
       commit,
       document,

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.ts
@@ -8,8 +8,8 @@ import {
 import { Result, UnprocessableEntityError } from '../../../../lib'
 import { getCachedChain } from '../../../../services/chains/chainCache'
 import { generateToolResponseMessages } from './generateToolResponseMessages'
-import { resumeConversation } from '../../../../services/documentLogs/addMessages/resumeConversation'
 import { AutogenerateToolResponseCopilotData } from './getCopilotData'
+import { resumePausedPrompt } from '../../../../services/documentLogs/addMessages/resumePausedPrompt'
 
 export async function respondToToolCalls({
   workspace,
@@ -54,7 +54,7 @@ export async function respondToToolCalls({
 
   if (responseMessagesResult.error) return responseMessagesResult
 
-  return resumeConversation({
+  return resumePausedPrompt({
     workspace,
     commit,
     document,

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/runDocumentUntilItStops.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/runDocumentUntilItStops.ts
@@ -1,7 +1,7 @@
 import { LogSources, StreamType } from '@latitude-data/constants'
 import { runDocumentAtCommit as runDocumentAtCommitFn } from '../../../../services/commits/runDocumentAtCommit'
 import { Commit, Workspace, DocumentVersion } from '../../../../browser'
-import { ChainResponse } from '../../../../services/providerLogs'
+import { ChainResponse } from '../../../../services/chains/run'
 import { ToolCall } from '@latitude-data/compiler'
 import { getToolCalls } from '../../../../services/chains/runStep'
 import { Result } from '../../../../lib'

--- a/packages/core/src/services/agents/runStep/index.ts
+++ b/packages/core/src/services/agents/runStep/index.ts
@@ -19,13 +19,10 @@ import { validateAgentStep } from '../AgentStepValidator'
 import { ChainError } from '../../../lib/streamManager/ChainErrors'
 import { RunErrorCodes } from '@latitude-data/constants/errors'
 import { streamAIResponse } from '../../../lib/streamManager'
-import { cacheChain } from '../../chains/chainCache'
-import { Chain } from 'promptl-ai'
 
 export async function runAgentStep({
   workspace,
   source,
-  originalChain,
   conversation,
   providersMap,
   controller,
@@ -38,7 +35,6 @@ export async function runAgentStep({
   workspace: Workspace
   source: LogSources
   conversation: Conversation
-  originalChain: Chain
   providersMap: CachedApiKeys
   controller: ReadableStreamDefaultController
   errorableUuid: string
@@ -107,13 +103,6 @@ export async function runAgentStep({
 
     // Stop the chain if there are tool calls
     if (toolCalls.length) {
-      await cacheChain({
-        workspace,
-        chain: originalChain as Chain,
-        documentLogUuid: errorableUuid,
-        previousResponse: response,
-      })
-
       streamConsumer.chainCompleted({
         step,
         response,
@@ -122,6 +111,8 @@ export async function runAgentStep({
           response,
         }),
       })
+
+      return response
     }
 
     // Stop the chain if completed
@@ -138,7 +129,6 @@ export async function runAgentStep({
     return runAgentStep({
       workspace,
       source,
-      originalChain,
       conversation: step.conversation,
       errorableUuid,
       providersMap,

--- a/packages/core/src/services/documentLogs/addMessages/findPausedChain.ts
+++ b/packages/core/src/services/documentLogs/addMessages/findPausedChain.ts
@@ -1,10 +1,4 @@
 import { Workspace } from '../../../browser'
-import { Result } from '../../../lib'
-import {
-  CommitsRepository,
-  DocumentLogsRepository,
-  DocumentVersionsRepository,
-} from '../../../repositories'
 import { getCachedChain } from '../../chains/chainCache'
 
 export async function findPausedChain({
@@ -17,27 +11,8 @@ export async function findPausedChain({
   const cachedData = await getCachedChain({ workspace, documentLogUuid })
   if (!cachedData) return undefined
 
-  const logsRepo = new DocumentLogsRepository(workspace.id)
-  const logResult = await logsRepo.findByUuid(documentLogUuid)
-  if (logResult.error) return logResult
-
-  const documentLog = logResult.value
-  const commitsRepo = new CommitsRepository(workspace.id)
-  const commitResult = await commitsRepo.find(documentLog.commitId)
-  if (commitResult.error) return commitResult
-
-  const commit = commitResult.value
-  const documentsRepo = new DocumentVersionsRepository(workspace.id)
-  const result = await documentsRepo.getDocumentAtCommit({
-    commitUuid: commit?.uuid,
-    documentUuid: documentLog.documentUuid,
-  })
-  if (result.error) return result
-
-  return Result.ok({
-    document: result.value,
-    commit,
+  return {
     pausedChain: cachedData.chain,
     previousResponse: cachedData.previousResponse,
-  })
+  }
 }

--- a/packages/core/src/services/documentLogs/addMessages/resumeAgent/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/resumeAgent/index.ts
@@ -1,0 +1,146 @@
+import { LogSources, Workspace, ProviderLog } from '../../../../browser'
+import { Result } from '../../../../lib'
+import { buildProvidersMap } from '../../../providerApiKeys/buildMap'
+import {
+  ContentType,
+  Conversation,
+  Message,
+  MessageRole,
+  ToolMessage,
+} from '@latitude-data/compiler'
+import {
+  AGENT_RETURN_TOOL_NAME,
+  ChainStepResponse,
+  ErrorableEntity,
+  StreamType,
+} from '../../../../constants'
+import { ChainEvent } from '@latitude-data/constants'
+import { runAgentStep } from '../../../agents/runStep'
+import { ChainResponse } from '../addChatMessage'
+import { buildProviderLogResponse } from '../../../providerLogs'
+import {
+  ChainError,
+  createChainRunError,
+} from '../../../../lib/streamManager/ChainErrors'
+import { RunErrorCodes } from '@latitude-data/constants/errors'
+import { FinishReason } from 'ai'
+
+function buildExtraMessages({
+  providerLog,
+  newMessages,
+}: {
+  providerLog: ProviderLog
+  newMessages: Message[]
+}) {
+  const agentFinishToolCalls =
+    providerLog.toolCalls?.filter(
+      (toolCall) => toolCall.name === AGENT_RETURN_TOOL_NAME,
+    ) ?? []
+
+  if (!agentFinishToolCalls.length) {
+    return newMessages
+  }
+
+  const agentToolCallResponseMessages: ToolMessage[] = agentFinishToolCalls.map(
+    (toolCall) => ({
+      role: MessageRole.tool,
+      content: [
+        {
+          type: ContentType.toolResult,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+          result: {},
+          isError: false,
+        },
+      ],
+    }),
+  )
+
+  return [...agentToolCallResponseMessages, ...newMessages]
+}
+
+/**
+ * Resume agent
+ * ::::::::::::::::::::
+ * Adds an additional message to an agent conversation, either paused or
+ * completed, and starts an autonomous workflow from that point.
+ */
+export async function resumeAgent({
+  workspace,
+  providerLog,
+  messages,
+  source,
+}: {
+  workspace: Workspace
+  providerLog: ProviderLog
+  messages: Message[]
+  source: LogSources
+}) {
+  const providersMap = await buildProvidersMap({
+    workspaceId: workspace.id,
+  })
+
+  const previousResponse: ChainStepResponse<StreamType> = {
+    text: buildProviderLogResponse(providerLog),
+    usage: {
+      completionTokens: 0,
+      promptTokens: 0,
+      totalTokens: 0,
+    },
+    finishReason: (providerLog.finishReason as FinishReason) ?? 'tool-calls',
+    chainCompleted: false,
+    documentLogUuid: providerLog.documentLogUuid!,
+    providerLog,
+    streamType: providerLog.responseObject ? 'object' : 'text',
+    toolCalls: providerLog.toolCalls,
+    object: providerLog.responseObject,
+  }
+
+  const previousMessages = providerLog.messages
+  const extraMessages = buildExtraMessages({
+    providerLog,
+    newMessages: messages,
+  })
+  const conversation: Conversation = {
+    config: providerLog.config!,
+    messages: previousMessages,
+  }
+
+  let responseResolve: (value: ChainResponse<StreamType>) => void
+
+  const response = new Promise<ChainResponse<StreamType>>((resolve) => {
+    responseResolve = resolve
+  })
+
+  const stream = new ReadableStream<ChainEvent>({
+    start(controller) {
+      runAgentStep({
+        controller,
+        workspace,
+        source,
+        conversation,
+        providersMap,
+        previousCount: previousMessages.length,
+        previousResponse,
+        errorableUuid: providerLog.documentLogUuid!,
+        stepCount: 0,
+        extraMessages,
+      })
+        .then((res) => {
+          responseResolve(Result.ok(res))
+        })
+        .catch(async (e: ChainError<RunErrorCodes>) => {
+          const error = await createChainRunError({
+            error: e,
+            errorableUuid: providerLog.documentLogUuid!,
+            errorableType: ErrorableEntity.DocumentLog,
+            persistErrors: true,
+          })
+
+          responseResolve(Result.error(error))
+        })
+    },
+  })
+
+  return Result.ok({ stream, response })
+}

--- a/packages/core/src/services/providerLogs/index.ts
+++ b/packages/core/src/services/providerLogs/index.ts
@@ -1,5 +1,4 @@
 export * from './create'
-export * from './addMessages'
 export * from './buildResponse'
 export * from './serialize'
 export * from './serializeForEvaluation'


### PR DESCRIPTION
This PR adds the feature to chat with agents, and fixed some other bugs with the chain streaming workflow.

https://github.com/user-attachments/assets/70fdfc6c-b0a4-46fe-9518-55e0a0fdc60b

Now, the addMessage endpoint runs the `documentLogs/addMessage` service, which depending on context will chose between the following:
- `addChatMessage`: Adds the message to a finished prompt (or chain) and returns a new response.
- `resumeAgent`: Adds a message to an agent conversation, either paused or finished, and continues the autonomous flow.
- `resumePausedPrompt`: Adds tool responses to a cached chain.

Pausing agents may or may not result in a cached chain. If the hardcoded chain is paused before it has finished, it will be cached just as a regular chain. If the chain already finished and the agent pauses in an autonomous step, it is not cached.

Bugfixes:
- Sometimes system messages do not appear in the playground when they are included after a step that gets paused.
- An error is raised when an agent is stopped by a tool-call (although the client behaviour is unaltered).
- A client error is raised when a chain/prompt/agent execution fails in the playground. This will be revised in the future.
- The response from the last step of a chain was sometimes repeated when starting the agent workflow.