### PR TITLE
Multiple bugs detected when using hardcoded tool-requests and tool responses

### DIFF
--- a/apps/gateway/package.json
+++ b/apps/gateway/package.json
@@ -30,7 +30,7 @@
     "drizzle-orm": "^0.33.0",
     "hono": "^4.6.6",
     "lodash-es": "^4.17.21",
-    "promptl-ai": "^0.4.5",
+    "promptl-ai": "^0.4.8",
     "rate-limiter-flexible": "^5.0.3",
     "zod": "^3.23.8"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,7 +51,7 @@
     "oslo": "1.2.0",
     "pdfjs-dist": "^4.9.155",
     "posthog-js": "^1.161.6",
-    "promptl-ai": "^0.4.5",
+    "promptl-ai": "^0.4.8",
     "rate-limiter-flexible": "^5.0.3",
     "react": "19.0.0-rc-5d19e1c8-20240923",
     "react-dom": "19.0.0-rc-5d19e1c8-20240923",

--- a/examples/sdks/python/requirements.txt
+++ b/examples/sdks/python/requirements.txt
@@ -1,3 +1,3 @@
-latitude-sdk==1.0.1
+latitude-sdk==1.0.2
 openai==1.58.1
 anthropic==0.40.0

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@latitude-data/compiler": "workspace:^",
-    "promptl-ai": "^0.4.5",
+    "promptl-ai": "^0.4.8",
     "json-schema": "^0.4.0",
     "zod": "^3.23.8"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -152,6 +152,6 @@
   "dependencies": {
     "date-fns": "^3.6.0",
     "diff-match-patch": "^1.0.5",
-    "promptl-ai": "^0.4.5"
+    "promptl-ai": "^0.4.8"
   }
 }

--- a/packages/core/src/lib/chainStreamManager/index.ts
+++ b/packages/core/src/lib/chainStreamManager/index.ts
@@ -117,7 +117,8 @@ export class ChainStreamManager {
   async getProviderResponse(args: Omit<ExecuteStepArgs, 'controller'>) {
     if (!this.controller) throw new Error('Stream not started')
 
-    this.messages = [...args.conversation.messages] // TODO: This may conflict with isolated steps
+    // TODO: This may conflict with isolated steps
+    this.messages = [...args.conversation.messages]
 
     this.sendEvent({ type: ChainEventTypes.StepStarted })
 

--- a/packages/core/src/lib/chainStreamManager/index.ts
+++ b/packages/core/src/lib/chainStreamManager/index.ts
@@ -186,10 +186,12 @@ export class ChainStreamManager {
    */
   error(error: ChainError<RunErrorCodes>) {
     if (this.finished) throw new Error('Chain already finished')
+
     this.sendEvent({
       type: ChainEventTypes.ChainError,
-      error,
+      error: new Error(error.runError ? error.runError.message : error.message),
     })
+
     this.resolveError?.(error)
     this.endStream()
   }
@@ -215,6 +217,7 @@ export class ChainStreamManager {
 
   private sendEvent(event: OmittedLatitudeEventData) {
     if (!this.controller) throw new Error('Stream not started')
+
     this.controller.enqueue({
       event: StreamEventTypes.Latitude,
       data: {

--- a/packages/core/src/lib/chainStreamManager/step/streamAIResponse.ts
+++ b/packages/core/src/lib/chainStreamManager/step/streamAIResponse.ts
@@ -81,7 +81,9 @@ export async function streamAIResponse({
   }
 
   const aiResult = await ai({
-    messages: [...conversation.messages], // TODO: vitest will cry when checking the parameters passed to this function when the object mutes afterwards. To fix this, we make a deep copy of the array so that it is immutable.
+    // TODO: vitest will cry when checking the parameters passed to this function when the object mutes afterwards.
+    // To fix this, we make a deep copy of the array so that it is immutable.
+    messages: [...conversation.messages],
     config: conversation.config as ValidatedConfig,
     provider: provider,
     schema: schema,

--- a/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
+++ b/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
@@ -26,6 +26,7 @@ const CONTENT_DEFINED_ATTRIBUTES = [
 ] as const
 
 type AttrArgs = { attributes: string[]; content: Record<string, unknown> }
+
 function genericAttributesProcessor({ attributes, content }: AttrArgs) {
   return attributes.reduce((acc, key) => ({ ...acc, [key]: content[key] }), {})
 }
@@ -74,6 +75,7 @@ export function extractContentMetadata({
   const providerAttributes = Object.keys(content).filter(
     (key) => !CONTENT_DEFINED_ATTRIBUTES.includes(key as any),
   )
+
   const definedData = definedAttributes.reduce(
     // @ts-ignore
     (acc, key) => ({ ...acc, [key]: content[key] }),
@@ -106,6 +108,7 @@ function removeUndefinedValues(data: Record<string, unknown>) {
 type MessageWithMetadata = Message & {
   experimental_providerMetadata?: Record<string, Record<string, unknown>>
 }
+
 export function extractMessageMetadata({
   message,
   provider,
@@ -133,20 +136,26 @@ export function extractMessageMetadata({
     }
   }
 
-  const { name: _, ...restWithoutName } = rest as {
+  const {
+    name: _name,
+    toolName: _toolName,
+    toolId: _toolId,
+    _promptlSourceMap,
+    ...attributes
+  } = rest as {
     name?: string
     [key: string]: unknown
   }
 
-  if (!Object.keys(restWithoutName).length) return common
+  if (!Object.keys(attributes).length) return common
 
   return {
     ...common,
     experimental_providerMetadata: {
       [getProviderMetadataKey(provider)]: processAttributes({
-        attributes: Object.keys(restWithoutName),
+        attributes: Object.keys(attributes),
         provider,
-        content: restWithoutName,
+        content: attributes,
       }),
     },
   }

--- a/packages/core/src/services/ai/providers/rules/vercel.test.ts
+++ b/packages/core/src/services/ai/providers/rules/vercel.test.ts
@@ -450,4 +450,46 @@ describe('applyVercelSdkRules', () => {
       },
     ])
   })
+
+  it('transform promptl tool messages into vercel tool messages', () => {
+    messages = [
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'text',
+            text: 'The location Manolo is in the country of Spain.',
+            _promptlSourceMap: [
+              {
+                start: 13,
+                end: 19,
+                identifier: 'location',
+              },
+            ],
+          },
+        ],
+        toolId: '1',
+        toolName: 'location-info',
+      },
+    ] as unknown as Message[]
+
+    const rules = vercelSdkRules(
+      { rules: [], messages, config },
+      Providers.OpenAI,
+    )
+
+    expect(rules.messages).toEqual([
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: '1',
+            toolName: 'location-info',
+            result: 'The location Manolo is in the country of Spain.',
+          },
+        ],
+      },
+    ])
+  })
 })

--- a/packages/core/src/services/chains/run.test.ts
+++ b/packages/core/src/services/chains/run.test.ts
@@ -7,10 +7,6 @@ import {
 import { v4 as uuid } from 'uuid'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  LatitudeErrorCodes,
-  RunErrorCodes,
-} from '@latitude-data/constants/errors'
 import { Workspace } from '../../browser'
 import {
   ErrorableEntity,
@@ -23,7 +19,6 @@ import * as factories from '../../tests/factories'
 import { testConsumeStream } from '../../tests/helpers'
 import * as aiModule from '../ai'
 import { setCachedResponse } from '../commits/promptCache'
-import { ChainError } from '../../lib/chainStreamManager/ChainErrors'
 import * as chainValidatorModule from './ChainValidator'
 import * as saveOrPublishProviderLogsModule from './ProviderProcessor/saveOrPublishProviderLogs'
 import { runChain } from './run'
@@ -596,16 +591,13 @@ describe('runChain', () => {
       data: expect.objectContaining({
         type: ChainEventTypes.ChainError,
         error: expect.objectContaining({
-          name: LatitudeErrorCodes.UnprocessableEntityError,
           message: 'Openai returned this error: provider error',
         }),
       }),
     })
+
     expect(error).toEqual(
-      new ChainError({
-        code: RunErrorCodes.Unknown,
-        message: 'Openai returned this error: provider error',
-      }),
+      new Error('Openai returned this error: provider error'),
     )
   })
 

--- a/packages/core/src/services/chains/runStep/index.ts
+++ b/packages/core/src/services/chains/runStep/index.ts
@@ -82,7 +82,9 @@ export async function runStep({
   promptlVersion,
   providersMap,
   errorableUuid,
-  newMessages = undefined, // Contains all messages added from the end of the last step to the beginning of this one, including the assistant response and tool results
+  // Contains all messages added from the end of the last step to the beginning of this one,
+  // including the assistant response and tool results
+  newMessages = undefined,
   configOverrides,
   removeSchema,
   stepCount = 0,
@@ -105,6 +107,7 @@ export async function runStep({
   }
 
   const validStepCount = assertValidStepCount({ stepCount, chain, step })
+
   if (validStepCount.error) {
     chainStreamManager.error(validStepCount.error)
     return step.conversation

--- a/packages/core/src/services/chains/runStep/index.ts
+++ b/packages/core/src/services/chains/runStep/index.ts
@@ -62,16 +62,13 @@ function assertValidStepCount({
 
 export type StepProps = {
   chainStreamManager: ChainStreamManager
-
   workspace: Workspace
   source: LogSources
   chain: SomeChain
   promptlVersion: number
   providersMap: CachedApiKeys
   errorableUuid: string
-
   newMessages: Message[] | undefined
-
   configOverrides?: ConfigOverrides
   removeSchema?: boolean
   stepCount?: number

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -2,10 +2,6 @@ import { ContentType, MessageRole } from '@latitude-data/compiler'
 import { v4 as uuid } from 'uuid'
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
-import {
-  LatitudeErrorCodes,
-  RunErrorCodes,
-} from '@latitude-data/constants/errors'
 import { eq } from 'drizzle-orm'
 import {
   Commit,
@@ -25,7 +21,6 @@ import { providerLogs } from '../../../schema'
 import { createDocumentLog, createProject } from '../../../tests/factories'
 import { testConsumeStream } from '../../../tests/helpers'
 import * as aiModule from '../../ai'
-import { ChainError } from '../../../lib/chainStreamManager/ChainErrors'
 import { addMessages } from './index'
 import { ChainEventTypes } from '@latitude-data/constants'
 
@@ -600,17 +595,13 @@ describe('addMessages', () => {
         data: expect.objectContaining({
           type: ChainEventTypes.ChainError,
           error: expect.objectContaining({
-            name: LatitudeErrorCodes.UnprocessableEntityError,
             message: 'Openai returned this error: provider error',
           }),
         }),
       },
     ])
     expect(error).toEqual(
-      new ChainError({
-        code: RunErrorCodes.Unknown,
-        message: 'Openai returned this error: provider error',
-      }),
+      new Error('Openai returned this error: provider error'),
     )
   })
 

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-sdk"
-version = "1.0.1"
+version = "1.0.2"
 description = "Latitude SDK for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2.10.3",
     "typing-extensions>=4.12.2",
     "latitude-telemetry>=1.0.0",
-    "promptl-ai>=1.0.1",
+    "promptl-ai>=1.0.2",
 ]
 
 [dependency-groups]

--- a/packages/sdks/python/uv.lock
+++ b/packages/sdks/python/uv.lock
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "latitude-sdk"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -343,7 +343,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "httpx-sse", specifier = ">=0.4.0" },
     { name = "latitude-telemetry", specifier = ">=1.0.0" },
-    { name = "promptl-ai", specifier = ">=1.0.1" },
+    { name = "promptl-ai", specifier = ">=1.0.2" },
     { name = "pydantic", specifier = ">=2.10.3" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
@@ -837,16 +837,16 @@ wheels = [
 
 [[package]]
 name = "promptl-ai"
-version = "1.0.1"
+version = "1.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
     { name = "wasmtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/99/be5bf3f5aa24d48b5d7f573a1f2a6ff83f10c3e42a1a16287a731ff4b1af/promptl_ai-1.0.1.tar.gz", hash = "sha256:8d30f33f480488f2e817057ef54a195bf8947dc1c1ae0fcaf1339732370ac30b", size = 983536 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/21/a17f945570b18a26f8a313e4ea7073385e0ef3443627162493124ff897b0/promptl_ai-1.0.2.tar.gz", hash = "sha256:f20ac209f472c70911775f7b1b861a792318f333e4964eeca37d9fe9c698d427", size = 984391 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/08/8a910211bcc687b96ea6ce026048adecb036fde85e966605897a1666c161/promptl_ai-1.0.1-py3-none-any.whl", hash = "sha256:030619f43a400f9e39bd665f1cdb5db60972447d29583de8cf94720b725e5843", size = 968511 },
+    { url = "https://files.pythonhosted.org/packages/31/61/cc4a1006be6b22abef71756c1e1637b8869157cdd7f37c1892a41120a716/promptl_ai-1.0.2-py3-none-any.whl", hash = "sha256:bee771bf7a64719c1965bbf090c3788c25cf0f2ae59bd9dea6ac220d1c3384d3", size = 969281 },
 ]
 
 [[package]]

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",
@@ -46,7 +46,7 @@
     "@t3-oss/env-core": "^0.10.1",
     "eventsource-parser": "^2.0.1",
     "node-fetch": "3.3.2",
-    "promptl-ai": "^0.4.5",
+    "promptl-ai": "^0.4.8",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/sdks/typescript/src/utils/handleStream.ts
+++ b/packages/sdks/typescript/src/utils/handleStream.ts
@@ -70,7 +70,7 @@ export async function handleStream({
             throw new LatitudeApiError({
               status: 402,
               message: data.error.message,
-              serverResponse: JSON.stringify(data.error),
+              serverResponse: data.error.message,
               errorCode: RunErrorCodes.AIRunError,
             })
           }
@@ -114,7 +114,6 @@ export async function handleStream({
         errorCode: ApiErrorCodes.InternalServerError,
       })
     }
-    onError?.(error)
     return Promise.reject(error)
   }
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
     "@latitude-data/eslint-config": "workspace:*",
-    "promptl-ai": "^0.3.5",
+    "promptl-ai": "^0.4.8",
     "@latitude-data/typescript-config": "workspace:*",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-avatar": "^1.1.0",

--- a/packages/web-ui/src/ds/molecules/Chat/ChatTextArea/ToolCallForm/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/ChatTextArea/ToolCallForm/index.tsx
@@ -18,9 +18,10 @@ const TextEditor = lazy(() => import('./Editor/index'))
 function generateExampleFunctionCall(toolCall: ToolCall) {
   const args = toolCall.arguments
   const functionName = toolCall.name
-  const formattedArgs = Object.keys(args).length
-    ? JSON.stringify(args, null, 2)
-    : ''
+  const formattedArgs =
+    typeof args === 'object' && Object.keys(args).length
+      ? JSON.stringify(args, null, 2)
+      : ''
 
   return `${functionName}(${formattedArgs ? formattedArgs : ''})`
 }

--- a/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Chat/Message/index.tsx
@@ -267,10 +267,14 @@ const Content = ({
     const headerIcon = isAgentResponse ? 'bot' : 'puzzle'
     const headerLabel = isAgentResponse ? 'Agent Response' : 'Tool requested'
 
+    // FIXME: Please kill old compiler
+    // @ts-ignore
+    let oldOrNewArgs = value.args || value.toolArguments
+    oldOrNewArgs = typeof oldOrNewArgs === 'object' ? oldOrNewArgs : {}
     const codeLanguage = isAgentResponse ? 'json' : 'javascript'
     const codeContent = isAgentResponse
-      ? JSON.stringify(value.args, null, 2)
-      : `${value.toolName}(${JSON.stringify(value.args, null, 2)})`
+      ? JSON.stringify(oldOrNewArgs, null, 2)
+      : `${value.toolName}(${JSON.stringify(oldOrNewArgs, null, 2)})`
 
     return (
       <div key={`${index}`} className='py-2 w-full'>

--- a/packages/web-ui/src/lib/versionedMessagesHelpers.ts
+++ b/packages/web-ui/src/lib/versionedMessagesHelpers.ts
@@ -47,7 +47,11 @@ function extractCompilerToolContents(messages: CompilerMessage[]): ToolPart[] {
       type: PromptlContentType.toolCall,
       toolCallId: content.toolCallId,
       toolName: content.toolName,
-      toolArguments: content.args,
+      // FIXME: Kill old compiler please
+      // We have a mess and sometimes messages produced by promptl are
+      // formatted with this code. So we have to check if `toolArguments` is there
+      // @ts-expect-error - toolArguments is not part of old messages but can be here
+      toolArguments: content.args ?? content.toolArguments,
     }))
   })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,8 +260,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       promptl-ai:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.4.8
+        version: 0.4.8
       rate-limiter-flexible:
         specifier: ^5.0.3
         version: 5.0.4
@@ -427,8 +427,8 @@ importers:
         specifier: ^1.161.6
         version: 1.176.0
       promptl-ai:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.4.8
+        version: 0.4.8
       rate-limiter-flexible:
         specifier: ^5.0.3
         version: 5.0.4
@@ -755,8 +755,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       promptl-ai:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.4.8
+        version: 0.4.8
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -780,8 +780,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5
       promptl-ai:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.4.8
+        version: 0.4.8
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^1.1.0
@@ -1003,8 +1003,8 @@ importers:
         specifier: 3.3.2
         version: 3.3.2
       promptl-ai:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.4.8
+        version: 0.4.8
       typescript:
         specifier: ^5.5.4
         version: 5.7.2
@@ -1321,8 +1321,8 @@ importers:
         specifier: ^8.4.39
         version: 8.4.47
       promptl-ai:
-        specifier: ^0.3.5
-        version: 0.3.5
+        specifier: ^0.4.8
+        version: 0.4.8
       react:
         specifier: 18.3.0
         version: 18.3.0
@@ -8381,6 +8381,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.0.3:
     resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
 
@@ -11338,11 +11341,8 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
-  promptl-ai@0.3.5:
-    resolution: {integrity: sha512-g3RtXgCOtMky68rkdalGGApO85DBZvL65gJy7SzZ+D+eEpCB2hR+7q2G67y+s66AHDzG2DM+sU+1WTRbDCrfyg==}
-
-  promptl-ai@0.4.5:
-    resolution: {integrity: sha512-bJkWlLtyxJkxt28+InTtKF8e4OZ67J9QtkOnI9xKBeEv6ILRFHcU09quTbCFi0wCL+6lw6okL2tV1yix21Jf6g==}
+  promptl-ai@0.4.8:
+    resolution: {integrity: sha512-RHw+LlTTzeOJTe5ZxyI79weq+U/GLJZlpJ7nmmgQhK7vgboXjrL8ilZrHHOF5zgRN7LiLf4F15i6viomad39wg==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -22568,6 +22568,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.0.3: {}
 
   fast-xml-parser@4.4.1:
@@ -26549,18 +26551,11 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
-  promptl-ai@0.3.5:
+  promptl-ai@0.4.8:
     dependencies:
       acorn: 8.14.0
       code-red: 1.0.4
-      locate-character: 3.0.0
-      yaml: 2.6.0
-      zod: 3.23.8
-
-  promptl-ai@0.4.5:
-    dependencies:
-      acorn: 8.14.0
-      code-red: 1.0.4
+      fast-sha256: 1.3.0
       locate-character: 3.0.0
       yaml: 2.6.0
       zod: 3.23.8


### PR DESCRIPTION
# What?
This PR fix several issues we discovered when a users used new promptl syntax to hardcode tool requests and tool responses

This would be an example of such prompt
```
<assistant>
  <tool-call id="1" name="location-info" arguments={{ { location: location } }} />
</assistant>
<tool id="1" name="location-info">
  The location {{ location }} is in the country of Spain.
</tool>
```

# TODO
- [x] Parse correctly harcoded tool requests/ tool responses pairs. Wait for [this PR](https://github.com/latitude-dev/latitude-llm/pull/835) to be merged

## Issue one: tool arguments in Playground form does not handle `toolArguments` only `args`
This happens because we're maintaining an old version of promptl (pre-promtl) where we called `args` but new promptl call it `toolArguments`

## Issue two: Tool arguments on messages appears as `undefined`
Exactly the same issue as in issue one.

## Issue three: Typescript SDK is sending twice `onError` callback
This might not be an error per se but is an error for ourselves because we're using SDK to handle run documents in playground. The way we're doing it is managing our own stream in our NextJS server. The problem is that SDK is sending twice the `onError` callback and provoking this error:
```
.error(): Value stream is already closed.
```
These are the Sentries issues related with it
https://latitude-l5.sentry.io/issues/?alert_rule_id=15461351&alert_type=issue&environment=production&notification_uuid=74fa9c51-8028-4e4b-95c8-f6637d41642f&project=4507922531418112&query=Value%20stream%20is%20already%20closed&referrer=issue-list&statsPeriod=14d

## Issue 4: Promptl is not requiring `name` attribute
We need promptl to require `name` attribute for later format accordingly the tool response. Our tool calls are working when are generated by the AI. But when are hardcoded in promptl the format is incorrect:
We receive this error:
```
 Invalid prompt: messages must be an array of CoreMessage or UIMessage'
```
This is Vercel SDK telling us the format of the tool response is not correct. 

This last issue need to be fixed also on promptl package.