### PR TITLE
Fix: latitude tools and client tools compatibility

### DIFF
--- a/packages/core/src/services/agents/run.ts
+++ b/packages/core/src/services/agents/run.ts
@@ -27,7 +27,7 @@ export function runAgent<T extends boolean, C extends SomeChain>({
 
   const chainStreamManager = new ChainStreamManager({
     errorableUuid,
-    messages: pausedMessages,
+    messages: [...(pausedMessages ?? []), ...(newMessages ?? [])],
     tokenUsage: pausedTokenUsage,
   })
 

--- a/packages/core/src/services/builtInTools/index.ts
+++ b/packages/core/src/services/builtInTools/index.ts
@@ -1,4 +1,3 @@
-import { ChainStepResponse, StreamType } from '@latitude-data/constants'
 import { BuiltInToolCall, LatitudeTool } from '../../constants'
 import { runCode } from './runCode'
 import {
@@ -9,12 +8,17 @@ import {
   TypedResult,
 } from '../../lib'
 import { getLatitudeToolName, LatitudeToolInternalName } from './definitions'
-import { ContentType, MessageRole, ToolMessage } from '@latitude-data/compiler'
+import {
+  AssistantMessage,
+  ContentType,
+  MessageRole,
+  ToolMessage,
+} from '@latitude-data/compiler'
 
-export function getBuiltInToolCallsFromResponse(
-  response: ChainStepResponse<StreamType>,
+export function getBuiltInToolCallsFromAssistantMessage(
+  message: AssistantMessage,
 ): BuiltInToolCall[] {
-  const toolCalls = (response as ChainStepResponse<'text'>).toolCalls ?? []
+  const toolCalls = message.toolCalls ?? []
   const builtinToolCallNames = Object.values(LatitudeToolInternalName)
   return toolCalls.filter((toolCall) =>
     builtinToolCallNames.includes(toolCall.name as LatitudeToolInternalName),

--- a/packages/core/src/services/chains/run.ts
+++ b/packages/core/src/services/chains/run.ts
@@ -88,7 +88,7 @@ export function runChain<T extends boolean, C extends SomeChain>({
 
   const chainStreamManager = new ChainStreamManager({
     errorableUuid,
-    messages: pausedMessages,
+    messages: [...(pausedMessages ?? []), ...(newMessages ?? [])],
     tokenUsage: pausedTokenUsage,
   })
   const streamResult = chainStreamManager.start(async () => {

--- a/packages/core/src/services/documentLogs/addMessages/resumeAgent/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/resumeAgent/index.ts
@@ -75,7 +75,7 @@ function buildExtraMessages({
 export async function resumeAgent({
   workspace,
   providerLog,
-  messages: newMessages,
+  messages: userProvidedMessags,
   source,
 }: {
   workspace: Workspace
@@ -87,9 +87,14 @@ export async function resumeAgent({
     workspaceId: workspace.id,
   })
 
+  const newMessages = buildExtraMessages({
+    providerLog,
+    newMessages: userProvidedMessags,
+  })
+
   const chainStreamManager = new ChainStreamManager({
     errorableUuid: providerLog.documentLogUuid!,
-    messages: providerLog.messages,
+    messages: [...providerLog.messages, ...newMessages],
     // TODO: Missing previous TokenUsage
   })
 
@@ -105,10 +110,7 @@ export async function resumeAgent({
       providersMap,
       errorableUuid: providerLog.documentLogUuid!,
       stepCount: 0,
-      newMessages: buildExtraMessages({
-        providerLog,
-        newMessages,
-      }),
+      newMessages,
     })
   })
 


### PR DESCRIPTION
### WAT
This PR fixes an error where both client tools and latitude tools request in the same assistant response are incompatible.
Before this PR, the Latitude tools were processed and executing before pausing the chain, but these tool responses were not stored neither in the paused chain or provider log.

https://github.com/user-attachments/assets/e6e7870c-379c-4812-a11a-2dabe00134d2

### HOW
Now, when the assistant responds with both client and latitude tools, the client tools will be addressed first: it pauses the chain and waits for the user to provide the client tools responses. Then, when resuming the chain, the rest of latitude tools will be processed and executed before continuing with the next step.
No need to store the Latitude Tools responses before pausing them. :)

https://github.com/user-attachments/assets/98490990-404e-494d-8977-f9c295219483


