### PR TITLE
Fix anthropic cache

### DIFF
--- a/packages/core/src/lib/chainStreamManager/ChainStreamConsumer/consumeStream.test.ts
+++ b/packages/core/src/lib/chainStreamManager/ChainStreamConsumer/consumeStream.test.ts
@@ -54,6 +54,7 @@ function buildFakeChain({
       usage: new Promise<LanguageModelUsage>(() => DEFAULT_USAGE),
       fullStream,
       providerName: Providers.OpenAI,
+      providerMetadata: new Promise<undefined>(() => undefined),
     },
   }
   return new Promise<void>((resolve) => {

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -35,7 +35,7 @@ type AIReturnObject = {
   type: 'object'
   data: Pick<
     StreamObjectResult<unknown, unknown, never>,
-    'fullStream' | 'object' | 'usage'
+    'fullStream' | 'object' | 'usage' | 'providerMetadata'
   > & {
     providerName: Providers
   }
@@ -51,7 +51,7 @@ type AIReturnText = {
   type: 'text'
   data: Pick<
     StreamTextResult<Record<string, CoreTool<any, any>>, PARTIAL_OUTPUT>,
-    'fullStream' | 'text' | 'usage' | 'toolCalls'
+    'fullStream' | 'text' | 'usage' | 'toolCalls' | 'providerMetadata'
   > & {
     providerName: Providers
   }
@@ -182,6 +182,7 @@ export async function ai({
           object: result.object,
           usage: result.usage,
           providerName: provider,
+          providerMetadata: result.providerMetadata,
         },
       })
     }
@@ -199,6 +200,7 @@ export async function ai({
         usage: result.usage,
         toolCalls: result.toolCalls,
         providerName: provider,
+        providerMetadata: result.providerMetadata,
       },
     })
   } catch (e) {

--- a/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
+++ b/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
@@ -90,7 +90,7 @@ export function extractContentMetadata({
 
   return {
     ...definedData,
-    experimental_providerMetadata: {
+    providerOptions: {
       [getProviderMetadataKey(provider)]: processAttributes({
         attributes: providerAttributes,
         provider,
@@ -108,7 +108,7 @@ function removeUndefinedValues(data: Record<string, unknown>) {
 }
 
 type MessageWithMetadata = Message & {
-  experimental_providerMetadata?: Record<string, Record<string, unknown>>
+  providerOptions?: Record<string, Record<string, unknown>>
 }
 
 export function extractMessageMetadata({
@@ -153,7 +153,7 @@ export function extractMessageMetadata({
 
   return {
     ...common,
-    experimental_providerMetadata: {
+    providerOptions: {
       [getProviderMetadataKey(provider)]: processAttributes({
         attributes: Object.keys(attributes),
         provider,

--- a/packages/core/src/services/ai/providers/rules/vercel.test.ts
+++ b/packages/core/src/services/ai/providers/rules/vercel.test.ts
@@ -100,7 +100,7 @@ describe('applyVercelSdkRules', () => {
       {
         role: 'system',
         content: 'I am a',
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             cacheControl: { type: 'ephemeral' },
           },
@@ -109,7 +109,7 @@ describe('applyVercelSdkRules', () => {
       {
         role: 'system',
         content: 'system message',
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             cacheControl: { type: 'ephemeral' },
           },
@@ -137,7 +137,7 @@ describe('applyVercelSdkRules', () => {
     expect(rules.messages).toEqual([
       {
         role: 'user',
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             cacheControl: { type: 'ephemeral' },
           },
@@ -146,7 +146,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'I am a',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 cacheControl: { type: 'ephemeral' },
               },
@@ -155,7 +155,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'system message',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 cacheControl: { type: 'ephemeral' },
               },
@@ -207,7 +207,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'Hello',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 some_attribute: 'some_user_value',
                 another_attribute: { another_user: 'value' },
@@ -215,7 +215,7 @@ describe('applyVercelSdkRules', () => {
             },
           },
         ],
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             some_attribute: 'some_user_value',
             another_attribute: { another_user: 'value' },
@@ -232,7 +232,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'I am good',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 some_attribute: 'some_assistant_value',
                 another_attribute: { another_assistant: 'value' },
@@ -240,7 +240,7 @@ describe('applyVercelSdkRules', () => {
             },
           },
         ],
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             some_attribute: 'some_assistant_value',
             another_attribute: { another_assistant: 'value' },
@@ -250,7 +250,7 @@ describe('applyVercelSdkRules', () => {
       {
         role: 'system',
         content: 'I am good',
-        experimental_providerMetadata: {
+        providerOptions: {
           anthropic: {
             some_attribute: 'some_system_value',
             cacheControl: { type: 'ephemeral' },
@@ -305,7 +305,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'Hello',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 some_attribute: 'some_user_value',
                 another_attribute: { another_user: 'value' },
@@ -324,7 +324,7 @@ describe('applyVercelSdkRules', () => {
           {
             type: 'text',
             text: 'I am good',
-            experimental_providerMetadata: {
+            providerOptions: {
               anthropic: {
                 some_attribute: 'some_assistant_value',
                 another_attribute: { another_assistant: 'value' },

--- a/packages/core/src/services/ai/providers/rules/vercel.ts
+++ b/packages/core/src/services/ai/providers/rules/vercel.ts
@@ -33,13 +33,12 @@ function flattenSystemMessage({
     extractMessageMetadata({
       message,
       provider,
-    }).experimental_providerMetadata ?? {}
+    }).providerOptions ?? {}
 
   return content.flatMap((content) => {
     const extracted = extractContentMetadata({ content, provider })
     // @ts-expect-error - metadata key can be not present
-    const metadata = (extracted.experimental_providerMetadata ??
-      {}) as ProviderMetadata
+    const metadata = (extracted.providerOptions ?? {}) as ProviderMetadata
     const baseMsg = { role: message.role, content: content.text }
 
     if (!Object.keys(metadata).length && !Object.keys(msgMetadata).length) {
@@ -50,7 +49,7 @@ function flattenSystemMessage({
 
     return {
       ...baseMsg,
-      experimental_providerMetadata: {
+      providerOptions: {
         [key]: {
           ...(msgMetadata?.[key] || {}),
           ...(metadata?.[key] || {}),
@@ -78,7 +77,7 @@ function groupContentMetadata({
     return [
       {
         ...baseMsg,
-        experimental_providerMetadata: messageMetadata,
+        providerOptions: messageMetadata,
       },
     ]
   }
@@ -88,12 +87,12 @@ function groupContentMetadata({
     if (!messageMetadata) return extracted
 
     // @ts-expect-error - metadata key can be not present
-    const contentMetadata = (extracted.experimental_providerMetadata ??
+    const contentMetadata = (extracted.providerOptions ??
       {}) as ProviderMetadata
 
     return {
       ...extracted,
-      experimental_providerMetadata: {
+      providerOptions: {
         [key]: {
           ...(messageMetadata?.[key] || {}),
           ...(contentMetadata?.[key] || {}),
@@ -197,7 +196,7 @@ export function vercelSdkRules(
     content = groupContentMetadata({
       content: content,
       provider: provider,
-      messageMetadata: extracted.experimental_providerMetadata,
+      messageMetadata: extracted.providerOptions,
     }) as unknown as Message['content']
 
     return [{ ...extracted, content } as Message]

--- a/packages/core/src/services/chains/ProviderProcessor/index.test.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/index.test.ts
@@ -80,6 +80,9 @@ describe('ProviderProcessor', () => {
             },
           }),
           providerName: Providers.OpenAI,
+          providerMetadata: new Promise<undefined>((resolve) =>
+            resolve(undefined),
+          ),
         },
       },
     })


### PR DESCRIPTION
# What?
Vercel SDK changed from `experimental_providerMetadata` to `providerOptions` [here](https://github.com/vercel/ai/pull/4585) and we didn't change what we do to send provider metadata after update to their latest SDK version

## Issue
Solves this issue https://github.com/latitude-dev/latitude-llm/issues/782#issue-2796067952

## Now we cache again
This is what Anthropic returns now.
```
{
  anthropic: { cacheCreationInputTokens: 0, cacheReadInputTokens: 7162 }
}
```