### PR TITLE
sub-agents fixes

### DIFF
--- a/packages/constants/src/helpers.ts
+++ b/packages/constants/src/helpers.ts
@@ -32,6 +32,33 @@ export function resolveRelativePath(refPath: string, from?: string): string {
   return resultSegments.join('/')
 }
 
+export function createRelativePath(refPath: string, from?: string): string {
+  if (!from) {
+    return '/' + refPath
+  }
+
+  const refSegments = refPath.split('/')
+  const currentSegments = from.split('/').slice(0, -1)
+
+  const commonSegments = []
+  for (let i = 0; i < refSegments.length && i < currentSegments.length; i++) {
+    if (refSegments[i] !== currentSegments[i]) {
+      break
+    }
+
+    commonSegments.push(refSegments[i])
+  }
+
+  const upSegments = currentSegments
+    .slice(commonSegments.length)
+    .map(() => '..')
+  const downSegments = refSegments.slice(commonSegments.length)
+
+  const fullRefPath = [...upSegments, ...downSegments].join('/')
+
+  return refPath.length < fullRefPath.length ? '/' + refPath : fullRefPath
+}
+
 export function promptConfigSchema({
   providerNames,
   fullPath,

--- a/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
+++ b/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
@@ -1,3 +1,4 @@
+import { resolveRelativePath } from '@latitude-data/constants'
 import { Commit, DocumentVersion, Workspace } from '../../../browser'
 import { Result } from '../../../lib'
 import { DocumentVersionsRepository } from '../../../repositories'
@@ -17,7 +18,13 @@ export async function getIncludedDocuments({
     document,
     commit,
   }).then((r) => r.unwrap())
-  const includedPaths = Array.from(metadata.includedPromptPaths)
+
+  const includedAgents: string[] = (metadata.config.agents as string[]) ?? []
+  const includedAgentsFullPaths = includedAgents.map((agentPath) =>
+    resolveRelativePath(agentPath, document.path),
+  )
+  const referencedPaths = Array.from(metadata.includedPromptPaths)
+  const includedPaths = [...includedAgentsFullPaths, ...referencedPaths]
   const documentScope = new DocumentVersionsRepository(workspace.id)
   const allDocs = await documentScope
     .getDocumentsAtCommit(commit)

--- a/packages/core/src/services/documents/forkDocument/index.test.ts
+++ b/packages/core/src/services/documents/forkDocument/index.test.ts
@@ -294,6 +294,16 @@ describe('forkDocument', () => {
         })
         expect(documents).toEqual([
           {
+            path: 'agents/agent1',
+            provider: 'google',
+            model: 'gemini-2.0-flash',
+          },
+          {
+            path: 'agents/agent2',
+            provider: 'google',
+            model: 'gemini-2.0-flash',
+          },
+          {
             path: 'some-folder/children/child1',
             provider: 'google',
             model: 'gemini-2.0-flash',

--- a/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
+++ b/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
@@ -19,6 +19,18 @@ export async function buildProjects() {
             content: 'Sibling Parent',
           }),
         },
+        agents: {
+          agent1: factories.helpers.createPrompt({
+            provider: 'myAnthropic',
+            content: 'Agent 1',
+            extraConfig: { type: 'agent' },
+          }),
+          agent2: factories.helpers.createPrompt({
+            provider: 'myAnthropic',
+            content: 'Agent 2',
+            extraConfig: { type: 'agent' },
+          }),
+        },
         'some-folder': {
           parent: factories.helpers.createPrompt({
             provider: 'openai',
@@ -33,6 +45,9 @@ export async function buildProjects() {
           children: {
             child1: factories.helpers.createPrompt({
               provider: 'myAnthropic',
+              extraConfig: {
+                agents: ['/agents/agent1', '../../agents/agent2'],
+              },
               content: `
             Child 1:
             <prompt path="./grandchildren/grandchild1" />


### PR DESCRIPTION
A few fixes for the sub-agents config:
- SubAgents included in the `agents` config will now be imported when forking a document
- Now the sub agents config UI supports relative paths