### PR TITLE
Import included sub-agents on Fork

### DIFF
--- a/packages/core/src/services/documents/forkDocument/index.test.ts
+++ b/packages/core/src/services/documents/forkDocument/index.test.ts
@@ -304,6 +304,16 @@ describe('forkDocument', () => {
             model: 'gemini-2.0-flash',
           },
           {
+            path: 'agents/subagent1',
+            provider: 'google',
+            model: 'gemini-2.0-flash',
+          },
+          {
+            path: 'agents/subagent2',
+            provider: 'google',
+            model: 'gemini-2.0-flash',
+          },
+          {
             path: 'some-folder/children/child1',
             provider: 'google',
             model: 'gemini-2.0-flash',

--- a/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
+++ b/packages/core/src/services/documents/forkDocument/testHelpers/buildProjects.ts
@@ -28,6 +28,16 @@ export async function buildProjects() {
           agent2: factories.helpers.createPrompt({
             provider: 'myAnthropic',
             content: 'Agent 2',
+            extraConfig: { type: 'agent', agents: ['./subagent1'] },
+          }),
+          subagent1: factories.helpers.createPrompt({
+            provider: 'myAnthropic',
+            content: 'Subagent 1',
+            extraConfig: { type: 'agent', agents: ['subagent2'] },
+          }),
+          subagent2: factories.helpers.createPrompt({
+            provider: 'myAnthropic',
+            content: 'Subagent 2',
             extraConfig: { type: 'agent' },
           }),
         },


### PR DESCRIPTION
Imports all tree of sub-agents when forking a prompt