### PR TITLE
Smarter agents

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/PromptConfiguration/BehaviourSettings.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/PromptConfiguration/BehaviourSettings.tsx
@@ -7,6 +7,7 @@ import {
 } from './utils'
 import { LatitudeTool } from '@latitude-data/constants'
 import { SubAgentSelector } from './_components/AgentSelector'
+import { useEffect } from 'react'
 
 export function BehaviourSettings({
   config,
@@ -21,6 +22,22 @@ export function BehaviourSettings({
     key: 'type',
     defaultValue: undefined,
   })
+
+  const {
+    value: disabledAgentOptimization,
+    setValue: setDisableAgentOptimization,
+  } = useConfigValue<boolean>({
+    config,
+    setConfig,
+    key: 'disableAgentOptimization',
+    defaultValue: false,
+  })
+
+  useEffect(() => {
+    if (agentValue !== 'agent') {
+      setDisableAgentOptimization(undefined)
+    }
+  }, [agentValue])
 
   const { tools, toggleTool } = useLatitudeToolsConfig({ config, setConfig })
 
@@ -41,6 +58,28 @@ Unlike regular prompts or predefined Chains, Agents can adapt dynamically, respo
           }
         />
       </ConfigElement>
+      {agentValue === 'agent' && (
+        <div className='w-full pl-6'>
+          <ConfigElement
+            label='Advanced agent optimization'
+            icon='sparkles'
+            summary='Automatically optimizes the agent behaviour without needing to add additional prompting.'
+            description={`When enabled, the agent will automatically know that they are in an autonomous workflow and how it works.
+                Otherwise, you will need to add custom prompting to avoid the AI falling into infinite loops and using the agent tools correctly.
+                This optimization is done without adding or modifying any SYSTEM or USER message from your prompt, it's all handled internally by Latitude.`}
+          >
+            <SwitchToogle
+              disabled={disabled}
+              checked={!disabledAgentOptimization}
+              onCheckedChange={() =>
+                setDisableAgentOptimization(
+                  disabledAgentOptimization ? undefined : true,
+                )
+              }
+            />
+          </ConfigElement>
+        </div>
+      )}
       <ConfigElement
         label='Run code'
         icon='terminal'

--- a/packages/constants/src/ai.ts
+++ b/packages/constants/src/ai.ts
@@ -68,6 +68,7 @@ export type Config = {
   azure?: AzureConfig
   google?: GoogleConfig
   type?: 'agent' | undefined
+  disableAgentOptimization?: boolean
   tools?: Record<string, ToolDefinition>
   agents?: string[]
 }

--- a/packages/constants/src/config.ts
+++ b/packages/constants/src/config.ts
@@ -7,7 +7,8 @@ export enum ParameterType {
 export const LATITUDE_TOOLS_CONFIG_NAME = 'latitudeTools'
 export const LATITUDE_TOOL_PREFIX = 'lat_tool'
 export const AGENT_TOOL_PREFIX = 'lat_agent'
-export const AGENT_RETURN_TOOL_NAME = 'agent_finish_task'
+export const AGENT_RETURN_TOOL_NAME = 'end_autonomous_chain'
+export const FAKE_AGENT_START_TOOL_NAME = 'start_autonomous_chain'
 
 export enum LatitudeTool {
   RunCode = 'code',

--- a/packages/core/src/lib/chainStreamManager/step/streamAIResponse.ts
+++ b/packages/core/src/lib/chainStreamManager/step/streamAIResponse.ts
@@ -27,6 +27,8 @@ export type ExecuteStepArgs = {
   documentLogUuid: string
   schema?: JSONSchema7
   output?: 'object' | 'array' | 'no-schema'
+  injectFakeAgentStartTool?: boolean
+  injectAgentFinishTool?: boolean
 }
 
 export async function streamAIResponse({
@@ -39,6 +41,8 @@ export async function streamAIResponse({
   documentLogUuid,
   schema,
   output,
+  injectFakeAgentStartTool,
+  injectAgentFinishTool,
 }: ExecuteStepArgs): Promise<{
   response: ChainStepResponse<StreamType>
   tokenUsage: LanguageModelUsage
@@ -55,6 +59,8 @@ export async function streamAIResponse({
     promptSource,
     messages: conversation.messages,
     config: conversation.config as Config,
+    injectFakeAgentStartTool,
+    injectAgentFinishTool,
   })
   if (injectionResult.error) throw injectionResult.error
   const { messages, config } = injectionResult.unwrap()

--- a/packages/core/src/services/agents/AgentStepValidator/index.ts
+++ b/packages/core/src/services/agents/AgentStepValidator/index.ts
@@ -101,32 +101,6 @@ const validateConfig = (
   return Result.ok(injectResult.unwrap() as Config)
 }
 
-const applyAgentTools = (config: Config): Config => {
-  const { schema, ...rest } = config
-
-  const DEFAULT_SCHEMA: JSONSchema7 = {
-    type: 'object',
-    properties: {
-      response: {
-        type: 'string',
-      },
-    },
-    required: ['response'],
-  }
-
-  return {
-    ...rest,
-    tools: {
-      ...(rest.tools ?? {}),
-      [AGENT_RETURN_TOOL_NAME]: {
-        description:
-          'You are an autonomous agent. You have been assigned a task, and your objective is to send messages autonomously following your instructions, obtaining information, and performing actions, indefinitely.\nWith this tool, you will be able to FINISH this workflow. Only use this tool when you have achieved your task and are ready to return the final results.\nUse this tool all by itself, do not include a response with it. If you need to both give a response and run this tool, do it in two separate messages.\nThis tool can ONLY be called once, and it will define the end of your task. Do not try to call it before finishing your task. Do not try to call it multiple times within the same message.\n',
-        parameters: schema ?? DEFAULT_SCHEMA,
-      },
-    },
-  }
-}
-
 function isChainCompleted(newMessages?: Message[]) {
   if (!newMessages?.length) return false
 
@@ -182,10 +156,10 @@ export const validateAgentStep = async ({
 
   return Result.ok({
     provider,
-    config: applyAgentTools(rule.config as Config),
+    config: rule.config as Config,
     conversation: {
       ...conversation,
-      config: applyAgentTools(config),
+      config,
       messages: rule?.messages ?? messages,
     },
     chainCompleted: isChainCompleted(newMessages),

--- a/packages/core/src/services/agents/promptInjection.ts
+++ b/packages/core/src/services/agents/promptInjection.ts
@@ -1,0 +1,156 @@
+import {
+  AssistantMessage,
+  ContentType,
+  Message,
+  MessageRole,
+  ToolMessage,
+} from '@latitude-data/compiler'
+import {
+  AGENT_RETURN_TOOL_NAME,
+  Config,
+  FAKE_AGENT_START_TOOL_NAME,
+} from '@latitude-data/constants'
+import { LatitudeError, Result, TypedResult } from '../../lib'
+import { JSONSchema7 } from 'json-schema'
+
+export const AGENT_RETURN_TOOL_DESCRIPTION = `
+The '${FAKE_AGENT_START_TOOL_NAME}' tool is used to start an autonomous chain-of-thought workflow.
+Within this workflow, you will generate messages autonomously.
+All of the Assistant messages within this workflow will be internal, used as a chain-of-thought and to execute tools in order to achieve your task. The user will not read these messages.
+Use this tool to stop the autonomous workflow and return a message to the user. It must contain the final result of the workflow.
+`.trim()
+
+const FAKE_AGENT_START_TOOL_CONTENT = `
+  Autonomous workflow started.
+  All messages from now on are for internal use only and will not be presented to the user.
+  Use this workflow to perform a chain-of-thought about your task and execute required tools.
+  You must explain your thought process on each and every step of the chain.
+  Start by understanding your task and explaining the intended course of actions to yourself.
+  Once you have finished your current task, use the '${AGENT_RETURN_TOOL_NAME}' tool to finish it. The tool call must include the requested result.
+`.trim()
+
+const DEFAULT_AGENT_RETURN_TOOL_SCHEMA: JSONSchema7 = {
+  type: 'object',
+  properties: {
+    response: {
+      type: 'string',
+    },
+  },
+  required: ['response'],
+}
+
+/**
+ * Injects fake assistant messages used to request the start of an autonomous workflow.
+ * These messages greatly help the AI understand they are in an autonomous workflow and how it works.
+ */
+function injectFakeStartAutonomousWorkflowMessages(
+  messages: Message[],
+): Message[] {
+  let wokflowCount = 1
+  const createFakeStartTool = (): [AssistantMessage, ToolMessage] => {
+    const toolId = `agent_start_${wokflowCount++}`
+    const toolName = FAKE_AGENT_START_TOOL_NAME
+
+    return [
+      {
+        role: MessageRole.assistant,
+        content: [
+          {
+            type: ContentType.toolCall,
+            toolCallId: toolId,
+            toolName,
+            args: {},
+          },
+        ],
+        toolCalls: [
+          {
+            id: toolId,
+            name: toolName,
+            arguments: {},
+          },
+        ],
+      },
+      {
+        role: MessageRole.tool,
+        content: [
+          {
+            type: ContentType.toolResult,
+            toolCallId: toolId,
+            toolName,
+            result: FAKE_AGENT_START_TOOL_CONTENT,
+            isError: false,
+          },
+        ],
+      },
+    ]
+  }
+
+  // Messages are injected in these cases:
+  // - Before starting the first workflow (before the first assistant message after the initial instructions)
+  // - Before starting a new workflow (after the user chat message added after the previous workflow was stopped)
+  let inAutonomousMode = false
+  const newMessages = messages.reduce((acc: Message[], message, index) => {
+    const isLast = index === messages.length - 1
+    const isAgentReturnTool =
+      message.role === MessageRole.assistant &&
+      message.toolCalls.some(
+        (toolCall) => toolCall.name === AGENT_RETURN_TOOL_NAME,
+      )
+
+    if (!inAutonomousMode && message.role === MessageRole.assistant) {
+      inAutonomousMode = true
+      return [...acc, ...createFakeStartTool(), message]
+    }
+
+    if (isLast && !inAutonomousMode) {
+      return [...acc, message, ...createFakeStartTool()]
+    }
+
+    if (inAutonomousMode && isAgentReturnTool) {
+      inAutonomousMode = false
+      return [...acc, message]
+    }
+
+    return [...acc, message]
+  }, [])
+
+  return newMessages
+}
+
+export function performAgentInjection({
+  messages: originalMessages,
+  config: originalConfig,
+  injectFakeAgentStartTool,
+  injectAgentFinishTool,
+}: {
+  messages: Message[]
+  config: Config
+  injectFakeAgentStartTool?: boolean
+  injectAgentFinishTool?: boolean
+}): TypedResult<{ messages: Message[]; config: Config }, LatitudeError> {
+  let config = originalConfig
+  let messages = originalMessages
+
+  if (injectFakeAgentStartTool) {
+    messages = injectFakeStartAutonomousWorkflowMessages(messages)
+  }
+
+  if (injectAgentFinishTool) {
+    const { schema, ...rest } = config
+    config = {
+      ...rest,
+      tools: {
+        ...(rest.tools ?? {}),
+        [AGENT_RETURN_TOOL_NAME]: {
+          description: AGENT_RETURN_TOOL_DESCRIPTION,
+          parameters: schema ?? DEFAULT_AGENT_RETURN_TOOL_SCHEMA,
+        },
+      },
+    }
+  }
+
+  return Result.ok({
+    messages,
+    config,
+  })
+}

--- a/packages/core/src/services/agents/runStep/index.ts
+++ b/packages/core/src/services/agents/runStep/index.ts
@@ -93,6 +93,8 @@ export async function runAgentStep({
       provider: step.provider,
       schema: step.schema,
       output: step.output,
+      injectAgentFinishTool: true,
+      injectFakeAgentStartTool: !step.config.disableAgentOptimization,
     })
 
   // Stop the chain if there are tool calls

--- a/packages/core/src/services/chains/runStep/index.ts
+++ b/packages/core/src/services/chains/runStep/index.ts
@@ -115,6 +115,9 @@ export async function runStep({
       provider: step.provider,
       schema: step.schema,
       output: step.output,
+      injectFakeAgentStartTool:
+        step.conversation.config.type === 'agent' &&
+        !step.conversation.config.disableAgentOptimization,
     })
 
   const isPromptl = chain instanceof PromptlChain


### PR DESCRIPTION
## WAT

Currently, creating a competent agent requires lots of prompting and the user knowing how the workflow actually works.

Without the required prompting, the LLM tends to make some of these errors:
- Responding right away, without performing a chain-of-thought and without using the agent tool.
- Entering an infinite loop asking the user for more input without realizing it needs to use the agent tool to stop the workflow.
- Not using the agent tool correctly.

This PR tries to fix these issues, giving context to the AI about the workflow and giving them a push to work in a structured chain-of-thought process, without requiring extra prompting from the user. In order to respect the users control over their own prompt, this must be done without injecting or modifying SYSTEM / USER messages from the prompt.

## HOW

Okay, so this is what I have done.
Now, when the AI before an autonomous workflow, I add a phantom Assistant message with the fake request to start an autonomous workflow. This tool does not exist, and will do nothing, but it tricks the AI into thinking they requested it and thus know how behave from this point forward. Now, since "they requested" entering an autonomous workflow, they understand that they must make an explicit request to exit this workflow and return a response. In addition to this, the tool response to the fake workflow start request also gives indications about the workflow they just started, how it works and how and when to end it. No additional instructions are added about the task or how to solve it.

--- 

Let's see an example:

Take a look at this prompt:
```markdown
---
provider: openai
model: gpt-4o-mini
type: agent
---
You are a helpful AI assistant designed to assist users with any questions they might have. Your goal is to guide the user towards scheduling an appointment. As soon as the user wants an appointment, help them with that.

Here you can find all the info the user might ask about:

<prompt path="./docs" />

<user>
  {{ message }}
</user>
```

With this prompt, the AI does not know anything about the agentic workflow. For this reason, it tends to just return a response to the user without using the agent tool, see that the user hasn't responded (because the AI is still in a loop) and ask for further input for the user. Then, since it has still not ended the workflow, it repeats the last message. And over, and over, and over again.

Now, with the fake message injection, this is how this conversation actually looks like to the AI:
```
[SYSTEM]
You are a helpful AI assistant designed to assist users with any questions they might have. Your goal is to guide the user towards scheduling an appointment. As soon as the user wants an appointment, help them with that.
Here you can find all the info the user might ask about:
<docs>

[USER]
<message>

[ASSISTANT] (fake workflow request)
{
  toolId: 'agent_start_1',
  toolName: 'start_autonomous_chain'
  arguments: {}
}

[TOOL] (fake tool response)
Autonomous workflow started.
All messages from now on are for internal use only and will not be presented to the user.
Use this workflow to perform a chain-of-thought about your task and execute required tools.
You must explain your thought process on each and every step of the chain.
Start by understanding your task and explaining the intended course of actions to yourself.
Once you have finished your current task, use the 'end_autonomous_chain' tool to finish it. The tool call must include the requested result.
```

Now, the AI is informed about the autonomous workflow, no system instruction has been added that could conflict with the original prompt, and it will start a chain-of-thought process.

### Before
<img width="886" alt="image" src="https://github.com/user-attachments/assets/bcb78815-6b52-4c1c-af08-ff0d91b051c1" />

### After
<img width="893" alt="image" src="https://github.com/user-attachments/assets/3a5d0318-33aa-4a4d-b035-d73d43db73ff" />
