### PR TITLE
Request Tools on chat

### DIFF
--- a/packages/core/src/services/documentLogs/addMessages/addChatMessage/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/addChatMessage/index.ts
@@ -86,13 +86,17 @@ export async function addChatMessage({
       provider,
     }).then((r) => r.unwrap())
 
-    await chainStreamManager.getProviderResponse({
+    const { clientToolCalls } = await chainStreamManager.getProviderResponse({
       workspace,
       provider,
       source,
       documentLogUuid: providerLog.documentLogUuid!,
       conversation,
     })
+
+    if (clientToolCalls.length) {
+      return chainStreamManager.requestTools(clientToolCalls)
+    }
   })
 
   return Result.ok(streamResult)

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -681,19 +681,17 @@ describe('addMessages', () => {
       {
         event: StreamEventTypes.Latitude,
         data: expect.objectContaining({
-          type: ChainEventTypes.StepCompleted,
-        }),
-      },
-      {
-        event: StreamEventTypes.Latitude,
-        data: expect.objectContaining({
-          type: ChainEventTypes.ChainCompleted,
-          tokenUsage: {
-            promptTokens: expect.any(Number),
-            completionTokens: expect.any(Number),
-            totalTokens: expect.any(Number),
-          },
-          finishReason: 'stop',
+          type: ChainEventTypes.ToolsRequested,
+          tools: [
+            {
+              id: 'tool-call-id',
+              name: 'tool-call-name',
+              arguments: {
+                arg1: 'value1',
+                arg2: 'value2',
+              },
+            },
+          ],
         }),
       },
     ])


### PR DESCRIPTION
Fixes a bug where Tools requested on chat do not send Tools Requested events. This causes, for instance, the Mock Tool Response UI not appear in chat.