### PR TITLE
New tools schema

### DIFF
--- a/docs/guides/prompt-manager/latitude-tools.mdx
+++ b/docs/guides/prompt-manager/latitude-tools.mdx
@@ -24,48 +24,62 @@ Latitude comes with a selection of built-in tools that can be used in your promp
 
 Currently, Latitude supports the following built-in tools:
 
-- `code`
-- `search`
-- `extract`
+- `latitude/code`
+- `latitude/search`
+- `latitude/extract`
 
-To add them to your prompt, simply include them in a `latitudeTools` section in your prompt configuration as a list:
+To add them to your prompt, simply include them in the `tools` section in your prompt configuration:
 
 ```yaml
 ---
 provider: <your-provider-name>
 model: <your-model>
-latitudeTools:
-  - code
-  - search
-  - extract
+tools:
+  - latitude/code
+  - latitude/search
+  - latitude/extract
 ---
 ```
+
+You can also use `latitude/*` to include all available tools in your prompt.
+
+```yaml
+---
+provider: <your-provider-name>
+model: <your-model>
+tools:
+  - latitude/*
+```
+
+<Note>
+  Check the (Tools)[/guides/prompt-manager/tools] guide for more information on how to define custom tools in your prompts.
+</Note>
 
 ---
 
 ## Code Tool
 
-The `code` tool enables the execution of custom scripts in Python or JavaScript within the conversation. This tool is ideal for:
+The `latitude/code` tool enables the execution of custom scripts in Python or JavaScript within the conversation. This tool is ideal for:
 
 - Running complex calculations.
 - Making API calls to external services.
 - Processing and transforming data dynamically.
 
-When the `code` tool is available, the AI model can generate and request the execution of code snippets. These snippets can include dependencies that will be installed before execution. Once the code runs, the AI model receives the output as a response.
+When the `latitude/code` tool is available, the AI model can generate and request the execution of code snippets. These snippets can include dependencies that will be installed before execution. Once the code runs, the AI model receives the output as a response.
 
 ## Search Tool
 
-The `search` tool allows the AI model to query the web and retrieve real-time information. It is particularly useful for:
+The `latitude/search` tool allows the AI model to query the web and retrieve real-time information. It is particularly useful for:
 
 - Looking up recent news or events.
 - Finding definitions, facts, or background information.
 - Retrieving relevant sources and references.
 
-When this tool is enabled, the AI model can issue search queries, and the `search` tool will return a list of results, including titles, URLs, and short descriptions of the retrieved content.
+When this tool is enabled, the AI model can issue search queries, and the `latitude/search` tool will return a list of results, including titles, URLs, and short descriptions of the retrieved content.
 
 ## Extract Tool
 
-The `extract` tool fetches and processes structured content from a given URL. This is useful for:
+The `latitude/extract` tool fetches and processes structured content from a given URL. This is useful for:
 
 - Extracting text, metadata, or images from web pages.
 - Summarizing long articles.

--- a/docs/guides/prompt-manager/tools.mdx
+++ b/docs/guides/prompt-manager/tools.mdx
@@ -13,9 +13,24 @@ Latitude's prompt editor allows you to define **tools** in your prompts. Tools a
 
 ---
 
-## Defining Tools
+## Available Tools
 
-You can define tools as a list of functions. Each tool must include:
+In Latitude, you can specify a list of available tools to the AI model, which will be able to request its executions in order to accomplish a task. Although you can define your own custom tools, Latitude provides a set of built-in tools that can be used in your prompts.
+
+Currently, only Latitude Tools are supported. The following tools are available:
+- `latitude/code`
+- `latitude/search`
+- `latitude/extract`
+
+Take a look at the [Latitude Tools Section](/guides/prompt-manager/latitude-tools) for more information on how to use them.
+
+---
+
+## Defining Custom Tools
+
+You can define custom tools as a list of functions. These functions will not run in Latitude, but instead will be requested to your client through the SDK when the AI model calls them.
+
+Each tool must include:
 - A `name`
 - A `description`
 - An optional list of `parameters`
@@ -25,16 +40,16 @@ You can define tools as a list of functions. Each tool must include:
 provider: <your-provider-name>
 model: <your-model>
 tools:
-  <tool-name>:
-    description: <tool-description>
-    parameters:
-      type: object
-      properties:
-        <parameter-name>:
-          type: <parameter-type>
-          description: <parameter-description>
-      required: [<required-parameter-name>]
-      additionalProperties: false
+  - <tool-name>:
+      description: <tool-description>
+      parameters:
+        type: object
+        properties:
+          <parameter-name>:
+            type: <parameter-type>
+            description: <parameter-description>
+        required: [<required-parameter-name>]
+        additionalProperties: false
 ---
 ```
 
@@ -142,16 +157,16 @@ Here's an example of how you might define a tool to get the current weather for 
 provider: OpenAI
 model: gpt-4o
 tools:
-  get_weather:
-    description: Get the current weather for a specified location.
-    parameters:
-      type: object
-      properties:
-        location:
-          type: string
-          description: The name of the location to get the weather for.
-      required: [location]
-      additionalProperties: false
+  - get_weather:
+      description: Get the current weather for a specified location.
+      parameters:
+        type: object
+        properties:
+          location:
+            type: string
+            description: The name of the location to get the weather for.
+        required: [location]
+        additionalProperties: false
 ---
 
 You're a weather bot! Respond to any user's request

--- a/packages/constants/src/config.ts
+++ b/packages/constants/src/config.ts
@@ -4,7 +4,7 @@ export enum ParameterType {
   File = 'file',
 }
 
-export const LATITUDE_TOOLS_CONFIG_NAME = 'latitudeTools'
+export const LATITUDE_TOOLS_CONFIG_NAME = 'latitudeTools' // deprecated
 export const LATITUDE_TOOL_PREFIX = 'lat_tool'
 export const AGENT_TOOL_PREFIX = 'lat_agent'
 export const AGENT_RETURN_TOOL_NAME = 'end_autonomous_chain'

--- a/packages/constants/src/events/legacy.ts
+++ b/packages/constants/src/events/legacy.ts
@@ -1,5 +1,5 @@
 import { Message } from '@latitude-data/compiler'
-import { ChainEventDtoResponse, Config } from '..'
+import { ChainEventDtoResponse, PromptConfig } from '..'
 import { FinishReason } from 'ai'
 
 export enum LegacyChainEventTypes {
@@ -12,7 +12,7 @@ export enum LegacyChainEventTypes {
 export type LegacyEventData =
   | {
       type: LegacyChainEventTypes.Step
-      config: Config
+      config: PromptConfig
       isLastStep: boolean
       messages: Message[]
       uuid?: string
@@ -24,7 +24,7 @@ export type LegacyEventData =
     }
   | {
       type: LegacyChainEventTypes.Complete
-      config: Config
+      config: PromptConfig
       finishReason?: FinishReason
       messages?: Message[]
       object?: any

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -1,6 +1,6 @@
 import { LogSources } from '.'
 import { Message, ToolCall } from '@latitude-data/compiler'
-import { PartialConfig } from './ai'
+import { PartialPromptConfig } from './ai'
 
 export type DocumentLog = {
   id: number
@@ -49,7 +49,7 @@ export type ProviderLog = {
   providerId: number | null
   model: string | null
   finishReason: string | null
-  config: PartialConfig | null
+  config: PartialPromptConfig | null
   messages: Message[]
   responseObject: unknown | null
   responseText: string | null

--- a/packages/core/src/lib/chainStreamManager/legacyStreamConverter/index.ts
+++ b/packages/core/src/lib/chainStreamManager/legacyStreamConverter/index.ts
@@ -1,6 +1,6 @@
 import {
   ChainStepResponse,
-  Config,
+  PromptConfig,
   LegacyChainEvent,
   LegacyChainEventTypes,
   StreamEventTypes,
@@ -39,7 +39,7 @@ export function convertToLegacyChainStream(
   })
 
   let lastResponse: ChainStepResponse<StreamType>
-  let lastConfig: Config
+  let lastConfig: PromptConfig
   let messageCount = 0
   let isResumingPausedChain = false
 
@@ -86,12 +86,12 @@ export function convertToLegacyChainStream(
               documentLogUuid: data.uuid,
               messages: data.messages.slice(messageCount),
               isLastStep: false,
-              config: data.config as Config,
+              config: data.config as PromptConfig,
             },
           })
 
           messageCount = data.messages.length
-          lastConfig = data.config as Config
+          lastConfig = data.config as PromptConfig
           continue
         }
 

--- a/packages/core/src/lib/chainStreamManager/step/promptInjection/tools.ts
+++ b/packages/core/src/lib/chainStreamManager/step/promptInjection/tools.ts
@@ -1,0 +1,136 @@
+import {
+  PromptConfig,
+  LatitudeTool,
+  ToolDefinition,
+  VercelConfig,
+} from '@latitude-data/constants'
+import { Result, TypedResult } from '../../../Result'
+import { BadRequestError, LatitudeError, NotFoundError } from '../../../errors'
+import {
+  getLatitudeToolDefinition,
+  getLatitudeToolInternalName,
+} from '../../../../services/latitudeTools/helpers'
+
+const ALL_LATITUDE_TOOLS = Object.fromEntries(
+  Object.values(LatitudeTool).map((latitudeToolName) => [
+    getLatitudeToolInternalName(latitudeToolName),
+    getLatitudeToolDefinition(latitudeToolName)!,
+  ]),
+)
+
+function getToolFromId(
+  toolId: string,
+): TypedResult<Record<string, ToolDefinition>, LatitudeError> {
+  const [toolSource, toolName, ...other] = toolId
+    .split('/')
+    .map((s) => s.trim())
+  if (!toolSource || !toolName || other.length) {
+    return Result.error(new BadRequestError(`Invalid tool ID: '${toolId}'`))
+  }
+
+  if (toolSource === 'latitude') {
+    const toolName = toolId.slice('latitude:'.length) as LatitudeTool | '*'
+    if (toolName === '*') {
+      return Result.ok(ALL_LATITUDE_TOOLS)
+    }
+
+    if (!Object.values(LatitudeTool).includes(toolName)) {
+      return Result.error(
+        new NotFoundError(
+          `There is no Latitude tool with the name '${toolName}'`,
+        ),
+      )
+    }
+
+    return Result.ok({
+      [getLatitudeToolInternalName(toolName)]:
+        getLatitudeToolDefinition(toolName)!,
+    })
+  }
+
+  // TODO: This will include integrations
+  return Result.error(new NotFoundError(`Unknown tool source: '${toolSource}'`))
+}
+
+function inferToolsFromConfig(
+  config: PromptConfig,
+): TypedResult<Record<string, ToolDefinition>, LatitudeError> {
+  if (!config.tools) {
+    return Result.ok({})
+  }
+
+  const tools = config.tools ?? []
+
+  // Old schema: tools is a { [name: string]: ToolDefinition } object
+  if (typeof tools === 'object' && !Array.isArray(tools) && tools !== null) {
+    return Result.ok(tools)
+  }
+
+  // New schema: tools is an array
+  if (Array.isArray(tools)) {
+    let newTools: Record<string, ToolDefinition> = {}
+    for (const tool of tools) {
+      if (typeof tool === 'string') {
+        const toolResult = getToolFromId(tool)
+        if (toolResult.error) return toolResult
+        newTools = { ...newTools, ...toolResult.unwrap() }
+      } else {
+        newTools = { ...newTools, ...tool }
+      }
+    }
+
+    return Result.ok(newTools)
+  }
+
+  return Result.error(new BadRequestError('Invalid tools schema'))
+}
+
+function getLatitudeToolsDefinitions(
+  config: PromptConfig,
+): TypedResult<Record<string, ToolDefinition>, LatitudeError> {
+  if (!config.latitudeTools) {
+    return Result.ok({})
+  }
+
+  const unknownLatitudeTool = config.latitudeTools.find(
+    (tool) => !Object.values(LatitudeTool).includes(tool as LatitudeTool),
+  )
+  if (unknownLatitudeTool) {
+    return Result.error(
+      new NotFoundError(
+        `There is no Latitude tool with the name '${unknownLatitudeTool}'`,
+      ),
+    )
+  }
+
+  return Result.ok(
+    Object.fromEntries(
+      config.latitudeTools.map((latitudeToolName) => [
+        getLatitudeToolInternalName(latitudeToolName as LatitudeTool),
+        getLatitudeToolDefinition(latitudeToolName as LatitudeTool)!,
+      ]),
+    ),
+  )
+}
+
+export function injectCorrectToolsConfig(
+  config: PromptConfig,
+): TypedResult<VercelConfig, LatitudeError> {
+  const latitudeToolsResult = getLatitudeToolsDefinitions(config)
+  if (latitudeToolsResult.error) return latitudeToolsResult
+
+  const regularToolsResult = inferToolsFromConfig(config)
+  if (regularToolsResult.error) return regularToolsResult
+
+  const { latitudeTools: _1, tools: _2, ...rest } = config
+
+  const tools = {
+    ...latitudeToolsResult.unwrap(),
+    ...regularToolsResult.unwrap(),
+  }
+
+  return Result.ok({
+    ...rest,
+    tools: Object.keys(tools).length ? tools : undefined,
+  })
+}

--- a/packages/core/src/services/agents/agentsAsTools.ts
+++ b/packages/core/src/services/agents/agentsAsTools.ts
@@ -1,4 +1,4 @@
-import { AgentToolsMap, Config, ToolDefinition } from '@latitude-data/constants'
+import { AgentToolsMap, ToolDefinition } from '@latitude-data/constants'
 import {
   BadRequestError,
   LatitudeError,
@@ -121,20 +121,20 @@ export async function buildAgentsAsToolsDefinition({
   workspace,
   document,
   commit,
-  config,
+  agents,
 }: {
   workspace: Workspace
   document: DocumentVersion
   commit: Commit
-  config: Config
+  agents: string[]
 }): PromisedResult<Record<string, ToolDefinition>> {
-  if (!config.agents) return Result.ok({})
+  if (!agents.length) return Result.ok({})
 
   const docsScope = new DocumentVersionsRepository(workspace.id)
   const docsResult = await docsScope.getDocumentsAtCommit(commit)
   if (docsResult.error) return Result.error(docsResult.error)
   const docs = docsResult.unwrap()
-  const configAgentPaths = config.agents!.map((agentPath) =>
+  const configAgentPaths = agents.map((agentPath) =>
     resolvePath(document.path, agentPath),
   )
 

--- a/packages/core/src/services/agents/promptInjection.ts
+++ b/packages/core/src/services/agents/promptInjection.ts
@@ -7,8 +7,8 @@ import {
 } from '@latitude-data/compiler'
 import {
   AGENT_RETURN_TOOL_NAME,
-  Config,
   FAKE_AGENT_START_TOOL_NAME,
+  VercelConfig,
 } from '@latitude-data/constants'
 import { LatitudeError, Result, TypedResult } from '../../lib'
 import { JSONSchema7 } from 'json-schema'
@@ -124,10 +124,10 @@ export function performAgentInjection({
   injectAgentFinishTool,
 }: {
   messages: Message[]
-  config: Config
+  config: VercelConfig
   injectFakeAgentStartTool?: boolean
   injectAgentFinishTool?: boolean
-}): TypedResult<{ messages: Message[]; config: Config }, LatitudeError> {
+}): TypedResult<{ messages: Message[]; config: VercelConfig }, LatitudeError> {
   let config = originalConfig
   let messages = originalMessages
 

--- a/packages/core/src/services/ai/helpers.ts
+++ b/packages/core/src/services/ai/helpers.ts
@@ -12,13 +12,13 @@ import { Providers } from '../../constants'
 import { Result } from '../../lib'
 import { ChainError } from '../../lib/chainStreamManager/ChainErrors'
 
-import { PartialConfig } from '@latitude-data/constants'
+import { PartialPromptConfig } from '@latitude-data/constants'
 import type { ModelCost } from './estimateCost'
 import { ProviderApiKey } from '../../browser'
 import { vertexConfigurationSchema } from './providers/helpers/vertex'
 export {
-  type Config,
-  type PartialConfig,
+  type PromptConfig as Config,
+  type PartialPromptConfig as PartialConfig,
   googleConfig,
   azureConfig,
 } from '@latitude-data/constants'
@@ -76,7 +76,7 @@ export function createProvider({
   messages: Message[]
   apiKey: string
   url?: string
-  config?: PartialConfig
+  config?: PartialPromptConfig
 }) {
   const type = provider.provider
   switch (type) {

--- a/packages/core/src/services/chains/ChainValidator/index.ts
+++ b/packages/core/src/services/chains/ChainValidator/index.ts
@@ -15,7 +15,6 @@ import { azureConfig, Config, googleConfig } from '../../ai/helpers'
 import { ChainError } from '../../../lib/chainStreamManager/ChainErrors'
 import { checkFreeProviderQuota } from '../checkFreeProviderQuota'
 import { CachedApiKeys } from '../run'
-import { injectLatitudeToolsConfig } from '../../latitudeTools'
 
 type SomeChain = LegacyChain | PromptlChain
 
@@ -185,17 +184,7 @@ const validateConfig = (
     )
   }
 
-  const injectResult = injectLatitudeToolsConfig(parseResult.data)
-  if (!injectResult.ok) {
-    return Result.error(
-      new ChainError({
-        message: injectResult.error!.message,
-        code: RunErrorCodes.DocumentConfigError,
-      }),
-    )
-  }
-
-  return Result.ok(injectResult.unwrap() as Config)
+  return Result.ok(parseResult.data)
 }
 
 export const validateChain = async ({

--- a/packages/core/src/tests/factories/helpers.ts
+++ b/packages/core/src/tests/factories/helpers.ts
@@ -2,7 +2,7 @@ import { stringify as stringifyObjectToYaml } from 'yaml'
 import { faker } from '@faker-js/faker'
 
 import { ProviderApiKey } from '../../browser'
-import { Config } from '@latitude-data/constants'
+import { PromptConfig } from '@latitude-data/constants'
 
 const randomSentence = () => {
   const randomSentenceGenerators = [
@@ -24,7 +24,7 @@ function createFrontMatter({
 }: {
   provider: ProviderApiKey | string
   model?: string
-  extraConfig?: Omit<Config, 'provider' | 'model'>
+  extraConfig?: Omit<PromptConfig, 'provider' | 'model'>
 }) {
   const providerName = typeof provider === 'string' ? provider : provider.name
   const modelName = model ?? faker.internet.domainName()
@@ -51,7 +51,7 @@ function createPrompt({
   model?: string
   content?: string
   steps?: number
-  extraConfig?: Omit<Config, 'provider' | 'model'>
+  extraConfig?: Omit<PromptConfig, 'provider' | 'model'>
 }) {
   const frontMatter = createFrontMatter({ provider, model, extraConfig })
   const prompt = `


### PR DESCRIPTION
Improves the tools definition to merge both custom and built-in tools into a single config section. Forget about `latitudeTools`, `customTools` or `clientTools`.

Before:
```yaml
---
provider: openai
model: gpt-4o
tools:
  get_weather:
    description: Returns the weather for a given location
    parameters:
      type: object
      properties:
        location:
          type: string
          description: A location name
latitudeTools:
  - code
  - search
  - extract
---
```

After:
```yaml
---
provider: openai
model: gpt-4o
tools:
 - latitude/*
 - get_weather:
      description: Returns the weather for a given location
      parameters:
        type: object
        properties:
          location:
            type: string
            description: A location name
---
```

---

Call now and get an extra real-time parsing!

<img width="448" alt="image" src="https://github.com/user-attachments/assets/88e27911-a380-4175-ab6c-776ac8307ce7" />

<img width="306" alt="image" src="https://github.com/user-attachments/assets/7cd47678-d6f3-4d05-927d-25885148ecca" />
