### PR TITLE
Fix integrations tool schema

### DIFF
--- a/packages/core/src/services/integrations/McpClient/listTools/fixToolSchema.ts
+++ b/packages/core/src/services/integrations/McpClient/listTools/fixToolSchema.ts
@@ -1,0 +1,30 @@
+import { JSONSchema7 } from 'json-schema'
+
+export function fixToolSchema(schema: JSONSchema7): JSONSchema7 {
+  if (schema.type === 'object') {
+    if (schema.properties) {
+      Object.entries(schema.properties).forEach(([key, value]) => {
+        schema.properties![key] = fixToolSchema(value as JSONSchema7)
+      })
+    } else {
+      schema.properties = {}
+    }
+  }
+
+  if (schema.type === 'array') {
+    if (schema.items) {
+      if (Array.isArray(schema.items)) {
+        schema.items = schema.items.map((item) =>
+          fixToolSchema(item as JSONSchema7),
+        )
+      } else {
+        schema.items = fixToolSchema(schema.items as JSONSchema7)
+      }
+    } else {
+      // Required by OpenAI
+      schema.items = {} // "any" type
+    }
+  }
+
+  return schema
+}

--- a/packages/core/src/services/integrations/McpClient/listTools/index.ts
+++ b/packages/core/src/services/integrations/McpClient/listTools/index.ts
@@ -1,8 +1,10 @@
 import { McpTool } from '@latitude-data/constants'
-import { IntegrationDto } from '../../../browser'
-import { LatitudeError, PromisedResult, Result } from '../../../lib'
-import { getMcpClient } from './getMcpClient'
-import { touchIntegration } from '../touch'
+import { IntegrationDto } from '../../../../browser'
+import { LatitudeError, PromisedResult, Result } from '../../../../lib'
+import { getMcpClient } from '../getMcpClient'
+import { touchIntegration } from '../../touch'
+import { fixToolSchema } from './fixToolSchema'
+import { JSONSchema7 } from 'json-schema'
 
 export async function listTools(
   integration: IntegrationDto,
@@ -21,7 +23,12 @@ export async function listTools(
       return Result.error(new LatitudeError(touchResult.error.message))
     }
 
-    return Result.ok(tools as McpTool[])
+    const fixedTools = tools.map((tool) => ({
+      ...tool,
+      inputSchema: fixToolSchema(tool.inputSchema as JSONSchema7),
+    }))
+
+    return Result.ok(fixedTools as McpTool[])
   } catch (err) {
     const error = err as Error
     return Result.error(


### PR DESCRIPTION
Some of our integrations have incomplete input schema which is not supported by OpenAI.

One example is the Notion integration, where two of the tools have `type: "array"` properties missing an `items` attribute, which is required for all arrays with OpenAI.

This PR iterates over the schema of the listed tools, fixes incomplete properties, and returns a fixed schema.

---

<img width="527" alt="image" src="https://github.com/user-attachments/assets/7e1f7c63-060f-4856-9746-d8777d071a8d" />
