### PR TITLE
Adapt batch evaluation for datasets v2

### DIFF
--- a/apps/web/src/actions/documents/runDocumentInBatchAction.ts
+++ b/apps/web/src/actions/documents/runDocumentInBatchAction.ts
@@ -32,6 +32,7 @@ export const runDocumentInBatchAction = withDataset
                   prompt: ctx.document.content,
                 })
           const docParams = metadata.parameters
+          // @ts-expect-error - dataset V2 are not send here yet
           const headers = ctx.dataset.fileMetadata.headers
           const paramKeys = Object.keys(parameters)
           Array.from(docParams).forEach((key) => {

--- a/apps/web/src/actions/evaluations/_helpers.ts
+++ b/apps/web/src/actions/evaluations/_helpers.ts
@@ -1,18 +1,38 @@
-import { DatasetsRepository } from '@latitude-data/core/repositories'
+import {
+  DatasetsRepository,
+  DatasetsV2Repository,
+} from '@latitude-data/core/repositories'
 import { z } from 'zod'
 import { createServerActionProcedure } from 'zsa'
 
 import { withDocument } from '../procedures'
+import { DatasetVersion } from '@latitude-data/constants'
+import { Dataset, DatasetV2 } from '@latitude-data/core/browser'
 
 export const withDataset = createServerActionProcedure(withDocument)
-  .input(z.object({ datasetId: z.number() }))
+  .input(
+    z.object({
+      datasetId: z.number(),
+      datasetVersion: z.nativeEnum(DatasetVersion),
+    }),
+  )
   .handler(async ({ input, ctx }) => {
-    const datasetsRepo = new DatasetsRepository(ctx.workspace.id)
-    const dataset = await datasetsRepo
-      .find(input.datasetId)
-      .then((r) => r.unwrap())
+    const datasetVersion = input.datasetVersion
+    let response = { ...ctx, datasetVersion }
 
-    return { ...ctx, dataset }
+    // DEPRECATED
+    if (datasetVersion === DatasetVersion.V1) {
+      const datasetsRepo = new DatasetsRepository(ctx.workspace.id)
+      const dataset = await datasetsRepo
+        .find(input.datasetId)
+        .then((r) => r.unwrap())
+      return { ...response, dataset: dataset as Dataset }
+    }
+
+    const repo = new DatasetsV2Repository(ctx.workspace.id)
+    const dataset = await repo.find(input.datasetId).then((r) => r.unwrap())
+
+    return { ...response, dataset: dataset as DatasetV2 }
   })
 
 export const USER_DECIDED_TO_IGNORE_THIS_PARAMETER = -1

--- a/apps/web/src/actions/evaluations/runBatch.test.ts
+++ b/apps/web/src/actions/evaluations/runBatch.test.ts
@@ -1,15 +1,13 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  Commit,
   Dataset,
-  DocumentVersion,
+  DatasetV2,
+  DatasetVersion,
   EvaluationDto,
-  Project,
   Providers,
-  User,
-  Workspace,
 } from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type FactoryCreateProjectReturn } from '@latitude-data/core/factories'
 
 import { runBatchEvaluationAction } from './runBatch'
 
@@ -39,11 +37,14 @@ vi.mock('@latitude-data/core/jobs', () => ({
   setupJobs: vi.fn().mockImplementation(() => mocks.queues),
 }))
 
+let setup: FactoryCreateProjectReturn
+let evaluation: EvaluationDto
 describe('runBatchAction', () => {
   describe('unauthorized', () => {
     it('errors when the user is not authenticated', async () => {
       const [_, error] = await runBatchEvaluationAction({
         datasetId: 1,
+        datasetVersion: DatasetVersion.V2,
         projectId: 1,
         documentUuid: 'doc-uuid',
         commitUuid: 'commit-uuid',
@@ -57,169 +58,249 @@ describe('runBatchAction', () => {
   })
 
   describe('authorized', () => {
-    let workspace: Workspace,
-      user: User,
-      project: Project,
-      document: DocumentVersion,
-      commit: Commit,
-      dataset: Dataset,
-      evaluation: EvaluationDto
-
-    beforeEach(async () => {
-      vi.clearAllMocks()
-
-      const setup = await factories.createProject({
+    beforeAll(async () => {
+      setup = await factories.createProject({
         providers: [{ type: Providers.OpenAI, name: 'openai' }],
         documents: {
           'test-doc': factories.helpers.createPrompt({
             provider: 'openai',
-            content: 'Test content',
+            content:
+              'This is a test document using parameters: {{age}} and {{name}}',
           }),
         },
       })
-      workspace = setup.workspace
-      user = setup.user
-      project = setup.project
-      document = setup.documents[0]!
-      commit = setup.commit
-
-      dataset = await factories
-        .createDataset({
-          name: 'Test Dataset',
-          workspace,
-          author: user,
-        })
-        .then((result) => result.dataset)
 
       evaluation = await factories.createLlmAsJudgeEvaluation({
-        user,
-        workspace,
+        user: setup.user,
+        workspace: setup.workspace,
         name: 'Test Evaluation',
       })
 
       mocks.getSession.mockReturnValue({
-        user,
-        workspace: { id: workspace.id, name: workspace.name },
+        user: setup.user,
+        workspace: setup.workspace,
       })
     })
 
-    it('successfully enqueues a batch evaluation job', async () => {
-      const [result, error] = await runBatchEvaluationAction({
-        datasetId: dataset.id,
-        projectId: project.id,
-        documentUuid: document.documentUuid,
-        commitUuid: commit.uuid,
-        fromLine: 0,
-        toLine: 5,
-        evaluationIds: [evaluation.id],
+    describe('with dataset V2', () => {
+      let dataset: DatasetV2
+
+      beforeEach(async () => {
+        vi.clearAllMocks()
+
+        dataset = await factories
+          .createDatasetV2({
+            workspace: setup.workspace,
+            author: setup.user,
+            fileContent: `
+        age,name,surname
+        29,Paco,Merlo
+        48,Frank,Merlo
+        50,John,Doe
+      `,
+          })
+          .then((r) => r.dataset)
       })
 
-      expect(error).toBeNull()
-      expect(result).toEqual({
-        success: true,
-      })
-
-      expect(
-        mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
-          evaluation: expect.objectContaining({ id: evaluation.id }),
-          dataset: expect.objectContaining({ id: dataset.id }),
-          document: expect.objectContaining({
-            documentUuid: document.documentUuid,
-          }),
+      it('handles errors when resources are not found', async () => {
+        const [_, error] = await runBatchEvaluationAction({
+          datasetId: 999999,
+          datasetVersion: DatasetVersion.V2,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
           fromLine: 0,
           toLine: 5,
-          parametersMap: undefined,
-          batchId: expect.any(String),
-        }),
-      )
-    })
+          parameters: { age: 1 },
+          evaluationIds: [evaluation.id],
+        })
 
-    it('handles optional parameters', async () => {
-      const [result, error] = await runBatchEvaluationAction({
-        datasetId: dataset.id,
-        projectId: project.id,
-        documentUuid: document.documentUuid,
-        commitUuid: commit.uuid,
-        fromLine: 10,
-        toLine: 20,
-        evaluationIds: [evaluation.id],
-        parameters: { 1: 100, 2: 200 },
+        expect(error).not.toBeNull()
+        expect(error!.message).toContain('not found')
       })
 
-      expect(error).toBeNull()
-      expect(result).toEqual({
-        success: true,
-      })
-
-      expect(
-        mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
+      it('handles optional parameters', async () => {
+        const [result, error] = await runBatchEvaluationAction({
+          datasetId: dataset.id,
+          datasetVersion: DatasetVersion.V2,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
           fromLine: 10,
           toLine: 20,
-          parametersMap: { 1: 100, 2: 200 },
-        }),
-      )
+          evaluationIds: [evaluation.id],
+          parameters: { age: 1, name: 2 },
+        })
+
+        expect(error).toBeNull()
+        expect(result).toEqual({
+          success: true,
+        })
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fromLine: 10,
+            toLine: 20,
+            parametersMap: { age: 1, name: 2 },
+          }),
+        )
+      })
+
+      it('fails when doc has not parameters and parameters are passed', async () => {
+        const [_result, error] = await runBatchEvaluationAction({
+          datasetId: dataset.id,
+          datasetVersion: DatasetVersion.V2,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
+          fromLine: 0,
+          toLine: 5,
+          parameters: { noColumn: 1 },
+          evaluationIds: [evaluation.id],
+        })
+
+        expect(error?.fieldErrors).toEqual({
+          parameters: [
+            'age: Is not present in the parameters list',
+            'age: Has not a valid header assigned in this dataset. If you want to keep empty this parameter choose "Leave empty in that parameter"',
+            'name: Is not present in the parameters list',
+            'name: Has not a valid header assigned in this dataset. If you want to keep empty this parameter choose "Leave empty in that parameter"',
+          ],
+        })
+      })
+
+      it('successfully enqueues a batch evaluation job', async () => {
+        const [result, error] = await runBatchEvaluationAction({
+          datasetId: dataset.id,
+          datasetVersion: DatasetVersion.V2,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
+          fromLine: 0,
+          toLine: 5,
+          parameters: { age: 1, name: 2 },
+          evaluationIds: [evaluation.id],
+        })
+
+        expect(error).toBeNull()
+        expect(result).toEqual({
+          success: true,
+        })
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaluation: expect.objectContaining({ id: evaluation.id }),
+            dataset: expect.objectContaining({ id: dataset.id }),
+            document: expect.objectContaining({
+              documentUuid: setup.documents[0]!.documentUuid,
+            }),
+            fromLine: 0,
+            toLine: 5,
+            parametersMap: { age: 1, name: 2 },
+            batchId: expect.any(String),
+          }),
+        )
+      })
+
+      it('enqueues multiple evaluation jobs for multiple evaluationIds', async () => {
+        const evaluation2 = await factories.createLlmAsJudgeEvaluation({
+          user: setup.user,
+          workspace: setup.workspace,
+          name: 'Test Evaluation 2',
+        })
+
+        const [result, error] = await runBatchEvaluationAction({
+          datasetId: dataset.id,
+          datasetVersion: DatasetVersion.V2,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
+          fromLine: 0,
+          toLine: 5,
+          parameters: { age: 1, name: 2 },
+          evaluationIds: [evaluation.id, evaluation2.id],
+        })
+
+        expect(error).toBeNull()
+        expect(result).toEqual({
+          success: true,
+        })
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledTimes(2)
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaluation: expect.objectContaining({ id: evaluation.id }),
+          }),
+        )
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaluation: expect.objectContaining({ id: evaluation2.id }),
+          }),
+        )
+      })
     })
 
-    it('handles errors when resources are not found', async () => {
-      const [_, error] = await runBatchEvaluationAction({
-        datasetId: 999999,
-        projectId: project.id,
-        documentUuid: document.documentUuid,
-        commitUuid: commit.uuid,
-        fromLine: 0,
-        toLine: 5,
-        evaluationIds: [evaluation.id],
+    describe('with dataset V1 (DEPRECATED)', () => {
+      let dataset: Dataset
+
+      beforeEach(async () => {
+        vi.clearAllMocks()
+
+        dataset = await factories
+          .createDataset({
+            name: 'Test Dataset',
+            workspace: setup.workspace,
+            author: setup.user,
+          })
+          .then((result) => result.dataset)
       })
 
-      expect(error).not.toBeNull()
-      expect(error!.message).toContain('not found')
-    })
+      it('successfully enqueues a batch evaluation job', async () => {
+        const [result, error] = await runBatchEvaluationAction({
+          datasetId: dataset.id,
+          datasetVersion: DatasetVersion.V1,
+          projectId: setup.project.id,
+          documentUuid: setup.documents[0]!.documentUuid,
+          commitUuid: setup.commit.uuid,
+          fromLine: 0,
+          toLine: 5,
+          parameters: { age: 1, name: 2 },
+          evaluationIds: [evaluation.id],
+        })
 
-    it('enqueues multiple evaluation jobs for multiple evaluationIds', async () => {
-      const evaluation2 = await factories.createLlmAsJudgeEvaluation({
-        user,
-        workspace,
-        name: 'Test Evaluation 2',
+        expect(error).toBeNull()
+        expect(result).toEqual({
+          success: true,
+        })
+
+        expect(
+          mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaluation: expect.objectContaining({ id: evaluation.id }),
+            dataset: expect.objectContaining({ id: dataset.id }),
+            document: expect.objectContaining({
+              documentUuid: setup.documents[0]!.documentUuid,
+            }),
+            fromLine: 0,
+            toLine: 5,
+            parametersMap: { age: 1, name: 2 },
+            batchId: expect.any(String),
+          }),
+        )
       })
-
-      const [result, error] = await runBatchEvaluationAction({
-        datasetId: dataset.id,
-        projectId: project.id,
-        documentUuid: document.documentUuid,
-        commitUuid: commit.uuid,
-        fromLine: 0,
-        toLine: 5,
-        evaluationIds: [evaluation.id, evaluation2.id],
-      })
-
-      expect(error).toBeNull()
-      expect(result).toEqual({
-        success: true,
-      })
-
-      expect(
-        mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
-      ).toHaveBeenCalledTimes(2)
-
-      expect(
-        mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
-          evaluation: expect.objectContaining({ id: evaluation.id }),
-        }),
-      )
-
-      expect(
-        mocks.queues.defaultQueue.jobs.enqueueRunBatchEvaluationJob,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
-          evaluation: expect.objectContaining({ id: evaluation2.id }),
-        }),
-      )
     })
   })
 })

--- a/apps/web/src/app/(private)/AppTabs/index.tsx
+++ b/apps/web/src/app/(private)/AppTabs/index.tsx
@@ -20,7 +20,7 @@ export function AppTabs() {
       ...MAIN_NAV_LINKS,
       {
         label: 'datasets (NEW)',
-        value: ROUTES.datasetsV2.root as string,
+        value: ROUTES.datasetsV2.root(),
       },
     ]
   }, [hasNewDatasets, isLoading])

--- a/apps/web/src/app/(private)/datasets-v2/[datasetId]/not-found.tsx
+++ b/apps/web/src/app/(private)/datasets-v2/[datasetId]/not-found.tsx
@@ -4,7 +4,7 @@ import { ROUTES } from '$/services/routes'
 export default function Default() {
   return (
     <NotFoundPageComponent
-      route={ROUTES.datasetsV2.root}
+      route={ROUTES.datasetsV2.root()}
       label='Go to datasets'
       message="We couldn't the dataset you are looking for. Please make sure that the dataset exists and try again."
     />

--- a/apps/web/src/app/(private)/datasets-v2/_components/DatasetsTable/index.tsx
+++ b/apps/web/src/app/(private)/datasets-v2/_components/DatasetsTable/index.tsx
@@ -77,7 +77,7 @@ export function DatasetsTable({
           <LinkableTablePaginationFooter
             pagination={buildPagination({
               count: Infinity,
-              baseUrl: ROUTES.datasetsV2.root,
+              baseUrl: ROUTES.datasetsV2.root(),
               page: Number(page),
               pageSize: Number(pageSize),
             })}

--- a/apps/web/src/app/(private)/datasets-v2/_components/RootHeader/index.tsx
+++ b/apps/web/src/app/(private)/datasets-v2/_components/RootHeader/index.tsx
@@ -7,8 +7,14 @@ import Link from 'next/link'
 import { ROUTES } from '$/services/routes'
 import { NewDatasetModal } from './NewDatasetModal'
 
-export function RootDatasetHeader({ isCloud }: { isCloud: boolean }) {
-  const newDataset = useToggleModal()
+export function RootDatasetHeader({
+  isCloud,
+  openNewDatasetModal,
+}: {
+  isCloud: boolean
+  openNewDatasetModal: boolean
+}) {
+  const newDataset = useToggleModal({ initialState: openNewDatasetModal })
   return (
     <div className='flex flex-row items-center gap-2'>
       {isCloud ? (

--- a/apps/web/src/app/(private)/datasets-v2/generate/GenerateDatasetModal/index.tsx
+++ b/apps/web/src/app/(private)/datasets-v2/generate/GenerateDatasetModal/index.tsx
@@ -152,7 +152,7 @@ export function GenerateDatasetModal({
     <Modal
       open
       size='large'
-      onOpenChange={(open) => !open && navigate.push(ROUTES.datasetsV2.root)}
+      onOpenChange={(open) => !open && navigate.push(ROUTES.datasetsV2.root())}
       title='Generate new dataset'
       description='Generate a dataset of parameters using AI. Datasets can be used to run batch evaluations over prompts.'
       footer={

--- a/apps/web/src/app/(private)/datasets-v2/page.tsx
+++ b/apps/web/src/app/(private)/datasets-v2/page.tsx
@@ -11,9 +11,10 @@ export default async function DatasetsRoot({
   searchParams: Promise<{
     pageSize: string
     page?: string
+    modal?: 'new'
   }>
 }) {
-  const { pageSize, page: pageString } = await searchParams
+  const { pageSize, page: pageString, modal } = await searchParams
   const page = pageString?.toString?.()
   const { workspace } = await getCurrentUser()
   const scope = new DatasetsV2Repository(workspace.id)
@@ -24,7 +25,12 @@ export default async function DatasetsRoot({
   return (
     <TableWithHeader
       title='Datasets'
-      actions={<RootDatasetHeader isCloud={env.LATITUDE_CLOUD} />}
+      actions={
+        <RootDatasetHeader
+          isCloud={env.LATITUDE_CLOUD}
+          openNewDatasetModal={modal === 'new'}
+        />
+      }
       table={<DatasetsTable datasets={datasets} />}
     />
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/useMappedParametersFromLocalStorage.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/useMappedParametersFromLocalStorage.ts
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 
-import { Dataset, DocumentVersion } from '@latitude-data/core/browser'
+import {
+  Dataset,
+  DatasetV2,
+  DocumentVersion,
+} from '@latitude-data/core/browser'
 import { RunBatchParameters } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/useRunBatch'
 import { useDocumentParameters } from '$/hooks/useDocumentParameters'
 
@@ -21,7 +25,7 @@ export function useMappedParametersFromLocalStorage({
   document: DocumentVersion
   commitVersionUuid: string
   parametersList: string[]
-  selectedDataset: Dataset | null | undefined
+  selectedDataset: DatasetV2 | Dataset | null | undefined
   onDatasetReady: (_args: { mapped: RunBatchParameters }) => void
 }) {
   const {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/useRunDocumentInBatchFrom.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/batch/_components/RunPromptInBatchModal/useRunDocumentInBatchFrom.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { readMetadata } from '@latitude-data/compiler'
+import { Dataset, DocumentVersion } from '@latitude-data/core/browser'
+import { scan, type ConversationMetadata } from 'promptl-ai'
+import { SelectOption } from '@latitude-data/web-ui'
+import useDatasets from '$/stores/datasets'
+import { buildEmptyParameters } from '../../../evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/useRunBatchForm'
+import { useMappedParametersFromLocalStorage } from './useMappedParametersFromLocalStorage'
+import { RunBatchParameters } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/useRunBatch'
+
+export function useRunDocumentInBatchForm({
+  document,
+  commitVersionUuid,
+}: {
+  document: DocumentVersion
+  commitVersionUuid: string
+}) {
+  const [metadata, setMetadata] = useState<ConversationMetadata | undefined>()
+  const parametersList = useMemo(
+    () => Array.from(metadata?.parameters ?? []),
+    [metadata?.parameters],
+  )
+  const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null)
+  const [headers, setHeaders] = useState<SelectOption<string>[]>([])
+  const [wantAllLines, setAllRows] = useState(true)
+  const [fromLine, setFromLine] = useState<number | undefined>(undefined)
+  const [toLine, setToLine] = useState<number | undefined>(undefined)
+  const [parameters, setParameters] = useState(() =>
+    buildEmptyParameters(parametersList),
+  )
+  const onParameterChange = useCallback(
+    (param: string) => (header: string) => {
+      setParameters((prev: RunBatchParameters) => ({
+        ...prev,
+        [param]: selectedDataset?.fileMetadata?.headers?.indexOf?.(header),
+      }))
+    },
+    [selectedDataset],
+  )
+
+  const buildHeaders = useCallback(
+    (dataset: Dataset) => {
+      setHeaders([
+        { value: '-1', label: '-- Leave this parameter empty' },
+        ...dataset.fileMetadata.headers.map((header) => ({
+          value: header,
+          label: header,
+        })),
+      ])
+    },
+    [setHeaders, selectedDataset],
+  )
+
+  const { data: datasets, isLoading: isLoadingDatasets } = useDatasets()
+  const onSelectDataset = useCallback(
+    async (value: number) => {
+      const ds = datasets.find((ds) => ds.id === Number(value))
+      if (!ds) return
+
+      setSelectedDataset(ds)
+      setParameters(buildEmptyParameters(parametersList))
+      setFromLine(1)
+      setToLine(ds.fileMetadata.rowCount)
+      buildHeaders(ds)
+    },
+    [parametersList, datasets, buildHeaders],
+  )
+
+  useEffect(() => {
+    const fn = async () => {
+      if (!document || !document.content) return
+
+      // TODO: Include referenceFn, otherwise it will fail if the prompt contains references
+      const metadata =
+        document.promptlVersion === 0
+          ? await readMetadata({
+              prompt: document.content,
+            })
+          : await scan({ prompt: document.content })
+
+      setMetadata(metadata as ConversationMetadata)
+
+      // Only choose the dataset if it's not already selected
+      const ds = selectedDataset
+        ? undefined
+        : datasets.find((ds) => ds.id === document.datasetId)
+
+      if (!ds) return
+
+      setSelectedDataset(ds)
+      buildHeaders(ds)
+    }
+
+    fn()
+  }, [document, selectedDataset, setSelectedDataset, buildHeaders, datasets])
+
+  useMappedParametersFromLocalStorage({
+    document,
+    commitVersionUuid,
+    parametersList,
+    selectedDataset,
+    onDatasetReady: ({ mapped }) => {
+      setParameters(mapped)
+    },
+  })
+  return {
+    datasets,
+    isLoadingDatasets,
+    selectedDataset,
+    headers,
+    wantAllLines,
+    fromLine,
+    toLine,
+    parameters,
+    parametersList,
+    onParameterChange,
+    onSelectDataset,
+    setAllRows,
+    setFromLine,
+    setToLine,
+    // TODO: Make this also accept dataset V2
+    maxLineCount: selectedDataset?.fileMetadata?.rowCount,
+  }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/index.tsx
@@ -49,6 +49,7 @@ export default function CreateBatchEvaluationModal({
       toLine: form.toLine,
       wantAllLines: form.wantAllLines,
       parameters: form.parameters,
+      datasetVersion: form.datasetVersion,
     })
   }, [
     evaluation.id,
@@ -62,6 +63,7 @@ export default function CreateBatchEvaluationModal({
 
   return (
     <Modal
+      dismissible
       open={open}
       onOpenChange={onClose}
       size='large'
@@ -81,21 +83,24 @@ export default function CreateBatchEvaluationModal({
       }
     >
       <DatasetForm
+        datasetVersion={form.datasetVersion}
         document={document}
         errors={errors}
         datasets={form.datasets}
         isLoadingDatasets={form.isLoadingDatasets}
         selectedDataset={form.selectedDataset}
         onSelectDataset={form.onSelectDataset}
-        onToggleAllLines={form.setAllRows}
+        onToggleAllLines={form.onToggleAllLines}
         wantAllLines={form.wantAllLines}
         fromLine={form.fromLine}
         toLine={form.toLine}
+        onChangeFromLine={form.setFromLine}
         onChangeToLine={form.setToLine}
         headers={form.headers}
         parametersList={form.parametersList}
         onParametersChange={form.onParameterChange}
         parameters={form.parameters}
+        maxLineCount={form.maxLineCount}
       />
     </Modal>
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/useRunBatch.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationId]/_components/Actions/CreateBatchEvaluationModal/useRunBatch.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { DocumentVersion } from '@latitude-data/core/browser'
+import { DatasetVersion, DocumentVersion } from '@latitude-data/core/browser'
 import { runBatchEvaluationAction } from '$/actions/evaluations/runBatch'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 
@@ -30,6 +30,7 @@ export function useRunBatch({
       parameters,
       fromLine,
       toLine,
+      datasetVersion,
     }: {
       datasetId: number | undefined
       fromLine: number | undefined
@@ -37,6 +38,7 @@ export function useRunBatch({
       wantAllLines: boolean
       evaluationIds: number[]
       parameters: RunBatchParameters
+      datasetVersion: DatasetVersion
     }) => {
       await run({
         projectId: Number(projectId),
@@ -44,6 +46,7 @@ export function useRunBatch({
         commitUuid,
         evaluationIds,
         datasetId: datasetId!,
+        datasetVersion,
         fromLine: wantAllLines ? undefined : fromLine,
         toLine: wantAllLines ? undefined : toLine,
         parameters,

--- a/apps/web/src/app/api/dataset-rows/count/route.ts
+++ b/apps/web/src/app/api/dataset-rows/count/route.ts
@@ -1,0 +1,39 @@
+import { Workspace } from '@latitude-data/core/browser'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  DatasetRowsRepository,
+  DatasetsV2Repository,
+} from '@latitude-data/core/repositories'
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      req: NextRequest,
+      {
+        workspace,
+      }: {
+        workspace: Workspace
+      },
+    ) => {
+      const searchParams = req.nextUrl.searchParams
+      const datasetId = searchParams.get('datasetId')
+      const datasetRepo = new DatasetsV2Repository(workspace.id)
+      const result = await datasetRepo.find(Number(datasetId))
+
+      if (result.error) {
+        return NextResponse.json(
+          { message: `Dataset not found with id: ${datasetId}` },
+          { status: 404 },
+        )
+      }
+
+      const dataset = result.value
+      const repo = new DatasetRowsRepository(workspace.id)
+      const count = await repo.getCountByDataset(dataset.id)
+
+      return NextResponse.json(count, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/hooks/useFeatureFlag.ts
+++ b/apps/web/src/hooks/useFeatureFlag.ts
@@ -1,14 +1,19 @@
-import useCurrentWorkspace from '$/stores/currentWorkspace'
+/* import useCurrentWorkspace from '$/stores/currentWorkspace' */
 
 /**
  * Stupid feature flag until we have a real one
  */
 export function useFeatureFlag() {
-  const { data, isLoading } = useCurrentWorkspace()
+  /* const { data, isLoading } = useCurrentWorkspace() */
 
   // If your workspace in develop is not 1, you are not a developer
   return {
-    data: data ? data.id === 1 : undefined,
-    isLoading,
+    /* data: data ? data.id === 1 : undefined, */
+    /* isLoading, */
+
+    // For now, always return false
+    // I don't want to enable dataset V2 for anyone.
+    data: false,
+    isLoading: false,
   }
 }

--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -111,7 +111,10 @@ export const ROUTES = {
     preview: (id: string | number) => `/datasets/preview/${id}`,
   },
   datasetsV2: {
-    root: '/datasets-v2',
+    root: ({ modal }: { modal?: 'new' } = {}) => {
+      const root = '/datasets-v2'
+      return modal ? `${root}?modal=${modal}` : root
+    },
     generate: {
       root: `/datasets-v2/generate`,
     },

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -239,6 +239,7 @@ export const API_ROUTES = {
   },
   datasetsRows: {
     root: '/api/dataset-rows',
+    count: '/api/dataset-rows/count',
   },
   evaluationTemplates: {
     root: '/api/evaluationTemplates',

--- a/apps/web/src/stores/datasetRowsCount.ts
+++ b/apps/web/src/stores/datasetRowsCount.ts
@@ -1,0 +1,40 @@
+import type { DatasetV2 } from '@latitude-data/core/browser'
+import useFetcher from '$/hooks/useFetcher'
+import { ROUTES } from '$/services/routes'
+import useSWR, { SWRConfiguration } from 'swr'
+import { compactObject } from '@latitude-data/core/lib/compactObject'
+
+export default function useDatasetRowsCount(
+  {
+    dataset,
+    onFetched,
+  }: {
+    dataset?: DatasetV2
+    onFetched?: (count: number) => void
+  },
+  opts?: SWRConfiguration,
+) {
+  const fetcher = useFetcher(
+    dataset ? ROUTES.api.datasetsRows.count : undefined,
+    {
+      searchParams: compactObject({
+        datasetId: dataset?.id,
+      }) as Record<string, string>,
+    },
+  )
+  const { data, ...rest } = useSWR<number>(
+    ['datasetRowsCount', dataset?.id],
+    fetcher,
+    {
+      ...opts,
+      onSuccess: (data) => {
+        onFetched?.(data)
+      },
+    },
+  )
+
+  return {
+    data,
+    ...rest,
+  }
+}

--- a/apps/web/src/stores/datasets.ts
+++ b/apps/web/src/stores/datasets.ts
@@ -11,14 +11,16 @@ export default function useDatasets(
   {
     onCreateSuccess,
     onFetched,
+    enabled = true,
   }: {
+    enabled?: boolean
     onCreateSuccess?: (dataset: Dataset) => void
     onFetched?: (datasets: Dataset[]) => void
   } = {},
   opts?: SWRConfiguration,
 ) {
   const { toast } = useToast()
-  const fetcher = useFetcher(ROUTES.api.datasets.root, {
+  const fetcher = useFetcher(enabled ? ROUTES.api.datasets.root : undefined, {
     serializer: (rows) => rows.map(deserialize),
   })
   const {

--- a/apps/web/src/stores/datasetsV2.ts
+++ b/apps/web/src/stores/datasetsV2.ts
@@ -15,16 +15,18 @@ export default function useDatasets(
     onFetched,
     page,
     pageSize,
+    enabled = true,
   }: {
     onCreateSuccess?: (dataset: DatasetV2) => void
     onFetched?: (datasets: DatasetV2[]) => void
     page?: string | null | undefined
     pageSize?: string | null
+    enabled?: boolean
   } = {},
   opts?: SWRConfiguration,
 ) {
   const { toast } = useToast()
-  const fetcher = useFetcher(ROUTES.api.datasetsV2.root, {
+  const fetcher = useFetcher(enabled ? ROUTES.api.datasetsV2.root : undefined, {
     serializer: (rows) => rows.map(deserialize),
     searchParams: compactObject({
       page: page ? String(page) : undefined,

--- a/packages/constants/src/evaluations/index.ts
+++ b/packages/constants/src/evaluations/index.ts
@@ -236,4 +236,10 @@ export const EvaluationOptionsSchema = z.object({
 
 export const EVALUATION_SCORE_SCALE = 100
 
-export const DEFAULT_EVALUATION_LABEL_NAME = 'expected_output'
+export const DEFAULT_DATASET_LABEL = 'expected_output'
+
+// PROVISIONAL until migration to v2
+export enum DatasetVersion {
+  V1 = 'v1',
+  V2 = 'v2',
+}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -7,6 +7,7 @@ export enum LogSources {
   AgentAsTool = 'agent_as_tool',
 }
 
+export const NON_LIVE_EVALUABLE_LOG_SOURCES = [LogSources.Evaluation]
 export enum Providers {
   OpenAI = 'openai',
   Anthropic = 'anthropic',

--- a/packages/core/src/events/handlers/runLiveEvaluationsJob.ts
+++ b/packages/core/src/events/handlers/runLiveEvaluationsJob.ts
@@ -1,8 +1,18 @@
+import {
+  LogSources,
+  NON_LIVE_EVALUABLE_LOG_SOURCES,
+} from '@latitude-data/constants'
 import { findWorkspaceFromDocumentLog } from '../../data-access'
 import { setupJobs } from '../../jobs'
 import { NotFoundError } from '../../lib'
 import { EvaluationsRepository } from '../../repositories'
 import { DocumentLogCreatedEvent } from '../events'
+
+export function isLiveEvaluableSource(source: LogSources | null | undefined) {
+  if (!source) return true
+
+  return !NON_LIVE_EVALUABLE_LOG_SOURCES.includes(source)
+}
 
 export const runLiveEvaluationsJob = async ({
   data: event,
@@ -10,6 +20,8 @@ export const runLiveEvaluationsJob = async ({
   data: DocumentLogCreatedEvent
 }) => {
   const { data: documentLog } = event
+  if (!isLiveEvaluableSource(documentLog.source)) return
+
   const workspace = await findWorkspaceFromDocumentLog(documentLog)
   if (!workspace) {
     throw new NotFoundError('Workspace not found')

--- a/packages/core/src/repositories/datasetRowsRepository.ts
+++ b/packages/core/src/repositories/datasetRowsRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and, getTableColumns } from 'drizzle-orm'
+import { eq, and, getTableColumns, count, desc } from 'drizzle-orm'
 
 import { DatasetRow, DEFAULT_PAGINATION_SIZE } from '../browser'
 import { datasetRows } from '../schema'
@@ -30,11 +30,38 @@ export class DatasetRowsRepository extends Repository<DatasetRow> {
     datasetId: number
   }) {
     const offset = calculateOffset(page, pageSize)
+    const limit = parseInt(pageSize)
+    return this.findByDatasetWithOffsetAndLimit({ datasetId, offset, limit })
+  }
+
+  findByDatasetWithOffsetAndLimit({
+    datasetId,
+    offset,
+    limit,
+  }: {
+    datasetId: number
+    offset: number
+    limit: number
+  }) {
     return this.db
       .select(tt)
       .from(datasetRows)
       .where(and(this.scopeFilter, eq(datasetRows.datasetId, datasetId)))
-      .limit(parseInt(pageSize))
+      .limit(limit)
+      .orderBy(desc(datasetRows.createdAt))
       .offset(offset)
+  }
+
+  async getCountByDataset(datasetId: number) {
+    const result = await this.db
+      .select({
+        count: count(datasetRows.id),
+      })
+      .from(datasetRows)
+      .where(and(this.scopeFilter, eq(datasetRows.datasetId, datasetId)))
+
+    if (!result[0]) return 0
+
+    return result[0].count
   }
 }

--- a/packages/core/src/services/datasetRows/getRowsFromRange.ts
+++ b/packages/core/src/services/datasetRows/getRowsFromRange.ts
@@ -1,0 +1,55 @@
+import { DatasetRow, DatasetV2 } from '../../browser'
+import { DatasetRowsRepository } from '../../repositories'
+
+async function getToLine({
+  toLine,
+  dataset,
+  repo,
+}: {
+  dataset: DatasetV2
+  repo: DatasetRowsRepository
+  toLine: number | undefined
+}) {
+  if (toLine !== undefined) return toLine
+
+  return repo.getCountByDataset(dataset.id)
+}
+
+function extractValue(
+  value: DatasetRow['rowData'][keyof DatasetRow['rowData']],
+) {
+  if (value === null || value === undefined) return ''
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function extractValues(row: DatasetRow) {
+  return Object.values(row.rowData).map(extractValue)
+}
+
+export async function getRowsFromRange({
+  dataset,
+  fromLine,
+  toLine: to,
+}: {
+  dataset: DatasetV2
+  fromLine: number
+  toLine?: number
+}) {
+  const repo = new DatasetRowsRepository(dataset.workspaceId)
+  const toLine = await getToLine({ toLine: to, dataset, repo })
+
+  const limit = toLine - fromLine + 1 // ensure we include the last line
+  const offset = fromLine - 1 // fromLine is 1-based but offset is 0-based
+  const data = await repo.findByDatasetWithOffsetAndLimit({
+    datasetId: dataset.id,
+    offset,
+    limit,
+  })
+
+  return { rows: data.map(extractValues) }
+}

--- a/packages/core/src/services/documentLogs/buildDocumentLogDatasetRows/buildColumns.ts
+++ b/packages/core/src/services/documentLogs/buildDocumentLogDatasetRows/buildColumns.ts
@@ -1,7 +1,7 @@
 import {
   DATASET_COLUMN_ROLES,
   DatasetV2,
-  DEFAULT_EVALUATION_LABEL_NAME,
+  DEFAULT_DATASET_LABEL,
 } from '../../../browser'
 import { DocumentLogWithMetadataAndError } from '../../../repositories'
 import { Column } from '../../../schema'
@@ -42,7 +42,7 @@ export function buildColumns({
   let datasetColumns = dataset?.columns ?? []
   const logParameterNames = getUniqueParameterNamesFromLogs(logs)
   const fixedColumns = [
-    { name: DEFAULT_EVALUATION_LABEL_NAME, role: DATASET_COLUMN_ROLES.label },
+    { name: DEFAULT_DATASET_LABEL, role: DATASET_COLUMN_ROLES.label },
     { name: 'document_log_id', role: DATASET_COLUMN_ROLES.metadata },
     { name: 'tokens', role: DATASET_COLUMN_ROLES.metadata },
   ]

--- a/packages/core/src/tests/factories/datasetsV2.ts
+++ b/packages/core/src/tests/factories/datasetsV2.ts
@@ -8,6 +8,9 @@ import { createTestCsvFile } from '../../services/datasetRows/testHelper'
 import { DatasetV2CreatedEvent } from '../../events/events'
 import { createRowsFromUploadedDataset } from '../../services/datasetRows/createRowsFromUploadedDataset'
 import { HashAlgorithmFn } from '../../services/datasetsV2/utils'
+import getTestDisk from '../testDrive'
+
+const defaultTestDisk = getTestDisk()
 
 function generateCsvContent(delimiter: string): string {
   const headers = ['id', 'name', 'email', 'age']
@@ -25,18 +28,18 @@ function generateCsvContent(delimiter: string): string {
 }
 
 export type ICreateDatasetV2 = {
-  disk: DiskWrapper
   name?: string
   workspace?: Workspace | ICreateWorkspace
   author?: User
   csvDelimiter?: string
   fileContent?: string
+  disk?: DiskWrapper
   hashAlgorithm?: HashAlgorithmFn
 }
-type Props = Partial<ICreateDatasetV2> & { disk: DiskWrapper }
+type Props = Partial<ICreateDatasetV2>
 
 export async function createDatasetV2(datasetData: Props) {
-  const disk = datasetData.disk
+  const disk = datasetData.disk ?? defaultTestDisk
   let workspaceData = datasetData.workspace ?? {}
   let user: User
   let workspace: Workspace


### PR DESCRIPTION
# What?
While keeping compatibility with old datasets make run batch evaluations work with new datasets data model

## Issue
https://github.com/latitude-dev/latitude-llm/issues/916
https://github.com/latitude-dev/latitude-llm/issues/948

### TODO
- [x] Adapt hook to run batch evaluation to work with old and new datasets
- [x] Service to get rows from line `X` to line `Y` in new dataset rows
- [x] Test ☝️ that service
- [x] Fix test from job and action
- [x] 🐛 Temporary fix for run batch document to pick always V1. Client is not sending yet V2 datasets

## Another PR
- [ ] Add search functionality to datasets selector
