### PR TITLE
Fix agent tool maps recomputing too much

### DIFF
--- a/apps/web/src/stores/documentVersions.ts
+++ b/apps/web/src/stores/documentVersions.ts
@@ -24,6 +24,7 @@ import { useRouter } from 'next/navigation'
 import useSWR, { SWRConfiguration } from 'swr'
 import { useServerAction } from 'zsa-react'
 
+const EMPTY_DATA = [] as DocumentVersion[]
 export default function useDocumentVersions(
   {
     commitUuid = HEAD_COMMIT,
@@ -62,7 +63,7 @@ export default function useDocumentVersions(
 
   const {
     mutate,
-    data = [],
+    data = EMPTY_DATA,
     isValidating,
     isLoading,
     error: swrError,


### PR DESCRIPTION
# What?
Try to make more efficient the way we recompute metadata in the document editor. This [useEffect](https://github.com/latitude-dev/latitude-llm/blob/main/apps/web/src/app/(private)/projects/%5BprojectId%5D/versions/%5BcommitUuid%5D/documents/%5BdocumentUuid%5D/_components/DocumentEditor/Editor/index.tsx#L243-L254) is forcing recompute metadata all the time. 