### PR TITLE
Change webhook route expected input from json to form-data

### DIFF
--- a/apps/gateway/src/routes/webhook/email/bodySchema.ts
+++ b/apps/gateway/src/routes/webhook/email/bodySchema.ts
@@ -1,14 +1,16 @@
 import { z } from '@hono/zod-openapi'
 
-// https://documentation.mailgun.com/docs/mailgun/user-manual/receive-forward-store/#parsed-messages-parameters
+// https://mailgun-docs.redoc.ly/docs/mailgun/user-manual/receive-forward-store/#storing-and-retrieving-messages
 export const emailWebhookBodySchema = z.object({
   recipient: z.string(), // Recipient email address
   sender: z.string(), // Sender email address
   subject: z.string(),
   'body-plain': z.string(), // Body as plain text
-  'stripped-html': z.string(), // Body as HTML
-  'Message-Id': z.string(),
-  token: z.string(),
-  timestamp: z.string(),
-  signature: z.string(),
+  'stripped-html': z.string().optional(), // Body as HTML
+  'Message-Id': z.string().optional(),
+  token: z.string().optional(),
+  timestamp: z.string().optional(),
+  signature: z.string().optional(),
 })
+
+export type EmailWebhookBodySchema = z.infer<typeof emailWebhookBodySchema>

--- a/apps/gateway/src/routes/webhook/email/webhook.handler.ts
+++ b/apps/gateway/src/routes/webhook/email/webhook.handler.ts
@@ -4,6 +4,7 @@ import { verifyWebhookSignature } from '@latitude-data/core/services/documentTri
 import { EmailWebhookRoute } from './webhook.route'
 import { env } from '@latitude-data/env'
 import { UnauthorizedError } from '@latitude-data/core/lib/errors'
+import { EmailWebhookBodySchema } from './bodySchema'
 
 // @ts-expect-error: streamSSE has type issues with zod-openapi
 // https://github.com/honojs/middleware/issues/735
@@ -11,6 +12,8 @@ import { UnauthorizedError } from '@latitude-data/core/lib/errors'
 export const emailWebhookHandler: AppRouteHandler<EmailWebhookRoute> = async (
   c,
 ) => {
+  const formData = await c.req.formData()
+  const data = Object.fromEntries(formData.entries())
   const {
     recipient,
     subject,
@@ -20,7 +23,7 @@ export const emailWebhookHandler: AppRouteHandler<EmailWebhookRoute> = async (
     timestamp,
     signature,
     'Message-Id': messageId,
-  } = c.req.valid('json')
+  } = data as EmailWebhookBodySchema
 
   if (!env.MAILGUN_WEBHOOK_SIGNING_KEY) {
     throw new UnauthorizedError('Env MAILGUN_WEBHOOK_SIGNING_KEY missing.')

--- a/apps/gateway/src/routes/webhook/email/webhook.route.ts
+++ b/apps/gateway/src/routes/webhook/email/webhook.route.ts
@@ -11,7 +11,7 @@ export const emailWebhookRoute = createRoute({
   request: {
     body: {
       content: {
-        [http.MediaTypes.JSON]: {
+        'multipart/form-data': {
           schema: emailWebhookBodySchema,
         },
       },

--- a/packages/core/src/services/documentTriggers/helpers/verifySignature.ts
+++ b/packages/core/src/services/documentTriggers/helpers/verifySignature.ts
@@ -13,14 +13,18 @@ export function verifyWebhookSignature(
     signature,
   }: {
     signingKey: string
-    timestamp: string
-    token: string
-    signature: string
+    timestamp?: string
+    token?: string
+    signature?: string
   },
   options: VerifyWebhookSignatureOptions = {
     maxTimestampAge: 300, // 300 seconds = 5 minutes
   },
 ): TypedResult<undefined, UnauthorizedError> {
+  if (!timestamp || !token || !signature) {
+    return Result.error(new UnauthorizedError('Missing signature'))
+  }
+
   const now = Math.floor(Date.now() / 1000)
   const timeDiff = now - parseInt(timestamp, 10)
   if (timeDiff > options.maxTimestampAge) {


### PR DESCRIPTION
Apparently the POST request from Mailgun does not come as a json, but a form-data instead.

https://mailgun-docs.redoc.ly/docs/mailgun/user-manual/receive-forward-store/#storing-and-retrieving-messages
