### PR TITLE
Email Trigger – better parameters management

### DIFF
--- a/apps/gateway/src/routes/webhook/email/bodySchema.ts
+++ b/apps/gateway/src/routes/webhook/email/bodySchema.ts
@@ -4,6 +4,7 @@ import { z } from '@hono/zod-openapi'
 export const emailWebhookBodySchema = z.object({
   recipient: z.string(), // Recipient email address
   sender: z.string(), // Sender email address
+  from: z.string(), // Sender name and email
   subject: z.string(),
   'body-plain': z.string(), // Body as plain text
   'stripped-html': z.string(), // Body as HTML

--- a/apps/gateway/src/routes/webhook/email/webhook.handler.ts
+++ b/apps/gateway/src/routes/webhook/email/webhook.handler.ts
@@ -1,6 +1,7 @@
 import { AppRouteHandler } from '$/openApi/types'
 import { handleEmailTrigger } from '@latitude-data/core/services/documentTriggers/handlers/email'
 import { verifyWebhookSignature } from '@latitude-data/core/services/documentTriggers/helpers/verifySignature'
+import { extractEmailSender } from '@latitude-data/core/services/documentTriggers/helpers/extractEmailSender'
 import { EmailWebhookRoute } from './webhook.route'
 import { env } from '@latitude-data/env'
 import { UnauthorizedError } from '@latitude-data/core/lib/errors'
@@ -13,9 +14,10 @@ export const emailWebhookHandler: AppRouteHandler<EmailWebhookRoute> = async (
 ) => {
   const {
     recipient,
+    sender,
+    from,
     subject,
     'body-plain': body,
-    sender,
     token,
     timestamp,
     signature,
@@ -33,11 +35,17 @@ export const emailWebhookHandler: AppRouteHandler<EmailWebhookRoute> = async (
     signingKey: env.MAILGUN_WEBHOOK_SIGNING_KEY,
   }).unwrap()
 
+  const { email: senderEmail, name: senderName } = extractEmailSender({
+    from,
+    sender,
+  })
+
   const result = await handleEmailTrigger({
     recipient,
     subject,
     body,
-    sender,
+    senderEmail,
+    senderName,
     messageId,
   })
 

--- a/apps/web/src/actions/admin/documentTriggers/manualTrigger/email.ts
+++ b/apps/web/src/actions/admin/documentTriggers/manualTrigger/email.ts
@@ -11,7 +11,8 @@ export const manualEmailTriggerAction = withAdmin
   .input(
     z.object({
       recipient: z.string().email(),
-      sender: z.string().email(),
+      senderEmail: z.string().email(),
+      senderName: z.string(),
       subject: z.string(),
       body: z.string(),
       messageId: z.string().optional(),
@@ -29,7 +30,8 @@ export const manualEmailTriggerAction = withAdmin
       recipient: input.recipient,
       subject: input.subject,
       body: input.body,
-      sender: input.sender,
+      senderEmail: input.senderEmail,
+      senderName: input.senderName,
       messageId: input.messageId?.length ? input.messageId : undefined,
     })
 

--- a/apps/web/src/app/(admin)/backoffice/triggers/_components/SendEmailTrigger.tsx
+++ b/apps/web/src/app/(admin)/backoffice/triggers/_components/SendEmailTrigger.tsx
@@ -12,8 +12,11 @@ export default function SendEmailTrigger() {
       e.preventDefault()
       const formData = new FormData(e.currentTarget)
 
-      const sender = formData.get('sender')?.toString()
-      if (!sender) return
+      const senderEmail = formData.get('senderEmail')?.toString()
+      if (!senderEmail) return
+
+      const senderName = formData.get('senderName')?.toString()
+      if (!senderName) return
 
       const recipient = formData.get('recipient')?.toString()
       if (!recipient) return
@@ -26,7 +29,14 @@ export default function SendEmailTrigger() {
 
       const messageId = formData.get('messageId')?.toString()
 
-      await execute({ sender, recipient, subject, body: content, messageId })
+      await execute({
+        senderEmail,
+        senderName,
+        recipient,
+        subject,
+        body: content,
+        messageId,
+      })
     },
     [execute],
   )
@@ -34,11 +44,14 @@ export default function SendEmailTrigger() {
   return (
     <form onSubmit={handleSubmit}>
       <FormWrapper>
-        <Input
-          label='Sender email'
-          name='sender'
-          placeholder='user@latitude.so'
-        />
+        <div className='flex flex-row w-full gap-4'>
+          <Input label='Sender name' name='senderName' placeholder='John Doe' />
+          <Input
+            label='Sender email'
+            name='senderEmail'
+            placeholder='user@latitude.so'
+          />
+        </div>
         <Input
           label='Receiver email'
           name='recipient'

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -25,6 +25,13 @@ export enum DocumentTriggerType {
   Email = 'email',
 }
 
+export enum DocumentTriggerParameters {
+  SenderEmail = 'senderEmail',
+  SenderName = 'senderName',
+  Subject = 'subject',
+  Body = 'body',
+}
+
 export * from './models'
 export * from './ai'
 export * from './tools'

--- a/packages/core/src/services/documentTriggers/helpers/extractEmailSender.test.ts
+++ b/packages/core/src/services/documentTriggers/helpers/extractEmailSender.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { extractEmailSender } from './extractEmailSender'
+
+describe('extractEmailSender', () => {
+  it('extracts both name and email', () => {
+    const from = 'Bob <bob@email.com>'
+    const sender = 'bob@email.com'
+    const result = extractEmailSender({ from, sender })
+    expect(result).toEqual({ name: 'Bob', email: 'bob@email.com' })
+  })
+
+  it('returns only the email when "from" is not in the expected format', () => {
+    const from = 'Bob bob@email.com'
+    const sender = 'bob@email.com'
+    const result = extractEmailSender({ from, sender })
+    expect(result).toEqual({ name: undefined, email: 'bob@email.com' })
+  })
+})

--- a/packages/core/src/services/documentTriggers/helpers/extractEmailSender.ts
+++ b/packages/core/src/services/documentTriggers/helpers/extractEmailSender.ts
@@ -1,0 +1,17 @@
+const FROM_REGEX = /^(.+?)\s*<([^>]+)>$/
+
+export function extractEmailSender({
+  from, // Bob <bob@email.com>
+  sender, // bob@email.com
+}: {
+  from: string
+  sender: string
+}): { email: string; name: string | undefined } {
+  const match = from.match(FROM_REGEX)
+
+  if (match && match.length === 3) {
+    return { name: match[1], email: match[2]! }
+  }
+
+  return { name: undefined, email: sender }
+}

--- a/packages/core/src/services/documentTriggers/helpers/schema.ts
+++ b/packages/core/src/services/documentTriggers/helpers/schema.ts
@@ -1,13 +1,14 @@
-import { DocumentTriggerType } from '@latitude-data/constants'
+import {
+  DocumentTriggerParameters,
+  DocumentTriggerType,
+} from '@latitude-data/constants'
 import { z } from 'zod'
 
 export const emailTriggerConfigurationSchema = z.object({
   replyWithResponse: z.boolean(),
   emailWhitelist: z.array(z.string()).optional(),
   domainWhitelist: z.array(z.string()).optional(),
-  subjectParameters: z.array(z.string()).optional(),
-  contentParameters: z.array(z.string()).optional(),
-  senderParameters: z.array(z.string()).optional(),
+  parameters: z.record(z.nativeEnum(DocumentTriggerParameters)).optional(),
 })
 
 export type EmailTriggerConfiguration = z.infer<


### PR DESCRIPTION
Originally, the configuration for an email trigger contained different arrays for `subjectParameters`, `senderParameters` and `contentParameters`, which represented which parameters from the document were filled with each value from the email.

Adding more parameter types is a PITA.

I just simplified it to a single `parameters` object, with the name of the parameter as the key, and an Enum representing the source of the value as its value.

Also, added an "Sender Name" parameter too :)