### PR TITLE
Improve email trigger template and UI

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/index.tsx
@@ -4,6 +4,7 @@ import { Button, DotIndicator, Popover, Text } from '@latitude-data/web-ui'
 import { TriggerSettings } from './Settings'
 import useDocumentTriggers from '$/stores/documentTriggers'
 import useCurrentWorkspace from '$/stores/currentWorkspace'
+import { NotEditableBanner } from '../_components/NotEditableBanner'
 
 export function DocumentTriggersButton({
   document,
@@ -36,6 +37,7 @@ export function DocumentTriggersButton({
         </Button>
       </Popover.Trigger>
       <Popover.Content maxHeight='none' width={500} align='end'>
+        <NotEditableBanner description='Trigger settings cannot be modified in a Draft.' />
         <TriggerSettings document={document} projectId={projectId} />
       </Popover.Content>
     </Popover.Root>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/PublishDocument/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/PublishDocument/index.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { APP_DOMAIN } from '$/app/(private)/_lib/constants'
 import { ROUTES } from '$/services/routes'
+import { NotEditableBanner } from '../_components/NotEditableBanner'
 
 function UnpublishedDocumentSettings({
   document,
@@ -204,6 +205,7 @@ export function PublishDocumentButton({
         </Button>
       </Popover.Trigger>
       <Popover.Content maxHeight='none' width={500} align='end'>
+        <NotEditableBanner description='Publish settings cannot be modified in a Draft.' />
         {isPublished ? (
           <PublishedDocumentSettings
             document={document}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/_components/NotEditableBanner.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/_components/NotEditableBanner.tsx
@@ -1,0 +1,9 @@
+import { Alert, useCurrentCommit } from '@latitude-data/web-ui'
+
+export function NotEditableBanner({ description }: { description: string }) {
+  const { isHead } = useCurrentCommit()
+
+  if (isHead) return null
+
+  return <Alert variant='warning' description={description}></Alert>
+}

--- a/packages/core/src/mailers/emails/_components/Layout/index.tsx
+++ b/packages/core/src/mailers/emails/_components/Layout/index.tsx
@@ -9,6 +9,7 @@ import {
   Heading,
   Html,
   Img,
+  Link,
   Preview,
   Section,
   Tailwind,
@@ -19,10 +20,12 @@ export default function Layout({
   children,
   title,
   previewText,
+  footerText = 'The Latitude Team',
 }: {
   children: ReactNode
   title?: string
   previewText: string
+  footerText?: string | string[]
 }) {
   const rootUrl = env.APP_URL
   return (
@@ -54,17 +57,27 @@ export default function Layout({
               )}
               {children}
               <Section className='pt-4'>
-                <Text className='text-gray-500 text-sm'>The Latitude Team</Text>
+                {Array.isArray(footerText) ? (
+                  footerText.map((text) => (
+                    <Text key={text} className='text-gray-500 text-sm'>
+                      {text}
+                    </Text>
+                  ))
+                ) : (
+                  <Text className='text-gray-500 text-sm'>{footerText}</Text>
+                )}
               </Section>
             </Section>
             <Section className='w-full pt-4'>
-              <Img
-                src={`${rootUrl}/logodark.png`}
-                width='32'
-                height='32'
-                alt="Latitude's Logo"
-                className='mx-auto'
-              />
+              <Link href={rootUrl} className='text-center'>
+                <Img
+                  src={`${rootUrl}/logodark.png`}
+                  width='32'
+                  height='32'
+                  alt="Latitude's Logo"
+                  className='mx-auto'
+                />
+              </Link>
             </Section>
           </Container>
         </Tailwind>

--- a/packages/core/src/mailers/emails/documentTrigger/DocumentTriggerResponseMail.tsx
+++ b/packages/core/src/mailers/emails/documentTrigger/DocumentTriggerResponseMail.tsx
@@ -39,7 +39,7 @@ export default function DocumentTriggerResponseMail({
   if (result.error) {
     return (
       <Layout title='Error' previewText='An error occurred.'>
-        <Text>There was an error running the prompt:</Text>
+        <Text>There was an error running your prompt:</Text>
         <Text>{result.error.message}</Text>
       </Layout>
     )
@@ -49,7 +49,10 @@ export default function DocumentTriggerResponseMail({
   const agentResponse = getAgentResponse(message)
 
   return (
-    <Layout title='Response' previewText={`Prompt response.`}>
+    <Layout
+      previewText='Prompt response.'
+      footerText={['This is an AI-generated response.', 'Powered by Latitude.']}
+    >
       {agentResponse ? (
         <AgentResponseContent agentResponse={agentResponse} />
       ) : (


### PR DESCRIPTION
- Improved triggered email templates by removing the "Response" title and adding a footer.
- Added a link to Latitude on the email's footer logo
- Added a banner on Publish and Triggers settings to explain settings are not editable in Drafts