### PR TITLE
Email trigger name customization

### DIFF
--- a/apps/web/src/actions/documents/triggers/updateDocumentTriggerConfigurationAction.ts
+++ b/apps/web/src/actions/documents/triggers/updateDocumentTriggerConfigurationAction.ts
@@ -3,7 +3,10 @@
 import { updateDocumentTriggerConfiguration } from '@latitude-data/core/services/documentTriggers/update'
 
 import { withDocument } from '../../procedures'
-import { documentTriggerConfigurationsUnionSchema } from '@latitude-data/core/services/documentTriggers/helpers/schema'
+import {
+  documentTriggerConfigurationsUnionSchema,
+  EmailTriggerConfiguration,
+} from '@latitude-data/core/services/documentTriggers/helpers/schema'
 import { z } from 'zod'
 import { DocumentTriggersRepository } from '@latitude-data/core/repositories'
 
@@ -16,7 +19,10 @@ export const updateDocumentTriggerConfigurationAction = withDocument
     }),
   )
   .handler(async ({ input, ctx }) => {
-    const { documentTriggerId, configuration } = input
+    const { documentTriggerId, configuration } = input as {
+      documentTriggerId: number
+      configuration: EmailTriggerConfiguration
+    }
 
     const scope = new DocumentTriggersRepository(ctx.workspace.id)
     const trigger = await scope.find(documentTriggerId)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/EmailTrigger/Config.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/EmailTrigger/Config.tsx
@@ -161,6 +161,9 @@ export function EmailTriggerConfig({
   const [replyWithResponse, setReplyWithResponse] = useState<boolean>(
     emailTriggerConfig?.replyWithResponse ?? true,
   )
+  const [name, setName] = useState<string>(
+    emailTriggerConfig?.name ?? document.path.split('/').at(-1)!,
+  )
   const [parameters, setParameters] = useState<
     Record<string, DocumentTriggerParameters>
   >(emailTriggerConfig?.parameters ?? {})
@@ -217,6 +220,7 @@ export function EmailTriggerConfig({
       domainWhitelist: domainWhitelist.length > 0 ? domainWhitelist : undefined,
       replyWithResponse,
       parameters,
+      name,
     })
   }, [
     emailWhitelist,
@@ -224,6 +228,7 @@ export function EmailTriggerConfig({
     replyWithResponse,
     parameters,
     emailAvailability,
+    name,
   ])
 
   return (
@@ -286,15 +291,25 @@ export function EmailTriggerConfig({
       </Section>
       {emailAvailability !== EmailAvailabilityOptions.Disabled && (
         <>
-          <Section title='Parameters'>
-            <ParameterSelects
-              parameterNames={documentParameters}
-              parameters={parameters}
-              setParameters={setParameters}
-              disabled={!canEdit}
-            />
-          </Section>
+          {documentParameters.length && (
+            <Section title='Parameters'>
+              <ParameterSelects
+                parameterNames={documentParameters}
+                parameters={parameters}
+                setParameters={setParameters}
+                disabled={!canEdit}
+              />
+            </Section>
+          )}
           <Section title='Email settings'>
+            <Input
+              name='emailName'
+              label='Name'
+              value={name}
+              disabled={!canEdit}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={document.path.split('/').at(-1)}
+            />
             <Text.H5 color='foregroundMuted'>
               Send an email to this address to run the prompt:
             </Text.H5>

--- a/packages/core/src/services/documentTriggers/helpers/schema.ts
+++ b/packages/core/src/services/documentTriggers/helpers/schema.ts
@@ -5,6 +5,7 @@ import {
 import { z } from 'zod'
 
 export const emailTriggerConfigurationSchema = z.object({
+  name: z.string().optional(),
   replyWithResponse: z.boolean(),
   emailWhitelist: z.array(z.string()).optional(),
   domainWhitelist: z.array(z.string()).optional(),


### PR DESCRIPTION
Added an option to modify the "Name" that appears when receiving the email, instead of just showing the whole indecipherable email address

Before (bottom) and after (top):
<img width="542" alt="image" src="https://github.com/user-attachments/assets/3003802a-be13-49b2-8282-618e09fd6ea1" />
