### PR TITLE
fix: email threads

### DIFF
--- a/apps/web/src/app/(admin)/backoffice/triggers/_components/SendEmailTrigger.tsx
+++ b/apps/web/src/app/(admin)/backoffice/triggers/_components/SendEmailTrigger.tsx
@@ -70,7 +70,7 @@ export default function SendEmailTrigger() {
           placeholder='Optional message ID – Allows sending the response as a reply'
         />
         <Input
-          label='References (optional)'
+          label='Thread Message IDs (optional)'
           name='references'
           placeholder='Optional list of past message IDs – Used to add follow-up messages to a previous conversation'
         />

--- a/packages/core/src/mailers/mailers/Mailer.ts
+++ b/packages/core/src/mailers/mailers/Mailer.ts
@@ -31,10 +31,8 @@ export default abstract class Mailer {
     let result
     try {
       result = await this.adapter.sendMail({
-        to: options.to,
+        ...options,
         from: options.from || Mailer.from,
-        subject: options.subject,
-        html: options.html,
       })
       const info = this.ensureSendMessageInfo(result, options)
       const failed = info.rejected.concat(info.pending).filter(Boolean)

--- a/packages/core/src/mailers/mailers/mailers/documentEmailTrigger/DocumentTriggerMailer.ts
+++ b/packages/core/src/mailers/mailers/mailers/documentEmailTrigger/DocumentTriggerMailer.ts
@@ -9,30 +9,20 @@ import type { AssistantMessage } from '@latitude-data/compiler'
 import DocumentTriggerResponseMail from '../../../emails/documentTrigger/DocumentTriggerResponseMail'
 
 export class DocumentTriggerMailer extends Mailer {
-  subject: string
   result: TypedResult<AssistantMessage, LatitudeError>
 
   constructor(
+    result: TypedResult<AssistantMessage, LatitudeError>,
     options: Mail.Options,
-    {
-      subject,
-      result,
-    }: {
-      subject: string
-      result: TypedResult<AssistantMessage, LatitudeError>
-    },
   ) {
     super(options)
 
-    this.subject = subject
     this.result = result
   }
 
   async send(): Promise<TypedResult<SMTPTransport.SentMessageInfo, Error>> {
     return this.sendMail({
-      to: this.options.to,
-      from: this.options.from,
-      subject: this.subject,
+      ...this.options,
       html: await render(DocumentTriggerResponseMail({ result: this.result })),
     })
   }

--- a/packages/core/src/services/documentTriggers/handlers/email/index.ts
+++ b/packages/core/src/services/documentTriggers/handlers/email/index.ts
@@ -128,23 +128,20 @@ export async function handleEmailTrigger(
     return Result.nil()
   }
 
-  const replyHeaders = messageId
-    ? { inReplyTo: messageId, references: parentMessageIds ?? [messageId] }
-    : {}
-
   const from = `${JSON.stringify(name.unwrap())} <${trigger.documentUuid}@${EMAIL_TRIGGER_DOMAIN}>`
 
-  const mailer = new DocumentTriggerMailer(
-    {
-      to: senderEmail,
-      from,
-      ...replyHeaders,
-    },
-    {
-      subject: 'Re: ' + subject,
-      result: responseResult,
-    },
-  )
+  const references = [
+    ...(parentMessageIds ?? []),
+    ...(messageId ? [messageId] : []),
+  ]
+
+  const mailer = new DocumentTriggerMailer(responseResult, {
+    to: senderEmail,
+    from,
+    inReplyTo: messageId,
+    references,
+    subject: 'Re: ' + subject,
+  })
 
   const sendResult = await mailer.send()
   if (sendResult.error) return sendResult


### PR DESCRIPTION
Fixes email threads, as many headers (`options`) required for replying were not actually being sent to the Mailer adapter