### PR TITLE
feat: fix workers/queues connection config

### DIFF
--- a/apps/gateway/src/jobs/index.ts
+++ b/apps/gateway/src/jobs/index.ts
@@ -1,3 +1,3 @@
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 
-export const queues = setupJobs()
+export const queues = setupQueues()

--- a/apps/gateway/src/routes/api/v3/otlp/traces/traces.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/otlp/traces/traces.handler.test.ts
@@ -24,7 +24,7 @@ const mocks = vi.hoisted(() => ({
 
 // Replace the mock setup with spies
 // @ts-ignore
-vi.spyOn(jobsModule, 'setupJobs').mockResolvedValue(mocks.queues)
+vi.spyOn(jobsModule, 'setupQueues').mockResolvedValue(mocks.queues)
 
 describe('POST /api/v2/otlp/v1/traces', () => {
   let workspace: Workspace

--- a/apps/gateway/src/routes/api/v3/otlp/traces/traces.handler.ts
+++ b/apps/gateway/src/routes/api/v3/otlp/traces/traces.handler.ts
@@ -1,6 +1,6 @@
 import { chunk } from 'lodash-es'
 
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 import { AppRouteHandler } from '$/openApi/types'
 import { CreateTracesRoute } from './traces.route'
 
@@ -23,7 +23,7 @@ export const tracesHandler: AppRouteHandler<CreateTracesRoute> = async (c) => {
 
   // Process spans in batches
   const batches = chunk(allSpans, BATCH_SIZE)
-  const queues = await setupJobs()
+  const queues = await setupQueues()
 
   await Promise.all(
     batches.map((batch) =>

--- a/apps/web/src/actions/documents/runDocumentInBatchAction.ts
+++ b/apps/web/src/actions/documents/runDocumentInBatchAction.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { publisher } from '@latitude-data/core/events/publisher'
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { z } from 'zod'
 
@@ -36,7 +36,7 @@ export const runDocumentInBatchAction = withDataset
       .getCommitByUuid({ uuid: ctx.currentCommitUuid })
       .then((r) => r.unwrap())
 
-    const queues = await setupJobs()
+    const queues = await setupQueues()
 
     queues.defaultQueue.jobs.enqueueRunDocumentInBatchJob({
       commit,

--- a/apps/web/src/actions/evaluations/runBatch.test.ts
+++ b/apps/web/src/actions/evaluations/runBatch.test.ts
@@ -34,7 +34,7 @@ vi.mock('$/services/auth/getSession', () => ({
 }))
 
 vi.mock('@latitude-data/core/jobs', () => ({
-  setupJobs: vi.fn().mockImplementation(() => mocks.queues),
+  setupQueues: vi.fn().mockImplementation(() => mocks.queues),
 }))
 
 let setup: FactoryCreateProjectReturn

--- a/apps/web/src/actions/evaluations/runBatch.ts
+++ b/apps/web/src/actions/evaluations/runBatch.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { publisher } from '@latitude-data/core/events/publisher'
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 import { EvaluationsRepository } from '@latitude-data/core/repositories'
 import { nanoid } from 'nanoid'
 import { z } from 'zod'
@@ -38,7 +38,7 @@ export const runBatchEvaluationAction = withDataset
     const evaluations = await evaluationsRepo
       .filterById(input.evaluationIds)
       .then((r) => r.unwrap())
-    const queues = await setupJobs()
+    const queues = await setupQueues()
     evaluations.forEach((evaluation) => {
       const batchId = `evaluation:${evaluation.id}:${nanoid(5)}`
 

--- a/apps/web/src/jobs/index.ts
+++ b/apps/web/src/jobs/index.ts
@@ -1,3 +1,3 @@
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 
-export const queues = setupJobs()
+export const queues = setupQueues()

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -4,13 +4,13 @@ import express from 'express'
 import { createBullBoard } from '@bull-board/api'
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter.js'
 import { ExpressAdapter } from '@bull-board/express'
-import { setupJobs } from '@latitude-data/core/jobs'
+import { setupQueues } from '@latitude-data/core/jobs'
 
 import { captureException, captureMessage } from './utils/sentry'
 import startWorkers from './workers'
 import { env } from '@latitude-data/env'
 
-const queues = await setupJobs()
+const queues = await setupQueues()
 const app = express()
 const workers = await startWorkers()
 
@@ -19,7 +19,7 @@ const serverAdapter = new ExpressAdapter()
 serverAdapter.setBasePath('/admin/queues')
 
 createBullBoard({
-  queues: Object.values(queues).map((queue) => new BullMQAdapter(queue.queue)),
+  queues: Object.values(queues).map((q) => new BullMQAdapter(q.queue)),
   serverAdapter,
 })
 

--- a/packages/core/src/events/handlers/createDocumentLogsFromSpansJob.ts
+++ b/packages/core/src/events/handlers/createDocumentLogsFromSpansJob.ts
@@ -1,5 +1,5 @@
 import { BulkCreateTracesAndSpansEvent } from '../events'
-import { setupJobs } from '../../jobs'
+import { setupQueues } from '../../jobs'
 import { database } from '../../client'
 import { and, eq, inArray } from 'drizzle-orm'
 import { spans as spansModel } from '../../schema'
@@ -43,9 +43,9 @@ export async function createDocumentLogsFromSpansJob({
   )
   if (!spansToImport.length) return
 
-  const jobs = await setupJobs()
+  const queues = await setupQueues()
   spansToImport.forEach(async (data) => {
-    jobs.defaultQueue.jobs.enqueueCreateDocumentLogFromSpanJob({
+    queues.defaultQueue.jobs.enqueueCreateDocumentLogFromSpanJob({
       ...data,
     })
   })

--- a/packages/core/src/events/handlers/requestDocumentSuggestionJob.test.ts
+++ b/packages/core/src/events/handlers/requestDocumentSuggestionJob.test.ts
@@ -89,7 +89,7 @@ describe('requestDocumentSuggestionJob', () => {
     result = r
 
     mocks = { enqueueGenerateDocumentSuggestionJob: vi.fn() }
-    vi.spyOn(jobs, 'setupJobs').mockResolvedValue({
+    vi.spyOn(jobs, 'setupQueues').mockResolvedValue({
       defaultQueue: {
         jobs: {
           enqueueGenerateDocumentSuggestionJob:

--- a/packages/core/src/events/handlers/requestDocumentSuggestionJob.ts
+++ b/packages/core/src/events/handlers/requestDocumentSuggestionJob.ts
@@ -1,6 +1,6 @@
 import { LogSources } from '../../browser'
 import { unsafelyFindWorkspace } from '../../data-access'
-import { setupJobs } from '../../jobs'
+import { setupQueues } from '../../jobs'
 import { generateDocumentSuggestionJobKey } from '../../jobs/job-definitions'
 import { NotFoundError } from '../../lib'
 import { hasEvaluationResultPassed } from '../../services/evaluationResults'
@@ -24,7 +24,7 @@ export const requestDocumentSuggestionJob = async ({
   if (documentLog.source !== LogSources.Playground) return
   if (hasEvaluationResultPassed({ result, evaluation })) return
 
-  const queues = await setupJobs()
+  const queues = await setupQueues()
   queues.defaultQueue.jobs.enqueueGenerateDocumentSuggestionJob(
     {
       workspaceId: workspace.id,

--- a/packages/core/src/events/handlers/runLiveEvaluationsJob.ts
+++ b/packages/core/src/events/handlers/runLiveEvaluationsJob.ts
@@ -3,7 +3,7 @@ import {
   NON_LIVE_EVALUABLE_LOG_SOURCES,
 } from '@latitude-data/constants'
 import { findWorkspaceFromDocumentLog } from '../../data-access'
-import { setupJobs } from '../../jobs'
+import { setupQueues } from '../../jobs'
 import { NotFoundError } from '../../lib'
 import { EvaluationsRepository } from '../../repositories'
 import { DocumentLogCreatedEvent } from '../events'
@@ -31,11 +31,11 @@ export const runLiveEvaluationsJob = async ({
     .findByDocumentUuid(documentLog.documentUuid)
     .then((r) => r.unwrap())
 
-  const jobs = await setupJobs()
+  const queues = await setupQueues()
   evaluations
     .filter((ev) => !!ev.live)
     .forEach((ev) => {
-      jobs.liveEvaluationsQueue.jobs.enqueueRunLiveEvaluationJob({
+      queues.liveEvaluationsQueue.jobs.enqueueRunLiveEvaluationJob({
         evaluation: ev,
         documentLog,
         documentUuid: documentLog.documentUuid,

--- a/packages/core/src/events/publisher.ts
+++ b/packages/core/src/events/publisher.ts
@@ -1,9 +1,9 @@
-import { setupJobs } from '../jobs'
+import { setupQueues } from '../jobs'
 import { LatitudeEvent } from './events'
 
 export const publisher = {
   publishLater: async (event: LatitudeEvent) => {
-    const queues = await setupJobs()
+    const queues = await setupQueues()
 
     queues.eventsQueue.jobs.enqueueCreateEventJob(event)
     queues.eventsQueue.jobs.enqueuePublishEventJob(event)

--- a/packages/core/src/jobs/index.ts
+++ b/packages/core/src/jobs/index.ts
@@ -1,22 +1,10 @@
-import Redis from 'ioredis'
 import { setupQueues } from './queues'
 
+export { setupQueues } from './queues'
 export { Worker } from 'bullmq'
 
-let queues: Awaited<ReturnType<typeof setupQueues>>
-
-export async function setupJobs(connection?: Redis) {
-  if (!queues) {
-    queues = await setupQueues(connection)
-  }
-
-  return queues
-}
-
-export async function setupSchedules(connection?: Redis) {
-  if (!queues) {
-    queues = await setupQueues(connection)
-  }
+export async function setupSchedules() {
+  const queues = await setupQueues()
 
   // Every day at 8 AM
   await queues.defaultQueue.jobs.scheduleRequestDocumentSuggestionsJob(

--- a/packages/core/src/jobs/job-definitions/batchEvaluations/runBatchEvaluationJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/batchEvaluations/runBatchEvaluationJob.test.ts
@@ -51,10 +51,10 @@ previewDatasetSpy.mockResolvedValue({
   }),
 })
 
-// Replace the mock of setupJobs with a spy
-const setupJobsSpy = vi.spyOn(jobsModule, 'setupJobs')
-// @ts-expect-error - mock implementation
-setupJobsSpy.mockResolvedValue(mocks.queues)
+// Replace the mock of setupQueues with a spy
+const setupQueuesSpy = vi.spyOn(jobsModule, 'setupQueues')
+// @ts-ignore
+setupQueuesSpy.mockResolvedValue(mocks.queues)
 
 // Replace the mock for ProgressTracker with a spy
 const progressTrackerSpy = {
@@ -168,7 +168,7 @@ describe('runBatchEvaluationJob', () => {
     it('should setup jobs', async () => {
       await runBatchEvaluationJob(buildFakeJob(commonJobData))
 
-      expect(setupJobsSpy).toHaveBeenCalled()
+      expect(setupQueuesSpy).toHaveBeenCalled()
     })
 
     it('should use provided batchId', async () => {

--- a/packages/core/src/jobs/job-definitions/batchEvaluations/runDocumentJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/batchEvaluations/runDocumentJob.test.ts
@@ -64,7 +64,7 @@ describe('runDocumentJob', () => {
       emit: vi.fn(),
     } as any)
 
-    vi.spyOn(jobs, 'setupJobs').mockResolvedValue({
+    vi.spyOn(jobs, 'setupQueues').mockResolvedValue({
       defaultQueue: {
         jobs: {
           enqueueRunEvaluationJob: vi.fn(),
@@ -79,7 +79,7 @@ describe('runDocumentJob', () => {
       },
     } as any)
 
-    vi.spyOn(queues, 'queues').mockResolvedValue({} as any)
+    vi.spyOn(queues, 'queuesConnection').mockResolvedValue({} as any)
     vi.spyOn(commits, 'runDocumentAtCommit')
     // @ts-ignore
     vi.spyOn(utils, 'ProgressTracker').mockImplementation(() => ({
@@ -113,9 +113,9 @@ describe('runDocumentJob', () => {
       }),
     )
 
-    const setupJobsResult = await jobs.setupJobs()
+    const setupQueuesResult = await jobs.setupQueues()
     expect(
-      setupJobsResult.defaultQueue.jobs.enqueueRunEvaluationJob,
+      setupQueuesResult.defaultQueue.jobs.enqueueRunEvaluationJob,
     ).toHaveBeenCalledWith(
       {
         workspaceId: workspace.id,
@@ -152,9 +152,9 @@ describe('runDocumentJob', () => {
     })
 
     expect(commits.runDocumentAtCommit).toHaveBeenCalled()
-    const setupJobsResult = await jobs.setupJobs()
+    const setupQueuesResult = await jobs.setupQueues()
     expect(
-      setupJobsResult.defaultQueue.jobs.enqueueRunEvaluationJob,
+      setupQueuesResult.defaultQueue.jobs.enqueueRunEvaluationJob,
     ).not.toHaveBeenCalled()
 
     expect(incrementErrorsMock).toHaveBeenCalled()

--- a/packages/core/src/jobs/job-definitions/batchEvaluations/runDocumentJob.ts
+++ b/packages/core/src/jobs/job-definitions/batchEvaluations/runDocumentJob.ts
@@ -1,9 +1,9 @@
 import { env } from '@latitude-data/env'
 import { Job } from 'bullmq'
 
-import { setupJobs } from '../../'
+import { setupQueues } from '../../'
 import { NotFoundError } from '../../../lib/errors'
-import { queues } from '../../../queues'
+import { queuesConnection } from '../../../queues'
 import { WebsocketClient } from '../../../websockets/workers'
 import { ProgressTracker } from '../../utils/progressTracker'
 import { runDocumentAtCommitWithAutoToolResponses } from '../documents/runDocumentAtCommitWithAutoToolResponses'
@@ -31,10 +31,10 @@ export const runDocumentForEvaluationJob = async (
     evaluationId,
     batchId,
   } = job.data
-  const progressTracker = new ProgressTracker(await queues(), batchId)
+  const progressTracker = new ProgressTracker(await queuesConnection(), batchId)
 
   try {
-    const jobs = await setupJobs()
+    const queues = await setupQueues()
     const result = await runDocumentAtCommitWithAutoToolResponses({
       workspaceId,
       projectId,
@@ -50,7 +50,7 @@ export const runDocumentForEvaluationJob = async (
       throw new NotFoundError('Provider log not found after running document')
     }
 
-    await jobs.defaultQueue.jobs.enqueueRunEvaluationJob(
+    await queues.defaultQueue.jobs.enqueueRunEvaluationJob(
       {
         workspaceId,
         documentUuid,

--- a/packages/core/src/jobs/job-definitions/batchEvaluations/runEvaluationJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/batchEvaluations/runEvaluationJob.test.ts
@@ -20,8 +20,7 @@ import * as websockets from '../../../websockets/workers'
 import * as progressTracker from '../../utils/progressTracker'
 import { runEvaluationJob, type RunEvaluationJobData } from './runEvaluationJob'
 
-// @ts-ignore
-vi.spyOn(queues, 'queues').mockResolvedValue({})
+vi.spyOn(queues, 'queuesConnection').mockResolvedValue({} as any)
 const runEvaluationSpy = vi.spyOn(evaluations, 'runEvaluation')
 
 const FAKE_ERRORABLE_UUID = '12345678-1234-1234-1234-123456789012'

--- a/packages/core/src/jobs/job-definitions/batchEvaluations/runEvaluationJob.ts
+++ b/packages/core/src/jobs/job-definitions/batchEvaluations/runEvaluationJob.ts
@@ -1,7 +1,7 @@
 import { Job } from 'bullmq'
 
 import { getUnknownError, Result } from '../../../lib'
-import { queues } from '../../../queues'
+import { queuesConnection } from '../../../queues'
 import {
   EvaluationsRepository,
   ProviderLogsRepository,
@@ -58,7 +58,7 @@ export async function runEvaluationJob(job: Job<RunEvaluationJobData>) {
   const websockets = await WebsocketClient.getSocket()
   let progressTracker: ProgressTracker | undefined
   if (batchId) {
-    progressTracker = new ProgressTracker(await queues(), batchId)
+    progressTracker = new ProgressTracker(await queuesConnection(), batchId)
   }
   const { providerLog, evaluation } = await fetchData({
     workspaceId,

--- a/packages/core/src/jobs/job-definitions/documentLogs/uploadDocumentLogsJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentLogs/uploadDocumentLogsJob.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq'
 
-import { setupJobs } from '../..'
+import { setupQueues } from '../..'
 import { Commit } from '../../../browser'
 import { LogSources, messagesSchema } from '../../../constants'
 
@@ -16,7 +16,7 @@ export const uploadDocumentLogsJob = async (
   job: Job<UploadDocumentLogsJobData>,
 ) => {
   const { workspaceId, source, documentUuid, commit, csv } = job.data
-  const jobs = await setupJobs()
+  const queues = await setupQueues()
 
   csv.data.forEach((row) => {
     const messages = JSON.parse(row.record[0]!)
@@ -27,7 +27,7 @@ export const uploadDocumentLogsJob = async (
       return
     }
 
-    jobs.defaultQueue.jobs.enqueueCreateDocumentLogJob({
+    queues.defaultQueue.jobs.enqueueCreateDocumentLogJob({
       workspaceId,
       documentUuid,
       commit,

--- a/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.test.ts
@@ -367,7 +367,7 @@ describe('requestDocumentSuggestionsJob', () => {
     ]
 
     mocks = { enqueueGenerateDocumentSuggestionJob: vi.fn() }
-    vi.spyOn(jobs, 'setupJobs').mockResolvedValue({
+    vi.spyOn(jobs, 'setupQueues').mockResolvedValue({
       defaultQueue: {
         jobs: {
           enqueueGenerateDocumentSuggestionJob:

--- a/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.ts
@@ -16,7 +16,7 @@ import {
   EVALUATION_RESULT_RECENCY_DAYS,
 } from '../../../browser'
 import { database } from '../../../client'
-import { setupJobs } from '../../../jobs'
+import { setupQueues } from '../../../jobs'
 import {
   commits,
   connectedEvaluations,
@@ -127,7 +127,7 @@ export const requestDocumentSuggestionsJob = async (
       ),
     )
 
-  const queues = await setupJobs()
+  const queues = await setupQueues()
   for (const candidate of candidates) {
     queues.defaultQueue.jobs.enqueueGenerateDocumentSuggestionJob(
       {

--- a/packages/core/src/jobs/job-definitions/documentTriggers/checkScheduledDocumentTriggersJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentTriggers/checkScheduledDocumentTriggersJob.ts
@@ -1,7 +1,7 @@
 import { Job } from 'bullmq'
 import { findScheduledTriggersDueToRun } from '../../../services/documentTriggers/handlers/scheduled'
 import { ProcessScheduledTriggerJobData } from './processScheduledTriggerJob'
-import { setupJobs } from '../../../jobs'
+import { setupQueues } from '../../../jobs'
 import { HEAD_COMMIT } from '../../../constants'
 
 export type CheckScheduledDocumentTriggersJobData = unknown
@@ -28,7 +28,7 @@ export const checkScheduledDocumentTriggersJob = async (
   console.log(`Found ${triggers.length} scheduled triggers due to run`)
 
   // Get the queue instance
-  const jobQueues = await setupJobs()
+  const jobQueues = await setupQueues()
 
   // Enqueue individual jobs for each trigger
   const jobPromises = triggers.map(async (trigger) => {

--- a/packages/core/src/jobs/job-definitions/documentTriggers/processScheduledTriggerJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentTriggers/processScheduledTriggerJob.ts
@@ -1,7 +1,7 @@
 import { Job } from 'bullmq'
 import { DocumentTrigger, HEAD_COMMIT } from '../../../browser'
 import { updateScheduledTriggerLastRun } from '../../../services/documentTriggers/handlers/scheduled'
-import { setupJobs } from '../../../jobs'
+import { setupQueues } from '../../../jobs'
 import { RunDocumentJobData } from '../documents/runDocumentJob'
 import { DEFAULT_JOB_OPTIONS } from '../../queues'
 import { ScheduledTriggerConfiguration } from '../../../services/documentTriggers/helpers/schema'
@@ -44,7 +44,7 @@ export const processScheduledTriggerJob = async (
     )
 
     // Get the queues to enqueue the document run job
-    const jobQueues = await setupJobs()
+    const jobQueues = await setupQueues()
 
     // Prepare data for the document run job
     const runJobData: RunDocumentJobData = {

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentInBatchJob.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentInBatchJob.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq'
 
-import { setupJobs } from '../..'
+import { setupQueues } from '../..'
 import { Commit, Dataset, DocumentVersion, Workspace } from '../../../browser'
 import { getBatchParamaters } from '../batchEvaluations'
 
@@ -33,10 +33,10 @@ export const runDocumentInBatchJob = async (
     parametersMap,
   })
 
-  const jobs = await setupJobs()
+  const queues = await setupQueues()
 
   for (let i = 0; i < parameters.length; i++) {
-    await jobs.defaultQueue.jobs.enqueueRunDocumentJob({
+    await queues.defaultQueue.jobs.enqueueRunDocumentJob({
       workspaceId: workspace.id,
       documentUuid: document.documentUuid,
       commitUuid: commit.uuid,

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentJob.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentJob.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto'
 import { env } from '@latitude-data/env'
 import { Job } from 'bullmq'
 
-import { queues } from '../../../queues'
+import { queuesConnection } from '../../../queues'
 import { WebsocketClient, WorkerSocket } from '../../../websockets/workers'
 import { ProgressTracker } from '../../utils/progressTracker'
 import { runDocumentAtCommitWithAutoToolResponses } from './runDocumentAtCommitWithAutoToolResponses'
@@ -51,7 +51,7 @@ export const runDocumentJob = async (job: Job<RunDocumentJobData>) => {
     batchId = randomUUID(),
   } = job.data
   const websockets = await WebsocketClient.getSocket()
-  const progressTracker = new ProgressTracker(await queues(), batchId)
+  const progressTracker = new ProgressTracker(await queuesConnection(), batchId)
 
   try {
     await runDocumentAtCommitWithAutoToolResponses({

--- a/packages/core/src/jobs/job-definitions/events/publishEventJob.ts
+++ b/packages/core/src/jobs/job-definitions/events/publishEventJob.ts
@@ -1,6 +1,6 @@
 import { Job } from 'bullmq'
 
-import { setupJobs } from '../..'
+import { setupQueues } from '../..'
 import { LatitudeEvent } from '../../../events/events'
 import { EventHandlers } from '../../../events/handlers/index'
 
@@ -9,7 +9,7 @@ export const publishEventJob = async (job: Job<LatitudeEvent>) => {
   const handlers = EventHandlers[event.type]
   if (!handlers?.length) return
 
-  const queues = await setupJobs()
+  const queues = await setupQueues()
 
   handlers.forEach((handler) => {
     queues.eventsQueue.queue.add(handler.name, event)

--- a/packages/core/src/queues/index.ts
+++ b/packages/core/src/queues/index.ts
@@ -5,16 +5,14 @@ import { buildRedisConnection } from '../redis'
 
 let connection: Redis
 
-export const queues = async (
-  { enableOfflineQueue } = { enableOfflineQueue: false },
-) => {
+export const queuesConnection = async () => {
   if (connection) return connection
 
   connection = await buildRedisConnection({
     host: env.QUEUE_HOST,
     port: env.QUEUE_PORT,
     password: env.QUEUE_PASSWORD,
-    enableOfflineQueue,
+    enableOfflineQueue: true,
     maxRetriesPerRequest: null,
     retryStrategy: (times: number) =>
       Math.max(Math.min(Math.exp(times), 20000), 1000), // Exponential backoff with a max of 20 seconds and a min of 1 second

--- a/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.test.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.test.ts
@@ -27,9 +27,9 @@ const mocks = vi.hoisted(() => ({
     },
   },
 }))
-const setupJobsSpy = vi.spyOn(jobsModule, 'setupJobs')
+const setupQueuesSpy = vi.spyOn(jobsModule, 'setupQueues')
 // @ts-expect-error - mock implementation
-setupJobsSpy.mockResolvedValue(mocks.queues)
+setupQueuesSpy.mockResolvedValue(mocks.queues)
 
 let data: ReturnType<typeof buildProviderLogDto>
 let workspace: Workspace

--- a/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
@@ -5,7 +5,7 @@ import { ProviderApiKey, ProviderLog, Workspace } from '../../../browser'
 import { ChainStepResponse, LogSources, StreamType } from '../../../constants'
 import { AIProviderCallCompletedData } from '../../../events/events'
 import { publisher } from '../../../events/publisher'
-import { setupJobs } from '../../../jobs'
+import { setupQueues } from '../../../jobs'
 import { generateUUIDIdentifier } from '../../../lib'
 import { PartialConfig } from '../../ai'
 import { createProviderLog } from '../../providerLogs'
@@ -49,7 +49,7 @@ export async function saveOrPublishProviderLogs<
     return providerLog as P
   }
 
-  const queues = await setupJobs()
+  const queues = await setupQueues()
   queues.defaultQueue.jobs.enqueueCreateProviderLogJob({
     ...providerLogsData,
     generatedAt: data.generatedAt.toISOString(),

--- a/packages/core/src/services/documentLogs/bulkUpload.ts
+++ b/packages/core/src/services/documentLogs/bulkUpload.ts
@@ -1,6 +1,6 @@
 import { Commit, DocumentVersion, Workspace } from '../../browser'
 import { LogSources } from '../../constants'
-import { setupJobs } from '../../jobs'
+import { setupQueues } from '../../jobs'
 import { syncReadCsv } from '../../lib/readCsv'
 
 export async function bulkUploadDocumentLogs({
@@ -20,7 +20,7 @@ export async function bulkUploadDocumentLogs({
     delimiter: csvDelimiter,
     columns: false,
   }).then((r) => r.unwrap())
-  const queues = await setupJobs()
+  const queues = await setupQueues()
 
   queues.defaultQueue.jobs.enqueueUploadDocumentLogsJob({
     workspaceId: workspace.id,

--- a/packages/core/src/services/documentLogs/evaluate.ts
+++ b/packages/core/src/services/documentLogs/evaluate.ts
@@ -5,7 +5,7 @@ import {
   WorkspaceDto,
 } from '../../browser'
 import { findLastProviderLogFromDocumentLogUuid } from '../../data-access'
-import { setupJobs } from '../../jobs'
+import { setupQueues } from '../../jobs'
 import { NotFoundError, Result } from '../../lib'
 
 export async function evaluateDocumentLog(
@@ -13,7 +13,7 @@ export async function evaluateDocumentLog(
   workspace: WorkspaceDto | Workspace,
   { evaluations }: { evaluations?: EvaluationDto[] } = {},
 ) {
-  const queues = await setupJobs()
+  const queues = await setupQueues()
   const providerLog = await findLastProviderLogFromDocumentLogUuid(
     documentLog.uuid,
   )


### PR DESCRIPTION
We were initializing queues and workers with enableOfflineQueue: true but that is not the correct production configuration. Queues need to be initialized with enableOfflineQueue: true but workers need to be initialized with enableOfflineQueue: false.

This commit fixes the issue by initializing queues with enableOfflineQueue: true and workers with enableOfflineQueue: false.

I've also simplified some code in the queues initialization.