### PR TITLE
Fix missing environment variables and improve Traefik security in Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,9 @@ NODE_ENV=production
 # Traefik
 TRAEFIK_HOST=traefik.${APP_DOMAIN}
 TRAEFIK_ACME_EMAIL=your@email.com
-TRAEFIK_ADMIN_PASS="your_secure_password" # Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
-
-BULL_ADMIN_USER=admin
-BULL_ADMIN_PASS=password
-MCP_NODE_GROUP_NAME=default-group
-MCP_DOCKER_IMAGE=ghcr.io/latitude-dev/web:latest
-MCP_SCHEME=http
+# Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
+# Example command to generate a password for user admin: echo $(htpasswd -nb admin password) | sed -e s/\\$/\\$\\$/g
+TRAEFIK_ADMIN_PASS="your_secure_password"
 
 # Database
 POSTGRES_USER=latitude

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,17 @@
 # Environment
 NODE_ENV=production
 
+# Traefik
+TRAEFIK_HOST=traefik.${APP_DOMAIN}
+TRAEFIK_ACME_EMAIL=your@email.com
+TRAEFIK_ADMIN_PASS="your_secure_password" # Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
+
+BULL_ADMIN_USER=admin
+BULL_ADMIN_PASS=password
+MCP_NODE_GROUP_NAME=default-group
+MCP_DOCKER_IMAGE=ghcr.io/latitude-dev/web:latest
+MCP_SCHEME=http
+
 # Database
 POSTGRES_USER=latitude
 POSTGRES_PASSWORD=secret

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ tmp
 TODO.md
 .cursorrules
 .vscode/settings.json
+/acme
 
 # Sentry
 .sentryclirc

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For more detailed information on each step, explore our documentation or join ou
 
 ### Latitude Self-Hosted
 
-Follow the instructions in the [self-hosted guide](https://docs.latitude.so/self-hosted/production) to get started with Latitude Self-Hosted.
+Follow the instructions in the [self-hosted guide](https://docs.latitude.so/guides/self-hosted/production) to get started with Latitude Self-Hosted.
 
 After setting up Latitude Self-Hosted, you can follow the same steps as in the Latitude Cloud guide to create, test, evaluate, and deploy your prompts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ x-gateway-common: &gateway-common
   labels:
     - "traefik.enable=true"
     - "traefik.docker.network=web"
-    - "traefik.http.services.gateway-service.loadbalancer.server.port=8081"
+    - "traefik.http.services.gateway-service.loadbalancer.server.port=8080"
     - "traefik.http.routers.gateway-http.entrypoints=http"
     - "traefik.http.routers.gateway-http.service=gateway-service"
     - "traefik.http.routers.gateway-http.rule=Host(`gateway-latitude.${APP_DOMAIN}`)"
@@ -75,7 +75,7 @@ services:
       --providers.file.watch=true
       --api.dashboard=true
       --api.debug=false
-      --api.insecure=false
+      --api.insecure=${TRAEFIK_API_INSECURE:-false}
       --metrics.prometheus=true
       --metrics.prometheus.buckets=0.1,0.3,1.2,5.0
       --metrics.prometheus.addEntryPointsLabels=true
@@ -83,7 +83,7 @@ services:
       --entrypoints.https.address=:443
       --entryPoints.http.forwardedHeaders.insecure
       --entryPoints.https.forwardedHeaders.insecure
-      --certificatesresolvers.letsencryptresolver.acme.email=${TRAEFIK_ACME_EMAIL}
+      --certificatesresolvers.letsencryptresolver.acme.email=${TRAEFIK_ACME_EMAIL:-your@email.com}
       --certificatesresolvers.letsencryptresolver.acme.storage=/acme/acme.json
       --certificatesresolvers.letsencryptresolver.acme.httpchallenge.entrypoint=http
       --log.level=INFO
@@ -140,7 +140,7 @@ services:
       - .env
     volumes:
       - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-      - pgdata:/var/lib/postgresql/data
+      - ./docker/pgdata:/var/lib/postgresql/data
     networks:
       - web
 
@@ -246,6 +246,3 @@ services:
 networks:
   web:
     external: true
-
-volumes:
-  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,25 @@ x-common-service: &common-service
   depends_on:
     - db
     - redis
+  networks:
+    - web
 
 x-web-common: &web-common
   <<: *common-service
   labels:
-    - 'traefik.enable=true'
-    - 'traefik.http.routers.web.rule=Host(`app.latitude.localhost`)'
-    - 'traefik.http.services.web.loadbalancer.server.port=8080'
+    - "traefik.enable=true"
+    - "traefik.docker.network=web"
+    - "traefik.http.services.web-service.loadbalancer.server.port=8080"
+    - "traefik.http.routers.web-http.entrypoints=http"
+    - "traefik.http.routers.web-http.service=web-service"
+    - "traefik.http.routers.web-http.rule=Host(`app-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.web-https.tls.certresolver=letsencryptresolver"
+    - "traefik.http.middlewares.web-redirect.redirectscheme.scheme=https"
+    - "traefik.http.routers.web-http.middlewares=web-redirect"
+    - "traefik.http.routers.web-https.entrypoints=https"
+    - "traefik.http.routers.web-https.tls=true"
+    - "traefik.http.routers.web-https.rule=Host(`app-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.web-https.service=web-service"
   depends_on:
     - db
     - redis
@@ -19,18 +31,95 @@ x-web-common: &web-common
 x-gateway-common: &gateway-common
   <<: *common-service
   labels:
-    - 'traefik.enable=true'
-    - 'traefik.http.routers.gateway.rule=Host(`gateway.latitude.localhost`)'
-    - 'traefik.http.services.gateway.loadbalancer.server.port=8081'
+    - "traefik.enable=true"
+    - "traefik.docker.network=web"
+    - "traefik.http.services.gateway-service.loadbalancer.server.port=8081"
+    - "traefik.http.routers.gateway-http.entrypoints=http"
+    - "traefik.http.routers.gateway-http.service=gateway-service"
+    - "traefik.http.routers.gateway-http.rule=Host(`gateway-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.gateway-https.tls.certresolver=letsencryptresolver"
+    - "traefik.http.middlewares.gateway-redirect.redirectscheme.scheme=https"
+    - "traefik.http.routers.gateway-http.middlewares=gateway-redirect"
+    - "traefik.http.routers.gateway-https.entrypoints=https"
+    - "traefik.http.routers.gateway-https.tls=true"
+    - "traefik.http.routers.gateway-https.rule=Host(`gateway-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.gateway-https.service=gateway-service"
 
 x-websockets-common: &websockets-common
   <<: *common-service
   labels:
-    - 'traefik.enable=true'
-    - 'traefik.http.routers.websockets.rule=Host(`ws.latitude.localhost`)'
-    - 'traefik.http.services.websockets.loadbalancer.server.port=4002'
+    - "traefik.enable=true"
+    - "traefik.docker.network=web"
+    - "traefik.http.services.websockets-service.loadbalancer.server.port=4002"
+    - "traefik.http.routers.websockets-http.entrypoints=http"
+    - "traefik.http.routers.websockets-http.service=websockets-service"
+    - "traefik.http.routers.websockets-http.rule=Host(`ws-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.websockets-https.tls.certresolver=letsencryptresolver"
+    - "traefik.http.middlewares.websockets-redirect.redirectscheme.scheme=https"
+    - "traefik.http.routers.websockets-http.middlewares=websockets-redirect"
+    - "traefik.http.routers.websockets-https.entrypoints=https"
+    - "traefik.http.routers.websockets-https.tls=true"
+    - "traefik.http.routers.websockets-https.rule=Host(`ws-latitude.${APP_DOMAIN}`)"
+    - "traefik.http.routers.websockets-https.service=websockets-service"
 
 services:
+  traefik:
+    image: traefik
+    container_name: traefik
+    restart: always
+    command:
+      --api=true
+      --ping=true
+      --providers.docker=true
+      --providers.file.directory=/etc/traefik/
+      --providers.file.watch=true
+      --api.dashboard=true
+      --api.debug=false
+      --api.insecure=false
+      --metrics.prometheus=true
+      --metrics.prometheus.buckets=0.1,0.3,1.2,5.0
+      --metrics.prometheus.addEntryPointsLabels=true
+      --entrypoints.http.address=:80
+      --entrypoints.https.address=:443
+      --entryPoints.http.forwardedHeaders.insecure
+      --entryPoints.https.forwardedHeaders.insecure
+      --certificatesresolvers.letsencryptresolver.acme.email=${TRAEFIK_ACME_EMAIL}
+      --certificatesresolvers.letsencryptresolver.acme.storage=/acme/acme.json
+      --certificatesresolvers.letsencryptresolver.acme.httpchallenge.entrypoint=http
+      --log.level=INFO
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8123:8123"
+      - "8082:8082"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./acme/:/acme/
+      - ./fileprovider:/etc/traefik:ro
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=web"
+      - "traefik.http.routers.dashboard-http-router.entrypoints=http"
+      - "traefik.http.routers.dashboard-http-router.rule=Host(`${TRAEFIK_HOST}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+      - "traefik.http.middlewares.dashboard-auth.basicauth.users=admin:${TRAEFIK_ADMIN_PASS}"
+      - "traefik.http.routers.dashboard-https-router.tls.certresolver=letsencryptresolver"
+      - "traefik.http.middlewares.dashboard-redirect.redirectscheme.scheme=https"
+      - "traefik.http.routers.dashboard-http-router.middlewares=dashboard-redirect"
+      - "traefik.http.routers.dashboard-https-router.middlewares=dashboard-auth"
+      - "traefik.http.routers.dashboard-https-router.service=api@internal"
+      - "traefik.http.routers.dashboard-https-router.entrypoints=https"
+      - "traefik.http.routers.dashboard-https-router.tls=true"
+      - "traefik.http.routers.dashboard-https-router.rule=Host(`${TRAEFIK_HOST}`) && (PathPrefix(`/api`) || PathPrefix(`/dashboard`))"
+    healthcheck:
+      test: ["CMD-SHELL", "traefik healthcheck --ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - web
+
   mailpit:
     image: axllent/mailpit
     ports:
@@ -38,34 +127,31 @@ services:
       - 1025:1025
     profiles:
       - development
-
-  traefik:
-    image: traefik:v2.10
-    command:
-      - '--api.insecure=true'
-      - '--providers.docker=true'
-      - '--providers.docker.exposedbydefault=false'
-      - '--entrypoints.web.address=:80'
-    ports:
-      - '80:80'
-      - '8090:8080'
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - web
 
   db:
     image: postgres:15.8
+    restart: always
+    container_name: latitude-llm-db
     ports:
       - '5432:5432'
     env_file:
       - .env
     volumes:
       - ./docker/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-      - ./docker/pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - web
 
   redis:
     image: redis
+    restart: always
+    container_name: latitude-llm-redis
     ports:
       - '6379:6379'
+    networks:
+      - web
 
   web-local:
     <<: *web-common
@@ -79,6 +165,8 @@ services:
   web:
     <<: *web-common
     image: ghcr.io/latitude-dev/web:latest
+    restart: always
+    container_name: latitude-llm-web
     platform: linux/amd64
 
   migrations-local:
@@ -96,7 +184,10 @@ services:
   migrations:
     <<: *common-service
     image: ghcr.io/latitude-dev/migrations:latest
+    container_name: latitude-llm-migrations
     platform: linux/amd64
+    labels:
+      - "traefik.enable=false"
     depends_on:
       - db
 
@@ -113,6 +204,8 @@ services:
   gateway:
     <<: *gateway-common
     image: ghcr.io/latitude-dev/gateway:latest
+    restart: always
+    container_name: latitude-llm-gateway
     platform: linux/amd64
 
   workers-local:
@@ -128,6 +221,8 @@ services:
   workers:
     <<: *common-service
     image: ghcr.io/latitude-dev/workers:latest
+    restart: always
+    container_name: latitude-llm-workers
     platform: linux/amd64
 
   websockets-local:
@@ -143,4 +238,14 @@ services:
   websockets:
     <<: *websockets-common
     image: ghcr.io/latitude-dev/websockets:latest
+    restart: always
+    container_name: latitude-llm-websockets
     platform: linux/amd64
+
+# You need to create external network for Traefik to work (docker network create web)
+networks:
+  web:
+    external: true
+
+volumes:
+  pgdata:

--- a/docs/guides/getting-started/quick-start.mdx
+++ b/docs/guides/getting-started/quick-start.mdx
@@ -40,6 +40,6 @@ For more detailed information on each step, explore our documentation or join ou
 
 ## Latitude Self-Hosted
 
-Follow the instructions in the [self-hosted guide](https://docs.latitude.so/self-hosted/production) to get started with Latitude Self-Hosted.
+Follow the instructions in the [self-hosted guide](https://docs.latitude.so/guides/self-hosted/production) to get started with Latitude Self-Hosted.
 
 After setting up Latitude Self-Hosted, you can follow the same steps as in the Latitude Cloud guide to create, test, evaluate, and deploy your prompts.

--- a/docs/guides/self-hosted/production.mdx
+++ b/docs/guides/self-hosted/production.mdx
@@ -37,7 +37,7 @@ Make sure this network is created before running the containers with  `docker co
 
 - **Traefik Settings**:
 
-  - `TRAEFIK_ACME_EMAIL`: Database credentials
+  - `TRAEFIK_ACME_EMAIL`: Email address used for Let's Encrypt ACME registration. Required for issuing and renewing SSL certificates. It is also used to receive expiration and renewal notifications.
   - `TRAEFIK_ADMIN_PASS`: Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
     Example command to generate a password for user admin:
     ```bash

--- a/docs/guides/self-hosted/production.mdx
+++ b/docs/guides/self-hosted/production.mdx
@@ -22,7 +22,27 @@ workers, websockets, database, and Redis.
 cp .env.example .env
 ```
 
-2. Configure your `.env` file with your production settings. The following key configurations are available:
+2. For proper functioning of the project, you need to create a Docker network named web. This network is used for communication between the various services, including Traefik.
+
+You can create the network using the following command:
+
+```bash
+docker network create web
+```
+
+Make sure this network is created before running the containers with  `docker compose`.
+
+
+3. Configure your `.env` file with your production settings. The following key configurations are available:
+
+- **Traefik Settings**:
+
+  - `TRAEFIK_ACME_EMAIL`: Database credentials
+  - `TRAEFIK_ADMIN_PASS`: Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
+    Example command to generate a password for user admin:
+    ```bash
+    echo $(htpasswd -nb admin password) | sed -e s/\\$/\\$\\$/g
+    ```
 
 - **Database Settings**:
 


### PR DESCRIPTION
Hello, I don't often make PRs to open-source repositories, so please don't judge me too harshly if something is wrong. :)

I encountered an issue when trying to deploy the project using Docker Compose in a production environment. The first thing I noticed was the insecure Traefik setup. Additionally, several required environment variables were missing from .env.example:

```bash
Invalid environment variables: {
  BULL_ADMIN_USER: [ 'Required' ],
  BULL_ADMIN_PASS: [ 'Required' ],
  MCP_NODE_GROUP_NAME: [ 'Required' ],
  MCP_DOCKER_IMAGE: [ 'Required' ],
  MCP_SCHEME: [ 'Required' ]
}
```
To address these issues, I propose an improved Docker Compose configuration, which includes:

Updated Traefik version with SSL certificates and FQDN support.
A complete .env.example file with required variables.
Corrections to documentation links for self-hosted production deployment.
Let me know if any adjustments are needed!
