### PR TITLE
minor: reduce latency for simpler agents

### DIFF
--- a/packages/core/src/services/agents/run.ts
+++ b/packages/core/src/services/agents/run.ts
@@ -22,6 +22,7 @@ export function runAgent<T extends boolean, C extends SomeChain>({
   configOverrides,
   promptSource,
   abortSignal,
+  isChain,
 }: RunChainArgs<T, C>) {
   const errorableUuid = generateUUID()
   const chainStartTime = Date.now()
@@ -54,6 +55,7 @@ export function runAgent<T extends boolean, C extends SomeChain>({
       removeSchema: true, // Removes the schema configuration for the AI generation, as it is reserved for the agent's Return function
       promptSource,
       abortSignal,
+      isChain,
     })
 
     const chainEventsReader = chainResult.stream.getReader()

--- a/packages/core/src/services/chains/run.ts
+++ b/packages/core/src/services/chains/run.ts
@@ -42,6 +42,7 @@ type CommonArgs<T extends boolean = true, C extends SomeChain = LegacyChain> = {
   source: LogSources
   promptlVersion: number
   chain: C
+  isChain?: boolean
   promptSource: PromptSource
   globalConfig: PromptConfig
 
@@ -83,6 +84,7 @@ export function runChain<T extends boolean, C extends SomeChain>({
   removeSchema = false,
   promptSource,
   abortSignal,
+  isChain = true,
 }: RunChainArgs<T, C>) {
   const errorableUuid = generateUUID()
   const chainStartTime = Date.now()
@@ -115,6 +117,7 @@ export function runChain<T extends boolean, C extends SomeChain>({
         newMessages,
         previousConfig: globalConfig,
         abortSignal,
+        injectAgentFinishTool: isChain === false,
       })
 
       resolveConversation(conversation)

--- a/packages/core/src/services/commits/RunDocumentChecker/index.ts
+++ b/packages/core/src/services/commits/RunDocumentChecker/index.ts
@@ -74,6 +74,7 @@ export class RunDocumentChecker {
             includeSourceMap: true,
           }),
           config: metadata.config,
+          isChain: true,
         })
       } else {
         const metadata = await scan({
@@ -97,6 +98,7 @@ export class RunDocumentChecker {
             includeSourceMap: true,
           }),
           config: metadata.config,
+          isChain: metadata.isChain,
         })
       }
     } catch (e) {

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -138,6 +138,7 @@ export async function runDocumentAtCommit({
     errorableType,
     workspace,
     chain: checkerResult.value.chain,
+    isChain: checkerResult.value.isChain,
     globalConfig: checkerResult.value.config as PromptConfig,
     promptlVersion: document.promptlVersion,
     providersMap,


### PR DESCRIPTION
When running an agent, the process goes like this: First, all steps from the original chain are executed in order, without allowing them to use the "finish" tool. Then, once the original chain has finished, the autonomous loop starts, with ability to use the "finish" tool.

This has been done to respect the chain workflow even when the prompt is an agent.

However, in simpler single-step prompts, it comes with an issue: It must first create an initial response (the one from the "chain" step) before being able to use the "finish" tool, essentially forcing the workflow to always run at least 2 steps. This adds unnecessary latency for the simpler agents.

This PR fixes this, enabling the chain to return the "finish" tool when it only contains 1 step and it is configured as an agent. Advanced Agent Optimization still suggests them to start a chain-of-thought, and follow the regular workflow, so the more complex prompts will still do multiple steps and therefore are not affected.