### PR TITLE
ts sdk: render agents and local tool management

### DIFF
--- a/docs/guides/sdk/typescript.mdx
+++ b/docs/guides/sdk/typescript.mdx
@@ -124,12 +124,11 @@ const response = await openai.chat.completions.create({
 })
 ```
 
-You can also execute [chains](/promptl/advanced/chains) by providing an `onStep` callback to the
-`renderChain` method, which will be called for each step of the chain to generate
-the corresponding response:
+To execute [chains](/promptl/advanced/chains) or [agents](/guides/prompt-manager/agents) locally, you can use the `renderChain` and `renderAgent` methods.
+In these cases, you must provide the `onStep` callback that will be called to generate the response for each step of the chain or agent.
 
 ```typescript
-await sdk.prompts.renderChain({
+const { messages } = await sdk.prompts.renderChain({
   prompt,
   parameters: {
     // Any parameters your prompt expects
@@ -146,9 +145,27 @@ await sdk.prompts.renderChain({
 })
 ```
 
+If your prompt contains tools, you can also provide callbacks for each tool with the `tools` argument, and they will be automatically called when the LLM invokes them.
+
+```typescript
+const { messages, result } = await sdk.prompts.renderAgent({
+  prompt,
+  parameters: {
+    // Any parameters your prompt expects
+  },
+  tools: {
+    get_weather: async ({ latitude, longitude }) => {
+      // your custom tool logic here
+      const temperature = await fetch(...)
+      return { temperature }
+    },
+  },
+})
+```
+
 <Note>
-  `render` and `renderChain` only work with the latest version of Latitude's
-  open source prompt syntax: [PromptL](https://promptl.ai/)
+  Make sure the tool definitions in the prompt match the function signatures you
+  provide, otherwise it may not work as expected.
 </Note>
 
 ### Run a prompt through Latitude Gateway
@@ -210,12 +227,19 @@ const response = await sdk.prompts.run<Tools>(documentPath, {
   stream: true,
   tools: {
     get_coordinates: async ({ location }) => {
-      const data = fetch('https://api.example.com/coordinates?location=' + location)
+      const data = fetch(
+        'https://api.example.com/coordinates?location=' + location,
+      )
       const { latitude, longitude } = await data.json()
       return { latitude, longitude }
     },
     get_weather: async ({ latitude, longitude }) => {
-      const data = fetch('https://api.example.com/weather?latitude=' + latitude + '&longitude=' + longitude)
+      const data = fetch(
+        'https://api.example.com/weather?latitude=' +
+          latitude +
+          '&longitude=' +
+          longitude,
+      )
       const { temperature } = await data.json()
       return { temperature }
     },
@@ -276,6 +300,7 @@ await sdk.logs.create('path/to/your/prompt', messages, {
 ```
 
 <Note>
-  Logs follow the [PromptL format](/promptl/getting-started/introduction).
-  If you're using a different method to run your prompts, you'll need to format your logs accordingly.
+  Logs follow the [PromptL format](/promptl/getting-started/introduction). If
+  you're using a different method to run your prompts, you'll need to format
+  your logs accordingly.
 </Note>

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "2.1.7",
+  "version": "2.2.0",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/sdks/typescript/src/utils/agents.ts
+++ b/packages/sdks/typescript/src/utils/agents.ts
@@ -1,0 +1,30 @@
+import { AGENT_RETURN_TOOL_NAME } from '@latitude-data/constants'
+import { Config } from 'promptl-ai'
+
+export function injectAgentFinishTool(config: Config) {
+  const { schema, tools, ...rest } = config
+
+  const toolSchema = schema ?? {
+    type: 'object',
+    properties: {
+      response: {
+        type: 'string',
+        description:
+          'The final output or answer to the user or calling system.',
+      },
+    },
+    required: ['response'],
+  }
+
+  return {
+    ...rest,
+    tools: {
+      ...(tools ?? {}),
+      [AGENT_RETURN_TOOL_NAME]: {
+        description:
+          'This tool acts as the final step in your agentic workflow, used to return the final output or answer to the user or calling system. Until this tool is called, you are part of an autonomous workflow, generating infinite messages in a loop.',
+        parameters: toolSchema,
+      },
+    },
+  }
+}

--- a/packages/sdks/typescript/src/utils/types.ts
+++ b/packages/sdks/typescript/src/utils/types.ts
@@ -152,6 +152,13 @@ export type ToolCallDetails = {
   pauseExecution: () => void
 }
 
+type RenderToolCallDetails = {
+  toolId: string
+  toolName: string
+  requestedToolCalls: ToolCall[]
+  messages: Message[]
+}
+
 export type ToolSpec = Record<string, Record<string, unknown>>
 export type ToolHandler<T extends ToolSpec, K extends keyof T> = (
   toolCall: T[K],
@@ -159,6 +166,14 @@ export type ToolHandler<T extends ToolSpec, K extends keyof T> = (
 ) => Promise<unknown>
 export type ToolCalledFn<Tools extends ToolSpec> = {
   [K in keyof Tools]: ToolHandler<Tools, K>
+}
+
+export type RenderToolHandler<T extends ToolSpec, K extends keyof T> = (
+  toolCall: T[K],
+  details: RenderToolCallDetails,
+) => Promise<string | Omit<PromptlMessage, 'role'> | PromptlMessage[]>
+export type RenderToolCalledFn<Tools extends ToolSpec> = {
+  [K in keyof Tools]: RenderToolHandler<Tools, K>
 }
 
 export type SdkApiVersion = 'v1' | 'v2' | 'v3'
@@ -211,6 +226,7 @@ export type RenderChainOptions<M extends AdapterMessageType = PromptlMessage> =
       config: Config
       messages: M[]
     }) => Promise<string | Omit<M, 'role'>>
+    tools?: RenderToolCalledFn<ToolSpec>
     logResponses?: boolean
   }
 


### PR DESCRIPTION
Added a new `renderAgent` method to run a prompt locally with agentic behaviour. It automatically injects a custom tool, and manages its request to stop the loop.

Additionally, added a new `tools` parameter to both `renderChain` and `renderAgent` to include tool execution management. Before this, the user had no way at all of handling tool calls, not even manually!