### PR TITLE
Using local and s3 storage in docker compose setup #1026

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,11 +55,13 @@ SENTRY_PROJECT=
 DRIVE_DISK=local # options: local, s3
 
 # Paths for local storage (optional)
-FILE_PUBLIC_PATH= # e.g files
-FILES_STORAGE_PATH= # e.g /app/storage/files
-PUBLIC_FILES_STORAGE_PATH= # e.g /app/storage/public/files (IMPORTANT: has to be in nextjs's public folder)
+FILE_STORAGE_ROOT_PATH="/app/storage/files" # e.g /app/storage/files
+FILE_PUBLIC_PATH="files" # e.g files
+FILES_STORAGE_PATH="/app/storage/files" # e.g /app/storage/files
+PUBLIC_FILES_STORAGE_PATH="/app/apps/web/public/files" # e.g /app/storage/public/files (IMPORTANT: has to be in nextjs's public folder)
 
 # AWS S3 (optional)
+# If you are using AWS IAM roles, you can skip AWS_ACCESS_KEY and AWS_ACCESS_SECRET
 ASW_REGION=
 AWS_ACCESS_KEY=
 AWS_ACCESS_SECRET=

--- a/apps/gateway/docker/Dockerfile
+++ b/apps/gateway/docker/Dockerfile
@@ -87,6 +87,7 @@ RUN apk add --no-cache \
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 latitude
 # Set permissions for local storage
+# User ID and Group ID 1001 is used to match the user 'latitude' and group 'nodejs' in the builder image.
 RUN set -e; \
     mkdir -p /app/storage/files; \
     mkdir -p /app/apps/web/public/files; \

--- a/apps/gateway/docker/Dockerfile
+++ b/apps/gateway/docker/Dockerfile
@@ -86,6 +86,11 @@ RUN apk add --no-cache \
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 latitude
+# Set permissions for local storage
+RUN set -e; \
+    mkdir -p /app/storage/files; \
+    mkdir -p /app/apps/web/public/files; \
+    chown -R 1001:1001 /app/storage/files /app/apps/web/public/files
 USER latitude
 
 WORKDIR /app

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -157,6 +157,7 @@ COPY --from=builder --chown=nodejs:nextjs /app/apps/web/.next/static ./apps/web/
 COPY --from=builder --chown=nodejs:nextjs /app/node_modules ./node_modules
 COPY --from=builder --chown=nodejs:nextjs /app/apps/web/node_modules ./apps/web/node_modules
 # Set permissions for local storage
+# User ID and Group ID 1001 is used to match the user 'nextjs' and group 'nodejs' in the runner image.
 RUN set -e; \
     mkdir -p /app/storage/files; \
     mkdir -p /app/apps/web/public/files; \

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -156,6 +156,11 @@ COPY --from=builder --chown=nodejs:nextjs /app/apps/web/.next/static ./apps/web/
 # Copy all node_modules to ensure dependencies are available
 COPY --from=builder --chown=nodejs:nextjs /app/node_modules ./node_modules
 COPY --from=builder --chown=nodejs:nextjs /app/apps/web/node_modules ./apps/web/node_modules
+# Set permissions for local storage
+RUN set -e; \
+    mkdir -p /app/storage/files; \
+    mkdir -p /app/apps/web/public/files; \
+    chown -R 1001:1001 /app/storage/files /app/apps/web/public/files
 
 USER nextjs
 

--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -74,6 +74,11 @@ RUN apk add --no-cache \
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 latitude
+# Set permissions for local storage
+RUN set -e; \
+    mkdir -p /app/storage/files; \
+    mkdir -p /app/apps/web/public/files; \
+    chown -R 1001:1001 /app/storage/files /app/apps/web/public/files
 USER latitude
 
 WORKDIR /app

--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -75,6 +75,7 @@ RUN apk add --no-cache \
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 latitude
 # Set permissions for local storage
+# User ID and Group ID 1001 is used to match the user 'latitude' and group 'nodejs' in the runner image.
 RUN set -e; \
     mkdir -p /app/storage/files; \
     mkdir -p /app/apps/web/public/files; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,8 +171,6 @@ services:
     restart: always
     container_name: latitude-llm-web
     platform: linux/amd64
-    profiles:
-      - default
 
   migrations-local:
     <<: *common-service
@@ -196,8 +194,6 @@ services:
       - "traefik.enable=false"
     depends_on:
       - db
-    profiles:
-      - default
 
   gateway-local:
     <<: *gateway-common
@@ -214,8 +210,6 @@ services:
     restart: always
     container_name: latitude-llm-gateway
     platform: linux/amd64
-    profiles:
-      - default
 
   workers-local:
     <<: *common-service
@@ -232,8 +226,6 @@ services:
     restart: always
     container_name: latitude-llm-workers
     platform: linux/amd64
-    profiles:
-      - default
 
   websockets-local:
     <<: *websockets-common
@@ -250,8 +242,6 @@ services:
     restart: always
     container_name: latitude-llm-websockets
     platform: linux/amd64
-    profiles:
-      - default
 
 # You need to create external network for Traefik to work (docker network create web)
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 x-common-service: &common-service
   env_file:
     - .env
+  volumes:
+    - shared-storage:/app/storage/files:rw
+    - shared-storage:/app/apps/web/public/files:rw
   depends_on:
     - db
     - redis
@@ -168,6 +171,8 @@ services:
     restart: always
     container_name: latitude-llm-web
     platform: linux/amd64
+    profiles:
+      - default
 
   migrations-local:
     <<: *common-service
@@ -175,7 +180,8 @@ services:
     build:
       context: .
       dockerfile: packages/core/docker/Dockerfile
-
+    labels:
+      - "traefik.enable=false"
     depends_on:
       - db
     profiles:
@@ -190,6 +196,8 @@ services:
       - "traefik.enable=false"
     depends_on:
       - db
+    profiles:
+      - default
 
   gateway-local:
     <<: *gateway-common
@@ -197,7 +205,6 @@ services:
     build:
       context: .
       dockerfile: apps/gateway/docker/Dockerfile
-
     profiles:
       - local
 
@@ -207,6 +214,8 @@ services:
     restart: always
     container_name: latitude-llm-gateway
     platform: linux/amd64
+    profiles:
+      - default
 
   workers-local:
     <<: *common-service
@@ -214,7 +223,6 @@ services:
     build:
       context: .
       dockerfile: apps/workers/docker/Dockerfile
-
     profiles:
       - local
 
@@ -224,6 +232,8 @@ services:
     restart: always
     container_name: latitude-llm-workers
     platform: linux/amd64
+    profiles:
+      - default
 
   websockets-local:
     <<: *websockets-common
@@ -231,7 +241,6 @@ services:
     build:
       context: .
       dockerfile: apps/websockets/docker/Dockerfile
-
     profiles:
       - local
 
@@ -241,8 +250,13 @@ services:
     restart: always
     container_name: latitude-llm-websockets
     platform: linux/amd64
+    profiles:
+      - default
 
 # You need to create external network for Traefik to work (docker network create web)
 networks:
   web:
     external: true
+
+volumes:
+  shared-storage:

--- a/docs/guides/self-hosted/production.mdx
+++ b/docs/guides/self-hosted/production.mdx
@@ -71,7 +71,67 @@ Make sure this network is created before running the containers with  `docker co
 - **Storage Configuration**:
 
   - `DRIVE_DISK`: Choose between `local` or `s3` for file storage
-  - AWS S3 credentials (if using S3 storage)
+    1. `local` file storage configuration:
+      - Files are stored locally on the host machine using Docker volumes.
+      - Default variables used:
+
+        ```bash
+        # Paths for local storage (optional)
+        FILE_STORAGE_ROOT_PATH="/app/storage/files" # e.g /app/storage/files
+        FILE_PUBLIC_PATH="files" # e.g files
+        FILES_STORAGE_PATH="/app/storage/files" # e.g /app/storage/files
+        PUBLIC_FILES_STORAGE_PATH="/app/apps/web/public/files" # e.g /app/storage/public/files (IMPORTANT: has to be in nextjs's public folder)
+        ```
+
+    2. `s3` AWS S3 storage configuration:
+      - With environment variables (for convenience/legacy):
+        You explicitly provide AWS credentials (AWS_ACCESS_KEY and AWS_ACCESS_SECRET) via .env file.
+        Required variables:
+
+        ```bash
+        AWS_ACCESS_KEY=your-access-key-here
+        AWS_ACCESS_SECRET=your-secret-here
+        AWS_REGION=us-east-1
+        S3_BUCKET=app-files-bucket
+        PUBLIC_S3_BUCKET=public-files-bucket
+        ```
+      - AWS S3 with IAM Roles (recommended):
+        No explicit AWS keys needed!
+        Use IAM Roles attached to your AWS services (ECS, EC2, Lambda).
+        Ensure AWS resource has proper IAM Role with S3 access (GetObject, PutObject, DeleteObject).
+        Only required environment variables (no keys explicitly stored):
+
+        ```bash
+        AWS_REGION=us-east-1
+        S3_BUCKET=app-files-bucket
+        PUBLIC_S3_BUCKET=public-files-bucket
+        ```
+        How to configure IAM Role (example):
+        1. Go to AWS IAM → Create Role.
+        2. Select trusted entity type (e.g., AWS Service).
+        3. Attach policy that allows access to required S3 buckets.
+
+        ```json
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Action": [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:DeleteObject",
+              "s3:ListBucket"
+            ],
+            "Resource": [
+              "arn:aws:s3:::your-bucket-name-here",
+              "arn:aws:s3:::your-bucket-name-here/*"
+            ]
+          }]
+        }
+        ```
+        4. Attach this IAM role to AWS infrastructure (EC2 Instance / ECS Task Definition / Lambda function).
+
+        AWS SDK automatically handles credentials from attached IAM roles.
 
 - **Optional Features**:
   - Sentry integration for error tracking

--- a/packages/core/src/lib/disk.ts
+++ b/packages/core/src/lib/disk.ts
@@ -27,12 +27,11 @@ function getAwsConfig() {
   const bucket = env.S3_BUCKET
   const publicBucket = env.PUBLIC_S3_BUCKET
   const region = env.AWS_REGION
-  
-  if (!bucket || !publicBucket || !region) {
+
+  if (!bucket || !publicBucket || !region)
     throw new Error(
-      '(PUBLIC)_S3_BUCKET and AWS_REGION variables are required.',
+      `Missing required AWS configuration variables: ${[!bucket && 'S3_BUCKET', !publicBucket && 'PUBLIC_S3_BUCKET', !region && 'AWS_REGION'].filter(Boolean).join(', ')}.`,
     )
-  }
 
   const accessKeyId = env.AWS_ACCESS_KEY
   const secretAccessKey = env.AWS_ACCESS_SECRET

--- a/packages/core/src/lib/disk.ts
+++ b/packages/core/src/lib/disk.ts
@@ -109,26 +109,20 @@ export class DiskWrapper {
 
   async putStream(key: string, contents: Readable, options?: WriteOptions) {
     try {
-      console.log(`Uploading file: key=${key}, contentLength=${contents.readableLength}`)
-  
       await this.disk.putStream(key, contents, {
         ...options,
         contentLength: contents.readableLength,
       })
-  
-      console.log(`Successfully uploaded: key=${key}`)
       return Result.nil()
     } catch (e) {
-      console.error(`Error uploading file: key=${key}`, e)
-  
       if (e instanceof errors.E_CANNOT_WRITE_FILE) {
         return Result.error(new Error('Cannot write file'))
       }
-  
-      return Result.error(e as Error)
+
+      const error = e as Error
+      return Result.error(error)
     }
   }
-  
 
   async delete(key: string | null | undefined) {
     if (!key) return Result.nil()

--- a/packages/core/src/lib/disk.ts
+++ b/packages/core/src/lib/disk.ts
@@ -38,7 +38,6 @@ function getAwsConfig() {
   const secretAccessKey = env.AWS_ACCESS_SECRET
 
   if (accessKeyId && secretAccessKey) {
-    // Используем заданные ключи доступа
     return {
       region,
       bucket,
@@ -47,12 +46,11 @@ function getAwsConfig() {
     }
   }
 
-  // Если ключи не заданы — подразумеваем IAM-роль
+  // If AWS_ACCESS_KEY and AWS_ACCESS_SECRET are not set, the SDK will use AWS IAM role.
   return {
     region,
     bucket,
     publicBucket,
-    // не передаем credentials
   }
 }
 


### PR DESCRIPTION
This PR enhances our storage capabilities and adds support for IAM roles in AWS environments.

### What was changed:
- **IAM role support for S3**: Made AWS credentials in S3 storage optional to allow the use of IAM roles instead of plain keys and secrets.
- **Docker Compose adjustments**: Added shared-storage volumes to docker-compose configuration:

```yaml
volumes:
  - shared-storage:/app/storage/files:rw 
  - shared-storage:/app/apps/web/public/files:rw
```
- **Dockerfile permissions**: Adjusted Dockerfile to create directories and set proper ownership and permissions to ensure local storage directories are writable by the running application:

```bash
RUN set -e; \
        mkdir -p /app/storage/files; \
        mkdir -p /app/apps/web/public/files; \
        chown -R 1001:1001 /app/storage/files /app/apps/web/public/files
```

### Why it was changed:
To improve security by leveraging IAM roles in AWS environments instead of embedding sensitive credentials.
To enable seamless and consistent local storage use with proper volume management and file permissions.

Closes #1026

I have read the CLA Document and I hereby sign the CLA