### PR TITLE
Run email triggers in jobs

### DIFF
--- a/packages/core/src/jobs/constants.ts
+++ b/packages/core/src/jobs/constants.ts
@@ -34,6 +34,7 @@ export enum Jobs {
   autoScaleJob = 'autoScaleJob',
   updateMcpServerLastUsedJob = 'updateMcpServerLastUsedJob',
   scaleDownMcpServerJob = 'scaleDownMcpServerJob',
+  runEmailTriggerJob = 'runEmailTriggerJob',
 }
 
 export const QUEUES = {
@@ -53,6 +54,7 @@ export const QUEUES = {
       'requestDocumentSuggestionsJob',
       'checkScheduledDocumentTriggersJob',
       'processScheduledTriggerJob',
+      'runEmailTriggerJob',
     ],
   },
   [Queues.maintenanceQueue]: {

--- a/packages/core/src/jobs/job-definitions/documentTriggers/index.ts
+++ b/packages/core/src/jobs/job-definitions/documentTriggers/index.ts
@@ -1,4 +1,9 @@
 import { checkScheduledDocumentTriggersJob } from './checkScheduledDocumentTriggersJob'
 import { processScheduledTriggerJob } from './processScheduledTriggerJob'
+import { runEmailTriggerJob } from './runEmailTriggerJob'
 
-export { checkScheduledDocumentTriggersJob, processScheduledTriggerJob }
+export {
+  checkScheduledDocumentTriggersJob,
+  processScheduledTriggerJob,
+  runEmailTriggerJob,
+}

--- a/packages/core/src/jobs/job-definitions/documentTriggers/runEmailTriggerJob/index.ts
+++ b/packages/core/src/jobs/job-definitions/documentTriggers/runEmailTriggerJob/index.ts
@@ -1,0 +1,120 @@
+import { Job } from 'bullmq'
+import { EMAIL_TRIGGER_DOMAIN } from '@latitude-data/constants'
+import { PromptLFile } from 'promptl-ai'
+import { unsafelyFindWorkspace } from '../../../../data-access'
+import { DocumentTrigger, HEAD_COMMIT, Workspace } from '../../../../browser'
+import {
+  DocumentTriggersRepository,
+  DocumentVersionsRepository,
+} from '../../../../repositories'
+import { getEmailResponse } from './getResponse'
+import { EmailTriggerConfiguration } from '../../../../services/documentTriggers/helpers/schema'
+import { LatitudeError, PromisedResult, Result } from '../../../../lib'
+import { DocumentTriggerMailer } from '../../../../mailers'
+
+export type RunEmailTriggerJobData = {
+  workspaceId: number
+  triggerId: number
+  recipient: string
+  senderEmail: string
+  senderName: string | undefined
+  messageId?: string
+  parentMessageIds?: string[]
+  subject: string
+  body: string
+  attachments: PromptLFile[]
+}
+
+async function getTriggerName(
+  trigger: DocumentTrigger,
+): PromisedResult<string, LatitudeError> {
+  const configName = (
+    trigger.configuration as EmailTriggerConfiguration
+  ).name?.trim()
+  if (configName?.length) {
+    return Result.ok(configName)
+  }
+
+  const docsScope = new DocumentVersionsRepository(trigger.workspaceId)
+  const documentResult = await docsScope.getDocumentAtCommit({
+    projectId: trigger.projectId,
+    commitUuid: HEAD_COMMIT,
+    documentUuid: trigger.documentUuid,
+  })
+  if (documentResult.error) return documentResult
+
+  const document = documentResult.unwrap()
+  const docName = document.path.split('/').pop()!
+  return Result.ok(docName)
+}
+
+export const runEmailTriggerJob = async (job: Job<RunEmailTriggerJobData>) => {
+  const {
+    workspaceId,
+    triggerId,
+    senderEmail,
+    senderName,
+    messageId,
+    parentMessageIds,
+    subject,
+    body,
+    attachments,
+  } = job.data
+
+  const workspace = (await unsafelyFindWorkspace(workspaceId)) as Workspace
+
+  const triggerScope = new DocumentTriggersRepository(workspace.id)
+  const triggerResult = await triggerScope.find(triggerId)
+  const trigger = triggerResult.unwrap()
+
+  const nameResult = await getTriggerName(trigger)
+  const name = nameResult.unwrap()
+
+  const responseResult = await getEmailResponse({
+    documentUuid: trigger.documentUuid,
+    trigger,
+    messageId,
+    parentMessageIds,
+    senderEmail,
+    senderName,
+    subject,
+    body,
+    attachments,
+  })
+
+  const configuration = trigger.configuration as EmailTriggerConfiguration
+  if (configuration.replyWithResponse === false) {
+    return
+  }
+
+  const from = `${JSON.stringify(name)} <${trigger.documentUuid}@${EMAIL_TRIGGER_DOMAIN}>`
+
+  const references = [
+    ...(parentMessageIds ?? []),
+    ...(messageId ? [messageId] : []),
+  ].join(' ')
+
+  const headers = messageId
+    ? {
+        'In-Reply-To': messageId,
+        References: references,
+        // It seems like nodemailer-mailgun-transport is ignoring the "References" header.
+        // Maybe some of these will work:
+        'X-Mailgun-References': references,
+        'h:References': references,
+        'h:X-Mailgun-References': references,
+      }
+    : undefined
+
+  const mailer = new DocumentTriggerMailer(responseResult, {
+    to: senderEmail,
+    from,
+    inReplyTo: messageId,
+    references,
+    subject: 'Re: ' + subject,
+    headers,
+  })
+
+  const result = await mailer.send()
+  result.unwrap()
+}


### PR DESCRIPTION
Mailgun is re-triggering the webhook because it is not receiving a successful response in time (the request probably times out).

I moved the execution logic to a dedicated job. When the webhook is received, we just validate the info required to run the prompt, enqueue the job, and then return a successful response. This way the document is executed in the background and Mailgun is happy.