### PR TITLE
fix: errors from deleted prompts

### DIFF
--- a/packages/core/src/services/documents/recomputeChanges/index.ts
+++ b/packages/core/src/services/documents/recomputeChanges/index.ts
@@ -78,7 +78,7 @@ async function resolveDocumentChanges({
           referenceFn: getDocumentContent,
           configSchema,
         })
-        if (metadata.errors.length > 0) {
+        if (!d.deletedAt && metadata.errors.length > 0) {
           errors[d.documentUuid] = metadata.errors
         }
 
@@ -95,7 +95,7 @@ async function resolveDocumentChanges({
         configSchema,
       })
 
-      if (metadata.errors.length > 0) {
+      if (!d.deletedAt && metadata.errors.length > 0) {
         errors[d.documentUuid] = metadata.errors as CompileError[]
       }
 


### PR DESCRIPTION
If a prompt is deleted in a draft and it contained errors, the draft cannot be published because "a prompt contains errors" (but this prompt has been deleted...)

Steps to reproduce:
 - Create a prompt "a"
 - Create a prompt "b", importing "a".
 - Publish the version
 - Create a new draft
 - Rename the prompt "a" to something else. Now the prompt "b" contains errors because the import is wrong.
 - Delete the prompt "b"
 - Try to publish