### PR TITLE
Replace Chart curve type

### DIFF
--- a/packages/web-ui/src/ds/molecules/Charts/AreaChart/index.tsx
+++ b/packages/web-ui/src/ds/molecules/Charts/AreaChart/index.tsx
@@ -23,8 +23,13 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '../../../atoms/Charts'
+import { CurveType } from 'recharts/types/shape/Curve'
 
-export function AreaChart({ config }: { config: AreaChartConfig }) {
+export function AreaChart({
+  config: { curveType, ...config },
+}: {
+  config: AreaChartConfig & { curveType?: CurveType }
+}) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [dimensions, setDimensions] = useState<{
     width: number
@@ -179,7 +184,7 @@ export function AreaChart({ config }: { config: AreaChartConfig }) {
         )}
         <Area
           dataKey='y'
-          type='natural'
+          type={curveType ?? 'linear'}
           stroke={color}
           fill='url(#chartGradient)'
           data={config.data}


### PR DESCRIPTION
Added a `curveType` option to the chart config, which defaults to `linear`.

Other interesting curve types:
![image](https://github.com/user-attachments/assets/d4fb2745-45c7-4c99-adf5-d7e97d543360)
