### PR TITLE
Pass to Vercel SKD providerOptions when calling streamText or streamObject

### DIFF
--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -133,7 +133,7 @@ export async function ai({
     }
 
     const { provider: providerType, token: apiKey, url } = provider
-    const config = rule.config as VercelConfig
+    const config = rule.config
     const messages = rule.messages
     const model = config.model
     const tools = config.tools
@@ -159,13 +159,15 @@ export async function ai({
     const toolsResult = buildTools(tools)
     if (toolsResult.error) return toolsResult
 
+    const schemaLessConfig = omit(config, ['schema'])
     const commonOptions = {
-      ...omit(config, ['schema']),
+      ...schemaLessConfig,
       model: languageModel,
       prompt,
       messages: messages as CoreMessage[],
       tools: toolsResult.value,
       abortSignal,
+      providerOptions: config.providerOptions,
       experimental_telemetry: {
         isEnabled: true,
       },

--- a/packages/core/src/services/ai/providers/rules/VertexAnthropic.test.ts
+++ b/packages/core/src/services/ai/providers/rules/VertexAnthropic.test.ts
@@ -1,14 +1,13 @@
 import { type Message, MessageRole } from '@latitude-data/compiler'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
-import { ProviderRules } from './types'
+import { AppliedRules, ProviderRules } from './types'
 import { applyProviderRules } from './index'
 
 const providerType = Providers.AnthropicVertex
 
-let config = {} as PartialConfig
+let config = {} as AppliedRules['config']
 let messages: Message[]
 describe('applyAnthropicRules', () => {
   describe('with system messages not at the beggining', () => {

--- a/packages/core/src/services/ai/providers/rules/anthropic.test.ts
+++ b/packages/core/src/services/ai/providers/rules/anthropic.test.ts
@@ -1,14 +1,13 @@
 import { type Message, MessageRole } from '@latitude-data/compiler'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
-import { ProviderRules } from './types'
+import { AppliedRules, ProviderRules } from './types'
 import { applyProviderRules } from '.'
 
 const providerType = Providers.Anthropic
 
-let config = {} as PartialConfig
+let config = {} as AppliedRules['config']
 let messages: Message[]
 describe('applyAnthropicRules', () => {
   describe('with system messages not at the beggining', () => {

--- a/packages/core/src/services/ai/providers/rules/custom.test.ts
+++ b/packages/core/src/services/ai/providers/rules/custom.test.ts
@@ -2,8 +2,9 @@ import type { Message } from '@latitude-data/compiler'
 import { describe, expect, it } from 'vitest'
 
 import { applyCustomRules } from './custom'
-import { ProviderRules } from './types'
+import { AppliedRules, ProviderRules } from './types'
 
+let config = {} as AppliedRules['config']
 describe('applyCustomRules', () => {
   it('not warns when no rules are violated', () => {
     const messages = [
@@ -52,7 +53,7 @@ describe('applyCustomRules', () => {
     ] as Message[]
 
     const rules = applyCustomRules({
-      config: {},
+      config,
       messages: messages,
       rules: [],
     })
@@ -113,7 +114,7 @@ describe('applyCustomRules', () => {
     const rules = applyCustomRules({
       rules: [],
       messages,
-      config: {},
+      config,
     })
 
     expect(rules).toEqual({
@@ -191,7 +192,7 @@ describe('applyCustomRules', () => {
     const rules = applyCustomRules({
       rules: [],
       messages,
-      config: {},
+      config,
     })
 
     expect(rules).toEqual({
@@ -256,7 +257,7 @@ describe('applyCustomRules', () => {
     const rules = applyCustomRules({
       rules: [],
       messages,
-      config: {},
+      config,
     })
 
     expect(rules).toEqual({

--- a/packages/core/src/services/ai/providers/rules/google.test.ts
+++ b/packages/core/src/services/ai/providers/rules/google.test.ts
@@ -1,14 +1,13 @@
 import type { Message } from '@latitude-data/compiler'
 import { beforeAll, describe, expect, it } from 'vitest'
 
-import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
-import { ProviderRules } from './types'
+import { AppliedRules, ProviderRules } from './types'
 import { applyProviderRules } from '.'
 
 const providerType = Providers.Google
 
-let config = {} as PartialConfig
+let config = {} as AppliedRules['config']
 let messages: Message[]
 describe('applyGoogleRules', () => {
   describe('with system messages not at the beggining', () => {

--- a/packages/core/src/services/ai/providers/rules/index.test.ts
+++ b/packages/core/src/services/ai/providers/rules/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { applyAllRules } from './index'
+import { Providers } from '@latitude-data/constants'
+
+describe('rules', () => {
+  it('add providerOptions to rules config', () => {
+    expect(
+      applyAllRules({
+        providerType: Providers.Anthropic,
+        messages: [],
+        config: {
+          model: 'claude-3-7-sonnet-latest',
+          thinking: { type: 'enabled', budgetTokens: 1024 },
+        },
+      }),
+    ).toEqual({
+      rules: [
+        {
+          rule: 'anthropic',
+          ruleMessage:
+            'Only system messages are present. You at least need one <user>your message</user> or <assistant>your message</assistant> in Anthropic.',
+        },
+      ],
+      messages: [],
+      config: {
+        model: 'claude-3-7-sonnet-latest',
+        thinking: { type: 'enabled', budgetTokens: 1024 },
+        providerOptions: {
+          anthropic: {
+            model: 'claude-3-7-sonnet-latest',
+            thinking: { type: 'enabled', budgetTokens: 1024 },
+          },
+        },
+      },
+    })
+  })
+})

--- a/packages/core/src/services/ai/providers/rules/openai.test.ts
+++ b/packages/core/src/services/ai/providers/rules/openai.test.ts
@@ -1,13 +1,12 @@
 import { type Message, MessageRole } from '@latitude-data/compiler'
 import { describe, expect, it } from 'vitest'
 
-import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
-import { ProviderRules } from './types'
+import { AppliedRules, ProviderRules } from './types'
 import { applyProviderRules } from '.'
 
 let model = 'o1-mini'
-let config = { model } as PartialConfig
+let config = { model } as AppliedRules['config']
 describe('applyOpenAIRules', () => {
   it('Warns when model is in the o1 family and has system messages', () => {
     const messages = [
@@ -60,7 +59,7 @@ describe('applyOpenAIRules', () => {
 
   it('does not warn when model official o1', () => {
     model = 'o1'
-    config = { model } as PartialConfig
+    config = { model } as AppliedRules['config']
 
     const messages = [
       {
@@ -84,7 +83,7 @@ describe('applyOpenAIRules', () => {
 
   it('does not warn when model is not in the o1 family', () => {
     model = 'gpt-3.5-turbo'
-    config = { model } as PartialConfig
+    config = { model } as AppliedRules['config']
 
     const messages = [
       {

--- a/packages/core/src/services/ai/providers/rules/types.ts
+++ b/packages/core/src/services/ai/providers/rules/types.ts
@@ -1,4 +1,5 @@
 import type { Config, Message } from '@latitude-data/compiler'
+import { PartialConfig } from '../../helpers'
 
 export enum ProviderRules {
   Anthropic = 'anthropic',
@@ -16,8 +17,14 @@ export enum ProviderRules {
 
 type ProviderRule = { rule: ProviderRules; ruleMessage: string }
 
+type AnyConfig = Config | PartialConfig
 export type AppliedRules = {
   rules: ProviderRule[]
   messages: Message[]
-  config: Config
+  config: AnyConfig & {
+    // This is here because provider configs are not typed
+    // in Vercel SDK so we don't exactly what are passed.
+    // We just pass everything under `config.providerOptions[NAME_OF_PROVIDER]`
+    [key: string]: unknown
+  }
 }

--- a/packages/core/src/services/ai/providers/rules/vercel.test.ts
+++ b/packages/core/src/services/ai/providers/rules/vercel.test.ts
@@ -1,12 +1,12 @@
 import type { Message } from '@latitude-data/compiler'
 import { describe, expect, it } from 'vitest'
 
-import { PartialConfig } from '../../helpers'
 import { Providers } from '../models'
 import { vercelSdkRules } from './vercel'
+import { AppliedRules } from './types'
 
 let messages: Message[]
-let config = {} as PartialConfig
+let config = {} as AppliedRules['config']
 
 describe('applyVercelSdkRules', () => {
   it('modify plain text messages to object', () => {


### PR DESCRIPTION
# What?
With a prompt like this
```yaml
---
provider: anthropic
model: claude-3-7-sonnet-latest
temperature: 0.1
---

<step 
  model="claude-3-7-sonnet-latest" 
  provider="anthropic" 
  thinking={{ { 
    type: 'enabled', 
    budgetTokens: 1024
    } 
  }} 
  maxTokens={{30000}}
>
  <user>
    Your prompt here...
  </user>
</step>
```

We were not propagating `thinking` attribute to anthropic. as explained in [Vercel SDK docs](https://github.com/vercel/ai/blob/main/content/docs/02-guides/20-sonnet-3-7.mdx#reasoning-ability). Now we are sending it. 