### PR TITLE
Include agentResponse in returned object from sdk

### DIFF
--- a/apps/gateway/src/presenters/runPresenter.ts
+++ b/apps/gateway/src/presenters/runPresenter.ts
@@ -5,6 +5,7 @@ import {
   ChainStepObjectResponse,
   ChainStepTextResponse,
   RunSyncAPIResponse,
+  extractAgentToolCalls,
 } from '@latitude-data/constants'
 import { ToolCall } from '@latitude-data/compiler'
 
@@ -63,11 +64,14 @@ export function runPresenter({
     return Result.error(error)
   }
 
+  const [agentTools, toolRequests] = extractAgentToolCalls(toolCalls)
+
   const type = response.streamType
   return Result.ok({
     uuid: uuid!,
     conversation: conversation!,
-    toolRequests: toolCalls,
+    toolRequests,
+    agentResponse: agentTools[0]?.arguments,
     response: {
       streamType: type,
       usage: response.usage!,

--- a/docs/guides/sdk/typescript.mdx
+++ b/docs/guides/sdk/typescript.mdx
@@ -206,6 +206,36 @@ await sdk.prompts.run('path/to/your/prompt', {
 })
 ```
 
+#### Running agents
+
+Running an agent through Latitude's Gateway is works in the same way as
+running a prompt! In this case, however, the returned object will contain the
+`agentResponse` property, which contains the agent's response.
+
+```typescript
+const result = await sdk.prompts.run('path/to/your/agent', {
+  projectId,
+  parameters: {
+    my_location: 'Barcelona and Miami',
+    other_location: 'Boston',
+  },
+  versionUuid: commitUuid,
+  stream: true,
+})
+
+console.log('??', result.agentResponse)
+```
+
+The `agentResponse` property will always be defined when the prompt is an agent,
+and it will contain the agent's response as an object. The structure of the
+response will depend on the agent's configuration, although by default it looks
+like this:
+```json
+{
+  "response": "Your agent's response"
+}
+```
+
 #### Running a prompt with tools
 
 When you run a prompt with tools, you can define and supply the corresponding

--- a/packages/constants/src/ai.ts
+++ b/packages/constants/src/ai.ts
@@ -212,6 +212,7 @@ export type RunSyncAPIResponse = {
   conversation: Message[]
   toolRequests: ToolCall[]
   response: ChainCallResponseDto
+  agentResponse?: { response: string } | Record<string, unknown>
 }
 
 export type ChatSyncAPIResponse = RunSyncAPIResponse

--- a/packages/constants/src/helpers.ts
+++ b/packages/constants/src/helpers.ts
@@ -1,11 +1,13 @@
 import { z } from 'zod'
 import { AgentToolsMap } from '.'
 import {
+  AGENT_RETURN_TOOL_NAME,
   LATITUDE_TOOLS_CONFIG_NAME,
   LatitudeTool,
   MAX_STEPS_CONFIG_NAME,
   ParameterType,
 } from './config'
+import { ToolCall } from '@latitude-data/compiler'
 
 export function resolveRelativePath(refPath: string, from?: string): string {
   if (refPath.startsWith('/')) {
@@ -212,3 +214,25 @@ const jsonSchema: z.ZodType<any> = z.lazy(() =>
     $ref: z.string().optional(), // Reference to another schema
   }),
 )
+
+/**
+ * From a list of tool calls, extracts all agent finish tool calls and returns
+ * and array with the following structure:
+ *
+ * @returns [agentToolCalls, otherToolCalls]
+ */
+export function extractAgentToolCalls(
+  toolCalls: ToolCall[],
+): [ToolCall[], ToolCall[]] {
+  return toolCalls.reduce(
+    (acc, tool) => {
+      if (tool.name === AGENT_RETURN_TOOL_NAME) {
+        acc[0].push(tool)
+      } else {
+        acc[1].push(tool)
+      }
+      return acc
+    },
+    [[], []] as [ToolCall[], ToolCall[]],
+  )
+}

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "LGPL-3.0",

--- a/packages/sdks/typescript/src/tests/helpers/run.ts
+++ b/packages/sdks/typescript/src/tests/helpers/run.ts
@@ -44,10 +44,12 @@ export function mockStreamResponse({
   server,
   apiVersion,
   customChunks,
+  closeOnLastCustomChunk = false,
 }: {
   server: Server
   apiVersion: SdkApiVersion
   customChunks?: string[]
+  closeOnLastCustomChunk?: boolean
 }) {
   let stream: ReadableStream
   const chunks = customChunks ?? CHUNKS
@@ -65,8 +67,10 @@ export function mockStreamResponse({
               )
 
               // customChunks is used to test the case where the server returns errors
-              if (index === chunks.length - 1 && !customChunks) {
-                controller.close()
+              if (index === chunks.length - 1) {
+                if (!customChunks || closeOnLastCustomChunk) {
+                  controller.close()
+                }
               }
             })
           },

--- a/packages/sdks/typescript/src/utils/handleStream.ts
+++ b/packages/sdks/typescript/src/utils/handleStream.ts
@@ -16,6 +16,7 @@ import {
   StreamEventTypes,
   ChainEventTypes,
   LatitudeEventData,
+  extractAgentToolCalls,
 } from '@latitude-data/constants'
 
 function parseJSON(line: string) {
@@ -95,11 +96,14 @@ export async function handleStream({
       throw new Error('Stream ended without returning a provider response.')
     }
 
+    const [agentTools, otherTools] = extractAgentToolCalls(toolsRequested)
+
     const finalResponse = {
       conversation,
       uuid,
       response: chainResponse,
-      toolRequests: toolsRequested,
+      toolRequests: otherTools,
+      agentResponse: agentTools[0]?.arguments,
     }
 
     return finalResponse

--- a/packages/sdks/typescript/src/utils/toolHelpers.ts
+++ b/packages/sdks/typescript/src/utils/toolHelpers.ts
@@ -143,6 +143,7 @@ type OriginalResponse = {
   conversation: Message[]
   toolRequests: ToolCall[]
   response: ChainCallResponseDto
+  agentResponse?: { response: string } | Record<string, unknown>
 }
 
 export function hasToolRequests<Tools extends ToolSpec>({

--- a/packages/sdks/typescript/src/utils/types.ts
+++ b/packages/sdks/typescript/src/utils/types.ts
@@ -123,6 +123,7 @@ export type StreamChainResponse = {
   uuid: string
   conversation: Message[]
   response: ChainCallResponseDto
+  agentResponse?: { response: string } | Record<string, unknown>
 }
 
 export type StreamResponseCallbacks = {


### PR DESCRIPTION
When running agents via the sdk, the only way to obtain the agent response is to look into `response.toolCalls` and find the one with the correct name.

Now, all returned objects will contain an `agentResponse` property, which is undefined for any non-agentic run, and will contain the agent response when included. This response is not fully typed, since the user can redefine it in the prompt itself, although by default it is `{ response: string }`