### PR TITLE
Add SMTP Support for Mail Transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,6 @@
 # Environment
 NODE_ENV=production
 
-# Traefik
-TRAEFIK_HOST=traefik.${APP_DOMAIN}
-TRAEFIK_ACME_EMAIL=your@email.com
-# Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
-# Example command to generate a password for user admin: echo $(htpasswd -nb admin password) | sed -e s/\\$/\\$\\$/g
-TRAEFIK_ADMIN_PASS="your_secure_password"
-
 # Database
 POSTGRES_USER=latitude
 POSTGRES_PASSWORD=secret
@@ -30,6 +23,13 @@ GATEWAY_SSL=false
 APP_DOMAIN=latitude.localhost # e.g latitude.so
 APP_URL=http://app.latitude.localhost # e.g https://app.latitude.so
 
+# Traefik
+TRAEFIK_HOST=traefik.${APP_DOMAIN}
+TRAEFIK_ACME_EMAIL=your@email.com
+# Passwords must be hashed using MD5, SHA1, or BCrypt. Read more: https://doc.traefik.io/traefik/middlewares/http/basicauth/
+# Example command to generate a password for user admin: echo $(htpasswd -nb admin password) | sed -e s/\\$/\\$\\$/g
+TRAEFIK_ADMIN_PASS="your_secure_password"
+
 # Websockets
 WEBSOCKETS_SERVER=http://websockets
 WEBSOCKETS_SERVER_PORT=8080
@@ -37,11 +37,19 @@ WEBSOCKET_REFRESH_SECRET_TOKEN_KEY=websocket-refresh-secret-token
 WEBSOCKET_SECRET_TOKEN_KEY=websocket-secret-token
 
 # Email Configuration
+MAIL_TRANSPORT= # smtp, mailgun, mailpit - default transport is mailpit
 FROM_MAILER_EMAIL=hello@latitude.localhost # e.g hello@latitude.so
 MAILGUN_EMAIL_DOMAIN=latitude.localhost # e.g email.latitude.so
 MAILGUN_MAILER_API_KEY= # (optional)
 MAILGUN_HOST=api.eu.mailgun.net # (optional)
 MAILGUN_PROTOCOL=https # (optional)
+# SMTP Email Configuration (if MAIL_TRANSPORT is set to smtp)
+# NOTE: If you are using Mailpit, you can skip SMTP configuration
+SMTP_HOST= # e.g. smtp.gmail.com
+SMTP_PORT=465 # e.g. 465 or 587
+SMTP_SECURE=true # e.g. true SMTPS (465) or false for STARTTLS (587)
+SMTP_USER=your_email@gmail.com # your email address
+SMTP_PASS=your_app_password # your email password (app password for Gmail)
 
 # Sentry (optional)
 NEXT_PUBLIC_SENTRY_DSN=

--- a/docs/guides/self-hosted/production.mdx
+++ b/docs/guides/self-hosted/production.mdx
@@ -76,6 +76,12 @@ Make sure this network is created before running the containers with `docker com
   - `SMTP_USER`: Your email address used for authentication (e.g., `your_email@gmail.com`)
   - `SMTP_PASS`: The password for your email account (use an **app password** if using Gmail)
 
+  Security Considerations:
+
+  **TLS/SSL Encryption**:
+   - Ensure that **SMTP** connections use TLS/SSL (via `SMTP_SECURE` set to `true` for SMTPS or `false` for STARTTLS). This is crucial for protecting your email credentials and the contents of your email.
+   - Always use a secure connection to prevent the exposure of sensitive data over the network.
+
 - **Storage Configuration**:
 
   - `DRIVE_DISK`: Choose between `local` or `s3` for file storage

--- a/docs/guides/self-hosted/production.mdx
+++ b/docs/guides/self-hosted/production.mdx
@@ -62,10 +62,19 @@ Make sure this network is created before running the containers with `docker com
 
 - **Email Configuration**:
 
+  - `MAIL_TRANSPORT`: `smtp`, `mailgun`, `mailpit` - `default` transport is `mailpit`
   - `MAILGUN_EMAIL_DOMAIN`: Email domain for sending emails
   - `FROM_MAILER_EMAIL`: Sender email address
   - `MAILGUN_MAILER_API_KEY`: Mailgun API key (optional)
   - `DISABLE_EMAIL_AUTHENTICATION`: Disable email authentication (optional, default: `false`)
+
+  If `MAIL_TRANSPORT` is set to `smtp`, you must provide the following environment variables:
+  
+  - `SMTP_HOST`: The SMTP server host (e.g., `smtp.gmail.com`)
+  - `SMTP_PORT`: The SMTP port number (e.g., `465` for SMTPS or `587` for STARTTLS)
+  - `SMTP_SECURE`: Set to `true` for SMTPS (`465`) or `false` for STARTTLS (`587`)
+  - `SMTP_USER`: Your email address used for authentication (e.g., `your_email@gmail.com`)
+  - `SMTP_PASS`: The password for your email account (use an **app password** if using Gmail)
 
 - **Storage Configuration**:
 

--- a/packages/core/src/mailers/mailers/adapters/index.ts
+++ b/packages/core/src/mailers/mailers/adapters/index.ts
@@ -5,7 +5,7 @@ import SMTPTransport from 'nodemailer/lib/smtp-transport'
 
 import createMailgunTransport from './mailgun'
 import createMailpitTransport from './mailpit'
-import createSmtpTransport from './smtp' 
+import createSmtpTransport from './smtp'
 
 const htmlToText = HTMLToText.htmlToText
 

--- a/packages/core/src/mailers/mailers/adapters/index.ts
+++ b/packages/core/src/mailers/mailers/adapters/index.ts
@@ -5,6 +5,7 @@ import SMTPTransport from 'nodemailer/lib/smtp-transport'
 
 import createMailgunTransport from './mailgun'
 import createMailpitTransport from './mailpit'
+import createSmtpTransport from './smtp' 
 
 const htmlToText = HTMLToText.htmlToText
 
@@ -32,6 +33,9 @@ export function createAdapter() {
       break
     case 'mailpit':
       transport = createMailpitTransport(options)
+      break
+    case 'smtp':
+      transport = createSmtpTransport(options)
       break
     default:
       throw new Error('Invalid MAIL_TRANSPORT')

--- a/packages/core/src/mailers/mailers/adapters/smtp.ts
+++ b/packages/core/src/mailers/mailers/adapters/smtp.ts
@@ -1,0 +1,28 @@
+import { env } from '@latitude-data/env'
+import nodemailer, { Transporter } from 'nodemailer'
+
+import { MailerOptions } from '.'
+
+export default function createSmtpTransport({
+  transportOptions,
+}: MailerOptions): Transporter | null {
+  const host = env.SMTP_HOST
+  const port = env.SMTP_PORT
+  const secure = env.SMTP_SECURE === 'true'
+  const user = env.SMTP_USER
+  const pass = env.SMTP_PASS
+
+  if (!host || !port || !user || !pass) return null
+
+  const transport = nodemailer.createTransport({
+    host,
+    port: Number(port),
+    secure,
+    auth: {
+      user,
+      pass,
+    },
+  }, transportOptions)
+
+  return transport
+}

--- a/packages/core/src/mailers/mailers/adapters/smtp.ts
+++ b/packages/core/src/mailers/mailers/adapters/smtp.ts
@@ -8,21 +8,28 @@ export default function createSmtpTransport({
 }: MailerOptions): Transporter | null {
   const host = env.SMTP_HOST
   const port = env.SMTP_PORT
-  const secure = env.SMTP_SECURE === 'true'
+  const secure = env.SMTP_SECURE
   const user = env.SMTP_USER
   const pass = env.SMTP_PASS
 
-  if (!host || !port || !user || !pass) return null
+  if (!host || !port || !user || !pass) {
+    throw new Error(
+      'SMTP_HOST, SMTP_PORT, SMTP_USER, and SMTP_PASS must be set when MAIL_TRANSPORT=smtp',
+    )
+  }
 
-  const transport = nodemailer.createTransport({
-    host,
-    port: Number(port),
-    secure,
-    auth: {
-      user,
-      pass,
+  const transport = nodemailer.createTransport(
+    {
+      host,
+      port: Number(port),
+      secure,
+      auth: {
+        user,
+        pass,
+      },
     },
-  }, transportOptions)
+    transportOptions,
+  )
 
   return transport
 }

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -197,8 +197,13 @@ export const env = createEnv({
     MAILGUN_EMAIL_DOMAIN: z.string().optional(),
     MAILGUN_MAILER_API_KEY: z.string().optional(),
     DISABLE_EMAIL_AUTHENTICATION: z.boolean().optional().default(false),
+    SMTP_HOST: z.string().optional(),
+    SMTP_PORT: z.union([z.string(), z.number()]).optional(),
+    SMTP_SECURE: z.string().optional(),
+    SMTP_USER: z.string().optional(),
+    SMTP_PASS: z.string().optional(),
     MAIL_TRANSPORT: z
-      .enum(['mailpit', 'mailgun'])
+      .enum(['mailpit', 'mailgun', 'smtp'])
       .optional()
       .default('mailpit'),
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -199,7 +199,7 @@ export const env = createEnv({
     DISABLE_EMAIL_AUTHENTICATION: z.boolean().optional().default(false),
     SMTP_HOST: z.string().optional(),
     SMTP_PORT: z.union([z.string(), z.number()]).optional(),
-    SMTP_SECURE: z.string().optional(),
+    SMTP_SECURE: z.coerce.boolean().optional().default(true),
     SMTP_USER: z.string().optional(),
     SMTP_PASS: z.string().optional(),
     MAIL_TRANSPORT: z


### PR DESCRIPTION
This PR adds support for sending emails via SMTP by introducing a new transport option: `smtp`. It extends the current mailer configuration to support three transport types:

- `mailpit` (default)
- `mailgun`
- `smtp` ✅ (new)

### 📦 What's Included

- `createSmtpTransport` adapter using `nodemailer` with SMTP credentials
- Update to the environment schema (`MAIL_TRANSPORT` now accepts `'smtp'`)
- Build error fixes related to incorrect type assignments and missing env vars
- Updated type definitions and transport logic to support SMTP
- Documentation on required SMTP environment variables

### 🔧 Required Environment Variables (for SMTP)

If `MAIL_TRANSPORT=smtp`, ensure the following are set:

```env
SMTP_HOST=smtp.gmail.com         # Your SMTP server
SMTP_PORT=465                    # Port 465 for SMTPS or 587 for STARTTLS
SMTP_SECURE=true                 # true for SMTPS, false for STARTTLS
SMTP_USER=your_email@gmail.com  # Your SMTP username (email)
SMTP_PASS=your_app_password     # Your SMTP password or Gmail app password
```
> **Note:** If using Gmail, an [app-specific password](https://support.google.com/accounts/answer/185833?hl=en) is required.

### ✅ Tested

- [x] Mail is sent via SMTP using Gmail
- [x] No breaking changes for `mailpit` or `mailgun` users

I have read the CLA Document and I hereby sign the CLA