### PR TITLE
fix: agent run returns no response

### DIFF
--- a/packages/core/src/lib/chainStreamManager/index.ts
+++ b/packages/core/src/lib/chainStreamManager/index.ts
@@ -10,14 +10,12 @@ import {
   ChainEvent,
   ChainEventTypes,
   OmittedLatitudeEventData,
-} from '@latitude-data/constants'
-import { streamAIResponse } from './step/streamAIResponse'
-import type {
   ChainStepResponse,
   LogSources,
-  PromptSource,
   StreamType,
-} from '../../constants'
+} from '@latitude-data/constants'
+import { streamAIResponse } from './step/streamAIResponse'
+import type { PromptSource } from '../../constants'
 import { buildMessagesFromResponse } from '../../helpers'
 import { FinishReason, LanguageModelUsage } from 'ai'
 import { ChainError } from './ChainErrors'
@@ -237,7 +235,7 @@ export class ChainStreamManager {
         this.tokenUsage.completionTokens + tokenUsage.completionTokens,
       totalTokens: this.tokenUsage.totalTokens + tokenUsage.totalTokens,
     }
-    this.lastResponse = response
+    this.setLastResponse(response)
 
     this.sendEvent({
       type: ChainEventTypes.ProviderCompleted,
@@ -405,6 +403,10 @@ export class ChainStreamManager {
 
     this.messages = event.data.messages
     this.sendEvent(event.data)
+  }
+
+  setLastResponse(response: ChainStepResponse<StreamType>) {
+    this.lastResponse = response
   }
 
   private addMessageFromResponse(response: ChainStepResponse<StreamType>) {

--- a/packages/core/src/services/agents/run.ts
+++ b/packages/core/src/services/agents/run.ts
@@ -77,6 +77,10 @@ export function runAgent<T extends boolean, C extends SomeChain>({
         return
       }
 
+      if (value.data.type === ChainEventTypes.ProviderCompleted) {
+        chainStreamManager.setLastResponse(value.data.response)
+      }
+
       // Forward all other events
       chainStreamManager.forwardEvent(value)
 


### PR DESCRIPTION
### Error
Running an agent prompt _sometimes_ returns an error:
```
{"name":"InternalServerError","errorCode":"internal_server_error","message":"Cannot read properties of undefined (reading 'providerLog')","details":{}}
```

### Cause
When Agents were first introduced, they required to ALWAYS run all steps in a chain first, and only then it would be able to return an agent response. This requirement was put for prompt consistency and behaviour expectations, but it also made it a bit easier to manage both Chain and Agent workflows, where each is managed by a different ChainStreamManager: Just run the Chain one first, and then the Agent one.

However this requirement sometimes led to unexpected and inefficient agents: When the prompt is a single step with instructions, the agent was always required to perform at least 2 steps: the one from the "chain", and then the agent steps.

A few weeks ago an improvement was made, where single-step chain prompts (or prompts where no step is defined) can respond with the agent response tool directly in the first step. This worked fine, although the `lastResponse` generated into the chain's `ChainStreamManager` is not shared with the agent's manager. This PR fixes it.