### PR TITLE
feat: dynamic allocation of albs for k8s deployments

### DIFF
--- a/packages/core/src/services/mcpServers/k8sTemplates.ts
+++ b/packages/core/src/services/mcpServers/k8sTemplates.ts
@@ -91,8 +91,9 @@ metadata:
     kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: {{SCHEME}}
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/group.name: latitude-mcps-{{NODE_ENV}}
+    alb.ingress.kubernetes.io/group.name: {{ALB_GROUP_NAME}}
     alb.ingress.kubernetes.io/healthcheck-path: /health
+    external-dns.alpha.kubernetes.io/hostname: {{NAME}}.{{LATITUDE_MCP_HOST}}
 spec:
   ingressClassName: alb
   rules:

--- a/packages/core/src/services/mcpServers/manifestGenerator.ts
+++ b/packages/core/src/services/mcpServers/manifestGenerator.ts
@@ -54,6 +54,7 @@ export function generateK8sManifest(params: K8sDeploymentParams): {
     SCHEME: env.MCP_SCHEME,
     SECRET_HASH: secretHash,
     NODE_GROUP_NAME: env.MCP_NODE_GROUP_NAME,
+    ALB_GROUP_NAME: `alb-${env.NODE_ENV}-${params.workspaceId}`,
   }
 
   // Add command and args if provided


### PR DESCRIPTION
We've reached the maximum number of rule evaluations for our single alb that we were using for all k8s deployments. We are now gonna allocate new albs per workspace and dynamically add route53 records to the relevant alb on each deployment, ensuring integrations cluster can scale.