### PR TITLE
feat: nginx controller

### DIFF
--- a/packages/core/src/services/mcpServers/k8sTemplates.ts
+++ b/packages/core/src/services/mcpServers/k8sTemplates.ts
@@ -88,13 +88,12 @@ metadata:
   name: {{NAME}}-ingress
   namespace: {{NAMESPACE}}
   annotations:
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: {{SCHEME}}
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/group.name: latitude-mcps-{{NODE_ENV}}
-    alb.ingress.kubernetes.io/healthcheck-path: /health
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{#TLS_ENABLED}}true{{/TLS_ENABLED}}{{^TLS_ENABLED}}false{{/TLS_ENABLED}}"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "{{#TLS_ENABLED}}true{{/TLS_ENABLED}}{{^TLS_ENABLED}}false{{/TLS_ENABLED}}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
 spec:
-  ingressClassName: alb
+  ingressClassName: {{INGRESS_CLASS_NAME}}
   rules:
     - host: {{NAME}}.{{LATITUDE_MCP_HOST}}
       http:

--- a/packages/core/src/services/mcpServers/manifestGenerator.ts
+++ b/packages/core/src/services/mcpServers/manifestGenerator.ts
@@ -54,6 +54,9 @@ export function generateK8sManifest(params: K8sDeploymentParams): {
     SCHEME: env.MCP_SCHEME,
     SECRET_HASH: secretHash,
     NODE_GROUP_NAME: env.MCP_NODE_GROUP_NAME,
+    // TODO: Remove NODE_ENV check and move to proper env var
+    INGRESS_CLASS_NAME:
+      env.NODE_ENV === 'production' ? 'ingress-internal-prod' : 'nginx',
   }
 
   // Add command and args if provided


### PR DESCRIPTION
We've reached the limit of provisioned listener rules and AWS refuses to increase the number to a suitable amount so we are switching strategies and deploying via an nginx reverse proxy within the cluster.