### PR TITLE
fix: share prompt modal race condition

### DIFF
--- a/apps/web/src/actions/documents/sharing/publishDocumentAction.test.ts
+++ b/apps/web/src/actions/documents/sharing/publishDocumentAction.test.ts
@@ -1,0 +1,143 @@
+import {
+  Providers,
+  type Commit,
+  type DocumentVersion,
+  type Project,
+  type User,
+  type Workspace,
+} from '@latitude-data/core/browser'
+import * as factories from '@latitude-data/core/factories'
+import { helpers } from '@latitude-data/core/factories'
+import { PublishedDocumentRepository } from '@latitude-data/core/repositories/publishedDocumentsRepository'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { publishDocumentAction } from './publishDocumentAction'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+  }
+})
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+
+let workspace: Workspace
+let project: Project
+let user: User
+let commit: Commit
+let document: DocumentVersion
+
+describe('publishDocumentAction', () => {
+  beforeEach(async () => {
+    const {
+      commit: cmt,
+      workspace: wp,
+      user: usr,
+      project: prj,
+      documents: docs,
+    } = await factories.createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      documents: {
+        doc1: helpers.createPrompt({ provider: 'openai', content: 'content' }),
+      },
+    })
+    user = usr
+    workspace = wp
+    project = prj
+    commit = cmt
+    document = docs[0]!
+  })
+
+  describe('unauthorized', () => {
+    it('errors when the user is not authenticated', async () => {
+      const [_, error] = await publishDocumentAction({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+
+      expect(error!.name).toEqual('UnauthorizedError')
+    })
+  })
+
+  describe('authorized', () => {
+    beforeEach(async () => {
+      mocks.getSession.mockReturnValue({
+        user,
+        workspace: { id: workspace.id, name: workspace.name },
+      })
+    })
+
+    it('returns error when project is not found', async () => {
+      const [_, error] = await publishDocumentAction({
+        projectId: 999992,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+
+      expect(error!.name).toEqual('NotFoundError')
+    })
+
+    it('creates a new published document when document has not been published before', async () => {
+      const [data] = await publishDocumentAction({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+
+      expect(data!).toBeDefined()
+      expect(data!.isPublished).toBe(true)
+      expect(data!.documentUuid).toBe(document.documentUuid)
+      expect(data!.workspaceId).toBe(workspace.id)
+      expect(data!.projectId).toBe(project.id)
+    })
+
+    it('updates an existing published document when document was previously published', async () => {
+      // First publish
+      await publishDocumentAction({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+
+      const scope = new PublishedDocumentRepository(workspace.id)
+      const publishedDocs = await scope.findByProject(project.id)
+      expect(publishedDocs.length).toBe(1)
+
+      // Update the published document
+      const [data] = await publishDocumentAction({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+
+      expect(data!).toBeDefined()
+      expect(data!.isPublished).toBe(true)
+      expect(data!.documentUuid).toBe(document.documentUuid)
+
+      // Verify no duplicate was created
+      const updatedPublishedDocs = await scope.findByProject(project.id)
+      expect(updatedPublishedDocs.length).toBe(1)
+    })
+
+    it('returns error when document does not belong to project', async () => {
+      const { documents: otherDocs } = await factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          doc1: helpers.createPrompt({
+            provider: 'openai',
+            content: 'content',
+          }),
+        },
+      })
+
+      const [_, error] = await publishDocumentAction({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: otherDocs[0]!.documentUuid,
+      })
+
+      expect(error!.name).toEqual('NotFoundError')
+    })
+  })
+})

--- a/apps/web/src/actions/documents/sharing/publishDocumentAction.ts
+++ b/apps/web/src/actions/documents/sharing/publishDocumentAction.ts
@@ -1,0 +1,31 @@
+'use server'
+
+import { withDocument } from '$/actions/procedures'
+import { PublishedDocumentRepository } from '@latitude-data/core/repositories/publishedDocumentsRepository'
+import { createPublishedDocument } from '@latitude-data/core/services/publishedDocuments/create'
+import { updatePublishedDocument } from '@latitude-data/core/services/publishedDocuments/update'
+
+export const publishDocumentAction = withDocument
+  .createServerAction()
+  .handler(async ({ ctx }) => {
+    const scope = new PublishedDocumentRepository(ctx.workspace.id)
+    const rows = await scope.findByProject(Number(ctx.project.id))
+    const publishedDocument = rows.find(
+      (d) => d.documentUuid === ctx.document.documentUuid,
+    )
+
+    if (publishedDocument) {
+      return updatePublishedDocument({
+        publishedDocument,
+        data: { isPublished: true },
+      }).then((r) => r.unwrap())
+    } else {
+      return createPublishedDocument({
+        workspace: ctx.workspace,
+        project: ctx.project,
+        document: ctx.document,
+        commitUuid: ctx.currentCommitUuid,
+        isPublished: true,
+      }).then((r) => r.unwrap())
+    }
+  })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/PublishDocument/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/PublishDocument/index.tsx
@@ -24,18 +24,23 @@ function UnpublishedDocumentSettings({
 }) {
   const {
     data: publishedData,
-    isPublishing: isLoading,
-    setPublished,
+    publish,
+    isPublishing,
   } = usePublishedDocument({
     documentUuid: document.documentUuid,
     projectId,
   })
 
-  const { isHead: canEdit } = useCurrentCommit()
+  const { commit, isHead: canEdit } = useCurrentCommit()
 
   const onPublish = () => {
     if (!canEdit) return
-    setPublished(true)
+
+    publish({
+      documentUuid: document.documentUuid,
+      projectId,
+      commitUuid: commit.uuid,
+    })
   }
 
   return (
@@ -55,7 +60,7 @@ function UnpublishedDocumentSettings({
           fullWidth
           fancy
           variant='default'
-          isLoading={isLoading}
+          isLoading={isPublishing}
           disabled={!canEdit}
           onClick={onPublish}
         >
@@ -74,14 +79,15 @@ function PublishedDocumentSettings({
   projectId: number
 }) {
   const { isHead: canEdit } = useCurrentCommit()
-  const { data, isUpdating, update, setPublished } = usePublishedDocument({
+  const { data, isUpdating, update } = usePublishedDocument({
     documentUuid: document.documentUuid,
     projectId,
   })
 
   const onUnpublish = () => {
     if (!canEdit) return
-    setPublished(false)
+
+    update({ isPublished: false })
   }
 
   const [title, setTitle] = useState<string | undefined>()
@@ -101,6 +107,7 @@ function PublishedDocumentSettings({
 
   const onSaveChanges = useCallback(() => {
     if (isUpdating) return
+
     update({
       title,
       description,

--- a/packages/core/src/services/publishedDocuments/create.ts
+++ b/packages/core/src/services/publishedDocuments/create.ts
@@ -19,11 +19,13 @@ export async function createPublishedDocument(
     workspace,
     document,
     commitUuid,
+    isPublished = false,
   }: {
     project: Project
     workspace: Workspace
     document: DocumentVersion
     commitUuid: string
+    isPublished?: boolean
   },
   db = database,
 ) {
@@ -69,7 +71,7 @@ export async function createPublishedDocument(
         workspaceId: workspace.id,
         documentUuid: document.documentUuid,
         projectId: project.id,
-        isPublished: false,
+        isPublished,
         canFollowConversation: false,
         title: document.path,
       })


### PR DESCRIPTION
Publishing action was buggy becasue it relied in some FE business logic to perform the full update. This commit fixes the issue by moving the whole publishing logic to a single server action.