### PR TITLE
Initial prompt parameters extracted from document logs

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
@@ -2,12 +2,7 @@ import {
   UseDocumentParameters,
   useDocumentParameters,
 } from '$/hooks/useDocumentParameters'
-import { useGenerateDocumentLogDetailUrl } from '$/hooks/useGenerateDocumentLogDetailUrl'
-import {
-  DocumentLog,
-  DocumentVersion,
-  PlaygroundInput,
-} from '@latitude-data/core/browser'
+import { DocumentVersion, PlaygroundInput } from '@latitude-data/core/browser'
 import { Badge } from '@latitude-data/web-ui/atoms/Badge'
 import { cn } from '@latitude-data/web-ui/utils'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
@@ -16,7 +11,6 @@ import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
 import { Tooltip } from '@latitude-data/web-ui/atoms/Tooltip'
 import { ICommitContextType } from '@latitude-data/web-ui/providers'
-import { format } from 'date-fns'
 import Link from 'next/link'
 
 import { ParametersPaginationNav } from '../PaginationNav'
@@ -28,32 +22,7 @@ import {
 import { ChangeEvent, useCallback, useEffect, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { ParametersWrapper } from '../ParametersWrapper'
-
-function usePaginatedDocumentLogUrl({
-  page,
-  selectedLog,
-  isLoading,
-}: {
-  selectedLog: DocumentLog | undefined
-  page: number | undefined
-  isLoading: boolean
-}) {
-  const uuid = selectedLog?.uuid
-  const { url } = useGenerateDocumentLogDetailUrl({
-    page,
-    documentLogUuid: uuid,
-  })
-
-  if (isLoading || !uuid || !url) return undefined
-
-  const shortCode = uuid.split('-')[0]
-  const createdAt = format(selectedLog.createdAt, 'PPp')
-  return {
-    url,
-    shortCode,
-    createdAt,
-  }
-}
+import { usePaginatedDocumentLogUrl } from '$/hooks/playgrounds/usePaginatedDocumentLogUrl'
 
 function DebouncedTextArea({
   input,
@@ -80,7 +49,7 @@ function DebouncedTextArea({
       setLocalValue(value)
       setInputDebounced(value)
     },
-    [setInput, input],
+    [setInputDebounced],
   )
 
   useEffect(() => {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/HistoryLogParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/HistoryLogParams/index.tsx
@@ -1,0 +1,229 @@
+import { ChangeEvent, useCallback, useEffect, useState } from 'react'
+import {
+  DocumentVersion,
+  EvaluationType,
+  EvaluationV2,
+  LLM_EVALUATION_PROMPT_PARAMETERS,
+  LlmEvaluationMetricAnyCustom,
+} from '@latitude-data/core/browser'
+import { Badge } from '@latitude-data/web-ui/atoms/Badge'
+import { cn } from '@latitude-data/web-ui/utils'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
+import { Tooltip } from '@latitude-data/web-ui/atoms/Tooltip'
+import { ICommitContextType } from '@latitude-data/web-ui/providers'
+import Link from 'next/link'
+
+import { type UseLogHistoryParams } from './useLogHistoryParams'
+import { useDebouncedCallback } from 'use-debounce'
+import { usePaginatedDocumentLogUrl } from '$/hooks/playgrounds/usePaginatedDocumentLogUrl'
+
+import {
+  type UseEvaluationParameters,
+  useEvaluationParameters,
+} from '../../../hooks/useEvaluationParamaters'
+// TODO: maybe move to common
+import { ParametersPaginationNav } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/PaginationNav'
+import { getEvaluationMetricSpecification } from '$/components/evaluations'
+
+function DebouncedTextArea({
+  input,
+  setInputs,
+  param,
+  disabled,
+  minRows = 1,
+  placeholder = 'Type here...',
+}: {
+  param: string
+  input: string
+  setInputs: UseEvaluationParameters['history']['setInputs']
+  disabled: boolean
+  minRows?: number
+  placeholder?: string
+}) {
+  const [localValue, setLocalValue] = useState(input ?? '')
+  const setInputDebounced = useDebouncedCallback(
+    async (value: string) => {
+      setInputs({ [param]: value })
+    },
+    100,
+    { leading: false, trailing: true },
+  )
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value
+      setLocalValue(value)
+      setInputDebounced(value)
+    },
+    [setInputDebounced],
+  )
+
+  useEffect(() => {
+    setLocalValue(input ?? '')
+  }, [input])
+
+  return (
+    <TextArea
+      value={localValue}
+      minRows={minRows}
+      maxRows={6}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  )
+}
+
+function ParameterInput({
+  param,
+  input,
+  setInputs,
+  isLoading,
+  includedInPrompt,
+  minRows,
+  placeholder,
+}: {
+  includedInPrompt: boolean
+  param: string
+  input: string
+  setInputs: UseEvaluationParameters['history']['setInputs']
+  isLoading: boolean
+  minRows?: number
+  placeholder?: string
+}) {
+  return (
+    <div className='grid col-span-2 grid-cols-subgrid gap-3 w-full items-start'>
+      <div className='flex flex-row items-center gap-x-2 min-h-8'>
+        <Badge variant={includedInPrompt ? 'accent' : 'muted'}>
+          &#123;&#123;{param}&#125;&#125;
+        </Badge>
+        {!includedInPrompt && (
+          <Tooltip trigger={<Icon name='info' />}>
+            This variable is not included in the current prompt
+          </Tooltip>
+        )}
+      </div>
+      <div className='flex flex-grow w-full min-w-0'>
+        <DebouncedTextArea
+          param={param}
+          input={input}
+          setInputs={setInputs}
+          disabled={isLoading}
+          minRows={minRows}
+          placeholder={placeholder}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function HistoryLogParams({
+  commit,
+  document,
+  evaluation,
+  data,
+}: {
+  commit: ICommitContextType['commit']
+  document: DocumentVersion
+  evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
+  data: UseLogHistoryParams
+}) {
+  const specification = getEvaluationMetricSpecification(evaluation)
+  const {
+    history: { inputs, setInputs, expectedOutput },
+  } = useEvaluationParameters({
+    commitVersionUuid: commit.uuid,
+    document,
+    evaluation,
+  })
+
+  const urlData = usePaginatedDocumentLogUrl({
+    selectedLog: data.selectedLog,
+    page: data.page,
+    isLoading: data.isLoadingLog,
+  })
+
+  const hasLogs = data.count > 0
+  const isLoading = data.isLoading
+
+  return (
+    <div className='flex flex-col gap-y-4'>
+      <div className='flex flex-row gap-x-4 justify-between items-center border-border border-b pb-4'>
+        {data.isLoading || hasLogs ? (
+          <>
+            <div className='flex flex-grow min-w-0'>
+              {data.isLoadingLog ? (
+                <div className='flex flex-row gap-x-2 w-full'>
+                  <Skeleton height='h3' className='w-2/3' />
+                  <Skeleton height='h3' className='w-1/3' />
+                </div>
+              ) : null}
+              {!data.isLoadingLog && urlData ? (
+                <Link
+                  href={urlData.url}
+                  className='flex-grow min-w-0 flex flex-row items-center gap-x-2'
+                >
+                  <Text.H5 ellipsis noWrap>
+                    {urlData.createdAt}
+                  </Text.H5>
+                  <Badge variant='accent'>{urlData.shortCode}</Badge>
+                  <Icon
+                    name='externalLink'
+                    color='foregroundMuted'
+                    className='flex-none'
+                  />
+                </Link>
+              ) : null}
+            </div>
+            <ParametersPaginationNav
+              disabled={data.isLoadingLog}
+              label='history logs'
+              currentIndex={data.position}
+              totalCount={data.count}
+              onPrevPage={data.onPrevPage}
+              onNextPage={data.onNextPage}
+            />
+          </>
+        ) : (
+          <div className='w-full flex justify-center'>
+            <Text.H5>No logs found</Text.H5>
+          </div>
+        )}
+      </div>
+      <div className={cn({ 'opacity-50': data.isLoading })}>
+        <div className='grid grid-cols-[auto_1fr] gap-y-3'>
+          {specification.requiresExpectedOutput ? (
+            <ParameterInput
+              includedInPrompt={expectedOutput.metadata.includedInPrompt}
+              input={expectedOutput.value}
+              param='expectedOutput'
+              setInputs={setInputs}
+              isLoading={isLoading}
+              placeholder='Put here the expected output to compare with'
+              minRows={3}
+            />
+          ) : null}
+          {LLM_EVALUATION_PROMPT_PARAMETERS.map((param, idx) => {
+            const input = inputs?.[param]
+            const includedInPrompt = input?.metadata?.includedInPrompt ?? true
+
+            if (!input) return null
+
+            return (
+              <ParameterInput
+                key={idx}
+                includedInPrompt={includedInPrompt}
+                input={input.value}
+                param={param}
+                setInputs={setInputs}
+                isLoading={isLoading}
+              />
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/HistoryLogParams/useLogHistoryParams.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/HistoryLogParams/useLogHistoryParams.ts
@@ -1,0 +1,43 @@
+import {
+  DocumentVersion,
+  EvaluationType,
+  EvaluationV2,
+  LlmEvaluationMetricAnyCustom,
+} from '@latitude-data/core/browser'
+import { useCallback } from 'react'
+
+import { useEvaluationParameters } from '../../../hooks/useEvaluationParamaters/index'
+import { useSerializedLogs, type OnHistoryFetchedFn } from './useSerializedLogs'
+
+export function useLogHistoryParams({
+  document,
+  evaluation,
+  commitVersionUuid,
+}: {
+  document: DocumentVersion
+  evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
+  commitVersionUuid: string
+}) {
+  const {
+    history: { setHistoryLog, logUuid, mapLogParametersToInputs },
+  } = useEvaluationParameters({
+    document,
+    evaluation,
+    commitVersionUuid,
+  })
+
+  const onHistoryFetched: OnHistoryFetchedFn = useCallback(
+    (log) => {
+      mapLogParametersToInputs(log)
+      setHistoryLog(log.uuid)
+    },
+    [setHistoryLog, mapLogParametersToInputs],
+  )
+  return useSerializedLogs({
+    document,
+    logUuid,
+    onHistoryFetched,
+  })
+}
+
+export type UseLogHistoryParams = ReturnType<typeof useLogHistoryParams>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/EvaluationParams/index.tsx
@@ -1,0 +1,69 @@
+import {
+  DocumentVersion,
+  EvaluationType,
+  EvaluationV2,
+  LlmEvaluationMetricAnyCustom,
+} from '@latitude-data/core/browser'
+import { ICommitContextType } from '@latitude-data/web-ui/providers'
+import { OnToggleFn } from '@latitude-data/web-ui/molecules/CollapsibleBox'
+import { ClientOnly } from '@latitude-data/web-ui/atoms/ClientOnly'
+import { CollapsibleBox } from '@latitude-data/web-ui/molecules/CollapsibleBox'
+import {
+  type UseLogHistoryParams,
+  useLogHistoryParams,
+} from './HistoryLogParams/useLogHistoryParams'
+import { HistoryLogParams } from './HistoryLogParams'
+
+export type Props = {
+  document: DocumentVersion
+  commit: ICommitContextType['commit']
+  evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
+  onToggle?: OnToggleFn
+  isExpanded?: boolean
+}
+type ContentProps = Props & { historyInfo: UseLogHistoryParams }
+
+function ExpandedContent({
+  historyInfo,
+  commit,
+  document,
+  evaluation,
+}: ContentProps) {
+  return (
+    <div className='w-full flex flex-col gap-4'>
+      <HistoryLogParams
+        commit={commit}
+        document={document}
+        evaluation={evaluation}
+        data={historyInfo}
+      />
+    </div>
+  )
+}
+
+export default function EvaluationParams({
+  onToggle,
+  isExpanded,
+  ...props
+}: Props) {
+  const commit = props.commit
+  const historyInfo = useLogHistoryParams({
+    commitVersionUuid: commit.uuid,
+    document: props.document,
+    evaluation: props.evaluation,
+  })
+
+  const contentProps = { ...props, historyInfo }
+
+  return (
+    <ClientOnly>
+      <CollapsibleBox
+        title='Log parameters'
+        icon='braces'
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        expandedContent={<ExpandedContent {...contentProps} />}
+      />
+    </ClientOnly>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/useRunEvaluationPlaygroundPrompt.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/useRunEvaluationPlaygroundPrompt.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react'
+import {
+  Commit,
+  DocumentVersion,
+  EvaluationType,
+  EvaluationV2,
+  LlmEvaluationMetricAnyCustom,
+} from '@latitude-data/core/browser'
+import { useStreamHandler } from '$/hooks/playgrounds/useStreamHandler'
+import { ROUTES } from '$/services/routes'
+
+export function useRunEvaluationPlaygroundPrompt({
+  projectId,
+  commit,
+  document,
+  evaluation,
+  parameters,
+}: {
+  projectId: number
+  commit: Commit
+  document: DocumentVersion
+  evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
+  parameters: Record<string, unknown> | undefined
+}) {
+  const { createStreamHandler } = useStreamHandler()
+  const runPromptFn = useCallback(async () => {
+    // TODO: Implement action for running evaluation prompt
+    const response = await fetch(ROUTES.api.documents.detail('foo-bar').run, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        projectId,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        evaluationUuid: evaluation.uuid,
+        parameters: parameters,
+      }),
+    })
+
+    return createStreamHandler(response)
+  }, [
+    parameters,
+    createStreamHandler,
+    projectId,
+    commit.uuid,
+    document.documentUuid,
+    evaluation.uuid,
+  ])
+
+  return runPromptFn
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/index.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/index.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect } from 'react'
+import type { ConversationMetadata } from 'promptl-ai'
+import {
+  DocumentVersion,
+  EvaluationType,
+  EvaluationV2,
+  LlmEvaluationMetricAnyCustom,
+} from '@latitude-data/core/browser'
+import {
+  AppLocalStorage,
+  useLocalStorage,
+} from '@latitude-data/web-ui/hooks/useLocalStorage'
+
+import { EVALUATION_EMPTY_INPUTS, EvaluationInputsByDocument } from './types'
+import { getDocState } from './utils'
+import { useEvaluatedLogInputs } from './logInputParamaters'
+
+export function useEvaluationParameters({
+  commitVersionUuid,
+  document,
+  evaluation,
+  metadata,
+}: {
+  commitVersionUuid: string
+  document: DocumentVersion
+  evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
+  metadata?: ConversationMetadata | undefined
+}) {
+  const state = useEvaluatedLogInputs()
+  const { value: allInputs, setValue } =
+    useLocalStorage<EvaluationInputsByDocument>({
+      key: AppLocalStorage.evaluationPlaygroundParameters,
+      defaultValue: {},
+    })
+  const key = `${commitVersionUuid}:${document.documentUuid}:evaluation:${evaluation.uuid}`
+  const inputs = allInputs[key] ?? EVALUATION_EMPTY_INPUTS
+  const logUuid = inputs['history'].logUuid
+  const setHistoryLog = useCallback(
+    (logUuid: string) => {
+      setValue((old) => {
+        const { state, doc } = getDocState(old, key)
+        return {
+          ...state,
+          [key]: {
+            ...doc,
+            history: {
+              ...doc.history,
+              logUuid,
+            },
+          },
+        }
+      })
+    },
+    [key, setValue],
+  )
+
+  const onMetadataChange = state.onMetadataChange
+
+  useEffect(() => {
+    onMetadataChange(metadata)
+  }, [metadata, onMetadataChange])
+
+  return {
+    parametersReady: state.logsInitiallyLoaded,
+    parameters: state.filteredParameters,
+    history: {
+      logUuid: logUuid,
+      setHistoryLog,
+      inputs: state.inputs,
+      expectedOutput: state.expectedOutput,
+      setInputs: state.setInputs,
+      mapLogParametersToInputs: state.mapLogParametersToInputs,
+    },
+  }
+}
+export type UseEvaluationParameters = ReturnType<typeof useEvaluationParameters>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/logInputParamaters.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/logInputParamaters.ts
@@ -1,0 +1,257 @@
+import { create } from 'zustand'
+
+import type { ConversationMetadata } from 'promptl-ai'
+import {
+  EvaluatedDocumentLog,
+  LLM_EVALUATION_PROMPT_PARAMETERS,
+} from '@latitude-data/core/browser'
+
+type LogInput = { value: string; metadata: { includedInPrompt: boolean } }
+type EvaluatedLogParamaters = Pick<
+  EvaluatedDocumentLog,
+  | 'actualOutput'
+  | 'conversation'
+  | 'messages'
+  | 'toolCalls'
+  | 'cost'
+  | 'tokens'
+  | 'duration'
+  | 'prompt'
+  | 'config'
+  | 'parameters'
+>
+
+function typedFilterObject<T extends object>(
+  obj: T,
+  keys: (keyof T)[],
+): Partial<T> {
+  return Object.keys(obj).reduce((acc, key) => {
+    const typedKey = key as keyof T
+    const value = obj[typedKey]
+    if (keys.includes(typedKey) && value !== undefined && value !== null) {
+      acc[typedKey] = value
+    }
+    return acc
+  }, {} as Partial<T>)
+}
+
+function safeStringify(value: unknown): string {
+  if (value === undefined || value === null) return ''
+
+  try {
+    return typeof value === 'string' ? value : JSON.stringify(value)
+  } catch {
+    return ''
+  }
+}
+
+function serializeInputs(
+  params: EvaluatedLogParamaters,
+  includedInPromptKeys: string[],
+): Record<string, LogInput> {
+  return Object.entries(params).reduce(
+    (acc, [key, value]) => {
+      acc[key] = {
+        value: safeStringify(value),
+        metadata: { includedInPrompt: includedInPromptKeys.includes(key) },
+      }
+      return acc
+    },
+    {} as Record<string, LogInput>,
+  )
+}
+
+function safeParseJson<T>(value: string): T | null {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
+type ReturnDeserializedInputs = EvaluatedLogParamaters & {
+  expectedOutput: string
+}
+function deserializeInputs(
+  inputs: Record<string, string>,
+): ReturnDeserializedInputs {
+  const result = {} as ReturnDeserializedInputs
+
+  for (const [key, value] of Object.entries(inputs)) {
+    switch (key) {
+      case 'tokens':
+      case 'duration':
+      case 'cost':
+        result[key] = Number(value)
+        break
+
+      case 'actualOutput':
+      case 'expectedOutput':
+      case 'prompt':
+        result[key] = value
+        break
+
+      case 'config': {
+        const config = safeParseJson<EvaluatedDocumentLog['config']>(value)
+        if (!config) break
+        result[key] = config
+        break
+      }
+      case 'parameters': {
+        const parsed = safeParseJson<EvaluatedDocumentLog['parameters']>(value)
+        if (!parsed) break
+
+        result[key] = parsed
+        break
+      }
+      case 'conversation': {
+        const parsed =
+          safeParseJson<EvaluatedDocumentLog['conversation']>(value)
+        if (!parsed) break
+
+        result[key] = parsed
+        break
+      }
+      case 'messages': {
+        const parsed = safeParseJson<EvaluatedDocumentLog['messages']>(value)
+        if (!parsed) break
+
+        result[key] = parsed
+        break
+      }
+      case 'toolCalls': {
+        const parsed = safeParseJson<EvaluatedDocumentLog['toolCalls']>(value)
+        if (!parsed) break
+
+        result[key] = parsed
+        break
+      }
+    }
+  }
+
+  return result
+}
+
+const INITIAL_INPUTS = LLM_EVALUATION_PROMPT_PARAMETERS.reduce(
+  (acc, key) => {
+    acc[key] = {
+      value: '',
+      metadata: { includedInPrompt: false },
+    }
+    return acc
+  },
+  {} as Record<string, LogInput>,
+)
+
+type EvaluatedLogInputsState = {
+  logsInitiallyLoaded: boolean
+  inputs: Record<string, LogInput>
+  parameters: EvaluatedLogParamaters | undefined
+  filteredParameters: Partial<EvaluatedLogParamaters> | undefined
+  metadataParameters: string[]
+  expectedOutput: LogInput
+  mapLogParametersToInputs: (log: EvaluatedDocumentLog) => void
+  onMetadataChange: (metadata: ConversationMetadata | undefined) => void
+  setInputs: (inputs: Record<string, string>) => void
+}
+
+export const useEvaluatedLogInputs = create<EvaluatedLogInputsState>(
+  (set, get) => ({
+    logsInitiallyLoaded: false,
+    inputs: INITIAL_INPUTS,
+    expectedOutput: { value: '', metadata: { includedInPrompt: false } },
+    parameters: {} as EvaluatedLogParamaters,
+    filteredParameters: {} as Partial<EvaluatedLogParamaters>,
+    metadataParameters: [],
+    mapLogParametersToInputs: (log: EvaluatedDocumentLog) => {
+      const { expectedOutput, metadataParameters } = get()
+      const parameters = {
+        actualOutput: log.actualOutput,
+        conversation: log.conversation,
+        messages: log.messages,
+        toolCalls: log.toolCalls,
+        cost: log.cost,
+        tokens: log.tokens,
+        duration: log.duration,
+        prompt: log.prompt,
+        config: log.config,
+        parameters: log.parameters,
+      }
+      const filteredParameters = typedFilterObject(
+        { ...parameters, expectedOutput: expectedOutput.value },
+        metadataParameters as (keyof EvaluatedLogParamaters)[],
+      )
+      const inputs = serializeInputs(parameters, metadataParameters)
+      set({ parameters, filteredParameters, inputs, logsInitiallyLoaded: true })
+    },
+    onMetadataChange: (metadata: ConversationMetadata | undefined) => {
+      if (!metadata) return
+
+      const metadataParameters = Array.from(metadata.parameters)
+      const { expectedOutput, parameters } = get()
+      const params = parameters ?? ({} as EvaluatedLogParamaters)
+      const filteredParameters = typedFilterObject(
+        { ...params, expectedOutput: expectedOutput.value },
+        metadataParameters as (keyof EvaluatedLogParamaters)[],
+      )
+      const inputs = serializeInputs(params, metadataParameters)
+      expectedOutput.metadata.includedInPrompt =
+        metadataParameters.includes('expectedOutput')
+      set({ metadataParameters, filteredParameters, inputs })
+    },
+    setInputs: (allUpdatedInputs: Record<string, string>) => {
+      const {
+        parameters = {} as EvaluatedLogParamaters,
+        expectedOutput,
+        inputs,
+        metadataParameters,
+      } = get()
+
+      const { expectedOutput: updatedExpectedOutput, ...updatedInputs } =
+        allUpdatedInputs
+      const deserializedParameters = deserializeInputs(updatedInputs)
+
+      const expectedOutputValue =
+        updatedExpectedOutput !== undefined
+          ? updatedExpectedOutput
+          : expectedOutput.value
+
+      deserializedParameters.expectedOutput
+      const newParameters: Partial<EvaluatedLogParamaters> = {
+        ...parameters,
+        ...deserializedParameters,
+      }
+
+      const newInputs: Record<string, LogInput> = {
+        ...inputs,
+        ...Object.keys(updatedInputs).reduce(
+          (acc, key) => {
+            acc[key] = {
+              value: updatedInputs[key]!,
+              metadata: {
+                includedInPrompt: metadataParameters.includes(key),
+              },
+            }
+            return acc
+          },
+          {} as Record<string, LogInput>,
+        ),
+      }
+
+      const filteredParameters = typedFilterObject(
+        { ...newParameters, expectedOutput: expectedOutputValue },
+        metadataParameters as (keyof EvaluatedLogParamaters)[],
+      )
+
+      set({
+        parameters: newParameters as EvaluatedLogParamaters,
+        filteredParameters,
+        inputs: newInputs,
+        expectedOutput: {
+          ...expectedOutput,
+          value: expectedOutputValue,
+        },
+      })
+    },
+  }),
+)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/types.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/types.ts
@@ -1,0 +1,23 @@
+export const EVALUATION_INPUT_SOURCE = {
+  history: 'history',
+} as const
+
+export type EvaluationInputSource =
+  (typeof EVALUATION_INPUT_SOURCE)[keyof typeof EVALUATION_INPUT_SOURCE]
+
+export type EvaluationPlaygroundInputs<S extends EvaluationInputSource> = {
+  source: S
+  history: {
+    logUuid: string | undefined
+  }
+}
+
+export type EvaluationInputsByDocument = Record<
+  string,
+  EvaluationPlaygroundInputs<EvaluationInputSource>
+>
+
+export const EVALUATION_EMPTY_INPUTS: EvaluationPlaygroundInputs<'history'> = {
+  source: EVALUATION_INPUT_SOURCE.history,
+  history: { logUuid: undefined },
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/utils.ts
@@ -1,0 +1,10 @@
+import { EvaluationInputsByDocument, EVALUATION_EMPTY_INPUTS } from './types'
+
+export function getDocState(
+  oldState: EvaluationInputsByDocument | null,
+  key: string,
+) {
+  const state = oldState ?? {}
+  const doc = state[key] ?? EVALUATION_EMPTY_INPUTS
+  return { state, doc }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/logs/_components/DocumentLogs/DocumentLogInfo/index.tsx
@@ -69,7 +69,7 @@ export function DocumentLogInfo({
     if (!ref.current) return
 
     setTarget(ref.current)
-  }, [ref.current])
+  }, [])
   const scrollableArea = usePanelDomRef({ selfRef: target })
   const beacon = stickyRef?.current
   useStickyNested({

--- a/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/evaluatedLogs/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/evaluatedLogs/route.ts
@@ -1,0 +1,77 @@
+import { Workspace } from '@latitude-data/core/browser'
+import { computeDocumentLogsQuery } from '@latitude-data/core/services/documentLogs/computeDocumentLogs'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { NextRequest, NextResponse } from 'next/server'
+import { parseApiDocumentLogParams } from '@latitude-data/core/services/documentLogs/logsFilterUtils/parseApiLogFilterParams'
+import { serializeEvaluatedDocumentLog } from '@latitude-data/core/services/evaluationsV2/llm/serializeEvaluatedDocumentLog'
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      req: NextRequest,
+      {
+        params,
+        workspace,
+      }: {
+        params: {
+          projectId: string
+          documentUuid: string
+        }
+        workspace: Workspace
+      },
+    ) => {
+      const { documentUuid } = params
+      const searchParams = req.nextUrl.searchParams
+      const queryParams = parseApiDocumentLogParams({ searchParams })
+
+      if (+queryParams.pageSize > 1) {
+        return NextResponse.json(
+          {
+            message:
+              'At the moment we only support pageSize=1 for evaluated logs',
+          },
+          { status: 422 },
+        )
+      }
+
+      if (queryParams.isEmptyResponse) {
+        return NextResponse.json([], { status: 200 })
+      }
+
+      const rows = await computeDocumentLogsQuery({
+        workspaceId: workspace.id,
+        documentUuid,
+        filterOptions: queryParams.filterOptions,
+        page: queryParams.page,
+        pageSize: queryParams.pageSize,
+      })
+
+      const documentLog = rows[0]
+
+      if (!documentLog) {
+        return NextResponse.json([], { status: 200 })
+      }
+
+      // NOTE: This provoke N+1 queries becuase for each log we fetch the provider logs
+      // but is not a problem at the moment because we just fetch one by one on
+      // custom llm evalution playground
+      //
+      // Please consider refactoring this if you want to fetch more than one evaluated log
+      const evaluatedLogResult = await serializeEvaluatedDocumentLog({
+        workspace,
+        documentLog,
+      })
+
+      if (evaluatedLogResult.error) {
+        return NextResponse.json(
+          { message: evaluatedLogResult.error.message },
+          { status: 422 },
+        )
+      }
+
+      const evaluatedLog = evaluatedLogResult.value
+      return NextResponse.json([evaluatedLog], { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/components/evaluations/llm/index.tsx
+++ b/apps/web/src/components/evaluations/llm/index.tsx
@@ -417,7 +417,7 @@ function ResultPanelMessages<M extends LlmEvaluationMetric>({
       </div>
       <MessageList
         messages={conversation}
-        parameters={LLM_EVALUATION_PROMPT_PARAMETERS}
+        parameters={LLM_EVALUATION_PROMPT_PARAMETERS as unknown as string[]}
         collapseParameters={!expandParameters}
       />
     </>

--- a/apps/web/src/hooks/playgrounds/usePaginatedDocumentLogUrl.ts
+++ b/apps/web/src/hooks/playgrounds/usePaginatedDocumentLogUrl.ts
@@ -1,0 +1,29 @@
+import { format } from 'date-fns'
+import { DocumentLog, EvaluatedDocumentLog } from '@latitude-data/core/browser'
+import { useGenerateDocumentLogDetailUrl } from '$/hooks/useGenerateDocumentLogDetailUrl'
+
+export function usePaginatedDocumentLogUrl({
+  page,
+  selectedLog,
+  isLoading,
+}: {
+  selectedLog: DocumentLog | EvaluatedDocumentLog | undefined
+  page: number | undefined
+  isLoading: boolean
+}) {
+  const uuid = selectedLog?.uuid
+  const { url } = useGenerateDocumentLogDetailUrl({
+    page,
+    documentLogUuid: uuid,
+  })
+
+  if (isLoading || !uuid || !url) return undefined
+
+  const shortCode = uuid.split('-')[0]
+  const createdAt = format(selectedLog.createdAt, 'PPp')
+  return {
+    url,
+    shortCode,
+    createdAt,
+  }
+}

--- a/apps/web/src/hooks/useDocumentParameters/index.ts
+++ b/apps/web/src/hooks/useDocumentParameters/index.ts
@@ -102,7 +102,7 @@ export function useDocumentParameters({
           newInputs,
         }),
       ),
-    [setValue],
+    [key, setValue],
   )
 
   const setInput = useCallback(
@@ -122,7 +122,7 @@ export function useDocumentParameters({
         }
       }
     },
-    [source, inputsBySource],
+    [inputsBySource, setHistoryInputs, setManualInputs],
   )
 
   const setManualInput = useCallback(
@@ -158,7 +158,7 @@ export function useDocumentParameters({
   const copyDatasetToManual = useCallback(() => {
     const dsInputs = dsId ? (inputs.datasetV2?.[dsId]?.inputs ?? {}) : {}
     setManualInputs(dsInputs)
-  }, [inputs.datasetV2, dsId])
+  }, [inputs.datasetV2, dsId, setManualInputs])
 
   const setHistoryLog = useCallback(
     (logUuid: string) => {
@@ -176,7 +176,7 @@ export function useDocumentParameters({
         }
       })
     },
-    [allInputs, key, setValue],
+    [key, setValue],
   )
 
   const mapDocParametersToInputs = useCallback(
@@ -200,14 +200,13 @@ export function useDocumentParameters({
         })
       })
     },
-    [inputs, key, setValue, emptyInputs.history],
+    [key, setValue, emptyInputs.history],
   )
 
   const onMetadataChange = useCallback(
     (metadata: ConversationMetadata) => {
       setValue((oldState) => {
         const prevInputs = useMetadataParameters.getState().prevInputs
-        const dsId = document.datasetV2Id
         return recalculateAllInputs({
           key,
           oldState,
@@ -229,7 +228,7 @@ export function useDocumentParameters({
         })
       })
     },
-    [key, document.datasetId, setValue],
+    [key, setValue, dsId],
   )
   const lastMetadataRef = useRef<ConversationMetadata | null>(null)
 
@@ -259,13 +258,20 @@ export function useDocumentParameters({
     setParameters(Array.from(nextParams))
     onMetadataChange(metadata)
     lastMetadataRef.current = metadata
-  }, [metadata, setParameters, onMetadataChange])
+  }, [
+    metadata,
+    setParameters,
+    onMetadataChange,
+    snapshotCurrentDoc,
+    document,
+    setValue,
+  ])
 
   const parameters = useMemo(() => {
     if (!metadataParameters) return undefined
 
     return convertToParams(inputsBySource)
-  }, [inputsBySource])
+  }, [inputsBySource, metadataParameters])
 
   return {
     metadataParameters,

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -185,6 +185,25 @@ export const API_ROUTES = {
                 comparison: (experimentUuids: string[]) =>
                   `${documentRoot}/experiments/comparison?uuids=${experimentUuids.join(',')}`,
               },
+              // These are logs serialized that includes the information included
+              // in the genered provider logs together with document log
+              evaluatedLogs: {
+                root: ({
+                  page,
+                  pageSize,
+                  filterOptions,
+                }: Partial<PaginationParameters> & {
+                  filterOptions: DocumentLogFilterOptions
+                }) =>
+                  generateDocumentLogsApiRouteWithParams({
+                    path: `${documentRoot}/evaluatedLogs`,
+                    params: {
+                      page,
+                      pageSize,
+                      filterOptions,
+                    },
+                  }),
+              },
               logs: {
                 root: ({
                   page,

--- a/apps/web/src/stores/evaluatedDocumentLogs.ts
+++ b/apps/web/src/stores/evaluatedDocumentLogs.ts
@@ -1,0 +1,64 @@
+import {
+  DocumentLogFilterOptions,
+  EvaluatedDocumentLog,
+} from '@latitude-data/core/browser'
+import useFetcher from '$/hooks/useFetcher'
+import { ROUTES } from '$/services/routes'
+import useSWR, { SWRConfiguration } from 'swr'
+
+const EMPTY_ARRAY: [] = []
+export default function useEvaluatedDocumentLogs(
+  {
+    projectId,
+    documentUuid,
+    filterOptions,
+    page,
+    pageSize,
+    onFetched,
+  }: {
+    projectId: number
+    documentUuid?: string
+    filterOptions: DocumentLogFilterOptions
+    page: string | null | undefined
+    pageSize: string | null
+    onFetched?: (logs: EvaluatedDocumentLog[]) => void
+  },
+  { fallbackData }: SWRConfiguration = {},
+) {
+  const fetcher = useFetcher<EvaluatedDocumentLog[], EvaluatedDocumentLog[]>(
+    documentUuid
+      ? ROUTES.api.projects
+          .detail(projectId)
+          .documents.detail(documentUuid)
+          .evaluatedLogs.root({
+            page: page ? Number(page) : undefined,
+            pageSize: pageSize ? Number(pageSize) : undefined,
+            filterOptions,
+          })
+      : undefined,
+  )
+
+  const {
+    data = EMPTY_ARRAY,
+    isLoading,
+    mutate,
+  } = useSWR<EvaluatedDocumentLog[]>(
+    [
+      'evaluatedDocumentLogs',
+      projectId,
+      documentUuid,
+      filterOptions,
+      page,
+      pageSize,
+    ],
+    fetcher,
+    {
+      fallbackData,
+      onSuccess: (logs) => {
+        onFetched?.(logs)
+      },
+    },
+  )
+
+  return { data, mutate, isLoading }
+}

--- a/apps/web/src/workers/readMetadata.ts
+++ b/apps/web/src/workers/readMetadata.ts
@@ -34,7 +34,10 @@ self.onmessage = async function (event: { data: ReadMetadataWorkerProps }) {
     ...rest
   } = event.data
 
-  const referenceFn = readDocument(document, documents, prompt)
+  const referenceFn =
+    document && documents
+      ? readDocument(document, documents, prompt)
+      : undefined
   const configSchema =
     document && providerNames
       ? promptConfigSchema({

--- a/packages/constants/src/evaluations/llm.ts
+++ b/packages/constants/src/evaluations/llm.ts
@@ -180,6 +180,10 @@ export enum LlmEvaluationMetric {
   CustomLabeled = 'custom_labeled',
 }
 
+export type LlmEvaluationMetricAnyCustom =
+  | LlmEvaluationMetric.Custom
+  | LlmEvaluationMetric.CustomLabeled
+
 // prettier-ignore
 export type LlmEvaluationConfiguration<M extends LlmEvaluationMetric = LlmEvaluationMetric> =
   M extends LlmEvaluationMetric.Binary ? LlmEvaluationBinaryConfiguration :
@@ -235,4 +239,7 @@ export const LLM_EVALUATION_PROMPT_PARAMETERS = [
   'prompt',
   'config',
   'parameters',
-]
+] as const
+
+export type LlmEvaluationPromptParameter =
+  (typeof LLM_EVALUATION_PROMPT_PARAMETERS)[number]

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -203,6 +203,13 @@ export type SerializedDocumentLog = SerializedProviderLog & {
   parameters: Record<string, unknown>
 }
 
+export type EvaluatedDocumentLog = SerializedDocumentLog & {
+  uuid: string
+  createdAt: Date
+  actualOutput: string
+  conversation: CompilerMessage[]
+}
+
 export const SERIALIZED_DOCUMENT_LOG_FIELDS = [
   'messages',
   'context',

--- a/packages/core/src/services/evaluationsV2/llm/serializeEvaluatedDocumentLog.ts
+++ b/packages/core/src/services/evaluationsV2/llm/serializeEvaluatedDocumentLog.ts
@@ -1,0 +1,47 @@
+import {
+  buildConversation,
+  DocumentLog,
+  formatMessage,
+  EvaluatedDocumentLog,
+  Workspace,
+} from '@latitude-data/core/browser'
+import { serializeAggregatedProviderLog } from '../../documentLogs/serialize'
+import { database } from '../../../client'
+import { ProviderLogsRepository } from '../../../repositories'
+import { Result, TypedResult } from '../../../lib/Result'
+
+export async function serializeEvaluatedDocumentLog(
+  {
+    workspace,
+    documentLog,
+  }: {
+    workspace: Workspace
+    documentLog: DocumentLog
+  },
+  db = database,
+): Promise<TypedResult<EvaluatedDocumentLog, Error>> {
+  const providerLogsScope = new ProviderLogsRepository(workspace.id, db)
+  const providerLogsResult = await providerLogsScope.findByDocumentLogUuid(
+    documentLog.uuid,
+  )
+
+  if (providerLogsResult.error) return Result.error(providerLogsResult.error)
+
+  const providerLogs = providerLogsResult.value
+  const aggregatedProviderLog = serializeAggregatedProviderLog({
+    documentLog,
+    providerLogs,
+  }).unwrap()
+
+  const providerLog = providerLogs[providerLogs.length - 1]!
+  const conversation = buildConversation(providerLog)
+  const actualOutput = formatMessage(conversation.at(-1)!)
+
+  return Result.ok({
+    ...aggregatedProviderLog,
+    uuid: documentLog.uuid,
+    createdAt: documentLog.createdAt,
+    actualOutput,
+    conversation,
+  })
+}

--- a/packages/core/src/services/evaluationsV2/llm/shared.ts
+++ b/packages/core/src/services/evaluationsV2/llm/shared.ts
@@ -84,7 +84,7 @@ export async function runPrompt<
   try {
     const result = await scan({
       prompt: prompt,
-      withParameters: LLM_EVALUATION_PROMPT_PARAMETERS,
+      withParameters: LLM_EVALUATION_PROMPT_PARAMETERS as unknown as string[],
     })
     if (result.errors.length > 0) {
       throw new ChainError({

--- a/packages/web-ui/src/lib/hooks/useLocalStorage.ts
+++ b/packages/web-ui/src/lib/hooks/useLocalStorage.ts
@@ -14,6 +14,7 @@ export enum AppLocalStorage {
   editorMinimap = 'editorMinimap',
   editorCopilot = 'editorCopilot',
   playgroundParameters = 'playgroundParameters',
+  evaluationPlaygroundParameters = 'evaluationPlaygroundParameters',
   playgroundActions = 'playgroundActions',
   expandParameters = 'expandParameters',
 }


### PR DESCRIPTION
# What?
Evaluations playground with document logs parameters from the evaluated document

## NEXT
- [ ] Run evaluation prompt for evaluations v2
- [ ] Display JSON fields in logs parameters and load Monaco editor to edit it
- [ ] Forbid tools in custom LLM evaluation in the playground
- [ ] Pass the integrations to `runReadMetadata`. I think I removed it. Copy from document playground
- [ ] Inform users that evaluation prompts. Don't have tools, agents and other prompts references