### PR TITLE
Display evaluations v2 on the project sidebar

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ClientFilesTree/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ClientFilesTree/index.tsx
@@ -48,7 +48,7 @@ export default function ClientFilesTree({
 
       return router.push(documentDetails.root)
     },
-    [sidebarLinkContext],
+    [sidebarLinkContext, router],
   )
   const { toast } = useToast()
 

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/_components/EvaluationActions.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/_components/EvaluationActions.tsx
@@ -244,7 +244,7 @@ function EditEvaluation<
         onClick={() => setOpenUpdateModal(true)}
         disabled={isUpdatingEvaluation}
       >
-        Edit evaluation
+        Settings
       </TableWithHeader.Button>
       <ConfirmModal
         dismissible

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/_components/EvaluationPage.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations-v2/[evaluationUuid]/_components/EvaluationPage.tsx
@@ -129,7 +129,7 @@ export function EvaluationPage<
     if (targetUrl !== window.location.href) {
       router.replace(targetUrl, { scroll: false })
     }
-  }, [debouncedSearch])
+  }, [debouncedSearch, router])
 
   const { data: commits, isLoading: isLoadingCommits } = useCommits()
 

--- a/apps/web/src/components/Sidebar/Files/DocumentHeader/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/DocumentHeader/index.tsx
@@ -11,6 +11,7 @@ import NodeHeaderWrapper, {
 import { useTempNodes } from '../useTempNodes'
 import { Node } from '../useTree'
 import { ROUTES } from '$/services/routes'
+import { EvaluationList } from '$/components/Sidebar/Files/EvaluationList'
 
 export default function DocumentHeader({
   open,
@@ -52,18 +53,19 @@ export default function DocumentHeader({
       }
       reset()
     },
-    [reset, onCreateFile, onRenameFile, node.path, node.isPersisted],
+    [reset, onCreateFile, onRenameFile, node],
   )
+  const documentUuid = node.doc!.documentUuid
   const url = useMemo(() => {
     if (selected) return undefined
     if (!node.isPersisted) return undefined
-    if (!node.doc?.documentUuid) return undefined
+    if (!documentUuid) return undefined
 
     return ROUTES.projects
       .detail({ id: sidebarLinkContext.projectId })
       .commits.detail({ uuid: sidebarLinkContext.commitUuid })
-      .documents.detail({ uuid: node.doc.documentUuid }).root
-  }, [node.doc!.documentUuid, selected, node.isPersisted, sidebarLinkContext])
+      .documents.detail({ uuid: documentUuid }).root
+  }, [documentUuid, selected, node.isPersisted, sidebarLinkContext])
   const [isEditing, setIsEditing] = useState(node.name === ' ')
   const actions = useMemo<MenuOption[]>(
     () => [
@@ -91,18 +93,12 @@ export default function DocumentHeader({
           if (isMerged) {
             onMergeCommitClick()
           } else {
-            onDeleteFile({ node, documentUuid: node.doc!.documentUuid })
+            onDeleteFile({ node, documentUuid })
           }
         },
       },
     ],
-    [
-      node.doc!.documentUuid,
-      onDeleteFile,
-      isLoading,
-      isMerged,
-      onMergeCommitClick,
-    ],
+    [node, documentUuid, onDeleteFile, isLoading, isMerged, onMergeCommitClick],
   )
   const icon = useMemo<IconName>(() => {
     const docType = node.doc?.documentType
@@ -129,6 +125,14 @@ export default function DocumentHeader({
       onSaveValue={onSaveValue}
       onLeaveWithoutSave={() => deleteTmpFolder({ id: node.id })}
       icons={[icon]}
-    />
+    >
+      {selected ? (
+        <EvaluationList
+          changeType={node.changeType}
+          indentation={indentation}
+          documentUuid={documentUuid}
+        />
+      ) : null}
+    </NodeHeaderWrapper>
   )
 }

--- a/apps/web/src/components/Sidebar/Files/EvaluationList/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/EvaluationList/index.tsx
@@ -1,0 +1,123 @@
+import { useEvaluationsV2 } from '$/stores/evaluationsV2'
+import { EvaluationV2 } from '@latitude-data/constants'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import Link from 'next/link'
+import {
+  useCurrentCommit,
+  useCurrentProject,
+} from '@latitude-data/web-ui/providers'
+import { useMemo } from 'react'
+import { ROUTES } from '$/services/routes'
+import { usePathname } from 'next/navigation'
+import { getEvaluationMetricSpecification } from '$/components/evaluations'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { TextColor } from '@latitude-data/web-ui/tokens'
+import { IndentType } from '$/components/Sidebar/Files/NodeHeaderWrapper'
+import { ModifiedDocumentType } from '@latitude-data/core/browser'
+import { cn } from '@latitude-data/web-ui/utils'
+import { useModifiedColors } from '$/components/Sidebar/Files/useModifiedColors'
+import { IndentationBar } from '$/components/Sidebar/Files/IndentationBar'
+
+function EvaluationItem({
+  isLast,
+  color,
+  indentation: promptIndentation,
+  selectedBackgroundColor,
+  commitUuid,
+  projectId,
+  documentUuid,
+  evaluation,
+  currentEvaluationUuid,
+}: {
+  isLast: boolean
+  color: TextColor
+  indentation: IndentType[]
+  selectedBackgroundColor: string
+  evaluation: EvaluationV2
+  commitUuid: string
+  projectId: number
+  documentUuid: string
+  currentEvaluationUuid?: string | null
+}) {
+  const spec = getEvaluationMetricSpecification(evaluation)
+  const isSelected = evaluation.uuid === currentEvaluationUuid
+  const url = isSelected
+    ? '#'
+    : ROUTES.projects
+        .detail({ id: projectId })
+        .commits.detail({ uuid: commitUuid })
+        .documents.detail({ uuid: documentUuid })
+        .evaluationsV2.detail({ uuid: evaluation.uuid }).root
+  const ItemComponent = isSelected ? 'div' : Link
+  const indentation = useMemo(
+    () => [...promptIndentation, { isLast }],
+    [isLast, promptIndentation],
+  )
+  return (
+    <ItemComponent
+      href={url}
+      className={cn('flex flex-row items-center gap-x-1 min-w-0 py-0.5 pr-2', {
+        [selectedBackgroundColor]: isSelected,
+        'hover:bg-muted cursor-pointer': !isSelected,
+      })}
+    >
+      <IndentationBar indentation={indentation} hasChildren={false} />
+      <Icon name={spec.icon} className='flex-none' color={color} />
+      <Text.H5M ellipsis noWrap userSelect={false} color={color}>
+        {evaluation.name}
+      </Text.H5M>
+    </ItemComponent>
+  )
+}
+
+const EVALUATION_PATH_REGEX =
+  /evaluations-v2\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+
+export function EvaluationList({
+  indentation,
+  changeType,
+  documentUuid,
+}: {
+  changeType?: ModifiedDocumentType | undefined
+  indentation: IndentType[]
+  documentUuid: string
+}) {
+  const { project } = useCurrentProject()
+  const { commit } = useCurrentCommit()
+  const document = useMemo(
+    () => ({ documentUuid, commitId: commit.id }),
+    [documentUuid, commit.id],
+  )
+  const pathname = usePathname()
+  const match = pathname.match(EVALUATION_PATH_REGEX)
+  const currentEvaluationUuid = match ? match[1] : null
+  const { color, selectedBackgroundColor } = useModifiedColors({
+    changeType,
+  })
+  const { data } = useEvaluationsV2({
+    project,
+    commit,
+    document,
+  })
+  const evaluationsSize = data.length
+
+  return (
+    <ul className='flex flex-col gap-y-1 min-w-0'>
+      {data.map((evaluation, index) => (
+        <li key={evaluation.uuid}>
+          <EvaluationItem
+            isLast={index === evaluationsSize - 1}
+            indentation={indentation}
+            color={color}
+            selectedBackgroundColor={selectedBackgroundColor}
+            projectId={project.id}
+            commitUuid={commit.uuid}
+            documentUuid={documentUuid}
+            evaluation={evaluation}
+            currentEvaluationUuid={currentEvaluationUuid}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/apps/web/src/components/Sidebar/Files/IndentationBar/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/IndentationBar/index.tsx
@@ -1,0 +1,32 @@
+import { IndentType } from '$/components/Sidebar/Files/NodeHeaderWrapper'
+
+export function IndentationBar({
+  indentation,
+  hasChildren,
+}: {
+  hasChildren: boolean
+  indentation: IndentType[]
+}) {
+  return indentation.map((indent, index) => {
+    const anyNextIndentIsNotLast = !!indentation
+      .slice(index)
+      .find((i) => !i.isLast)
+    const showBorder = anyNextIndentIsNotLast ? false : indent.isLast
+    return (
+      <div key={index} className='h-6 min-w-6'>
+        {index > 0 ? (
+          <div className='relative w-6 h-full flex justify-center'>
+            {hasChildren || !showBorder ? (
+              <div className='-ml-px bg-border w-px h-8 -mt-1' />
+            ) : (
+              <div className='-ml-px relative -mt-1'>
+                <div className='border-l h-2.5' />
+                <div className='absolute top-2.5 border-l border-b h-2 w-2 rounded-bl-sm' />
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    )
+  })
+}

--- a/apps/web/src/components/Sidebar/Files/useModifiedColors.ts
+++ b/apps/web/src/components/Sidebar/Files/useModifiedColors.ts
@@ -1,0 +1,22 @@
+import { ModifiedDocumentType } from '@latitude-data/core/browser'
+import {
+  MODIFICATION_BACKGROUNDS,
+  MODIFICATION_COLORS,
+} from '@latitude-data/web-ui/molecules/DocumentChange'
+import { useMemo } from 'react'
+
+export function useModifiedColors({
+  changeType,
+}: {
+  changeType: ModifiedDocumentType | undefined
+}) {
+  const color = changeType ? MODIFICATION_COLORS[changeType] : 'foreground'
+  const selectedBackgroundColor = changeType
+    ? MODIFICATION_BACKGROUNDS[changeType]
+    : MODIFICATION_BACKGROUNDS[ModifiedDocumentType.UpdatedPath]
+
+  return useMemo(
+    () => ({ color, selectedBackgroundColor }),
+    [color, selectedBackgroundColor],
+  )
+}

--- a/packages/web-ui/src/ds/molecules/DocumentChange/colors.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentChange/colors.ts
@@ -16,7 +16,7 @@ export const MODIFICATION_COLORS: Record<ModifiedDocumentType, TextColor> = {
 }
 export const MODIFICATION_BACKGROUNDS: Record<ModifiedDocumentType, string> = {
   [ModifiedDocumentType.Created]: 'bg-success/10',
-  [ModifiedDocumentType.Updated]: 'bg-accent-foreground/10',
-  [ModifiedDocumentType.UpdatedPath]: 'bg-accent-foreground/10',
+  [ModifiedDocumentType.Updated]: 'bg-accent-foreground/5',
+  [ModifiedDocumentType.UpdatedPath]: 'bg-accent-foreground/5',
   [ModifiedDocumentType.Deleted]: 'bg-destructive/10',
 }

--- a/packages/web-ui/src/providers/ProjectProvider.tsx
+++ b/packages/web-ui/src/providers/ProjectProvider.tsx
@@ -25,9 +25,11 @@ const ProjectProvider = ({
 
 const useCurrentProject = () => {
   const context = useContext(ProjectContext)
+
   if (!context) {
     throw new Error('useCurrentProject must be used within a ProjectProvider')
   }
+
   return context
 }
 


### PR DESCRIPTION
# What?
When editing an evaluation, the playground is super similar to the one used in the edition of the document. By displaying the current selected evaluation, we think it will make it clear

## TODO
- [x] Style evaluation item
- [x] Show what the current evaluation is

## Next PR
- [ ] Use evaluation icons in the header to make it short
- [ ] Search for `TODO(evalsv2)` and `Go to LLM evaluation editor when LLM V2 evaluations are available` and add the right link.
- [ ] Add to evals editor the schema to only allow the right parameters
- [ ] Enforce structure outputs on evaluations editor
- [ ] Review evals editor lagging