### PR TITLE
Fix experiment variants

### DIFF
--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/DatasetSelector.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/DatasetSelector.tsx
@@ -13,9 +13,7 @@ export function DatasetSelector({
   selectedDataset,
   onSelectDataset,
   parameters,
-}: ExperimentFormPayload & {
-  parameters?: string[]
-}) {
+}: ExperimentFormPayload) {
   const { data: datasets, isLoading: isLoadingDatasets } = useDatasets()
 
   const selectOptions = useMemo(

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/ParametersSelection.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/ParametersSelection.tsx
@@ -80,9 +80,7 @@ export function ParametersSelection({
   datasetLabels,
   setDatasetLabels,
   parameters,
-}: ExperimentFormPayload & {
-  parameters?: string[]
-}) {
+}: ExperimentFormPayload) {
   const { labels, buildLabels } = useLabels()
   useEffect(() => {
     if (!selectedDataset) return

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/ExperimentVariant.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/ExperimentVariant.tsx
@@ -1,11 +1,13 @@
-import { useMetadata } from '$/hooks/useMetadata'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { Input } from '@latitude-data/web-ui/atoms/Input'
 import { cn } from '@latitude-data/web-ui/utils'
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { ExperimentFormPayload } from '../../useExperimentFormPayload'
-import { VariantPromptSettings } from './PromptSettings'
+import {
+  VariantPromptSettings,
+  VariantPromptSettingsPlaceholder,
+} from './PromptSettings'
 
 export function NewVariantCard({ onClick }: { onClick: () => void }) {
   return (
@@ -26,9 +28,9 @@ export function ExperimentVariantCard({
   index,
   variants,
   setVariants,
-  document,
+  isLoadingMetadata,
 }: ExperimentFormPayload & { index: number }) {
-  const { name, prompt } = variants[index]!
+  const { name, provider, model } = variants[index]!
 
   const setName = useCallback(
     (name: string) => {
@@ -41,22 +43,22 @@ export function ExperimentVariantCard({
     [setVariants, index],
   )
 
-  const setPrompt = useCallback(
-    (prompt: string) => {
+  const setProvider = useCallback(
+    (newProvider: string) => {
       setVariants((prev) => {
         const newVariants = [...prev]
-        newVariants[index]!.prompt = prompt
+        newVariants[index]!.provider = newProvider
         return newVariants
       })
     },
     [setVariants, index],
   )
 
-  const setParameters = useCallback(
-    (parameters: string[]) => {
+  const setModel = useCallback(
+    (newModel: string) => {
       setVariants((prev) => {
         const newVariants = [...prev]
-        newVariants[index]!.parameters = parameters
+        newVariants[index]!.model = newModel
         return newVariants
       })
     },
@@ -70,20 +72,6 @@ export function ExperimentVariantCard({
       return newVariants
     })
   }, [setVariants, index])
-
-  const { metadata, runReadMetadata } = useMetadata()
-  useEffect(() => {
-    runReadMetadata({
-      promptlVersion: document.promptlVersion,
-      prompt,
-      document,
-    })
-  }, [document, prompt, runReadMetadata])
-
-  useEffect(() => {
-    if (!metadata) return
-    setParameters(Array.from(metadata.parameters))
-  }, [metadata, setParameters])
 
   return (
     <div className='flex flex-col relative gap-2 p-4 border border-border rounded-md min-w-[300px]'>
@@ -107,11 +95,16 @@ export function ExperimentVariantCard({
         onChange={(e) => setName(e.target.value)}
         placeholder='Describe this variant'
       />
-      <VariantPromptSettings
-        prompt={prompt}
-        setPrompt={setPrompt}
-        metadata={metadata}
-      />
+      {isLoadingMetadata ? (
+        <VariantPromptSettingsPlaceholder />
+      ) : (
+        <VariantPromptSettings
+          provider={provider}
+          setProvider={setProvider}
+          model={model}
+          setModel={setModel}
+        />
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/PromptSettings.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/PromptSettings.tsx
@@ -1,10 +1,8 @@
 import useModelOptions from '$/hooks/useModelOptions'
-import { updatePromptMetadata } from '$/lib/promptMetadata'
 import useProviderApiKeys from '$/stores/providerApiKeys'
 import { Select } from '@latitude-data/web-ui/atoms/Select'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
-import { Config, ConversationMetadata } from 'promptl-ai'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 
 export function VariantPromptSettingsPlaceholder() {
   return (
@@ -15,38 +13,27 @@ export function VariantPromptSettingsPlaceholder() {
 }
 
 export function VariantPromptSettings({
-  prompt,
-  setPrompt,
-  metadata,
+  provider,
+  setProvider,
+  model,
+  setModel,
 }: {
-  prompt: string
-  setPrompt: (prompt: string) => void
-  metadata?: ConversationMetadata
+  provider: string
+  setProvider: (provider: string) => void
+  model: string
+  setModel: (model: string) => void
 }) {
   const { data: providers, isLoading: isLoadingProviders } =
     useProviderApiKeys()
 
-  const setConfig = useCallback(
-    (newConfig: Config) => {
-      const newPrompt = updatePromptMetadata(prompt, newConfig)
-      setPrompt(newPrompt)
-    },
-    [prompt, setPrompt],
-  )
   const selectedProvider = useMemo(() => {
-    if (!metadata) return undefined
-    const provider = providers.find((p) => p.name === metadata.config.provider)
-    return provider
-  }, [metadata, providers])
+    return providers.find((p) => p.name === provider)
+  }, [provider, providers])
 
   const modelOptions = useModelOptions({
     provider: selectedProvider?.provider,
     name: selectedProvider?.name,
   })
-
-  if (!metadata) {
-    return <VariantPromptSettingsPlaceholder />
-  }
 
   return (
     <div className='flex flex-col gap-2'>
@@ -61,25 +48,19 @@ export function VariantPromptSettings({
         }))}
         onChange={(value) => {
           const newProvider = providers.find((p) => p.name === value)
-          setConfig({
-            provider: value,
-            model: newProvider?.defaultModel,
-          })
+          setProvider(value as string)
+          setModel(newProvider?.defaultModel ?? '')
         }}
         loading={isLoadingProviders}
         required
       />
       <Select
-        value={metadata?.config.model}
+        value={model}
         name='model'
         label='Model'
         placeholder='Select a model'
         options={modelOptions}
-        onChange={(value) =>
-          setConfig({
-            model: value,
-          })
-        }
+        onChange={(value) => setModel(value as string)}
         loading={isLoadingProviders}
         required
       />

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/index.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/VariantsInput/index.tsx
@@ -1,19 +1,10 @@
-import { useCallback } from 'react'
 import { ExperimentFormPayload } from '../../useExperimentFormPayload'
 import { ExperimentVariantCard, NewVariantCard } from './ExperimentVariant'
 
 const MAX_EXPERIMENTS = 3
 
 export function ExperimentVariantsInput(payload: ExperimentFormPayload) {
-  const { variants, setVariants, document } = payload
-
-  const createNewVariant = useCallback(() => {
-    setVariants((prev) => {
-      const newVariants = [...prev]
-      newVariants.push({ name: '', prompt: document?.content, parameters: [] })
-      return newVariants
-    })
-  }, [document, setVariants])
+  const { variants, addNewVariant } = payload
 
   return (
     <div className='flex flex-row gap-4 max-w-full overflow-auto custom-scrollbar pt-4'>
@@ -21,7 +12,7 @@ export function ExperimentVariantsInput(payload: ExperimentFormPayload) {
         return <ExperimentVariantCard key={index} index={index} {...payload} />
       })}
       {variants.length < MAX_EXPERIMENTS && (
-        <NewVariantCard onClick={createNewVariant} />
+        <NewVariantCard onClick={addNewVariant} />
       )}
     </div>
   )

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/index.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/index.tsx
@@ -4,17 +4,9 @@ import { DatasetSelector } from './_components/DatasetSelector'
 import { DatasetRowsInput } from './_components/DatasetRowsInput'
 import { ParametersSelection } from './_components/ParametersSelection'
 import { EvaluationsSelector } from './_components/EvaluationsSelector'
-import { useMemo } from 'react'
 import { ExperimentVariantsInput } from './_components/VariantsInput'
 
-export default function DatasetForm(payload: ExperimentFormPayload) {
-  const parameters = useMemo(() => {
-    const set = new Set<string>([
-      ...payload.variants.flatMap((v) => v.parameters),
-    ])
-    return Array.from(set)
-  }, [payload.variants])
-
+export default function ExperimentModalForm(payload: ExperimentFormPayload) {
   return (
     <NumeredList>
       <NumeredList.Item
@@ -30,9 +22,9 @@ export default function DatasetForm(payload: ExperimentFormPayload) {
 
       <NumeredList.Item title='Select your dataset and configure parameters'>
         <div className='flex flex-col gap-2'>
-          <DatasetSelector {...payload} parameters={parameters} />
+          <DatasetSelector {...payload} />
           <DatasetRowsInput {...payload} />
-          <ParametersSelection {...payload} parameters={parameters} />
+          <ParametersSelection {...payload} />
         </div>
       </NumeredList.Item>
     </NumeredList>

--- a/apps/web/src/components/RunExperimentModal/index.tsx
+++ b/apps/web/src/components/RunExperimentModal/index.tsx
@@ -10,9 +10,9 @@ import {
 } from '@latitude-data/core/browser'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { CloseTrigger, Modal } from '@latitude-data/web-ui/atoms/Modal'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useExperimentFormPayload } from './ExperimentForm/useExperimentFormPayload'
-import DatasetForm from './ExperimentForm'
+import ExperimentModalForm from './ExperimentForm'
 import { useNavigate } from '$/hooks/useNavigate'
 import { DocumentRoutes, ROUTES } from '$/services/routes'
 
@@ -36,6 +36,13 @@ export function RunExperimentModal({
   navigateOnCreate?: boolean
 }) {
   const router = useNavigate()
+
+  const { count } = useExperiments({
+    projectId: project.id,
+    documentUuid: document.documentUuid,
+    page: 1,
+    pageSize: 1,
+  })
 
   const { create, isCreating } = useExperiments(
     {
@@ -66,6 +73,7 @@ export function RunExperimentModal({
     commit,
     document,
     initialEvaluation,
+    experimentCount: count,
   })
 
   const createExperiment = useCallback(() => {
@@ -86,6 +94,13 @@ export function RunExperimentModal({
     })
   }, [formPayload, project.id, commit.uuid, document.documentUuid, create])
 
+  const { setVariants, addNewVariant } = formPayload
+
+  useEffect(() => {
+    setVariants([])
+    addNewVariant()
+  }, [setVariants, addNewVariant, isOpen])
+
   return (
     <Modal
       open={isOpen}
@@ -93,6 +108,7 @@ export function RunExperimentModal({
       size='xl'
       title='Run New Experiment'
       description='Create and evaluate a batch of logs for this document based on a selected dataset.'
+      dismissible
       footer={
         <>
           <CloseTrigger />
@@ -107,7 +123,7 @@ export function RunExperimentModal({
       }
     >
       <div className='w-full max-w-full relative'>
-        <DatasetForm {...formPayload} />
+        <ExperimentModalForm {...formPayload} />
       </div>
     </Modal>
   )


### PR DESCRIPTION
Fixes the prompt generation when selecting Experiment variants. The new prompt is now configured in the backend, rather than the frontend, to reduce entropy.

Also added default variant names that make sense