### PR TITLE
improvement: Race condition when inserting closing tag

### DIFF
--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
@@ -17,14 +17,6 @@ const createAutoClosingTagsHandler = (
     const selection = editor.getSelection()
     if (!model || !selection) return
 
-    // position where we want the cursor to be after the closing tag is inserted
-    const nextCursorPosition = new monaco.Selection(
-      selection.selectionStartLineNumber,
-      selection.selectionStartColumn + 1,
-      selection.endLineNumber,
-      selection.endColumn + 1,
-    )
-
     const contentBeforeChange = model.getValueInRange({
       startLineNumber: selection.selectionStartLineNumber,
       startColumn: 1,
@@ -35,18 +27,29 @@ const createAutoClosingTagsHandler = (
     const match = contentBeforeChange.match(/<([\w-]+)([^>/]*)$/)
     if (!match) return
 
+    event.preventDefault()
+    event.stopPropagation()
+
     const [, tag] = match
 
     const edit = {
-      range: nextCursorPosition,
-      text: `</${tag}>`,
+      range: selection,
+      text: `></${tag}>`,
       forceMoveMarkers: true,
     }
+
+    // position where we want the cursor to be after the closing tag is inserted
+    const nextCursorPosition = new monaco.Selection(
+      selection.selectionStartLineNumber,
+      selection.selectionStartColumn + 1,
+      selection.endLineNumber,
+      selection.endColumn + 1,
+    )
 
     // wait for next tick to avoid adding the closing tag before the '>' key is inserted
     setTimeout(() => {
       editor.executeEdits('auto-close-tag', [edit], [nextCursorPosition])
-    }, 20)
+    }, 0)
   })
 }
 

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
@@ -46,10 +46,7 @@ const createAutoClosingTagsHandler = (
       selection.endColumn + 1,
     )
 
-    // wait for next tick to avoid adding the closing tag before the '>' key is inserted
-    setTimeout(() => {
-      editor.executeEdits('auto-close-tag', [edit], [nextCursorPosition])
-    }, 0)
+    editor.executeEdits('auto-close-tag', [edit], [nextCursorPosition])
   })
 }
 

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
@@ -46,7 +46,7 @@ const createAutoClosingTagsHandler = (
     // wait for next tick to avoid adding the closing tag before the '>' key is inserted
     setTimeout(() => {
       editor.executeEdits('auto-close-tag', [edit], [nextCursorPosition])
-    }, 0)
+    }, 10)
   })
 }
 

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/useAutoClosingTags.ts
@@ -46,7 +46,7 @@ const createAutoClosingTagsHandler = (
     // wait for next tick to avoid adding the closing tag before the '>' key is inserted
     setTimeout(() => {
       editor.executeEdits('auto-close-tag', [edit], [nextCursorPosition])
-    }, 10)
+    }, 20)
   })
 }
 


### PR DESCRIPTION
To improve the stability of the feature in different browsers (my mistake not having tested the feature in different ones) I modified a little bit the auto-closing tag function. Right now, depending on the device/browser, the `</tag>` was inserted before the `>`, generating something like `<tag</tag>>`