### PR TITLE
feat: make additionalProperties mandatory in integration/latitude tools

### DIFF
--- a/packages/constants/src/ai.ts
+++ b/packages/constants/src/ai.ts
@@ -83,7 +83,7 @@ export type ToolDefinition = JSONSchema7 & {
     type: 'object'
     properties: Record<string, JSONSchema7>
     required?: string[]
-    additionalProperties?: boolean
+    additionalProperties: boolean
   }
 }
 

--- a/packages/constants/src/mcp.ts
+++ b/packages/constants/src/mcp.ts
@@ -6,5 +6,6 @@ export type McpTool = {
   inputSchema: {
     type: 'object'
     properties: Record<string, JSONSchema7>
+    additionalProperties: boolean
   }
 }

--- a/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.test.ts
+++ b/packages/core/src/jobs/job-definitions/documents/runDocumentAtCommitWithAutoToolResponses/respondToToolCalls.test.ts
@@ -50,10 +50,10 @@ describe('respondToToolCalls', () => {
                     location: {
                       type: 'string',
                       description: "location, e.g., 'Valencia, Spain'.",
-                      required: ['location'],
-                      additionalProperties: false,
                     },
                   },
+                  required: ['location'],
+                  additionalProperties: false,
                 },
               },
               get_the_time: {
@@ -64,15 +64,19 @@ describe('respondToToolCalls', () => {
                     location: {
                       type: 'string',
                       description: "location, e.g., 'Valencia, Spain'.",
-                      required: ['location'],
-                      additionalProperties: false,
                     },
                   },
+                  required: ['location'],
+                  additionalProperties: false,
                 },
               },
               not_called_tool: {
                 description: 'This should not be used to generate the response',
-                parameters: { type: 'object', properties: {} },
+                parameters: {
+                  type: 'object',
+                  properties: {},
+                  additionalProperties: false,
+                },
               },
             },
           },
@@ -160,12 +164,12 @@ describe('respondToToolCalls', () => {
               type: 'object',
               properties: {
                 location: {
-                  type: 'string',
                   description: "location, e.g., 'Valencia, Spain'.",
-                  required: ['location'],
-                  additionalProperties: false,
+                  type: 'string',
                 },
               },
+              required: ['location'],
+              additionalProperties: false,
             },
           },
           get_the_time: {
@@ -174,12 +178,12 @@ describe('respondToToolCalls', () => {
               type: 'object',
               properties: {
                 location: {
-                  type: 'string',
                   description: "location, e.g., 'Valencia, Spain'.",
-                  required: ['location'],
-                  additionalProperties: false,
+                  type: 'string',
                 },
               },
+              additionalProperties: false,
+              required: ['location'],
             },
           },
         },

--- a/packages/core/src/lib/chainStreamManager/step/toolExecution/index.test.ts
+++ b/packages/core/src/lib/chainStreamManager/step/toolExecution/index.test.ts
@@ -169,6 +169,7 @@ describe('getBuiltInToolCallResponses', () => {
             },
           },
           required: ['location'],
+          additionalProperties: false,
         },
       },
     }
@@ -396,6 +397,7 @@ describe('getBuiltInToolCallResponses', () => {
               },
             },
             required: ['input'],
+            additionalProperties: false,
           },
         },
         sourceData: {

--- a/packages/core/src/services/integrations/McpClient/listTools/fixToolSchema.ts
+++ b/packages/core/src/services/integrations/McpClient/listTools/fixToolSchema.ts
@@ -9,6 +9,9 @@ export function fixToolSchema(schema: JSONSchema7): JSONSchema7 {
     } else {
       schema.properties = {}
     }
+    if (!schema.additionalProperties) {
+      schema.additionalProperties = false
+    }
   }
 
   if (schema.type === 'array') {


### PR DESCRIPTION
Since it's optional in some providers but required for othersd, we make it mandatory and defeault to false as the most sensible option.