### PR TITLE
feat: Add optional CACHE_PASSWORD env for Redis AUTH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ QUEUE_PORT=6379
 QUEUE_HOST=redis
 CACHE_PORT=6379
 CACHE_HOST=redis
+CACHE_PASSWORD= # Optional: set your cache password if Redis requires authentication
 
 # Gateway Configuration
 GATEWAY_BIND_ADDRESS=localhost

--- a/packages/core/src/cache/index.ts
+++ b/packages/core/src/cache/index.ts
@@ -8,10 +8,14 @@ let connection: Redis
 export const cache = async () => {
   if (connection) return connection
 
-  connection = await buildRedisConnection({
+  const redisOptions: any = {
+    // Use 'any' or a more specific type for options
     host: env.CACHE_HOST,
     port: env.CACHE_PORT,
-  })
-
+  }
+  if (env.CACHE_PASSWORD) {
+    redisOptions.password = env.CACHE_PASSWORD
+  }
+  connection = await buildRedisConnection(redisOptions)
   return connection
 }

--- a/packages/core/src/jobs/utils/progressTracker.ts
+++ b/packages/core/src/jobs/utils/progressTracker.ts
@@ -18,10 +18,15 @@ export class ProgressTracker {
 
   private async ensureConnection() {
     if (!this.redis) {
-      this.redis = await buildRedisConnection({
+      const redisOptions: any = {
+        // Use 'any' or a more specific type for options
         host: env.CACHE_HOST,
         port: env.CACHE_PORT,
-      })
+      }
+      if (env.CACHE_PASSWORD) {
+        redisOptions.password = env.CACHE_PASSWORD
+      }
+      this.redis = await buildRedisConnection(redisOptions)
     }
 
     return this.redis as Redis

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -115,6 +115,7 @@ export const env = createEnv({
     // Cache
     CACHE_HOST: z.string(),
     CACHE_PORT: z.coerce.number().optional().default(6379),
+    CACHE_PASSWORD: z.string().optional(),
 
     // Postgres
     DATABASE_URL: z.string().url(),
@@ -262,6 +263,7 @@ export const env = createEnv({
   runtimeEnv: {
     ...process.env,
     CACHE_PORT: process.env.CACHE_PORT ?? '6379',
+    CACHE_PASSWORD: process.env.CACHE_PASSWORD,
     NEXT_PUBLIC_DEFAULT_PROVIDER_NAME: 'Latitude', // TODO: Move to env in infra
     DRIVE_DISK: process.env.DRIVE_DISK ?? 'local',
     FILE_PUBLIC_PATH: process.env.FILE_PUBLIC_PATH ?? UPLOADS_PATH,

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
     "DATABASE_URL",
     "CACHE_HOST",
     "CACHE_PORT",
+    "CACHE_PASSWORD",
     "QUEUE_HOST",
     "QUEUE_PORT",
     "QUEUE_PASSWORD",


### PR DESCRIPTION
This pull request adds an optional `CACHE_PASSWORD` environment variable to support Redis cache with authentication. This allows users to configure a password for their Redis cache instance, enhancing security.