### PR TITLE
feat: remove fluff from some events

### DIFF
--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -108,7 +108,7 @@ export type ExperimentVariantsCreatedEvent = LatitudeEventGeneric<
 
 export type ProviderLogCreatedEvent = LatitudeEventGeneric<
   'providerLogCreated',
-  ProviderLog
+  Pick<ProviderLog, 'id'> & { workspaceId: number }
 >
 
 export type StreamCommonData = {
@@ -181,7 +181,7 @@ export type CommitCreatedEvent = LatitudeEventGeneric<
 
 export type DocumentLogCreatedEvent = LatitudeEventGeneric<
   'documentLogCreated',
-  DocumentLog & { workspaceId: number }
+  Pick<DocumentLog, 'id'> & { workspaceId: number }
 >
 
 export type DocumentSuggestionCreatedEvent = LatitudeEventGeneric<

--- a/packages/core/src/events/handlers/evaluateLiveLog.ts
+++ b/packages/core/src/events/handlers/evaluateLiveLog.ts
@@ -7,7 +7,11 @@ import {
 import { runEvaluationV2JobKey } from '../../jobs/job-definitions'
 import { evaluationsQueue } from '../../jobs/queues'
 import { NotFoundError } from '../../lib/errors'
-import { CommitsRepository, EvaluationsV2Repository } from '../../repositories'
+import {
+  CommitsRepository,
+  DocumentLogsRepository,
+  EvaluationsV2Repository,
+} from '../../repositories'
 import { getEvaluationMetricSpecification } from '../../services/evaluationsV2/specifications'
 import { DocumentLogCreatedEvent } from '../events'
 
@@ -16,7 +20,9 @@ export const evaluateLiveLogJob = async ({
 }: {
   data: DocumentLogCreatedEvent
 }) => {
-  const documentLog = event.data
+  const { id, workspaceId } = event.data
+  const repo = new DocumentLogsRepository(workspaceId)
+  const documentLog = await repo.find(id).then((r) => r.unwrap())
 
   const workspace = await findWorkspaceFromDocumentLog(documentLog)
   if (!workspace)

--- a/packages/core/src/events/handlers/notifyToClientDocumentLogCreatedJob.ts
+++ b/packages/core/src/events/handlers/notifyToClientDocumentLogCreatedJob.ts
@@ -1,5 +1,6 @@
 import { findWorkspaceFromDocumentLog } from '../../data-access'
 import { findCommitById } from '../../data-access/commits'
+import { DocumentLogsRepository } from '../../repositories'
 import { computeDocumentLogWithMetadata } from '../../services/documentLogs/computeDocumentLogWithMetadata'
 import { WebsocketClient } from '../../websockets/workers'
 import { DocumentLogCreatedEvent } from '../events'
@@ -10,7 +11,9 @@ export const notifyToClientDocumentLogCreatedJob = async ({
 }: {
   data: DocumentLogCreatedEvent
 }) => {
-  const documentLog = event.data
+  const { id, workspaceId } = event.data
+  const repo = new DocumentLogsRepository(workspaceId)
+  const documentLog = await repo.find(id).then((r) => r.unwrap())
   const workspace = await findWorkspaceFromDocumentLog(documentLog)
   if (!workspace) throw new NotFoundError('Workspace not found')
 

--- a/packages/core/src/events/handlers/touchApiKeyJob.ts
+++ b/packages/core/src/events/handlers/touchApiKeyJob.ts
@@ -1,3 +1,4 @@
+import { ProviderLogsRepository } from '../../repositories'
 import { touchApiKey } from '../../services/apiKeys/touch'
 import { EventHandler, ProviderLogCreatedEvent } from '../events'
 
@@ -6,7 +7,9 @@ export const touchApiKeyJob: EventHandler<ProviderLogCreatedEvent> = async ({
 }: {
   data: ProviderLogCreatedEvent
 }) => {
-  const { data: providerLog } = event
+  const { id, workspaceId } = event.data
+  const repo = new ProviderLogsRepository(workspaceId)
+  const providerLog = await repo.find(id).then((r) => r.unwrap())
 
   if (providerLog.apiKeyId) {
     await touchApiKey(providerLog.apiKeyId).then((r) => r.unwrap())

--- a/packages/core/src/events/handlers/touchProviderApiKeyJob.ts
+++ b/packages/core/src/events/handlers/touchProviderApiKeyJob.ts
@@ -1,10 +1,13 @@
+import { ProviderLogsRepository } from '../../repositories'
 import { touchProviderApiKey } from '../../services/providerApiKeys/touch'
 import { EventHandler, ProviderLogCreatedEvent } from '../events'
 
 export const touchProviderApiKeyJob: EventHandler<
   ProviderLogCreatedEvent
 > = async ({ data: event }: { data: ProviderLogCreatedEvent }) => {
-  const { data: providerLog } = event
+  const { id, workspaceId } = event.data
+  const repo = new ProviderLogsRepository(workspaceId)
+  const providerLog = await repo.find(id).then((r) => r.unwrap())
 
   if (providerLog.providerId) {
     await touchProviderApiKey(providerLog.providerId).then((r) => r.unwrap())

--- a/packages/core/src/jobs/job-definitions/webhooks/processIndividualWebhookJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/processIndividualWebhookJob.test.ts
@@ -347,16 +347,8 @@ describe('processIndividualWebhookJob', () => {
     const event = {
       type: 'documentLogCreated',
       data: {
-        uuid: documentLog.uuid,
-        documentUuid: document.documentUuid,
-        duration: 1000,
-        parameters: { test: 'value' },
-        customIdentifier: undefined,
-        source: 'playground',
+        id: documentLog.id,
         workspaceId: workspace.id,
-        commitId: commit.id,
-        userEmail: 'test@example.com',
-        messages,
       },
     }
 
@@ -390,7 +382,7 @@ describe('processIndividualWebhookJob', () => {
           prompt: expect.any(Object),
           uuid: documentLog.uuid,
           parameters: { test: 'value' },
-          customIdentifier: undefined,
+          customIdentifier: null,
           duration: expect.any(Number),
           source: expect.any(String),
           commitId: commit.id,

--- a/packages/core/src/services/chains/run-errors.test.ts
+++ b/packages/core/src/services/chains/run-errors.test.ts
@@ -172,6 +172,7 @@ describe('run chain error handling', () => {
       message: 'Something undefined happened',
       details: {
         errorCode: RunErrorCodes.Unknown,
+        stack: expect.any(String),
       },
       createdAt: expect.any(Date),
       updatedAt: expect.any(Date),

--- a/packages/core/src/services/documentLogs/buildDocumentLogDatasetRows/index.ts
+++ b/packages/core/src/services/documentLogs/buildDocumentLogDatasetRows/index.ts
@@ -25,6 +25,7 @@ async function findLogs({
   workspace: Workspace
   documentLogIds: number[]
 }) {
+  // TODO(perf): remove this repo
   const repo = new DocumentLogsWithMetadataAndErrorsRepository(workspace.id)
   const results = await repo
     .findMany(documentLogIds, { ordering: [desc(documentLogs.createdAt)] })

--- a/packages/core/src/services/documentLogs/create.ts
+++ b/packages/core/src/services/documentLogs/create.ts
@@ -99,7 +99,7 @@ export async function createDocumentLog(
     publisher.publishLater({
       type: 'documentLogCreated',
       data: {
-        ...documentLog,
+        id: documentLog.id,
         workspaceId: workspace.id,
       },
     })

--- a/packages/core/src/services/providerLogs/create.test.ts
+++ b/packages/core/src/services/providerLogs/create.test.ts
@@ -73,7 +73,10 @@ describe('create provider', () => {
     )
     expect(publisherSpy).toHaveBeenCalledWith({
       type: 'providerLogCreated',
-      data: providerLog,
+      data: {
+        id: providerLog.id,
+        workspaceId: workspace.id,
+      },
     })
   })
 

--- a/packages/core/src/services/providerLogs/create.ts
+++ b/packages/core/src/services/providerLogs/create.ts
@@ -100,7 +100,10 @@ export async function createProviderLog(
 
     publisher.publishLater({
       type: 'providerLogCreated',
-      data: log,
+      data: {
+        id: log.id,
+        workspaceId: workspace.id,
+      },
     })
 
     return Result.ok(log)


### PR DESCRIPTION
Remove data from providerlogs created events: it takes lots of disk space for no real benefit (logs are supposed to frozen anyway)