### PR TITLE
Improved JSONSchema validation

### DIFF
--- a/packages/constants/src/latitudePromptSchema/index.ts
+++ b/packages/constants/src/latitudePromptSchema/index.ts
@@ -4,6 +4,7 @@ import { AgentToolsMap, resolveRelativePath } from '../index'
 import { azureConfig as azureConfigSchema } from './providers/azure'
 import { JSONSchema7 } from 'json-schema'
 import { buildToolsSchema } from './toolsSchema'
+import { zodJsonSchema } from './zodJsonSchema'
 
 export function latitudePromptConfigSchema({
   providerNames,
@@ -21,7 +22,7 @@ export function latitudePromptConfigSchema({
   const tools = buildToolsSchema({ integrationNames })
   const outputSchema = noOutputSchemaConfig
     ? z.never({ message: noOutputSchemaConfig?.message }).optional()
-    : undefined
+    : zodJsonSchema.optional()
 
   const agentsConfigSchema =
     fullPath && agentToolsMap
@@ -69,7 +70,7 @@ export function latitudePromptConfigSchema({
     [MAX_STEPS_CONFIG_NAME]: z.number().min(1).max(150).optional(),
     tools: tools.optional(),
     agents: agentsConfigSchema.optional(),
-    ...(outputSchema ? { schema: outputSchema } : {}),
+    schema: outputSchema,
     azure: azureConfigSchema.optional(),
   })
 }

--- a/packages/constants/src/latitudePromptSchema/toolsSchema.ts
+++ b/packages/constants/src/latitudePromptSchema/toolsSchema.ts
@@ -1,47 +1,7 @@
 import { z } from 'zod'
 import { LatitudeTool } from '../config'
 import { openAIToolsList } from './providers/openai/index'
-
-const JSON_SCHEMA_TYPES: readonly [string, ...string[]] = [
-  'string',
-  'number',
-  'boolean',
-  'object',
-  'integer',
-  'null',
-  'array',
-]
-const jsonSchema: z.ZodType<any> = z.lazy(() =>
-  z.object({
-    type: z.enum(JSON_SCHEMA_TYPES),
-    description: z.string().optional(),
-
-    // object
-    properties: z.record(jsonSchema).optional(),
-    required: z.array(z.string()).optional(),
-    additionalProperties: z.union([z.boolean(), jsonSchema]).optional(),
-
-    // array
-    items: z.union([jsonSchema, z.array(jsonSchema)]).optional(),
-
-    // common
-    enum: z
-      .array(z.union([z.string(), z.number(), z.boolean(), z.null()]))
-      .optional(),
-
-    // string
-    minLength: z.number().optional(),
-    maxLength: z.number().optional(),
-    pattern: z.string().optional(),
-    format: z.string().optional(),
-
-    // number
-    minimum: z.number().optional(),
-    maximum: z.number().optional(),
-
-    $ref: z.string().optional(), // Reference to another schema
-  }),
-)
+import { zodJsonSchema } from './zodJsonSchema'
 
 const toolDefinitionObject = z.record(
   z.object({
@@ -54,7 +14,7 @@ const toolDefinitionObject = z.record(
           required_error: 'Parameters must be an object',
           invalid_type_error: 'Parameters must be an object',
         }),
-        properties: z.record(jsonSchema),
+        properties: z.record(zodJsonSchema),
         required: z.array(z.string()).optional(),
         additionalProperties: z.boolean().optional(),
       })

--- a/packages/constants/src/latitudePromptSchema/zodJsonSchema.ts
+++ b/packages/constants/src/latitudePromptSchema/zodJsonSchema.ts
@@ -1,0 +1,187 @@
+import { z } from 'zod'
+
+const JSON_SCHEMA_TYPES = [
+  'string',
+  'number',
+  'integer',
+  'boolean',
+  'object',
+  'array',
+  'null',
+] as const
+
+const JSON_ENUM_VALUES = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+])
+
+export const zodJsonSchema: z.ZodType<unknown> = z.lazy(() =>
+  z
+    .object({
+      // Meta‐Keywords
+      $id: z.string().url().optional(),
+      $schema: z.string().url().optional(),
+      $ref: z.string().optional(),
+
+      title: z.string().optional(),
+      description: z.string().optional(),
+      default: z.any().optional(),
+      examples: z.array(z.any()).optional(),
+
+      // Core Validation Keywords
+      type: z
+        .union([
+          z.enum(JSON_SCHEMA_TYPES),
+          z.array(z.enum(JSON_SCHEMA_TYPES)).nonempty(),
+        ])
+        .optional(),
+
+      enum: z.array(JSON_ENUM_VALUES).optional(),
+      const: JSON_ENUM_VALUES.optional(),
+
+      // Numeric validation
+      multipleOf: z.number().positive().optional(),
+      maximum: z.number().optional(),
+      exclusiveMaximum: z.number().optional(),
+      minimum: z.number().optional(),
+      exclusiveMinimum: z.number().optional(),
+
+      // String validation
+      maxLength: z.number().int().min(0).optional(),
+      minLength: z.number().int().min(0).optional(),
+      pattern: z.string().optional(),
+      format: z.string().optional(),
+
+      // Array validation
+      maxItems: z.number().int().min(0).optional(),
+      minItems: z.number().int().min(0).optional(),
+      uniqueItems: z.boolean().optional(),
+
+      items: z
+        .union([zodJsonSchema, z.array(zodJsonSchema).nonempty()])
+        .optional(),
+      additionalItems: z.union([z.boolean(), zodJsonSchema]).optional(),
+      contains: zodJsonSchema.optional(),
+
+      // Object validation
+      maxProperties: z.number().int().min(0).optional(),
+      minProperties: z.number().int().min(0).optional(),
+      required: z.array(z.string()).optional(),
+      properties: z.record(zodJsonSchema).optional(),
+      patternProperties: z.record(zodJsonSchema).optional(),
+      additionalProperties: z.union([z.boolean(), zodJsonSchema]).optional(),
+      dependencies: z
+        .record(z.union([z.array(z.string()).nonempty(), zodJsonSchema]))
+        .optional(),
+      propertyNames: zodJsonSchema.optional(),
+
+      // Combining / Logic keywords
+      allOf: z.array(zodJsonSchema).optional(),
+      anyOf: z.array(zodJsonSchema).optional(),
+      oneOf: z.array(zodJsonSchema).optional(),
+      not: zodJsonSchema.optional(),
+
+      //? Conditional (draft‐07+):
+      // if: zodJsonSchema.optional(),
+      // then: zodJsonSchema.optional(),
+      // else: zodJsonSchema.optional(),
+
+      // Annotations
+      readOnly: z.boolean().optional(),
+      writeOnly: z.boolean().optional(),
+      deprecated: z.boolean().optional(),
+
+      // Definitions / $defs
+      definitions: z.record(zodJsonSchema).optional(),
+      $defs: z.record(zodJsonSchema).optional(),
+    })
+    .superRefine((obj, ctx) => {
+      // 1) items requires type: array
+      if (obj.items !== undefined) {
+        if (obj.type !== undefined) {
+          const types = Array.isArray(obj.type) ? obj.type : [obj.type]
+          if (!types.includes('array')) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "`items` is only allowed when `type` includes 'array'.",
+              path: ['items'],
+            })
+          }
+        }
+      }
+
+      // 2) object-only keywords require type: object
+      const objectOnlyKeys = [
+        'properties',
+        'patternProperties',
+        'required',
+        'maxProperties',
+        'minProperties',
+        'additionalProperties',
+        'dependencies',
+        'propertyNames',
+      ] as const
+
+      for (const key of objectOnlyKeys) {
+        if ((obj as any)[key] !== undefined) {
+          if (obj.type !== undefined) {
+            const types = Array.isArray(obj.type) ? obj.type : [obj.type]
+            if (!types.includes('object')) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `\`${key}\` is only allowed when \`type\` includes 'object'.`,
+                path: [key],
+              })
+            }
+          }
+        }
+      }
+
+      // 3) string-only keywords require type: string
+      const stringOnlyKeys = [
+        'pattern',
+        'format',
+        'minLength',
+        'maxLength',
+      ] as const
+      for (const key of stringOnlyKeys) {
+        if ((obj as any)[key] !== undefined) {
+          if (obj.type !== undefined) {
+            const types = Array.isArray(obj.type) ? obj.type : [obj.type]
+            if (!types.includes('string')) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `\`${key}\` is only allowed when \`type\` includes 'string'.`,
+                path: [key],
+              })
+            }
+          }
+        }
+      }
+
+      // 4) numeric-only keywords require type: number or integer
+      const numericOnlyKeys = [
+        'multipleOf',
+        'minimum',
+        'maximum',
+        'exclusiveMinimum',
+        'exclusiveMaximum',
+      ] as const
+      for (const key of numericOnlyKeys) {
+        if ((obj as any)[key] !== undefined) {
+          if (obj.type !== undefined) {
+            const types = Array.isArray(obj.type) ? obj.type : [obj.type]
+            if (!types.includes('number') && !types.includes('integer')) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `\`${key}\` is only allowed when \`type\` includes 'number' or 'integer'.`,
+                path: [key],
+              })
+            }
+          }
+        }
+      }
+    }),
+)


### PR DESCRIPTION
The `JSONSchema` validation we're performing on tool definition is too basic, which fails on more complex definitions.

A more precise definition of the JSONSchema using Zod has been defined.