### PR TITLE
latte: get error messages when reading and modifying prompts

### DIFF
--- a/packages/core/src/services/copilot/latte/tools/presenters.ts
+++ b/packages/core/src/services/copilot/latte/tools/presenters.ts
@@ -1,3 +1,5 @@
+import type { ConversationMetadata as LegacyMetadata } from '@latitude-data/compiler'
+import type { ConversationMetadata as PromptlMetadata } from 'promptl-ai'
 import { Commit, DocumentVersion, Project } from '../../../../browser'
 
 export function projectPresenter(project: Project) {
@@ -20,10 +22,12 @@ export function promptPresenter({
   document,
   projectId,
   versionUuid,
+  metadata,
 }: {
   document: DocumentVersion
   projectId: number
   versionUuid: string
+  metadata?: LegacyMetadata | PromptlMetadata
 }) {
   if (document.deletedAt) {
     return {
@@ -32,10 +36,13 @@ export function promptPresenter({
     }
   }
 
+  const errors = metadata?.errors?.length ? { errors: metadata.errors } : {}
+
   return {
     uuid: document.documentUuid,
     path: document.path,
     isAgent: document.documentType === 'agent',
     href: `/projects/${projectId}/versions/${versionUuid}/documents/${document.documentUuid}`,
+    ...errors,
   }
 }


### PR DESCRIPTION
> "Fix my prompt"

> "What does this error mean"

When Latte reads a prompt, it will now obtain a list of its errors too.

Also, when Latte modifies a project, it will then obtain a list of all errors in the project too. This way, it will find any errors introduced with any of the changes it just made and fix it before responding back to the user.


