### PR TITLE
Playground simple block editor. AST to Simple blocks

### DIFF
--- a/.prettierrcignore
+++ b/.prettierrcignore
@@ -5,3 +5,4 @@ build
 **/tests/fixtures
 examples/src/**
 docs/examples/**
+ONLY_FOR_COPILOT

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/BlocksEditor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/BlocksEditor/index.tsx
@@ -1,0 +1,29 @@
+import { memo, Suspense } from 'react'
+import { AstError } from '@latitude-data/constants/simpleBlocks'
+import { TextEditorPlaceholder } from '@latitude-data/web-ui/molecules/TextEditorPlaceholder'
+import { AnyBlock } from '@latitude-data/constants/simpleBlocks'
+import { CodeBlock } from '@latitude-data/web-ui/atoms/CodeBlock'
+
+export const PlaygroundBlocksEditor = memo(
+  ({
+    value: _prompt,
+    blocks = [],
+  }: {
+    compileErrors: AstError[] | undefined
+    blocks: AnyBlock[] | undefined
+    value: string
+    defaultValue?: string
+    isSaved: boolean
+    readOnlyMessage?: string
+    onChange: (value: string) => void
+  }) => {
+    if (!blocks.length) return null
+
+    return (
+      <Suspense fallback={<TextEditorPlaceholder />}>
+        Blocks Editor
+        <CodeBlock language='json'>{JSON.stringify(blocks, null, 2)}</CodeBlock>
+      </Suspense>
+    )
+  },
+)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import { Commit, Project } from '@latitude-data/core/browser'
-import { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 
 import { RunExperimentModal } from '$/components/RunExperimentModal'
@@ -19,7 +19,7 @@ export default function Preview({
   expandParameters,
   setExpandParameters,
 }: {
-  metadata: ConversationMetadata | undefined
+  metadata: ResolvedMetadata | undefined
   parameters: Record<string, unknown> | undefined
   runPrompt: () => void
 } & ActionsState) {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
@@ -13,8 +13,7 @@ import {
   useCurrentProject,
 } from '@latitude-data/web-ui/providers'
 import { cn } from '@latitude-data/web-ui/utils'
-import type { ConversationMetadata } from 'promptl-ai'
-
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import Chat from '$/components/PlaygroundCommon/Chat'
 import {
   DOCUMENT_PLAYGROUND_COLLAPSED_SIZE,
@@ -37,7 +36,7 @@ export const Playground = memo(
     document: DocumentVersion
     prompt: string
     setPrompt: (prompt: string) => void
-    metadata: ConversationMetadata
+    metadata: ResolvedMetadata
   }) => {
     const [mode, setMode] = useState<'preview' | 'chat'>('preview')
     const { commit } = useCurrentCommit()

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/TextEditor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/TextEditor/index.tsx
@@ -10,7 +10,7 @@ import {
   IProjectContextType,
 } from '@latitude-data/web-ui/providers'
 import type { DiffOptions } from 'node_modules/@latitude-data/web-ui/src/ds/molecules/DocumentTextEditor/types'
-import { CompileError } from 'promptl-ai'
+import type { AstError } from '@latitude-data/constants/simpleBlocks'
 import { memo, Suspense, useCallback } from 'react'
 import { DocumentRefinement } from '../DocumentRefinement'
 import { DocumentSuggestions } from '../DocumentSuggestions'
@@ -31,7 +31,7 @@ export const PlaygroundTextEditor = memo(
     readOnlyMessage,
     highlightedCursorIndex,
   }: {
-    compileErrors: CompileError[] | undefined
+    compileErrors: AstError[] | undefined
     project: IProjectContextType['project']
     commit: ICommitContextType['commit']
     document: DocumentVersion

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/index.tsx
@@ -18,7 +18,7 @@ import {
   useLocalStorage,
 } from '@latitude-data/web-ui/hooks/useLocalStorage'
 import { useCurrentProject } from '@latitude-data/web-ui/providers'
-import type { ConversationMetadata } from 'promptl-ai'
+import type { ResolvedMetadata } from '$/workers/readMetadata'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useEvaluationParameters } from '../hooks/useEvaluationParamaters'
 import EvaluationParams from './EvaluationParams'
@@ -35,7 +35,7 @@ export const Playground = memo(
     commit: Commit
     document: DocumentVersion
     evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
-    metadata: ConversationMetadata
+    metadata: ResolvedMetadata
     selectedDocumentLogUuid?: string
   }) => {
     const { project } = useCurrentProject()

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/TextEditor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/TextEditor/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { CompileError } from 'promptl-ai'
+import type { AstError } from '@latitude-data/constants/simpleBlocks'
 import { DocumentTextEditor } from '@latitude-data/web-ui/molecules/DocumentTextEditor'
 import { TextEditorPlaceholder } from '@latitude-data/web-ui/molecules/TextEditorPlaceholder'
 import { LLM_EVALUATION_PROMPT_PARAMETERS } from '@latitude-data/constants'
@@ -33,7 +33,7 @@ export function TextEditor({
   isMerged,
   onChange,
 }: {
-  compileErrors: CompileError[] | undefined
+  compileErrors: AstError[] | undefined
   value: string
   defaultValue?: string
   isSaved: boolean

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/index.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/index.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import type { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import {
   DocumentVersion,
   EvaluationType,
@@ -24,7 +24,7 @@ export function useEvaluationParameters({
   commitVersionUuid: string
   document: DocumentVersion
   evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
-  metadata?: ConversationMetadata | undefined
+  metadata?: ResolvedMetadata | undefined
 }) {
   const state = useEvaluatedLogInputs()
   const { value: allInputs, setValue } =

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/logInputParamaters.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/hooks/useEvaluationParamaters/logInputParamaters.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand'
 
-import type { ConversationMetadata } from 'promptl-ai'
 import {
   EvaluatedDocumentLog,
   LLM_EVALUATION_PROMPT_PARAMETERS,
 } from '@latitude-data/core/browser'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 
 export type LogInput = {
   value: string
@@ -158,7 +158,7 @@ type EvaluatedLogInputsState = {
   metadataParameters: string[]
   expectedOutput: LogInput
   mapLogParametersToInputs: (log: EvaluatedDocumentLog) => void
-  onMetadataChange: (metadata: ConversationMetadata | undefined) => void
+  onMetadataChange: (metadata: ResolvedMetadata | undefined) => void
   setInputs: (inputs: Record<string, string>) => void
 }
 
@@ -193,7 +193,7 @@ export const useEvaluatedLogInputs = create<EvaluatedLogInputsState>(
       const inputs = serializeInputs(parameters, metadataParameters)
       set({ parameters, filteredParameters, inputs, logsInitiallyLoaded: true })
     },
-    onMetadataChange: (metadata: ConversationMetadata | undefined) => {
+    onMetadataChange: (metadata: ResolvedMetadata | undefined) => {
       if (!metadata) return
 
       const metadataParameters = Array.from(metadata.parameters)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/index.tsx
@@ -69,6 +69,7 @@ export function EvaluationEditor({
     ({ promptValue }: { promptValue: string }) => {
       return {
         prompt: promptValue,
+        editorType: 'code' as const,
         promptlVersion: 1,
         providerNames,
         integrationNames,

--- a/apps/web/src/components/EditorHeader/index.tsx
+++ b/apps/web/src/components/EditorHeader/index.tsx
@@ -3,7 +3,7 @@ import { memo, ReactNode, useEffect, useState } from 'react'
 import { updatePromptMetadata } from '$/lib/promptMetadata'
 import { ROUTES } from '$/services/routes'
 import { DocumentVersion, ProviderApiKey } from '@latitude-data/core/browser'
-import type { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import {
   AppLocalStorage,
   useLocalStorage,
@@ -42,7 +42,7 @@ export const EditorHeader = memo(
   }: {
     title: string | ReactNode
     titleVerticalAlign?: 'top' | 'center'
-    metadata: ConversationMetadata | undefined
+    metadata: ResolvedMetadata | undefined
     prompt: string
     onChangePrompt: (prompt: string) => void
     rightActions?: ReactNode

--- a/apps/web/src/components/PlaygroundCommon/PreviewPrompt/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/PreviewPrompt/index.tsx
@@ -6,7 +6,7 @@ import {
   LATITUDE_DOCS_URL,
   ProviderRules,
 } from '@latitude-data/core/browser'
-import { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { cn } from '@latitude-data/web-ui/utils'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
@@ -61,7 +61,7 @@ export default function PreviewPrompt({
   setExpandParameters,
   actions,
 }: {
-  metadata: ConversationMetadata | undefined
+  metadata: ResolvedMetadata | undefined
   parameters: Record<string, unknown> | undefined
   runPrompt: () => void
   actions?: ReactNode

--- a/apps/web/src/components/Providers/FeatureFlags/flags.ts
+++ b/apps/web/src/components/Providers/FeatureFlags/flags.ts
@@ -2,6 +2,7 @@ import { env } from '@latitude-data/env'
 
 export const FEATURE_FLAGS = {
   latte: 'latte',
+  blocksEditor: 'blocksEditor',
 } as const
 
 export type FeatureFlag = keyof typeof FEATURE_FLAGS
@@ -14,6 +15,7 @@ export const FEATURE_FLAGS_CONDITIONS: Record<
   FeatureFlagCondition
 > = {
   latte: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1] },
+  blocksEditor: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [] },
 }
 
 export type ResolvedFeatureFlags = Record<FeatureFlag, { enabled: boolean }>

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/useExperimentFormPayload.ts
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/useExperimentFormPayload.ts
@@ -61,6 +61,7 @@ export function useExperimentFormPayload({
   useEffect(() => {
     runReadMetadata({
       promptlVersion: document.promptlVersion,
+      editorType: 'code',
       prompt: document.content,
       document,
     })

--- a/apps/web/src/hooks/playgrounds/usePreviewConversation.ts
+++ b/apps/web/src/hooks/playgrounds/usePreviewConversation.ts
@@ -4,11 +4,8 @@ import {
   Message as ConversationMessage,
   Chain as LegacyChain,
 } from '@latitude-data/compiler'
-import {
-  Adapters,
-  ConversationMetadata,
-  Chain as PromptlChain,
-} from 'promptl-ai'
+import { Adapters, Chain as PromptlChain } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import { AppliedRules, applyProviderRules } from '@latitude-data/core/browser'
 import useProviderApiKeys from '$/stores/providerApiKeys'
 
@@ -18,7 +15,7 @@ export function usePreviewConversation({
   metadata,
 }: {
   promptlVersion: number
-  metadata: ConversationMetadata | undefined
+  metadata: ResolvedMetadata | undefined
   parameters: Record<string, unknown> | undefined
 }) {
   const [error, setError] = useState<Error | undefined>(undefined)

--- a/apps/web/src/hooks/useDocumentParameters/index.ts
+++ b/apps/web/src/hooks/useDocumentParameters/index.ts
@@ -15,7 +15,6 @@ import {
   useLocalStorage,
 } from '@latitude-data/web-ui/hooks/useLocalStorage'
 import { useCurrentProject } from '@latitude-data/web-ui/providers'
-import type { ConversationMetadata } from 'promptl-ai'
 import { detectParamChanges } from './detectParameterChanges'
 import { useMetadataParameters } from './metadataParametersStore'
 import {
@@ -27,6 +26,7 @@ import {
   recalculateAllInputs,
   updateInputsState,
 } from './utils'
+import { type ResolvedMetadata } from '$/workers/readMetadata'
 
 function convertToParams(inputs: Inputs<InputSource>) {
   return Object.fromEntries(
@@ -47,7 +47,7 @@ export function useDocumentParameters({
 }: {
   document: DocumentVersion
   commitVersionUuid: string
-  metadata?: ConversationMetadata | undefined
+  metadata?: ResolvedMetadata | undefined
 }) {
   const { metadataParameters, setParameters, emptyInputs } =
     useMetadataParameters()
@@ -205,7 +205,7 @@ export function useDocumentParameters({
   )
 
   const onMetadataChange = useCallback(
-    (metadata: ConversationMetadata) => {
+    (metadata: ResolvedMetadata) => {
       setValue((oldState) => {
         const prevInputs = useMetadataParameters.getState().prevInputs
         return recalculateAllInputs({
@@ -231,7 +231,7 @@ export function useDocumentParameters({
     },
     [key, setValue, dsId],
   )
-  const lastMetadataRef = useRef<ConversationMetadata | null>(null)
+  const lastMetadataRef = useRef<ResolvedMetadata | null>(null)
 
   const snapshotCurrentDoc = useCallback(() => {
     setValue((oldState) => {

--- a/apps/web/src/hooks/useDocumentParameters/recalculateInputs/index.test.ts
+++ b/apps/web/src/hooks/useDocumentParameters/recalculateInputs/index.test.ts
@@ -1,4 +1,4 @@
-import type { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import { describe, expect, it } from 'vitest'
 
 import { recalculateInputs } from './index'
@@ -26,7 +26,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -54,7 +54,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -85,7 +85,7 @@ describe('recalculateInputs', () => {
       metadata: {
         parameters: new Set(['param1']),
         config: {},
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -116,7 +116,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -150,7 +150,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -183,7 +183,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -210,7 +210,7 @@ describe('recalculateInputs', () => {
       metadata: {
         parameters: new Set(['param1']),
         config: {},
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({
@@ -242,7 +242,7 @@ describe('recalculateInputs', () => {
             },
           },
         },
-      } as unknown as ConversationMetadata,
+      } as unknown as ResolvedMetadata,
     })
 
     expect(newInputs).toEqual({

--- a/apps/web/src/hooks/useDocumentParameters/recalculateInputs/index.ts
+++ b/apps/web/src/hooks/useDocumentParameters/recalculateInputs/index.ts
@@ -1,6 +1,6 @@
 import { ParameterType } from '@latitude-data/constants'
 import { Inputs, InputSource } from '@latitude-data/core/browser'
-import type { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 
 const ParameterTypes = Object.values(ParameterType) as string[]
 
@@ -11,7 +11,7 @@ export function recalculateInputs<S extends InputSource>({
 }: {
   inputs: Inputs<S>
   fallbackInputs?: Inputs<S>
-  metadata: ConversationMetadata
+  metadata: ResolvedMetadata
 }): Inputs<S> {
   const config = (prompt.config.parameters || {}) as Record<
     string,

--- a/apps/web/src/hooks/useDocumentParameters/utils.ts
+++ b/apps/web/src/hooks/useDocumentParameters/utils.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'lodash-es'
-import { ConversationMetadata } from 'promptl-ai'
+import { ResolvedMetadata } from '$/workers/readMetadata'
 import {
   INPUT_SOURCE,
   LinkedDataset,
@@ -124,7 +124,7 @@ export function recalculateAllInputs({
 }: {
   key: string
   oldState: InputsByDocument
-  metadata: ConversationMetadata
+  metadata: ResolvedMetadata
   config: {
     manual?: {
       fallbackInputs?: Inputs<'manual'>

--- a/apps/web/src/hooks/useMetadata.ts
+++ b/apps/web/src/hooks/useMetadata.ts
@@ -2,9 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react'
 
-import type { ConversationMetadata } from 'promptl-ai'
 import { useDebouncedCallback } from 'use-debounce'
-import type { ReadMetadataWorkerProps } from '../workers/readMetadata'
+import type {
+  ReadMetadataWorkerProps,
+  ResolvedMetadata,
+} from '../workers/readMetadata'
 
 let workerPath: string | null = null
 
@@ -22,7 +24,7 @@ async function getWorkerUrl(): Promise<string | null> {
 
 export function useMetadata() {
   const workerRef = useRef<Worker | null>(null)
-  const [metadata, setMetadata] = useState<ConversationMetadata>()
+  const [metadata, setMetadata] = useState<ResolvedMetadata>()
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/apps/web/src/workers/readMetadata.ts
+++ b/apps/web/src/workers/readMetadata.ts
@@ -1,17 +1,26 @@
-import {
-  readMetadata,
-  CompileError as CompilerCompileError,
-} from '@latitude-data/compiler'
 import { AgentToolsMap, resolveRelativePath } from '@latitude-data/constants'
 import { latitudePromptConfigSchema } from '@latitude-data/constants/latitudePromptSchema'
+import {
+  astToSimpleBlocks,
+  type AnyBlock,
+} from '@latitude-data/constants/simpleBlocks'
 import type { DocumentVersion } from '@latitude-data/core/browser'
+import { AstError } from '@latitude-data/constants/simpleBlocks'
 
-import { CompileError as PromptlCompileError, scan } from 'promptl-ai'
+import {
+  CompileError as PromptlCompileError,
+  ConversationMetadata as PromptlConversationMetadata,
+  Fragment,
+  scan,
+  parse,
+} from 'promptl-ai'
 
-type CompileError = PromptlCompileError | CompilerCompileError
+type CompileError = PromptlCompileError
 
-export type ReadMetadataWorkerProps = Parameters<typeof readMetadata>[0] & {
+type EditorType = 'code' | 'visual'
+export type ReadMetadataWorkerProps = Parameters<typeof scan>[0] & {
   promptlVersion: number
+  editorType: EditorType
   document?: DocumentVersion
   documents?: DocumentVersion[]
   providerNames?: string[]
@@ -20,12 +29,83 @@ export type ReadMetadataWorkerProps = Parameters<typeof readMetadata>[0] & {
   noOutputSchemaConfig?: { message: string }
 }
 
+function readDocument(
+  document?: DocumentVersion,
+  documents?: DocumentVersion[],
+  prompt?: string,
+) {
+  if (!document || !documents || !prompt) return undefined
+
+  return async (refPath: string, from?: string) => {
+    const fullPath = resolveRelativePath(refPath, from)
+
+    if (fullPath === document.path) {
+      return {
+        path: fullPath,
+        content: prompt,
+      }
+    }
+
+    const content = documents.find((d) => d.path === fullPath)?.content
+    if (content === undefined) return undefined
+
+    return {
+      path: fullPath,
+      content,
+    }
+  }
+}
+
+function handleMetadata({
+  prompt,
+  editorType,
+  metadata,
+  ast,
+}: {
+  prompt: string
+  editorType: EditorType
+  metadata: PromptlConversationMetadata
+  ast: Fragment
+}) {
+  const { setConfig: _, errors: rawErrors, ...returnedMetadata } = metadata
+  const errors = rawErrors.map((error: CompileError) => {
+    return {
+      startIndex: error.startIndex,
+      endIndex: error.endIndex,
+      start: {
+        line: error.start?.line ?? 0,
+        column: error.start?.column ?? 0,
+      },
+      end: {
+        line: error.end?.line ?? 0,
+        column: error.end?.column ?? 0,
+      },
+      message: error.message,
+      name: error.name,
+    } satisfies AstError
+  })
+
+  let blocks: AnyBlock[] = []
+
+  if (ast && editorType === 'visual') {
+    blocks = astToSimpleBlocks({ ast, prompt, errors })
+  }
+
+  return {
+    ...(returnedMetadata as PromptlConversationMetadata),
+    errors,
+    blocks,
+  }
+}
+
+export type ResolvedMetadata = Awaited<ReturnType<typeof handleMetadata>>
+
 self.onmessage = async function (event: { data: ReadMetadataWorkerProps }) {
   const {
+    prompt,
+    editorType,
     document,
     documents,
-    prompt,
-    promptlVersion,
     providerNames,
     agentToolsMap,
     integrationNames,
@@ -54,57 +134,17 @@ self.onmessage = async function (event: { data: ReadMetadataWorkerProps }) {
     configSchema,
   }
 
-  const metadata =
-    // FIXME
-    // @ts-ignore - scan props are not matching
-    promptlVersion === 0 ? await readMetadata(props) : await scan(props)
-
-  const { setConfig: _, errors: errors, ...returnedMetadata } = metadata
-
-  const errorsWithPositions = errors.map((error: CompileError) => {
-    return {
-      start: {
-        line: error.start?.line ?? 0,
-        column: error.start?.column ?? 0,
-      },
-      end: {
-        line: error.end?.line ?? 0,
-        column: error.end?.column ?? 0,
-      },
-      message: error.message,
-      name: error.name,
-    }
-  })
-
-  self.postMessage({
-    ...returnedMetadata,
-    errors: errorsWithPositions,
-  })
-}
-
-function readDocument(
-  document?: DocumentVersion,
-  documents?: DocumentVersion[],
-  prompt?: string,
-) {
-  if (!document || !documents || !prompt) return undefined
-
-  return async (refPath: string, from?: string) => {
-    const fullPath = resolveRelativePath(refPath, from)
-
-    if (fullPath === document.path) {
-      return {
-        path: fullPath,
-        content: prompt,
-      }
-    }
-
-    const content = documents.find((d) => d.path === fullPath)?.content
-    if (content === undefined) return undefined
-
-    return {
-      path: fullPath,
-      content,
-    }
+  const ast = parse(prompt)
+  const scanParams = {
+    prompt,
+    serialized: ast,
+    fullPath: document?.path,
+    referenceFn: props.referenceFn,
+    withParamters: props.withParameters,
+    requireConfig: true,
+    configSchema: props.configSchema as any,
   }
+  const metadata = await scan(scanParams)
+
+  self.postMessage(handleMetadata({ editorType, metadata, prompt, ast }))
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -8,7 +8,9 @@
   "type": "module",
   "scripts": {
     "lint": "eslint src",
-    "tc": "tsc --noEmit"
+    "tc": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "exports": {
     ".": "./src/index.ts",
@@ -18,17 +20,23 @@
     "./experiments": "./src/experiments.ts",
     "./tracing": "./src/tracing/index.ts",
     "./latitudePromptSchema": "./src/latitudePromptSchema/index.ts",
-    "./latte": "./src/latte/index.ts"
+    "./latte": "./src/latte/index.ts",
+    "./simpleBlocks": "./src/simpleBlocks/index.ts"
   },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",
     "@latitude-data/typescript-config": "workspace:*",
-    "@types/json-schema": "^7.0.15"
+    "@types/json-schema": "^7.0.15",
+    "@types/lodash.camelcase": "^4.3.9",
+    "@types/lodash.kebabcase": "^4.1.9",
+    "vitest": "^3.1.4"
   },
   "dependencies": {
     "@latitude-data/compiler": "workspace:^",
     "ai": "^4.2.9",
     "json-schema": "^0.4.0",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.kebabcase": "^4.1.1",
     "promptl-ai": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/constants/src/simpleBlocks/astParsingUtils.ts
+++ b/packages/constants/src/simpleBlocks/astParsingUtils.ts
@@ -1,0 +1,335 @@
+import camelCase from 'lodash.camelcase'
+import kebabCase from 'lodash.kebabcase'
+
+import {
+  CONTENT_BLOCK,
+  type ElementTag,
+  type MessageBlockType,
+  type ContentBlockType,
+  type MustacheTag,
+  IfBlock,
+  ForBlock,
+  TemplateNode,
+  Text,
+  BLOCK_TYPES,
+  BlockType,
+  StepBlock,
+  BlockAttributes,
+  PromptBlock,
+  FileBlock,
+  ToolCallBlock,
+} from './types'
+
+export function isMessageBlock(tag: ElementTag): boolean {
+  const promptlToBlockType: Record<string, MessageBlockType> = {
+    system: 'system',
+    user: 'user',
+    assistant: 'assistant',
+    developer: 'developer',
+  }
+  return tag.name in promptlToBlockType
+}
+
+export function getMessageBlockType(tag: ElementTag): MessageBlockType {
+  const promptlToBlockType: Record<string, MessageBlockType> = {
+    system: 'system',
+    user: 'user',
+    assistant: 'assistant',
+    developer: 'developer',
+  }
+  return promptlToBlockType[tag.name] || 'system'
+}
+
+export function isContentBlock(tag: ElementTag): boolean {
+  return CONTENT_BLOCK.includes(tag.name as ContentBlockType)
+}
+
+export function isStepBlock(tag: ElementTag): boolean {
+  return tag.name === 'step'
+}
+
+export function expressionToString(
+  expression: MustacheTag['expression'],
+): string {
+  if (expression.type === 'Identifier') {
+    return expression.name
+  }
+  if (expression.type === 'Literal') {
+    return JSON.stringify(expression.value)
+  }
+  if (expression.type === 'MemberExpression') {
+    const object = expressionToString(expression.object)
+    const property = expressionToString(expression.property)
+    // Use bracket notation for array access to preserve original format
+    if (expression.computed) {
+      return `${object}[${property}]`
+    }
+    return `${object}.${property}`
+  }
+  if (expression.type === 'BinaryExpression') {
+    return `${expressionToString(expression.left)} ${expression.operator} ${expressionToString(expression.right)}`
+  }
+
+  return JSON.stringify(expression)
+}
+
+function convertIfBlockToText(ifBlock: IfBlock, insideStep = false): string {
+  let result = `{{#if ${expressionToString(ifBlock.expression)}}}\n`
+  result += extractTextContent(ifBlock.children || [], insideStep)
+
+  if (ifBlock.else) {
+    result += '\n{{else}}\n'
+    result += extractTextContent(ifBlock.else.children || [], insideStep)
+  }
+
+  result += '\n{{/if}}'
+  return result
+}
+
+function convertForBlockToText(forBlock: ForBlock, insideStep = false): string {
+  const context = forBlock.context.name
+  const index = forBlock.index ? `, ${forBlock.index.name}` : ''
+
+  let result = `{{#for ${expressionToString(forBlock.expression)} as ${context}${index}}}\n`
+  result += extractTextContent(forBlock.children || [], insideStep)
+
+  if (forBlock.else) {
+    result += '\n{{else}}\n'
+    result += extractTextContent(forBlock.else.children || [], insideStep)
+  }
+
+  result += '\n{{/for}}'
+  return result
+}
+
+export function nodeToText(node: TemplateNode, insideStep = false): string {
+  switch (node.type) {
+    case 'Text':
+      return (node as Text).data
+
+    case 'MustacheTag': {
+      const mustache = node as MustacheTag
+      return `{{${expressionToString(mustache.expression)}}}`
+    }
+
+    case 'IfBlock':
+      return convertIfBlockToText(node as IfBlock, insideStep)
+
+    case 'ForBlock':
+      return convertForBlockToText(node as ForBlock, insideStep)
+
+    case 'ElementTag': {
+      const tag = node as ElementTag
+      // Always convert element tags to text when they're nested in content
+      return convertElementToText(tag, insideStep)
+    }
+
+    case 'Config':
+      // Config nodes should not appear in content
+      return ''
+
+    case 'Comment':
+      return `<!-- ${node.data} -->`
+
+    default:
+      return ''
+  }
+}
+
+export function extractTextContent(
+  nodes: TemplateNode[],
+  insideStep = false,
+): string {
+  return nodes.map((node) => nodeToText(node, insideStep)).join('')
+}
+
+export function getPromptAttributes({
+  tag,
+  prompt,
+}: {
+  tag: ElementTag
+  prompt: string
+}) {
+  const attributes = getAttributes({
+    tag,
+    prompt,
+    shouldCamelCase: ['as', 'isolated'],
+  })
+
+  // Ensure path attribute exists
+  if (!('path' in attributes)) {
+    attributes.path = ''
+  }
+
+  return attributes as PromptBlock['attributes']
+}
+
+export function isTopLevelBlock(tag: ElementTag): boolean {
+  return BLOCK_TYPES.includes(tag.name as BlockType)
+}
+
+export function convertElementToText(
+  tag: ElementTag,
+  insideStep = false,
+): string {
+  const attrs = tag.attributes
+    .map((attr: any) => {
+      if (attr.value === true) {
+        return attr.name
+      }
+
+      if (Array.isArray(attr.value)) {
+        return `${attr.name}="${extractTextContent(attr.value, insideStep)}"`
+      }
+
+      return `${attr.name}="${attr.value}"`
+    })
+    .join(' ')
+
+  const attrsStr = attrs ? ` ${attrs}` : ''
+  const content = extractTextContent(tag.children, insideStep)
+
+  if (content.trim()) {
+    return `<${tag.name}${attrsStr}>${content}</${tag.name}>`
+  } else {
+    return `<${tag.name}${attrsStr} />`
+  }
+}
+
+function getAttributes({
+  tag,
+  prompt,
+  shouldCamelCase = [],
+}: {
+  tag: ElementTag
+  prompt: string
+  shouldCamelCase?: string[]
+}) {
+  return tag.attributes.reduce((acc, attr) => {
+    const name = shouldCamelCase.includes(attr.name)
+      ? camelCase(attr.name)
+      : attr.name
+
+    if (Array.isArray(attr.value)) {
+      const firstNode = attr.value[0]!
+      const lastNode = attr.value[attr.value.length - 1]!
+
+      const start = firstNode.start || 0
+      const end = lastNode.end || prompt.length
+      acc[name] = prompt.slice(start, end).trim()
+      return acc
+    }
+
+    acc[name] = attr.value
+    return acc
+  }, {} as BlockAttributes)
+}
+
+export function attributesToString({
+  attributes,
+  shouldKebabCase = [],
+}: {
+  attributes?: BlockAttributes
+  shouldKebabCase?: string[]
+}) {
+  if (!attributes || Object.keys(attributes).length === 0) {
+    return ''
+  }
+
+  const stepAttrs = []
+  if (attributes) {
+    for (const [key, value] of Object.entries(attributes)) {
+      if (value === undefined || value === null || value === '') {
+        continue
+      }
+
+      const treatedKey = shouldKebabCase.includes(key) ? kebabCase(key) : key
+      if (value === true) {
+        stepAttrs.push(treatedKey)
+      } else {
+        stepAttrs.push(`${treatedKey}="${value}"`)
+      }
+    }
+  }
+
+  return stepAttrs.length > 0 ? ` ${stepAttrs.join(' ')}` : ''
+}
+
+export function getStepAttributes({
+  tag,
+  prompt,
+}: {
+  tag: ElementTag
+  prompt: string
+}) {
+  let attr: StepBlock['attributes'] = {}
+
+  const attributes = getAttributes({
+    tag,
+    prompt,
+    shouldCamelCase: ['as', 'isolated'],
+  })
+
+  if ('as' in attributes) {
+    if (typeof attributes.as === 'string') {
+      attr.as = attributes.as.trim()
+    }
+  }
+
+  if ('isolated' in attributes) {
+    if (attributes.isolated === true) {
+      attr.isolated = true
+    }
+  }
+
+  if (!Object.keys(attributes).length) return undefined
+
+  return attr
+}
+
+export function getContentFileAttributes({
+  tag,
+  prompt,
+}: {
+  tag: ElementTag
+  prompt: string
+}) {
+  const attributes = getAttributes({
+    tag,
+    prompt,
+  })
+
+  // Ensure name attribute exists (required by promptl compiler)
+  if (!('name' in attributes)) {
+    attributes.name = ''
+  }
+
+  return attributes as FileBlock['attributes']
+}
+
+export function getToolCallAttributes({
+  tag,
+  prompt,
+}: {
+  tag: ElementTag
+  prompt: string
+}) {
+  let attr: ToolCallBlock['attributes'] = {}
+  const attributes = getAttributes({
+    tag,
+    prompt,
+  })
+
+  attr.id = 'id' in attributes ? (attributes.id as string) : ''
+  attr.name = 'name' in attributes ? (attributes.name as string) : ''
+  if ('id' in attributes) {
+    delete attributes.id
+  }
+  if ('name' in attributes) {
+    delete attributes.name
+  }
+
+  attr.parameters = attributes
+
+  return attr
+}

--- a/packages/constants/src/simpleBlocks/astToSimpleBlocks.ts
+++ b/packages/constants/src/simpleBlocks/astToSimpleBlocks.ts
@@ -1,0 +1,318 @@
+import {
+  convertElementToText,
+  extractTextContent,
+  getMessageBlockType,
+  getStepAttributes,
+  getPromptAttributes,
+  getContentFileAttributes,
+  getToolCallAttributes,
+  isContentBlock,
+  isMessageBlock,
+  isStepBlock,
+  isTopLevelBlock,
+  nodeToText,
+} from './astParsingUtils'
+import {
+  type ElementTag,
+  type ContentBlock,
+  TemplateNode,
+  Fragment,
+  AnyBlock,
+  MessageChild,
+  StepChild,
+  BlockError,
+  AstError,
+} from './types'
+
+function createIdGenerator() {
+  let counter = 0
+  return (): string => `block_${Date.now()}_${++counter}`
+}
+type IdGenerator = ReturnType<typeof createIdGenerator>
+
+// Helper function to find errors for a given AST node based on start position
+function findErrorsForNode(
+  node: ElementTag | TemplateNode,
+  errors: AstError[],
+): BlockError[] {
+  if (!('start' in node) || node.start === undefined) {
+    return []
+  }
+
+  return errors
+    .filter((error) => error.startIndex === node.start)
+    .map((error) => ({
+      message: error.message,
+      startIndex: error.startIndex,
+      endIndex: error.endIndex,
+    }))
+}
+
+function createContentBlock({
+  prompt,
+  tag,
+  generateIdFn,
+  errors = [],
+}: {
+  prompt: string
+  tag: ElementTag
+  generateIdFn: IdGenerator
+  errors?: AstError[]
+}): ContentBlock {
+  const blockErrors = findErrorsForNode(tag, errors)
+
+  if (tag.name === 'prompt') {
+    return {
+      id: generateIdFn(),
+      type: 'prompt',
+      attributes: getPromptAttributes({ tag, prompt }),
+      ...(blockErrors.length > 0 && { errors: blockErrors }),
+    }
+  } else if (tag.name === 'content-image') {
+    return {
+      id: generateIdFn(),
+      type: 'content-image',
+      content: extractTextContent(tag.children),
+      ...(blockErrors.length > 0 && { errors: blockErrors }),
+    }
+  } else if (tag.name === 'content-file') {
+    return {
+      id: generateIdFn(),
+      type: 'content-file',
+      content: extractTextContent(tag.children),
+      attributes: getContentFileAttributes({ tag, prompt }),
+      ...(blockErrors.length > 0 && { errors: blockErrors }),
+    }
+  } else if (tag.name === 'tool-call') {
+    return {
+      id: generateIdFn(),
+      type: 'tool-call',
+      attributes: getToolCallAttributes({ tag, prompt }),
+      ...(blockErrors.length > 0 && { errors: blockErrors }),
+    }
+  } else {
+    return {
+      id: generateIdFn(),
+      type: 'text',
+      content: extractTextContent(tag.children),
+      ...(blockErrors.length > 0 && { errors: blockErrors }),
+    }
+  }
+}
+
+function messageTagToBlock({
+  prompt,
+  tag,
+  generateIdFn,
+  errors = [],
+}: {
+  prompt: string
+  tag: ElementTag
+  generateIdFn: IdGenerator
+  errors?: AstError[]
+}): {
+  id: string
+  type: 'system' | 'user' | 'assistant' | 'developer'
+  children: MessageChild[]
+  errors?: BlockError[]
+} {
+  const messageChildren: MessageChild[] = []
+  let textContent = ''
+  const blockErrors = findErrorsForNode(tag, errors)
+
+  for (const child of tag.children) {
+    if (child.type === 'ElementTag') {
+      const childTag = child as ElementTag
+      if (isContentBlock(childTag)) {
+        if (textContent) {
+          messageChildren.push({
+            id: generateIdFn(),
+            type: 'text',
+            content: textContent,
+          })
+          textContent = ''
+        }
+
+        messageChildren.push(
+          createContentBlock({ prompt, tag: childTag, generateIdFn, errors }),
+        )
+      } else {
+        textContent += convertElementToText(childTag, true)
+      }
+    } else {
+      textContent += nodeToText(child, true)
+    }
+  }
+
+  if (textContent) {
+    messageChildren.push({
+      id: generateIdFn(),
+      type: 'text',
+      content: textContent,
+    })
+  }
+
+  return {
+    id: generateIdFn(),
+    type: getMessageBlockType(tag),
+    children: messageChildren,
+    ...(blockErrors.length > 0 && { errors: blockErrors }),
+  }
+}
+
+// Helper function to process nodes and convert them to blocks
+function processNodes({
+  nodes,
+  generateIdFn,
+  prompt,
+  errors = [],
+}: {
+  nodes: TemplateNode[]
+  generateIdFn: IdGenerator
+  prompt: string
+  errors?: AstError[]
+}): AnyBlock[] {
+  const blocks: AnyBlock[] = []
+  let i = 0
+
+  while (i < nodes.length) {
+    const node = nodes[i]!
+
+    if (node.type === 'Config') {
+      i++
+      continue
+    }
+
+    if (node.type === 'ElementTag') {
+      const tag = node as ElementTag
+
+      if (isMessageBlock(tag)) {
+        blocks.push(messageTagToBlock({ prompt, tag, generateIdFn, errors }))
+      } else if (isContentBlock(tag)) {
+        blocks.push(createContentBlock({ prompt, tag, generateIdFn, errors }))
+      } else if (isStepBlock(tag)) {
+        const stepChildren: StepChild[] = []
+        const blockErrors = findErrorsForNode(tag, errors)
+
+        for (const child of tag.children) {
+          if (child.type === 'ElementTag') {
+            const childTag = child as ElementTag
+            if (isMessageBlock(childTag)) {
+              stepChildren.push(
+                messageTagToBlock({
+                  prompt,
+                  tag: childTag,
+                  generateIdFn,
+                  errors,
+                }),
+              )
+            } else if (isContentBlock(childTag)) {
+              stepChildren.push(
+                createContentBlock({
+                  prompt,
+                  tag: childTag,
+                  generateIdFn,
+                  errors,
+                }),
+              )
+            } else {
+              const content = convertElementToText(childTag, true)
+              if (content) {
+                stepChildren.push({
+                  id: generateIdFn(),
+                  type: 'text',
+                  content: content,
+                })
+              }
+            }
+          } else {
+            const content = nodeToText(child, true)
+            if (content) {
+              stepChildren.push({
+                id: generateIdFn(),
+                type: 'text',
+                content: content,
+              })
+            }
+          }
+        }
+
+        const stepAttributes = getStepAttributes({ tag, prompt })
+        blocks.push({
+          id: generateIdFn(),
+          type: 'step',
+          children: stepChildren,
+          attributes: stepAttributes,
+          ...(blockErrors.length > 0 && { errors: blockErrors }),
+        })
+      } else {
+        const childBlocks = processNodes({
+          nodes: tag.children,
+          generateIdFn,
+          prompt,
+          errors,
+        })
+        blocks.push(...childBlocks)
+      }
+      i++
+    } else {
+      // Accumulate consecutive non-ElementTag nodes into a single block
+      const accumulatedContent: string[] = []
+
+      while (i < nodes.length) {
+        const currentNode = nodes[i]!
+
+        // Stop if we hit an ElementTag that creates a block
+        if (currentNode.type === 'ElementTag') {
+          const tag = currentNode as ElementTag
+          if (isTopLevelBlock(tag)) {
+            break
+          }
+        }
+
+        // Accumulate content from this node
+        if (currentNode.type === 'Config') {
+          // Skip config nodes in content accumulation
+        } else {
+          accumulatedContent.push(nodeToText(currentNode))
+        }
+
+        i++
+      }
+
+      const content = accumulatedContent.join('')
+
+      if (content) {
+        const systemTagMatch = content.match(/^<s>([\s\S]*?)<\/system>/)
+        if (systemTagMatch) {
+          blocks.push({
+            id: generateIdFn(),
+            type: 'system',
+            children: [],
+          })
+        } else {
+          blocks.push({
+            id: generateIdFn(),
+            type: 'text',
+            content: content,
+          })
+        }
+      }
+    }
+  }
+
+  return blocks
+}
+
+export function astToSimpleBlocks({
+  ast,
+  prompt,
+  errors = [],
+}: {
+  ast: Fragment
+  prompt: string
+  errors?: AstError[]
+}): AnyBlock[] {
+  const generateIdFn = createIdGenerator()
+  return processNodes({ nodes: ast.children, generateIdFn, prompt, errors })
+}

--- a/packages/constants/src/simpleBlocks/errors.test.ts
+++ b/packages/constants/src/simpleBlocks/errors.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect } from 'vitest'
+import { parse } from 'promptl-ai'
+import { astToSimpleBlocks } from './astToSimpleBlocks'
+import {
+  AstError,
+  StepBlock,
+  MessageBlock,
+  PromptBlock,
+  ToolCallBlock,
+  FileBlock,
+  ImageBlock,
+} from './types'
+
+describe('astToSimpleBlocks with errors', () => {
+  describe('no errors', () => {
+    it('should handle prompts without errors', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt, errors: [] })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeUndefined()
+    })
+
+    it('should handle prompts when errors parameter is omitted', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeUndefined()
+    })
+  })
+
+  describe('prompt block errors', () => {
+    it('should map errors to prompt blocks by start position', () => {
+      const prompt = `<prompt location="test" />`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 25,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 26 },
+          message: 'Reference tags must have a prompt attribute',
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const promptBlock = blocks[0] as PromptBlock
+      expect(promptBlock.type).toBe('prompt')
+      expect(promptBlock.errors).toBeDefined()
+      expect(promptBlock.errors).toHaveLength(1)
+      expect(promptBlock.errors?.[0]?.message).toBe(
+        'Reference tags must have a prompt attribute',
+      )
+      expect(promptBlock.errors?.[0]?.startIndex).toBe(0)
+      expect(promptBlock.errors?.[0]?.endIndex).toBe(25)
+    })
+
+    it('should handle multiple errors on the same prompt block', () => {
+      const prompt = `<prompt location="test" />`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 25,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 26 },
+          message: 'Reference tags must have a prompt attribute',
+          name: 'CompileError',
+        },
+        {
+          startIndex: 0,
+          endIndex: 25,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 26 },
+          message: 'Invalid location attribute',
+          name: 'ValidationError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const promptBlock = blocks[0] as PromptBlock
+      expect(promptBlock.errors).toHaveLength(2)
+      expect(promptBlock.errors?.[0]?.message).toBe(
+        'Reference tags must have a prompt attribute',
+      )
+      expect(promptBlock.errors?.[1]?.message).toBe(
+        'Invalid location attribute',
+      )
+    })
+  })
+
+  describe('tool-call block errors', () => {
+    it('should map errors to tool-call blocks', () => {
+      const prompt = `<tool-call name="test" />`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 23,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 24 },
+          message: 'Tool call must have an id attribute',
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const toolCallBlock = blocks[0] as ToolCallBlock
+      expect(toolCallBlock.type).toBe('tool-call')
+      expect(toolCallBlock.errors).toBeDefined()
+      expect(toolCallBlock.errors).toHaveLength(1)
+      expect(toolCallBlock.errors?.[0]?.message).toBe(
+        'Tool call must have an id attribute',
+      )
+    })
+  })
+
+  describe('content-file block errors', () => {
+    it('should map errors to content-file blocks', () => {
+      const prompt = `<content-file>test.pdf</content-file>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 36,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 37 },
+          message: 'Content file must have a name attribute',
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const fileBlock = blocks[0] as FileBlock
+      expect(fileBlock.type).toBe('content-file')
+      expect(fileBlock.errors).toBeDefined()
+      expect(fileBlock.errors).toHaveLength(1)
+      expect(fileBlock.errors?.[0]?.message).toBe(
+        'Content file must have a name attribute',
+      )
+    })
+  })
+
+  describe('content-image block errors', () => {
+    it('should map errors to content-image blocks', () => {
+      const prompt = `<content-image>invalid-url</content-image>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 41,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 42 },
+          message: 'Invalid image URL format',
+          name: 'ValidationError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const imageBlock = blocks[0] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.errors).toBeDefined()
+      expect(imageBlock.errors).toHaveLength(1)
+      expect(imageBlock.errors?.[0]?.message).toBe('Invalid image URL format')
+    })
+  })
+
+  describe('message block errors', () => {
+    it('should map errors to message blocks', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 23,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 24 },
+          message: 'User message cannot be empty',
+          name: 'ValidationError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeDefined()
+      expect(userBlock.errors).toHaveLength(1)
+      expect(userBlock.errors?.[0]?.message).toBe(
+        'User message cannot be empty',
+      )
+    })
+  })
+
+  describe('step block errors', () => {
+    it('should map errors to step blocks', () => {
+      const prompt = `<step>
+<user>Hello</user>
+</step>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 30,
+          start: { line: 1, column: 1 },
+          end: { line: 3, column: 7 },
+          message: "Step must have an 'as' attribute",
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const stepBlock = blocks[0] as StepBlock
+      expect(stepBlock.type).toBe('step')
+      expect(stepBlock.errors).toBeDefined()
+      expect(stepBlock.errors).toHaveLength(1)
+      expect(stepBlock.errors?.[0]?.message).toBe(
+        "Step must have an 'as' attribute",
+      )
+    })
+  })
+
+  describe('nested errors', () => {
+    it('should map errors to nested blocks correctly', () => {
+      const prompt = `<step as="test">
+<user>Please analyze this:
+<content-image>invalid-url</content-image>
+</user>
+</step>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 17, // Position of <user> tag (not 17 as before)
+          endIndex: 94,
+          start: { line: 2, column: 1 },
+          end: { line: 4, column: 7 },
+          message: 'User message validation failed',
+          name: 'ValidationError',
+        },
+        {
+          startIndex: 44, // Position of <content-image> tag (not 43 as before)
+          endIndex: 86,
+          start: { line: 3, column: 1 },
+          end: { line: 3, column: 33 },
+          message: 'Invalid image URL',
+          name: 'ValidationError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const stepBlock = blocks[0] as StepBlock
+      expect(stepBlock.type).toBe('step')
+      expect(stepBlock.errors).toBeUndefined() // No error for step itself
+
+      const userBlock = stepBlock.children![1] as MessageBlock // Changed from index 0 to 1
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeDefined()
+      expect(userBlock.errors).toHaveLength(1)
+      expect(userBlock.errors?.[0]?.message).toBe(
+        'User message validation failed',
+      )
+
+      const imageBlock = userBlock.children.find(
+        (child) => child.type === 'content-image',
+      ) as ImageBlock
+      expect(imageBlock).toBeDefined()
+      expect(imageBlock.errors).toBeDefined()
+      expect(imageBlock.errors).toHaveLength(1)
+      expect(imageBlock.errors?.[0]?.message).toBe('Invalid image URL')
+    })
+  })
+
+  describe('mixed content with errors', () => {
+    it('should handle mixed content types with various errors', () => {
+      const prompt = `<user>
+Review this document:
+<content-file>document.pdf</content-file>
+
+And this image:
+<content-image>https://example.com/image.jpg</content-image>
+
+Then call this tool:
+<tool-call name="analyze">{"data": "test"}</tool-call>
+</user>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 29, // Position of content-file (corrected from 23)
+          endIndex: 70,
+          start: { line: 3, column: 1 },
+          end: { line: 3, column: 37 },
+          message: 'Content file must have name attribute',
+          name: 'CompileError',
+        },
+        {
+          startIndex: 171, // Position of tool-call (corrected from 130)
+          endIndex: 225,
+          start: { line: 8, column: 1 },
+          end: { line: 8, column: 53 },
+          message: 'Tool call must have id attribute',
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeUndefined()
+
+      const fileBlock = userBlock.children.find(
+        (child) => child.type === 'content-file',
+      ) as FileBlock
+      expect(fileBlock).toBeDefined()
+      expect(fileBlock.errors).toBeDefined()
+      expect(fileBlock.errors).toHaveLength(1)
+      expect(fileBlock.errors?.[0]?.message).toBe(
+        'Content file must have name attribute',
+      )
+
+      const imageBlock = userBlock.children.find(
+        (child) => child.type === 'content-image',
+      ) as ImageBlock
+      expect(imageBlock).toBeDefined()
+      expect(imageBlock.errors).toBeUndefined() // No error for image
+
+      const toolCallBlock = userBlock.children.find(
+        (child) => child.type === 'tool-call',
+      ) as ToolCallBlock
+      expect(toolCallBlock).toBeDefined()
+      expect(toolCallBlock.errors).toBeDefined()
+      expect(toolCallBlock.errors).toHaveLength(1)
+      expect(toolCallBlock.errors?.[0]?.message).toBe(
+        'Tool call must have id attribute',
+      )
+    })
+  })
+
+  describe('errors without matching AST nodes', () => {
+    it('should ignore errors that do not match any AST node start position', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 999, // Position that doesn't exist in AST
+          endIndex: 1010,
+          start: { line: 10, column: 1 },
+          end: { line: 10, column: 12 },
+          message: "Some error that doesn't match",
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.errors).toBeUndefined()
+    })
+  })
+
+  describe('error edge cases', () => {
+    it('should handle empty errors array', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt, errors: [] })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.errors).toBeUndefined()
+    })
+
+    it('should handle undefined start position in AST node', () => {
+      const prompt = `<user>Hello world</user>`
+      const ast = parse(prompt)
+
+      // Simulate AST node without start position
+      if (ast.children[0] && 'start' in ast.children[0]) {
+        delete (ast.children[0] as any).start
+      }
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 23,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 24 },
+          message: 'Some error',
+          name: 'CompileError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.errors).toBeUndefined() // Should not crash, just ignore error
+    })
+
+    it('should preserve error details correctly', () => {
+      const prompt = `<prompt path="test" />`
+      const ast = parse(prompt)
+
+      const errors: AstError[] = [
+        {
+          startIndex: 0,
+          endIndex: 21,
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 22 },
+          message: 'Custom error message with special chars: <>&"\'',
+          name: 'CustomError',
+        },
+      ]
+
+      const blocks = astToSimpleBlocks({ ast, prompt, errors })
+
+      expect(blocks).toHaveLength(1)
+      const promptBlock = blocks[0] as PromptBlock
+      expect(promptBlock.errors).toBeDefined()
+      expect(promptBlock.errors).toHaveLength(1)
+      expect(promptBlock.errors?.[0]?.message).toBe(
+        'Custom error message with special chars: <>&"\'',
+      )
+      expect(promptBlock.errors?.[0]?.startIndex).toBe(0)
+      expect(promptBlock.errors?.[0]?.endIndex).toBe(21)
+    })
+  })
+})

--- a/packages/constants/src/simpleBlocks/index.test.ts
+++ b/packages/constants/src/simpleBlocks/index.test.ts
@@ -1,0 +1,1164 @@
+import { describe, it, expect } from 'vitest'
+import { parse } from 'promptl-ai'
+import { astToSimpleBlocks } from './astToSimpleBlocks'
+import { simpleBlocksToText } from './simpleBlocksToText'
+import {
+  StepBlock,
+  MessageBlock,
+  AnyBlock,
+  PromptBlock,
+  TextBlock,
+  ImageBlock,
+  FileBlock,
+  ToolCallBlock,
+} from './types'
+
+describe('astToSimpleBlocks', () => {
+  it('should convert plain text to simple blocks', () => {
+    const prompt = 'This is a simple text prompt.'
+    const ast = parse(prompt)
+    const blocks = astToSimpleBlocks({ ast, prompt })
+    const output = simpleBlocksToText(blocks)
+
+    expect(blocks).toHaveLength(1)
+    const textBlock = blocks[0] as TextBlock
+    expect(textBlock.type).toBe('text')
+    expect(textBlock.content).toBe(prompt)
+    expect(output.trim()).toBe(prompt.trim())
+  })
+
+  describe('content-image blocks', () => {
+    it('should handle top-level content-image blocks', () => {
+      const prompt = `<system>
+You are an image analysis assistant.
+</system>
+
+<content-image>
+https://example.com/image.jpg
+</content-image>
+
+<user>
+What do you see in this image?
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      // Normalize whitespace for comparison
+      const normalizedInput = prompt.trim()
+      const normalizedOutput = output.trim()
+
+      expect(normalizedOutput).toBe(normalizedInput)
+
+      expect(blocks).toHaveLength(5) // system, whitespace, content-image, whitespace, user
+      expect(blocks[0]?.type).toBe('system')
+      expect(blocks[1]?.type).toBe('text') // whitespace between blocks
+      expect(blocks[2]?.type).toBe('content-image')
+      const imageBlock = blocks[2] as ImageBlock
+      expect(imageBlock.content.trim()).toBe('https://example.com/image.jpg')
+      expect(blocks[3]?.type).toBe('text') // whitespace between blocks
+      expect(blocks[4]?.type).toBe('user')
+    })
+
+    it('should handle multiple content-image blocks', () => {
+      const prompt = `<content-image>
+https://example.com/image1.jpg
+</content-image>
+
+<content-image>
+https://example.com/image2.jpg
+</content-image>
+
+<user>
+Compare these two images.
+</user>`
+
+      const ast = parse(prompt)
+
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(prompt.trim())
+
+      const imageBlocks = blocks.filter(
+        (block) => block.type === 'content-image',
+      ) as ImageBlock[]
+
+      expect(imageBlocks).toHaveLength(2)
+      expect(imageBlocks[0]?.content.trim()).toBe(
+        'https://example.com/image1.jpg',
+      )
+      expect(imageBlocks[1]?.content.trim()).toBe(
+        'https://example.com/image2.jpg',
+      )
+    })
+
+    it('should handle content-image with data URLs', () => {
+      const prompt = `<content-image>
+data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...
+</content-image>`
+
+      const ast = parse(prompt)
+
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const imageBlock = blocks[0] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.content.trim()).toBe(
+        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD...',
+      )
+
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(prompt.trim())
+    })
+  })
+
+  describe('content-image blocks in steps', () => {
+    it('should handle content-image blocks within steps', () => {
+      const prompt = `<step as="analysis">
+First, examine this image:
+
+<content-image>
+https://example.com/main.jpg
+</content-image>
+
+Then compare with this reference:
+
+<content-image>
+https://example.com/reference.jpg
+</content-image>
+
+Provide your analysis.
+</step>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      expect(blocks).toHaveLength(1)
+      const stepBlock = blocks[0] as StepBlock
+      expect(stepBlock.type).toBe('step')
+      expect(stepBlock.attributes?.as).toBe('analysis')
+      const children = stepBlock.children || []
+      expect(children.length).toBeGreaterThan(0)
+
+      const imageChildren = children.filter(
+        (child) => child.type === 'content-image',
+      )
+      expect(imageChildren).toHaveLength(2)
+      expect(imageChildren[0]?.content.trim()).toBe(
+        'https://example.com/main.jpg',
+      )
+      expect(imageChildren[1]?.content.trim()).toBe(
+        'https://example.com/reference.jpg',
+      )
+
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle mixed content with images in steps', () => {
+      const prompt = `<step as="preparation" isolated>
+Review the document:
+
+<content-image>
+https://example.com/document.png
+</content-image>
+
+Analyze the chart:
+
+<content-image>
+https://example.com/chart.jpg
+</content-image>
+
+Consider the implications.
+</step>`
+
+      const ast = parse(prompt)
+
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const stepBlock = blocks[0] as StepBlock
+
+      expect(stepBlock.attributes?.as).toBe('preparation')
+      expect(stepBlock.attributes?.isolated).toBe(true)
+
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(prompt.trim())
+    })
+  })
+
+  describe('complex scenarios with content-image', () => {
+    it('should handle full conversation with mixed content', () => {
+      const prompt = `<system>
+You are a multimodal assistant.
+</system>
+
+<user>
+Here are my vacation photos:
+</user>
+
+<content-image>
+https://vacation.com/beach.jpg
+</content-image>
+
+<content-image>
+https://vacation.com/sunset.jpg
+</content-image>
+
+<step as="analysis">
+Analyze each photo for:
+
+<content-image>
+https://reference.com/ideal-beach.jpg
+</content-image>
+
+Compare with this ideal reference.
+</step>
+
+<assistant>
+Based on my analysis: {{analysis}}
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(11) // system, ws, user, ws, content-image, ws, content-image, ws, step, ws, assistant
+
+      const topLevelImages = blocks.filter(
+        (block) => block.type === 'content-image',
+      )
+      expect(topLevelImages).toHaveLength(2)
+
+      // Check content-image block within step
+      const stepBlock = blocks.find((block) => block.type === 'step')
+      const stepImages =
+        stepBlock?.children?.filter(
+          (child) => child.type === 'content-image',
+        ) || []
+      expect(stepImages).toHaveLength(1)
+    })
+
+    it('should preserve content-image blocks with mustache expressions', () => {
+      const prompt = `<content-image>
+{{imageUrl}}
+</content-image>
+
+<step as="dynamic">
+Process this dynamic image:
+
+<content-image>
+{{images[0]}}
+</content-image>
+
+And compare with:
+
+<content-image>
+{{referenceImage}}
+</content-image>
+</step>`
+
+      const ast = parse(prompt)
+
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      const imageBlock = blocks[0] as ImageBlock
+      expect(imageBlock.content.trim()).toBe('{{imageUrl}}')
+
+      const stepBlock = blocks[2] as StepBlock // blocks[1] is whitespace, blocks[2] is step
+      const stepChildren = stepBlock.children || []
+      const stepImages = stepChildren.filter(
+        (child) => child.type === 'content-image',
+      )
+      expect(stepImages[0]?.content.trim()).toBe('{{images[0]}}')
+      expect(stepImages[1]?.content.trim()).toBe('{{referenceImage}}')
+    })
+  })
+
+  describe('edge cases with content-image', () => {
+    it('should handle empty content-image blocks', () => {
+      const prompt = `<content-image></content-image>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe('<content-image />')
+      const imageBlock = blocks[0] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.content.trim()).toBe('')
+    })
+
+    it('should handle self-closing content-image blocks', () => {
+      const prompt = `<content-image />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+      expect(blocks[0]?.type).toBe('content-image')
+    })
+
+    it('should handle content-image with whitespace variations', () => {
+      const prompt = `<content-image>
+
+https://example.com/image.jpg
+
+</content-image>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+      const imageBlock = blocks[0] as ImageBlock
+      expect(imageBlock.content).toContain('https://example.com/image.jpg')
+    })
+  })
+
+  describe('round-trip consistency', () => {
+    const testCases = [
+      {
+        name: 'simple content-image',
+        input: `<content-image>https://example.com/test.jpg</content-image>`,
+      },
+      {
+        name: 'multiple content-images',
+        input: `<content-image>image1.jpg</content-image>
+
+<content-image>image2.jpg</content-image>`,
+      },
+      {
+        name: 'content-image in conversation',
+        input: `<system>System prompt</system>
+
+<user>User message</user>
+
+<content-image>user-image.jpg</content-image>
+
+<assistant>Response</assistant>`,
+      },
+      {
+        name: 'content-image in step',
+        input: `<step as="test">
+Text before
+
+<content-image>step-image.jpg</content-image>
+
+Text after
+</step>`,
+      },
+      {
+        name: 'simple content-file',
+        input: `<content-file name="test.pdf">/path/to/test.pdf</content-file>`,
+      },
+      {
+        name: 'simple tool-call',
+        input: `<tool-call id="call_1" name="test_tool" param="value" />`,
+      },
+      {
+        name: 'content-file in conversation',
+        input: `<user>Please review this document</user>
+
+<content-file name="report.pdf">/uploads/report.pdf</content-file>
+
+<assistant>I'll review the document</assistant>`,
+      },
+      {
+        name: 'tool-call in conversation',
+        input: `<assistant>I'll search for that information</assistant>
+
+<tool-call id="search_1" name="web_search" query="AI trends 2024" />`,
+      },
+      {
+        name: 'mixed content types',
+        input: `<user>Analyze this image and document</user>
+
+<content-image>chart.png</content-image>
+
+<content-file name="data.csv">data.csv</content-file>
+
+<tool-call id="analyze_1" name="analyze_data" image="chart.png" data="data.csv" />`,
+      },
+    ]
+
+    testCases.forEach(({ name, input }) => {
+      it(`should maintain round-trip consistency for ${name}`, () => {
+        const prompt = input.trim()
+        const ast = parse(prompt)
+        const blocks = astToSimpleBlocks({ ast, prompt })
+        const output = simpleBlocksToText(blocks)
+
+        expect(output.trim()).toBe(input.trim())
+      })
+    })
+  })
+
+  describe('content blocks inside message blocks', () => {
+    it('should handle content-image inside assistant block', () => {
+      const prompt = `<assistant>
+Here is the image about the cat you requested:
+<content-image>https://google.com/img/cat.jpg</content-image>
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(1)
+      const assistantBlock = blocks[0] as MessageBlock
+      expect(assistantBlock?.type).toBe('assistant')
+      expect(assistantBlock?.children).toBeDefined()
+      expect(assistantBlock?.children?.length).toBeGreaterThan(0)
+
+      const contentImageChild = assistantBlock?.children?.find(
+        (child) => child.type === 'content-image',
+      )
+      expect(contentImageChild).toBeDefined()
+      expect(contentImageChild?.content.trim()).toBe(
+        'https://google.com/img/cat.jpg',
+      )
+    })
+
+    it('should handle text before and after content-image in message block', () => {
+      const prompt = `<user>
+Please analyze this image:
+
+<content-image>https://example.com/analysis.jpg</content-image>
+
+What do you see?
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock?.type).toBe('user')
+      expect(userBlock?.children).toBeDefined()
+      expect(userBlock?.children?.length).toBeGreaterThan(0)
+
+      const textChildren = userBlock?.children?.filter(
+        (child) => child.type === 'text',
+      )
+      const imageChildren = userBlock?.children?.filter(
+        (child) => child.type === 'content-image',
+      )
+
+      expect(textChildren?.length).toBeGreaterThan(0)
+      expect(imageChildren?.length).toBe(1)
+    })
+
+    it('should handle multiple content blocks in a single message', () => {
+      const prompt = `<system>
+You are an image analysis assistant.
+
+<content-image>https://example.com/reference.jpg</content-image>
+
+Use this as a reference for comparison.
+
+<content-image>https://example.com/guidelines.pdf</content-image>
+
+Follow these guidelines.
+</system>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(1)
+      const systemBlock = blocks[0] as MessageBlock
+      expect(systemBlock?.type).toBe('system')
+
+      const imageChildren = systemBlock?.children?.filter(
+        (child) => child.type === 'content-image',
+      )
+      expect(imageChildren?.length).toBe(2)
+    })
+
+    it('should handle empty content-image inside message block', () => {
+      const prompt = `<assistant>
+Here's an empty image placeholder:
+<content-image></content-image>
+Please provide an image.
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      // The empty content-image should become self-closing
+      const expected = `<assistant>
+Here's an empty image placeholder:
+<content-image />
+Please provide an image.
+</assistant>`
+
+      expect(output.trim()).toBe(expected.trim())
+    })
+
+    it('should handle only content-image in message block (no text)', () => {
+      const prompt = `<user>
+<content-image>https://example.com/only-image.jpg</content-image>
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock?.children?.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('message blocks with content tags', () => {
+    it('should handle assistant message with content-image block', () => {
+      const prompt = `<assistant>
+Here is the image about the cat you requested:
+<content-image>https://google.com/img/cat.jpg</content-image>
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      expect(blocks).toHaveLength(1)
+      const assistantBlock = blocks[0] as MessageBlock
+      expect(assistantBlock.type).toBe('assistant')
+      expect(assistantBlock.children).toHaveLength(3)
+      const textBlock = assistantBlock.children[0] as TextBlock
+      expect(textBlock.type).toBe('text')
+      expect(textBlock.content).toContain(
+        'Here is the image about the cat you requested:',
+      )
+      const imageBlock = assistantBlock.children[1] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.content.trim()).toBe('https://google.com/img/cat.jpg')
+      expect(assistantBlock.children[2]?.type).toBe('text')
+    })
+
+    it('should handle user message with content before and after content-image', () => {
+      const prompt = `<user>
+Please analyze this image:
+
+<content-image>https://example.com/analysis.jpg</content-image>
+
+What do you see in it?
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+      expect(userBlock.children).toHaveLength(3)
+      const textBlock = userBlock.children[0] as TextBlock
+      expect(textBlock.type).toBe('text')
+      expect(textBlock.content).toContain('Please analyze this image:')
+      const imageBlock = userBlock.children[1] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.content.trim()).toBe('https://example.com/analysis.jpg')
+      const textBlock2 = userBlock.children[2] as TextBlock
+      expect(textBlock2.type).toBe('text')
+      expect(textBlock2.content).toContain('What do you see in it?')
+    })
+
+    it('should handle multiple content-image blocks in assistant message', () => {
+      const prompt = `<assistant>
+Here are the images you requested:
+
+<content-image>https://example.com/image1.jpg</content-image>
+
+And here's another one:
+
+<content-image>https://example.com/image2.jpg</content-image>
+
+Hope these help!
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      const assistantBlock = blocks[0] as MessageBlock
+      expect(assistantBlock.type).toBe('assistant')
+      expect(assistantBlock.children).toHaveLength(5)
+
+      const imageBlocks = assistantBlock.children.filter(
+        (child) => child.type === 'content-image',
+      )
+      expect(imageBlocks).toHaveLength(2)
+      expect(imageBlocks[0]?.content.trim()).toBe(
+        'https://example.com/image1.jpg',
+      )
+      expect(imageBlocks[1]?.content.trim()).toBe(
+        'https://example.com/image2.jpg',
+      )
+    })
+
+    it('should handle empty content-image in message blocks', () => {
+      const prompt = `<assistant>
+Here's an empty image tag:
+<content-image></content-image>
+Done.
+</assistant>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      // The output should normalize empty content-image to self-closing
+      expect(output.trim()).toBe(`<assistant>
+Here's an empty image tag:
+<content-image />
+Done.
+</assistant>`)
+
+      const assistantBlock = blocks[0] as MessageBlock
+      const imageBlock = assistantBlock.children[1] as ImageBlock
+      expect(imageBlock.type).toBe('content-image')
+      expect(imageBlock.content).toBe('')
+    })
+
+    it('should handle system message with content tags', () => {
+      const prompt = `<system>
+You are an AI assistant. Here's a reference image:
+<content-image>https://example.com/reference.jpg</content-image>
+Use this as context for your responses.
+</system>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+
+      const systemBlock = blocks[0] as MessageBlock
+      expect(systemBlock.type).toBe('system')
+      expect(systemBlock.children).toHaveLength(3)
+      expect(systemBlock.children[1]?.type).toBe('content-image')
+    })
+  })
+
+  describe('ID uniqueness', () => {
+    it('should generate unique IDs for all blocks in complex prompt', () => {
+      const prompt = `---
+provider: OpenAI
+model: gpt-4o-mini
+tools:
+  - latitude/code
+---
+Say hi to {{ name }}
+
+
+
+
+<user>
+  Hola
+  {{if thing }}
+    Do this
+  {{ endif }}
+  <prompt path="use-mo1" location={{thing}} />
+</user>
+
+<user>
+  <content-image>https://t4.ftcdn.net/jpg/02/66/72/41/360_F_266724172_Iy8gdKgMa7XmrhYYxLCxyhx6J7070Pr8.jpg</content-image>
+</user>
+
+<step isolated as="cosa">
+  I'm a pre user text
+  <user>This is me asking</user>
+  <assistant>
+    This is you responding
+
+
+
+
+
+  </assistant>
+</step>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      // Collect all IDs from all blocks and their children recursively
+      function collectAllIds(blocks: AnyBlock[]): string[] {
+        const ids: string[] = []
+
+        function collectFromBlock(block: AnyBlock) {
+          ids.push(block.id)
+          if ('children' in block && block.children) {
+            block.children.forEach(collectFromBlock)
+          }
+        }
+
+        blocks.forEach(collectFromBlock)
+        return ids
+      }
+
+      const allIds = collectAllIds(blocks)
+      const uniqueIds = [...new Set(allIds)]
+
+      expect(allIds.length).toBe(uniqueIds.length)
+      expect(allIds.length).toBe(uniqueIds.length)
+    })
+  })
+
+  describe('prompt blocks', () => {
+    it('should handle prompt block with path and attributes', () => {
+      const prompt = `<user>
+  Here you can find your guidelines for the city
+  <prompt path="./guidelines/cities" location={{city}} />
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0]?.type).toBe('user')
+
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.children).toHaveLength(3) // text, prompt, trailing newline
+
+      const textBlock = userBlock.children[0] as TextBlock
+      expect(textBlock.type).toBe('text')
+      expect(textBlock.content).toContain(
+        'Here you can find your guidelines for the city',
+      )
+
+      const promptBlock = userBlock.children[1] as PromptBlock
+      expect(promptBlock?.type).toBe('prompt')
+      expect(promptBlock.attributes.path).toBe('./guidelines/cities')
+      expect(promptBlock.attributes.location).toBe('{{city}}')
+    })
+
+    it('should handle prompt block with static attributes', () => {
+      const prompt = `<user>
+  <prompt path="./guidelines/cities" location="Barcelona" />
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0]?.type).toBe('user')
+
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.children).toHaveLength(3) // leading whitespace, prompt, trailing newline
+
+      const leadingTextBlock = userBlock.children[0] as TextBlock
+      expect(leadingTextBlock?.type).toBe('text')
+      expect(leadingTextBlock?.content).toBe('\n  ')
+
+      const promptBlock = userBlock.children[1] as PromptBlock
+      expect(promptBlock?.type).toBe('prompt')
+      expect(promptBlock.attributes.path).toBe('./guidelines/cities')
+      expect(promptBlock.attributes.location).toBe('Barcelona')
+
+      const trailingTextBlock = userBlock.children[2] as TextBlock
+      expect(trailingTextBlock?.type).toBe('text')
+      expect(trailingTextBlock?.content).toBe('\n')
+    })
+
+    it('should handle prompt block at root level', () => {
+      const prompt = `<prompt path="./shared/intro" />
+
+Some text here`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      expect(blocks).toHaveLength(2)
+
+      const promptBlock = blocks[0]
+      expect(promptBlock?.type).toBe('prompt')
+      if (promptBlock?.type === 'prompt') {
+        expect(promptBlock.attributes.path).toBe('./shared/intro')
+      }
+
+      const textBlock = blocks[1] as TextBlock
+      expect(textBlock?.type).toBe('text')
+      expect(textBlock.content).toContain('Some text here')
+    })
+
+    it('should handle prompt block inside step', () => {
+      const prompt = `<step as="planning">
+  <prompt path="./planning/template" project={{projectName}} />
+  Additional planning content
+</step>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+
+      expect(blocks).toHaveLength(1)
+      expect(blocks[0]?.type).toBe('step')
+
+      const stepBlock = blocks[0]
+      if (stepBlock?.type === 'step') {
+        expect(stepBlock.children).toHaveLength(3) // leading whitespace, prompt, text with additional content
+
+        const leadingTextBlock = stepBlock.children?.[0]
+        expect(leadingTextBlock?.type).toBe('text')
+        if (leadingTextBlock?.type === 'text') {
+          expect(leadingTextBlock.content).toBe('\n  ')
+        }
+
+        const promptBlock = stepBlock.children?.[1]
+        expect(promptBlock?.type).toBe('prompt')
+        if (promptBlock?.type === 'prompt') {
+          expect(promptBlock.attributes.path).toBe('./planning/template')
+          expect(promptBlock.attributes.project).toBe('{{projectName}}')
+        }
+
+        const textBlock = stepBlock.children?.[2]
+        expect(textBlock?.type).toBe('text')
+        if (textBlock?.type === 'text') {
+          expect(textBlock.content).toContain('Additional planning content')
+        }
+      }
+    })
+
+    it('should maintain round-trip consistency for prompt blocks', () => {
+      const prompt = `<user>
+  Guidelines: <prompt path="./guidelines/cities" location={{city}} />
+
+  Or default: <prompt path="./guidelines/cities" location="Barcelona" />
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      // Parse the output again to ensure it's valid
+      const roundTripAst = parse(output.trim())
+      const roundTripBlocks = astToSimpleBlocks({
+        ast: roundTripAst,
+        prompt: output.trim(),
+      })
+
+      expect(roundTripBlocks).toHaveLength(blocks.length)
+      expect(roundTripBlocks[0]?.type).toBe('user')
+
+      const userBlock = roundTripBlocks[0]
+      if (userBlock?.type === 'user') {
+        expect(userBlock.children).toHaveLength(5) // text, prompt, text, prompt, text
+      }
+    })
+  })
+
+  describe('content-file blocks', () => {
+    it('should handle top-level content-file blocks', () => {
+      const prompt = `<content-file name="document.pdf">
+/path/to/document.pdf
+</content-file>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(1)
+      const fileBlock = blocks[0] as FileBlock
+      expect(fileBlock.type).toBe('content-file')
+      expect(fileBlock.content.trim()).toBe('/path/to/document.pdf')
+      expect(fileBlock.attributes?.name).toBe('document.pdf')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle multiple content-file blocks', () => {
+      const prompt = `<content-file name="doc1.pdf">
+/path/to/doc1.pdf
+</content-file>
+
+<content-file name="doc2.docx">
+/path/to/doc2.docx
+</content-file>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(3) // 2 file blocks + 1 text block for whitespace
+      const fileBlock1 = blocks[0] as FileBlock
+      const fileBlock2 = blocks[2] as FileBlock
+
+      expect(fileBlock1.type).toBe('content-file')
+      expect(fileBlock1.attributes?.name).toBe('doc1.pdf')
+      expect(fileBlock2.type).toBe('content-file')
+      expect(fileBlock2.attributes?.name).toBe('doc2.docx')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle content-file without name attribute', () => {
+      const prompt = `<content-file>
+/path/to/unnamed.pdf
+</content-file>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const fileBlock = blocks[0] as FileBlock
+
+      expect(fileBlock.type).toBe('content-file')
+      expect(fileBlock.attributes?.name).toBe('') // Should default to empty string
+    })
+
+    it('should handle empty content-file blocks', () => {
+      const prompt = `<content-file name="empty.txt"></content-file>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe('<content-file name="empty.txt" />')
+      const fileBlock = blocks[0] as FileBlock
+      expect(fileBlock.type).toBe('content-file')
+      expect(fileBlock.content.trim()).toBe('')
+    })
+
+    it('should handle self-closing content-file blocks', () => {
+      const prompt = `<content-file name="test.pdf" />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+      expect(blocks[0]?.type).toBe('content-file')
+    })
+  })
+
+  describe('tool-call blocks', () => {
+    it('should handle top-level tool-call blocks', () => {
+      const prompt = `<tool-call id="call_123" name="get_weather" location="New York" unit="celsius" />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(1)
+      const toolCallBlock = blocks[0] as ToolCallBlock
+      expect(toolCallBlock.type).toBe('tool-call')
+      expect(toolCallBlock.attributes?.id).toBe('call_123')
+      expect(toolCallBlock.attributes?.name).toBe('get_weather')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle multiple tool-call blocks', () => {
+      const prompt = `<tool-call id="call_1" name="search" query="AI" />
+
+<tool-call id="call_2" name="calculate" expression="2+2" />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(3) // 2 tool-call blocks + 1 text block for whitespace
+      const toolCall1 = blocks[0] as ToolCallBlock
+      const toolCall2 = blocks[2] as ToolCallBlock
+
+      expect(toolCall1.type).toBe('tool-call')
+      expect(toolCall1.attributes?.id).toBe('call_1')
+      expect(toolCall1.attributes?.name).toBe('search')
+      expect(toolCall2.type).toBe('tool-call')
+      expect(toolCall2.attributes?.id).toBe('call_2')
+      expect(toolCall2.attributes?.name).toBe('calculate')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle tool-call without attributes', () => {
+      const prompt = `<tool-call>
+{"action": "test"}
+</tool-call>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const toolCallBlock = blocks[0] as ToolCallBlock
+
+      expect(toolCallBlock.type).toBe('tool-call')
+      expect(toolCallBlock.attributes?.id).toBe('') // Should default to empty string
+      expect(toolCallBlock.attributes?.name).toBe('') // Should default to empty string
+    })
+
+    it('should handle empty tool-call blocks', () => {
+      const prompt = `<tool-call id="empty" name="noop"></tool-call>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe('<tool-call id="empty" name="noop" />')
+      const toolCallBlock = blocks[0] as ToolCallBlock
+      expect(toolCallBlock.type).toBe('tool-call')
+    })
+
+    it('should handle self-closing tool-call blocks', () => {
+      const prompt = `<tool-call id="test" name="ping" />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(output.trim()).toBe(prompt.trim())
+      expect(blocks[0]?.type).toBe('tool-call')
+    })
+
+    it('should handle tool-call with additional parameters', () => {
+      const prompt = `<tool-call id="search_1" name="web_search" timeout="30" retry="true" query="AI trends 2024" limit="10" />`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const toolCallBlock = blocks[0] as ToolCallBlock
+
+      expect(toolCallBlock.type).toBe('tool-call')
+      expect(toolCallBlock.attributes?.id).toBe('search_1')
+      expect(toolCallBlock.attributes?.name).toBe('web_search')
+      expect(toolCallBlock.attributes?.parameters?.timeout).toBe('30')
+      expect(toolCallBlock.attributes?.parameters?.retry).toBe('true')
+
+      // The output should only include id and name attributes, not parameters
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(
+        `<tool-call id="search_1" name="web_search" timeout="30" retry="true" query="AI trends 2024" limit="10" />`,
+      )
+    })
+
+    it('should separate parameters from core attributes in tool-call', () => {
+      const prompt = `<tool-call id="calc_1" name="calculator" precision="high" async="false" debug="true" />`
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const toolCallBlock = blocks[0] as ToolCallBlock
+
+      // Core attributes
+      expect(toolCallBlock.attributes?.id).toBe('calc_1')
+      expect(toolCallBlock.attributes?.name).toBe('calculator')
+
+      // Additional parameters
+      expect(toolCallBlock.attributes?.parameters?.precision).toBe('high')
+      expect(toolCallBlock.attributes?.parameters?.async).toBe('false')
+      expect(toolCallBlock.attributes?.parameters?.debug).toBe('true')
+
+      // Round-trip should only preserve core attributes
+      const output = simpleBlocksToText(blocks)
+      expect(output.trim()).toBe(
+        `<tool-call id="calc_1" name="calculator" precision="high" async="false" debug="true" />`,
+      )
+    })
+  })
+
+  describe('content-file and tool-call in steps', () => {
+    it('should handle content-file blocks in steps', () => {
+      const prompt = `<step as="document_review">
+Please review this document:
+
+<content-file name="report.pdf">
+/uploads/report.pdf
+</content-file>
+
+Provide feedback.
+</step>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(1)
+      const stepBlock = blocks[0] as StepBlock
+      expect(stepBlock.type).toBe('step')
+      expect(stepBlock.attributes?.as).toBe('document_review')
+
+      const fileChild = stepBlock.children?.find(
+        (child) => child.type === 'content-file',
+      ) as FileBlock
+      expect(fileChild).toBeDefined()
+      expect(fileChild.attributes?.name).toBe('report.pdf')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+
+    it('should handle tool-call blocks in steps', () => {
+      const prompt = `<step as="api_call">
+Making API call:
+
+<tool-call id="weather_1" name="get_weather" city="London" />
+
+Processing response.
+</step>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(1)
+      const stepBlock = blocks[0] as StepBlock
+      expect(stepBlock.type).toBe('step')
+
+      const toolCallChild = stepBlock.children?.find(
+        (child) => child.type === 'tool-call',
+      ) as ToolCallBlock
+      expect(toolCallChild).toBeDefined()
+      expect(toolCallChild.attributes?.id).toBe('weather_1')
+      expect(toolCallChild.attributes?.name).toBe('get_weather')
+      expect(output.trim()).toBe(prompt.trim())
+    })
+  })
+
+  describe('mixed content blocks', () => {
+    it('should handle content-image, content-file, and tool-call together', () => {
+      const prompt = `<user>
+Here's an image:
+<content-image>https://example.com/image.jpg</content-image>
+
+And a document:
+<content-file name="data.csv">/path/to/data.csv</content-file>
+
+Please analyze both and call this tool:
+<tool-call id="analyze_1" name="analyze_data" image_url="https://example.com/image.jpg" data_file="/path/to/data.csv" />
+</user>`
+
+      const ast = parse(prompt)
+      const blocks = astToSimpleBlocks({ ast, prompt })
+      const output = simpleBlocksToText(blocks)
+
+      expect(blocks).toHaveLength(1)
+      const userBlock = blocks[0] as MessageBlock
+      expect(userBlock.type).toBe('user')
+
+      const imageChild = userBlock.children?.find(
+        (child) => child.type === 'content-image',
+      )
+      const fileChild = userBlock.children?.find(
+        (child) => child.type === 'content-file',
+      ) as FileBlock
+      const toolCallChild = userBlock.children?.find(
+        (child) => child.type === 'tool-call',
+      ) as ToolCallBlock
+
+      expect(imageChild).toBeDefined()
+      expect(fileChild).toBeDefined()
+      expect(fileChild.attributes?.name).toBe('data.csv')
+      expect(toolCallChild).toBeDefined()
+      expect(toolCallChild.attributes?.id).toBe('analyze_1')
+      expect(toolCallChild.attributes?.name).toBe('analyze_data')
+
+      expect(output.trim()).toBe(prompt.trim())
+    })
+  })
+})

--- a/packages/constants/src/simpleBlocks/index.ts
+++ b/packages/constants/src/simpleBlocks/index.ts
@@ -1,0 +1,3 @@
+export type { AnyBlock, AstError } from './types'
+export * from './astToSimpleBlocks'
+export * from './simpleBlocksToText'

--- a/packages/constants/src/simpleBlocks/simpleBlocksToText.ts
+++ b/packages/constants/src/simpleBlocks/simpleBlocksToText.ts
@@ -1,0 +1,99 @@
+import { attributesToString } from './astParsingUtils'
+import { AnyBlock, StepChild, MessageChild, BlockAttributes } from './types'
+
+function messageChildToText(child: MessageChild): string {
+  switch (child.type) {
+    case 'content-image':
+      if (child.content === '') {
+        return `<content-image />`
+      } else {
+        return `<content-image>${child.content}</content-image>`
+      }
+    case 'content-file': {
+      const attrsString = attributesToString({
+        attributes: child.attributes,
+      })
+      if (child.content === '') {
+        return `<content-file${attrsString} />`
+      } else {
+        return `<content-file${attrsString}>${child.content}</content-file>`
+      }
+    }
+    case 'tool-call': {
+      // For tool-call blocks, include id, name, and parameters as attributes
+      const toolCallAttrs: BlockAttributes = {}
+      if (child.attributes.id) {
+        toolCallAttrs.id = child.attributes.id
+      }
+      if (child.attributes.name) {
+        toolCallAttrs.name = child.attributes.name
+      }
+      // Add parameters as individual attributes
+      if (child.attributes.parameters) {
+        Object.assign(toolCallAttrs, child.attributes.parameters)
+      }
+
+      const attrsString = attributesToString({
+        attributes: toolCallAttrs,
+      })
+      return `<tool-call${attrsString} />`
+    }
+    case 'prompt': {
+      const attrsString = Object.entries(child.attributes)
+        .map(([key, value]) => `${key}="${value}"`)
+        .join(' ')
+
+      return `<prompt ${attrsString} />`
+    }
+    case 'text':
+      return child.content
+    default:
+      return ''
+  }
+}
+
+function stepChildToText(block: StepChild): string {
+  switch (block.type) {
+    case 'system':
+    case 'assistant':
+    case 'developer':
+    case 'user':
+      return `<${block.type}>${block.children.map(messageChildToText).join('')}</${block.type}>`
+
+    case 'content-image':
+    case 'content-file':
+    case 'tool-call':
+    case 'prompt':
+    case 'text':
+      return messageChildToText(block)
+  }
+}
+
+export function simpleBlocksToText(blocks: AnyBlock[]): string {
+  return blocks
+    .map((block) => {
+      switch (block.type) {
+        case 'step': {
+          const children = block.children ?? []
+          const attr = attributesToString({
+            attributes: block.attributes,
+            shouldKebabCase: ['as', 'isolate'],
+          })
+          const stepContent = children.map(stepChildToText).join('')
+
+          return `<step${attr}>${stepContent}</step>`
+        }
+        case 'text':
+        case 'content-image':
+        case 'content-file':
+        case 'tool-call':
+        case 'prompt':
+        case 'system':
+        case 'user':
+        case 'assistant':
+        case 'developer':
+          return stepChildToText(block)
+      }
+    })
+    .join('')
+}

--- a/packages/constants/src/simpleBlocks/types.ts
+++ b/packages/constants/src/simpleBlocks/types.ts
@@ -1,0 +1,111 @@
+import type { CompileError, Fragment, IParser } from 'promptl-ai'
+
+type ElementTag = IParser.ElementTag
+type TemplateNode = IParser.TemplateNode
+type IfBlock = IParser.IfBlock
+type ForBlock = IParser.ForBlock
+type MustacheTag = IParser.MustacheTag
+type Text = IParser.Text
+
+const MESSAGE_BLOCK = ['system', 'user', 'assistant', 'developer'] as const
+export const CONTENT_BLOCK = [
+  'content-image',
+  'content-file',
+  'tool-call',
+  'text',
+  'prompt',
+] as const
+export const BLOCK_TYPES = [...MESSAGE_BLOCK, ...CONTENT_BLOCK, 'step'] as const
+export type MessageBlockType = (typeof MESSAGE_BLOCK)[number]
+export type ContentBlockType = (typeof CONTENT_BLOCK)[number]
+
+export type BlockType = (typeof BLOCK_TYPES)[number]
+export type BlockAttributes = Record<string, string | boolean>
+
+export type BlockError = {
+  message: string
+  startIndex: number
+  endIndex: number
+}
+
+type SimpleBlock = {
+  id: string
+  errors?: BlockError[]
+}
+
+export type ImageBlock = SimpleBlock & {
+  type: 'content-image'
+  content: string
+}
+
+export type FileBlock = SimpleBlock & {
+  type: 'content-file'
+  content: string
+  attributes: BlockAttributes & {
+    name?: string
+  }
+}
+
+export type ToolCallBlock = SimpleBlock & {
+  type: 'tool-call'
+  attributes: {
+    id?: string
+    name?: string
+    parameters?: BlockAttributes
+  }
+}
+
+export type TextBlock = SimpleBlock & {
+  type: 'text'
+  content: string
+}
+
+export type PromptBlock = SimpleBlock & {
+  type: 'prompt'
+  attributes: BlockAttributes & {
+    path: string
+  }
+}
+export type ContentBlock =
+  | ImageBlock
+  | FileBlock
+  | ToolCallBlock
+  | TextBlock
+  | PromptBlock
+
+export type MessageChild = ContentBlock
+export type MessageBlock = SimpleBlock & {
+  type: MessageBlockType
+  children: MessageChild[]
+}
+
+export type StepChild = MessageBlock | ContentBlock
+export type StepBlock = SimpleBlock & {
+  type: 'step'
+  children?: StepChild[]
+  attributes?: {
+    as?: string
+    isolated?: boolean
+  }
+}
+
+export type AnyBlock = StepBlock | MessageBlock | ContentBlock
+
+export type AstError = {
+  startIndex: CompileError['startIndex']
+  endIndex: CompileError['endIndex']
+  start: CompileError['start']
+  end: CompileError['end']
+  message: CompileError['message']
+  name: CompileError['name']
+}
+
+export type {
+  Fragment,
+  ElementTag,
+  TemplateNode,
+  IfBlock,
+  ForBlock,
+  MustacheTag,
+  Text,
+}

--- a/packages/constants/vitest.config.ts
+++ b/packages/constants/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    testTimeout: 5000,
+    environment: 'node',
+    include: ['./src/**/*.test.ts'],
+  },
+})

--- a/packages/web-ui/src/ds/atoms/Switch/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Switch/index.tsx
@@ -60,6 +60,7 @@ type Props = ToogleProps &
     name?: string
     checked?: boolean
     defaultChecked?: boolean
+    fullWidth?: boolean
   }
 function SwitchInput({
   className,
@@ -69,6 +70,7 @@ function SwitchInput({
   name,
   checked,
   defaultChecked,
+  fullWidth = true,
   ...rest
 }: Props) {
   const error = errors?.[0]
@@ -86,7 +88,9 @@ function SwitchInput({
 
   return (
     <div
-      className={cn('flex flex-col gap-y-2 w-full', className)}
+      className={cn('flex flex-col gap-y-2', className, {
+        'w-full': fullWidth,
+      })}
       aria-describedby={
         !error
           ? `${formDescriptionId}`

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/index.tsx
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/Editor/index.tsx
@@ -3,7 +3,7 @@ import { CheckCircle2, LoaderCircle } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 
 import { MarkerSeverity, type editor } from 'monaco-editor'
-import { CompileError } from 'promptl-ai'
+import { AstError } from '@latitude-data/constants/simpleBlocks'
 
 import {
   AppLocalStorage,
@@ -18,7 +18,7 @@ import { CopilotSection } from './CopilotSection'
 import { MonacoDiffEditor } from './DiffEditor'
 import { RegularMonacoEditor } from './RegularEditor'
 
-const NO_ERRORS: CompileError[] = []
+const NO_ERRORS: AstError[] = []
 export function DocumentTextEditor({
   value,
   path,
@@ -53,7 +53,7 @@ export function DocumentTextEditor({
 
   const errorMarkers = useMemo<DocumentError[]>(
     () =>
-      errors.map((error: CompileError) => {
+      errors.map((error) => {
         return {
           startLineNumber: error.start?.line ?? 0,
           startColumn: error.start?.column ?? 0,

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/types.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react'
 
-import type { CompileError } from 'promptl-ai'
+import type { AstError } from '@latitude-data/constants/simpleBlocks'
 
 export type DiffOptions = {
   newValue: string
@@ -13,7 +13,7 @@ export type DocumentTextEditorProps = {
   value: string
   defaultValue?: string
   path?: string
-  compileErrors?: CompileError[]
+  compileErrors?: AstError[]
   onChange?: (value: string) => void
   autoFocus?: boolean
   readOnlyMessage?: string

--- a/packages/web-ui/src/ds/molecules/ErrorComponent/index.tsx
+++ b/packages/web-ui/src/ds/molecules/ErrorComponent/index.tsx
@@ -21,7 +21,7 @@ export function ErrorComponent({
           'text-destructive': type === 'red',
         })}
       >
-        <Icon name='logoMonochrome' size='xxxlarge' />
+        <Icon name='logoMonochrome' size='xxxlarge' className='opacity-25' />
         <Text.H5 align='center' color='foregroundMuted'>
           {message}
         </Text.H5>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 8.16.0
       version: 8.16.0
     promptl-ai:
-      specifier: 0.6.6
-      version: 0.6.6
+      specifier: 0.7.4
+      version: 0.7.4
     zod:
       specifier: 3.24.2
       version: 3.24.2
@@ -142,7 +142,7 @@ importers:
         version: 4.17.21
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       rate-limiter-flexible:
         specifier: 5.0.3
         version: 5.0.3
@@ -308,7 +308,7 @@ importers:
         version: 1.252.1
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       rate-limiter-flexible:
         specifier: 5.0.3
         version: 5.0.3
@@ -593,9 +593,15 @@ importers:
       json-schema:
         specifier: ^0.4.0
         version: 0.4.0
+      lodash.camelcase:
+        specifier: ^4.3.0
+        version: 4.3.0
+      lodash.kebabcase:
+        specifier: ^4.1.1
+        version: 4.1.1
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       zod:
         specifier: 'catalog:'
         version: 3.24.2
@@ -609,6 +615,15 @@ importers:
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
+      '@types/lodash.camelcase':
+        specifier: ^4.3.9
+        version: 4.3.9
+      '@types/lodash.kebabcase':
+        specifier: ^4.1.9
+        version: 4.1.9
+      vitest:
+        specifier: ^3.1.4
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.15.31)(jiti@1.21.7)(jsdom@24.1.3(canvas@2.11.2))(msw@2.10.2(@types/node@22.15.31)(typescript@5.8.3))(terser@5.42.0)(tsx@4.20.0)(yaml@2.8.0)
 
   packages/core:
     dependencies:
@@ -794,7 +809,7 @@ importers:
         version: 4.2.0
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       react:
         specifier: 18.3.0
         version: 18.3.0
@@ -925,7 +940,7 @@ importers:
         version: 3.3.2
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       typescript:
         specifier: ^5.5.4
         version: 5.8.3
@@ -1098,7 +1113,7 @@ importers:
         version: 4.104.0(ws@8.18.2)(zod@3.24.2)
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       rollup:
         specifier: ^4.41.0
         version: 4.43.0
@@ -1315,7 +1330,7 @@ importers:
         version: 16.1.0(postcss@8.5.4)
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.6.6(ws@8.18.2)
+        version: 0.7.4(ws@8.18.2)
       recast:
         specifier: ^0.23.4
         version: 0.23.11
@@ -6557,6 +6572,12 @@ packages:
   '@types/lodash-es@4.17.12':
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
+  '@types/lodash.camelcase@4.3.9':
+    resolution: {integrity: sha512-ys9/hGBfsKxzmFI8hckII40V0ASQ83UM2pxfQRghHAwekhH4/jWtjz/3/9YDy7ZpUd/H0k2STSqmPR28dnj7Zg==}
+
+  '@types/lodash.kebabcase@4.1.9':
+    resolution: {integrity: sha512-kPrrmcVOhSsjAVRovN0lRfrbuidfg0wYsrQa5IYuoQO1fpHHGSme66oyiYA/5eQPVl8Z95OA3HG0+d2SvYC85w==}
+
   '@types/lodash@4.17.17':
     resolution: {integrity: sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==}
 
@@ -10477,6 +10498,9 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -11928,8 +11952,8 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
-  promptl-ai@0.6.6:
-    resolution: {integrity: sha512-TYm9nm7kVGUsNtRtEPdHEPNzFZoNR0XtdbqxSwfssOPp5ZcTtiTLf3tkSsvwnRUcBC+amoYsQalXh5XQnuRgAg==}
+  promptl-ai@0.7.4:
+    resolution: {integrity: sha512-9gQDYWAJkuFgwrnGvSM1VnagoZcPsPsTZ/d+bue8rMHKBv94zCYHcrxsqked/z7zHWIwQDJDK5dorox8wttoyw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -21148,6 +21172,14 @@ snapshots:
     dependencies:
       '@types/lodash': 4.17.17
 
+  '@types/lodash.camelcase@4.3.9':
+    dependencies:
+      '@types/lodash': 4.17.17
+
+  '@types/lodash.kebabcase@4.1.9':
+    dependencies:
+      '@types/lodash': 4.17.17
+
   '@types/lodash@4.17.17': {}
 
   '@types/long@4.0.2': {}
@@ -25704,6 +25736,8 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
+  lodash.kebabcase@4.1.1: {}
+
   lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
@@ -27543,7 +27577,7 @@ snapshots:
 
   progress@2.0.3: {}
 
-  promptl-ai@0.6.6(ws@8.18.2):
+  promptl-ai@0.7.4(ws@8.18.2):
     dependencies:
       acorn: 8.15.0
       code-red: 1.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,5 +9,5 @@ catalog:
   drizzle-orm: 0.44.2
   drizzle-kit: 0.31.1
   dd-trace: 5.43.0
-  promptl-ai: 0.6.6
+  promptl-ai: 0.7.4
   zod: 3.24.2


### PR DESCRIPTION
# What?
We want to offer a simpler playground experience for building agents where advanced features like for loops or conditionals are not so critical. That's our hypothesis. So, for that, we're going to offer a simple mode experience where the user introduces the prompts as plain text (kind of)


### TODO
- [x] Feature flag to show toggle between current (advance) and simple editors
- [x] Promptl AST -> Simple Editor blocks 
- [x] Simple Editor Blocks -> Promptl Text
- [x] AST to Blocks for `<step />` tag
- [x] AST to Blocks for `<system />` tag
- [x] AST to Blocks for `<user />` tag
- [x] AST to Blocks for `<assistant />` tag
- [x] Simple block for `<prompt />` tag
- [x] Simple block for `<content-image />` tag
- [x] Add tests for `astToSimpleBlocks` function 
- [x] Handle nested message tags inside `<step />` tags
- [x] Handde nested content (prompt, image, file, and tool-call) tags inside `<step />`
- [x] Handle nested content (prompt, image, file, and tool-call) tags inside Message tags
- [x] Simple block for `<content-file />` tag
- [x] Simple block for `<tool-call />` tag
- [x] Map Errors with blocks
- [x] ~Think about performance and unique block IDs~ didn't think much but I think is ok, let's see
