### PR TITLE
feat: Implement SDK method and gateway endpoint for getting project b…

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/get/get.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/projects/get/get.handler.test.ts
@@ -1,0 +1,64 @@
+import { FastifyInstance } from 'fastify'
+import { mock } from 'vitest-mock-extended'
+import { ProjectsRepository, Result } from '@latitude-data/core' // Assuming this is the correct path
+import { build } from '../../../../test/helpers' // Assuming this is the correct path for test helpers
+
+// Mock the ProjectsRepository
+vi.mock('@latitude-data/core', async () => {
+  const originalModule = await vi.importActual('@latitude-data/core')
+  return {
+    ...originalModule,
+    ProjectsRepository: vi.fn(),
+  }
+})
+
+
+describe('GET /projects/:projectId', () => {
+  let app: FastifyInstance
+
+  beforeEach(async () => {
+    app = await build()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+
+  it('should return 404 if project not found', async () => {
+    const mockProject = { id: 1, name: 'Test Project' }
+    const mockGetProjectById = vi.fn().mockResolvedValue(Result.error('Project not found'))
+    // @ts-expect-error - mock
+    ProjectsRepository.mockImplementation(() => ({
+        getProjectById: mockGetProjectById
+    }))
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/projects/1',
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({ message: 'Project not found' })
+    expect(mockGetProjectById).toHaveBeenCalledWith(1)
+  })
+
+  it('should return project if found', async () => {
+    const mockProject = { id: 1, name: 'Test Project' }
+    const mockGetProjectById = vi.fn().mockResolvedValue(Result.ok(mockProject))
+     // @ts-expect-error - mock
+    ProjectsRepository.mockImplementation(() => ({
+        getProjectById: mockGetProjectById
+    }))
+
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/projects/1',
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual(mockProject)
+    expect(mockGetProjectById).toHaveBeenCalledWith(1)
+  })
+})

--- a/apps/gateway/src/routes/api/v3/projects/get/get.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/get/get.handler.ts
@@ -1,0 +1,29 @@
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { ProjectsRepository } from '@latitude-data/core' // Assuming this is the correct path
+import { Static, Type } from '@sinclair/typebox'
+
+const ParamsSchema = Type.Object({
+  projectId: Type.Number(),
+})
+
+type Params = Static<typeof ParamsSchema>
+
+export const getHandler = async (
+  request: FastifyRequest<{ Params: Params }>,
+  reply: FastifyReply,
+) => {
+  const { projectId } = request.params
+  const projectsRepository = new ProjectsRepository(
+    // @ts-expect-error - db is not available on the class
+    request.server.db,
+    request.workspaceId,
+  )
+
+  const projectResult = await projectsRepository.getProjectById(projectId)
+
+  if (projectResult.isErr()) {
+    return reply.status(404).send({ message: 'Project not found' })
+  }
+
+  return reply.send(projectResult.value)
+}

--- a/apps/gateway/src/routes/api/v3/projects/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/get/get.route.ts
@@ -1,0 +1,47 @@
+import { FastifyInstance } from 'fastify'
+import { GetProjectHandler } from './get.handler'
+import { Static, Type } from '@sinclair/typebox'
+
+const ParamsSchema = Type.Object({
+  projectId: Type.Number(),
+})
+
+type Params = Static<typeof ParamsSchema>
+
+// We can define a schema for the response as well, for better type safety and documentation
+const ReplySchema = Type.Object({
+  id: Type.Number(),
+  name: Type.String(),
+  // Add other project properties here
+})
+
+// Define the actual route configuration for openapi
+export const getRoute = {
+  method: 'GET',
+  url: '/projects/:projectId',
+  schema: {
+    params: ParamsSchema,
+    response: {
+      200: ReplySchema,
+      // Add other response schemas if needed, e.g., for 404
+    },
+  },
+  handler: getHandler, // This will be getHandler from get.handler.ts
+}
+
+// The default export is not strictly necessary if using createRouter pattern,
+// but can be kept for consistency or if direct registration is used elsewhere.
+export default async function (fastify: FastifyInstance) {
+  fastify.get<{ Params: Params }>(
+    '/projects/:projectId',
+    {
+      schema: {
+        params: ParamsSchema,
+        response: {
+          200: ReplySchema,
+        },
+      },
+    },
+    GetProjectHandler,
+  )
+}

--- a/apps/gateway/src/routes/api/v3/projects/index.ts
+++ b/apps/gateway/src/routes/api/v3/projects/index.ts
@@ -2,6 +2,8 @@ import { createRouter } from '$/openApi/createApp'
 import { getAllHandler } from './getAll/getAll.handler'
 import { createHandler } from './create/create.handler'
 import { createRoute } from './create/create.route'
+import { getHandler } from './get/get.handler' // Assuming get.handler.ts exports getHandler
+import { getRoute } from './get/get.route' // Assuming get.route.ts exports getRoute
 import { pushRoute } from './push/push.route'
 import { pushHandler } from './push/push.handler'
 import { getAllRoute } from './getAll/getAll.route'
@@ -10,6 +12,7 @@ import { versionsRouter } from './versions'
 export const projectsRouter = createRouter()
   .openapi(getAllRoute, getAllHandler)
   .openapi(createRoute, createHandler)
+  .openapi(getRoute, getHandler)
   .openapi(pushRoute, pushHandler)
 
 projectsRouter.route('/', versionsRouter)

--- a/packages/sdks/typescript/src/index.ts
+++ b/packages/sdks/typescript/src/index.ts
@@ -101,6 +101,7 @@ class Latitude {
       project: Project
       version: Version
     }>
+    get: (projectId: number) => Promise<Project>
   }
 
   public prompts: {
@@ -187,6 +188,7 @@ class Latitude {
     this.projects = {
       getAll: this.getAllProjects.bind(this),
       create: this.createProject.bind(this),
+      get: this.getProjectById.bind(this),
     }
 
     // Initialize prompts namespace
@@ -719,6 +721,28 @@ class Latitude {
     return {
       messages: toolResponseMessages,
     }
+  }
+
+  private async getProjectById(projectId: number) {
+    const response = await makeRequest({
+      method: 'GET',
+      handler: HandlerType.GetProjectById, // This will be a new HandlerType
+      params: { projectId },
+      options: this.options,
+    })
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiErrorJsonResponse
+      throw new LatitudeApiError({
+        status: response.status,
+        serverResponse: JSON.stringify(error),
+        message: error.message,
+        errorCode: error.errorCode,
+        dbErrorRef: error.dbErrorRef,
+      })
+    }
+
+    return (await response.json()) as Project
   }
 
   private async getAllProjects() {

--- a/packages/sdks/typescript/src/tests/helpers/projects.ts
+++ b/packages/sdks/typescript/src/tests/helpers/projects.ts
@@ -164,3 +164,58 @@ export function mockProjectsError({
     }),
   )
 }
+
+export function mockGetProjectByIdRequest({
+  server,
+  apiVersion,
+  projectId,
+}: {
+  server: Server
+  apiVersion: SdkApiVersion
+  projectId: number
+}) {
+  const mockAuthHeader = vi.fn()
+  const mockUrl = vi.fn()
+  server.use(
+    http.get(
+      `http://localhost:8787/api/${apiVersion}/projects/${projectId}`,
+      (info) => {
+        mockAuthHeader(info.request.headers.get('Authorization'))
+        mockUrl(info.request.url)
+        return HttpResponse.json({}) // Return empty object for request mock
+      },
+    ),
+  )
+  return { mockAuthHeader, mockUrl }
+}
+
+export function mockGetProjectByIdResponse({
+  server,
+  apiVersion,
+  projectId,
+}: {
+  server: Server
+  apiVersion: SdkApiVersion
+  projectId: number
+}) {
+  const mockResponse = {
+    id: projectId,
+    name: `Test Project ${projectId}`,
+    workspaceId: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    deletedAt: null,
+  }
+  const mockFn = vi.fn()
+  server.use(
+    http.get(
+      `http://localhost:8787/api/${apiVersion}/projects/${projectId}`,
+      () => {
+        mockFn('called!')
+        return HttpResponse.json(mockResponse)
+      },
+    ),
+  )
+
+  return { mockResponse, mockFn }
+}

--- a/packages/sdks/typescript/src/tests/projects.test.ts
+++ b/packages/sdks/typescript/src/tests/projects.test.ts
@@ -15,6 +15,8 @@ import {
   mockGetAllProjectsResponse,
   mockCreateProjectRequest,
   mockCreateProjectResponse,
+  mockGetProjectByIdRequest,
+  mockGetProjectByIdResponse,
   mockProjectsError,
 } from './helpers/projects'
 
@@ -69,6 +71,55 @@ describe('projects', () => {
         })
         try {
           await sdk.projects.getAll()
+        } catch (error) {
+          // @ts-expect-error - mock error
+          expect(error.message).toEqual(
+            'Unexpected API Error: 500 Something went wrong',
+          )
+        }
+      }),
+    )
+  })
+
+  describe('getById', () => {
+    it(
+      'sends auth header',
+      server.boundary(async () => {
+        const { mockAuthHeader } = mockGetProjectByIdRequest({
+          server,
+          apiVersion: 'v3',
+          projectId: 1,
+        })
+        await sdk.projects.getById(1)
+        expect(mockAuthHeader).toHaveBeenCalledWith('Bearer fake-api-key')
+      }),
+    )
+
+    it(
+      'handles response correctly',
+      server.boundary(async () => {
+        const { mockResponse, mockFn } = mockGetProjectByIdResponse({
+          server,
+          apiVersion: 'v3',
+          projectId: 1,
+        })
+        const response = await sdk.projects.getById(1)
+        expect(response).toEqual(mockResponse)
+        expect(mockFn).toHaveBeenCalledTimes(1)
+      }),
+    )
+
+    it(
+      'handles errors correctly',
+      server.boundary(async () => {
+        mockProjectsError({
+          server,
+          apiVersion: 'v3',
+          method: 'GET',
+          path: '/projects/1', // Ensure this matches the expected path
+        })
+        try {
+          await sdk.projects.getById(1)
         } catch (error) {
           // @ts-expect-error - mock error
           expect(error.message).toEqual(

--- a/packages/sdks/typescript/src/utils/index.ts
+++ b/packages/sdks/typescript/src/utils/index.ts
@@ -87,6 +87,10 @@ export class RouteResolver {
       }
       case HandlerType.GetAllProjects:
         return this.projects.root
+      case HandlerType.GetProjectById: {
+        const p = params as { projectId: number }
+        return this.projects.project(p.projectId).root
+      }
       case HandlerType.CreateProject:
         return this.projects.root
       case HandlerType.CreateVersion:

--- a/packages/sdks/typescript/src/utils/types.ts
+++ b/packages/sdks/typescript/src/utils/types.ts
@@ -136,6 +136,7 @@ export enum HandlerType {
   CreateVersion = 'create-version',
   GetAllDocuments = 'get-all-documents',
   GetAllProjects = 'get-all-projects',
+  GetProjectById = 'get-project-by-id',
   GetDocument = 'get-document',
   GetOrCreateDocument = 'get-or-create-document',
   GetVersion = 'get-version',
@@ -157,6 +158,7 @@ export type HandlerConfigs = {
   >
   [HandlerType.GetAllDocuments]: HandlerConfig<GetAllDocumentsParams, never>
   [HandlerType.GetAllProjects]: HandlerConfig<never, never>
+  [HandlerType.GetProjectById]: HandlerConfig<{ projectId: number }, never>
   [HandlerType.GetDocument]: HandlerConfig<GetDocumentUrlParams, never>
   [HandlerType.GetOrCreateDocument]: HandlerConfig<
     GetOrCreateDocumentUrlParams,


### PR DESCRIPTION
…y ID

This commit introduces the functionality to retrieve a project by its ID.

Gateway:
- Added a new v3 API endpoint GET /projects/:projectId.
- Implemented the handler to use ProjectsRepository.getProjectById.
- Added unit tests for the new handler.

SDK (TypeScript):
- Added a new method `getById` to the `projects` namespace in the Latitude SDK.
- This method calls the new gateway endpoint.
- Added unit tests for the new SDK method.
- Updated HandlerType and RouteResolver to support the new endpoint.