### PR TITLE
Update changelog for July 4, 2025

### DIFF
--- a/docs/changelog/changelog.mdx
+++ b/docs/changelog/changelog.mdx
@@ -3,6 +3,34 @@ title: Changelog
 description: All notable changes to Latitude.
 ---
 
+<Update label='2025-07-04'>
+
+## Ingest Spans and Process Segments
+Implemented a feature related to issue #1273, which involves ingesting spans and processing segments. [PR #1436](https://github.com/latitude-dev/latitude-llm/pull/1436)
+
+## Project Retrieval by ID
+Added a new API endpoint to retrieve projects by their ID, along with corresponding SDK methods and unit tests. [PR #1420](https://github.com/latitude-dev/latitude-llm/pull/1420)
+
+## New Gemini Models
+Added support for several new Gemini models, including gemini-2.5-pro and gemini-2.5-flash. [PR #1415](https://github.com/latitude-dev/latitude-llm/pull/1415)
+
+## Lexical Block Editor
+Explored the use of Lexical as a block editor, implementing features like drag & drop and keyboard navigation. [PR #1425](https://github.com/latitude-dev/latitude-llm/pull/1425)
+
+## Prompt Inclusion
+Implemented the ability to include prompts within other prompts using the "@" symbol. [PR #1434](https://github.com/latitude-dev/latitude-llm/pull/1434)
+
+## Variables in Blocks Editor
+Added functionality to insert and display variables in the blocks editor. [PR #1433](https://github.com/latitude-dev/latitude-llm/pull/1433)
+
+## Commands in Blocks Editor
+Enabled triggering commands by typing "/" in the blocks editor. [PR #1432](https://github.com/latitude-dev/latitude-llm/pull/1432)
+
+## Dependency Update
+Updated the `mintlify` dependency from version 4.0.571 to 4.1.97. [PR #1438](https://github.com/latitude-dev/latitude-llm/pull/1438)
+
+</Update>
+
 <Update label='2025-06-04'>
 
 ## Numeric similarity evaluation metric


### PR DESCRIPTION
This pull request updates the changelog with the latest changes as of July 4, 2025. The following updates have been made:

1. **Ingest Spans and Process Segments**: Implemented a feature related to issue #1273, which involves ingesting spans and processing segments. [PR #1436](https://github.com/latitude-dev/latitude-llm/pull/1436)

2. **Project Retrieval by ID**: Added a new API endpoint to retrieve projects by their ID, along with corresponding SDK methods and unit tests. [PR #1420](https://github.com/latitude-dev/latitude-llm/pull/1420)

3. **New Gemini Models**: Added support for several new Gemini models, including gemini-2.5-pro and gemini-2.5-flash. [PR #1415](https://github.com/latitude-dev/latitude-llm/pull/1415)

4. **Lexical Block Editor**: Explored the use of Lexical as a block editor, implementing features like drag & drop and keyboard navigation. [PR #1425](https://github.com/latitude-dev/latitude-llm/pull/1425)

5. **Prompt Inclusion**: Implemented the ability to include prompts within other prompts using the "@" symbol. [PR #1434](https://github.com/latitude-dev/latitude-llm/pull/1434)

6. **Variables in Blocks Editor**: Added functionality to insert and display variables in the blocks editor. [PR #1433](https://github.com/latitude-dev/latitude-llm/pull/1433)

7. **Commands in Blocks Editor**: Enabled triggering commands by typing "/" in the blocks editor. [PR #1432](https://github.com/latitude-dev/latitude-llm/pull/1432)

8. **Dependency Update**: Updated the `mintlify` dependency from version 4.0.571 to 4.1.97. [PR #1438](https://github.com/latitude-dev/latitude-llm/pull/1438)

Please review the changes and merge them into the main branch.