### PR TITLE
Make more vertical space when running a prompt in the playground

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/BlocksEditor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/BlocksEditor/index.tsx
@@ -64,7 +64,7 @@ export const PlaygroundBlocksEditor = memo(
       [documents],
     )
     const onToogleDevEditor = useCallback(() => {
-      onToggleBlocksEditor(false)
+      onToggleBlocksEditor(true)
     }, [onToggleBlocksEditor])
 
     const onError = useCallback(

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/Preview.tsx
@@ -34,6 +34,7 @@ export default function Preview({
   return (
     <>
       <PreviewPrompt
+        showHeader={false}
         metadata={metadata}
         parameters={parameters}
         runPrompt={runPrompt}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/index.tsx
@@ -1,9 +1,9 @@
-import { memo, useCallback, useEffect, useState } from 'react'
+import { memo, useCallback, useState } from 'react'
 
+import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { useDocumentParameters } from '$/hooks/useDocumentParameters'
 import useDocumentLogWithMetadata from '$/stores/documentLogWithMetadata'
 import { DocumentVersion, LogSources } from '@latitude-data/core/browser'
-import { SplitPane } from '@latitude-data/web-ui/atoms/SplitPane'
 import {
   AppLocalStorage,
   useLocalStorage,
@@ -15,16 +15,13 @@ import {
 import { cn } from '@latitude-data/web-ui/utils'
 import { ResolvedMetadata } from '$/workers/readMetadata'
 import Chat from '$/components/PlaygroundCommon/Chat'
-import {
-  DOCUMENT_PLAYGROUND_COLLAPSED_SIZE,
-  DOCUMENT_PLAYGROUND_GAP_PADDING,
-} from '$/hooks/playgrounds/constants'
 import { useExpandParametersOrEvaluations } from '$/hooks/playgrounds/useExpandParametersOrEvaluations'
 import DocumentEvaluations from './DocumentEvaluations'
 import DocumentParams from './DocumentParams'
 import DocumentParamsLoading from './DocumentParams/DocumentParamsLoading'
 import { useRunPlaygroundPrompt } from './hooks/useRunPlaygroundPrompt'
 import Preview from './Preview'
+import Actions from '$/components/PlaygroundCommon/Actions'
 
 export const Playground = memo(
   ({
@@ -41,14 +38,9 @@ export const Playground = memo(
     const [mode, setMode] = useState<'preview' | 'chat'>('preview')
     const { commit } = useCurrentCommit()
     const { project } = useCurrentProject()
-    const [forcedSize, setForcedSize] = useState<number | undefined>()
     const expander = useExpandParametersOrEvaluations({
       initialExpanded: 'parameters',
     })
-    const collapsed = expander.expandedSection === null
-    useEffect(() => {
-      setForcedSize(collapsed ? DOCUMENT_PLAYGROUND_COLLAPSED_SIZE : undefined)
-    }, [collapsed])
     const {
       parameters,
       source,
@@ -81,7 +73,10 @@ export const Playground = memo(
       [setRunCount, setDocumentLogUuid, setHistoryLog],
     )
     const clearChat = useCallback(() => setMode('preview'), [setMode])
-    const runPrompt = useCallback(() => setMode('chat'), [setMode])
+    const runPrompt = useCallback(() => {
+      expander.closeAll()
+      setMode('chat')
+    }, [setMode, expander])
     const { runPromptFn, addMessagesFn, abortCurrentStream, hasActiveStream } =
       useRunPlaygroundPrompt({
         commit,
@@ -91,31 +86,35 @@ export const Playground = memo(
       })
 
     return (
-      <SplitPane
-        direction='vertical'
-        gap={4}
-        initialPercentage={50}
-        forcedSize={forcedSize}
-        minSize={
-          DOCUMENT_PLAYGROUND_COLLAPSED_SIZE + DOCUMENT_PLAYGROUND_GAP_PADDING
-        }
-        dragDisabled={collapsed}
-        firstPane={
-          <div className={cn('grid gap-2 w-full pr-0.5', expander.cssClass)}>
-            {!parameters ? (
-              <DocumentParamsLoading source={source} />
-            ) : (
-              <DocumentParams
-                commit={commit}
-                document={document}
-                prompt={prompt}
-                source={source}
-                setSource={setSource}
-                setPrompt={setPrompt}
-                onToggle={expander.onToggle('parameters')}
-                isExpanded={expander.parametersExpanded}
-              />
-            )}
+      <div className='h-full px-4 relative min-h-0 flex flex-col gap-y-4 min-w-0'>
+        <div className='min-h-8 flex flex-row items-center justify-between w-full'>
+          <Text.H4M>Preview</Text.H4M>
+          <Actions
+            expandParameters={expandParameters}
+            setExpandParameters={setExpandParameters}
+          />
+        </div>
+        <div
+          className={cn(
+            'gap-2 w-full flex flex-col gap-y-2',
+            expander.cssClass,
+          )}
+        >
+          {!parameters ? (
+            <DocumentParamsLoading source={source} />
+          ) : (
+            <DocumentParams
+              commit={commit}
+              document={document}
+              prompt={prompt}
+              source={source}
+              setSource={setSource}
+              setPrompt={setPrompt}
+              onToggle={expander.onToggle('parameters')}
+              isExpanded={expander.parametersExpanded}
+            />
+          )}
+          {mode === 'chat' ? (
             <DocumentEvaluations
               documentLog={documentLog}
               commit={commit}
@@ -125,35 +124,34 @@ export const Playground = memo(
               onToggle={expander.onToggle('evaluations')}
               isLoading={isDocumentLogLoading}
             />
-          </div>
-        }
-        secondPane={
-          <div className='h-full flex-grow flex-shrink min-h-0 flex flex-col gap-2 overflow-hidden pr-0.5'>
-            {mode === 'preview' ? (
-              <Preview
-                metadata={metadata}
-                parameters={parameters}
-                runPrompt={runPrompt}
-                expandParameters={expandParameters}
-                setExpandParameters={setExpandParameters}
-              />
-            ) : (
-              <Chat
-                canChat
-                parameters={parameters}
-                clearChat={clearChat}
-                abortCurrentStream={abortCurrentStream}
-                hasActiveStream={hasActiveStream}
-                runPromptFn={runPromptFn}
-                addMessagesFn={addMessagesFn}
-                onPromptRan={onPromptRan}
-                expandParameters={expandParameters}
-                setExpandParameters={setExpandParameters}
-              />
-            )}
-          </div>
-        }
-      />
+          ) : null}
+        </div>
+        <div className='h-full flex-grow flex flex-col gap-2 overflow-hidden pr-0.5'>
+          {mode === 'preview' ? (
+            <Preview
+              metadata={metadata}
+              parameters={parameters}
+              runPrompt={runPrompt}
+              expandParameters={expandParameters}
+              setExpandParameters={setExpandParameters}
+            />
+          ) : (
+            <Chat
+              canChat
+              showHeader={false}
+              parameters={parameters}
+              clearChat={clearChat}
+              abortCurrentStream={abortCurrentStream}
+              hasActiveStream={hasActiveStream}
+              runPromptFn={runPromptFn}
+              addMessagesFn={addMessagesFn}
+              onPromptRan={onPromptRan}
+              expandParameters={expandParameters}
+              setExpandParameters={setExpandParameters}
+            />
+          )}
+        </div>
+      </div>
     )
   },
 )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -307,12 +307,13 @@ export default function DocumentEditor({
   return (
     <>
       <SplitPane
+        visibleHandle={false}
         className='pt-6'
         direction='horizontal'
         reversed
         initialWidthClass='min-w-1/2'
         minSize={350}
-        initialPercentage={40}
+        initialPercentage={50}
         firstPane={
           <SplitPane.Pane>
             <div className='flex flex-col flex-1 flex-grow flex-shrink gap-y-4 min-w-0 min-h-0 pl-6 pr-4 pb-6'>
@@ -381,14 +382,12 @@ export default function DocumentEditor({
         }
         secondPane={
           <SplitPane.Pane>
-            <div className='flex-1 relative max-h-full px-4'>
-              <Playground
-                document={document}
-                prompt={document.content}
-                setPrompt={onChange}
-                metadata={metadata!}
-              />
-            </div>
+            <Playground
+              document={document}
+              prompt={document.content}
+              setPrompt={onChange}
+              metadata={metadata!}
+            />
           </SplitPane.Pane>
         }
       />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/Playground/index.tsx
@@ -89,6 +89,7 @@ export const Playground = memo(
         <div className='h-full flex-grow flex-shrink min-h-0 flex flex-col gap-2 overflow-hidden pr-0.5'>
           {mode === 'preview' ? (
             <PreviewPrompt
+              showHeader
               metadata={metadata}
               parameters={parameters}
               runPrompt={runPrompt}
@@ -97,6 +98,7 @@ export const Playground = memo(
             />
           ) : (
             <Chat
+              showHeader
               canChat={false}
               parameters={parameters}
               clearChat={clearChat}

--- a/apps/web/src/components/Documentation/OpenInDocsButton.tsx
+++ b/apps/web/src/components/Documentation/OpenInDocsButton.tsx
@@ -15,6 +15,7 @@ export function OpenInDocsButton({ route }: { route: DocsRoute }) {
       asChild
       trigger={
         <Button
+          size='none'
           iconProps={{
             name: 'bookMarked',
             className: 'w-4 h-4',

--- a/apps/web/src/components/PlaygroundCommon/Chat/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/Chat/index.tsx
@@ -34,14 +34,16 @@ export default function Chat({
   onPromptRan,
   expandParameters,
   setExpandParameters,
+  showHeader,
 }: {
   canChat: boolean
   parameters: Record<string, unknown> | undefined
   clearChat: () => void
-  onPromptRan?: (documentLogUuid?: string, error?: Error) => void
   runPromptFn: RunPromptFn
   abortCurrentStream: () => boolean
   hasActiveStream: () => boolean
+  showHeader: boolean
+  onPromptRan?: (documentLogUuid?: string, error?: Error) => void
   addMessagesFn?: AddMessagesFn
 } & ActionsState) {
   const runOnce = useRef(false)
@@ -111,14 +113,15 @@ export default function Chat({
 
   return (
     <div className='flex flex-col flex-1 h-full overflow-hidden'>
-      {/* Header */}
-      <div className='flex flex-row items-center justify-between w-full pb-3'>
-        <Text.H6M>Prompt</Text.H6M>
-        <Actions
-          expandParameters={expandParameters}
-          setExpandParameters={setExpandParameters}
-        />
-      </div>
+      {showHeader ? (
+        <div className='flex flex-row items-center justify-between w-full pb-3'>
+          <Text.H6M>Prompt</Text.H6M>
+          <Actions
+            expandParameters={expandParameters}
+            setExpandParameters={setExpandParameters}
+          />
+        </div>
+      ) : null}
 
       {/* Messages container */}
       <div

--- a/apps/web/src/components/PlaygroundCommon/PreviewPrompt/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/PreviewPrompt/index.tsx
@@ -60,10 +60,12 @@ export default function PreviewPrompt({
   expandParameters,
   setExpandParameters,
   actions,
+  showHeader,
 }: {
   metadata: ResolvedMetadata | undefined
   parameters: Record<string, unknown> | undefined
   runPrompt: () => void
+  showHeader: boolean
   actions?: ReactNode
 } & ActionsState) {
   const { document } = useCurrentDocument()
@@ -77,13 +79,15 @@ export default function PreviewPrompt({
   return (
     <div className='flex flex-col flex-1 gap-2 h-full overflow-hidden'>
       {preview.warningRule ? <Warnings warnings={preview.warningRule} /> : null}
-      <div className='flex flex-row items-center justify-between w-full'>
-        <Text.H6M>Preview</Text.H6M>
-        <Actions
-          expandParameters={expandParameters}
-          setExpandParameters={setExpandParameters}
-        />
-      </div>
+      {showHeader ? (
+        <div className='flex flex-row items-center justify-between w-full'>
+          <Text.H6M>Preview</Text.H6M>
+          <Actions
+            expandParameters={expandParameters}
+            setExpandParameters={setExpandParameters}
+          />
+        </div>
+      ) : null}
       <div
         ref={containerRef}
         className={cn(
@@ -112,7 +116,7 @@ export default function PreviewPrompt({
         )}
       </div>
 
-      <div className='absolute bottom-3 flex flex-row items-center justify-center w-full'>
+      <div className='absolute left-0 right-0 bottom-3 flex flex-row items-center justify-center'>
         <ToolBarWrapper>
           {preview.error || (metadata?.errors.length ?? 0) > 0 ? (
             <Tooltip

--- a/apps/web/src/hooks/playgrounds/useExpandParametersOrEvaluations.ts
+++ b/apps/web/src/hooks/playgrounds/useExpandParametersOrEvaluations.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 type Section = 'parameters' | 'evaluations'
 
@@ -19,17 +19,29 @@ export function useExpandParametersOrEvaluations({
   )
   const parametersExpanded = expandedSection === 'parameters'
   const evaluationsExpanded = expandedSection === 'evaluations'
-  const cssClass = {
-    'grid-rows-[1fr,auto]': parametersExpanded,
-    'grid-rows-[auto,1fr]': evaluationsExpanded,
-    'grid-rows-2': expandedSection === null,
-  }
+  const closeAll = useCallback(() => {
+    setExpandedSection(null)
+  }, [])
 
-  return {
-    expandedSection,
-    cssClass,
-    onToggle,
-    parametersExpanded,
-    evaluationsExpanded,
-  }
+  return useMemo(
+    () => ({
+      expandedSection,
+      cssClass: {
+        'grid-rows-[1fr,auto]': parametersExpanded,
+        'grid-rows-[auto,1fr]': evaluationsExpanded,
+        'grid-rows-2': expandedSection === null,
+      },
+      onToggle,
+      parametersExpanded,
+      evaluationsExpanded,
+      closeAll,
+    }),
+    [
+      expandedSection,
+      onToggle,
+      parametersExpanded,
+      evaluationsExpanded,
+      closeAll,
+    ],
+  )
 }

--- a/packages/web-ui/src/ds/atoms/Switch/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Switch/index.tsx
@@ -137,7 +137,7 @@ function SwitchInput({
           formDescriptionId={formDescriptionId}
           formMessageId={formMessageId}
         >
-          <div>
+          <div className='flex items-center'>
             <input
               type='hidden'
               name={name}

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/index.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/index.tsx
@@ -171,7 +171,9 @@ export function BlocksEditor({
             onRequestPromptMetadata={onRequestPromptMetadata}
             onToggleDevEditor={onToggleDevEditor}
           />
-          <ReferenceEditPlugin />
+          <ReferenceEditPlugin
+            onRequestPromptMetadata={onRequestPromptMetadata}
+          />
           <HierarchyValidationPlugin />
           <VariableTransformPlugin />
           <HistoryPlugin />

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/ReferenceNode/ReferenceLink/index.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/ReferenceNode/ReferenceLink/index.tsx
@@ -84,7 +84,7 @@ function ReferenceLinkReal({
         label: prompt.path,
         ellipsis: true,
         onClick: () => {
-          triggerReferencePathUpdate(nodeKey, prompt.path)
+          triggerReferencePathUpdate(nodeKey, prompt)
         },
       })),
     [prompts, relativePath, nodeKey],

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/ReferenceNode/index.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/ReferenceNode/index.tsx
@@ -75,6 +75,23 @@ export class ReferenceNode extends DecoratorNode<JSX.Element> {
     })
   }
 
+  onChangeReference({
+    path,
+    attributes,
+  }: {
+    path: string
+    attributes: SerializedReferenceLink['attributes']
+  }) {
+    const writable = this.getWritable()
+    writable.__path = path
+    writable.__attributes = attributes
+
+    // When changing reference we reset loading errors
+    writable.__errors = undefined
+    writable.__isLoading = false
+    return writable
+  }
+
   setPath(newPath: string) {
     const writable = this.getWritable()
     writable.__path = newPath
@@ -88,6 +105,7 @@ export class ReferenceNode extends DecoratorNode<JSX.Element> {
       ...attributes,
     }
     writable.__isLoading = false
+    return writable
   }
 
   exportJSON(): SerializedReferenceLink {

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/StepBlock/StepHeader/index.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/StepBlock/StepHeader/index.tsx
@@ -19,6 +19,7 @@ import {
   triggerStepNameUpdate,
 } from '../../../plugins/StepEditPlugin'
 import { SwitchInput } from '../../../../../../atoms/Switch'
+import { triggerToggleDevEditor } from '../../../plugins/ReferencesPlugin'
 
 function StepName({
   as,
@@ -51,9 +52,11 @@ function StepName({
 function RightArea({
   isolated,
   stepKey,
+  otherAttributes,
 }: {
   isolated: boolean
   stepKey: string
+  otherAttributes: Record<string, unknown> | undefined
 }) {
   const onIsolatedChange = useCallback(
     (newIsolated: boolean) => {
@@ -62,20 +65,39 @@ function RightArea({
     [stepKey],
   )
   return (
-    <div className='flex flex-row items-center gap-x-2'>
-      <div className='flex flex-row items-center gap-x-1'>
-        <SwitchInput
-          fullWidth={false}
-          defaultChecked={isolated}
-          checked={isolated}
-          onCheckedChange={onIsolatedChange}
-        />
-        <Tooltip triggerIcon={{ name: 'circleHelp', color: 'foregroundMuted' }}>
-          {`Isolated: Prevent this step from inheriting context
+    <div className='flex flex-row items-center gap-x-1'>
+      <Tooltip triggerIcon={{ name: 'circleHelp', color: 'foregroundMuted' }}>
+        {`Isolated: Prevent this step from inheriting context
         from previous steps. This can reduce unnecessary costs or confusion for
         the model. Type '{{ nameOfStep }}' to reference the step name in the prompt.`}
+      </Tooltip>
+      <Text.H6 color='foregroundMuted'>Isolated</Text.H6>
+      <SwitchInput
+        fullWidth={false}
+        defaultChecked={isolated}
+        checked={isolated}
+        onCheckedChange={onIsolatedChange}
+      />
+
+      {otherAttributes ? (
+        <Tooltip
+          asChild
+          trigger={
+            <Button
+              size='icon'
+              variant='nope'
+              iconProps={{
+                name: 'settings',
+                color: 'foregroundMuted',
+              }}
+              onClick={() => triggerToggleDevEditor()}
+            />
+          }
+        >
+          This step has extra configuration. Please click to edit it on the code
+          editor.
         </Tooltip>
-      </div>
+      ) : null}
       <Button
         size='icon'
         variant='nope'
@@ -95,11 +117,13 @@ export function StepHeader({
   stepIndex,
   as,
   isolated,
+  otherAttributes,
 }: {
   stepKey: string
   stepIndex: number
   as: string | undefined
   isolated: boolean
+  otherAttributes: Record<string, unknown> | undefined
 }) {
   const inputWrapper = useRef<HTMLDivElement>(null)
   const [editing, setEditing] = useState(false)
@@ -183,7 +207,11 @@ export function StepHeader({
             )}
           </div>
         </div>
-        <RightArea isolated={isolated} stepKey={stepKey} />
+        <RightArea
+          isolated={isolated}
+          stepKey={stepKey}
+          otherAttributes={otherAttributes}
+        />
       </div>
     </TooltipProvider>
   )

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/StepBlock/index.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/nodes/StepBlock/index.tsx
@@ -31,6 +31,7 @@ const HEADER_CLASS = 'step-header'
 export class StepBlockNode extends ElementNode {
   __stepName: string | undefined
   __isolated: boolean = false
+  __otherAttributes: Record<string, unknown> | undefined = undefined
   __headerRoot?: Root
 
   static getType(): string {
@@ -38,13 +39,24 @@ export class StepBlockNode extends ElementNode {
   }
 
   static clone(node: StepBlockNode): StepBlockNode {
-    return new StepBlockNode(node.__stepName, node.__isolated, node.__key)
+    return new StepBlockNode(
+      node.__stepName,
+      node.__isolated,
+      node.__otherAttributes,
+      node.__key,
+    )
   }
 
-  constructor(stepName?: string, isolated?: boolean, key?: NodeKey) {
+  constructor(
+    stepName?: string,
+    isolated?: boolean,
+    __otherAttributes?: Record<string, unknown>,
+    key?: NodeKey,
+  ) {
     super(key)
     this.__stepName = stepName
     this.__isolated = isolated ?? false
+    this.__otherAttributes = __otherAttributes
   }
 
   createDOM(_config: EditorConfig): HTMLElement {
@@ -99,6 +111,7 @@ export class StepBlockNode extends ElementNode {
         stepKey={this.getKey()}
         as={this.getStepName()}
         isolated={this.getIsolated()}
+        otherAttributes={this.__otherAttributes}
       />,
     )
   }
@@ -127,6 +140,7 @@ export class StepBlockNode extends ElementNode {
     return new StepBlockNode(
       serializedNode.attributes?.as,
       serializedNode.attributes?.isolated ?? false,
+      serializedNode.attributes?.otherAttributes,
     )
   }
 
@@ -137,6 +151,7 @@ export class StepBlockNode extends ElementNode {
       attributes: {
         as: this.__stepName,
         isolated: this.__isolated,
+        otherAttributes: this.__otherAttributes,
       },
     }
   }

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/plugins/ReferencesPlugin.tsx
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/plugins/ReferencesPlugin.tsx
@@ -50,13 +50,9 @@ export function EventListeners({
 }) {
   useEffect(() => {
     const abortController = new AbortController()
-    const handleGoToDevEditor = () => {
-      onToggleDevEditor()
-    }
-
     document.addEventListener(
       CUSTOM_EVENTS.GO_TO_DEV_EDITOR,
-      handleGoToDevEditor,
+      onToggleDevEditor,
       { signal: abortController.signal },
     )
 
@@ -64,7 +60,7 @@ export function EventListeners({
       abortController.abort()
       document.removeEventListener(
         CUSTOM_EVENTS.GO_TO_DEV_EDITOR,
-        handleGoToDevEditor,
+        onToggleDevEditor,
       )
     }
   }, [onToggleDevEditor])
@@ -105,7 +101,7 @@ function ReferencePickerMenuItem({
   )
 }
 
-function buildEmptyAttributes(metadata: ConversationMetadata) {
+export function buildEmptyAttributes(metadata: ConversationMetadata) {
   return Object.fromEntries(
     Array.from(metadata.parameters).map((key) => [key, undefined]),
   )

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/astParsingUtils.ts
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/astParsingUtils.ts
@@ -7,7 +7,6 @@ import {
   type ContentBlockType,
   type MustacheTag,
   TemplateNode,
-  StepBlock,
   BlockAttributes,
   ReferenceLink,
   FileBlock,
@@ -239,27 +238,23 @@ export function getStepAttributes({
   tag: ElementTag
   prompt: string
 }) {
-  let attr: StepBlock['attributes'] = {}
-
   const attributes = getAttributes({
     tag,
     prompt,
     shouldCamelCase: ['as', 'isolated'],
   })
 
-  if ('as' in attributes) {
-    if (typeof attributes.as === 'string') {
-      attr.as = attributes.as.trim()
-    }
+  const { as, isolated, ...rest } = attributes
+
+  const attr: Record<string, string | boolean | object> = {}
+  if (typeof as === 'string') attr.as = as.trim()
+  if (isolated === true) attr.isolated = true
+
+  if (Object.keys(rest).length) {
+    attr.otherAttributes = rest
   }
 
-  if ('isolated' in attributes) {
-    if (attributes.isolated === true) {
-      attr.isolated = true
-    }
-  }
-
-  if (!Object.keys(attributes).length) return undefined
+  if (!Object.keys(attr).length) return undefined
 
   return attr
 }

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/fromBlocksToText.ts
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/fromBlocksToText.ts
@@ -124,8 +124,12 @@ export function fromBlocksToText(rootNode: BlockRootNode): string {
         case BLOCK_EDITOR_TYPE.STEP: {
           const children = block.children ?? []
           const attr = attributesToString({
-            attributes: block.attributes as BlockAttributes,
-            shouldKebabCase: ['as', 'isolate'],
+            attributes: {
+              as: block.attributes?.as,
+              isolated: block.attributes?.isolated,
+              ...block.attributes?.otherAttributes,
+            },
+            shouldKebabCase: ['as', 'isolated'],
           })
           const stepContent = children
             .map((child: any) => stepChildToText(child))

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/index.test.ts
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/index.test.ts
@@ -840,4 +840,18 @@ How are you?
     const output = fromBlocksToText(rootNode)
     expect(output).toBe(prompt)
   })
+
+  it('should parse steps with everything', () => {
+    const prompt = `
+<step as="analysis" isolated raw="rawAnalysis" schema={{{type: "object", properties: {correct: {type: "boolean"}}, required: ["correct"]}}}>
+  Is this statement correct? {{statement}}
+  Respond only with "correct: true" or "correct: false" in a JSON object.
+</step>
+`
+    const ast = parse(prompt)
+    const rootNode = fromAstToBlocks({ ast, prompt })
+
+    const output = fromBlocksToText(rootNode)
+    expect(output).toBe(prompt)
+  })
 })

--- a/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/types.ts
+++ b/packages/web-ui/src/ds/molecules/BlocksEditor/Editor/state/promptlToLexical/types.ts
@@ -118,6 +118,7 @@ export interface StepBlock extends SerializedElementNode {
   attributes?: {
     as?: string
     isolated?: boolean
+    otherAttributes?: Record<string, unknown>
   }
 }
 


### PR DESCRIPTION
# What?
When running a prompt we want to give users maximum vertical space

## TODO
- [x] Vertically align headers
- [x] Only show evaluations when run prompt
- [x] Go to devMode from broken reference 🐛 
- [x] Isolated label 
- [x] Steps custom config go to dev mode

## Another PR
- [ ] Make non-editable code blocks
