### PR TITLE
fix: some pipedream tool parameters were being ignored

### DIFF
--- a/packages/web-ui/src/ds/molecules/ChatWrapper/Message/ToolResult.tsx
+++ b/packages/web-ui/src/ds/molecules/ChatWrapper/Message/ToolResult.tsx
@@ -74,7 +74,7 @@ export function ToolResultContent({
     const strResult = JSON.stringify(toolResponse.result, null, 2)
     return (
       <CodeBlock
-        language={strResult.length > MAX_LENGTH_JSON_PREVIEW ? '' : 'json'}
+        language={strResult?.length > MAX_LENGTH_JSON_PREVIEW ? '' : 'json'}
         bgColor={toolResponse.isError ? 'bg-destructive-muted' : undefined}
       >
         {JSON.stringify(toolResponse.result, null, 2)}


### PR DESCRIPTION
Fixes some issues when running tools from Pipedream Integrations:
- Component props must be reloaded before running the action. This ensures Pipedream does not ignore some of the props.
- Errors when running actions through the SDK are now being handled correctly
- CodeBlock crashed the app when there's no content. Fixed.