### PR TITLE
Fix UI bugs adding and deleting integration triggers

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/IntegrationTriggers/BlankSlate.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/IntegrationTriggers/BlankSlate.tsx
@@ -25,7 +25,7 @@ export function TriggersBlankSlate({
           fullWidth
           fancy
           variant='default'
-          onClick={openTriggerModal}
+          onClick={() => openTriggerModal()}
           disabled={!isHead}
         >
           Add Trigger

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/IntegrationTriggers/TriggerList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/DocumentTriggers/Settings/IntegrationTriggers/TriggerList.tsx
@@ -43,7 +43,7 @@ function DeleteTriggerButton({
   )
 
   return (
-    <>
+    <div onClick={(e) => e.stopPropagation()}>
       <Button
         variant='ghost'
         className='p-0'
@@ -99,7 +99,7 @@ function DeleteTriggerButton({
           </div>
         </div>
       </Modal>
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
Fix two bugs of the integration triggers:

Number 1 - When adding a new integration trigger when not having any, it would open the modal in "update trigger" mode and not in "add trigger" mode. This was the reason why we couldnt create a new trigger in last fridays demo

https://github.com/user-attachments/assets/325ebd17-478b-47bd-afe9-dd9921ecf97b

Number 2 - When clicking the trash icon, it wouldnt open the delete trigger modal

https://github.com/user-attachments/assets/c8e81cb2-ba07-40f3-b974-32407127533a

Now works like this:

https://github.com/user-attachments/assets/af5aa94a-4266-40ab-8bfe-9f35edb9cd04


