### PR TITLE
Fix bug json parsing

### DIFF
--- a/apps/web/src/components/ChatWrapper/Message/ToolResult.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/ToolResult.tsx
@@ -67,13 +67,13 @@ export function ToolResultContent({
       )
     }
 
-    const strResult = JSON.stringify(toolResponse.result, null, 2)
+    const strResult = JSON.stringify(result, null, 2)
     return (
       <CodeBlock
         language={strResult?.length > MAX_LENGTH_JSON_PREVIEW ? '' : 'json'}
         bgColor={toolResponse.isError ? 'bg-destructive-muted' : undefined}
       >
-        {JSON.stringify(result, null, 2)}
+        {strResult}
       </CodeBlock>
     )
   }
@@ -118,9 +118,7 @@ export function UnresolvedToolResultContent({ value }: { value: ToolContent }) {
           color={value.isError ? 'destructive' : 'foregroundMuted'}
         />
       ) : (
-        <CodeBlock language='json'>
-          {JSON.stringify(value.result, null, 2)}
-        </CodeBlock>
+        <CodeBlock language='json'>{JSON.stringify(result, null, 2)}</CodeBlock>
       )}
     </ContentCard>
   )


### PR DESCRIPTION
Creating this as a PR to confirm my understanding of this situation:

The getResult() method returns a parsed JSON object if its a JSON string, or already an object, or double encoded JSON string, passing the isString to false, and a string if its just a simple string.

If this is the case, then the result from this getResult should be the one used to calculate the length of the JSON, not the previous object passed from the backend. Also, there is no need to stringify again if its done above

Do u also agree?

