### PR TITLE
Latte: Debug Mode — Custom Draft

### DIFF
--- a/apps/web/src/actions/latte/new.ts
+++ b/apps/web/src/actions/latte/new.ts
@@ -11,11 +11,12 @@ export const createNewLatteAction = authProcedure
     z.object({
       message: z.string(),
       context: z.string(),
+      debugVersionUuid: z.string().optional(),
     }),
   )
   .handler(async ({ ctx, input }) => {
     const { workspace, user } = ctx
-    const { message, context } = input
+    const { message, context, debugVersionUuid } = input
 
     const thread = await createLatteThread({
       user,
@@ -28,6 +29,7 @@ export const createNewLatteAction = authProcedure
       user,
       message,
       context,
+      debugVersionUuid,
     })
 
     runResult.unwrap()

--- a/apps/web/src/app/api/latte/debug/versions/route.ts
+++ b/apps/web/src/app/api/latte/debug/versions/route.ts
@@ -1,0 +1,23 @@
+import { Workspace } from '@latitude-data/core/browser'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { NextRequest, NextResponse } from 'next/server'
+import { getLatteDebugVersions } from '@latitude-data/core/services/copilot/latte/debugVersions'
+import { adminHandler } from '$/middlewares/adminHandler'
+
+export const GET = errorHandler(
+  adminHandler(
+    async (
+      _: NextRequest,
+      {
+        workspace,
+      }: {
+        workspace: Workspace
+      },
+    ) => {
+      const result = await getLatteDebugVersions(workspace.id)
+      const latteVersions = result.unwrap()
+
+      return NextResponse.json(latteVersions, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/components/LatteChat/LatteChatInput.tsx
+++ b/apps/web/src/components/LatteChat/LatteChatInput.tsx
@@ -9,6 +9,7 @@ import { useTypeWriterValue } from '@latitude-data/web-ui/browser'
 import { cn } from '@latitude-data/web-ui/utils'
 import React, { KeyboardEvent, useCallback, useEffect, useState } from 'react'
 import { ChangeList } from './_components/ChangesList'
+import { LatteDebugVersionSelector } from './_components/DebugVersionSelector'
 
 const INPUT_PLACEHOLDERS = [
   'How can I see the logs of my agent?',
@@ -143,6 +144,7 @@ export function LatteChatInput({
         className={cn(
           'absolute bottom-[2px] left-3 w-[calc(100%-0.75rem-2px)] pt-2 pb-3 pr-3',
           'flex flex-row-reverse items-end justify-between bg-background rounded-br-2xl',
+          'gap-4',
         )}
       >
         <Button
@@ -163,6 +165,7 @@ export function LatteChatInput({
         >
           Send
         </Button>
+        {!inConversation && <LatteDebugVersionSelector />}
         {inConversation && (
           <Button
             variant='ghost'
@@ -177,7 +180,9 @@ export function LatteChatInput({
             className='text-latte-input-foreground group-hover:text-latte-input-foreground/75'
             userSelect={false}
           >
-            New chat
+            <Text.H5 noWrap color='latteInputForeground'>
+              New chat
+            </Text.H5>
           </Button>
         )}
       </div>

--- a/apps/web/src/components/LatteChat/_components/DebugVersionSelector.tsx
+++ b/apps/web/src/components/LatteChat/_components/DebugVersionSelector.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useLatteDebugMode } from '$/hooks/latte'
+import { DotIndicator } from '@latitude-data/web-ui/atoms/DotIndicator'
+import { Select, SelectOption } from '@latitude-data/web-ui/atoms/Select'
+import { useMemo } from 'react'
+
+export function LatteDebugVersionSelector() {
+  const {
+    enabled,
+    isLoading,
+    data,
+    selectedVersionUuid,
+    setSelectedVersionUuid,
+  } = useLatteDebugMode()
+
+  const options = useMemo<SelectOption<string>[]>(
+    () =>
+      data.map((v) => ({
+        label: v.name,
+        value: v.uuid,
+        icon: v.isLive ? <DotIndicator variant='success' pulse /> : null,
+      })),
+    [data],
+  )
+
+  if (!enabled) return null
+
+  return (
+    <Select
+      name='debugVersionUuid'
+      loading={isLoading}
+      value={selectedVersionUuid}
+      options={options}
+      onChange={setSelectedVersionUuid}
+    />
+  )
+}

--- a/apps/web/src/components/Providers/FeatureFlags/flags.ts
+++ b/apps/web/src/components/Providers/FeatureFlags/flags.ts
@@ -2,6 +2,7 @@ import { env } from '@latitude-data/env'
 
 export const FEATURE_FLAGS = {
   latte: 'latte',
+  latteDebugMode: 'latteDebugMode',
   blocksEditor: 'blocksEditor',
   integrationTriggers: 'integrationTriggers',
   tracing: 'tracing',
@@ -17,6 +18,7 @@ export const FEATURE_FLAGS_CONDITIONS: Record<
   FeatureFlagCondition
 > = {
   latte: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1] },
+  latteDebugMode: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1] },
   blocksEditor: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1, 10240] },
   integrationTriggers: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1] },
   tracing: { workspaceIds: env.ENABLE_ALL_FLAGS ? 'all' : [1] },

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -382,4 +382,11 @@ export const API_ROUTES = {
       }
     },
   },
+  latte: {
+    debug: {
+      versions: {
+        root: `/api/latte/debug/versions`,
+      },
+    },
+  },
 }

--- a/apps/web/src/stores/latte.ts
+++ b/apps/web/src/stores/latte.ts
@@ -20,6 +20,9 @@ interface LatteState {
   changes: LatteChange[]
   latteActionsFeedbackUuid: string | undefined
 
+  // Debug state
+  debugVersionUuid: string | undefined
+
   // Actions
   setThreadUuid: (uuid: string | undefined) => void
   setIsLoading: (loading: boolean) => void
@@ -45,6 +48,7 @@ interface LatteState {
   ) => void
   removeChange: (draftUuid: string, documentUuid: string) => void
   setLatteActionsFeedbackUuid: (uuid: string | undefined) => void
+  setDebugVersionUuid: (uuid: string | undefined) => void
 
   // Reset functions
   resetChat: () => void
@@ -60,6 +64,7 @@ const useStore = create<LatteState>((set) => ({
   changes: [],
   latteActionsFeedbackUuid: undefined,
   threadUuid: undefined,
+  debugVersionUuid: undefined,
 
   // Chat actions
   setIsLoading: (loading: boolean) => set({ isLoading: loading }),
@@ -147,6 +152,9 @@ const useStore = create<LatteState>((set) => ({
 
   setLatteActionsFeedbackUuid: (uuid: string | undefined) =>
     set({ latteActionsFeedbackUuid: uuid }),
+
+  setDebugVersionUuid: (uuid: string | undefined) =>
+    set({ debugVersionUuid: uuid }),
 
   // Reset functions
   resetChat: () =>

--- a/packages/core/src/jobs/job-definitions/copilot/chat.ts
+++ b/packages/core/src/jobs/job-definitions/copilot/chat.ts
@@ -14,6 +14,7 @@ export type RunLatteJobData = {
   threadUuid: string
   message: string
   context: string
+  debugVersionUuid?: string
 }
 
 async function emitError({
@@ -35,7 +36,14 @@ async function emitError({
 }
 
 export const runLatteJob = async (job: Job<RunLatteJobData>) => {
-  const { workspaceId, userId, threadUuid, message, context } = job.data
+  const {
+    workspaceId,
+    userId,
+    threadUuid,
+    message,
+    context,
+    debugVersionUuid,
+  } = job.data
   const workspace = await unsafelyFindWorkspace(workspaceId).then((w) => w!)
 
   const usersScope = new UsersRepository(workspace.id)
@@ -50,7 +58,7 @@ export const runLatteJob = async (job: Job<RunLatteJobData>) => {
   }
   const user = userResult.unwrap()
 
-  const copilotResult = await getCopilotDocument()
+  const copilotResult = await getCopilotDocument(debugVersionUuid)
   if (!copilotResult.ok) {
     await emitError({
       workspaceId,

--- a/packages/core/src/services/copilot/latte/createLatteJob.ts
+++ b/packages/core/src/services/copilot/latte/createLatteJob.ts
@@ -12,12 +12,14 @@ export async function createLatteJob({
   message,
   context,
   user,
+  debugVersionUuid,
 }: {
   workspace: Workspace
   threadUuid: string
   message: string
   context: string
   user: User
+  debugVersionUuid?: string
 }): PromisedResult<undefined> {
   const supportResult = assertCopilotIsSupported()
   if (!supportResult.ok) return supportResult as ErrorResult<LatitudeError>
@@ -28,6 +30,7 @@ export async function createLatteJob({
     message,
     context,
     userId: user.id,
+    debugVersionUuid,
   } as RunLatteJobData)
 
   return Result.nil()

--- a/packages/core/src/services/copilot/latte/debugVersions.ts
+++ b/packages/core/src/services/copilot/latte/debugVersions.ts
@@ -1,0 +1,66 @@
+import { UnauthorizedError } from '@latitude-data/constants/errors'
+import { Result } from '../../../lib/Result'
+import { PromisedResult } from '../../../lib/Transaction'
+import { isFeatureEnabledByName } from '../../workspaceFeatures/isFeatureEnabledByName'
+import { assertCopilotIsSupported, getCopilotDocument } from './helpers'
+import { CommitsRepository } from '../../../repositories'
+
+export type LatteVersion = {
+  uuid: string
+  name: string
+  isLive: boolean
+}
+
+async function assertLatteDebugModeIsEnabled(
+  workspaceId: number,
+): PromisedResult<undefined> {
+  const isEnabledResult = await isFeatureEnabledByName(
+    workspaceId,
+    'latteDebugMode',
+  )
+
+  // TODO: This returns `boolean | Result<boolean>` for some reason
+  const isEnabled =
+    typeof isEnabledResult === 'boolean'
+      ? isEnabledResult
+      : isEnabledResult.value
+
+  if (!isEnabled) {
+    return Result.error(
+      new UnauthorizedError('This workspace cannot use Latte Debug Mode'),
+    )
+  }
+
+  return Result.nil()
+}
+
+export async function getLatteDebugVersions(
+  workspaceId: number,
+): PromisedResult<LatteVersion[]> {
+  const featureEnabledResult = await assertLatteDebugModeIsEnabled(workspaceId)
+  if (!Result.isOk(featureEnabledResult)) return featureEnabledResult
+
+  const latteSupportedResult = assertCopilotIsSupported()
+  if (!Result.isOk(latteSupportedResult)) return latteSupportedResult
+
+  const latteResult = await getCopilotDocument()
+  if (!Result.isOk(latteResult)) return latteResult
+
+  const {
+    workspace: latteWorkspace,
+    project: latteProject,
+    commit: latteCommit,
+  } = latteResult.unwrap()
+
+  const latteCommitsScope = new CommitsRepository(latteWorkspace.id)
+  const latteDrafts = await latteCommitsScope.getDrafts(latteProject.id)
+
+  return Result.ok([
+    { uuid: latteCommit.uuid, name: latteCommit.title, isLive: true },
+    ...latteDrafts.map((d) => ({
+      uuid: d.uuid,
+      name: d.title,
+      isLive: false,
+    })),
+  ])
+}


### PR DESCRIPTION
Added a debug selector to select a custom version for Latte.

<img width="531" height="524" alt="image" src="https://github.com/user-attachments/assets/8f726173-5d64-42de-a9ff-72a0e5c281d0" />


This feature is flagged under the new `latteDebugMode` flag!