### PR TITLE
Bugfix - PlaygroundV2 scroll not working automatically

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
@@ -128,9 +128,7 @@ function DocumentEditorContent({
   return (
     <LatteLayout>
       <div
-        className={cn('relative flex flex-col px-4 pt-6 pb-4 h-full min-h-0', {
-          'h-auto min-h-full': isPlaygroundOpen && !isPlaygroundTransitioning,
-        })}
+        className={cn('relative flex flex-col px-4 pt-6 pb-4 h-full min-h-0')}
       >
         <div className='pb-5'>
           <DocumentTabSelector

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
@@ -18,11 +18,12 @@ import {
   asPromptLFile,
   PromptLFileParameter,
 } from '$/components/PromptLFileParameter'
-import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, useCallback, useEffect, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { ParametersWrapper } from '../ParametersWrapper'
 import { usePaginatedDocumentLogUrl } from '$/hooks/playgrounds/usePaginatedDocumentLogUrl'
 import { ParametersPaginationNav } from '$/components/ParametersPaginationNav'
+import { useLimitedHistoryLogs } from '../../../V2Playground/hooks/useLimitedHistoryLogs'
 
 export const MAX_HISTORY_LOGS = 100
 
@@ -92,9 +93,7 @@ export function HistoryLogParams({
   })
 
   const hasLogs = data.count > 0
-  const limitedTotalCount = useMemo(() => {
-    return data.count > MAX_HISTORY_LOGS ? MAX_HISTORY_LOGS : data.count
-  }, [data.count])
+  const { limitedCount, limitedPosition } = useLimitedHistoryLogs(data)
 
   return (
     <div className='flex flex-col gap-y-4'>
@@ -128,8 +127,8 @@ export function HistoryLogParams({
             <ParametersPaginationNav
               disabled={data.isLoadingLog}
               label='history logs'
-              currentIndex={data.position}
-              totalCount={limitedTotalCount}
+              currentIndex={limitedPosition}
+              totalCount={limitedCount}
               onPrevPage={data.onPrevPage}
               onNextPage={data.onNextPage}
             />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/index.tsx
@@ -20,22 +20,17 @@ import { ICommitContextType } from '@latitude-data/web-ui/providers'
 
 import { OpenInDocsButton } from '$/components/Documentation/OpenInDocsButton'
 import { DocsRoute } from '$/components/Documentation/routes'
-import { ParametersPaginationNav } from '$/components/ParametersPaginationNav'
 import { DatasetParams } from '../../Playground/DocumentParams/DatasetParams'
 import {
   UseSelectDataset,
   useSelectDataset,
 } from '../../Playground/DocumentParams/DatasetParams/useSelectDataset'
-import {
-  HistoryLogParams,
-  MAX_HISTORY_LOGS,
-} from '../../Playground/DocumentParams/HistoryLogParams'
+import { HistoryLogParams } from '../../Playground/DocumentParams/HistoryLogParams'
 import {
   UseLogHistoryParams,
   useLogHistoryParams,
 } from '../../Playground/DocumentParams/HistoryLogParams/useLogHistoryParams'
 import { ManualParams } from '../../Playground/DocumentParams/ManualParams'
-import { useMemo } from 'react'
 
 export const TABS: TabSelectorOption<InputSource>[] = [
   { label: 'Manual', value: INPUT_SOURCE.manual },
@@ -98,48 +93,6 @@ function ParamsTabs({
   )
 }
 
-function CollapsedContentHeader({
-  source,
-  datasetInfo,
-  historyInfo,
-}: ContentProps) {
-  const src = INPUT_SOURCE
-  const isDataset =
-    source === INPUT_SOURCE.dataset && datasetInfo.selectedDataset
-  const isHistory = source === src.history && historyInfo.count > 0
-  const limitedTotalCount = useMemo(() => {
-    return historyInfo.count > MAX_HISTORY_LOGS
-      ? MAX_HISTORY_LOGS
-      : historyInfo.count
-  }, [historyInfo.count])
-  return (
-    <div className='w-full flex items-center justify-between gap-4'>
-      <OpenInDocsButton route={DocsRoute.Playground} />
-      <div className='flex items-center gap-4'>
-        {isDataset && (
-          <ParametersPaginationNav
-            zeroIndex
-            label='rows in dataset'
-            currentIndex={datasetInfo.position}
-            totalCount={datasetInfo.count}
-            onPrevPage={datasetInfo.onPrevPage}
-            onNextPage={datasetInfo.onNextPage}
-          />
-        )}
-        {isHistory && (
-          <ParametersPaginationNav
-            label='history logs'
-            currentIndex={historyInfo.position}
-            totalCount={limitedTotalCount}
-            onPrevPage={historyInfo.onPrevPage}
-            onNextPage={historyInfo.onNextPage}
-          />
-        )}
-      </div>
-    </div>
-  )
-}
-
 type DocumentParamsProps = Props & {
   maxHeight?: string
   expandedHeight?: number
@@ -183,7 +136,6 @@ export default function DocumentParams({
         maxHeight={maxHeight}
         expandedHeight={expandedHeight}
         onToggle={onToggle}
-        collapsedContentHeader={<CollapsedContentHeader {...contentProps} />}
         expandedContent={<ParamsTabs {...contentProps} />}
         expandedContentHeader={
           <div className='flex flex-row flex-grow items-center justify-start'>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/hooks/useLimitedHistoryLogs.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/hooks/useLimitedHistoryLogs.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import { UseLogHistoryParams } from '../../Playground/DocumentParams/HistoryLogParams/useLogHistoryParams'
+
+const MAX_HISTORY_LOGS = 100
+
+export function useLimitedHistoryLogs(data: UseLogHistoryParams) {
+  const limitedCount = useMemo(() => {
+    return data.count > MAX_HISTORY_LOGS ? MAX_HISTORY_LOGS : data.count
+  }, [data.count])
+
+  const limitedPosition = useMemo(() => {
+    return data.position
+      ? data.position > MAX_HISTORY_LOGS
+        ? MAX_HISTORY_LOGS
+        : data.position
+      : undefined
+  }, [data.position])
+
+  return {
+    limitedCount,
+    limitedPosition,
+  }
+}

--- a/packages/web-ui/src/lib/hooks/useAutoScroll.ts
+++ b/packages/web-ui/src/lib/hooks/useAutoScroll.ts
@@ -38,11 +38,24 @@ export function useAutoScroll(
       }
     }
 
+    const mutationObserver = new MutationObserver((mutations) => {
+      const hasContentChanges = mutations.some(
+        (mutation) =>
+          mutation.type === 'childList' || mutation.type === 'characterData',
+      )
+
+      if (hasContentChanges && isScrolledToBottom) {
+        resizeHandler()
+      }
+    })
+
     const resizeObserver = new ResizeObserver(resizeHandler)
     resizeObserver.observe(container)
-
-    const mutationObserver = new MutationObserver(resizeHandler)
-    mutationObserver.observe(container, { childList: true, subtree: true })
+    mutationObserver.observe(container, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    })
 
     container.addEventListener('scroll', scrollHandler)
     scrollHandler()


### PR DESCRIPTION
## TODOS
- [x] Fix autoscroll PlaygroundV2
- [x] Remove redundant collapsed header information in DocumentParameters of new Latte Layout
- [x] Improved useAutoScroll custom hook to perform better when streaming (Affects Latte as well)
- [x] Fix bug position of history logs out of MAX_LOGS limit