### PR TITLE
fix experiment form - dataset select not scrollable

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/DocumentParams/HistoryLogParams/index.tsx
@@ -25,8 +25,6 @@ import { usePaginatedDocumentLogUrl } from '$/hooks/playgrounds/usePaginatedDocu
 import { ParametersPaginationNav } from '$/components/ParametersPaginationNav'
 import { useLimitedHistoryLogs } from '../../../V2Playground/hooks/useLimitedHistoryLogs'
 
-export const MAX_HISTORY_LOGS = 100
-
 function DebouncedTextArea({
   input,
   setInput,

--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/DatasetSelector.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/DatasetSelector.tsx
@@ -14,7 +14,10 @@ export function DatasetSelector({
   onSelectDataset,
   parameters,
 }: ExperimentFormPayload) {
-  const { data: datasets, isLoading: isLoadingDatasets } = useDatasets()
+  const { data: datasets, isLoading: isLoadingDatasets } = useDatasets({
+    page: '1',
+    pageSize: '10000', // No pagination
+  })
 
   const selectOptions = useMemo(
     () =>
@@ -49,6 +52,7 @@ export function DatasetSelector({
             options={selectOptions}
             onChange={onSelectOption}
             value={selectedDataset?.id}
+            searchable
           />
         </div>
       )}


### PR DESCRIPTION
Fix experiment form only showing default 25 datasets