### PR TITLE
Revert the changes here https://github.com/latitude-dev/latitude-llm/commit/7d5944d36852d04f64d22809c7f5f98741228fd5

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
@@ -1,15 +1,17 @@
-'use client'
-
 import { FreeRunsBanner } from '$/components/FreeRunsBanner'
 import { LatteLayout } from '$/components/LatteLayout'
+import { MetadataProvider } from '$/components/MetadataProvider'
 import { RunExperimentModal } from '$/components/RunExperimentModal'
 import { usePlaygroundChat } from '$/hooks/playgroundChat/usePlaygroundChat'
+import { DevModeProvider } from '$/hooks/useDevMode'
 import { useDocumentParameters } from '$/hooks/useDocumentParameters'
-import { useDocumentValue } from '$/hooks/useDocumentValueContext'
+import {
+  DocumentValueProvider,
+  useDocumentValue,
+} from '$/hooks/useDocumentValueContext'
 import { useIsLatitudeProvider } from '$/hooks/useIsLatitudeProvider'
 import { useMetadata } from '$/hooks/useMetadata'
 import { useToggleModal } from '$/hooks/useToogleModal'
-import useDocumentVersions from '$/stores/documentVersions'
 import {
   Commit,
   DocumentVersion,
@@ -34,6 +36,21 @@ import { RunButton } from './RunButton'
 import { V2Playground } from './V2Playground'
 import DocumentParams from './V2Playground/DocumentParams'
 
+export function DocumentEditor(props: DocumentEditorProps) {
+  return (
+    <MetadataProvider>
+      <DevModeProvider>
+        <DocumentValueProvider
+          document={props.document}
+          documents={props.documents}
+        >
+          <DocumentEditorContent {...props} />
+        </DocumentValueProvider>
+      </DevModeProvider>
+    </MetadataProvider>
+  )
+}
+
 const MANUAL_BASE_HEIGHT = 64
 const DATASET_BASE_HEIGHT = 64 + 49 + 16
 const HISTORY_BASE_HEIGHT = 64 + 41 + 16
@@ -49,34 +66,16 @@ const HISTORY_ELM_HEIGHT = 44
  * @param props.freeRunsCount - Number of free runs available
  * @param props.initialDiff - Initial diff data for the document
  */
-export function DocumentEditor({
-  document: _document,
-  documents: _documents,
+function DocumentEditorContent({
   freeRunsCount,
   initialDiff,
   refinementEnabled,
 }: DocumentEditorProps) {
-  const { updateDocumentContent } = useDocumentValue()
+  const { updateDocumentContent, document } = useDocumentValue()
   const [mode, setMode] = useState<'preview' | 'chat'>('preview')
   const { metadata } = useMetadata()
   const { commit } = useCurrentCommit()
   const { project } = useCurrentProject()
-  const { data: documents } = useDocumentVersions(
-    {
-      commitUuid: commit.uuid,
-      projectId: project.id,
-    },
-    {
-      fallbackData: _documents,
-    },
-  )
-  const document = useMemo(
-    () =>
-      documents?.find((d) => d.documentUuid === _document.documentUuid) ??
-      _document,
-    [documents, _document],
-  )
-
   const {
     isPlaygroundOpen,
     isPlaygroundTransitioning,

--- a/apps/web/src/hooks/useDocumentValueContext.tsx
+++ b/apps/web/src/hooks/useDocumentValueContext.tsx
@@ -22,6 +22,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
@@ -36,6 +37,7 @@ type DocumentValueContextType = {
   value: string
   setValue: updateContentFn
   updateDocumentContent: updateContentFn
+  document: DocumentVersion
   isSaved: boolean
 }
 
@@ -46,15 +48,35 @@ const DocumentValueContext = createContext<
 type DocumentValueProviderProps = {
   children: ReactNode
   document: DocumentVersion
+  documents?: DocumentVersion[]
 }
 
 export function DocumentValueProvider({
   children,
-  document,
+  document: _document,
+  documents: _documents,
 }: DocumentValueProviderProps) {
-  const [value, setValue] = useState(document.content)
-  const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
+  const { project } = useCurrentProject()
+  const { data: documents } = useDocumentVersions(
+    {
+      commitUuid: commit.uuid,
+      projectId: project.id,
+    },
+    {
+      fallbackData: _documents,
+      keepPreviousData: true,
+      revalidateOnMount: true,
+    },
+  )
+  const document = useMemo(
+    () =>
+      documents?.find((d) => d.documentUuid === _document.documentUuid) ??
+      _document,
+    [documents, _document],
+  )
+
+  const [value, setValue] = useState(document.content)
   const { updateContent, isUpdatingContent } = useDocumentVersions({
     commitUuid: commit.uuid,
     projectId: project.id,
@@ -87,7 +109,6 @@ export function DocumentValueProvider({
           description: 'There was an error saving the document.',
           variant: 'destructive',
         })
-        console.error('🛠️ Error saving document:', error)
         setContentValue(document.content)
       }
     },
@@ -111,6 +132,7 @@ export function DocumentValueProvider({
         setValue: setContentValue,
         updateDocumentContent,
         isSaved: !isUpdatingContent,
+        document,
       }}
     >
       {children}


### PR DESCRIPTION
# What?
Revert the changes here:
https://github.com/latitude-dev/latitude-llm/commit/7d5944d36852d04f64d22809c7f5f98741228fd5 related with cache issues.

The bug re-appeared so we're trying again with handling the value in the provider instead of re-rendering all the editor by forcing the `key` prop