### PR TITLE
bugfix(experiments) - Add Metadata Provider to experiments page

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsPage/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsPage/index.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { ExperimentComparison } from '../ExperimentsComparison'
 import { EmptyPage } from './EmptyPage'
 import { useSearchParams } from 'next/navigation'
+import { MetadataProvider } from '$/components/MetadataProvider'
 
 export function ExperimentsPageContent({
   initialCount,
@@ -85,45 +86,47 @@ export function ExperimentsPageContent({
   )
 
   return (
-    <div className='w-full p-6 flex flex-col gap-4'>
-      <div className='w-full items-center justify-between flex gap-2'>
-        <Text.H4B>Experiment history</Text.H4B>
-        <Button
-          isLoading={isCreatingExperiment}
-          variant='default'
-          fancy
-          onClick={() => setIsModalOpen(true)}
-        >
-          Run Experiment
-        </Button>
-      </div>
+    <MetadataProvider>
+      <div className='w-full p-6 flex flex-col gap-4'>
+        <div className='w-full items-center justify-between flex gap-2'>
+          <Text.H4B>Experiment history</Text.H4B>
+          <Button
+            isLoading={isCreatingExperiment}
+            variant='default'
+            fancy
+            onClick={() => setIsModalOpen(true)}
+          >
+            Run Experiment
+          </Button>
+        </div>
 
-      {(count ?? initialCount) === 0 ? (
-        <EmptyPage
-          isCreatingExperiment={isCreatingExperiment}
-          setIsModalOpen={setIsModalOpen}
+        {(count ?? initialCount) === 0 ? (
+          <EmptyPage
+            isCreatingExperiment={isCreatingExperiment}
+            setIsModalOpen={setIsModalOpen}
+          />
+        ) : (
+          <>
+            <ExperimentComparison
+              selectedExperimentUuids={selectedExperimentUuids}
+              onUnselectExperiment={handleExperimentSelect}
+            />
+            <ExperimentsTable
+              count={count ?? initialCount}
+              selectedExperiments={selectedExperimentUuids}
+              onSelectExperiment={handleExperimentSelect}
+            />
+          </>
+        )}
+        <RunExperimentModal
+          project={project as Project}
+          commit={commit as Commit}
+          document={document}
+          isOpen={isModalOpen}
+          setOpen={setIsModalOpen}
+          onCreate={onCreateExperiments}
         />
-      ) : (
-        <>
-          <ExperimentComparison
-            selectedExperimentUuids={selectedExperimentUuids}
-            onUnselectExperiment={handleExperimentSelect}
-          />
-          <ExperimentsTable
-            count={count ?? initialCount}
-            selectedExperiments={selectedExperimentUuids}
-            onSelectExperiment={handleExperimentSelect}
-          />
-        </>
-      )}
-      <RunExperimentModal
-        project={project as Project}
-        commit={commit as Commit}
-        document={document}
-        isOpen={isModalOpen}
-        setOpen={setIsModalOpen}
-        onCreate={onCreateExperiments}
-      />
-    </div>
+      </div>
+    </MetadataProvider>
   )
 }


### PR DESCRIPTION
With the documentEditor design, we migrated the metadata web worker logic to a provider used within the documentEditor (old and new). 

However, we didnt change the experiments page component which used to call this web worker logic hook. It worked well now as the metadata is stored in a zustand store, so when going from the document editor to the experiments page, it worked well, but if we refreshed within the experiments page, the metadata was lost.