### PR TITLE
filter project unconfigured integrations

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersBlankSlate.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersBlankSlate.tsx
@@ -7,14 +7,8 @@ import Link from 'next/link'
 import { ROUTES } from '$/services/routes'
 import { useCurrentProject } from '@latitude-data/web-ui/providers'
 import { useCurrentCommit } from '@latitude-data/web-ui/providers'
-import { UnconfiguredIntegrations } from './UnconfiguredIntegrations'
-import { IntegrationDto } from '@latitude-data/core/schema/types'
 
-export function TriggersBlankSlate({
-  integrations,
-}: {
-  integrations: IntegrationDto[]
-}) {
+export function TriggersBlankSlate() {
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
 
@@ -26,9 +20,6 @@ export function TriggersBlankSlate({
           Add triggers to run this project from a chat box, an event, a
           schedule…
         </Text.H5>
-      </div>
-      <div className='w-full px-12'>
-        <UnconfiguredIntegrations integrations={integrations} />
       </div>
       <TriggersPreview />
       <Link

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
@@ -169,7 +169,7 @@ export function TriggersList({
   })
 
   if (triggers.length === 0) {
-    return <TriggersBlankSlate integrations={integrations} />
+    return <TriggersBlankSlate />
   }
 
   return (
@@ -187,7 +187,10 @@ export function TriggersList({
         <>
           <div className='flex-1 min-h-0'>
             <div className='flex flex-col gap-6'>
-              <UnconfiguredIntegrations integrations={integrations} />
+              <UnconfiguredIntegrations
+                integrations={integrations}
+                triggers={triggers}
+              />
 
               <div className='flex flex-col border rounded-lg divide-y divide-border overflow-hidden'>
                 {triggers.map((trigger) => (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/UnconfiguredIntegrations/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/UnconfiguredIntegrations/index.tsx
@@ -1,6 +1,7 @@
 import { useConfigureIntegrationAccount } from '$/hooks/useConfigureIntegrationAccount'
-import { IntegrationType } from '@latitude-data/constants'
+import { DocumentTriggerType, IntegrationType } from '@latitude-data/constants'
 import {
+  DocumentTrigger,
   IntegrationDto,
   PipedreamIntegration,
 } from '@latitude-data/core/schema/types'
@@ -52,17 +53,28 @@ export function UnconfiguredIntegration({
 
 export function UnconfiguredIntegrations({
   integrations,
+  triggers,
 }: {
   integrations: IntegrationDto[]
+  triggers: DocumentTrigger[]
 }) {
+  const integrationTriggers = useMemo(() => {
+    return triggers.filter(
+      (trigger) => trigger.triggerType === DocumentTriggerType.Integration,
+    ) as DocumentTrigger<DocumentTriggerType.Integration>[]
+  }, [triggers])
+
   const unconfiguredIntegrations = useMemo(
     () =>
       integrations.filter(
         (integration) =>
           integration.type === IntegrationType.Pipedream &&
-          !isIntegrationConfigured(integration),
+          !isIntegrationConfigured(integration) &&
+          integrationTriggers.some(
+            (trigger) => trigger.configuration.integrationId === integration.id,
+          ),
       ) as PipedreamIntegration[],
-    [integrations],
+    [integrations, integrationTriggers],
   )
 
   if (unconfiguredIntegrations.length === 0) return null


### PR DESCRIPTION
The Preview page is showing all unconfigured integrations, not just the ones from the current project.

This PR filters them to only show unconfigured integrations used from triggers in the current project