### PR TITLE
Fix search integrations in pipedream (ex.: Outlook)

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
@@ -174,15 +174,12 @@ export function TriggersList({
   return (
     <div
       ref={ref}
-      className={cn(
-        'relative max-h-full h-full flex flex-col items-stretch p-12 space-y-8',
-        {
-          'overflow-y-auto custom-scrollbar pb-0': mode === 'chat',
-        },
-      )}
+      className={cn('relative max-h-full h-full flex flex-col p-12 space-y-8', {
+        'overflow-y-auto custom-scrollbar pb-0': mode === 'chat',
+      })}
     >
       <TriggersHeader project={project} />
-      {!mode || mode === 'preview' ? (
+      {mode === 'preview' ? (
         <>
           <div className='flex-1 min-h-0'>
             <div className='flex flex-col gap-6'>

--- a/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/Pipedream/AppSelector.tsx
+++ b/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/Pipedream/AppSelector.tsx
@@ -22,6 +22,7 @@ export function AppSelector({
       cursor: string | undefined
     }) => {
       const params = new URLSearchParams()
+      params.append('withTools', 'true')
       if (query) params.append('query', query)
       if (cursor) params.append('cursor', cursor)
 

--- a/apps/web/src/app/api/integrations/pipedream/apps/route.ts
+++ b/apps/web/src/app/api/integrations/pipedream/apps/route.ts
@@ -9,7 +9,13 @@ export const GET = errorHandler(
     const query = searchParams.get('query') || undefined
     const cursor = searchParams.get('cursor') || undefined
     const withTriggers = searchParams.get('withTriggers') === 'true'
-    const result = await listApps({ query, cursor, withTriggers })
+    const withTools = searchParams.get('withTools') === 'true'
+    const result = await listApps({
+      query,
+      cursor,
+      withTriggers,
+      withTools,
+    })
 
     return NextResponse.json(result.unwrap(), { status: 200 })
   }),

--- a/apps/web/src/stores/pipedreamApps.ts
+++ b/apps/web/src/stores/pipedreamApps.ts
@@ -47,15 +47,27 @@ export default function usePipedreamApps(
   {
     query,
     withTriggers = false,
-  }: { query?: string; withTriggers?: boolean } = {},
+    withTools = false,
+  }: {
+    query?: string
+    withTriggers?: boolean
+    withTools?: boolean
+  } = {},
   opts?: SWRInfiniteConfiguration<PipedreamAppsResponse, any>,
 ) {
   const hasTriggers = withTriggers ? 'true' : 'false'
+  const hasTools = withTools ? 'true' : 'false'
 
   const getKey = useCallback(
     (pageIndex: number, previousPageData: PipedreamAppsResponse | null) => {
       if (pageIndex === 0) {
-        return ['pipedream-apps', hasTriggers, query || '', ''] as const
+        return [
+          'pipedream-apps',
+          hasTriggers,
+          hasTools,
+          query || '',
+          '',
+        ] as const
       }
 
       // If previous page data is empty or doesn't have a cursor, we've reached the end
@@ -66,11 +78,12 @@ export default function usePipedreamApps(
       return [
         'pipedream-apps',
         hasTriggers,
+        hasTools,
         query || '',
         previousPageData.cursor,
       ] as const
     },
-    [hasTriggers, query],
+    [hasTriggers, hasTools, query],
   )
 
   // Use the reusable infinite fetcher hook
@@ -79,10 +92,11 @@ export default function usePipedreamApps(
     useCallback((key: string[]) => {
       const searchParams: Record<string, string> = {}
 
-      // Extract params from key: [cacheName, withTriggers, query, cursor]
+      // Extract params from key: [cacheName, withTriggers, withTools, query, cursor]
       if (key[1]) searchParams.withTriggers = key[1]
-      if (key[2]) searchParams.query = key[2]
-      if (key[3]) searchParams.cursor = key[3]
+      if (key[2]) searchParams.withTools = key[2]
+      if (key[3]) searchParams.query = key[3]
+      if (key[4]) searchParams.cursor = key[4]
 
       return searchParams
     }, []),

--- a/packages/core/src/services/integrations/pipedream/apps.test.ts
+++ b/packages/core/src/services/integrations/pipedream/apps.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Result, TypedResult } from '../../../lib/Result'
+import { listApps } from './apps'
+import type {
+  BackendClient,
+  GetAppsOpts,
+  GetAppsResponse,
+  GetComponentsOpts,
+  GetComponentsResponse,
+  App,
+  V1Component,
+} from '@pipedream/sdk/server'
+import { AppAuthType } from '@pipedream/sdk/server'
+
+describe('listApps', () => {
+  const mockApps = [
+    {
+      id: 'app1',
+      name: 'Test App 1',
+      name_slug: 'test-app-1',
+      auth_type: AppAuthType.OAuth,
+      img_src: 'https://example.com/app1.png',
+      categories: ['productivity'],
+      description: 'A test app for productivity',
+      custom_fields_json: '{}',
+      featured_weight: 100,
+    },
+    {
+      id: 'app2',
+      name: 'Test App 2',
+      name_slug: 'test-app-2',
+      auth_type: AppAuthType.Keys,
+      img_src: 'https://example.com/app2.png',
+      categories: ['communication'],
+      description: 'A test app for communication',
+      custom_fields_json: '{}',
+      featured_weight: 90,
+    },
+  ] satisfies App[]
+
+  const mockComponents = [
+    {
+      name: 'Test Component 1',
+      key: 'test-app-1-action',
+      version: '1.0.0',
+      configurable_props: [],
+      component_type: 'action',
+    },
+    {
+      name: 'Test Component 2',
+      key: 'test-app-2-trigger',
+      version: '1.0.0',
+      configurable_props: [],
+      component_type: 'trigger',
+    },
+  ] satisfies V1Component[]
+
+  // Type for our mock client with spy methods attached
+  type MockClientWithSpies = BackendClient & {
+    __getAppsSpy: ReturnType<typeof vi.fn>
+    __getComponentsSpy: ReturnType<typeof vi.fn>
+  }
+
+  const createMockPipedreamClient = (): MockClientWithSpies => {
+    const getAppsSpy = vi.fn()
+    const getComponentsSpy = vi.fn()
+
+    const mockClient: Partial<BackendClient> = {
+      getApps: (opts: GetAppsOpts = {}): Promise<GetAppsResponse> => {
+        getAppsSpy(opts)
+        // For testing purposes, we'll add integrations as a custom property
+        // This simulates the behavior that the listApps function expects
+        const appsWithIntegrations = mockApps.map((app) => ({
+          ...app,
+          ...(opts.hasComponents && {
+            integrations: mockComponents.filter((c) =>
+              c.key.includes(app.name_slug),
+            ),
+          }),
+        }))
+        return Promise.resolve({
+          data: appsWithIntegrations,
+          page_info: {
+            total_count: appsWithIntegrations.length,
+            end_cursor: 'test-cursor',
+            count: appsWithIntegrations.length,
+            start_cursor: 'start-cursor',
+          },
+        })
+      },
+      getComponents: (
+        opts: GetComponentsOpts = {},
+      ): Promise<GetComponentsResponse> => {
+        getComponentsSpy(opts)
+        return Promise.resolve({
+          data: mockComponents,
+          page_info: {
+            total_count: mockComponents.length,
+            end_cursor: 'comp-cursor',
+            count: mockComponents.length,
+            start_cursor: 'comp-start-cursor',
+          },
+        })
+      },
+    }
+
+    // Attach spies to the mock for testing
+    const clientWithSpies = mockClient as MockClientWithSpies
+    clientWithSpies.__getAppsSpy = getAppsSpy
+    clientWithSpies.__getComponentsSpy = getComponentsSpy
+
+    return clientWithSpies
+  }
+
+  const mockPipedreamClientBuilder = (): (() => TypedResult<
+    BackendClient,
+    Error
+  >) => {
+    return () => Result.ok(createMockPipedreamClient())
+  }
+
+  it('should return apps with default parameters', async () => {
+    const result = await listApps({
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      expect(result.value.totalCount).toBe(2)
+      expect(result.value.cursor).toBe('test-cursor')
+      expect(result.value.apps[0]).toEqual(mockApps[0])
+      expect(result.value.apps[1]).toEqual(mockApps[1])
+    }
+  })
+
+  it('should return apps without triggers when withTriggers is false', async () => {
+    const result = await listApps({
+      withTriggers: false,
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      expect(result.value.apps[0]).not.toHaveProperty('triggerCount')
+      expect(result.value.apps[1]).not.toHaveProperty('triggerCount')
+    }
+  })
+
+  it('should return apps with triggers when withTriggers is true', async () => {
+    const result = await listApps({
+      withTriggers: true,
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      // Apps should have triggerCount added by fetchTriggerCounts
+      expect(result.value.apps[0]).toHaveProperty('triggerCount')
+      expect(result.value.apps[1]).toHaveProperty('triggerCount')
+    }
+  })
+
+  it('should return apps without integrations when withTools is false', async () => {
+    const result = await listApps({
+      withTools: false,
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      expect(result.value.apps[0]).not.toHaveProperty('integrations')
+      expect(result.value.apps[1]).not.toHaveProperty('integrations')
+    }
+  })
+
+  it('should return apps with integrations when withTools is true', async () => {
+    const result = await listApps({
+      withTools: true,
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      // Apps should have integrations added
+      expect(result.value.apps[0]).toHaveProperty('integrations')
+      expect(result.value.apps[1]).toHaveProperty('integrations')
+    }
+  })
+
+  it('should return apps with both triggers and integrations when both flags are true', async () => {
+    const result = await listApps({
+      withTriggers: true,
+      withTools: true,
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      expect(result.value.apps[0]).toHaveProperty('triggerCount')
+      expect(result.value.apps[0]).toHaveProperty('integrations')
+      expect(result.value.apps[1]).toHaveProperty('triggerCount')
+      expect(result.value.apps[1]).toHaveProperty('integrations')
+    }
+  })
+
+  it('should return empty array when no apps found', async () => {
+    const emptyClientBuilder = () =>
+      Result.ok({
+        getApps: () =>
+          Promise.resolve({
+            data: [],
+            page_info: {
+              total_count: 0,
+              end_cursor: '',
+              count: 0,
+              start_cursor: '',
+            },
+          }),
+        getComponents: () =>
+          Promise.resolve({
+            data: [],
+            page_info: {
+              total_count: 0,
+              end_cursor: '',
+              count: 0,
+              start_cursor: '',
+            },
+          }),
+      } as unknown as BackendClient)
+
+    const result = await listApps({
+      pipedreamClientBuilder: emptyClientBuilder,
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toEqual([])
+    }
+  })
+
+  it('should handle cursor parameter correctly', async () => {
+    const result = await listApps({
+      cursor: 'custom-cursor',
+      pipedreamClientBuilder: mockPipedreamClientBuilder(),
+    })
+
+    expect(result.ok).toBe(true)
+    if (Result.isOk(result)) {
+      expect(result.value.apps).toHaveLength(2)
+      expect(result.value.cursor).toBe('test-cursor')
+    }
+  })
+
+  it('should return error when pipedream client builder fails', async () => {
+    const errorClientBuilder = () =>
+      Result.error(new Error('Failed to create client'))
+
+    const result = await listApps({
+      pipedreamClientBuilder: errorClientBuilder,
+    })
+
+    expect(result.ok).toBe(false)
+
+    if (!Result.isOk(result)) {
+      expect(result.error.message).toBe('Failed to create client')
+    }
+  })
+
+  it('should handle apps API error gracefully', async () => {
+    const errorClientBuilder = () =>
+      Result.ok({
+        getApps: () => Promise.reject(new Error('Apps API failed')),
+        getComponents: () =>
+          Promise.resolve({
+            data: mockComponents,
+            page_info: {
+              total_count: mockComponents.length,
+              end_cursor: 'comp-cursor',
+              count: mockComponents.length,
+              start_cursor: 'comp-start-cursor',
+            },
+          }),
+      } as unknown as BackendClient)
+
+    const result = await listApps({
+      pipedreamClientBuilder: errorClientBuilder,
+    })
+
+    expect(result.ok).toBe(false)
+
+    if (!Result.isOk(result)) {
+      expect(result.error.message).toBe('Apps API failed')
+    }
+  })
+
+  it('should handle components API error when withTools is true', async () => {
+    const errorClientBuilder = () =>
+      Result.ok({
+        getApps: ({ hasComponents }: { hasComponents?: boolean } = {}) => {
+          if (hasComponents) {
+            return Promise.reject(new Error('Components API failed'))
+          }
+          return Promise.resolve({
+            data: mockApps,
+            page_info: {
+              total_count: mockApps.length,
+              end_cursor: 'test-cursor',
+              count: mockApps.length,
+              start_cursor: 'start-cursor',
+            },
+          })
+        },
+        getComponents: () =>
+          Promise.resolve({
+            data: mockComponents,
+            page_info: {
+              total_count: mockComponents.length,
+              end_cursor: 'comp-cursor',
+              count: mockComponents.length,
+              start_cursor: 'comp-start-cursor',
+            },
+          }),
+      } as unknown as BackendClient)
+
+    const result = await listApps({
+      withTools: true,
+      pipedreamClientBuilder: errorClientBuilder,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!Result.isOk(result)) {
+      expect(result.error?.message).toBe('Components API failed')
+    }
+  })
+
+  it('should not call components API when withTools is false', async () => {
+    let componentsApiCalled = false
+    const clientBuilder = () =>
+      Result.ok({
+        getApps: () =>
+          Promise.resolve({
+            data: mockApps,
+            page_info: {
+              total_count: mockApps.length,
+              end_cursor: 'test-cursor',
+              count: mockApps.length,
+              start_cursor: 'start-cursor',
+            },
+          }),
+        getComponents: () => {
+          componentsApiCalled = true
+          return Promise.resolve({
+            data: mockComponents,
+            page_info: {
+              total_count: mockComponents.length,
+              end_cursor: 'comp-cursor',
+              count: mockComponents.length,
+              start_cursor: 'comp-start-cursor',
+            },
+          })
+        },
+      } as unknown as BackendClient)
+
+    const result = await listApps({
+      withTools: false,
+      pipedreamClientBuilder: clientBuilder,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(componentsApiCalled).toBe(false)
+  })
+
+  it('should call getApps with correct parameters when withTools is true', async () => {
+    const mockClient = createMockPipedreamClient()
+    const clientBuilder = () => Result.ok(mockClient)
+
+    await listApps({
+      withTools: true,
+      query: 'test-query',
+      cursor: 'test-cursor',
+      pipedreamClientBuilder: clientBuilder,
+    })
+
+    // Verify getApps was called with the correct parameters
+    expect(mockClient.__getAppsSpy).toHaveBeenCalledWith({
+      hasComponents: true,
+      hasTriggers: false,
+      q: 'test-query',
+      after: 'test-cursor',
+      limit: 64,
+    })
+  })
+
+  it('should call getApps with correct parameters when withTools is false', async () => {
+    const mockClient = createMockPipedreamClient()
+    const clientBuilder = () => Result.ok(mockClient)
+
+    await listApps({
+      withTools: false,
+      query: 'test-query',
+      pipedreamClientBuilder: clientBuilder,
+    })
+
+    expect(mockClient.__getAppsSpy).toHaveBeenCalledWith({
+      hasTriggers: false,
+      q: 'test-query',
+      after: undefined,
+      limit: 64,
+    })
+  })
+
+  it('should call getApps without hasComponents when only withTriggers is true', async () => {
+    const mockClient = createMockPipedreamClient()
+    const clientBuilder = () => Result.ok(mockClient)
+
+    await listApps({
+      withTriggers: true,
+      withTools: false,
+      query: 'test-query',
+      pipedreamClientBuilder: clientBuilder,
+    })
+
+    // Verify getApps was called without hasComponents parameter
+    expect(mockClient.__getAppsSpy).toHaveBeenCalledWith({
+      hasTriggers: true,
+      q: 'test-query',
+      after: undefined,
+      limit: 64,
+    })
+  })
+
+  it('should not call getComponents directly', async () => {
+    const mockClient = createMockPipedreamClient()
+    const clientBuilder = () => Result.ok(mockClient)
+
+    await listApps({
+      withTools: true,
+      pipedreamClientBuilder: clientBuilder,
+    })
+
+    expect(mockClient.__getComponentsSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
# What?
When I worked on triggers I remove the flag `withComponents` when
searching apps in pipedream. This change fix it by making it a flag that
can be passed.