### PR TITLE
fix(latte-steps)/adapting-to-stop-mechanism

### DIFF
--- a/apps/web/src/components/LatteChat/LatteChatInput.tsx
+++ b/apps/web/src/components/LatteChat/LatteChatInput.tsx
@@ -38,6 +38,7 @@ export function LatteChatInput({
   feedbackRequested,
   addFeedbackToLatteChange,
   stopLatteChat,
+  setShowThinking,
 }: {
   isBrewing: boolean
   inConversation: boolean
@@ -54,6 +55,7 @@ export function LatteChatInput({
     evaluationResultUuid?: string,
   ) => void
   stopLatteChat?: () => void
+  setShowThinking: (value: boolean) => void
 }) {
   const placeholder = useTypeWriterValue(
     inConversation ? [] : INPUT_PLACEHOLDERS,
@@ -75,7 +77,8 @@ export function LatteChatInput({
     if (value.trim() === '') return
     setValue('')
     sendMessage(value)
-  }, [value, sendMessage, isBrewing])
+    setShowThinking(false)
+  }, [value, sendMessage, isBrewing, setShowThinking])
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/CollapsedInteractionSteps.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/CollapsedInteractionSteps.tsx
@@ -1,15 +1,23 @@
 import { useState, useEffect } from 'react'
 import { LatteInteractionStep } from '$/hooks/latte/types'
 import { InteractionStep } from './InteractionStep'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { cn } from '@latitude-data/web-ui/utils'
 
 const STEP_LINE_HEIGHT = 1.25 // rem
 
 export const CollapsedInteractionSteps = ({
   steps,
   isLoading = false,
+  lastInteraction,
+  isOpen,
+  showThinking,
 }: {
   steps: LatteInteractionStep[]
   isLoading?: boolean
+  lastInteraction: boolean
+  isOpen: boolean
+  showThinking: boolean
 }) => {
   const [currentLine, setCurrentLine] = useState(steps.length)
 
@@ -18,29 +26,49 @@ export const CollapsedInteractionSteps = ({
   }, [steps.length])
 
   return (
-    <div className='w-full relative overflow-hidden h-6 leading-6'>
-      <div
-        className='absolute inset-x-0 transition-transform duration-500 ease-in-out flex flex-col justify-center'
-        style={{
-          transform: `translateY(-${currentLine * STEP_LINE_HEIGHT}rem)`,
-        }}
-      >
-        {/* Thinking step*/}
-        <InteractionStep
-          key={-1}
-          step={undefined}
-          isLoading={isLoading}
-          singleLine
-        />{' '}
-        {steps.map((step, index) => (
-          <InteractionStep
-            key={index}
-            step={step}
-            isLoading={isLoading && index === steps.length - 1}
-            singleLine
-          />
-        ))}
+    <>
+      {(lastInteraction || steps.length > 0) && (
+        <Icon
+          name='chevronRight'
+          color='latteOutputForegroundMuted'
+          className={cn('transition-all min-w-4 mt-0.5', {
+            'rotate-90': isOpen,
+          })}
+        />
+      )}
+      <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
+        <div className='w-full relative overflow-hidden h-6 leading-6'>
+          <div
+            className='absolute inset-x-0 transition-transform duration-500 ease-in-out flex flex-col justify-center'
+            style={{
+              transform: `translateY(-${currentLine * STEP_LINE_HEIGHT}rem)`,
+            }}
+          >
+            {/* Thinking step*/}
+            {(lastInteraction || steps.length > 0) && (
+              <InteractionStep
+                key={-1}
+                step={undefined}
+                isLoading={isLoading && showThinking}
+                singleLine
+              />
+            )}{' '}
+            {steps.map((step, index) => (
+              <InteractionStep
+                key={index}
+                step={step}
+                isLoading={
+                  isLoading &&
+                  index === steps.length - 1 &&
+                  !showThinking &&
+                  lastInteraction
+                }
+                singleLine
+              />
+            ))}
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/UnCollapsedInteractionSteps.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/UnCollapsedInteractionSteps.tsx
@@ -1,0 +1,40 @@
+import { LatteInteraction } from '$/hooks/latte/types'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { cn } from '@latitude-data/web-ui/utils'
+import { InteractionStep } from './InteractionStep'
+
+export const UncollapsedInteractionSteps = ({
+  interaction,
+  isOpen,
+  showThinking,
+}: {
+  interaction: LatteInteraction
+  isLoading: boolean
+  isOpen: boolean
+  showThinking: boolean
+}) => {
+  return (
+    <>
+      <Icon
+        name='chevronRight'
+        color='latteOutputForegroundMuted'
+        className={cn('transition-all min-w-4 mt-0.5', {
+          'rotate-90': isOpen,
+        })}
+      />
+      <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
+        {interaction.steps.map((step, i) => (
+          <InteractionStep
+            key={i}
+            step={step}
+            isLoading={
+              interaction.output === undefined &&
+              i === interaction.steps.length - 1 &&
+              !showThinking
+            }
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/index.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/index.tsx
@@ -1,18 +1,20 @@
 import { LatteInteraction } from '$/hooks/latte/types'
-import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
-import { cn } from '@latitude-data/web-ui/utils'
 import { useState } from 'react'
 import { CollapsedInteractionSteps } from './CollapsedInteractionSteps'
-import { InteractionStep } from './InteractionStep'
 import { MarkdownResponse } from './MarkdownText'
+import { UncollapsedInteractionSteps } from './UnCollapsedInteractionSteps'
 
 export function ChatInteraction({
   interaction,
-  isStreaming,
+  isBrewing,
+  lastInteraction,
+  showThinking,
 }: {
   interaction: LatteInteraction
-  isStreaming?: boolean
+  isBrewing?: boolean
+  lastInteraction: boolean
+  showThinking: boolean
 }) {
   const [isOpen, setIsOpen] = useState(false)
 
@@ -24,37 +26,27 @@ export function ChatInteraction({
         </Text.H5>
       </div>
 
-      {interaction.steps.length > 0 || (!interaction.output && isStreaming) ? (
+      {interaction.steps.length > 0 || (!interaction.output && isBrewing) ? (
         <div
           className='flex flex-row items-start gap-2 hover:opacity-80 cursor-pointer'
           onClick={() => setIsOpen((prev) => !prev)}
         >
-          <Icon
-            name='chevronRight'
-            color='latteOutputForegroundMuted'
-            className={cn('transition-all min-w-4 mt-0.5', {
-              'rotate-90': isOpen,
-            })}
-          />
-          <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
-            {isOpen && interaction.steps.length > 0 ? (
-              interaction.steps.map((step, i) => (
-                <InteractionStep
-                  key={i}
-                  step={step}
-                  isLoading={
-                    interaction.output === undefined &&
-                    i === interaction.steps.length - 1
-                  }
-                />
-              ))
-            ) : (
-              <CollapsedInteractionSteps
-                steps={interaction.steps}
-                isLoading={interaction.output === undefined}
-              />
-            )}
-          </div>
+          {isOpen && interaction.steps.length > 0 ? (
+            <UncollapsedInteractionSteps
+              interaction={interaction}
+              isLoading={interaction.output === undefined}
+              isOpen={isOpen}
+              showThinking={showThinking}
+            />
+          ) : (
+            <CollapsedInteractionSteps
+              steps={interaction.steps}
+              isLoading={interaction.output === undefined}
+              lastInteraction={lastInteraction}
+              isOpen={isOpen}
+              showThinking={showThinking}
+            />
+          )}
         </div>
       ) : null}
 

--- a/apps/web/src/components/LatteChat/_components/MessageList.tsx
+++ b/apps/web/src/components/LatteChat/_components/MessageList.tsx
@@ -3,18 +3,23 @@ import { ChatInteraction } from './ChatInteraction'
 
 export function LatteMessageList({
   interactions,
-  isStreaming,
+  isBrewing,
+  showThinking,
 }: {
   interactions: LatteInteraction[]
-  isStreaming?: boolean
+  isBrewing: boolean
+  showThinking: boolean
 }) {
+  const lastInteractionIndex = interactions.length - 1
   return (
     <div className='flex flex-col gap-8 px-8 pt-8 w-full'>
       {interactions.map((interaction, i) => (
         <ChatInteraction
           key={i}
           interaction={interaction}
-          isStreaming={isStreaming}
+          isBrewing={isBrewing}
+          showThinking={showThinking}
+          lastInteraction={i === lastInteractionIndex}
         />
       ))}
     </div>

--- a/apps/web/src/components/LatteChat/index.tsx
+++ b/apps/web/src/components/LatteChat/index.tsx
@@ -36,7 +36,7 @@ export function LatteChat() {
 
   useSyncLatteUrlState()
 
-  const isBrewingThread = useLoadThreadFromProviderLogs()
+  const isLoadingThread = useLoadThreadFromProviderLogs()
 
   const {
     isBrewing,
@@ -48,7 +48,6 @@ export function LatteChat() {
     usage,
     jobId,
   } = useLatteStore()
-
   const { sendMessage, stopChat } = useLatteChatActions()
   const { acceptChanges, undoChanges, addFeedbackToLatteChange } =
     useLatteChangeActions()
@@ -58,9 +57,11 @@ export function LatteChat() {
     addFeedbackToLatteChange('')
   }, [resetChatStore, addFeedbackToLatteChange])
 
+  const [showThinking, setShowThinking] = useState(false)
   const stopLatteChat = useCallback(() => {
     stopChat({ jobId: jobId })
-  }, [stopChat, jobId])
+    setShowThinking(true)
+  }, [stopChat, jobId, setShowThinking])
 
   const inConversation = interactions.length > 0
   const containerRef = useRef<HTMLDivElement>(null)
@@ -100,8 +101,8 @@ export function LatteChat() {
             className='w-full h-full overflow-hidden custom-scrollbar flex flex-col gap-4 items-center shadow-sm pb-8'
             ref={containerRef}
           >
-            {isBrewingThread && !isBrewing && <ChatSkeleton />}
-            {!isBrewingThread &&
+            {isLoadingThread && !isBrewing && <ChatSkeleton />}
+            {!isLoadingThread &&
               (!inConversation ? (
                 <div className='flex flex-col items-center justify-center h-full gap-8 min-w-[50%] p-8'>
                   <div className='flex flex-col items-center justify-center gap-6'>
@@ -138,13 +139,15 @@ export function LatteChat() {
                     isBrewing={isBrewing}
                     feedbackRequested={!!latteActionsFeedbackUuid}
                     addFeedbackToLatteChange={addFeedbackToLatteChange}
+                    setShowThinking={setShowThinking}
                   />
                 </div>
               ) : (
                 <>
                   <LatteMessageList
                     interactions={interactions}
-                    isStreaming={isBrewing}
+                    isBrewing={isBrewing}
+                    showThinking={showThinking}
                   />
                   {error && (
                     <div className='w-full px-8'>
@@ -192,6 +195,7 @@ export function LatteChat() {
                 feedbackRequested={!!latteActionsFeedbackUuid}
                 addFeedbackToLatteChange={addFeedbackToLatteChange}
                 stopLatteChat={stopLatteChat}
+                setShowThinking={setShowThinking}
               />
               {!!usage && !!workspace && (
                 <LatteUsageInfo


### PR DESCRIPTION
Now the step interactions are adapted to the stop mechanism.

We now:
- Don't show "Brewing..." default step when its an older interaction of the message chain (this occurs if you stop the response of Latte before it start writing)
- When stopping an agent while using a tool, the loading animation stops.
- Only animates the interaction steps of the current interaction the user is doing with Latte