### PR TITLE
fix: latte changes action buttons do nothing after resetting chat

### DIFF
--- a/apps/web/src/components/LatteChat/index.tsx
+++ b/apps/web/src/components/LatteChat/index.tsx
@@ -45,7 +45,7 @@ export function LatteChat() {
 
   const {
     isBrewing,
-    resetChat: resetChatStore,
+    resetAll,
     interactions,
     error,
     changes,
@@ -59,9 +59,9 @@ export function LatteChat() {
     useLatteChangeActions()
 
   const resetChat = useCallback(() => {
-    resetChatStore()
     addFeedbackToLatteChange('')
-  }, [resetChatStore, addFeedbackToLatteChange])
+    resetAll()
+  }, [resetAll, addFeedbackToLatteChange])
 
   const stopLatteChat = useCallback(() => {
     stopChat({ jobId: jobId })

--- a/apps/web/src/stores/latte.ts
+++ b/apps/web/src/stores/latte.ts
@@ -61,7 +61,6 @@ interface LatteState {
   setJobId: (jobId: string | undefined) => void
 
   // Reset functions
-  resetChat: () => void
   resetChanges: () => void
   resetAll: () => void
 }
@@ -175,15 +174,6 @@ const useStore = create<LatteState>((set) => ({
   setJobId: (jobId: string | undefined) => set({ jobId: jobId }),
 
   // Reset functions
-  resetChat: () =>
-    set({
-      isBrewing: false,
-      interactions: [],
-      error: undefined,
-      threadUuid: undefined,
-      jobId: undefined,
-    }),
-
   resetChanges: () =>
     set({
       changes: [],
@@ -192,13 +182,13 @@ const useStore = create<LatteState>((set) => ({
 
   resetAll: () =>
     set({
-      isBrewing: false,
-      interactions: [],
-      error: undefined,
       changes: [],
       latteActionsFeedbackUuid: undefined,
       threadUuid: undefined,
       jobId: undefined,
+      interactions: [],
+      isBrewing: false,
+      error: undefined,
     }),
 }))
 
@@ -223,12 +213,6 @@ export const useLatteStore = () => {
     [store, setStoredThreadUuid],
   )
 
-  const resetChat = useCallback(() => {
-    store.resetChat()
-    setStoredThreadUuid(undefined)
-    setStoredJobId(undefined)
-  }, [store, setStoredThreadUuid, setStoredJobId])
-
   const setJobId = useCallback(
     (jobId: string | undefined) => {
       store.setJobId(jobId)
@@ -240,9 +224,8 @@ export const useLatteStore = () => {
     () => ({
       ...store,
       setThreadUuid,
-      resetChat,
       setJobId: setJobId,
     }),
-    [store, setThreadUuid, resetChat, setJobId],
+    [store, setThreadUuid, setJobId],
   )
 }


### PR DESCRIPTION
### WAT
Resetting the Chat does not reset the list of changes made by Latte. However, clicking on either "Keep" or "Discard" will do nothing.

### FIX
We cannot currently reset the Chat and not reset the list of changes too. The list of changes is tied to a specific Latte thread’s checkpoints. If we reset the chat, the thread ID is removed, making it impossible to keep or discard changes, as the thread no longer exists.

So, I removed the `resetChat` callback and kept only `resetChanges` and `resetAll`
