### PR TITLE
Latte: Delete prompt tool

### DIFF
--- a/packages/constants/src/latte/index.ts
+++ b/packages/constants/src/latte/index.ts
@@ -10,6 +10,7 @@ export enum LatteTool {
   listPrompts = 'list_prompts',
   readPrompt = 'read_prompt',
   writePrompt = 'write_prompt',
+  deletePrompt = 'delete_prompt',
   editProject = 'edit_project',
 
   listProviders = 'list_providers',

--- a/packages/core/src/services/copilot/latte/tools/index.ts
+++ b/packages/core/src/services/copilot/latte/tools/index.ts
@@ -8,6 +8,7 @@ import listPrompts from './documents/list'
 import readPrompt from './documents/read'
 import editProject from './projects/editProject'
 import writePrompt from './projects/writePrompt'
+import deletePrompt from './projects/deletePrompt'
 import listProjects from './projects/list'
 import listIntegrations from './settings/listIntegrations'
 import listIntegrationTools from './settings/listIntegrationTools'
@@ -31,6 +32,7 @@ export const LATTE_TOOLS: Record<LatteTool, LatteToolFn<any>> = {
   [LatteTool.listPrompts]: listPrompts,
   [LatteTool.readPrompt]: readPrompt,
   [LatteTool.editProject]: editProject,
+  [LatteTool.deletePrompt]: deletePrompt,
   [LatteTool.listProviders]: listProviders,
   [LatteTool.listIntegrations]: listIntegrations,
   [LatteTool.listIntegrationTools]: listIntegrationTools,

--- a/packages/core/src/services/copilot/latte/tools/projects/deletePrompt.test.ts
+++ b/packages/core/src/services/copilot/latte/tools/projects/deletePrompt.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Providers } from '../../../../../constants'
+import deletePrompt from './deletePrompt'
+import { DocumentVersionsRepository } from '../../../../../repositories'
+import { Commit, Project, User, Workspace } from '../../../../../browser'
+import * as factories from '../../../../../tests/factories'
+import { createLatteThread } from '../../threads/createThread'
+import { LatteToolContext } from '../types'
+import { WebsocketClient } from '../../../../../websockets/workers'
+import { mergeCommit } from '../../../../commits'
+
+vi.spyOn(WebsocketClient, 'sendEvent').mockImplementation(vi.fn())
+
+describe('deletePrompt', () => {
+  let workspace: Workspace
+  let user: User
+  let project: Project
+  let draft: Commit
+
+  let latteContext: LatteToolContext
+
+  beforeEach(async () => {
+    const {
+      workspace: w,
+      user: u,
+      project: p,
+      commit: c,
+    } = await factories.createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      skipMerge: true,
+    })
+
+    workspace = w
+    user = u
+    project = p
+    draft = c
+
+    const latteThread = await createLatteThread({ workspace, user }).then((r) =>
+      r.unwrap(),
+    )
+
+    // @ts-expect-error Only defining stuff being used in deletePrompt
+    latteContext = {
+      workspace,
+      user,
+      threadUuid: latteThread.uuid,
+    }
+  })
+
+  it('deletes an existing prompt in a draft', async () => {
+    const path = 'prompts/to-delete'
+    const content = 'This prompt will be deleted'
+
+    const { documentVersion } = await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft,
+      path: path,
+      content: content,
+    })
+
+    const result = await deletePrompt(
+      {
+        projectId: project.id,
+        versionUuid: draft.uuid,
+        path: path,
+      },
+      latteContext,
+    )
+
+    expect(result.ok).toBe(true)
+    const {
+      success,
+      deletedPromptUuid,
+      path: deletedPath,
+    } = result.unwrap() as {
+      success: boolean
+      deletedPromptUuid: string
+      path: string
+    }
+    expect(success).toBe(true)
+    expect(deletedPromptUuid).toBe(documentVersion.documentUuid)
+    expect(deletedPath).toBe(path)
+
+    // Verify the document was soft deleted by checking with includeDeleted option
+    const documentScope = new DocumentVersionsRepository(
+      workspace.id,
+      undefined,
+      { includeDeleted: true },
+    )
+    const docsIncludingDeleted = await documentScope
+      .getDocumentsAtCommit(draft)
+      .then((r) => r.unwrap())
+
+    const deletedDoc = docsIncludingDeleted.find(
+      (doc) => doc.documentUuid === documentVersion.documentUuid,
+    )
+    expect(deletedDoc).toBeDefined()
+    expect(deletedDoc!.deletedAt).not.toBeNull()
+
+    // Verify that getDocumentsAtCommit without includeDeleted returns empty array
+    const normalScope = new DocumentVersionsRepository(workspace.id)
+    const normalDocs = await normalScope
+      .getDocumentsAtCommit(draft)
+      .then((r) => r.unwrap())
+    expect(normalDocs).toHaveLength(0)
+  })
+
+  it('returns an error when trying to delete a non-existent prompt', async () => {
+    const nonExistentPath = 'prompts/non-existent-path'
+
+    const result = await deletePrompt(
+      {
+        projectId: project.id,
+        versionUuid: draft.uuid,
+        path: nonExistentPath,
+      },
+      latteContext,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('not found')
+  })
+
+  it('returns an error when trying to delete from a merged commit', async () => {
+    const path = 'prompts/in-merged-commit'
+    const content = 'Content in merged commit'
+
+    // Create a document in the draft first
+    await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft,
+      path: path,
+      content: content,
+    })
+
+    // Merge the commit
+    await mergeCommit(draft)
+
+    const result = await deletePrompt(
+      {
+        projectId: project.id,
+        versionUuid: draft.uuid,
+        path: path,
+      },
+      latteContext,
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeDefined()
+    expect(result.error!.message).toContain('Cannot edit a merged commit')
+  })
+
+  it('handles deleting a prompt that was already deleted', async () => {
+    const path = 'prompts/already-deleted'
+    const content = 'This prompt is already deleted'
+
+    await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft,
+      path: path,
+      content: content,
+    })
+
+    // First deletion
+    const firstResult = await deletePrompt(
+      {
+        projectId: project.id,
+        versionUuid: draft.uuid,
+        path: path,
+      },
+      latteContext,
+    )
+
+    expect(firstResult.ok).toBe(true)
+
+    // After first deletion, the document still exists in the commit (just marked as deleted)
+    // A second deletion attempt should fail because our implementation fetches documents
+    // without includeDeleted, so it won't find the document
+    const secondResult = await deletePrompt(
+      {
+        projectId: project.id,
+        versionUuid: draft.uuid,
+        path: path,
+      },
+      latteContext,
+    )
+
+    expect(secondResult.ok).toBe(false)
+    expect(secondResult.error!.message).toContain('not found')
+  })
+})

--- a/packages/core/src/services/copilot/latte/tools/projects/deletePrompt.ts
+++ b/packages/core/src/services/copilot/latte/tools/projects/deletePrompt.ts
@@ -1,0 +1,87 @@
+import { BadRequestError, NotFoundError } from '@latitude-data/constants/errors'
+import { Result } from '../../../../../lib/Result'
+import {
+  CommitsRepository,
+  DocumentVersionsRepository,
+} from '../../../../../repositories'
+import { defineLatteTool } from '../types'
+import { LatteEditAction } from '@latitude-data/constants/latte'
+import { z } from 'zod'
+import { executeLatteActions } from './latteActions/executeActions'
+
+const deletePrompt = defineLatteTool(
+  async (
+    { projectId, versionUuid, path: rawPath },
+    { workspace, threadUuid },
+  ) => {
+    const commitsScope = new CommitsRepository(workspace.id)
+    const commitResult = await commitsScope.getCommitByUuid({
+      projectId: projectId,
+      uuid: versionUuid,
+    })
+    if (!commitResult.ok) return commitResult
+    const commit = commitResult.unwrap()
+
+    if (commit.mergedAt) {
+      return Result.error(
+        new BadRequestError(
+          `Cannot edit a merged commit. Select an existing draft or create a new one.`,
+        ),
+      )
+    }
+
+    const documentsScope = new DocumentVersionsRepository(workspace.id)
+    const documents = await documentsScope
+      .getDocumentsAtCommit(commit)
+      .then((r) => r.unwrap())
+
+    const path = rawPath.startsWith('/') ? rawPath.slice(1) : rawPath
+    const document = documents.find((doc) => doc.path === path)
+    if (!document) {
+      return Result.error(
+        new NotFoundError(
+          `Document with path ${path} not found in commit ${versionUuid}.`,
+        ),
+      )
+    }
+
+    const latteAction: LatteEditAction = {
+      type: 'prompt',
+      operation: 'delete',
+      promptUuid: document.documentUuid,
+    }
+
+    const actionResults = await executeLatteActions({
+      workspace,
+      threadUuid,
+      commit,
+      documents,
+      actions: [latteAction],
+    })
+    if (!actionResults.ok) {
+      return Result.error(actionResults.error!)
+    }
+    const { changes } = actionResults.unwrap()
+
+    if (changes.length !== 1) {
+      return Result.error(
+        new BadRequestError(
+          `Expected exactly one document change, but got ${changes.length}.`,
+        ),
+      )
+    }
+
+    return Result.ok({
+      success: true,
+      deletedPromptUuid: document.documentUuid,
+      path,
+    })
+  },
+  z.object({
+    projectId: z.number(),
+    versionUuid: z.string(),
+    path: z.string(),
+  }),
+)
+
+export default deletePrompt


### PR DESCRIPTION
Latte originally had a single tool to modify prompts: `editProject`. This tool allowed to pass an array of actions with "create", "update" or "delete" types to modify prompts. However, this tool is too complex for Latte, as it required not only performing many actions at one, but handling many prompts at the same time.

Because of this complexity, we created `writePrompt`, a tool that allows Latte to either create or update a single prompt at a time.

Now, following this path, I have created `deletePrompt`.