### PR TITLE
Include draft triggers when checking references before deleting an integration

### DIFF
--- a/apps/web/src/app/(private)/settings/integrations/[integrationId]/destroy/page.tsx
+++ b/apps/web/src/app/(private)/settings/integrations/[integrationId]/destroy/page.tsx
@@ -10,25 +10,29 @@ import useIntegrationReferences from '$/stores/integrationReferences'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import useDocumentVersion from '$/stores/useDocumentVersion'
 import Link from 'next/link'
-import { HEAD_COMMIT, IntegrationReference } from '@latitude-data/constants'
+import { IntegrationReference } from '@latitude-data/constants'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
 import useProjects from '$/stores/projects'
 
-function ReferenceItem({ reference }: { reference: IntegrationReference }) {
-  const { data: document } = useDocumentVersion(reference.documentUuid)
+function TriggerReference({
+  reference: { data },
+}: {
+  reference: Extract<IntegrationReference, { type: 'trigger' }>
+}) {
+  const { data: document } = useDocumentVersion(data.documentUuid)
   const { data: projects } = useProjects()
   const project = useMemo(() => {
-    return projects.find((p) => p.id === reference.projectId)
-  }, [projects, reference.projectId])
+    return projects.find((p) => p.id === data.projectId)
+  }, [projects, data.projectId])
 
   return (
     <Link
       href={
         ROUTES.projects
-          .detail({ id: reference.projectId })
-          .commits.detail({ uuid: HEAD_COMMIT })
-          .documents.detail({ uuid: reference.documentUuid }).root
+          .detail({ id: data.projectId })
+          .commits.detail({ uuid: data.commitUuid })
+          .preview.triggers.edit(data.triggerUuid).root
       }
       className='flex flex-row items-center justify-between gap-2 p-4 bg-secondary rounded-md hover:bg-accent'
       target='_blank'
@@ -90,9 +94,13 @@ export default function DestroyIntegration({
             prompts:
           </Text.H5>
           <div className='flex flex-col gap-2'>
-            {references.map((reference, idx) => (
-              <ReferenceItem key={idx} reference={reference} />
-            ))}
+            {references.map((reference, idx) => {
+              if (reference.type === 'trigger') {
+                return <TriggerReference key={idx} reference={reference} />
+              }
+
+              return null
+            })}
           </div>
           <Text.H5>
             You must remove them all before deleting the integration.

--- a/packages/constants/src/integrations.ts
+++ b/packages/constants/src/integrations.ts
@@ -109,9 +109,15 @@ export enum HostedIntegrationType {
   // Loops = 'loops', // Does not exist
 }
 
-export type IntegrationReference = {
-  projectId: number
-  documentUuid: string
-  asTrigger: boolean
-  // asTool: boolean // TODO: This would be really useful
-}
+// TODO: Add support for tools: { type: 'tool', data: { ... } }
+export type IntegrationReference =
+  | {
+      type: 'trigger'
+      data: {
+        projectId: number
+        documentUuid: string
+        commitUuid: string
+        triggerUuid: string
+      }
+    }
+  | never

--- a/packages/core/src/repositories/commitsRepository/index.ts
+++ b/packages/core/src/repositories/commitsRepository/index.ts
@@ -6,6 +6,7 @@ import {
   isNotNull,
   isNull,
   lt,
+  inArray,
   not,
   or,
 } from 'drizzle-orm'
@@ -112,6 +113,10 @@ export class CommitsRepository extends RepositoryLegacy<
 
   async getCommits() {
     return this.db.select().from(this.scope)
+  }
+
+  async getCommitsByIds(ids: number[]) {
+    return this.db.select().from(this.scope).where(inArray(this.scope.id, ids))
   }
 
   async getFirstCommitForProject(project: Project) {

--- a/packages/core/src/services/integrations/destroy.ts
+++ b/packages/core/src/services/integrations/destroy.ts
@@ -17,9 +17,11 @@ export async function destroyIntegration(
 ) {
   return transaction.call(async (trx) => {
     const referencesResult = await listReferences(integration, trx)
+
     if (!Result.isOk(referencesResult)) {
       return referencesResult
     }
+
     const references = referencesResult.unwrap()
     if (references.length > 0) {
       return Result.error(

--- a/packages/core/src/services/integrations/references.test.ts
+++ b/packages/core/src/services/integrations/references.test.ts
@@ -82,9 +82,13 @@ describe('listReferences', () => {
     expect(Result.isOk(result)).toBe(true)
     expect(result.unwrap()).toEqual([
       {
-        projectId: trigger.projectId,
-        documentUuid: trigger.documentUuid,
-        asTrigger: true,
+        type: 'trigger',
+        data: {
+          projectId: trigger.projectId,
+          documentUuid: trigger.documentUuid,
+          commitUuid: commit.uuid,
+          triggerUuid: trigger.uuid,
+        },
       },
     ])
   })

--- a/packages/core/src/services/integrations/references.ts
+++ b/packages/core/src/services/integrations/references.ts
@@ -1,7 +1,10 @@
 import { LatitudeError } from '@latitude-data/constants/errors'
-import { DocumentTrigger, IntegrationDto } from '../../browser'
+import { Commit, DocumentTrigger, IntegrationDto } from '../../browser'
 import { PromisedResult } from '../../lib/Transaction'
-import { DocumentTriggersRepository } from '../../repositories'
+import {
+  CommitsRepository,
+  DocumentTriggersRepository,
+} from '../../repositories'
 import { database } from '../../client'
 import { Result } from '../../lib/Result'
 import {
@@ -9,16 +12,42 @@ import {
   IntegrationReference,
 } from '@latitude-data/constants'
 
+async function findCommitsByTrigger(
+  {
+    triggers,
+    workspaceId,
+  }: {
+    workspaceId: number
+    triggers: DocumentTrigger[]
+  },
+  db = database,
+): Promise<Map<number, Commit>> {
+  const commitsScope = new CommitsRepository(workspaceId, db)
+  const commitIds = triggers.map((t) => t.commitId)
+  const commits = await commitsScope.getCommitsByIds(commitIds)
+
+  // Create a Map of trigger.id -> Commit
+  const triggerToCommitMap = new Map<number, Commit>()
+
+  for (const trigger of triggers) {
+    const commit = commits.find((c: Commit) => c.id === trigger.commitId)
+    if (commit) {
+      triggerToCommitMap.set(trigger.id, commit)
+    }
+  }
+
+  return triggerToCommitMap
+}
+
 export async function listReferences(
   integration: IntegrationDto,
   db = database,
 ): PromisedResult<IntegrationReference[], LatitudeError> {
-  const triggersScope = new DocumentTriggersRepository(
-    integration.workspaceId,
-    db,
-  )
+  const workspaceId = integration.workspaceId
+  const triggersScope = new DocumentTriggersRepository(workspaceId, db)
 
-  const triggersResult = await triggersScope.getAllActiveTriggersInWorkspace()
+  const triggersResult = await triggersScope.getAllTriggers()
+
   if (!Result.isOk(triggersResult)) return triggersResult
 
   const triggers = triggersResult.unwrap()
@@ -29,11 +58,28 @@ export async function listReferences(
         .configuration.integrationId === integration.id,
   )
 
+  // Get commits for all triggers to include commitUuid in references
+  const triggerToCommitMap = await findCommitsByTrigger(
+    {
+      triggers: references,
+      workspaceId,
+    },
+    db,
+  )
+
   return Result.ok(
-    references.map((trigger) => ({
-      projectId: trigger.projectId,
-      documentUuid: trigger.documentUuid,
-      asTrigger: true,
-    })),
+    references.map((trigger) => {
+      const commit = triggerToCommitMap.get(trigger.id)
+      trigger
+      return {
+        type: 'trigger',
+        data: {
+          projectId: trigger.projectId,
+          documentUuid: trigger.documentUuid,
+          commitUuid: commit!.uuid,
+          triggerUuid: trigger.uuid,
+        },
+      }
+    }),
   )
 }


### PR DESCRIPTION
# What?
When showing destroy modal for integration show also in the list triggers that are draft versions of documents
<img width="716" height="503" alt="image" src="https://github.com/user-attachments/assets/2bc674ee-e9e1-4564-9c04-8ad433d1c4dc" />
