### PR TITLE
fix: "Actual output is required" in Latte feedback

### DIFF
--- a/packages/core/src/services/copilot/latte/threads/evaluateChanges.ts
+++ b/packages/core/src/services/copilot/latte/threads/evaluateChanges.ts
@@ -9,6 +9,10 @@ import {
 import { annotateEvaluationV2 } from '../../../evaluationsV2/annotate'
 import { getCopilotDocument } from '../helpers'
 import { NotImplementedError } from '@latitude-data/constants/errors'
+import {
+  AssistantMessage,
+  MessageRole,
+} from '@latitude-data/constants/legacyCompiler'
 
 export async function evaluateLatteThreadChanges(
   {
@@ -58,6 +62,22 @@ export async function evaluateLatteThreadChanges(
     return Result.error(evaluationResult.error!)
   }
   const evaluation = evaluationResult.unwrap()
+
+  // If output message is empty, fill it with "[ABORTED]"
+  if (providerLog.responseText === '') {
+    providerLog.responseText = '[ABORTED]'
+    providerLog.output = [
+      {
+        role: MessageRole.assistant,
+        content: [
+          {
+            type: 'text',
+            text: '[ABORTED]',
+          },
+        ],
+      } as AssistantMessage,
+    ]
+  }
 
   return annotateEvaluationV2(
     {


### PR DESCRIPTION
Fixes this issue:

<img width="500" height="247" alt="image" src="https://github.com/user-attachments/assets/5c3ed33a-a242-43de-b80a-e67650d0f598" />

To reproduce:
- Start a conversation with Latte
- Make it modify any files
- Ask something else, and immediately abort it before it generates any token
- Accept / Deny the changes