### PR TITLE
Improve rendering of latter streaming messages

### DIFF
--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/CollapsedInteractionSteps.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/CollapsedInteractionSteps.tsx
@@ -1,4 +1,4 @@
-import { LatteInteractionStep } from '$/hooks/latte/types'
+import { LatteStepGroup } from '$/hooks/latte/types'
 import { useEffect, useState } from 'react'
 import { InteractionStep } from './InteractionStep'
 
@@ -9,7 +9,7 @@ export const CollapsedInteractionSteps = ({
   isLoading = false,
   isStreaming = false,
 }: {
-  steps: LatteInteractionStep[]
+  steps: LatteStepGroup['steps'][number][]
   isLoading?: boolean
   isStreaming?: boolean
 }) => {

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/InteractionStep.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/InteractionStep.tsx
@@ -1,4 +1,4 @@
-import { LatteInteractionStep } from '$/hooks/latte/types'
+import { LatteStepGroup, LatteStepGroupItem } from '$/hooks/latte/types'
 import { LatteEditAction } from '@latitude-data/constants/latte'
 import { Icon, IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
@@ -10,7 +10,7 @@ export function InteractionStep({
   isLoading = false,
   isStreaming = false,
 }: {
-  step?: LatteInteractionStep
+  step?: LatteStepGroup['steps'][number]
   singleLine?: boolean
   isLoading?: boolean
   isStreaming?: boolean
@@ -19,8 +19,8 @@ export function InteractionStep({
     return (
       <Text.H5
         color='latteOutputForegroundMuted'
-        noWrap={singleLine}
-        ellipsis={singleLine}
+        noWrap
+        ellipsis
         userSelect={false}
         animate
       >
@@ -75,7 +75,7 @@ function ToolStep({
   isLoading,
   isStreaming,
 }: {
-  step: Extract<LatteInteractionStep, { type: 'tool' }>
+  step: Extract<LatteStepGroupItem, { type: 'tool' }>
   singleLine?: boolean
   isLoading?: boolean
   isStreaming?: boolean
@@ -155,7 +155,7 @@ function EditActionStep({
   isLoading,
   isStreaming,
 }: {
-  step: Extract<LatteInteractionStep, { type: 'action' }>
+  step: Extract<LatteStepGroupItem, { type: 'action' }>
   singleLine?: boolean
   isLoading?: boolean
   isStreaming?: boolean

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/MarkdownText.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/MarkdownText.tsx
@@ -1,9 +1,9 @@
+import { memo, LegacyRef, ReactNode, useMemo } from 'react'
 import { CodeBlock } from '@latitude-data/web-ui/atoms/CodeBlock'
 import { Icon, IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { Markdown } from '@latitude-data/web-ui/atoms/Markdown'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import Link from 'next/link'
-import React, { ReactNode, useMemo } from 'react'
 import type { Components } from 'react-markdown'
 
 function isCodeBlockInline(children: string, className?: string) {
@@ -48,7 +48,7 @@ function LatteLink({ children, href }: { children: ReactNode; href: string }) {
   )
 }
 
-export const MarkdownResponse = React.memo(
+export const MarkdownResponse = memo(
   function MarkdownResponse({ text }: { text: string }) {
     const components = useMemo<Components>(
       () => ({
@@ -87,7 +87,7 @@ export const MarkdownResponse = React.memo(
             return (
               <div
                 {...restProps}
-                ref={ref as React.LegacyRef<HTMLDivElement>}
+                ref={ref as LegacyRef<HTMLDivElement>}
                 className='bg-latte-background rounded-sm px-1 py-0.5 inline-flex flex-wrap'
               >
                 <Text.H6M color='latteInputForeground'>{content}</Text.H6M>

--- a/apps/web/src/components/LatteChat/_components/ChatInteraction/index.tsx
+++ b/apps/web/src/components/LatteChat/_components/ChatInteraction/index.tsx
@@ -1,27 +1,102 @@
-import { LatteInteraction } from '$/hooks/latte/types'
-import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { Fragment, ReactNode, useEffect, useState } from 'react'
+import { LatteInteraction, LatteStepGroup } from '$/hooks/latte/types'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { MarkdownResponse } from './MarkdownText'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { cn } from '@latitude-data/web-ui/utils'
-import { useEffect, useState } from 'react'
 import { CollapsedInteractionSteps } from './CollapsedInteractionSteps'
 import { InteractionStep } from './InteractionStep'
-import { MarkdownResponse } from './MarkdownText'
+
+function StepGroup({
+  group,
+  isLoading,
+  isStreaming,
+  isOpenLastGroup,
+  showLoaderIcon = false,
+}: {
+  group: LatteStepGroup
+  isLoading: boolean
+  isStreaming: boolean
+  isOpenLastGroup: boolean
+  showLoaderIcon?: boolean
+}) {
+  const [isOpen, setIsOpen] = useState(isOpenLastGroup)
+  useEffect(() => {
+    if (isOpenLastGroup) setIsOpen(true)
+  }, [isOpenLastGroup])
+  return (
+    <div
+      className='flex flex-row items-start gap-2 hover:opacity-80 cursor-pointer'
+      onClick={() => setIsOpen((prev) => !prev)}
+    >
+      <Icon
+        spin={showLoaderIcon}
+        name={showLoaderIcon ? 'loader' : 'chevronRight'}
+        color='latteOutputForegroundMuted'
+        className={cn('transition-all min-w-4 mt-0.5', {
+          'rotate-90': isOpen,
+        })}
+      />
+      <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
+        {isOpen && group.steps.length > 0 ? (
+          group.steps.map((step, i) => (
+            <InteractionStep
+              key={i}
+              step={step}
+              isLoading={isLoading && i === group.steps.length - 1}
+              isStreaming={isStreaming}
+            />
+          ))
+        ) : (
+          <CollapsedInteractionSteps
+            steps={group.steps}
+            isLoading={isLoading}
+            isStreaming={isStreaming}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function StepWrap({ children }: { children: ReactNode }) {
+  return (
+    <li className='flex flex-col gap-4 flex-grow max-w-[75%]'>{children}</li>
+  )
+}
+
+/**
+ * A step group with an empty group is in brewing state
+ * We use this to render this in the UI while the websocket arrives
+ * with the actual steps
+ */
+function BrewingStep({ isStreaming }: { isStreaming?: boolean }) {
+  if (!isStreaming) return null
+
+  return (
+    <StepWrap>
+      <StepGroup
+        showLoaderIcon
+        group={{ type: 'group', steps: [] }}
+        isLoading
+        isStreaming
+        isOpenLastGroup={false}
+      />
+    </StepWrap>
+  )
+}
 
 export function ChatInteraction({
   interaction,
-  isLoading,
-  isStreaming,
+  isLoading = false,
+  isStreaming = false,
 }: {
   interaction: LatteInteraction
   isLoading?: boolean
   isStreaming?: boolean
 }) {
-  const [isOpen, setIsOpen] = useState(false)
-  useEffect(() => {
-    if (isStreaming) setIsOpen(true)
-    else setIsOpen(false)
-  }, [isStreaming])
-
+  const onlyFirstText =
+    interaction.steps.length === 1 && interaction.steps[0]?.type === 'text'
   return (
     <div className='flex flex-col justify-center gap-4 w-full relative'>
       <div className='flex flex-col justify-center p-4 gap-2 bg-latte-input rounded-2xl ml-auto max-w-[75%]'>
@@ -34,42 +109,37 @@ export function ChatInteraction({
         </Text.H5>
       </div>
 
-      {interaction.steps.length > 0 || (!interaction.output && isStreaming) ? (
-        <div
-          className='flex flex-row items-start gap-2 hover:opacity-80 cursor-pointer'
-          onClick={() => setIsOpen((prev) => !prev)}
-        >
-          <Icon
-            name='chevronRight'
-            color='latteOutputForegroundMuted'
-            className={cn('transition-all min-w-4 mt-0.5', {
-              'rotate-90': isOpen,
+      <ul className='flex flex-col gap-4'>
+        {interaction.steps.length > 0 ? (
+          <>
+            {interaction.steps.map((step, i) => {
+              const isLastGroup =
+                step.type === 'group' && i === interaction.steps.length - 1
+              return (
+                <Fragment key={i}>
+                  <StepWrap key={i}>
+                    {step.type === 'text' ? (
+                      <MarkdownResponse text={step.text} />
+                    ) : step.type === 'group' ? (
+                      <StepGroup
+                        group={step}
+                        isStreaming={isLastGroup && isStreaming}
+                        isLoading={isLastGroup && isLoading}
+                        isOpenLastGroup={isLastGroup && isStreaming}
+                      />
+                    ) : null}
+                  </StepWrap>
+                  {onlyFirstText ? (
+                    <BrewingStep isStreaming={isStreaming} />
+                  ) : null}
+                </Fragment>
+              )
             })}
-          />
-          <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
-            {isOpen && interaction.steps.length > 0 ? (
-              interaction.steps.map((step, i) => (
-                <InteractionStep
-                  key={i}
-                  step={step}
-                  isLoading={isLoading && i === interaction.steps.length - 1}
-                  isStreaming={isStreaming}
-                />
-              ))
-            ) : (
-              <CollapsedInteractionSteps
-                steps={interaction.steps}
-                isLoading={isLoading}
-                isStreaming={isStreaming}
-              />
-            )}
-          </div>
-        </div>
-      ) : null}
-
-      <div className='flex flex-col gap-4 flex-grow max-w-[75%]'>
-        {interaction.output && <MarkdownResponse text={interaction.output} />}
-      </div>
+          </>
+        ) : (
+          <BrewingStep isStreaming={isStreaming} />
+        )}
+      </ul>
     </div>
   )
 }

--- a/apps/web/src/hooks/latte/types.ts
+++ b/apps/web/src/hooks/latte/types.ts
@@ -24,13 +24,24 @@ export type LatteActionStep = ILatteInteractionStep & {
   action: LatteEditAction
 }
 
-export type LatteInteractionStep =
+export type LatteTextStep = {
+  type: 'text'
+  text: string
+}
+
+export type LatteStepGroupItem =
   | LatteThoughtStep
   | LatteToolStep
   | LatteActionStep
 
+export type LatteStepGroup = {
+  type: 'group'
+  steps: LatteStepGroupItem[]
+}
+
+export type LatteInteractionStep = LatteStepGroup | LatteTextStep
+
 export type LatteInteraction = {
   input: string
   steps: LatteInteractionStep[]
-  output: string | undefined
 }

--- a/apps/web/src/hooks/latte/useLatteChatActions.ts
+++ b/apps/web/src/hooks/latte/useLatteChatActions.ts
@@ -68,7 +68,6 @@ export function useLatteChatActions() {
       const newInteraction: LatteInteraction = {
         input: message,
         steps: [],
-        output: undefined,
       }
 
       addInteractions([newInteraction])

--- a/apps/web/src/hooks/latte/useLoadThreadFromProviderLogs.ts
+++ b/apps/web/src/hooks/latte/useLoadThreadFromProviderLogs.ts
@@ -8,15 +8,14 @@ import { LatteInteraction } from './types'
 /**
  * Fetches the latest provider log for the current thread UUID.
  */
-const useLatteThreadProviderLog = () => {
-  const { threadUuid } = useLatteStore()
-  const { data: providerLogs, ...rest } = useProviderLogs({
+const useLatteThreadProviderLog = ({ threadUuid }: { threadUuid?: string }) => {
+  const { data: providerLogs, isLoading } = useProviderLogs({
     documentLogUuid: threadUuid,
   })
   const { data: providerLog } = useProviderLog(
     sortBy(providerLogs, 'generatedAt').at(-1)?.id,
   )
-  return useMemo(() => ({ providerLog, ...rest }), [providerLog, rest])
+  return useMemo(() => ({ providerLog, isLoading }), [providerLog, isLoading])
 }
 
 /**
@@ -26,48 +25,59 @@ const useLatteThreadProviderLog = () => {
  * Only runs if there are no previous interactions stored in the current chat state so to avoid overriding the current state.
  */
 export function useLoadThreadFromProviderLogs() {
-  const { interactions, setInteractions } = useLatteStore()
-  const { providerLog, isLoading } = useLatteThreadProviderLog()
+  const { threadUuid, interactions, setInteractions } = useLatteStore()
+  const { providerLog, isLoading } = useLatteThreadProviderLog({ threadUuid })
 
   useEffect(() => {
     if (interactions.length > 0) return
     if (!providerLog) return
 
-    // iterate over provider log messages and transform them to an array of interactions. Interactors are input/output pairs input defined as any message from a user and outputs defined as all messages not from user until the next user message.
+    // iterate over provider log messages and transform them to an array of interactions.
+    // Interactors are input/output pairs input defined as any message from a user and outputs
+    // defined as all messages not from user until the next user message.
     const messages = providerLog.messages || []
     const _interactions: LatteInteraction[] = []
     let currentInteraction: LatteInteraction | null = null
 
     for (const message of messages) {
       if (message.role === 'user') {
-        // Start a new interaction for user messages
         if (currentInteraction) {
           _interactions.push(currentInteraction)
         }
+
         currentInteraction = {
           input:
             message.content.filter((t) => t.type === 'text').at(-1)?.text ?? '',
           steps: [],
-          output: undefined,
         }
       } else if (message.role === 'assistant' && currentInteraction) {
-        currentInteraction.output =
+        const textContent =
           typeof message.content === 'string'
             ? message.content
             : // @ts-expect-error - cast message content to TextContent
               (message.content.filter((t) => t.type === 'text').at(-1)?.text ??
               '')
+
+        if (textContent) {
+          currentInteraction.steps.push({
+            type: 'text',
+            text: textContent,
+          })
+        }
       }
     }
 
-    // Add the last interaction if it exists
     if (currentInteraction) {
-      currentInteraction.output = providerLog.response
+      if (providerLog.response) {
+        currentInteraction.steps.push({
+          type: 'text',
+          text: providerLog.response,
+        })
+      }
 
       _interactions.push(currentInteraction)
     }
 
-    // Update the interactions state if we have any
     if (_interactions.length > 0) {
       setInteractions(_interactions)
     }


### PR DESCRIPTION
# What?
Unify steps and output making a new type of step in interaction for the text delta. This way iterating the steps is easier and fix an issue we have where streamed text is concatenated without space and after the tools where it should go before the tools.


### Improve text render of text deltas

Before: `I'll create a pokemon guesser agent that provides cryptic descriptions for you to guess.Perfect! I've created....`

After: 
```
I'll create a pokemon guesser agent that provides cryptic descriptions for you to guess. Perfect! I've created....
```
☝️ Notice the space between `guess.` and `Perfect!...`


### TODO
- [x] Change grouping logic

### Grouping logic
We want to accumulate steps by type: `text` and the rest. So what we render are groups of steps. 

```bash
TEXT
> [
  TOOL
  THINKING
]

TEXT

> [
  TOOL
  THINKING
]
...
```
