### PR TITLE
Implement CRUD functionality for Latte Chat triggers

### DIFF
--- a/apps/web/src/hooks/latte/helpers.ts
+++ b/apps/web/src/hooks/latte/helpers.ts
@@ -17,7 +17,8 @@ export function getDescriptionFromToolCall(
 
 function getTriggerName(params: Record<string, unknown>): string {
   return (params.componentId ||
-    (params.action as Record<string, unknown>).triggerType) as string
+    (params.triggerSpecification as Record<string, unknown>)
+      .triggerType) as string
 }
 
 function getDescriptionFromLatteTool(
@@ -164,7 +165,7 @@ function getLatteSubagentDescription(
       }
     case 'lat_agent_latte_managers_build_manager':
       return {
-        activeDescription: 'Planning out next moves...',
+        activeDescription: 'Planning out the brewing process...',
         finishedDescription: 'Brewed to perfection',
       }
     case 'lat_agent_latte_managers_investigator':

--- a/packages/constants/src/latte/triggers.ts
+++ b/packages/constants/src/latte/triggers.ts
@@ -1,5 +1,6 @@
 import { DocumentTriggerType } from '..'
 import {
+  ChatTriggerConfiguration,
   EmailTriggerConfiguration,
   IntegrationTriggerConfiguration,
   ScheduledTriggerConfiguration,
@@ -11,6 +12,10 @@ type LatteDeleteScheduledTriggerAction = {
 
 type LatteDeleteEmailTriggerAction = {
   triggerType: DocumentTriggerType.Email
+}
+
+type LatteDeleteChatTriggerAction = {
+  triggerType: DocumentTriggerType.Chat
 }
 
 type LatteDeleteIntegrationTriggerAction = {
@@ -33,13 +38,20 @@ type LatteUpdateIntegrationTriggerAction = {
   configuration: IntegrationTriggerConfiguration
 }
 
+type LatteUpdateChatTriggerAction = {
+  triggerType: DocumentTriggerType.Chat
+  configuration: ChatTriggerConfiguration
+}
+
 export type LatteTriggerAction =
   | LatteDeleteScheduledTriggerAction
   | LatteDeleteEmailTriggerAction
   | LatteDeleteIntegrationTriggerAction
+  | LatteDeleteChatTriggerAction
   | LatteUpdateScheduledTriggerAction
   | LatteUpdateEmailTriggerAction
   | LatteUpdateIntegrationTriggerAction
+  | LatteUpdateChatTriggerAction
 
 export type LatteTriggerChanges = {
   projectId: number

--- a/packages/core/src/services/copilot/latte/tools/documents/list.ts
+++ b/packages/core/src/services/copilot/latte/tools/documents/list.ts
@@ -25,13 +25,13 @@ const listPrompts = defineLatteTool(
 
     const documentTriggerScope = new DocumentTriggersRepository(workspace.id)
 
-    const existingTriggersAtLiveCommit = await documentTriggerScope
+    const existingTriggersAtCommit = await documentTriggerScope
       .getTriggersInProject({ projectId, commit })
       .then((r) => r.unwrap())
 
     const promptObjects = await Promise.all(
       documents.map(async (doc) => {
-        const existingTriggers = existingTriggersAtLiveCommit.filter(
+        const existingTriggers = existingTriggersAtCommit.filter(
           (trigger) => trigger.documentUuid === doc.documentUuid,
         )
         return promptPresenter({

--- a/packages/core/src/services/copilot/latte/tools/triggers/actions/createTrigger.test.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/actions/createTrigger.test.ts
@@ -29,7 +29,7 @@ describe('Latte create document triggers', () => {
   let commit: Commit
   let documents: DocumentVersion[]
   let promptUuid: string
-  let action
+  let triggerSpecification
 
   beforeEach(async () => {
     const project = await factories.createProject({
@@ -66,7 +66,7 @@ describe('Latte create document triggers', () => {
       })
     })
 
-    const action: {
+    const triggerSpecification: {
       triggerType: DocumentTriggerType.Email
       configuration: EmailTriggerConfiguration
     } = {
@@ -82,7 +82,7 @@ describe('Latte create document triggers', () => {
         projectId: 1,
         versionUuid: 'commit-uuid',
         promptUuid: '1111-1111-1111-1111',
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -108,7 +108,7 @@ describe('Latte create document triggers', () => {
       })
     })
 
-    const action: {
+    const triggerSpecification: {
       triggerType: DocumentTriggerType.Email
       configuration: EmailTriggerConfiguration
     } = {
@@ -124,7 +124,7 @@ describe('Latte create document triggers', () => {
         projectId: 1,
         versionUuid: 'commit-uuid',
         promptUuid: '1111-1111-1111-1111',
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -136,7 +136,7 @@ describe('Latte create document triggers', () => {
   })
 
   it('should create a document trigger', async () => {
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
       configuration: {
         name: 'Test Email Trigger',
@@ -164,7 +164,7 @@ describe('Latte create document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -176,7 +176,7 @@ describe('Latte create document triggers', () => {
   })
 
   it('should handle document not found when creating a trigger', async () => {
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
       configuration: {
         name: 'Test Email Trigger',
@@ -193,7 +193,7 @@ describe('Latte create document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid: '00000000-0000-0000-0000-000000000000',
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -205,7 +205,7 @@ describe('Latte create document triggers', () => {
   })
 
   it('should throw an error if creating a trigger fails', async () => {
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
       configuration: {
         cronExpression: '* * * 9 0',
@@ -225,7 +225,7 @@ describe('Latte create document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,

--- a/packages/core/src/services/copilot/latte/tools/triggers/actions/deleteTrigger.test.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/actions/deleteTrigger.test.ts
@@ -19,7 +19,7 @@ describe('Latte delete document triggers', () => {
   let commit: Commit
   let documents: DocumentVersion[]
   let promptUuid: string
-  let action
+  let triggerSpecification
 
   beforeEach(async () => {
     const project = await factories.createProject({
@@ -42,7 +42,7 @@ describe('Latte delete document triggers', () => {
     documents = project.documents
     promptUuid = documents[0]!.documentUuid
 
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
       configuration: {
         name: 'Test Email Trigger',
@@ -55,7 +55,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -66,7 +66,7 @@ describe('Latte delete document triggers', () => {
 
   it('should delete a document trigger', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
     }
 
@@ -83,7 +83,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -97,7 +97,7 @@ describe('Latte delete document triggers', () => {
 
   it('should handle document not found when deleting a trigger', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
     }
 
@@ -111,7 +111,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid: '00000000-0000-0000-0000-000000000000', // Non-existent UUID
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -125,7 +125,7 @@ describe('Latte delete document triggers', () => {
 
   it('should throw an error if deleting a trigger fails', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Email as const,
     }
     const expectedError = new Error('Failed to delete document trigger')
@@ -140,7 +140,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -153,7 +153,7 @@ describe('Latte delete document triggers', () => {
 
   it('should throw error if deleting email trigger that does not exist but integration triggers do', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
     }
 
@@ -167,7 +167,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -189,7 +189,7 @@ describe('Latte delete document triggers', () => {
       },
     })
 
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Integration as const,
       configuration: {
         componentId: 'non-existent-component-id',
@@ -207,7 +207,7 @@ describe('Latte delete document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,

--- a/packages/core/src/services/copilot/latte/tools/triggers/actions/deleteTrigger.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/actions/deleteTrigger.ts
@@ -15,7 +15,7 @@ import { LatteTriggerChanges } from '@latitude-data/constants/latte'
 
 const deleteTrigger = defineLatteTool(
   async (
-    { projectId, versionUuid, promptUuid, action },
+    { projectId, versionUuid, promptUuid, triggerSpecification },
     { workspace },
   ): PromisedResult<LatteTriggerChanges> => {
     const commitsScope = new CommitsRepository(workspace.id)
@@ -34,7 +34,7 @@ const deleteTrigger = defineLatteTool(
     }
 
     const triggerResult = await getTriggerDocument(
-      action,
+      triggerSpecification,
       workspace.id,
       currentVersionCommit,
       promptUuid,
@@ -46,7 +46,7 @@ const deleteTrigger = defineLatteTool(
 
     const documentTrigger = triggerResult.unwrap()
 
-    if (action.triggerType === DocumentTriggerType.Integration) {
+    if (triggerSpecification.triggerType === DocumentTriggerType.Integration) {
       const projectsRepository = new ProjectsRepository(workspace.id)
       const project = await projectsRepository
         .getProjectById(currentVersionCommit.projectId)
@@ -75,14 +75,14 @@ const deleteTrigger = defineLatteTool(
       projectId: currentVersionCommit.projectId,
       versionUuid: currentVersionCommit.uuid,
       promptUuid: promptUuid,
-      triggerType: action.triggerType,
+      triggerType: triggerSpecification.triggerType,
     })
   },
   z.object({
     projectId: z.number(),
     versionUuid: z.string(),
     promptUuid: z.string(),
-    action: z.union([
+    triggerSpecification: z.union([
       z.object({
         triggerType: z.literal(DocumentTriggerType.Email),
       }),
@@ -92,6 +92,9 @@ const deleteTrigger = defineLatteTool(
       z.object({
         triggerType: z.literal(DocumentTriggerType.Integration),
         configuration: integrationTriggerConfigurationSchema,
+      }),
+      z.object({
+        triggerType: z.literal(DocumentTriggerType.Chat),
       }),
     ]),
   }),

--- a/packages/core/src/services/copilot/latte/tools/triggers/actions/getTriggerDocument.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/actions/getTriggerDocument.ts
@@ -8,7 +8,7 @@ import { NotFoundError } from '@latitude-data/constants/errors'
 import { DocumentTriggersRepository } from '../../../../../../repositories'
 
 export async function getTriggerDocument(
-  action: LatteTriggerAction,
+  triggerSpecification: LatteTriggerAction,
   workspaceId: number,
   commit: Commit,
   promptUuid: string,
@@ -30,20 +30,23 @@ export async function getTriggerDocument(
     )
   }
 
-  if (action.triggerType === DocumentTriggerType.Integration) {
+  if (triggerSpecification.triggerType === DocumentTriggerType.Integration) {
     const integrationTriggers = documentTriggers.filter(
       (trigger) => trigger.triggerType === DocumentTriggerType.Integration,
     )
 
     const integrationTrigger = integrationTriggers.find((trigger) => {
       const config = trigger.configuration as IntegrationTriggerConfiguration
-      return config.integrationId === action.configuration.integrationId
+      return (
+        config.integrationId ===
+        triggerSpecification.configuration.integrationId
+      )
     })
 
     if (!integrationTrigger) {
       return Result.error(
         new NotFoundError(
-          `Integration trigger with ID ${action.configuration.integrationId} not found for document with UUID ${promptUuid}.`,
+          `Integration trigger with ID ${triggerSpecification.configuration.integrationId} not found for document with UUID ${promptUuid}.`,
         ),
       )
     }
@@ -53,13 +56,13 @@ export async function getTriggerDocument(
 
   // For email and scheduled triggers, there can only be one per document
   const triggerOfType = documentTriggers.find(
-    (trigger) => trigger.triggerType === action.triggerType,
+    (trigger) => trigger.triggerType === triggerSpecification.triggerType,
   )
 
   if (!triggerOfType) {
     return Result.error(
       new NotFoundError(
-        `${action.triggerType} trigger not found for document with UUID ${promptUuid}.`,
+        `${triggerSpecification.triggerType} trigger not found for document with UUID ${promptUuid}.`,
       ),
     )
   }

--- a/packages/core/src/services/copilot/latte/tools/triggers/actions/updateTrigger.test.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/actions/updateTrigger.test.ts
@@ -29,7 +29,7 @@ describe('Latte update document triggers', () => {
   let commit: Commit
   let documents: DocumentVersion[]
   let promptUuid: string
-  let action
+  let triggerSpecification
 
   beforeEach(async () => {
     const project = await factories.createProject({
@@ -52,7 +52,7 @@ describe('Latte update document triggers', () => {
     documents = project.documents
     promptUuid = documents[0]!.documentUuid
 
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
       configuration: {
         cronExpression: '0 * * * *',
@@ -64,7 +64,7 @@ describe('Latte update document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -85,7 +85,7 @@ describe('Latte update document triggers', () => {
       })
     })
 
-    const action: {
+    const triggerSpecification: {
       triggerType: DocumentTriggerType.Email
       configuration: EmailTriggerConfiguration
     } = {
@@ -101,7 +101,7 @@ describe('Latte update document triggers', () => {
         projectId: 1,
         versionUuid: 'commit-uuid',
         promptUuid: '1111-1111-1111-1111',
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -127,7 +127,7 @@ describe('Latte update document triggers', () => {
       })
     })
 
-    const action: {
+    const triggerSpecification: {
       triggerType: DocumentTriggerType.Email
       configuration: EmailTriggerConfiguration
     } = {
@@ -143,7 +143,7 @@ describe('Latte update document triggers', () => {
         projectId: 1,
         versionUuid: 'commit-uuid',
         promptUuid: '1111-1111-1111-1111',
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -156,7 +156,7 @@ describe('Latte update document triggers', () => {
 
   it('should update a document trigger', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
       configuration: {
         cronExpression: '0 0 0 0 0',
@@ -176,7 +176,7 @@ describe('Latte update document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -190,7 +190,7 @@ describe('Latte update document triggers', () => {
 
   it('should handle document not found when updating a trigger', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
       configuration: {
         cronExpression: '0 0 0 0 0',
@@ -207,7 +207,7 @@ describe('Latte update document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid: '00000000-0000-0000-0000-000000000000', // Non-existent UUID
-        action,
+        triggerSpecification,
       },
       {
         workspace,
@@ -221,7 +221,7 @@ describe('Latte update document triggers', () => {
 
   it('should throw an error if updating a trigger fails', async () => {
     // Arrange
-    action = {
+    triggerSpecification = {
       triggerType: DocumentTriggerType.Scheduled as const,
       configuration: {
         cronExpression: '0 0 0 0 0',
@@ -245,7 +245,7 @@ describe('Latte update document triggers', () => {
         projectId: commit.projectId,
         versionUuid: commit.uuid,
         promptUuid,
-        action,
+        triggerSpecification,
       },
       {
         workspace,

--- a/packages/core/src/services/copilot/latte/tools/triggers/listIntegrationTriggers.ts
+++ b/packages/core/src/services/copilot/latte/tools/triggers/listIntegrationTriggers.ts
@@ -7,7 +7,7 @@ import { buildLatitudeIntegration } from '../../../../integrations/list'
 
 const listIntegrationTriggers = defineLatteTool(
   async ({ name }, { workspace }) => {
-    // TODO - change when we merge Latitude integrations with its triggers
+    // For Latte, we are listing the triggers from the Latitude integration for it to better understand
     if (name === 'latitude') {
       const latitudeIntegration = buildLatitudeIntegration(workspace)
       const triggersResult = await listTriggers(latitudeIntegration)

--- a/packages/core/src/services/integrations/McpClient/listTriggers.ts
+++ b/packages/core/src/services/integrations/McpClient/listTriggers.ts
@@ -37,7 +37,12 @@ export async function listTriggers(integration: IntegrationDto): PromisedResult<
       description: 'Trigger that runs when an email is received',
     }
 
-    return Result.ok([scheduledTrigger, emailTrigger])
+    const chatTrigger = {
+      name: 'Chat Trigger',
+      description: 'Trigger that runs when a chat message is received',
+    }
+
+    return Result.ok([scheduledTrigger, emailTrigger, chatTrigger])
   }
 
   return Result.error(new NotImplementedError('Unsupported integration type'))


### PR DESCRIPTION
Latte was not aware of the existence of Chat triggers. This PR adds the capability for Latte to CRUD Chat triggers.

# TODOS
- [x] Add capability for Latte to CRUD Latte Chat triggers
- [x] Aligned Latte interaction steps to our brand
- [x] Improved naming "action" argument of Latte trigger tools to be clearer 