### PR TITLE
Wait for backend to update document configuration until enable sub-agents and integrations toggles once the user clicks on one of the toggles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ apps/web/scripts-dist
 # File uploads in development
 apps/web/uploads
 apps/web/public/uploads
+apps/web/public/storage
 uploads
+storage
 
 # Temporal
 tmp

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentEditor.tsx
@@ -77,7 +77,8 @@ function DocumentEditorContent({
   freeRunsCount,
   refinementEnabled,
 }: Omit<DocumentEditorProps, 'experimentDiff'>) {
-  const { updateDocumentContent, document } = useDocumentValue()
+  const { updateDocumentContent, isUpdatingContent, document } =
+    useDocumentValue()
   const [mode, setMode] = useState<'preview' | 'chat'>('preview')
   const { metadata } = useMetadata()
   const { commit } = useCurrentCommit()
@@ -186,6 +187,7 @@ function DocumentEditorContent({
             <AgentToolbar
               isMerged={isMerged}
               isAgent={metadata?.config?.type === 'agent'}
+              isUpdatingContent={isUpdatingContent}
               config={metadata?.config}
               prompt={document.content}
               onChangePrompt={updateDocumentContent}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/EditorHeader/AgentToolbar/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/EditorHeader/AgentToolbar/index.tsx
@@ -149,11 +149,10 @@ function SubAgentItem({
   isFirst?: boolean
   disabled?: boolean
 }) {
-  const [checked, setChecked] = useState(availableAgents.includes(agentPath))
+  const checked = availableAgents.includes(agentPath)
   const onClick = useCallback(() => {
-    setChecked(!checked)
     toggleAgent(agentPath)
-  }, [toggleAgent, agentPath, checked])
+  }, [toggleAgent, agentPath])
   const name = agentPath.split('/').pop() || ''
   return (
     <ItemWrapper isFirst={isFirst}>
@@ -171,7 +170,9 @@ function SubAgentItem({
     </ItemWrapper>
   )
 }
+
 function Content({
+  isUpdatingContent,
   isMerged,
   prompt,
   selectedTab,
@@ -181,6 +182,7 @@ function Content({
   selectedTab: TabSection
   prompt: EditorHeaderProps['prompt']
   subAgents: UseLatitudeAgentsConfig
+  isUpdatingContent: boolean
 }) {
   const { data: integrations, isLoading } = useIntegrations({
     includeLatitudeTools: true,
@@ -195,7 +197,7 @@ function Content({
     <>
       {selectedTab === TAB_SECTIONS.tools ? (
         <IntegrationsList
-          disabled={isMerged}
+          disabled={isMerged || isUpdatingContent}
           isLoading={isLoading}
           integrations={integrations ?? []}
           activeIntegrations={activeIntegrations as ActiveIntegrations}
@@ -213,7 +215,7 @@ function Content({
                 agentPath={agent}
                 toggleAgent={subAgents.toggleAgent}
                 availableAgents={subAgents.selectedAgents}
-                disabled={isMerged}
+                disabled={isMerged || isUpdatingContent}
               />
             </li>
           ))}
@@ -231,10 +233,12 @@ export function AgentToolbar({
   isAgent,
   config,
   onChangePrompt,
+  isUpdatingContent,
   prompt,
   isMerged,
 }: {
   isAgent: boolean
+  isUpdatingContent: boolean
   config: Config | undefined
   onChangePrompt: EditorHeaderProps['onChangePrompt']
   prompt: EditorHeaderProps['prompt']
@@ -318,6 +322,7 @@ export function AgentToolbar({
                 prompt={prompt}
                 selectedTab={tabs.selected}
                 subAgents={counters.subAgents}
+                isUpdatingContent={isUpdatingContent}
               />
             </div>
           }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/EditorHeader/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/EditorHeader/index.tsx
@@ -8,6 +8,7 @@ export type EditorHeaderProps = {
   freeRunsCount: number | undefined
   isLatitudeProvider: boolean
   isMerged: boolean
+  isUpdatingContent: boolean
   metadata: ResolvedMetadata | undefined
   onChangePrompt: (prompt: string) => void
   prompt: string
@@ -22,6 +23,7 @@ export const EditorHeader = memo(
     isMerged,
     isLatitudeProvider,
     freeRunsCount,
+    isUpdatingContent,
     onChangePrompt,
   }: EditorHeaderProps) => {
     const metadataConfig = metadata?.config
@@ -43,6 +45,7 @@ export const EditorHeader = memo(
         <AgentToolbar
           isMerged={isMerged}
           isAgent={isAgent}
+          isUpdatingContent={isUpdatingContent}
           config={metadataConfig}
           prompt={prompt}
           onChangePrompt={onChangePrompt}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/OldDocumentEditor.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/OldDocumentEditor.tsx
@@ -69,7 +69,8 @@ function OldDocumentEditorContent({
   const { data: providers } = useProviderApiKeys({
     fallbackData: providerApiKeys,
   })
-  const { document, value, updateDocumentContent, isSaved } = useDocumentValue()
+  const { document, value, updateDocumentContent, isSaved, isUpdatingContent } =
+    useDocumentValue()
   const { diff: latteDiff } = useSyncLatteChanges()
   const { diff: experimentDiff, setDiff: setEditorDiff } = useExperimentDiff()
   const oldHeaderEditorActions = useOldEditorHeaderActions({
@@ -127,6 +128,7 @@ function OldDocumentEditorContent({
                   isLatitudeProvider={isLatitudeProvider}
                   isMerged={isMerged}
                   freeRunsCount={freeRunsCount}
+                  isUpdatingContent={isUpdatingContent}
                 />
               ) : (
                 <EvaluationEditorHeader

--- a/apps/web/src/hooks/useDocumentValueContext.tsx
+++ b/apps/web/src/hooks/useDocumentValueContext.tsx
@@ -35,6 +35,7 @@ type DocumentValueContextType = {
   updateDocumentContent: updateContentFn
   document: DocumentVersion
   isSaved: boolean
+  isUpdatingContent: boolean
 }
 
 const DocumentValueContext = createContext<
@@ -126,6 +127,7 @@ export function DocumentValueProvider({
         setValue: setContentValue,
         updateDocumentContent,
         isSaved: !isUpdatingContent,
+        isUpdatingContent,
         document,
       }}
     >


### PR DESCRIPTION
# What?
What was happening if the user clicks to fast, we were entering on desynchronized states between what's in the document frontmatter and the UI for the integrations and sub-agents toggles.