### PR TITLE
fix-websockets-order

### DIFF
--- a/apps/websockets/package.json
+++ b/apps/websockets/package.json
@@ -18,6 +18,7 @@
     "@latitude-data/telemetry": "workspace:*",
     "cookie-parser": "1.4.6",
     "express": "4.21.0",
+    "ioredis": "5.6.0",
     "socket.io": "4.7.5"
   },
   "devDependencies": {

--- a/packages/core/src/websockets/workers.test.ts
+++ b/packages/core/src/websockets/workers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { WebsocketClient } from './workers'
+
+// Mock ioredis
+vi.mock('ioredis', () => ({
+  default: class MockRedis {
+    publish = vi.fn()
+    disconnect = vi.fn()
+  },
+}))
+
+describe('WebsocketClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('sendEvent', () => {
+    it('should publish a WebSocket event to Redis channel', async () => {
+      const testEvent = 'latteThreadUpdate'
+      const testData = {
+        workspaceId: 123,
+        data: {
+          threadUuid: 'test-thread',
+          type: 'toolStarted',
+          toolCallId: 'tool-123',
+          toolName: 'test-tool',
+        },
+      }
+
+      const client = WebsocketClient.getInstance()
+      const result = await client.sendEvent(testEvent, testData)
+
+      // Get the Redis instance to check the call
+      const redisInstance = await (client as any).getRedisClient()
+
+      // Verify the Redis publish was called with correct parameters
+      expect(redisInstance.publish).toHaveBeenCalledWith(
+        'websocket:workspace:123',
+        expect.stringContaining('"event":"latteThreadUpdate"'),
+      )
+
+      // Parse the message to verify structure
+      const publishCall = redisInstance.publish.mock.calls[0]
+      const channel = publishCall[0]
+      const message = JSON.parse(publishCall[1])
+
+      expect(channel).toBe('websocket:workspace:123')
+      expect(message).toMatchObject({
+        event: testEvent,
+        workspaceId: testData.workspaceId,
+        data: testData.data,
+        timestamp: expect.any(Number),
+      })
+
+      // Verify the result
+      expect(result).toEqual({
+        success: true,
+        channel: 'websocket:workspace:123',
+      })
+    })
+
+    it('should handle Redis publish errors gracefully', async () => {
+      // Mock Redis to throw error on publish
+      const publishError = new Error('Redis connection failed')
+
+      // Create a new instance and spy on it
+      const client = WebsocketClient.getInstance()
+      const redisInstance = await (client as any).getRedisClient()
+      redisInstance.publish.mockRejectedValue(publishError)
+
+      const testEvent = 'latteThreadUpdate'
+      const testData = {
+        workspaceId: 123,
+        data: { message: 'test' },
+      }
+
+      await expect(client.sendEvent(testEvent, testData)).rejects.toThrow(
+        'Failed to publish WebSocket event: Error: Redis connection failed',
+      )
+    })
+
+    it('should maintain singleton instance', () => {
+      const instance1 = WebsocketClient.getInstance()
+      const instance2 = WebsocketClient.getInstance()
+
+      expect(instance1).toBe(instance2)
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       express:
         specifier: 4.21.0
         version: 4.21.0
+      ioredis:
+        specifier: 5.6.0
+        version: 5.6.0
       socket.io:
         specifier: 4.7.5
         version: 4.7.5
@@ -21466,7 +21469,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.3)
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.31.0)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
@@ -23491,7 +23494,7 @@ snapshots:
       eslint-plugin-turbo: 2.5.4(eslint@8.57.1)(turbo@2.5.5)
       turbo: 2.5.5
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.31.0):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
 


### PR DESCRIPTION
### Problem

Currently, when a worker needs to send a message to a browser client, it must go through our WebSocket Server first:

```
WORKER ---HTTP---> WEBSOCKET SERVER ---WebSocket---> BROWSER
```

However, this approach has a major drawback:
Each message is sent as a separate HTTP request. Because the WebSocket server handles these requests independently, message order is **not guaranteed**. Network latency, payload size, and request handling can all cause messages to arrive out of sequence.

---

### Solution

Instead of sending individual HTTP requests, workers now publish messages to **Redis PubSub**.
The WebSocket Server subscribes to the Redis channel and forwards messages to the browser:

```
WORKER ---PubSub---> REDIS ---Subscription---> WEBSOCKET SERVER ---WebSocket---> BROWSER
```

Redis PubSub preserves **FIFO (first-in, first-out)** order, ensuring that messages always reach the client in the correct sequence.

---

### Benefits

* ✅ Guaranteed message ordering
* ✅ Reduced overhead on the WebSocket Server
* ✅ Cleaner separation of responsibilities between workers and message delivery
