### PR TITLE
chore: add workers build to catchup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "prettier --write \"{apps,packages}/**/*.{ts,tsx,md}\" --ignore-path .prettierrcignore",
     "prettier:check": "prettier --check \"**/*.{ts,tsx,md}\" --ignore-path .prettierrcignore",
     "test": "turbo test",
-    "catchup": "pnpm i && pnpm build --filter=\"./packages/**/*\" && pnpm --filter \"@latitude-data/core\" db:migrate",
+    "catchup": "pnpm i && pnpm build --filter=\"./packages/**/*\" && pnpm --filter \"@latitude-data/web\" workers:build && pnpm --filter \"@latitude-data/core\" db:migrate",
     "console": "clear && ./bin/console.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Could be useful for us, as catchup is the one-shot pnpm tool we use to get the project updated from changes done from other devs