### PR TITLE
Integrations table - Add sorting and created at field

### DIFF
--- a/packages/web-ui/src/ds/atoms/Table/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Table/index.tsx
@@ -306,3 +306,5 @@ export {
   ServerSideTableCell,
   TableCaption,
 }
+
+export { SortableTableHead, type SortDirection } from './sortedTable'

--- a/packages/web-ui/src/ds/atoms/Table/sortedTable/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Table/sortedTable/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react'
+import { TableHead } from '..'
+import { Icon } from '../../Icons'
+import { Text } from '../../Text'
+
+type SortDirection = 'asc' | 'desc' | null
+
+interface SortableTableHeadProps {
+  children: ReactNode
+  sortDirection: SortDirection
+  onSort: () => void
+}
+
+const SortableTableHead = ({
+  children,
+  sortDirection,
+  onSort,
+}: SortableTableHeadProps) => {
+  const getSortIcon = () => {
+    if (sortDirection === 'asc') return 'arrowUp'
+    if (sortDirection === 'desc') return 'arrowDown'
+    return 'arrowDownUp'
+  }
+
+  return (
+    <TableHead
+      className='cursor-pointer hover:bg-secondary/50 transition-colors'
+      onClick={onSort}
+    >
+      <div className='flex items-center gap-2'>
+        <Text.H5M noWrap>{children}</Text.H5M>
+        <Icon name={getSortIcon()} size='small' color='foregroundMuted' />
+      </div>
+    </TableHead>
+  )
+}
+
+export { SortableTableHead, type SortDirection }


### PR DESCRIPTION
Through my use of the app, there were times I wanted to know when the integration was created, and wanted to sort them by when it was last used or created at. This PR adds these functionalities


https://github.com/user-attachments/assets/b1a17462-1f22-4c2b-8d36-9a58a6495096

