### PR TITLE
Latte: show new unconfigured integrations in chat

### DIFF
--- a/apps/web/src/components/LatteChat/_components/UnconfiguredIntegrations.tsx
+++ b/apps/web/src/components/LatteChat/_components/UnconfiguredIntegrations.tsx
@@ -1,0 +1,37 @@
+import { UnconfiguredIntegration } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/UnconfiguredIntegrations'
+import useIntegrations from '$/stores/integrations'
+import { useLatteStore } from '$/stores/latte'
+import { IntegrationType } from '@latitude-data/constants'
+import { PipedreamIntegration } from '@latitude-data/core/browser'
+import { useEffect, useMemo } from 'react'
+
+export function LatteUnconfiguredIntegrations() {
+  const { data: integrations, mutate } = useIntegrations()
+  const { newIntegrationIds } = useLatteStore()
+
+  const newUnconfiguredIntegrations = useMemo(() => {
+    return integrations.filter((integration) => {
+      if (!newIntegrationIds.includes(integration.id)) return false
+      if (integration.type !== IntegrationType.Pipedream) return false
+      return !('connectionId' in integration.configuration)
+    }) as PipedreamIntegration[]
+  }, [integrations, newIntegrationIds])
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      mutate()
+    }, 1000)
+    return () => clearTimeout(timeout)
+  }, [newIntegrationIds, mutate])
+
+  return (
+    <div className='flex flex-col gap-2 w-full px-8'>
+      {newUnconfiguredIntegrations.map((integration) => (
+        <UnconfiguredIntegration
+          key={integration.id}
+          integration={integration}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/LatteChat/index.tsx
+++ b/apps/web/src/components/LatteChat/index.tsx
@@ -31,6 +31,7 @@ import { LatteUsageInfo } from './_components/LatteUsageInfo'
 import { LatteMessageList } from './_components/MessageList'
 import { LatteChatInput } from './LatteChatInput'
 import { useLatteEventHandlers } from '$/hooks/latte/useLatteEventHandlers'
+import { LatteUnconfiguredIntegrations } from './_components/UnconfiguredIntegrations'
 
 function ChatWrapper({ children }: { children: ReactNode }) {
   return (
@@ -135,6 +136,7 @@ export function LatteChatUI() {
                   interactions={interactions}
                   isStreaming={isBrewing}
                 />
+                <LatteUnconfiguredIntegrations />
                 {error && (
                   <div className='w-full px-8'>
                     <Alert

--- a/apps/web/src/hooks/latte/useLatteThreadUpdates.ts
+++ b/apps/web/src/hooks/latte/useLatteThreadUpdates.ts
@@ -91,6 +91,7 @@ export function useLatteThreadUpdates() {
     setError,
     setUsage,
     setIsLoadingUsage,
+    addIntegrationId,
   } = useLatteStore()
 
   const {
@@ -136,6 +137,17 @@ export function useLatteThreadUpdates() {
       if (update.type === 'fullResponse') {
         // Handle fullResponse outside of setInteractions to ensure setIsBrewing is called
         setIsBrewing(false)
+      }
+
+      if (
+        update.type === 'toolCompleted' &&
+        update.toolName === LatteTool.createIntegration
+      ) {
+        // TODO: Nasty hack
+        if ('id' in update.result) {
+          const integrationId = update.result.id as number
+          addIntegrationId(integrationId)
+        }
       }
 
       setInteractions((prev) => {
@@ -190,7 +202,14 @@ export function useLatteThreadUpdates() {
         return [...otherInteractions, lastInteraction]
       })
     },
-    [threadUuid, setInteractions, setIsBrewing, setError, mutateUsage],
+    [
+      threadUuid,
+      setInteractions,
+      setIsBrewing,
+      setError,
+      mutateUsage,
+      addIntegrationId,
+    ],
   )
 
   useSockets({

--- a/apps/web/src/stores/latte/index.ts
+++ b/apps/web/src/stores/latte/index.ts
@@ -128,6 +128,7 @@ export const useLatteStore = () => {
       addInteractions: store.addInteractions,
       setInteractions: store.setInteractions,
       addInteraction: store.addInteraction,
+      addIntegrationId: store.addIntegrationId,
       updateLastInteraction: store.updateLastInteraction,
       setError: store.setError,
       setLatteActionsFeedbackUuid: store.setLatteActionsFeedbackUuid,

--- a/apps/web/src/stores/latte/store.ts
+++ b/apps/web/src/stores/latte/store.ts
@@ -8,6 +8,7 @@ type ProjectLatteState = {
   usage: LatteUsage | undefined
   latteActionsFeedbackUuid: string | undefined
   interactions: LatteInteraction[]
+  newIntegrationIds: number[]
   isBrewing: boolean
   error: string | undefined
 }
@@ -18,6 +19,7 @@ const EMPTY_PROJECT_STATE = {
   usage: undefined,
   latteActionsFeedbackUuid: undefined,
   interactions: [],
+  newIntegrationIds: [], // TODO: refactor latte interactions to be stored in backend and have better step management
   isBrewing: false,
   error: undefined,
 } satisfies ProjectLatteState
@@ -39,6 +41,7 @@ type LatteState = {
   setThreadUuid: (uuid: string | undefined) => void
   setIsBrewing: (loading: boolean) => void
   addInteractions: (interactions: LatteInteraction[]) => void
+  addIntegrationId: (integrationId: number) => void
   setInteractions: (
     interactions:
       | LatteInteraction[]
@@ -192,6 +195,25 @@ export const useLatteZustandStore = create<LatteState>((set, get) => ({
           [state.currentProjectId]: {
             ...currentState,
             interactions: updatedInteractions,
+          },
+        },
+      }
+    }),
+
+  addIntegrationId: (integrationId: number) =>
+    set((state) => {
+      if (!state.currentProjectId) return state
+      const currentState =
+        state.projectStates[state.currentProjectId] ?? EMPTY_PROJECT_STATE
+      return {
+        projectStates: {
+          ...state.projectStates,
+          [state.currentProjectId]: {
+            ...currentState,
+            newIntegrationIds: [
+              ...currentState.newIntegrationIds,
+              integrationId,
+            ],
           },
         },
       }


### PR DESCRIPTION
<img width="686" height="240" alt="image" src="https://github.com/user-attachments/assets/90a5ac27-525c-4972-bd57-fdf88f500b6c" />

---

This approach is too hacky for my comfort, but it does offer a quick way to implement the feature.

Latte thread interactions need a rework. They should be generated in the backend and stored in the database. This approach will make them faster and more organized. It will also give us more control over what we display in the Chat UI. Additionally, it will keep the interactions fully storable and re-fetchable, which is not currently the case.

---

What I have actually done:

- A new `newIntegrationIds` array has been added to latte's store.
- Every time a `toolCompleted` event is received, we check if it is the `createIntegration` tool and add it to the array if it's a pipedream integration.
- When a new id is added to `newIntegrationIds`, we refetch the list of integrations, match the new integrations with the unconfigured ones existing in the workspace, and render them in the chat ui