### PR TITLE
Fix broken integration triggers - Remove redundant prevContext

### DIFF
--- a/apps/web/src/actions/integrations/pipedream/configureComponent.ts
+++ b/apps/web/src/actions/integrations/pipedream/configureComponent.ts
@@ -14,10 +14,6 @@ export const configurePipedreamComponentAction = authProcedure
       componentId: z.string(),
       propName: z.string(),
       configuredProps: z.record(z.any()).optional(),
-      previousContext: z.record(z.any()).optional(),
-
-      query: z.string().optional(),
-      page: z.number().optional(),
     }),
   )
   .handler(async ({ input, ctx }) => {
@@ -36,8 +32,5 @@ export const configurePipedreamComponentAction = authProcedure
       componentId: input.componentId,
       propName: input.propName,
       configuredProps: input.configuredProps,
-      previousContext: input.previousContext,
-      query: input.query,
-      page: input.page,
     }).then((r) => r.unwrap())
   })

--- a/apps/web/src/hooks/pipedreamProps/usePipedreamDynamicPropConfig.ts
+++ b/apps/web/src/hooks/pipedreamProps/usePipedreamDynamicPropConfig.ts
@@ -6,11 +6,9 @@ import {
   ConfigureComponentResponse,
   ConfiguredProps,
 } from '@pipedream/sdk/browser'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { useServerAction } from 'zsa-react'
-
-type ConfigureComponentContext = Record<string, unknown>
 
 export function usePipedreamDynamicPropConfig({
   integration,
@@ -23,35 +21,6 @@ export function usePipedreamDynamicPropConfig({
   prop: ConfigurableProp
   configuredProps: ConfiguredProps<ConfigurableProps>
 }) {
-  const [query, _setQuery] = useState<string | undefined>(undefined)
-  const [page, setPage] = useState<number | undefined>(undefined)
-
-  const setQuery = useCallback(
-    (newQuery: string | undefined) => {
-      setPage(undefined) // Reset page when query changes
-      _setQuery(newQuery)
-    },
-    [_setQuery],
-  )
-
-  const nextPage = useCallback(() => {
-    setPage((prevPage) => {
-      if (prevPage === undefined) return 1
-      return prevPage + 1
-    })
-  }, [])
-
-  const prevPage = useCallback(() => {
-    setPage((prevPage) => {
-      if (prevPage === undefined || prevPage <= 1) return undefined
-      return prevPage - 1
-    })
-  }, [])
-
-  const [context, setContext] = useState<ConfigureComponentContext | undefined>(
-    undefined,
-  )
-
   const [config, setConfig] = useState<ConfigureComponentResponse | undefined>(
     undefined,
   )
@@ -62,7 +31,6 @@ export function usePipedreamDynamicPropConfig({
   } = useServerAction(configurePipedreamComponentAction, {
     onSuccess: ({ data }) => {
       setConfig(data)
-      setContext(data.context)
     },
   })
 
@@ -77,11 +45,7 @@ export function usePipedreamDynamicPropConfig({
       componentId: component.key,
       propName: prop.name,
       configuredProps,
-      previousContext: context,
-      query,
-      page,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- context causes infinite loop
   }, [
     integration.name,
     component.key,
@@ -89,9 +53,6 @@ export function usePipedreamDynamicPropConfig({
     prop.remoteOptions,
     configuredProps,
     debouncedExecute,
-    // context, // TODO(triggers): Fix this, it causes infinite loop
-    query,
-    page,
   ])
 
   const errors = useMemo<[string, ...string[]] | undefined>(() => {
@@ -111,10 +72,5 @@ export function usePipedreamDynamicPropConfig({
     config,
     isLoading,
     errors,
-    query,
-    page,
-    setQuery,
-    nextPage,
-    prevPage,
   }
 }

--- a/packages/core/src/services/integrations/pipedream/components/configureComponent.ts
+++ b/packages/core/src/services/integrations/pipedream/components/configureComponent.ts
@@ -17,19 +17,11 @@ export async function configureComponent({
   componentId,
   propName,
   configuredProps: configuredClientProps,
-  previousContext,
-
-  query,
-  page,
 }: {
   integration: Extract<IntegrationDto, { type: IntegrationType.Pipedream }>
   componentId: string | ComponentId
   propName: string
   configuredProps?: ConfiguredProps<ConfigurableProps>
-  previousContext?: Record<string, unknown>
-
-  query?: string
-  page?: number
 }) {
   if (!isIntegrationConfigured(integration)) {
     return Result.error(
@@ -58,15 +50,13 @@ export async function configureComponent({
   }
 
   try {
+    // TODO - Add pagination possibilities, then start using prevContext, query, and page
     const response = await pipedream.configureComponent({
       externalUserId,
       userId: externalUserId,
       componentId,
       propName,
       configuredProps: configuredPropsResult.unwrap(),
-      prevContext: previousContext,
-      query,
-      page,
     })
 
     return Result.ok(response)


### PR DESCRIPTION
We didnt understand the use of prevContext when we implemented it, and we were using it incorrectly. Its used for pagination purposes, and as we were always sending it, at times it would make certain selects break when there was no more pages. We're removing it as we don't implement pagination yet with pipedream components