### PR TITLE
Avoid infinite re-renders

### DIFF
--- a/apps/web/src/hooks/latte/useLoadThread/index.ts
+++ b/apps/web/src/hooks/latte/useLoadThread/index.ts
@@ -24,10 +24,12 @@ export function useLoadThread() {
   const syncAndGetThreadUuid = useSyncAndGetThreadUuid({ project })
   const [isLoading, startTransition] = useTransition()
 
-  if (currentProjectId !== projectId) {
-    setCurrentProject(projectId)
-    lastLoadedProjectId.current = null // force a reload next time
-  }
+  useEffect(() => {
+    if (currentProjectId !== projectId) {
+      setCurrentProject(projectId)
+      lastLoadedProjectId.current = null // force a reload next time
+    }
+  }, [currentProjectId, projectId, setCurrentProject])
 
   useEffect(() => {
     // Don’t refetch if there are already interactions


### PR DESCRIPTION
We were setting the project state during the render phase of the LatteChat, which would cause infinite re-renders. This is an anti-pattern, and to fix it we should wrap it in a useEffect