### PR TITLE
Allow to see trigger details on merged versions

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/utils.ts
@@ -7,7 +7,7 @@ type GetCommitUrlParams = {
   projectId: number
   lastSeenCommitUuid: string | undefined
   lastSeenDocumentUuid?: string | undefined
-  PROJECT_ROUTE: (typeof ROUTES.projects.detail)
+  PROJECT_ROUTE: typeof ROUTES.projects.detail
   latteEnabled?: boolean
 }
 


### PR DESCRIPTION
# What?
Instead of blocking the edit modal show it in read mode 

<img width="1144" height="1053" alt="image" src="https://github.com/user-attachments/assets/daf35c3f-c9b7-4475-8472-3cc263388b13" />
