### PR TITLE
compatible agent names

### DIFF
--- a/packages/core/src/lib/streamManager/resolveTools/agentsAsTools.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/agentsAsTools.ts
@@ -5,7 +5,6 @@ import { Result, TypedResult } from '../../Result'
 import { ResolvedTools, ToolSource, ToolSourceData } from './types'
 import { DocumentVersion } from '../../../browser'
 import { DocumentVersionsRepository } from '../../../repositories'
-import { getAgentToolName } from '../../../services/agents/helpers'
 import { getToolDefinitionFromDocument } from '../../../services/agents/agentsAsTools'
 import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
 import { Tool } from 'ai'
@@ -104,17 +103,19 @@ export async function resolveAgentsAsTools({
     { definition: Tool; sourceData: ToolSourceData },
   ][] = await Promise.all(
     agentDocs.map(async (doc) => {
+      const { name, toolDefinition } = await getToolDefinitionFromDocument({
+        workspace,
+        commit: promptSource.commit,
+        document: doc,
+        referenceFn,
+        streamManager,
+        context: streamManager.$completion!.context,
+      })
+
       return [
-        getAgentToolName(doc.path),
+        name,
         {
-          definition: await getToolDefinitionFromDocument({
-            workspace,
-            commit: promptSource.commit,
-            document: doc,
-            referenceFn,
-            streamManager,
-            context: streamManager.$completion!.context,
-          }),
+          definition: toolDefinition,
           sourceData: {
             source: ToolSource.AgentAsTool,
             agentPath: doc.path,

--- a/packages/core/src/services/agents/agentsAsTools.ts
+++ b/packages/core/src/services/agents/agentsAsTools.ts
@@ -50,13 +50,14 @@ export async function getToolDefinitionFromDocument({
   ) => Promise<{ path: string; content: string } | undefined>
   streamManager: StreamManager
   context: TelemetryContext
-}): Promise<Tool> {
+}): Promise<{ name: string; toolDefinition: Tool }> {
   const metadata = await scan({
     prompt: document.content,
     fullPath: document.path,
     referenceFn,
   })
 
+  const name = metadata.config['name'] as string | undefined
   const description = metadata.config['description'] as string | undefined
   const params = Object.fromEntries(
     Object.entries(
@@ -77,7 +78,7 @@ export async function getToolDefinitionFromDocument({
     params[param] = DEFAULT_PARAM_DEFINITION
   })
 
-  return {
+  const toolDefinition: Tool = {
     description: description ?? 'An AI agent',
     parameters: {
       type: 'object',
@@ -155,6 +156,11 @@ export async function getToolDefinitionFromDocument({
         return result
       }
     },
+  }
+
+  return {
+    name: name ?? getAgentToolName(document.path),
+    toolDefinition,
   }
 }
 

--- a/packages/core/src/services/agents/helpers.test.ts
+++ b/packages/core/src/services/agents/helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentToolName, MAX_TOOL_NAME_LENGTH } from './helpers'
+
+describe('getAgentToolName', () => {
+  it('should never exceed the maximum tool name length', () => {
+    const testCases = [
+      '',
+      'short',
+      'a'.repeat(50),
+      'a'.repeat(100),
+      'a'.repeat(200),
+      'very/long/path/with/many/segments/that/could/exceed/the/maximum/length/limit',
+      'path/with/special/characters/!@#$%^&*()_+-=[]{}|;:,.<>?',
+      'path/with/unicode/characters/café/naïve/résumé',
+      '/' + 'a'.repeat(100),
+      'a'.repeat(100) + '/',
+      '/'.repeat(50),
+      'deeply/nested/folder/structure/with/very/long/names/that/definitely/exceed/sixty/four/characters/in/total/length',
+    ]
+
+    testCases.forEach((agentPath) => {
+      const result = getAgentToolName(agentPath)
+      expect(result.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+    })
+  })
+
+  it('should always start with the agent tool prefix', () => {
+    const testCases = ['', 'short', 'long'.repeat(20), 'path/with/slashes']
+
+    testCases.forEach((agentPath) => {
+      const result = getAgentToolName(agentPath)
+      expect(result).toMatch(/^lat_agent_/)
+    })
+  })
+
+  it('should replace forward slashes with underscores', () => {
+    const testCases = [
+      { input: 'path/to/agent', expected: 'lat_agent_path_to_agent' },
+      {
+        input: 'folder/subfolder/file',
+        expected: 'lat_agent_folder_subfolder_file',
+      },
+      { input: '/leading/slash', expected: 'lat_agent__leading_slash' },
+      { input: 'trailing/slash/', expected: 'lat_agent_trailing_slash_' },
+      {
+        input: '//double//slashes//',
+        expected: 'lat_agent___double__slashes__',
+      },
+    ]
+
+    testCases.forEach(({ input, expected }) => {
+      const result = getAgentToolName(input)
+      expect(result).toBe(expected)
+    })
+  })
+
+  it('handles empty string', () => {
+    const result = getAgentToolName('')
+    expect(result).toBe('lat_agent_')
+    expect(result.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  })
+
+  it('truncates long paths from the beginning', () => {
+    // Create a path that would exceed the limit
+    const longPath =
+      'very/long/path/that/definitely/exceeds/the/maximum/allowed/length/for/tool/names'
+    const result = getAgentToolName(longPath)
+
+    // Should start with lat_agent_
+    expect(result).toMatch(/^lat_agent_/)
+
+    // Should not exceed max length
+    expect(result.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+
+    // Should end with the last part of the original path (truncated from beginning)
+    expect(result).toMatch(/_tool_names$/)
+  })
+
+  it('handles paths that are exactly at the limit', () => {
+    // lat_agent_ is 10 characters, so we need 54 more characters to reach the limit
+    const exactLengthSuffix = 'a'.repeat(54)
+    const result = getAgentToolName(exactLengthSuffix)
+
+    expect(result).toBe(`lat_agent_${exactLengthSuffix}`)
+    expect(result.length).toBe(MAX_TOOL_NAME_LENGTH)
+  })
+
+  it('handles special characters in paths', () => {
+    const specialChars = 'path-with.special@chars#test'
+    const result = getAgentToolName(specialChars)
+
+    expect(result).toBe('lat_agent_path-with.special@chars#test')
+    expect(result.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  })
+
+  it('maintains consistency for the same input', () => {
+    const testPath = 'consistent/test/path'
+    const result1 = getAgentToolName(testPath)
+    const result2 = getAgentToolName(testPath)
+
+    expect(result1).toBe(result2)
+    expect(result1.length).toBeLessThanOrEqual(MAX_TOOL_NAME_LENGTH)
+  })
+})

--- a/packages/core/src/services/agents/helpers.ts
+++ b/packages/core/src/services/agents/helpers.ts
@@ -1,5 +1,12 @@
 import { AGENT_TOOL_PREFIX } from '@latitude-data/constants'
 
+export const MAX_TOOL_NAME_LENGTH = 64
+
 export function getAgentToolName(agentPath: string): string {
-  return `${AGENT_TOOL_PREFIX}_${agentPath.replace(/\//g, '_')}`
+  const maxSuffixLength = MAX_TOOL_NAME_LENGTH - AGENT_TOOL_PREFIX.length - 1
+  const suffix = agentPath
+    .slice(Math.max(0, agentPath.length - maxSuffixLength))
+    .replace(/\//g, '_')
+
+  return `${AGENT_TOOL_PREFIX}_${suffix}`
 }


### PR DESCRIPTION
### Summary

When importing subagents into a prompt, an automatic tool name is generated based on the agent’s path. These names often end up long, repetitive, and unhelpful.

For example:

```yaml
agents:
  - /agents/documentation/ask
```

is turned into:

```
lat_agent_agents_documentation_ask
```

This can cause problems:

* Some providers fail due to excessively long tool names.
* The generated name doesn’t provide meaningful context for the original agent.

---

### What’s Changed

This PR introduces two improvements:

1. **Safer automatic name generation**

   * Tool names will no longer exceed provider limits.
   * If the path is too long, only the last valid segment(s) will be used.

2. **Optional `name` attribute**

   * Agents can now define a custom tool name explicitly, avoiding verbose or confusing defaults.

---

### Next Steps / TODO

* Detect and disallow importing multiple agents that resolve to the same tool name (to prevent provider errors and improve editor feedback).
* Fix `agentAsToolMap` so the correct UI is displayed in chat (currently broken).

