### PR TITLE
feat: workers deploy protection

### DIFF
--- a/.github/workflows/deploy-bluegreen.yml
+++ b/.github/workflows/deploy-bluegreen.yml
@@ -28,11 +28,6 @@ jobs:
             codedeploy_app: LatitudeLLMCodeDeployGateway
             codedeploy_group: LatitudeLLMGatewayDeploymentGroup
             repo_name: latitude-llm-gateway-repo-b859826
-          - app: workers
-            task_family: LatitudeLLMWorkersTaskFamily
-            codedeploy_app: LatitudeLLMWorkersCodeDeployApp
-            codedeploy_group: LatitudeLLMWorkersDeploymentGroup
-            repo_name: latitude-llm-workers-repo-184cb29
     concurrency:
       group: deploy-${{ matrix.app }}
       cancel-in-progress: false

--- a/.github/workflows/deploy-rolling.yml
+++ b/.github/workflows/deploy-rolling.yml
@@ -18,6 +18,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - app: workers
+            task_family: LatitudeLLMWorkersTaskFamily
+            codedeploy_app: LatitudeLLMWorkersCodeDeployApp
+            codedeploy_group: LatitudeLLMWorkersDeploymentGroup
+            repo_name: latitude-llm-workers-repo-184cb29
           - app: websockets
             task-family: LatitudeLLMWebsocketsTaskFamily
             service: LatitudeLLMWebsockets-3ba81ef

--- a/apps/workers/src/workers/utils/createWorker.ts
+++ b/apps/workers/src/workers/utils/createWorker.ts
@@ -3,6 +3,7 @@ import { Queues } from '@latitude-data/core/queues/types'
 import { captureException } from '@latitude-data/core/utils/workers/sentry'
 import { WORKER_OPTIONS } from './connectionConfig'
 import { createJobHandler } from './createJobHandler'
+import { jobTracker } from './jobTracker'
 
 /**
  * Creates a fully configured BullMQ worker with job handling and error handling
@@ -20,6 +21,9 @@ export function createWorker<T extends Record<string, Function>>(
   worker.on('error', (error: Error) => {
     captureException(error)
   })
+
+  // Register worker with job tracker for scale-in protection
+  jobTracker.registerWorker(worker)
 
   return worker
 }

--- a/apps/workers/src/workers/utils/jobTracker.ts
+++ b/apps/workers/src/workers/utils/jobTracker.ts
@@ -1,0 +1,86 @@
+import { Worker } from 'bullmq'
+import { scaleInProtectionManager } from './scaleInProtection'
+
+/**
+ * Tracks active jobs across all BullMQ workers and manages scale-in protection
+ */
+export class JobTracker {
+  private activeJobsCount = 0
+  private workers: Worker[] = []
+
+  /**
+   * Register a worker to track its job activity
+   */
+  registerWorker(worker: Worker): void {
+    this.workers.push(worker)
+
+    // Listen for job start events
+    worker.on('active', (job) => {
+      this.activeJobsCount++
+      console.log(
+        `Job ${job?.id || 'unknown'} started processing. Active jobs: ${this.activeJobsCount}`,
+      )
+
+      // Enable protection when first job starts
+      if (this.activeJobsCount === 1) {
+        scaleInProtectionManager.enableProtection()
+      }
+    })
+
+    // Listen for job completion events
+    worker.on('completed', (job) => {
+      this.activeJobsCount = Math.max(0, this.activeJobsCount - 1)
+      console.log(
+        `Job ${job?.id || 'unknown'} completed. Active jobs: ${this.activeJobsCount}`,
+      )
+
+      // Disable protection when no jobs are active
+      if (this.activeJobsCount === 0) {
+        scaleInProtectionManager.disableProtection()
+      }
+    })
+
+    // Listen for job failure events
+    worker.on('failed', (job) => {
+      this.activeJobsCount = Math.max(0, this.activeJobsCount - 1)
+      console.log(
+        `Job ${job?.id || 'unknown'} failed. Active jobs: ${this.activeJobsCount}`,
+      )
+
+      // Disable protection when no jobs are active
+      if (this.activeJobsCount === 0) {
+        scaleInProtectionManager.disableProtection()
+      }
+    })
+
+    // Handle worker closing
+    worker.on('closing', () => {
+      console.log('Worker is closing, removing from tracker')
+      this.workers = this.workers.filter((w) => w !== worker)
+    })
+  }
+
+  /**
+   * Get the current count of active jobs
+   */
+  getActiveJobsCount(): number {
+    return this.activeJobsCount
+  }
+
+  /**
+   * Get all registered workers
+   */
+  getWorkers(): Worker[] {
+    return [...this.workers]
+  }
+
+  /**
+   * Force disable protection (useful for graceful shutdown)
+   */
+  async forceDisableProtection(): Promise<void> {
+    await scaleInProtectionManager.disableProtection()
+  }
+}
+
+// Global instance
+export const jobTracker = new JobTracker()

--- a/apps/workers/src/workers/utils/scaleInProtection.ts
+++ b/apps/workers/src/workers/utils/scaleInProtection.ts
@@ -1,0 +1,107 @@
+import { env } from '@latitude-data/env'
+
+/**
+ * Utility for managing ECS Fargate task scale-in protection
+ * Protects tasks from being terminated while processing BullMQ jobs
+ */
+
+export class ScaleInProtectionManager {
+  private protectionEnabled = false
+  private taskProtectionEndpoint: string | null = null
+
+  constructor() {
+    if (env.ECS_AGENT_URI) {
+      this.taskProtectionEndpoint = `${env.ECS_AGENT_URI}/task-protection/v1/state`
+    }
+  }
+
+  /**
+   * Enable scale-in protection for the current task
+   */
+  async enableProtection(): Promise<void> {
+    if (!this.taskProtectionEndpoint) {
+      console.warn('ECS_AGENT_URI not available, skipping scale-in protection')
+      return
+    }
+
+    if (this.protectionEnabled) {
+      return // Already protected
+    }
+
+    try {
+      const response = await fetch(this.taskProtectionEndpoint, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          protectionEnabled: true,
+        }),
+      })
+
+      if (response.ok) {
+        this.protectionEnabled = true
+        console.log('Scale-in protection enabled for ECS task')
+      } else {
+        console.error(
+          `Failed to enable scale-in protection: ${response.status} ${response.statusText}`,
+        )
+      }
+    } catch (error) {
+      console.error('Error enabling scale-in protection:', error)
+    }
+  }
+
+  /**
+   * Disable scale-in protection for the current task
+   */
+  async disableProtection(): Promise<void> {
+    if (!this.taskProtectionEndpoint) {
+      return
+    }
+
+    if (!this.protectionEnabled) {
+      return // Already unprotected
+    }
+
+    try {
+      const response = await fetch(this.taskProtectionEndpoint, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          protectionEnabled: false,
+        }),
+      })
+
+      if (response.ok) {
+        this.protectionEnabled = false
+        console.log('Scale-in protection disabled for ECS task')
+      } else {
+        console.error(
+          `Failed to disable scale-in protection: ${response.status} ${response.statusText}`,
+        )
+      }
+    } catch (error) {
+      console.error('Error disabling scale-in protection:', error)
+    }
+  }
+
+  /**
+   * Check if scale-in protection is currently enabled
+   */
+  isProtectionEnabled(): boolean {
+    return this.protectionEnabled
+  }
+
+  /**
+   * Check if the ECS environment is available
+   */
+  isEcsEnvironment(): boolean {
+    return this.taskProtectionEndpoint !== null
+  }
+}
+
+// Global instance
+export const scaleInProtectionManager = new ScaleInProtectionManager()

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -248,6 +248,9 @@ export const env = createEnv({
     BULL_ADMIN_USER: z.string().optional().default('admin'),
     BULL_ADMIN_PASS: z.string().optional().default('admin'),
 
+    // ECS Task Protection
+    ECS_AGENT_URI: z.string().optional(),
+
     // MCP Server feature configurations
     EKS_CA_DATA: z.string().optional(),
     EKS_CLUSTER_NAME: z.string().optional(),
@@ -321,5 +324,6 @@ export const env = createEnv({
       'tool-responses-generator',
     DEFAULT_PROVIDER_API_KEY:
       process.env.DEFAULT_PROVIDER_API_KEY ?? 'default_api_key',
+    ECS_AGENT_URI: process.env.ECS_AGENT_URI,
   },
 })

--- a/turbo.json
+++ b/turbo.json
@@ -59,7 +59,8 @@
     "TEMP",
     "GIT_PAGER",
     "PAGER",
-    "TEST_LATITUDE_API_KEY"
+    "TEST_LATITUDE_API_KEY",
+    "ECS_AGENT_URI"
   ],
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env.*local"],


### PR DESCRIPTION
Allows for workers to run for up to 2 hours before being terminated by ECS during scale-in events such as deployments or autoscaling events.