### PR TITLE
feat: load queues/pubsub lazily

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "@latitude-data/constants": "workspace:*",
     "@latitude-data/core": "workspace:*",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/sdk": "5.0.0-beta.2",
+    "@latitude-data/sdk": "5.0.0",
     "@latitude-data/socket.io-react-hook": "2.4.5",
     "@latitude-data/telemetry": "workspace:*",
     "@latitude-data/web-ui": "workspace:*",

--- a/apps/web/src/actions/datasets/createFromLogs.test.ts
+++ b/apps/web/src/actions/datasets/createFromLogs.test.ts
@@ -4,7 +4,6 @@ import {
   Providers,
 } from '@latitude-data/core/browser'
 import * as factories from '@latitude-data/core/factories'
-import { defaultQueue } from '@latitude-data/core/queues'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createDatasetFromLogsAction } from './createFromLogs'
@@ -16,6 +15,7 @@ const mocks = vi.hoisted(() => {
     findOrCreateDataset: vi.fn(),
     updateDatasetFromLogs: vi.fn(),
     queueAdd: vi.fn(),
+    defaultQueueAddMock: vi.fn(),
   }
 })
 
@@ -32,9 +32,11 @@ vi.mock('@latitude-data/core/services/datasets/createFromLogs', () => ({
 }))
 
 vi.mock('@latitude-data/core/queues', () => ({
-  defaultQueue: {
-    add: vi.fn(),
-  },
+  queues: vi.fn().mockResolvedValue({
+    defaultQueue: {
+      add: mocks.defaultQueueAddMock,
+    },
+  }),
 }))
 
 vi.mock('@latitude-data/core/events/publisher', () => ({
@@ -163,7 +165,7 @@ describe('createDatasetFromLogsAction', () => {
       })
 
       // Verify queue was not used
-      expect(defaultQueue.add).not.toHaveBeenCalled()
+      expect(mocks.defaultQueueAddMock).not.toHaveBeenCalled()
     })
   })
 
@@ -193,7 +195,7 @@ describe('createDatasetFromLogsAction', () => {
       expect(mocks.updateDatasetFromLogs).not.toHaveBeenCalled()
 
       // Verify queue was used with correct params
-      expect(defaultQueue.add).toHaveBeenCalledWith(
+      expect(mocks.defaultQueueAddMock).toHaveBeenCalledWith(
         'createDatasetFromLogsJob',
         {
           name: 'Test Dataset',
@@ -224,7 +226,7 @@ describe('createDatasetFromLogsAction', () => {
       expect(result).toEqual({ mode: 'async' })
 
       // Verify queue was used with correct params
-      expect(defaultQueue.add).toHaveBeenCalledWith(
+      expect(mocks.defaultQueueAddMock).toHaveBeenCalledWith(
         'createDatasetFromLogsJob',
         {
           name: 'Test Dataset',
@@ -255,7 +257,7 @@ describe('createDatasetFromLogsAction', () => {
       expect(result).toEqual({ mode: 'async' })
 
       // Verify queue was used with correct params
-      expect(defaultQueue.add).toHaveBeenCalledWith(
+      expect(mocks.defaultQueueAddMock).toHaveBeenCalledWith(
         'createDatasetFromLogsJob',
         {
           name: 'Test Dataset',

--- a/apps/web/src/actions/datasets/createFromLogs.ts
+++ b/apps/web/src/actions/datasets/createFromLogs.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { withDocument } from '../procedures'
 import { documentLogFilterOptionsSchema } from '@latitude-data/core/browser'
-import { defaultQueue } from '@latitude-data/core/queues'
+import { queues } from '@latitude-data/core/queues'
 import { findOrCreateDataset } from '@latitude-data/core/services/datasets/findOrCreate'
 import { updateDatasetFromLogs } from '@latitude-data/core/services/datasets/createFromLogs'
 
@@ -43,6 +43,8 @@ export const createDatasetFromLogsAction = withDocument
         result,
       }
     }
+
+    const { defaultQueue } = await queues()
 
     defaultQueue.add('createDatasetFromLogsJob', {
       name: input.name,

--- a/apps/web/src/actions/documentLogs/downloadLogs.ts
+++ b/apps/web/src/actions/documentLogs/downloadLogs.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { withDocument } from '../procedures'
 import { documentLogFilterOptionsSchema } from '@latitude-data/core/browser'
-import { defaultQueue } from '@latitude-data/core/queues'
+import { queues } from '@latitude-data/core/queues'
 import { generateUUIDIdentifier } from '@latitude-data/core/lib/generateUUID'
 
 export const downloadLogsAsyncAction = withDocument
@@ -18,6 +18,7 @@ export const downloadLogsAsyncAction = withDocument
   .handler(async ({ ctx, input }) => {
     const { user, document } = ctx
     const { selectionMode, excludedDocumentLogIds, filterOptions } = input
+    const { defaultQueue } = await queues()
 
     defaultQueue.add('downloadLogsJob', {
       user,

--- a/apps/web/src/actions/latte/stopChat.ts
+++ b/apps/web/src/actions/latte/stopChat.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { authProcedure } from '$/actions/procedures'
 import { cancelJob } from '@latitude-data/core/services/bullmq/cancelJob'
-import { documentsQueue } from '@latitude-data/core/queues'
+import { queues } from '@latitude-data/core/queues'
 
 export const stopChatLatteAction = authProcedure
   .createServerAction()
@@ -13,6 +13,7 @@ export const stopChatLatteAction = authProcedure
     }),
   )
   .handler(async ({ input }) => {
+    const { documentsQueue } = await queues()
     const { jobId } = input
     if (!jobId) return
     const job = await documentsQueue.getJob(jobId)

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -11,7 +11,7 @@ import {
 } from '@latitude-data/core/utils/workers/sentry'
 import { startWorkers, setupSchedules } from './workers'
 import { env } from '@latitude-data/env'
-import * as queues from '@latitude-data/core/queues'
+import { queues } from '@latitude-data/core/queues'
 import { jobTracker } from './workers/utils/jobTracker'
 
 setupSchedules()
@@ -24,7 +24,7 @@ const serverAdapter = new ExpressAdapter()
 serverAdapter.setBasePath('/admin/queues')
 
 createBullBoard({
-  queues: Object.values(queues).map((q) => new BullMQAdapter(q)),
+  queues: Object.values(await queues()).map((q) => new BullMQAdapter(q)),
   serverAdapter,
 })
 

--- a/apps/workers/src/workers/index.ts
+++ b/apps/workers/src/workers/index.ts
@@ -1,4 +1,4 @@
-import { maintenanceQueue } from '@latitude-data/core/queues'
+import { queues } from '@latitude-data/core/queues'
 import { startDefaultWorker } from './worker-definitions/defaultWorker'
 import { startDocumentSuggestionsWorker } from './worker-definitions/documentSuggestionsWorker'
 import { startDocumentsWorker } from './worker-definitions/documentsWorker'
@@ -38,6 +38,8 @@ export async function startWorkers() {
 }
 
 export async function setupSchedules() {
+  const { maintenanceQueue } = await queues()
+
   // Every day at 8 AM
   await maintenanceQueue.upsertJobScheduler(
     'requestDocumentSuggestionsJob',

--- a/apps/workers/src/workers/utils/createWorker.ts
+++ b/apps/workers/src/workers/utils/createWorker.ts
@@ -16,7 +16,10 @@ export function createWorker<T extends Record<string, Function>>(
   jobMappings: T,
   workerOptions: WorkerOptions = WORKER_OPTIONS,
 ): Worker {
-  const worker = new Worker(queue, createJobHandler(jobMappings), workerOptions)
+  const worker = new Worker(queue, createJobHandler(jobMappings), {
+    ...workerOptions,
+    prefix: 'latitude',
+  })
 
   worker.on('error', (error: Error) => {
     captureException(error)

--- a/packages/core/src/events/handlers/evaluateLiveLog.ts
+++ b/packages/core/src/events/handlers/evaluateLiveLog.ts
@@ -4,7 +4,7 @@ import {
   findWorkspaceFromDocumentLog,
 } from '../../data-access'
 import { runEvaluationV2JobKey } from '../../jobs/job-definitions'
-import { evaluationsQueue } from '../../jobs/queues'
+import { queues } from '../../jobs/queues'
 import { NotFoundError } from '../../lib/errors'
 import {
   CommitsRepository,
@@ -75,6 +75,7 @@ export const evaluateLiveLogJob = async ({
       providerLogUuid: providerLog.uuid,
     }
 
+    const { evaluationsQueue } = await queues()
     evaluationsQueue.add('runEvaluationV2Job', payload, {
       deduplication: { id: runEvaluationV2JobKey(payload) },
     })

--- a/packages/core/src/events/handlers/requestDocumentSuggestionJob.ts
+++ b/packages/core/src/events/handlers/requestDocumentSuggestionJob.ts
@@ -1,7 +1,7 @@
 import { LogSources } from '../../browser'
 import { unsafelyFindWorkspace } from '../../data-access'
 import { generateDocumentSuggestionJobKey } from '../../jobs/job-definitions'
-import { documentSuggestionsQueue } from '../../jobs/queues'
+import { queues } from '../../jobs/queues'
 import { NotFoundError } from '../../lib/errors'
 import { EvaluationResultV2CreatedEvent } from '../events'
 
@@ -22,6 +22,7 @@ export const requestDocumentSuggestionJobV2 = async ({
   if (result.hasPassed || result.error || result.usedForSuggestion) return
   if (!evaluation.enableSuggestions) return
 
+  const { documentSuggestionsQueue } = await queues()
   documentSuggestionsQueue.add(
     'generateDocumentSuggestionJob',
     {

--- a/packages/core/src/events/publisher.ts
+++ b/packages/core/src/events/publisher.ts
@@ -1,15 +1,15 @@
 import { LatitudeEvent } from './events'
-import { eventsQueue, webhooksQueue } from '../jobs/queues'
+import { queues } from '../jobs/queues'
 import {
-  pubSubEvents,
-  PubSubListener,
-  pubSubProducer,
-  PubSubEvent,
-  PubSubHandler,
+  pubSub,
+  type PubSubListener,
+  type PubSubEvent,
+  type PubSubHandler,
 } from '../pubSub'
 
 export const publisher = {
   publishLater: async (event: LatitudeEvent) => {
+    const { eventsQueue, webhooksQueue } = await queues()
     eventsQueue.add('createEventJob', event)
     eventsQueue.add('publishEventJob', event)
     eventsQueue.add('publishToAnalyticsJob', event)
@@ -17,18 +17,21 @@ export const publisher = {
     webhooksQueue.add('processWebhookJob', event)
   },
   publish: async (eventName: PubSubEvent, args: Record<string, unknown>) => {
-    pubSubProducer.publishEvent({ eventName, ...args })
+    const { producer } = await pubSub()
+    producer.publishEvent({ eventName, ...args })
   },
   subscribe: async (
     event: PubSubEvent,
     listener: PubSubHandler[typeof event],
   ) => {
-    pubSubEvents.on<PubSubListener>(event, listener)
+    const { events } = await pubSub()
+    events.on<PubSubListener>(event, listener)
   },
   unsubscribe: async (
     event: PubSubEvent,
     listener: PubSubHandler[typeof event],
   ) => {
-    pubSubEvents.removeListener(event, listener)
+    const { events } = await pubSub()
+    events.removeListener(event, listener)
   },
 }

--- a/packages/core/src/jobs/job-definitions/datasets/createFromLogsJob.ts
+++ b/packages/core/src/jobs/job-definitions/datasets/createFromLogsJob.ts
@@ -13,7 +13,7 @@ import { and, desc, eq, isNull, lt, notInArray } from 'drizzle-orm'
 import { buildLogsFilterSQLConditions } from '../../../services/documentLogs/logsFilterUtils'
 import { updateDatasetFromLogs } from '../../../services/datasets/createFromLogs'
 import { generateUUIDIdentifier } from '../../../lib/generateUUID'
-import { defaultQueue } from '../../queues'
+import { queues } from '../../queues'
 
 type CreateDatasetFromLogsJobProps = {
   name: string
@@ -120,6 +120,7 @@ export const createDatasetFromLogsJob = async (
     }
   }
 
+  const { defaultQueue } = await queues()
   defaultQueue.add('notifyClientOfDatasetUpdate', {
     userId: author.id,
     datasetId: dt.id,

--- a/packages/core/src/jobs/job-definitions/documentLogs/uploadDocumentLogsJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentLogs/uploadDocumentLogsJob.ts
@@ -2,7 +2,7 @@ import { Job } from 'bullmq'
 
 import { Commit } from '../../../browser'
 import { LogSources, messagesSchema } from '../../../constants'
-import { defaultQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export type UploadDocumentLogsJobData = {
   workspaceId: number
@@ -16,6 +16,7 @@ export const uploadDocumentLogsJob = async (
   job: Job<UploadDocumentLogsJobData>,
 ) => {
   const { workspaceId, source, documentUuid, commit, csv } = job.data
+  const { defaultQueue } = await queues()
 
   csv.data.forEach((row) => {
     const messages = JSON.parse(row.record[0]!)

--- a/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.ts
+++ b/packages/core/src/jobs/job-definitions/documentSuggestions/requestDocumentSuggestionsJob.ts
@@ -24,7 +24,7 @@ import {
   evaluationVersions,
   projects,
 } from '../../../schema'
-import { documentSuggestionsQueue } from '../../queues'
+import { queues } from '../../queues'
 import { generateDocumentSuggestionJobKey } from './generateDocumentSuggestionJob'
 
 export type RequestDocumentSuggestionsJobData = {}
@@ -181,6 +181,7 @@ export const requestDocumentSuggestionsJob = async (
     )
 
   for (const candidate of candidatesV2) {
+    const { documentSuggestionsQueue } = await queues()
     await documentSuggestionsQueue.add(
       'generateDocumentSuggestionJob',
       candidate,

--- a/packages/core/src/jobs/job-definitions/events/publishEventJob.ts
+++ b/packages/core/src/jobs/job-definitions/events/publishEventJob.ts
@@ -2,10 +2,11 @@ import { Job } from 'bullmq'
 
 import { LatitudeEvent } from '../../../events/events'
 import { EventHandlers } from '../../../events/handlers/index'
-import { eventHandlersQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export const publishEventJob = async (job: Job<LatitudeEvent>) => {
   const event = job.data
+  const { eventHandlersQueue } = await queues()
 
   // Async handlers
   const handlers = EventHandlers[event.type]

--- a/packages/core/src/jobs/job-definitions/experiments/runDocumentForExperimentJob.ts
+++ b/packages/core/src/jobs/job-definitions/experiments/runDocumentForExperimentJob.ts
@@ -7,7 +7,7 @@ import { ExperimentsRepository } from '../../../repositories'
 import { isErrorRetryable } from '../../../services/evaluationsV2/run'
 import { BACKGROUND } from '../../../telemetry'
 import { captureException } from '../../../utils/workers/sentry'
-import { evaluationsQueue } from '../../queues'
+import { queues } from '../../queues'
 import { runDocumentAtCommitWithAutoToolResponses } from '../documents/runDocumentAtCommitWithAutoToolResponses'
 import {
   RunEvaluationV2JobData,
@@ -69,6 +69,7 @@ export const runDocumentForExperimentJob = async (
         progressTracker.incrementEnqueued(experiment.evaluationUuids.length),
     ).then((r) => r.unwrap())
 
+    const { evaluationsQueue } = await queues()
     experiment.evaluationUuids.forEach((evaluationUuid) => {
       const payload: RunEvaluationV2JobData = {
         workspaceId,

--- a/packages/core/src/jobs/job-definitions/maintenance/refreshDocumentsStatsCacheJob.ts
+++ b/packages/core/src/jobs/job-definitions/maintenance/refreshDocumentsStatsCacheJob.ts
@@ -3,7 +3,7 @@ import { Job } from 'bullmq'
 import { and, inArray, isNull } from 'drizzle-orm'
 import { database } from '../../../client'
 import { commits, documentVersions } from '../../../schema'
-import { maintenanceQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export type RefreshDocumentsStatsCacheJobData = Record<string, never>
 
@@ -38,6 +38,7 @@ export const refreshDocumentsStatsCacheJob = async (
     .then((r) => r)
 
   for (const document of candidates) {
+    const { maintenanceQueue } = await queues()
     await maintenanceQueue.add(
       'refreshDocumentStatsCacheJob',
       { documentUuid: document.uuid },

--- a/packages/core/src/jobs/job-definitions/maintenance/refreshProjectsStatsCacheJob.ts
+++ b/packages/core/src/jobs/job-definitions/maintenance/refreshProjectsStatsCacheJob.ts
@@ -2,7 +2,7 @@ import { Job } from 'bullmq'
 import { isNull } from 'drizzle-orm'
 import { database } from '../../../client'
 import { projects } from '../../../schema'
-import { maintenanceQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export type RefreshProjectsStatsCacheJobData = Record<string, never>
 
@@ -16,6 +16,7 @@ export const refreshProjectsStatsCacheJob = async (
     .then((r) => r)
 
   for (const project of candidates) {
+    const { maintenanceQueue } = await queues()
     await maintenanceQueue.add(
       'refreshProjectStatsCacheJob',
       { projectId: project.id },

--- a/packages/core/src/jobs/job-definitions/maintenance/scheduleWorkspaceCleanupJobs.ts
+++ b/packages/core/src/jobs/job-definitions/maintenance/scheduleWorkspaceCleanupJobs.ts
@@ -3,7 +3,7 @@ import { eq, inArray } from 'drizzle-orm'
 import { FREE_PLANS } from '../../../plans'
 import { database } from '../../../client'
 import { subscriptions, workspaces } from '../../../schema'
-import { maintenanceQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export type ScheduleWorkspaceCleanupJobsData = Record<string, never>
 
@@ -35,6 +35,7 @@ export const scheduleWorkspaceCleanupJobs = async (
 
   // Enqueue individual cleanup job for each free workspace
   for (const workspace of freeWorkspaces) {
+    const { maintenanceQueue } = await queues()
     await maintenanceQueue.add(
       'cleanupWorkspaceOldLogsJob',
       { workspaceId: workspace.id },

--- a/packages/core/src/jobs/job-definitions/webhooks/processWebhookJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/processWebhookJob.test.ts
@@ -1,5 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { webhooksQueue } from '../../queues'
+import { describe, expect, it, vi } from 'vitest'
 import { processWebhookJob } from './processWebhookJob'
 import * as factories from '../../../tests/factories'
 import { Commit, Providers } from '../../../browser'
@@ -13,10 +12,13 @@ describe('processWebhookJob', () => {
     webhooksQueue: vi.fn(),
   }))
 
-  beforeEach(async () => {
-    // Mock the webhooksQueue.add method
-    vi.spyOn(webhooksQueue, 'add').mockImplementation(mocks.webhooksQueue)
-  })
+  vi.mock('../../queues', () => ({
+    queues: vi.fn().mockResolvedValue({
+      webhooksQueue: {
+        add: mocks.webhooksQueue,
+      },
+    }),
+  }))
 
   it('enqueues jobs for all active webhooks in the workspace', async () => {
     // Create a workspace and multiple webhooks

--- a/packages/core/src/jobs/job-definitions/webhooks/processWebhookJob.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/processWebhookJob.ts
@@ -3,7 +3,7 @@ import { eq, and } from 'drizzle-orm'
 import { database } from '../../../client'
 import { webhooks } from '../../../schema/models/webhooks'
 import { Events, LatitudeEvent } from '../../../events/events'
-import { webhooksQueue } from '../../queues'
+import { queues } from '../../queues'
 
 export const WEBHOOK_EVENTS: Array<Events> = [
   'commitPublished',
@@ -35,8 +35,9 @@ export async function processWebhookJob({
 
   // Enqueue a job for each webhook
   await Promise.all(
-    activeWebhooks.map((webhook) => {
-      webhooksQueue.add('processIndividualWebhookJob', {
+    activeWebhooks.map(async (webhook) => {
+      const { webhooksQueue } = await queues()
+      return webhooksQueue.add('processIndividualWebhookJob', {
         event,
         webhookId: webhook.id,
       })

--- a/packages/core/src/jobs/queues/index.ts
+++ b/packages/core/src/jobs/queues/index.ts
@@ -3,30 +3,52 @@ import { Queue, QueueOptions } from 'bullmq'
 import { Queues } from './types'
 import { buildRedisConnection } from '../../redis'
 
-const options: QueueOptions = {
-  prefix: 'latitude',
-  connection: await buildRedisConnection({
-    host: env.QUEUE_HOST,
-    port: env.QUEUE_PORT,
-    password: env.QUEUE_PASSWORD,
-  }),
-  defaultJobOptions: {
-    attempts: env.JOB_RETRY_ATTEMPTS,
-    backoff: {
-      type: 'exponential',
-      delay: 1000,
-    },
-    removeOnFail: true,
-    removeOnComplete: true,
-  },
-}
+let _queues:
+  | {
+      defaultQueue: Queue
+      documentSuggestionsQueue: Queue
+      documentsQueue: Queue
+      evaluationsQueue: Queue
+      eventHandlersQueue: Queue
+      eventsQueue: Queue
+      maintenanceQueue: Queue
+      tracingQueue: Queue
+      webhooksQueue: Queue
+    }
+  | undefined
 
-export const defaultQueue = new Queue(Queues.defaultQueue, options)
-export const documentSuggestionsQueue = new Queue(Queues.documentSuggestionsQueue, options) // prettier-ignore
-export const documentsQueue = new Queue(Queues.documentsQueue, options)
-export const evaluationsQueue = new Queue(Queues.evaluationsQueue, options)
-export const eventHandlersQueue = new Queue(Queues.eventHandlersQueue, options)
-export const eventsQueue = new Queue(Queues.eventsQueue, options)
-export const maintenanceQueue = new Queue(Queues.maintenanceQueue, options)
-export const tracingQueue = new Queue(Queues.tracingQueue, options)
-export const webhooksQueue = new Queue(Queues.webhooksQueue, options)
+export async function queues() {
+  if (_queues) return _queues
+
+  const options: QueueOptions = {
+    prefix: 'latitude',
+    connection: await buildRedisConnection({
+      host: env.QUEUE_HOST,
+      port: env.QUEUE_PORT,
+      password: env.QUEUE_PASSWORD,
+    }),
+    defaultJobOptions: {
+      attempts: env.JOB_RETRY_ATTEMPTS,
+      backoff: {
+        type: 'exponential',
+        delay: 1000,
+      },
+      removeOnFail: true,
+      removeOnComplete: true,
+    },
+  }
+
+  _queues = {
+    defaultQueue: new Queue(Queues.defaultQueue, options),
+    documentSuggestionsQueue: new Queue(Queues.documentSuggestionsQueue, options), // prettier-ignore
+    documentsQueue: new Queue(Queues.documentsQueue, options),
+    evaluationsQueue: new Queue(Queues.evaluationsQueue, options),
+    eventHandlersQueue: new Queue(Queues.eventHandlersQueue, options),
+    eventsQueue: new Queue(Queues.eventsQueue, options),
+    maintenanceQueue: new Queue(Queues.maintenanceQueue, options),
+    tracingQueue: new Queue(Queues.tracingQueue, options),
+    webhooksQueue: new Queue(Queues.webhooksQueue, options),
+  }
+
+  return _queues
+}

--- a/packages/core/src/services/__deprecated/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
+++ b/packages/core/src/services/__deprecated/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
@@ -7,7 +7,7 @@ import {
   LogSources,
   StreamType,
 } from '../../../../constants'
-import { defaultQueue } from '../../../../jobs/queues'
+import { queues } from '../../../../jobs/queues'
 import { generateUUIDIdentifier } from '../../../../lib/generateUUID'
 import { PartialConfig } from '../../../ai'
 import { createProviderLog } from '../../../providerLogs/create'
@@ -39,6 +39,7 @@ export async function saveOrPublishProviderLogs<
     return providerLog as P
   }
 
+  const { defaultQueue } = await queues()
   defaultQueue.add('createProviderLogJob', {
     ...providerLogsData,
     generatedAt: data.generatedAt.toISOString(),

--- a/packages/core/src/services/actions/createAgent.ts
+++ b/packages/core/src/services/actions/createAgent.ts
@@ -8,7 +8,7 @@ import {
 } from '../../browser'
 import { cache as getCache } from '../../cache'
 import { database } from '../../client'
-import { defaultQueue } from '../../jobs/queues'
+import { queues } from '../../jobs/queues'
 import { BadRequestError, UnprocessableEntityError } from '../../lib/errors'
 import { hashContent } from '../../lib/hashContent'
 import { Result } from '../../lib/Result'
@@ -53,6 +53,7 @@ ${parameters.prompt}
   const { project, commit } = creating.unwrap()
 
   try {
+    const { defaultQueue } = await queues()
     defaultQueue.add('generateProjectNameJob', {
       workspaceId: workspace.id,
       projectId: project.id,

--- a/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
+++ b/packages/core/src/services/chains/ProviderProcessor/saveOrPublishProviderLogs.ts
@@ -8,7 +8,7 @@ import {
   StreamType,
 } from '@latitude-data/constants'
 import { ProviderApiKey, Workspace } from '../../../browser'
-import { defaultQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { generateUUIDIdentifier } from '../../../lib/generateUUID'
 import { PartialConfig } from '../../ai'
 import { createProviderLog } from '../../providerLogs/create'
@@ -59,6 +59,7 @@ export async function saveOrPublishProviderLogs<
     return providerLog as P
   }
 
+  const { defaultQueue } = await queues()
   defaultQueue.add('createProviderLogJob', {
     ...providerLogsData,
     generatedAt: data.generatedAt.toISOString(),

--- a/packages/core/src/services/copilot/latte/createLatteJob.ts
+++ b/packages/core/src/services/copilot/latte/createLatteJob.ts
@@ -1,7 +1,7 @@
 import { LatitudeError } from '@latitude-data/constants/errors'
 import { User, Workspace, Project } from '../../../browser'
 import { RunLatteJobData } from '../../../jobs/job-definitions/copilot/chat'
-import { documentsQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { ErrorResult, Result } from '../../../lib/Result'
 import { PromisedResult } from '../../../lib/Transaction'
 import { checkLatteCredits } from './credits/check'
@@ -32,6 +32,7 @@ export async function createLatteJob({
     return Result.error(checking.error)
   }
 
+  const { documentsQueue } = await queues()
   const job = await documentsQueue.add('runLatteJob', {
     workspaceId: workspace.id,
     projectId: project.id,

--- a/packages/core/src/services/documentLogs/bulkUpload.ts
+++ b/packages/core/src/services/documentLogs/bulkUpload.ts
@@ -1,6 +1,6 @@
 import { Commit, DocumentVersion, Workspace } from '../../browser'
 import { LogSources } from '../../constants'
-import { defaultQueue } from '../../jobs/queues'
+import { queues } from '../../jobs/queues'
 import { syncReadCsv } from '../../lib/readCsv'
 
 export async function bulkUploadDocumentLogs({
@@ -20,6 +20,7 @@ export async function bulkUploadDocumentLogs({
     delimiter: csvDelimiter,
     columns: false,
   }).then((r) => r.unwrap())
+  const { defaultQueue } = await queues()
   defaultQueue.add('uploadDocumentLogsJob', {
     workspaceId: workspace.id,
     documentUuid: document.documentUuid,

--- a/packages/core/src/services/documentTriggers/triggerEvents/enqueueRunDocumentFromTriggerEventJob.ts
+++ b/packages/core/src/services/documentTriggers/triggerEvents/enqueueRunDocumentFromTriggerEventJob.ts
@@ -1,6 +1,6 @@
 import { ExecuteDocumentTriggerJobData } from '../../../jobs/job-definitions/documentTriggers/runDocumentTriggerEventJob'
 import { Commit, DocumentTriggerEvent, Workspace } from '../../../browser'
-import { documentsQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { PromisedResult } from '../../../lib/Transaction'
 import { Result } from '../../../lib/Result'
 
@@ -19,6 +19,7 @@ export async function enqueueRunDocumentFromTriggerEventJob({
     commitId: commit.id,
   }
 
+  const { documentsQueue } = await queues()
   await documentsQueue.add('runDocumentTriggerEventJob', jobData)
 
   return Result.nil()

--- a/packages/core/src/services/experiments/start/index.ts
+++ b/packages/core/src/services/experiments/start/index.ts
@@ -1,7 +1,7 @@
 import { Experiment } from '../../../browser'
 import { LatitudeError } from '../../../lib/errors'
 import { Workspace } from '../../../browser'
-import { documentsQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { experiments } from '../../../schema'
 import { eq } from 'drizzle-orm'
 import { getExperimentJobPayload } from './getExperimentJobPayload'
@@ -55,6 +55,7 @@ export async function startExperiment(
   }
 
   const { experiment, commit, rows } = updateResult.unwrap()
+  const { documentsQueue } = await queues()
 
   for await (const row of rows) {
     await documentsQueue.add('runDocumentForExperimentJob', {

--- a/packages/core/src/services/integrations/McpClient/hosted.ts
+++ b/packages/core/src/services/integrations/McpClient/hosted.ts
@@ -4,7 +4,7 @@ import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { IntegrationDto, McpServer } from '../../../browser'
 import { publisher } from '../../../events/publisher'
-import { maintenanceQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { Result, TypedResult } from '../../../lib/Result'
 import { StreamManager } from '../../../lib/streamManager'
 import { McpServerRepository } from '../../../repositories'
@@ -80,6 +80,7 @@ async function updateMcpServerLastUsed(
   }
 
   try {
+    const { maintenanceQueue } = await queues()
     await maintenanceQueue.add('updateMcpServerLastUsedJob', {
       workspaceId: integration.workspaceId,
       mcpServerId: mcpServerResult.value.id,

--- a/packages/core/src/services/mcpServers/autoScaleService.test.ts
+++ b/packages/core/src/services/mcpServers/autoScaleService.test.ts
@@ -6,15 +6,20 @@ import { SubscriptionPlan } from '../../plans'
 import { autoScaleInactiveServers } from './autoScaleService'
 import { createWorkspace, createMcpServer } from '../../tests/factories'
 import { workspaces } from '../../schema'
-import { maintenanceQueue } from '../../jobs/queues'
 
 const mocks = vi.hoisted(() => ({
   maintenanceQueue: vi.fn(),
 }))
 
-describe('autoScaleInactiveServers', () => {
-  vi.spyOn(maintenanceQueue, 'add').mockImplementation(mocks.maintenanceQueue)
+vi.mock('../../jobs/queues', () => ({
+  queues: vi.fn().mockResolvedValue({
+    maintenanceQueue: {
+      add: mocks.maintenanceQueue,
+    },
+  }),
+}))
 
+describe('autoScaleInactiveServers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })

--- a/packages/core/src/services/tracing/spans/enqueue.ts
+++ b/packages/core/src/services/tracing/spans/enqueue.ts
@@ -7,7 +7,7 @@ import {
   Workspace,
 } from '../../../browser'
 import { ingestSpansJobKey } from '../../../jobs/job-definitions/tracing/ingestSpansJob'
-import { tracingQueue } from '../../../jobs/queues'
+import { queues } from '../../../jobs/queues'
 import { diskFactory, DiskWrapper } from '../../../lib/disk'
 import { hashContent as hash } from '../../../lib/hashContent'
 import { Result, TypedResult } from '../../../lib/Result'
@@ -34,6 +34,7 @@ export async function enqueueSpans(
     workspaceId: workspace?.id,
   }
 
+  const { tracingQueue } = await queues()
   await tracingQueue.add('ingestSpansJob', payload, {
     attempts: TRACING_JOBS_MAX_ATTEMPTS,
     deduplication: { id: ingestSpansJobKey(payload) },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/env
       '@latitude-data/sdk':
-        specifier: 5.0.0-beta.2
-        version: 5.0.0-beta.2(typescript@5.8.3)(ws@8.18.3)
+        specifier: 5.0.0
+        version: 5.0.0(typescript@5.8.3)(ws@8.18.3)
       '@latitude-data/socket.io-react-hook':
         specifier: 2.4.5
         version: 2.4.5(react@19.0.0-rc-5d19e1c8-20240923)
@@ -3536,8 +3536,8 @@ packages:
     peerDependencies:
       typescript: ^5.5.4
 
-  '@latitude-data/sdk@5.0.0-beta.2':
-    resolution: {integrity: sha512-3niZ8aZTW4IkvlOL6sLQ9SIu9UdasEeoUEOxGJxMwhO/pAI0DiG8WfkoEz5PZjqI/j6qRn7HGN6LtZbVvz2KeQ==}
+  '@latitude-data/sdk@5.0.0':
+    resolution: {integrity: sha512-62tpSInd8/weR9zqDDx/wT8nEwFtUXkqao508cYuA+cLh2c/Pm+0pRmbohlZwNPh4B1b4//SjlBzyTbFjNtp8g==}
     peerDependencies:
       typescript: ^5.5.4
 
@@ -17056,7 +17056,7 @@ snapshots:
       - encoding
       - ws
 
-  '@latitude-data/sdk@5.0.0-beta.2(typescript@5.8.3)(ws@8.18.3)':
+  '@latitude-data/sdk@5.0.0(typescript@5.8.3)(ws@8.18.3)':
     dependencies:
       eventsource-parser: 2.0.1
       node-fetch: 2.7.0


### PR DESCRIPTION
NextJS does some static analysis of bundles which triggers redis connection attempts in an environment that shouldn't have any. Lazy loading redis connections fixed this.