### PR TITLE
Add latte debugMode for showing real descriptions

### DIFF
--- a/apps/web/src/actions/latte/addMessage.ts
+++ b/apps/web/src/actions/latte/addMessage.ts
@@ -18,11 +18,12 @@ export const addMessageToLatteAction = (
       threadUuid: z.string(),
       message: z.string(),
       context: z.string(),
+      debugVersionUuid: z.string().optional(),
     }),
   )
   .handler(async ({ ctx, input }) => {
     const { workspace, user } = ctx
-    const { message, threadUuid, context } = input
+    const { message, threadUuid, context, debugVersionUuid } = input
     const threadScope = new LatteThreadsRepository(workspace.id)
     const thread = await threadScope.findByUuidAndUser({
       threadUuid,
@@ -39,6 +40,7 @@ export const addMessageToLatteAction = (
       threadUuid: thread.uuid,
       message,
       context,
+      debugVersionUuid,
     })
 
     runResult.unwrap()

--- a/apps/web/src/hooks/latte/helpers.ts
+++ b/apps/web/src/hooks/latte/helpers.ts
@@ -2,12 +2,22 @@ import { LatteTool } from '@latitude-data/constants/latte'
 import { ToolCall } from 'ai'
 import { LatteToolStep } from './types'
 
-export function getDescriptionFromToolCall(
-  toolCall: ToolCall<string, Record<string, unknown>>,
-): Partial<LatteToolStep> {
+export function getDescriptionFromToolCall({
+  toolCall,
+  debugMode,
+}: {
+  toolCall: ToolCall<string, Record<string, unknown>>
+  debugMode: boolean
+}): Partial<LatteToolStep> {
   const name = toolCall.toolName
   const params = toolCall.args
   const latteTools = Object.values(LatteTool)
+
+  if (debugMode) {
+    return {
+      activeDescription: name,
+    }
+  }
 
   if (latteTools.includes(name as LatteTool)) {
     return getDescriptionFromLatteTool(name as LatteTool, params)

--- a/apps/web/src/hooks/latte/useLatteChatActions.ts
+++ b/apps/web/src/hooks/latte/useLatteChatActions.ts
@@ -83,6 +83,7 @@ export function useLatteChatActions() {
           projectId,
           message,
           context: latteContext,
+          debugVersionUuid,
         })
       } else {
         createNewChat({

--- a/apps/web/src/hooks/latte/useLatteThreadUpdates.ts
+++ b/apps/web/src/hooks/latte/useLatteThreadUpdates.ts
@@ -19,9 +19,12 @@ function createToolStep(
   update: Extract<LatteThreadUpdateArgs, { type: 'toolStarted' }>,
 ): LatteToolStep {
   const description = getDescriptionFromToolCall({
-    toolCallId: update.toolCallId,
-    toolName: update.toolName,
-    args: update.args,
+    toolCall: {
+      toolName: update.toolName,
+      args: update.args,
+      toolCallId: update.toolCallId,
+    },
+    debugMode: update.debugMode,
   })
 
   return {

--- a/packages/core/src/jobs/job-definitions/copilot/chat.ts
+++ b/packages/core/src/jobs/job-definitions/copilot/chat.ts
@@ -116,6 +116,7 @@ export const runLatteJob = async (job: Job<RunLatteJobData>) => {
         message,
         context,
         abortSignal: controller.signal,
+        debugVersionUuid,
       })
       if (!runResult.ok) {
         await emitError({
@@ -139,6 +140,7 @@ export const runLatteJob = async (job: Job<RunLatteJobData>) => {
       message,
       context,
       abortSignal: controller.signal,
+      debugVersionUuid,
     })
     if (!runResult.ok) {
       await emitError({

--- a/packages/core/src/services/copilot/latte/debugVersions.ts
+++ b/packages/core/src/services/copilot/latte/debugVersions.ts
@@ -59,3 +59,29 @@ export async function getLatteDebugVersions(
     })),
   ])
 }
+
+/**
+ * Returns true if the debugVersion is not the live Latte version, false otherwise
+ */
+export async function isLatteDebugSession(
+  workspaceId: number,
+  debugVersionUuid?: string,
+): PromisedResult<boolean> {
+  if (!debugVersionUuid) {
+    return Result.ok(false)
+  }
+
+  const latteVersionsResult = await getLatteDebugVersions(workspaceId)
+  if (!Result.isOk(latteVersionsResult)) {
+    return latteVersionsResult
+  }
+  const latteVersions = latteVersionsResult.unwrap()
+
+  const latteVersionUsed = latteVersions.find(
+    (v) => v.uuid === debugVersionUuid,
+  )
+
+  const isDebugSession = latteVersionUsed?.isLive === false
+
+  return Result.ok(isDebugSession)
+}

--- a/packages/core/src/services/copilot/latte/helpers.ts
+++ b/packages/core/src/services/copilot/latte/helpers.ts
@@ -152,10 +152,12 @@ export async function sendWebsockets({
   workspace,
   threadUuid,
   stream,
+  isLatteDebugSession,
 }: {
   workspace: Workspace
   threadUuid: string
   stream: ReadableStream<ChainEvent>
+  isLatteDebugSession: boolean
 }) {
   for await (const payload of streamToGenerator(stream)) {
     const { event, data } = payload
@@ -183,6 +185,7 @@ export async function sendWebsockets({
             toolCallId: data.toolCallId,
             toolName: data.toolName,
             args: data.args,
+            debugMode: isLatteDebugSession,
           } as LatteThreadUpdateArgs,
         })
       }

--- a/packages/core/src/websockets/constants.ts
+++ b/packages/core/src/websockets/constants.ts
@@ -135,6 +135,7 @@ type LatteThreadToolStarted = {
   type: 'toolStarted'
   toolName: string
   toolCallId: string
+  debugMode: boolean
   args: Record<string, unknown>
 }
 

--- a/packages/web-ui/src/ds/atoms/Select/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/index.tsx
@@ -28,12 +28,8 @@ export type SelectOptionGroup<V extends unknown = unknown> = {
   options: SelectOption<V>[]
 }
 export function Options({ options }: { options: SelectOption[] }) {
-  return options.map((option) => (
-    <SelectItem
-      key={option.label}
-      value={String(option.value)}
-      icon={option.icon}
-    >
+  return options.map((option, key) => (
+    <SelectItem key={key} value={String(option.value)} icon={option.icon}>
       {option.label}
     </SelectItem>
   ))


### PR DESCRIPTION
When debugging latte in different versions, we would still show the beautified descriptions and it would make it hard to debug. This fix fixes that, so from now on, all draft versions of Latte show the crud agent and tool names, and the live version the beautified.