### PR TITLE
Refactor provider API keys table

### DIFF
--- a/apps/web/src/actions/providerApiKeys/update.ts
+++ b/apps/web/src/actions/providerApiKeys/update.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { z } from 'zod'
+import { authProcedure } from '../procedures'
+import { ProviderApiKeysRepository } from '@latitude-data/core/repositories'
+import providerApiKeyPresenter from '$/presenters/providerApiKeyPresenter'
+import { updateProviderApiKeyName } from '@latitude-data/core/services/providerApiKeys/updateName'
+
+export const updateProviderApiKeyAction = authProcedure
+  .createServerAction()
+  .input(z.object({ id: z.coerce.number(), name: z.string() }))
+  .handler(async ({ input, ctx }) => {
+    const providerApiKeysRepository = new ProviderApiKeysRepository(
+      ctx.workspace.id,
+    )
+    const providerApiKey = await providerApiKeysRepository
+      .find(input.id)
+      .then((r) => r.unwrap())
+
+    return await updateProviderApiKeyName({
+      providerApiKey,
+      name: input.name,
+      workspaceId: ctx.workspace.id,
+    })
+      .then((r) => r.unwrap())
+      .then(providerApiKeyPresenter)
+  })

--- a/apps/web/src/app/(private)/settings/provider-api-keys/[providerApiKeyId]/update/page.tsx
+++ b/apps/web/src/app/(private)/settings/provider-api-keys/[providerApiKeyId]/update/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useFormAction } from '$/hooks/useFormAction'
+import { useNavigate } from '$/hooks/useNavigate'
+import useProviderApiKeys from '$/stores/providerApiKeys'
+import { ROUTES } from '$/services/routes'
+import { Input } from '@latitude-data/web-ui/atoms/Input'
+import { Modal } from '@latitude-data/web-ui/atoms/Modal'
+import { use, useMemo, useCallback } from 'react'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+
+export default function UpdateProviderApiKeyPage({
+  params,
+}: {
+  params: Promise<{ providerApiKeyId: string }>
+}) {
+  const { providerApiKeyId } = use(params)
+  const navigate = useNavigate()
+
+  const { data: apiKeys, update, isUpdating } = useProviderApiKeys()
+  const { action } = useFormAction(update, {
+    onSuccess: () => {
+      navigate.push(ROUTES.settings.root)
+    },
+  })
+  const apiKey = useMemo(
+    () => apiKeys.find((k) => k.id === Number(providerApiKeyId)),
+    [apiKeys, providerApiKeyId],
+  )
+
+  const onCancel = useCallback(() => {
+    navigate.push(ROUTES.settings.root)
+  }, [navigate])
+
+  return (
+    <Modal
+      open
+      dismissible
+      onOpenChange={(open) => !open && onCancel()}
+      title='Update provider API key'
+      description='Update the name for your provider API key'
+      footer={
+        <div className='flex flex-row gap-2'>
+          <Button
+            fancy
+            variant='outline'
+            onClick={onCancel}
+            disabled={isUpdating}
+          >
+            Cancel
+          </Button>
+          <Button
+            fancy
+            type='submit'
+            form='update-api-key-form'
+            disabled={isUpdating}
+          >
+            {isUpdating ? 'Updating...' : 'Update'}
+          </Button>
+        </div>
+      }
+    >
+      <form id='update-api-key-form' action={action}>
+        <Input type='hidden' name='id' value={providerApiKeyId} />
+        <Input
+          autoFocus
+          label='Name'
+          name='name'
+          defaultValue={apiKey?.name ?? ''}
+          placeholder='Enter new provider API key name'
+        />
+      </form>
+    </Modal>
+  )
+}

--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -88,6 +88,9 @@ export const ROUTES = {
       destroy: (id: number) => {
         return { root: `/settings/provider-api-keys/${id}/destroy` }
       },
+      update: (id: number) => {
+        return { root: `/settings/provider-api-keys/${id}/update` }
+      },
     },
     promocodes: {
       root: `/promocodes`,

--- a/apps/web/src/stores/providerApiKeys/index.ts
+++ b/apps/web/src/stores/providerApiKeys/index.ts
@@ -1,5 +1,6 @@
 import { createProviderApiKeyAction } from '$/actions/providerApiKeys/create'
 import { destroyProviderApiKeyAction } from '$/actions/providerApiKeys/destroy'
+import { updateProviderApiKeyAction } from '$/actions/providerApiKeys/update'
 import useFetcher from '$/hooks/useFetcher'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 import { ROUTES } from '$/services/routes'
@@ -63,6 +64,19 @@ export default function useProviderApiKeys(opts?: SWRConfiguration) {
     },
   )
 
+  const { execute: update, isPending: isUpdating } = useLatitudeAction(
+    updateProviderApiKeyAction,
+    {
+      onSuccess: async ({ data: apikey }) => {
+        toast({
+          title: 'Success',
+          description: `${apikey.name} updated successfully`,
+        })
+        mutate(data.map((item) => (item.id === apikey.id ? apikey : item)))
+      },
+    },
+  )
+
   return useMemo(
     () => ({
       data,
@@ -71,9 +85,21 @@ export default function useProviderApiKeys(opts?: SWRConfiguration) {
       mutate,
       isCreating,
       isDestroying,
+      update,
+      isUpdating,
       ...rest,
     }),
-    [data, create, destroy, mutate, isCreating, isDestroying, rest],
+    [
+      data,
+      create,
+      destroy,
+      update,
+      mutate,
+      isCreating,
+      isDestroying,
+      isUpdating,
+      rest,
+    ],
   )
 }
 

--- a/packages/core/src/data-access/providerLogs.ts
+++ b/packages/core/src/data-access/providerLogs.ts
@@ -16,17 +16,3 @@ export const findLastProviderLogFromDocumentLogUuid = async (
 
   return hydrateProviderLog(result).then((r) => r.unwrap())
 }
-
-export const unsafelyFindProviderLogByUuid = async (
-  providerLogUuid: string,
-  db = database,
-) => {
-  const result = await db
-    .select()
-    .from(providerLogs)
-    .where(eq(providerLogs.uuid, providerLogUuid))
-    .limit(1)
-  if (!result[0]) return
-
-  return hydrateProviderLog(result[0]).then((r) => r.unwrap())
-}

--- a/packages/core/src/services/providerApiKeys/helpers/validateName.ts
+++ b/packages/core/src/services/providerApiKeys/helpers/validateName.ts
@@ -1,0 +1,30 @@
+import { Result } from '../../../lib/Result'
+import { BadRequestError } from '../../../lib/errors'
+import { ProviderApiKeysRepository } from '../../../repositories/providerApiKeysRepository'
+import { database } from '../../../client'
+
+export async function validateProviderApiKeyName(
+  {
+    name,
+    workspaceId,
+  }: {
+    name: string
+    workspaceId: number
+  },
+  db = database,
+) {
+  const trimmedName = name.trim()
+  if (trimmedName.length < 1) {
+    return Result.error(
+      new BadRequestError('Name must be at least 1 characters long'),
+    )
+  }
+  const scope = new ProviderApiKeysRepository(workspaceId, db)
+  const result = await scope.findByName(trimmedName)
+  if (Result.isOk(result)) {
+    return Result.error(
+      new BadRequestError('A provider API key with this name already exists'),
+    )
+  }
+  return Result.ok(trimmedName)
+}

--- a/packages/core/src/services/providerApiKeys/updateName.test.ts
+++ b/packages/core/src/services/providerApiKeys/updateName.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { Providers, User, Workspace } from '../../browser'
+import { ProviderApiKeysRepository } from '../../repositories'
+import { createProject } from '../../tests/factories'
+import { createProviderApiKey } from './create'
+import { updateProviderApiKeyName } from './updateName'
+import { BadRequestError } from './../../lib/errors'
+
+describe('updateProviderApiKeyName', () => {
+  let workspace: Workspace
+  let user: User
+
+  beforeEach(async () => {
+    const { workspace: w, user: u } = await createProject({ providers: [] })
+    workspace = w
+    user = u
+  })
+
+  it('updates provider API key name successfully', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      provider: Providers.OpenAI,
+      token: 'fake-token',
+      name: 'Original Name',
+      author: user,
+    }).then((r) => r.unwrap())
+
+    const result = await updateProviderApiKeyName({
+      providerApiKey: provider,
+      workspaceId: workspace.id,
+      name: 'Updated Name',
+    })
+
+    expect(result.ok).toEqual(true)
+
+    const updatedProvider = result.unwrap()
+
+    expect(updatedProvider.id).toEqual(provider.id)
+    expect(updatedProvider.name).toEqual('Updated Name')
+    expect(updatedProvider.provider).toEqual(provider.provider)
+    expect(updatedProvider.token).toEqual(provider.token)
+
+    const providersScope = new ProviderApiKeysRepository(workspace.id)
+    const providers = await providersScope.findAll().then((r) => r.unwrap())
+
+    expect(providers).toHaveLength(1)
+    expect(providers[0]!.name).toEqual('Updated Name')
+  })
+
+  it('does not allow empty name', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      provider: Providers.OpenAI,
+      token: 'fake-token',
+      name: 'Original Name',
+      author: user,
+    }).then((r) => r.unwrap())
+
+    const result = await updateProviderApiKeyName({
+      providerApiKey: provider,
+      workspaceId: workspace.id,
+      name: '',
+    })
+
+    expect(result.ok).toEqual(false)
+    expect(result.error).toBeInstanceOf(BadRequestError)
+    expect(result.error!.message).toEqual(
+      'Name must be at least 1 characters long',
+    )
+
+    const providersScope = new ProviderApiKeysRepository(workspace.id)
+    const providers = await providersScope.findAll().then((r) => r.unwrap())
+
+    expect(providers).toHaveLength(1)
+    expect(providers[0]!.name).toEqual('Original Name')
+  })
+
+  it('trims whitespace from name', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      provider: Providers.OpenAI,
+      token: 'fake-token',
+      name: 'Original Name',
+      author: user,
+    }).then((r) => r.unwrap())
+
+    const result = await updateProviderApiKeyName({
+      providerApiKey: provider,
+      workspaceId: workspace.id,
+      name: '  Updated Name  ',
+    })
+
+    expect(result.ok).toEqual(true)
+
+    const updatedProvider = result.unwrap()
+
+    expect(updatedProvider.id).toEqual(provider.id)
+    expect(updatedProvider.name).toEqual('Updated Name')
+
+    const providersScope = new ProviderApiKeysRepository(workspace.id)
+    const providers = await providersScope.findAll().then((r) => r.unwrap())
+
+    expect(providers).toHaveLength(1)
+    expect(providers[0]!.name).toEqual('Updated Name')
+  })
+
+  it('does not allow name with only whitespace', async () => {
+    const provider = await createProviderApiKey({
+      workspace,
+      provider: Providers.OpenAI,
+      token: 'fake-token',
+      name: 'Original Name',
+      author: user,
+    }).then((r) => r.unwrap())
+
+    const result = await updateProviderApiKeyName({
+      providerApiKey: provider,
+      workspaceId: workspace.id,
+      name: '   ',
+    })
+
+    expect(result.ok).toEqual(false)
+    expect(result.error).toBeInstanceOf(BadRequestError)
+    expect(result.error!.message).toEqual(
+      'Name must be at least 1 characters long',
+    )
+
+    const providersScope = new ProviderApiKeysRepository(workspace.id)
+    const providers = await providersScope.findAll().then((r) => r.unwrap())
+
+    expect(providers).toHaveLength(1)
+    expect(providers[0]!.name).toEqual('Original Name')
+  })
+})
+
+// TODO - Add the action with the updateName function, then update the UI to add this possibility

--- a/packages/core/src/services/providerApiKeys/updateName.ts
+++ b/packages/core/src/services/providerApiKeys/updateName.ts
@@ -1,0 +1,43 @@
+import { eq } from 'drizzle-orm'
+import { ProviderApiKey } from '../../browser'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { providerApiKeys } from '../../schema'
+import { validateProviderApiKeyName } from './helpers/validateName'
+
+export async function updateProviderApiKeyName(
+  {
+    providerApiKey,
+    workspaceId,
+    name,
+  }: {
+    providerApiKey: ProviderApiKey
+    workspaceId: number
+    name: string
+  },
+  transaction = new Transaction(),
+) {
+  return transaction.call<ProviderApiKey>(async (tx) => {
+    const validatedNameResult = await validateProviderApiKeyName(
+      {
+        name,
+        workspaceId,
+      },
+      tx,
+    )
+
+    if (!Result.isOk(validatedNameResult)) {
+      return validatedNameResult
+    }
+
+    const validatedName = validatedNameResult.unwrap()
+
+    const result = await tx
+      .update(providerApiKeys)
+      .set({ name: validatedName })
+      .where(eq(providerApiKeys.id, providerApiKey.id))
+      .returning()
+
+    return Result.ok(result[0]!)
+  })
+}


### PR DESCRIPTION
# TODOS
- [x] Add createdAt column
- [x] Make createdAt and updatedAt sortable columns
- [x] add new functionality to update the name of the provider. 

Updating the name of the provider is a nice interaction to have now that with the marketplace, as other users may have different names of providers, and instead of changing the front matter provider name for each file, you can change now the name of your provider to match the one of the copied agents.


https://github.com/user-attachments/assets/c37a58c2-8d7d-4753-bdc2-24bc056b1c53

