### PR TITLE
feat: lazily get docs on document run

### DIFF
--- a/apps/gateway/src/common/documents/getData.ts
+++ b/apps/gateway/src/common/documents/getData.ts
@@ -88,7 +88,7 @@ export async function getAllDocumentsAtCommitWithMetadata({
     docs.map(async (document) => {
       const metadata = await getDocumentMetadata({
         document,
-        getDocumentByPath: (path) => docs.find((d) => d.path === path),
+        getDocumentByPath: async (path) => docs.find((d) => d.path === path),
       })
       return {
         document,

--- a/apps/gateway/src/presenters/documentPresenter.ts
+++ b/apps/gateway/src/presenters/documentPresenter.ts
@@ -40,14 +40,14 @@ export function documentPresenterWithProviderAndMetadata({
   const parameters =
     rawParams.length > 0
       ? rawParams.reduce(
-          (acc, rawParam) => {
-            if (acc[rawParam]) return acc
-            acc[rawParam] = { type: ParameterType.Text }
+        (acc, rawParam) => {
+          if (acc[rawParam]) return acc
+          acc[rawParam] = { type: ParameterType.Text }
 
-            return acc
-          },
-          { ...configParams },
-        )
+          return acc
+        },
+        { ...configParams },
+      )
       : configParams
 
   return {
@@ -72,7 +72,6 @@ export async function documentPresenter({
   workspace: Workspace
 }) {
   const metadataResult = await scanDocumentContent({
-    workspaceId: workspace.id,
     document,
     commit,
   })

--- a/apps/web/src/app/(public)/_data_access/index.ts
+++ b/apps/web/src/app/(public)/_data_access/index.ts
@@ -28,7 +28,6 @@ export const findSharedDocumentCached = cache(
 
     const { workspace, shared, document, commit } = result.value
     const metaResult = await scanDocumentContent({
-      workspaceId: shared.workspaceId,
       document,
       commit,
     })

--- a/packages/core/src/repositories/documentVersionsRepository/index.ts
+++ b/packages/core/src/repositories/documentVersionsRepository/index.ts
@@ -325,9 +325,7 @@ export class DocumentVersionsRepository extends RepositoryLegacy<
         maxMergedAt: commit.mergedAt,
       },
     ).then((r) => r.unwrap())
-
     if (commit.mergedAt !== null) {
-      // Referenced commit is merged. No additional documents to return.
       return Result.ok(documentsFromMergedCommits)
     }
 

--- a/packages/core/src/services/__deprecated/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/__deprecated/commits/runDocumentAtCommit.ts
@@ -92,7 +92,6 @@ export async function runDocumentAtCommitLegacy({
     workspaceId: workspace.id,
   })
   const result = await getResolvedContent({
-    workspaceId: workspace.id,
     document,
     commit,
     customPrompt,

--- a/packages/core/src/services/__deprecated/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/__deprecated/documentLogs/addMessages/index.ts
@@ -47,7 +47,6 @@ async function retrieveData({
   const providerLog = providerLogResult.value
 
   const metadataResult = await scanDocumentContent({
-    workspaceId: workspace.id,
     document,
     commit,
   })

--- a/packages/core/src/services/__deprecated/documentLogs/addMessages/resumePausedPrompt/index.ts
+++ b/packages/core/src/services/__deprecated/documentLogs/addMessages/resumePausedPrompt/index.ts
@@ -57,7 +57,6 @@ export async function resumePausedPrompt({
   abortSignal?: AbortSignal
 }) {
   const resultResolvedContent = await getResolvedContent({
-    workspaceId: workspace.id,
     document,
     commit,
   })

--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -6,16 +6,9 @@ import { APICallError } from 'ai'
 import { LogSources, Providers, StreamEventTypes } from '../../browser'
 import { publisher } from '../../events/publisher'
 import { ProviderLogsRepository } from '../../repositories'
-import {
-  createDocumentVersion,
-  createDraft,
-  createProject,
-  createTelemetryContext,
-  helpers,
-} from '../../tests/factories'
+import { createProject, createTelemetryContext } from '../../tests/factories'
 import { testConsumeStream } from '../../tests/helpers'
 import { Ok, Result } from './../../lib/Result'
-import { UnprocessableEntityError } from './../../lib/errors'
 import { runDocumentAtCommit } from './index'
 import * as createChainRunErrorMod from '../../lib/streamManager/ChainErrors'
 
@@ -101,38 +94,6 @@ describe('runDocumentAtCommit', () => {
   })
 
   describe('with an existing provider key', () => {
-    it('fails if document is not found in commit', async () => {
-      const { context, workspace, project, user, commit, provider } =
-        await buildData({
-          doc1Content: dummyDoc1Content,
-        })
-
-      const { commit: draft } = await createDraft({
-        project,
-        user,
-      })
-      const { documentVersion: documentNotInCommit } =
-        await createDocumentVersion({
-          workspace,
-          user,
-          commit: draft,
-          path: 'path/to/document',
-          content: helpers.createPrompt({ provider }),
-        })
-      const result = await runDocumentAtCommit({
-        context,
-        workspace,
-        document: documentNotInCommit,
-        commit,
-        parameters: {},
-        source: LogSources.API,
-      })
-
-      expect(result.error).toEqual(
-        new UnprocessableEntityError('Document not found in commit', {}),
-      )
-    })
-
     it('returns document resolvedContent', async () => {
       const { context, workspace, document, commit } = await buildData({
         doc1Content: dummyDoc1Content,

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -54,7 +54,6 @@ export async function runDocumentAtCommit({
     workspaceId: workspace.id,
   })
   const result = await getResolvedContent({
-    workspaceId: workspace.id,
     document,
     commit,
     customPrompt,

--- a/packages/core/src/services/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.ts
@@ -131,7 +131,6 @@ async function retrieveData({
   const providerLog = providerLogResult.value
 
   const metadataResult = await scanDocumentContent({
-    workspaceId: workspace.id,
     document,
     commit,
   })

--- a/packages/core/src/services/documents/forkDocument/buildDocuments.ts
+++ b/packages/core/src/services/documents/forkDocument/buildDocuments.ts
@@ -18,7 +18,7 @@ export async function buildDocuments({
     origin.documents.map(async (doc) => {
       const { config, setConfig } = await getDocumentMetadata({
         document: doc,
-        getDocumentByPath: (path) =>
+        getDocumentByPath: async (path) =>
           origin.documents.find((d) => d.path === path),
       })
       delete config.model

--- a/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
+++ b/packages/core/src/services/documents/forkDocument/getIncludedDocuments.ts
@@ -47,7 +47,6 @@ export async function getIncludedDocuments({
   document: DocumentVersion
 }) {
   const scannedDocuments = await scanCommitDocumentContents({
-    workspaceId: workspace.id,
     commit,
   }).then((r) => r.unwrap())
 

--- a/packages/core/src/services/documents/forkDocument/testHelpers/generateDocumentsOutput.ts
+++ b/packages/core/src/services/documents/forkDocument/testHelpers/generateDocumentsOutput.ts
@@ -22,7 +22,7 @@ export async function generateDocumentsOutput({
     allDocs.map(async (doc) => {
       const meta = await getDocumentMetadata({
         document: doc,
-        getDocumentByPath: (path) => allDocs.find((d) => d.path === path),
+        getDocumentByPath: async (path) => allDocs.find((d) => d.path === path),
       })
       return {
         path: doc.path,

--- a/packages/core/src/services/experiments/create.ts
+++ b/packages/core/src/services/experiments/create.ts
@@ -28,12 +28,10 @@ function calculateSelectedRangeCount({
 
 async function getPromptMetadata(
   {
-    workspace,
     commit,
     document,
     customPrompt,
   }: {
-    workspace: Workspace
     commit: Commit
     document: DocumentVersion
     customPrompt?: string // Prompt can be different than the current one
@@ -46,7 +44,6 @@ async function getPromptMetadata(
 }> {
   const metadata = await scanDocumentContent(
     {
-      workspaceId: workspace.id,
       document: {
         ...document,
         content: customPrompt ?? document.content,
@@ -104,7 +101,6 @@ export async function createExperiment(
 
     const promptMetadataResult = await getPromptMetadata(
       {
-        workspace,
         commit,
         document,
         customPrompt,

--- a/packages/core/src/tests/factories/documentLogs.ts
+++ b/packages/core/src/tests/factories/documentLogs.ts
@@ -66,8 +66,8 @@ async function generateProviderLogs({
         typeof message.content === 'string'
           ? message.content
           : message.content
-              .map((c) => (c.type === 'text' ? c.text : ''))
-              .join('')
+            .map((c) => (c.type === 'text' ? c.text : ''))
+            .join('')
       return acc + content.length
     }, 0)
     const completionTokens = mockedResponse.length
@@ -112,9 +112,8 @@ export async function createDocumentLog({
   skipProviderLogs,
   automaticProvidersGeneratedAt,
 }: IDocumentLogData) {
-  const workspace = (await findWorkspaceFromCommit(commit))!
+  const workspace = await findWorkspaceFromCommit(commit)
   const documentContent = await getResolvedContent({
-    workspaceId: workspace.id,
     document,
     commit,
   }).then((r) => r.unwrap())
@@ -134,7 +133,7 @@ export async function createDocumentLog({
   const duration =
     totalDuration ??
     Math.floor(Math.random() * 100) +
-      providerLogs.reduce((acc, log) => acc + (log?.duration ?? 0), 0)
+    providerLogs.reduce((acc, log) => acc + (log?.duration ?? 0), 0)
 
   let documentLog = await ogCreateDocumentLog({
     commit,


### PR DESCRIPTION
Trying to avoid db requests as much as possible before prompt execution by lazily computing the commit docs only when prompts have referenced documents.