### PR TITLE
feat: add 'today' latitude tool

### DIFF
--- a/packages/constants/src/config.ts
+++ b/packages/constants/src/config.ts
@@ -13,12 +13,14 @@ export enum LatitudeTool {
   RunCode = 'code',
   WebSearch = 'search',
   WebExtract = 'extract',
+  Today = 'today',
 }
 
 export enum LatitudeToolInternalName {
   RunCode = 'lat_tool_run_code',
   WebSearch = 'lat_tool_web_search',
   WebExtract = 'lat_tool_web_extract',
+  Today = 'lat_tool_today',
 }
 
 export const MAX_STEPS_CONFIG_NAME = 'maxSteps'

--- a/packages/core/src/services/latitudeTools/today/index.ts
+++ b/packages/core/src/services/latitudeTools/today/index.ts
@@ -1,0 +1,38 @@
+import {
+  LatitudeTool,
+  LatitudeToolInternalName,
+} from '@latitude-data/constants'
+import { LatitudeToolDefinition } from '../../../constants'
+import { LatitudeError } from '../../../lib/errors'
+import { Result } from '../../../lib/Result'
+import { PromisedResult } from '../../../lib/Transaction'
+import { TelemetryContext } from '../../../telemetry'
+import { withTelemetryWrapper } from '../telemetryWrapper'
+
+async function getToday(): PromisedResult<string, LatitudeError> {
+  const today = new Date().toISOString().split('T')[0]
+  return Result.ok(today)
+}
+
+export default {
+  name: LatitudeTool.Today,
+  internalName: LatitudeToolInternalName.Today,
+  method: getToday,
+  definition: (context: TelemetryContext) => ({
+    description:
+      "Returns today's date in UTC timezone and ISO format (YYYY-MM-DD).",
+    parameters: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+    execute: async (args: Record<string, never>, toolCall) =>
+      withTelemetryWrapper(getToday, {
+        toolName: LatitudeTool.Today,
+        context,
+        args,
+        toolCall,
+      }),
+  }),
+} as LatitudeToolDefinition

--- a/packages/core/src/services/latitudeTools/today/index.ts
+++ b/packages/core/src/services/latitudeTools/today/index.ts
@@ -10,7 +10,7 @@ import { TelemetryContext } from '../../../telemetry'
 import { withTelemetryWrapper } from '../telemetryWrapper'
 
 async function getToday(): PromisedResult<string, LatitudeError> {
-  const today = new Date().toISOString().split('T')[0]
+  const today = new Date().toISOString()
   return Result.ok(today)
 }
 
@@ -20,7 +20,7 @@ export default {
   method: getToday,
   definition: (context: TelemetryContext) => ({
     description:
-      "Returns today's date in UTC timezone and ISO format (YYYY-MM-DD).",
+      'Returns the current date and time in UTC timezone and ISO format (YYYY-MM-DDTHH:mm:ss.sssZ).',
     parameters: {
       type: 'object',
       properties: {},

--- a/packages/core/src/services/latitudeTools/tools.ts
+++ b/packages/core/src/services/latitudeTools/tools.ts
@@ -1,10 +1,12 @@
 import RunCodeTool from './runCode'
 import WebSearchTool from './webSearch'
 import WebExtractTool from './webExtract'
+import TodayTool from './today'
 import { LatitudeToolDefinition } from '../../constants'
 
 export const LATITUDE_TOOLS: LatitudeToolDefinition[] = [
   WebSearchTool,
   WebExtractTool,
   RunCodeTool,
+  TodayTool,
 ] as const


### PR DESCRIPTION
This PR adds a new latitude tool called 'today' that returns the current date and time in UTC timezone and ISO format (YYYY-MM-DDTHH:mm:ss.sssZ).

## Changes
- Added Today enum values to LatitudeTool and LatitudeToolInternalName in packages/constants/src/config.ts
- Created new today tool implementation in packages/core/src/services/latitudeTools/today/index.ts
- Registered the tool in the latitude tools registry in packages/core/src/services/latitudeTools/tools.ts

## Usage
The tool can be used as `latitude/today` and takes no parameters. It returns the current date and time in UTC as a full ISO 8601 timestamp string.

## Testing
The tool follows the same pattern as existing latitude tools (runCode, webSearch, webExtract) and integrates automatically with the existing tool resolution and execution infrastructure.