### PR TITLE
added "isLive" prop to DocumentRunRequestedEvent

### DIFF
--- a/apps/gateway/src/common/documents/getData.ts
+++ b/apps/gateway/src/common/documents/getData.ts
@@ -232,6 +232,12 @@ export async function publishDocumentRunRequestedEvent({
   parameters: Record<string, any>
 }) {
   const user = await findFirstUserInWorkspace(workspace)
+
+  const commitsScope = new CommitsRepository(workspace.id)
+  const headCommit = await commitsScope
+    .getHeadCommit(project.id)
+    .then((r) => r.unwrap())
+
   if (user) {
     publisher.publishLater({
       type: 'documentRunRequested',
@@ -239,6 +245,7 @@ export async function publishDocumentRunRequestedEvent({
         parameters,
         projectId: project.id,
         commitUuid: commit.uuid,
+        isLiveCommit: headCommit.uuid === commit.uuid,
         documentPath: document.path,
         workspaceId: workspace.id,
         userEmail: user.email,

--- a/apps/web/src/actions/sdk/runSharedPromptAction.ts
+++ b/apps/web/src/actions/sdk/runSharedPromptAction.ts
@@ -41,6 +41,7 @@ export async function runSharedPromptAction({
     data: {
       workspaceId: workspace.id,
       commitUuid,
+      isLiveCommit: true, // Shared prompts always run on the live commit
       projectId,
       documentPath,
       publishedDocumentUuid,

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -64,12 +64,18 @@ export const POST = errorHandler(
           'runs',
         ).then((r) => r.unwrap())
 
+        const commitsScope = new CommitsRepository(workspace.id)
+        const headCommit = await commitsScope
+          .getHeadCommit(projectId)
+          .then((r) => r.unwrap())
+
         // Publish document run event
         publisher.publishLater({
           type: 'documentRunRequested',
           data: {
             projectId,
             commitUuid,
+            isLiveCommit: headCommit.uuid === commitUuid,
             documentPath: path,
             parameters: _parameters,
             workspaceId: workspace.id,

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -329,6 +329,7 @@ export type DocumentCreatedEvent = LatitudeEventGeneric<
 type CommonDataDocumentRunRequestedEvent = {
   projectId: number
   commitUuid: string
+  isLiveCommit: boolean
   documentPath: string
   parameters: Record<string, unknown>
   workspaceId: number


### PR DESCRIPTION
added a `isLiveCommit` prop to track whether the requested commit is the current Live one or not for every new `documentRunRequested` request