### PR TITLE
Feature/new onboarding step 3 and 4

### DIFF
--- a/apps/web/src/actions/workspaceOnboarding/moveNextStep.ts
+++ b/apps/web/src/actions/workspaceOnboarding/moveNextStep.ts
@@ -16,6 +16,7 @@ export const moveNextOnboardingStepAction = authProcedure
 
     const nextOnboardingStep = await moveNextOnboardingStep({
       onboarding,
+      workspace: ctx.workspace,
     }).then((r) => r.unwrap())
 
     return nextOnboardingStep

--- a/apps/web/src/app/(onboarding)/onboarding/_components/Navbar/NocodersNavbar.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/Navbar/NocodersNavbar.tsx
@@ -5,7 +5,6 @@ import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { cn } from '@latitude-data/web-ui/utils'
 import { StatusFlagState } from '@latitude-data/web-ui/molecules/StatusFlag'
-import { completeOnboardingAction } from '$/actions/workspaceOnboarding/complete'
 import { ROUTES } from '$/services/routes'
 import { ONBOARDING_STEP_CONTENT } from '../../constants'
 import { calculateState } from './calculateState'
@@ -16,16 +15,18 @@ import { redirect } from 'next/navigation'
 export default function NocodersNavbar({
   currentStep,
   isLoadingOnboarding,
+  executeCompleteOnboarding,
 }: {
+  executeCompleteOnboarding: () => void
   currentStep: OnboardingStepKey | undefined | null // TODO(onboarding): remove null when data migration is done
   isLoadingOnboarding: boolean
 }) {
   const project = useCurrentProject()
 
   const skipOnboarding = useCallback(() => {
-    completeOnboardingAction()
+    executeCompleteOnboarding()
     redirect(ROUTES.dashboard.root)
-  }, [])
+  }, [executeCompleteOnboarding])
 
   return (
     <div className='flex flex-col p-6 items-start gap-8 h-full'>

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/configureTriggers/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/configureTriggers/index.tsx
@@ -39,7 +39,7 @@ export function ConfigureTriggersStep({
         (trigger) => trigger.triggerType === DocumentTriggerType.Integration,
       )
       .sort((a) => {
-        return a.triggerStatus === DocumentTriggerStatus.Deployed ? 1 : -1
+        return a.triggerStatus === DocumentTriggerStatus.Pending ? -1 : 1
       })
   }, [triggers])
 

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/index.tsx
@@ -16,7 +16,7 @@ import {
 import { useRunDocument } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/hooks/useRunDocument'
 import { useCurrentCommit } from '@latitude-data/web-ui/providers'
 import { usePlaygroundChat } from '$/hooks/playgroundChat/usePlaygroundChat'
-import { DocumentVersion } from '@latitude-data/core/browser'
+import { DocumentVersion } from '@latitude-data/core/schema/types'
 
 export function OnboardingClient() {
   const {

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/index.tsx
@@ -6,23 +6,48 @@ import useWorkspaceOnboarding from '$/stores/workspaceOnboarding'
 import { OnboardingStepKey } from '@latitude-data/constants/onboardingSteps'
 import { ConfigureTriggersStep } from './configureTriggers'
 import { TriggerAgentStep } from './triggerAgent'
+import { useCallback, useRef, useState } from 'react'
+import { useAutoScroll } from '@latitude-data/web-ui/hooks/useAutoScroll'
+import { RunAgentStep } from './runAgent'
+import {
+  ActiveTrigger,
+  FAKE_DOCUMENT,
+} from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList'
+import { useRunDocument } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/hooks/useRunDocument'
+import { useCurrentCommit } from '@latitude-data/web-ui/providers'
+import { usePlaygroundChat } from '$/hooks/playgroundChat/usePlaygroundChat'
+import { DocumentVersion } from '@latitude-data/core/browser'
 
 export function OnboardingClient() {
   const {
     onboarding: currentOnboarding,
     moveNextOnboardingStep,
     isLoading: isLoadingOnboarding,
+    executeCompleteOnboarding,
   } = useWorkspaceOnboarding()
 
   const currentStep = currentOnboarding?.currentStep
 
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useAutoScroll(containerRef, { startAtBottom: true })
+
+  const [activeTrigger, setActiveTrigger] = useState<ActiveTrigger>({
+    document: FAKE_DOCUMENT,
+    parameters: {},
+  })
+
   return (
-    <div className='flex flex-row flex-1 items-start self-stretch'>
+    <div className='flex flex-row flex-1 items-start custom-scrollbar'>
       <NocodersNavbar
+        executeCompleteOnboarding={executeCompleteOnboarding}
         currentStep={currentStep}
         isLoadingOnboarding={isLoadingOnboarding}
       />
-      <div className='flex-row flex-1 h-full'>
+      <div
+        ref={containerRef}
+        className='flex-row flex-1 h-full overflow-y-auto'
+      >
         {currentStep === OnboardingStepKey.SetupIntegrations && (
           <SetupIntegrationsStep
             moveNextOnboardingStep={moveNextOnboardingStep}
@@ -33,10 +58,85 @@ export function OnboardingClient() {
             moveNextOnboardingStep={moveNextOnboardingStep}
           />
         )}
-        {currentStep === OnboardingStepKey.TriggerAgent && (
-          <TriggerAgentStep moveNextOnboardingStep={moveNextOnboardingStep} />
+        {(currentStep === OnboardingStepKey.TriggerAgent ||
+          currentStep === OnboardingStepKey.RunAgent) && (
+          <PlaygroundSteps
+            moveNextOnboardingStep={moveNextOnboardingStep}
+            setActiveTrigger={setActiveTrigger}
+            currentStep={currentStep}
+            executeCompleteOnboarding={executeCompleteOnboarding}
+            activeTrigger={activeTrigger}
+          />
         )}
       </div>
     </div>
+  )
+}
+
+function PlaygroundSteps({
+  moveNextOnboardingStep,
+  setActiveTrigger,
+  currentStep,
+  executeCompleteOnboarding,
+  activeTrigger,
+}: {
+  moveNextOnboardingStep: () => void
+  setActiveTrigger: (trigger: ActiveTrigger) => void
+  currentStep: OnboardingStepKey
+  executeCompleteOnboarding: () => void
+  activeTrigger: ActiveTrigger
+}) {
+  const commit = useCurrentCommit()
+
+  const { runDocument, addMessages } = useRunDocument({
+    commit: commit.commit,
+  })
+
+  const runPromptFn = useCallback(
+    ({
+      document,
+      userMessage,
+      parameters = {},
+      aiParameters = true,
+    }: {
+      document: DocumentVersion
+      parameters: Record<string, unknown>
+      userMessage: string | undefined
+      aiParameters: boolean
+    }) =>
+      runDocument({
+        document,
+        parameters,
+        userMessage,
+        aiParameters,
+      }),
+    [runDocument],
+  )
+
+  const playground = usePlaygroundChat({
+    runPromptFn,
+    addMessagesFn: addMessages,
+    onPromptRan: (documentLogUuid, error) => {
+      if (!documentLogUuid || error) return
+    },
+  })
+
+  return (
+    <>
+      {currentStep === OnboardingStepKey.TriggerAgent && (
+        <TriggerAgentStep
+          moveNextOnboardingStep={moveNextOnboardingStep}
+          setActiveTrigger={setActiveTrigger}
+          playground={playground}
+        />
+      )}
+      {currentStep === OnboardingStepKey.RunAgent && (
+        <RunAgentStep
+          moveNextOnboardingStep={executeCompleteOnboarding}
+          activeTrigger={activeTrigger}
+          playground={playground}
+        />
+      )}
+    </>
   )
 }

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/runAgent/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/runAgent/index.tsx
@@ -1,0 +1,63 @@
+import { useCallback } from 'react'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import Chat from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/Chat'
+import { ActiveTrigger } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList'
+import { usePlaygroundChat } from '$/hooks/playgroundChat/usePlaygroundChat'
+import { redirect } from 'next/navigation'
+import { ROUTES } from '$/services/routes'
+import {
+  useCurrentCommit,
+  useCurrentProject,
+} from '@latitude-data/web-ui/providers'
+
+export function RunAgentStep({
+  moveNextOnboardingStep,
+  activeTrigger,
+  playground,
+}: {
+  moveNextOnboardingStep: () => void
+  activeTrigger: ActiveTrigger
+  playground: ReturnType<typeof usePlaygroundChat>
+}) {
+  const { project } = useCurrentProject()
+  const { commit } = useCurrentCommit()
+
+  const handleNext = useCallback(() => {
+    moveNextOnboardingStep()
+    redirect(
+      ROUTES.projects
+        .detail({ id: project.id })
+        .commits.detail({ uuid: commit.uuid }).preview.root,
+    )
+  }, [moveNextOnboardingStep, project, commit])
+
+  return (
+    <div className='flex flex-col items-center p-32 gap-10'>
+      <div className='flex flex-col items-center gap-2'>
+        <div className='p-2 rounded-lg bg-success-muted'>
+          <Icon name='checkClean' size='medium' />
+        </div>
+        <Text.H2M color='foreground' noWrap>
+          Done!
+        </Text.H2M>
+        <Text.H5 color='foregroundMuted'>Your agent is ready-to-go!</Text.H5>
+      </div>
+      <div className='flex flex-col items-center gap-2 border-dashed border-2 rounded-xl p-2 w-full max-w-[600px]'>
+        <Chat
+          showHeader={false}
+          playground={playground}
+          parameters={activeTrigger.parameters}
+        />
+      </div>
+      <Button
+        fancy
+        onClick={handleNext}
+        iconProps={{ name: 'chevronRight', placement: 'right' }}
+      >
+        Continue building
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/_components/RunTrigger.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/_components/RunTrigger.tsx
@@ -1,0 +1,177 @@
+import { DocumentTriggerType } from '@latitude-data/constants'
+import {
+  DocumentTrigger,
+  DocumentVersion,
+  IntegrationDto,
+} from '@latitude-data/core/browser'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { cn } from '@latitude-data/web-ui/utils'
+import { useCallback, useMemo } from 'react'
+import { TriggerEventsList } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerEventsList'
+import { OnRunTriggerFn } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList'
+import { useTriggerInfo } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersCard'
+import { useCurrentCommit } from '@latitude-data/web-ui/providers'
+import useDocumentVersions from '$/stores/documentVersions'
+
+function isChatTrigger(
+  trigger: DocumentTrigger,
+): trigger is DocumentTrigger<DocumentTriggerType.Chat> {
+  return trigger.triggerType === DocumentTriggerType.Chat
+}
+
+function isIntegrationTrigger(
+  trigger: DocumentTrigger,
+): trigger is DocumentTrigger<DocumentTriggerType.Integration> {
+  return trigger.triggerType === DocumentTriggerType.Integration
+}
+
+const RUNNABLE_TRIGGERS = [
+  DocumentTriggerType.Scheduled,
+  DocumentTriggerType.Chat,
+]
+
+export function RunTrigger({
+  trigger,
+  integrations,
+  onRunTrigger,
+  onRunChatTrigger,
+}: {
+  trigger: DocumentTrigger
+  integrations: IntegrationDto[]
+  onRunTrigger: OnRunTriggerFn
+  onRunChatTrigger: () => void
+}) {
+  const { commit } = useCurrentCommit()
+  const { data: documents } = useDocumentVersions({
+    projectId: trigger.projectId,
+    commitUuid: commit.uuid,
+  })
+
+  const document = useMemo<DocumentVersion | undefined>(
+    () => documents?.find((d) => d.documentUuid === trigger.documentUuid),
+    [documents, trigger.documentUuid],
+  )
+
+  // Loading documents. Triggers always should have a document linked
+  if (!document) return null
+
+  return (
+    <RunTriggerWrapper
+      trigger={trigger}
+      integrations={integrations}
+      document={document}
+      onRunTrigger={onRunTrigger}
+      onRunChatTrigger={onRunChatTrigger}
+    />
+  )
+}
+
+export function RunTriggerWrapper({
+  trigger,
+  integrations,
+  document,
+  onRunTrigger,
+  onRunChatTrigger,
+}: {
+  trigger: DocumentTrigger
+  integrations: IntegrationDto[]
+  document: DocumentVersion
+  onRunTrigger: OnRunTriggerFn
+  onRunChatTrigger: () => void
+}) {
+  const { image, title, description } = useTriggerInfo({
+    trigger,
+    document,
+    integrations,
+  })
+  const canRunTrigger = RUNNABLE_TRIGGERS.includes(trigger.triggerType)
+
+  const handleRunTrigger = useCallback(() => {
+    if (isIntegrationTrigger(trigger)) {
+      onRunTrigger({ document, parameters: {}, aiParameters: true })
+      return
+    }
+
+    if (isChatTrigger(trigger)) {
+      onRunChatTrigger()
+      return
+    }
+
+    // Schedule triggers don't have parameters
+    onRunTrigger({ document, parameters: {} })
+  }, [onRunTrigger, onRunChatTrigger, trigger, document])
+
+  return (
+    <div className='flex flex-col relative border rounded-lg w-full'>
+      <div
+        className={cn(
+          'w-full p-4 flex flex-row items-start justify-between gap-4 border-b border-border',
+        )}
+      >
+        <div className='flex flex-row gap-4 min-w-0'>
+          <div className='flex-none'>
+            <div
+              className={cn(
+                'size-10 rounded-md bg-backgroundCode flex items-center justify-center overflow-hidden',
+              )}
+            >
+              {image}
+            </div>
+          </div>
+          <div className='flex flex-col gap-1 min-w-0'>
+            <div className='flex flex-col min-w-0'>
+              <Text.H4M ellipsis noWrap>
+                {title}
+              </Text.H4M>
+              {description ? (
+                <Text.H5 color='foregroundMuted' ellipsis noWrap>
+                  {description}
+                </Text.H5>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {canRunTrigger ? (
+          <Button
+            fancy
+            variant='outline'
+            iconProps={{ name: 'circlePlay' }}
+            onClick={handleRunTrigger}
+          >
+            Run
+          </Button>
+        ) : null}
+        {trigger.triggerType === DocumentTriggerType.Integration ? (
+          <Button
+            fancy
+            variant='outline'
+            iconProps={{ name: 'bot' }}
+            onClick={handleRunTrigger}
+          >
+            Simulate with AI
+          </Button>
+        ) : null}
+      </div>
+      {!RUNNABLE_TRIGGERS.includes(trigger.triggerType) ? (
+        <TriggerEventsList
+          document={document}
+          trigger={trigger}
+          onRunTrigger={onRunTrigger}
+          emptyState={<TriggerEventsEmptyState title={title} />}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function TriggerEventsEmptyState({ title }: { title: string }) {
+  return (
+    <div className='flex flex-col items-start justify-center bg-warning-muted py-2 px-4'>
+      <Text.H5 color='warningMutedForeground'>
+        To use this trigger to preview your agent, perform the action that
+        triggers <Text.H5M color='warningMutedForeground'>{title}</Text.H5M>.
+      </Text.H5>
+    </div>
+  )
+}

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/_components/RunTrigger.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/_components/RunTrigger.tsx
@@ -3,7 +3,7 @@ import {
   DocumentTrigger,
   DocumentVersion,
   IntegrationDto,
-} from '@latitude-data/core/browser'
+} from '@latitude-data/core/schema/types'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { cn } from '@latitude-data/web-ui/utils'
@@ -13,23 +13,16 @@ import { OnRunTriggerFn } from '$/app/(private)/projects/[projectId]/versions/[c
 import { useTriggerInfo } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersCard'
 import { useCurrentCommit } from '@latitude-data/web-ui/providers'
 import useDocumentVersions from '$/stores/documentVersions'
-
-function isChatTrigger(
-  trigger: DocumentTrigger,
-): trigger is DocumentTrigger<DocumentTriggerType.Chat> {
-  return trigger.triggerType === DocumentTriggerType.Chat
-}
+import {
+  isChatTrigger,
+  RUNNABLE_TRIGGERS,
+} from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerWrapper'
 
 function isIntegrationTrigger(
   trigger: DocumentTrigger,
 ): trigger is DocumentTrigger<DocumentTriggerType.Integration> {
   return trigger.triggerType === DocumentTriggerType.Integration
 }
-
-const RUNNABLE_TRIGGERS = [
-  DocumentTriggerType.Scheduled,
-  DocumentTriggerType.Chat,
-]
 
 export function RunTrigger({
   trigger,

--- a/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/_components/OnboardingClient/triggerAgent/index.tsx
@@ -1,26 +1,41 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
-import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import useDocumentTriggers from '$/stores/documentTriggers'
 import {
   useCurrentCommit,
   useCurrentProject,
 } from '@latitude-data/web-ui/providers'
+import { DocumentTriggerType } from '@latitude-data/constants'
+import { RunTrigger } from './_components/RunTrigger'
+import useIntegrations from '$/stores/integrations'
+import { ChatTriggerTextarea } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/ChatTriggerTextarea'
+import { useActiveChatTrigger } from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/useActiveTrigger'
 import {
-  DocumentTriggerStatus,
-  DocumentTriggerType,
-} from '@latitude-data/constants'
+  ActiveTrigger,
+  OnRunTriggerFn,
+} from '$/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList'
+import { usePlaygroundChat } from '$/hooks/playgroundChat/usePlaygroundChat'
 
 export function TriggerAgentStep({
   moveNextOnboardingStep,
+  setActiveTrigger,
+  playground,
 }: {
   moveNextOnboardingStep: () => void
+  setActiveTrigger: (trigger: ActiveTrigger) => void
+  playground: ReturnType<typeof usePlaygroundChat>
 }) {
-  const handleNext = useCallback(() => {
-    moveNextOnboardingStep()
-  }, [moveNextOnboardingStep])
+  const [openChatInput, setOpenChatInput] = useState<boolean>(false)
+  const toggleOpenChatInput = useCallback(() => {
+    if (openChatInput) {
+      setOpenChatInput(false)
+    } else {
+      setOpenChatInput(true)
+    }
+  }, [openChatInput])
 
+  const { data: integrations } = useIntegrations()
   const project = useCurrentProject()
   const commit = useCurrentCommit()
 
@@ -29,28 +44,29 @@ export function TriggerAgentStep({
     commitUuid: commit.commit.uuid,
   })
 
-  const sortedIntegrationTriggersByPendingFirst = useMemo(() => {
-    return triggers
-      .filter(
-        (trigger) => trigger.triggerType === DocumentTriggerType.Integration,
-      )
-      .sort((a) => {
-        return a.triggerStatus === DocumentTriggerStatus.Deployed ? 1 : -1
-      })
+  const activeChatTrigger = useActiveChatTrigger({
+    commit: commit.commit,
+    project: project.project,
+    triggers,
+  })
+
+  const sortedTriggersByIntegrationFirst = useMemo(() => {
+    return triggers.sort((a) => {
+      return a.triggerType === DocumentTriggerType.Integration ? -1 : 1
+    })
   }, [triggers])
 
-  const allUnconfiguredTriggers = useMemo(() => {
-    return sortedIntegrationTriggersByPendingFirst.filter(
-      (trigger) => trigger.triggerStatus === DocumentTriggerStatus.Pending,
-    )
-  }, [sortedIntegrationTriggersByPendingFirst])
-
-  const allTriggersConfigured = useMemo(() => {
-    return allUnconfiguredTriggers.length === 0
-  }, [allUnconfiguredTriggers])
+  const onRunTrigger: OnRunTriggerFn = useCallback(
+    ({ document, parameters, userMessage, aiParameters = false }) => {
+      setActiveTrigger({ document, parameters, userMessage })
+      playground.start({ document, parameters, userMessage, aiParameters })
+      moveNextOnboardingStep()
+    },
+    [setActiveTrigger, moveNextOnboardingStep, playground],
+  )
 
   return (
-    <div className='flex flex-col h-full items-center p-32 gap-10'>
+    <div className='flex flex-col items-center p-32 gap-10'>
       <div className='flex flex-col items-center gap-2'>
         <div className='p-2 border-2 rounded-lg'>
           <Icon className='' name='mousePointerClick' size='medium' />
@@ -62,15 +78,41 @@ export function TriggerAgentStep({
           Perform one of the below actions to trigger and run the agent
         </Text.H5>
       </div>
-      <div className='flex flex-col items-center gap-2 border-dashed border-2 rounded-xl p-2 w-full max-w-[600px]'></div>
-      <Button
-        fancy
-        onClick={handleNext}
-        iconProps={{ name: 'chevronRight', placement: 'right' }}
-        disabled={!allTriggersConfigured}
-      >
-        Next
-      </Button>
+      <div className='flex flex-col items-center gap-2 border-dashed border-2 rounded-xl p-2 w-full max-w-[600px]'>
+        {sortedTriggersByIntegrationFirst.map((trigger) => (
+          <RunTrigger
+            key={trigger.uuid}
+            trigger={trigger}
+            onRunTrigger={onRunTrigger}
+            onRunChatTrigger={toggleOpenChatInput}
+            integrations={integrations}
+          />
+        ))}
+      </div>
+      <div className='flex flex-col gap-6 w-full max-w-[600px]'>
+        {activeChatTrigger.active && openChatInput ? (
+          <div className='sticky bottom-6'>
+            <ChatTriggerTextarea
+              key={activeChatTrigger.activeKey}
+              commit={commit.commit}
+              project={project.project}
+              document={activeChatTrigger.active.document}
+              chatTrigger={activeChatTrigger.active.trigger}
+              chatFocused={activeChatTrigger.chatBoxFocused}
+              onRunTrigger={onRunTrigger}
+              options={activeChatTrigger.options}
+              onChange={activeChatTrigger.onChange}
+            />
+          </div>
+        ) : null}
+        <div className='flex flex-col gap-2 w-full max-w-[600px]'>
+          <Text.H5 centered color='foregroundMuted'>
+            Agent will start running automatically
+            <br />
+            once you trigger it
+          </Text.H5>
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/Chat/Actions/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/Chat/Actions/index.tsx
@@ -3,8 +3,8 @@ import { SwitchToggle } from '@latitude-data/web-ui/atoms/Switch'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 
 export type ActionsState = {
-  expandParameters: boolean
-  setExpandParameters: (expand: boolean) => void
+  expandParameters?: boolean
+  setExpandParameters?: (expand: boolean) => void
 }
 
 export default function Actions(state: ActionsState) {
@@ -12,8 +12,8 @@ export default function Actions(state: ActionsState) {
     <ClientOnly className='flex flex-row gap-2 items-center'>
       <Text.H6M>Expand parameters</Text.H6M>
       <SwitchToggle
-        checked={state.expandParameters}
-        onCheckedChange={state.setExpandParameters}
+        checked={state.expandParameters ?? false}
+        onCheckedChange={state.setExpandParameters ?? (() => {})}
       />
     </ClientOnly>
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/Chat/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/Chat/index.tsx
@@ -47,7 +47,7 @@ export default function Chat({
       <Messages
         playground={playground}
         parameterKeys={parameterKeys}
-        expandParameters={expandParameters}
+        expandParameters={expandParameters ?? true} // by default, we show the parameters
         agentToolsMap={agentToolsMap}
         toolContentMap={toolContentMap}
       />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerEventsList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerEventsList/index.tsx
@@ -1,14 +1,12 @@
 import useDocumentTriggerEvents from '$/stores/documentTriggerEvents'
-import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import {
   useCurrentCommit,
   useCurrentProject,
 } from '@latitude-data/web-ui/providers'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
-import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { OnRunTriggerFn } from '../TriggersList'
-import { useCallback } from 'react'
+import { ReactNode, useCallback } from 'react'
 import { getDocumentTriggerEventRunParameters } from '@latitude-data/core/services/documentTriggers/triggerEvents/getDocumentTriggerRunParameters'
 import { DocumentTriggerEventItem } from './TriggerEvent'
 import {
@@ -41,31 +39,16 @@ function LoadingTriggerEvents() {
   )
 }
 
-function TriggerEventsEmptyState() {
-  return (
-    <div className='flex items-center justify-center '>
-      <div className='flex flex-col items-center justify-center py-20 gap-y-3 max-w-[400px]'>
-        <Icon name='clockFading' size='large' color='foregroundMuted' />
-        <Text.H5M>Waiting for events...</Text.H5M>
-        <Text.H5 centered color='foregroundMuted'>
-          There are no events for this trigger yet.
-        </Text.H5>
-        <Text.H5 centered color='foregroundMuted'>
-          When the trigger receives an event, it will be listed here.
-        </Text.H5>
-      </div>
-    </div>
-  )
-}
-
 export function TriggerEventsList({
   trigger,
   document,
   onRunTrigger,
+  emptyState,
 }: {
   trigger: DocumentTrigger
   document: DocumentVersion
   onRunTrigger: OnRunTriggerFn
+  emptyState: ReactNode
 }) {
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
@@ -90,7 +73,7 @@ export function TriggerEventsList({
   }
 
   if (triggerEvents.length === 0) {
-    return <TriggerEventsEmptyState />
+    return emptyState
   }
 
   return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerWrapper/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerWrapper/index.tsx
@@ -315,8 +315,26 @@ export function TriggerWrapper({
           document={document}
           trigger={trigger}
           onRunTrigger={onRunTrigger}
+          emptyState={<TriggerEventsEmptyState />}
         />
       ) : null}
+    </div>
+  )
+}
+
+function TriggerEventsEmptyState() {
+  return (
+    <div className='flex items-center justify-center '>
+      <div className='flex flex-col items-center justify-center py-20 gap-y-3 max-w-[400px]'>
+        <Icon name='clockFading' size='large' color='foregroundMuted' />
+        <Text.H5M>Waiting for events...</Text.H5M>
+        <Text.H5 centered color='foregroundMuted'>
+          There are no events for this trigger yet.
+        </Text.H5>
+        <Text.H5 centered color='foregroundMuted'>
+          When the trigger receives an event, it will be listed here.
+        </Text.H5>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerWrapper/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggerWrapper/index.tsx
@@ -102,13 +102,13 @@ function EditTriggerButton({
   )
 }
 
-function isChatTrigger(
+export function isChatTrigger(
   trigger: DocumentTrigger,
 ): trigger is DocumentTrigger<DocumentTriggerType.Chat> {
   return trigger.triggerType === DocumentTriggerType.Chat
 }
 
-const RUNNABLE_TRIGGERS = [
+export const RUNNABLE_TRIGGERS = [
   DocumentTriggerType.Scheduled,
   DocumentTriggerType.Chat,
 ]

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/preview/_components/TriggersList.tsx
@@ -105,14 +105,14 @@ export type OnRunTriggerFn = ({
   aiParameters?: boolean
 }) => void
 
-const FAKE_DOCUMENT = {
+export const FAKE_DOCUMENT = {
   id: 0,
   documentUuid: '',
   content: '',
   path: '',
 } as DocumentVersion
 
-type ActiveTrigger = {
+export type ActiveTrigger = {
   document: DocumentVersion
   parameters: Record<string, unknown>
   userMessage?: string

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -5,7 +5,6 @@ import { errorHandler } from '$/middlewares/errorHandler'
 import { ChainEventTypes, StreamEventTypes } from '@latitude-data/constants'
 import { LogSources } from '@latitude-data/core/constants'
 import { User, Workspace } from '@latitude-data/core/schema/types'
-import { unsafelyFindWorkspace } from '@latitude-data/core/data-access/workspaces'
 import { publisher } from '@latitude-data/core/events/publisher'
 import { Result } from '@latitude-data/core/lib/Result'
 import {

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -5,6 +5,7 @@ import { errorHandler } from '$/middlewares/errorHandler'
 import { ChainEventTypes, StreamEventTypes } from '@latitude-data/constants'
 import { LogSources } from '@latitude-data/core/constants'
 import { User, Workspace } from '@latitude-data/core/schema/types'
+import { unsafelyFindWorkspace } from '@latitude-data/core/data-access/workspaces'
 import { publisher } from '@latitude-data/core/events/publisher'
 import { Result } from '@latitude-data/core/lib/Result'
 import {
@@ -267,9 +268,18 @@ async function generateAIParameters({
         path,
       })
       .then((r) => r.unwrap())
-    const sdk = new Latitude(env.COPILOT_WORKSPACE_API_KEY!, {
+
+    const copilotWorkspace = await unsafelyFindWorkspace(
+      env.COPILOT_WORKSPACE_ID!,
+    )
+
+    const sdk = await createSdk({
+      workspace: copilotWorkspace,
+      apiKey: env.COPILOT_WORKSPACE_API_KEY!,
       projectId: env.COPILOT_PROJECT_ID,
-    })
+      __internal: { source: LogSources.Copilot },
+    }).then((r) => r.unwrap())
+
     const { parameters } = await scanDocumentContent({ document, commit }).then(
       (r) => r.unwrap(),
     )

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -18,7 +18,6 @@ import { env } from '@latitude-data/env'
 import {
   ChainEventDto,
   GenerationResponse,
-  Latitude,
   LatitudeApiError,
 } from '@latitude-data/sdk'
 import { NextRequest, NextResponse } from 'next/server'

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -268,12 +268,8 @@ async function generateAIParameters({
       })
       .then((r) => r.unwrap())
 
-    const copilotWorkspace = await unsafelyFindWorkspace(
-      env.COPILOT_WORKSPACE_ID!,
-    )
-
     const sdk = await createSdk({
-      workspace: copilotWorkspace,
+      workspace: workspace,
       apiKey: env.COPILOT_WORKSPACE_API_KEY!,
       projectId: env.COPILOT_PROJECT_ID,
       __internal: { source: LogSources.Copilot },

--- a/packages/core/src/services/actions/execute.test.ts
+++ b/packages/core/src/services/actions/execute.test.ts
@@ -1,12 +1,13 @@
 import * as env from '@latitude-data/env'
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
-import { ActionType, User, Workspace } from '../../schema/types'
+import { User, Workspace } from '../../schema/types'
 import { publisher } from '../../events/publisher'
 import { BadRequestError } from '../../lib/errors'
 import * as factories from '../../tests/factories'
 import { getWorkspaceOnboarding } from '../workspaceOnboarding/get'
 import * as onboardingServices from '../workspaceOnboarding/update'
 import { executeAction } from './execute'
+import { ActionType } from '@latitude-data/constants/actions'
 
 describe('executeAction', () => {
   let mocks: {

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -81,10 +81,9 @@ export default async function setupService(
 
     const isNewOnboardingEnabled = isNewOnboardingEnabledResult.unwrap()
     if (isNewOnboardingEnabled) {
-      await createWorkspaceOnboarding(
-        { workspaceId: workspace.id },
-        transaction,
-      ).then((r) => r.unwrap())
+      await createWorkspaceOnboarding({ workspace }, transaction).then((r) =>
+        r.unwrap(),
+      )
     } else {
       // TODO(onboarding): creating completed onboarding for now so old users dont get onboarded (rm later)
       await createCompletedWorkspaceOnboarding(

--- a/packages/core/src/services/workspaceOnboarding/create.ts
+++ b/packages/core/src/services/workspaceOnboarding/create.ts
@@ -1,20 +1,28 @@
 import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
 import { workspaceOnboarding } from '../../schema/models/workspaceOnboarding'
+import { getFirstStep } from './steps/getFirstStep'
+import { Workspace } from '../../schema/types'
 
 export async function createWorkspaceOnboarding(
   {
-    workspaceId,
+    workspace,
   }: {
-    workspaceId: number
+    workspace: Workspace
   },
   transaction = new Transaction(),
 ) {
   return transaction.call(async (tx) => {
+    const firstStepResult = await getFirstStep({ workspace }, tx)
+    if (!Result.isOk(firstStepResult)) {
+      return firstStepResult
+    }
+    const firstStep = firstStepResult.unwrap()
     const insertedOnboardings = await tx
       .insert(workspaceOnboarding)
       .values({
-        workspaceId,
+        workspaceId: workspace.id,
+        currentStep: firstStep,
       })
       .returning()
 

--- a/packages/core/src/services/workspaceOnboarding/steps/checkNextStepNecessary.test.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/checkNextStepNecessary.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { OnboardingStepKey } from '@latitude-data/constants/onboardingSteps'
+import {
+  DocumentTriggerStatus,
+  IntegrationType,
+} from '@latitude-data/constants'
+import { checkNextStepNecessary } from './checkNextStepNecessary'
+import * as factories from '../../../../src/tests/factories'
+import { Workspace } from '../../../schema/types'
+
+describe('checkNextStepNecessary', () => {
+  let workspace: Workspace
+
+  beforeEach(async () => {
+    const { workspace: createdWorkspace } = await factories.createWorkspace()
+    workspace = createdWorkspace
+  })
+
+  describe('SetupIntegrations step', () => {
+    it('returns false when no integrations exist', async () => {
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.SetupIntegrations,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.unwrap()).toBe(false)
+    })
+
+    it('returns true when integrations exist', async () => {
+      await factories.createIntegration({
+        workspace,
+        type: IntegrationType.Pipedream,
+        configuration: {
+          appName: 'slack',
+          authType: 'oauth',
+          metadata: {
+            displayName: 'Slack',
+          },
+        },
+      })
+
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.SetupIntegrations,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      const resultValue = result.unwrap()
+      expect(resultValue).toBe(true)
+    })
+  })
+
+  describe('ConfigureTriggers step', () => {
+    it('returns false when no document triggers exist', async () => {
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.ConfigureTriggers,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.unwrap()).toBe(false)
+    })
+
+    it('returns false when non-integration document triggers exist', async () => {
+      const { project, commit } = await factories.createProject({
+        workspace,
+        documents: {
+          'test.promptl': 'test content',
+        },
+      })
+
+      await factories.createScheduledDocumentTrigger({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitId: commit.id,
+      })
+
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.ConfigureTriggers,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      const resultValue = result.unwrap()
+      expect(resultValue).toBe(false)
+    })
+
+    it('returns true when pending integration document triggers exist', async () => {
+      const { project, commit } = await factories.createProject({
+        workspace,
+        documents: {
+          'test.promptl': 'test content',
+        },
+      })
+
+      const integration = await factories.createIntegration({
+        workspace,
+        type: IntegrationType.Pipedream,
+        configuration: {
+          appName: 'slack',
+          authType: 'oauth',
+        },
+      })
+
+      await factories.createIntegrationDocumentTrigger({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitId: commit.id,
+        integrationId: integration.id,
+        triggerStatus: DocumentTriggerStatus.Pending,
+      })
+
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.ConfigureTriggers,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      const resultValue = result.unwrap()
+      expect(resultValue).toBe(true)
+    })
+  })
+
+  describe('TriggerAgent step', () => {
+    it('returns true (always necessary)', async () => {
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.TriggerAgent,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      const resultValue = result.unwrap()
+      expect(resultValue).toBe(true)
+    })
+  })
+
+  describe('RunAgent step', () => {
+    it('returns true (always necessary)', async () => {
+      const result = await checkNextStepNecessary({
+        currentStep: OnboardingStepKey.RunAgent,
+        workspace,
+      })
+
+      expect(result.ok).toBe(true)
+      const resultValue = result.unwrap()
+      expect(resultValue).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/services/workspaceOnboarding/steps/checkNextStepNecessary.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/checkNextStepNecessary.ts
@@ -1,0 +1,66 @@
+import { OnboardingStepKey } from '@latitude-data/constants/onboardingSteps'
+import { Workspace } from '../../../schema/types'
+import { Result } from '../../../lib/Result'
+import { DocumentTriggersRepository } from '../../../repositories/documentTriggersRepository'
+import { IntegrationsRepository } from '../../../repositories/integrationsRepository'
+import {
+  DocumentTriggerStatus,
+  DocumentTriggerType,
+  IntegrationType,
+} from '@latitude-data/constants'
+import { database } from '../../../client'
+
+export async function checkNextStepNecessary(
+  {
+    currentStep,
+    workspace,
+  }: {
+    currentStep: OnboardingStepKey
+    workspace: Workspace
+  },
+  db = database,
+) {
+  if (currentStep === OnboardingStepKey.SetupIntegrations) {
+    const integrationsScope = new IntegrationsRepository(workspace.id, db)
+    const integrationsResult = await integrationsScope.findAll()
+    if (!Result.isOk(integrationsResult)) {
+      return integrationsResult
+    }
+    const integrations = integrationsResult.unwrap()
+    // Hosted MCPs are not supported anymore and don't need configuration
+    const configurableIntegrations = integrations.filter(
+      (integration) =>
+        integration.type === IntegrationType.Pipedream ||
+        integration.type === IntegrationType.ExternalMCP,
+    )
+    if (configurableIntegrations.length === 0) {
+      return Result.ok(false)
+    }
+    return Result.ok(true)
+  }
+
+  if (currentStep === OnboardingStepKey.ConfigureTriggers) {
+    const documentTriggersScope = new DocumentTriggersRepository(
+      workspace.id,
+      db,
+    )
+    const documentTriggersResult = await documentTriggersScope.findAll()
+    if (!Result.isOk(documentTriggersResult)) {
+      return documentTriggersResult
+    }
+    const documentTriggers = documentTriggersResult.unwrap()
+    // For now, only pipedream integrations have triggers
+    const pendingIntegrationTriggers = documentTriggers.filter(
+      (trigger) =>
+        trigger.triggerType === DocumentTriggerType.Integration &&
+        trigger.triggerStatus === DocumentTriggerStatus.Pending,
+    )
+    if (pendingIntegrationTriggers.length === 0) {
+      return Result.ok(false)
+    }
+    return Result.ok(true)
+  }
+
+  // We assume there will always be a trigger in an agent, so step 3 and 4 will always be necessary
+  return Result.ok(true)
+}

--- a/packages/core/src/services/workspaceOnboarding/steps/getFirstStep.test.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/getFirstStep.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ONBOARDING_STEPS,
+  OnboardingStepKey,
+} from '@latitude-data/constants/onboardingSteps'
+import {
+  IntegrationType,
+  DocumentTriggerStatus,
+} from '@latitude-data/constants'
+import { getFirstStep } from './getFirstStep'
+import * as factories from '../../../../src/tests/factories'
+import { Workspace } from '../../../schema/types'
+
+describe('getFirstStep', () => {
+  let workspace: Workspace
+
+  beforeEach(async () => {
+    const { workspace: createdWorkspace } = await factories.createWorkspace()
+    workspace = createdWorkspace
+  })
+
+  it('returns TriggerAgent when no integrations exist', async () => {
+    const result = await getFirstStep({
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const resultValue = result.unwrap()
+    expect(resultValue).toBe(OnboardingStepKey.TriggerAgent)
+  })
+
+  it('returns SetupIntegrations when pipedream integration exist', async () => {
+    await factories.createIntegration({
+      workspace,
+      type: IntegrationType.Pipedream,
+      configuration: {
+        appName: 'slack',
+        authType: 'oauth',
+        metadata: {
+          displayName: 'Slack',
+        },
+      },
+    })
+
+    const result = await getFirstStep({
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const resultValue = result.unwrap()
+    expect(resultValue).toBe(OnboardingStepKey.SetupIntegrations)
+  })
+
+  it('returns SetupIntegrations when external MCP integration exist', async () => {
+    await factories.createProject({
+      workspace,
+      documents: {
+        'test.promptl': 'test content',
+      },
+    })
+    await factories.createIntegration({
+      workspace,
+      type: IntegrationType.ExternalMCP,
+      configuration: {
+        url: 'https://example.com',
+      },
+    })
+
+    const result = await getFirstStep({
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const resultValue = result.unwrap()
+    expect(resultValue).toBe(OnboardingStepKey.SetupIntegrations)
+  })
+
+  it('returns ConfigureTriggers when it is the first step in order (testing getFirstStepByOrder works as expected)', async () => {
+    // Create a pending integration trigger to make ConfigureTriggers necessary
+    const { project, commit } = await factories.createProject({
+      workspace,
+      documents: {
+        'test.promptl': 'test content',
+      },
+    })
+
+    const integration = await factories.createIntegration({
+      workspace,
+      type: IntegrationType.Pipedream,
+      configuration: {
+        appName: 'slack',
+        authType: 'oauth',
+      },
+    })
+
+    await factories.createIntegrationDocumentTrigger({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitId: commit.id,
+      integrationId: integration.id,
+      triggerStatus: DocumentTriggerStatus.Pending,
+    })
+
+    // Mock the ONBOARDING_STEPS constant to make ConfigureTriggers the first step
+    const mockOnboardingSteps = {
+      [OnboardingStepKey.SetupIntegrations]: {
+        order: 2,
+      },
+      [OnboardingStepKey.TriggerAgent]: {
+        order: 3,
+      },
+      [OnboardingStepKey.RunAgent]: {
+        order: 4,
+      },
+      [OnboardingStepKey.ConfigureTriggers]: {
+        order: 1,
+      },
+    } as unknown as typeof ONBOARDING_STEPS
+
+    // Use vi.spyOn to mock the imported constant
+    const onboardingStepsSpy = vi.spyOn(
+      await import('@latitude-data/constants/onboardingSteps'),
+      'ONBOARDING_STEPS',
+      'get',
+    )
+    onboardingStepsSpy.mockReturnValue(mockOnboardingSteps)
+
+    const result = await getFirstStep({
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const resultValue = result.unwrap()
+    expect(resultValue).toBe(OnboardingStepKey.ConfigureTriggers)
+
+    // Clean up the mock
+    onboardingStepsSpy.mockRestore()
+  })
+})

--- a/packages/core/src/services/workspaceOnboarding/steps/getFirstStep.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/getFirstStep.ts
@@ -1,0 +1,53 @@
+import { Workspace } from '../../../schema/types'
+import { database } from '../../../client'
+import { Result } from '../../../lib/Result'
+import { PromisedResult } from '../../../lib/Transaction'
+import {
+  ONBOARDING_STEPS,
+  OnboardingStepKey,
+} from '@latitude-data/constants/onboardingSteps'
+import { checkNextStepNecessary } from './checkNextStepNecessary'
+import { getNextAvailableStep } from './getNextAvailableStep'
+
+export async function getFirstStep(
+  {
+    workspace,
+  }: {
+    workspace: Workspace
+  },
+  db = database,
+): PromisedResult<OnboardingStepKey> {
+  const firstStep = getFirstStepByOrder()
+  const checkNextStepNecessaryResult = await checkNextStepNecessary(
+    {
+      currentStep: firstStep,
+      workspace,
+    },
+    db,
+  )
+  if (!Result.isOk(checkNextStepNecessaryResult)) {
+    return checkNextStepNecessaryResult
+  }
+  const setupIntegrationsIsNecessary = checkNextStepNecessaryResult.unwrap()
+  if (setupIntegrationsIsNecessary) {
+    return Result.ok(firstStep)
+  }
+  const getNextStepNecessaryResult = await getNextAvailableStep(
+    {
+      currentStep: firstStep,
+      workspace,
+    },
+    db,
+  )
+  if (!Result.isOk(getNextStepNecessaryResult)) {
+    return getNextStepNecessaryResult
+  }
+  const nextStepNecessary = getNextStepNecessaryResult.unwrap()
+  return Result.ok(nextStepNecessary)
+}
+
+function getFirstStepByOrder(): OnboardingStepKey {
+  return Object.entries(ONBOARDING_STEPS).sort(
+    ([, a], [, b]) => a.order - b.order,
+  )[0][0] as OnboardingStepKey
+}

--- a/packages/core/src/services/workspaceOnboarding/steps/getNextAvailableStep.test.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/getNextAvailableStep.test.ts
@@ -1,29 +1,102 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { OnboardingStepKey } from '@latitude-data/constants/onboardingSteps'
 import { getNextAvailableStep } from './getNextAvailableStep'
+import { Workspace } from '../../../schema/types'
+import * as factories from '../../../../src/tests/factories'
+import {
+  DocumentTriggerStatus,
+  IntegrationType,
+} from '@latitude-data/constants'
 
 describe('getNextAvailableStep', () => {
-  it('succeeds when moving from first step to second', async () => {
+  let workspace: Workspace
+
+  beforeEach(async () => {
+    const { workspace: createdWorkspace } = await factories.createWorkspace()
+    workspace = createdWorkspace
+  })
+
+  it('moves from setup integrations to configure triggers when pending pipedream triggers exist', async () => {
+    const { project, commit } = await factories.createProject({
+      workspace,
+      documents: {
+        'test.promptl': 'test content',
+      },
+    })
+
+    const integration = await factories.createIntegration({
+      workspace,
+      type: IntegrationType.Pipedream,
+      configuration: {
+        appName: 'slack',
+        authType: 'oauth',
+      },
+    })
+    const integrationId = integration.id
+    await factories.createIntegrationDocumentTrigger({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitId: commit.id,
+      integrationId,
+      triggerStatus: DocumentTriggerStatus.Pending,
+    })
+
     const result = await getNextAvailableStep({
       currentStep: OnboardingStepKey.SetupIntegrations,
+      workspace,
     })
 
     expect(result.ok).toBe(true)
     expect(result.unwrap()).toBe(OnboardingStepKey.ConfigureTriggers)
   })
 
-  it('succeeds when moving from second step to third', async () => {
+  it('moves from setup integrations directly to trigger agent when no pending integration triggers exist', async () => {
     const result = await getNextAvailableStep({
-      currentStep: OnboardingStepKey.ConfigureTriggers,
+      currentStep: OnboardingStepKey.SetupIntegrations,
+      workspace,
     })
 
     expect(result.ok).toBe(true)
     expect(result.unwrap()).toBe(OnboardingStepKey.TriggerAgent)
   })
 
-  it('succeeds when moving from third step to fourth', async () => {
+  it('moves from setup integrations directly to trigger agent when non-pipedream triggers exist', async () => {
+    const { project, commit } = await factories.createProject({
+      workspace,
+      documents: {
+        'test.promptl': 'test content',
+      },
+    })
+
+    await factories.createScheduledDocumentTrigger({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitId: commit.id,
+    })
+
+    const result = await getNextAvailableStep({
+      currentStep: OnboardingStepKey.SetupIntegrations,
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.unwrap()).toBe(OnboardingStepKey.TriggerAgent)
+  })
+
+  it('moves always from configure triggers to trigger agent', async () => {
+    const result = await getNextAvailableStep({
+      currentStep: OnboardingStepKey.ConfigureTriggers,
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.unwrap()).toBe(OnboardingStepKey.TriggerAgent)
+  })
+
+  it('moves always from trigger agent to run agent', async () => {
     const result = await getNextAvailableStep({
       currentStep: OnboardingStepKey.TriggerAgent,
+      workspace,
     })
 
     expect(result.ok).toBe(true)
@@ -33,6 +106,7 @@ describe('getNextAvailableStep', () => {
   it('fails when already at the last step', async () => {
     const result = await getNextAvailableStep({
       currentStep: OnboardingStepKey.RunAgent,
+      workspace,
     })
 
     expect(result.ok).toBe(false)

--- a/packages/core/src/services/workspaceOnboarding/steps/moveNextOnboardingStep.ts
+++ b/packages/core/src/services/workspaceOnboarding/steps/moveNextOnboardingStep.ts
@@ -3,13 +3,15 @@ import Transaction from '../../../lib/Transaction'
 import { workspaceOnboarding } from '../../../schema/models/workspaceOnboarding'
 import { Result } from '../../../lib/Result'
 import { getNextAvailableStep } from './getNextAvailableStep'
-import { WorkspaceOnboarding } from '../../../schema/types'
+import { Workspace, WorkspaceOnboarding } from '../../../schema/types'
 
 export async function moveNextOnboardingStep(
   {
     onboarding,
+    workspace,
   }: {
     onboarding: WorkspaceOnboarding
+    workspace: Workspace
   },
   transaction = new Transaction(),
 ) {
@@ -18,9 +20,13 @@ export async function moveNextOnboardingStep(
       return Result.error(new Error('Onboarding current step is not set'))
     }
 
-    const getNextAvailableStepResult = await getNextAvailableStep({
-      currentStep: onboarding.currentStep,
-    })
+    const getNextAvailableStepResult = await getNextAvailableStep(
+      {
+        currentStep: onboarding.currentStep,
+        workspace,
+      },
+      tx,
+    )
 
     if (!Result.isOk(getNextAvailableStepResult)) {
       return getNextAvailableStepResult

--- a/packages/core/src/tests/factories/documentTriggers.ts
+++ b/packages/core/src/tests/factories/documentTriggers.ts
@@ -158,6 +158,7 @@ export async function createIntegrationDocumentTrigger({
   integrationId,
   properties = {},
   payloadParameters = [],
+  triggerStatus = DocumentTriggerStatus.Deployed,
 }: {
   workspaceId?: number
   projectId?: number
@@ -167,6 +168,7 @@ export async function createIntegrationDocumentTrigger({
   integrationId: number
   properties?: Record<string, unknown>
   payloadParameters?: string[]
+  triggerStatus?: DocumentTriggerStatus
 }): Promise<DocumentTrigger> {
   // Create project if not provided
   if (!commitId || !projectId || !workspaceId) {
@@ -195,7 +197,7 @@ export async function createIntegrationDocumentTrigger({
       commitId,
       documentUuid,
       triggerType: DocumentTriggerType.Integration,
-      triggerStatus: 'deployed',
+      triggerStatus,
       configuration,
       deploymentSettings,
       triggerHash: createTriggerHash({ configuration }),

--- a/packages/core/src/tests/factories/workspaces.ts
+++ b/packages/core/src/tests/factories/workspaces.ts
@@ -38,9 +38,7 @@ export async function createWorkspace(
   await createMembership({ workspace, user: userData }).then((r) => r.unwrap())
 
   if (workspaceData.onboarding) {
-    await createWorkspaceOnboarding({ workspaceId: workspace.id }).then((r) =>
-      r.unwrap(),
-    )
+    await createWorkspaceOnboarding({ workspace }).then((r) => r.unwrap())
   }
 
   if (workspaceData.features) {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -211,6 +211,7 @@ export const env = createEnv({
     COPILOT_PROJECT_ID: z.coerce.number().optional(),
     COPILOT_PROMPT_REFINE_PATH: z.string().optional(),
     COPILOT_WORKSPACE_API_KEY: z.string().optional(),
+    COPILOT_WORKSPACE_ID: z.coerce.number().optional(),
     COPILOT_LATTE_PROMPT_PATH: z.string().optional(),
     COPILOT_LATTE_CHANGES_FEEDBACK_HITL_EVALUATION_UUID: z.string().optional(),
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -211,7 +211,6 @@ export const env = createEnv({
     COPILOT_PROJECT_ID: z.coerce.number().optional(),
     COPILOT_PROMPT_REFINE_PATH: z.string().optional(),
     COPILOT_WORKSPACE_API_KEY: z.string().optional(),
-    COPILOT_WORKSPACE_ID: z.coerce.number().optional(),
     COPILOT_LATTE_PROMPT_PATH: z.string().optional(),
     COPILOT_LATTE_CHANGES_FEEDBACK_HITL_EVALUATION_UUID: z.string().optional(),
 


### PR DESCRIPTION
This PR includes the last two steps of the new onboarding: Trigger agent and Run Agent.

<img width="929" height="927" alt="image" src="https://github.com/user-attachments/assets/60ae3651-8334-4e04-a162-07c6ec292c5e" />

In addition to this, there are a few improvements
- The first step of the onboarding is dynamically calculated in the backend, depending on the pending integrations and triggers you have after cloning the agent. Like this, you don't land on the setupIntegration step if no integrations need configuring
- Move next step is now dynamically calculated based on what pending integrations and triggers you have. Like this, if there is no configurable triggers, you can jump smoothly from step 1 to step 3
 