### PR TITLE
Connect integrations modal in editor sidebar

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Section/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Section/index.tsx
@@ -23,24 +23,33 @@ export function SectionLoader({ items = 3 }: { items: number }) {
   )
 }
 
+const SidebarTitle = ({ children }: { children: ReactNode }) => {
+  return <Text.H5M>{children}</Text.H5M>
+}
+
 type SectionAction = {
   iconProps?: IconProps
   onClick: () => void
   disabled?: boolean
 }
-export function SidebarSection({
+const SidebarSection = ({
   children,
   title,
   actions,
 }: {
-  title: string
+  title: string | ReactNode
   children?: ReactNode
   actions?: SectionAction[]
-}) {
+}) => {
   return (
     <div className='flex flex-col gap-y-2'>
       <div className='flex justify-between gap-x-3'>
-        <Text.H5M>{title}</Text.H5M>
+        {typeof title === 'string' ? (
+          <SidebarTitle>{title}</SidebarTitle>
+        ) : (
+          title
+        )}
+
         {actions ? (
           <div className='flex flex-row gap-x-2'>
             {actions?.map((action, index) => (
@@ -60,3 +69,7 @@ export function SidebarSection({
     </div>
   )
 }
+
+SidebarSection.Title = SidebarTitle
+
+export { SidebarSection }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/ConnectPipedreamModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/ConnectPipedreamModal/index.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useState, FormEvent, useMemo } from 'react'
+import { CloseTrigger, Modal } from '@latitude-data/web-ui/atoms/Modal'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { PipedreamAppCard } from '$/app/(private)/settings/_components/Integrations/New/_components/Configuration/Pipedream/AppCard'
+import { Input } from '@latitude-data/web-ui/atoms/Input'
+import useIntegrations from '$/stores/integrations'
+import { toast } from '@latitude-data/web-ui/atoms/Toast'
+import { ValidIntegration } from '$/app/(private)/settings/_components/Integrations/New'
+import { Alert } from '@latitude-data/web-ui/atoms/Alert'
+import { AppDto } from '@latitude-data/core/constants'
+import { useConnectToPipedreamApp } from '$/hooks/useConnectToPipedreamApp'
+import { IntegrationType } from '@latitude-data/constants'
+import useCurrentWorkspace from '$/stores/currentWorkspace'
+import { PipedreamIntegration } from '@latitude-data/core/schema/types'
+
+/**
+ * FIXME: DRY this with Settings -> NewIntegration
+ * Some parts are common and could be extracted to a shared component
+ */
+export function ConnectPipedreamModal({
+  onOpenChange,
+  onConnect,
+  app,
+}: {
+  onOpenChange: (open: boolean) => void
+  onConnect: (integration: PipedreamIntegration) => void
+  app: AppDto
+}) {
+  const [integrationName, setIntegrationName] = useState<string>('')
+  const [isCreating, setIsCreating] = useState<boolean>(false)
+  const nameErrors = useMemo<string[] | undefined>(() => {
+    const errors = []
+    if (integrationName.includes(' ')) {
+      errors.push('Name cannot contain spaces')
+    }
+    if (integrationName.includes('/')) {
+      errors.push('Name cannot contain slashes')
+    }
+    return errors.length ? errors : undefined
+  }, [integrationName])
+  const { create } = useIntegrations({
+    withTools: true,
+    includeLatitudeTools: true,
+  })
+  const { data: workspace } = useCurrentWorkspace()
+  const { connect } = useConnectToPipedreamApp(app)
+  const [error, setError] = useState<Error | undefined>(undefined)
+  const validate: () => Promise<ValidIntegration> = useCallback(async () => {
+    if (!workspace) {
+      throw new Error(
+        'Authentication token not available. Please wait a few seconds and try again.',
+      )
+    }
+
+    const [connectionId, error] = await connect()
+    if (error) throw error
+
+    return {
+      type: IntegrationType.Pipedream,
+      configuration: {
+        appName: app.nameSlug,
+        connectionId,
+        externalUserId: String(workspace.id),
+        authType: app.authType ?? 'none',
+        oauthAppId: app.id,
+        metadata: {
+          displayName: app.name,
+          imageUrl: app.imgSrc,
+        },
+      },
+    } as unknown as ValidIntegration
+  }, [app, connect, workspace])
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      setIsCreating(true)
+      setError(undefined)
+      let integration: ValidIntegration
+
+      try {
+        integration = await validate()
+      } catch (err) {
+        setIsCreating(false)
+        setError(err as Error)
+        return
+      }
+
+      const [newApp, createError] = await create({
+        ...integration,
+        name: integrationName,
+      })
+      setIsCreating(false)
+
+      if (createError) {
+        toast({
+          title: 'Error creating integration',
+          description: createError.message,
+          variant: 'destructive',
+        })
+        return
+      }
+
+      onConnect(newApp as PipedreamIntegration)
+    },
+    [create, integrationName, validate, onConnect],
+  )
+  return (
+    <Modal
+      dismissible
+      open
+      onOpenChange={onOpenChange}
+      title='Create Integration'
+      description='Integrations allow your prompt to interact with external services.'
+      footer={
+        <>
+          <CloseTrigger />
+          <Button
+            fancy
+            form='createIntegrationForm'
+            type='submit'
+            isLoading={isCreating}
+            iconProps={{
+              name: 'unplug',
+            }}
+          >
+            {isCreating ? 'Connecting...' : 'Connect & Create'}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id='createIntegrationForm'
+        onSubmit={handleSubmit}
+        className='flex flex-col gap-4'
+      >
+        <Input
+          required
+          type='text'
+          name='name'
+          label='Name'
+          disabled={isCreating}
+          description="This is the name you'll use in the prompt editor to refer to use this integration and model."
+          placeholder='my_integration'
+          onChange={(event) => setIntegrationName(event.target.value)}
+          value={integrationName}
+          errors={nameErrors}
+        />
+
+        <PipedreamAppCard app={app} />
+        {error && (
+          <Alert
+            variant='destructive'
+            title={error.name}
+            description={error.message}
+          />
+        )}
+      </form>
+    </Modal>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/index.tsx
@@ -1,0 +1,339 @@
+import { use, useMemo, useState, useCallback, createContext } from 'react'
+import {
+  SearchableList,
+  Option as SearchableOption,
+  OptionItem as SearchableOptionItem,
+  OptionGroup as SearchableOptionGroup,
+  ItemPresenterProps,
+  ImageIcon,
+} from '@latitude-data/web-ui/molecules/SearchableList'
+import { Modal } from '@latitude-data/web-ui/atoms/Modal'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { cn } from '@latitude-data/web-ui/utils'
+import usePipedreamApps from '$/stores/pipedreamApps'
+import { useDebouncedCallback } from 'use-debounce'
+import { IntegrationType } from '@latitude-data/constants'
+import { IconName } from '@latitude-data/web-ui/atoms/Icons'
+import {
+  IntegrationDto,
+  PipedreamIntegration,
+} from '@latitude-data/core/schema/types'
+import { INTEGRATION_TYPE_VALUES } from '$/lib/integrationTypeOptions'
+import { pluralize } from '$/components/TriggersManagement/NewTrigger/IntegrationsList/utils'
+import useIntegrations from '$/stores/integrations'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { mergeConnectedAppsBySlug } from '@latitude-data/core/lib/pipedream/mergeConnectedAppsBySlug'
+import { ConnectPipedreamModal } from './ConnectPipedreamModal'
+import { AppDto } from '@latitude-data/core/constants'
+
+type ToolType = IntegrationType | 'UnConnectedPipedreamApp'
+
+type IConnectToolContext = {
+  onAdd: () => void
+  onConnect: (app: AppDto) => void
+}
+
+const ConnectToolContext = createContext<IConnectToolContext>({
+  onAdd: () => {},
+  onConnect: (_app: AppDto) => {},
+})
+
+function integrationOptions(integration: IntegrationDto) {
+  if (integration.type === IntegrationType.Pipedream) {
+    const imageUrl = integration.configuration.metadata?.imageUrl ?? 'unplug'
+    const label =
+      integration.configuration.metadata?.displayName ??
+      integration.configuration.appName
+    return {
+      label,
+      icon: {
+        type: 'image' as const,
+        src: imageUrl,
+        alt: label,
+      },
+    }
+  }
+
+  if (integration.type === IntegrationType.Latitude) {
+    const { label } = INTEGRATION_TYPE_VALUES[IntegrationType.Latitude]
+    return {
+      label,
+      icon: {
+        type: 'icon' as const,
+        name: 'logo' as IconName,
+      },
+    }
+  }
+  const { label, icon } = INTEGRATION_TYPE_VALUES[integration.type]
+  return { label, icon: { type: 'icon' as const, name: icon as IconName } }
+}
+
+function getToolsAndAccountsLabel({
+  type,
+  toolCount,
+  accountCount,
+}: {
+  type: ToolType
+  toolCount?: number
+  accountCount?: number
+}) {
+  if (type === 'UnConnectedPipedreamApp') {
+    const tools = pluralize(toolCount ?? 0, 'available tool', 'available tools')
+    return tools
+  }
+  if (type !== IntegrationType.Pipedream) return ''
+
+  return pluralize(accountCount ?? 1, 'account', 'accounts')
+}
+
+function ItemPresenter({ item }: ItemPresenterProps<ToolType>) {
+  const type = item.metadata?.type
+  const imageIcon = item.imageIcon
+  const title = item.title
+  const app = item.metadata?.app as AppDto | undefined
+  const { onAdd, onConnect } = use(ConnectToolContext)
+  const buttonLabel = type === 'UnConnectedPipedreamApp' ? 'Connect' : 'Add'
+  const buttonVariant =
+    type === 'UnConnectedPipedreamApp' ? 'outline' : 'default'
+  const onClick = useCallback(() => {
+    if (type === 'UnConnectedPipedreamApp' && app) {
+      onConnect(app)
+      return
+    }
+
+    onAdd()
+  }, [onAdd, onConnect, app, type])
+  return (
+    <div
+      className={cn(
+        'group p-4 cursor-pointer',
+        'flex flex-row min-w-0 gap-x-4',
+      )}
+    >
+      <div className='flex flex-row gap-x-4 min-w-0 flex-1'>
+        {imageIcon ? (
+          <div className='flex-none'>
+            <ImageIcon imageIcon={imageIcon} />
+          </div>
+        ) : null}
+        <div className='flex-1 flex flex-row items-center gap-x-2 min-w-0'>
+          <div
+            className={cn(
+              'flex flex-col',
+              'group-aria-selected:[&>span]:!text-accent-foreground min-w-0',
+            )}
+          >
+            <Text.H4 ellipsis noWrap>
+              {title}
+            </Text.H4>
+            <Text.H5 ellipsis noWrap color='foregroundMuted'>
+              {item.description}
+            </Text.H5>
+          </div>
+        </div>
+        <div className='flex-none flex items-center'>
+          <Button fancy variant={buttonVariant} size='small' onClick={onClick}>
+            {buttonLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function mergeAllConnectedApps(connectedApps: IntegrationDto[]) {
+  const pipedreamApps = connectedApps.filter((app) => app.type === 'pipedream')
+  const otherApps = connectedApps.filter((app) => app.type !== 'pipedream')
+
+  const mergedPipedreamApps = mergeConnectedAppsBySlug(pipedreamApps)
+
+  return [...otherApps, ...mergedPipedreamApps]
+}
+
+/**
+ * List connected tools Latitude and 3rd party (Pipedream)
+ */
+export function ConnectToolsModal({
+  onCloseModal,
+}: {
+  onCloseModal: () => void
+}) {
+  const [immediateQuery, setImmediateQuery] = useState('')
+  const [searchQuery, setSearchQuery] = useState<string>('')
+  const debouncedSetSearchQuery = useDebouncedCallback(setSearchQuery, 500)
+  const onSearchChange = useCallback(
+    (value: string) => {
+      setImmediateQuery(value)
+      debouncedSetSearchQuery(value)
+    },
+    [debouncedSetSearchQuery],
+  )
+  const {
+    data: pipedreamApps = [],
+    isLoading: isLoadingPipedreamApps,
+    loadMore,
+    isLoadingMore,
+    isReachingEnd,
+    totalCount,
+  } = usePipedreamApps({ query: searchQuery, withTools: true })
+
+  const { data: integrations, isLoading: isLoadingConnectedIntegrations } =
+    useIntegrations({
+      withTools: true,
+      includeLatitudeTools: true,
+    })
+
+  const connectedApps = useMemo(() => {
+    if (!integrations) return []
+    return mergeAllConnectedApps(integrations)
+  }, [integrations])
+  const isLoading = connectedApps.length === 0 && isLoadingConnectedIntegrations
+
+  // TODO: Filter active tool-sets. If Slack is used in this document, don't show it here
+  // Will pass active tool types as prop to this component
+  const optionGroups = useMemo<SearchableOption<ToolType>[]>(() => {
+    const items: SearchableOptionItem<ToolType>[] | null[] = connectedApps
+      .map((integration) => {
+        const labelIcon = integrationOptions(integration)
+        if (!labelIcon) return null
+        return {
+          type: 'item' as const,
+          value: String(integration.id),
+          title: labelIcon.label,
+          description: getToolsAndAccountsLabel({
+            type: integration.type,
+            accountCount:
+              integration.type === IntegrationType.Pipedream
+                ? integration.accountCount
+                : undefined,
+          }),
+          keywords: [labelIcon.label, integration.type],
+          metadata: { type: integration.type },
+          imageIcon: labelIcon.icon,
+        }
+      })
+      .filter((item) => item !== null)
+      .filter((item) =>
+        item.title.toLowerCase().includes(immediateQuery.trim().toLowerCase()),
+      )
+
+    const baseGroup: SearchableOptionGroup<ToolType> = {
+      type: 'group',
+      label: 'Available integrations',
+      items,
+      loading: isLoadingConnectedIntegrations,
+    }
+
+    const groups: SearchableOption<ToolType>[] = [baseGroup]
+    const availableApps: SearchableOptionItem<ToolType>[] = pipedreamApps
+      .filter(
+        (app) =>
+          !connectedApps.some(
+            (integration) =>
+              integration.type === IntegrationType.Pipedream &&
+              integration.configuration.appName === app.nameSlug,
+          ),
+      )
+      .map(
+        (app) =>
+          ({
+            type: 'item',
+            value: app.nameSlug,
+            title: app.name,
+            description: getToolsAndAccountsLabel({
+              type: 'UnConnectedPipedreamApp',
+              toolCount: app.tools.length,
+            }),
+            keywords: [app.name, app.nameSlug],
+            metadata: {
+              type: 'UnConnectedPipedreamApp',
+              app,
+            },
+            imageIcon: {
+              type: 'image',
+              src: app.imgSrc,
+              alt: app.name,
+            },
+          }) satisfies SearchableOptionItem<ToolType>,
+      )
+
+    groups.push({
+      type: 'group',
+      label: 'Connect a new integration',
+      loading: isLoadingPipedreamApps,
+      items: availableApps,
+    })
+
+    return groups
+  }, [
+    connectedApps,
+    isLoadingConnectedIntegrations,
+    pipedreamApps,
+    isLoadingPipedreamApps,
+    immediateQuery,
+  ])
+
+  const infiniteScroll = useMemo(
+    () => ({
+      onReachBottom: loadMore,
+      isLoadingMore,
+      isReachingEnd,
+      totalCount,
+    }),
+    [loadMore, isLoadingMore, isReachingEnd, totalCount],
+  )
+  const [connectingApp, setConnectingApp] = useState<AppDto | null>(null)
+  const onAdd = useCallback(() => {
+    console.log('Add clicked')
+    onCloseModal()
+  }, [onCloseModal])
+  const onConnect = useCallback((connectedApp: AppDto) => {
+    setConnectingApp(connectedApp)
+  }, [])
+  const onConnectSuccess = useCallback(
+    (newIntegration: PipedreamIntegration) => {
+      console.log('Connected', newIntegration)
+      setConnectingApp(null)
+      onAdd()
+    },
+    [onAdd, setConnectingApp],
+  )
+  const onCloseConnect = useCallback((_open?: boolean) => {
+    setConnectingApp(null)
+  }, [])
+
+  return (
+    <>
+      <Modal
+        open
+        dismissible
+        scrollable={false}
+        size='regular'
+        height='screen'
+        title='Add new toolset'
+        description='Select one of your existing integrations or create a new one.'
+        onOpenChange={onCloseModal}
+      >
+        <ConnectToolContext.Provider value={{ onAdd, onConnect }}>
+          <SearchableList<ToolType>
+            placeholder='Search integrations...'
+            emptyMessage='No integrations found'
+            multiGroup
+            items={optionGroups}
+            ItemPresenter={ItemPresenter}
+            onSearchChange={onSearchChange}
+            infiniteScroll={infiniteScroll}
+            loading={isLoading}
+          />
+        </ConnectToolContext.Provider>
+      </Modal>
+      {connectingApp ? (
+        <ConnectPipedreamModal
+          onOpenChange={onCloseConnect}
+          onConnect={onConnectSuccess}
+          app={connectingApp}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/index.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import { useCurrentCommit } from '$/app/providers/CommitProvider'
+import { useToggleModal } from '$/hooks/useToogleModal'
+import { SidebarSection } from '../Section'
+import { ConnectToolsModal } from './ConnectToolsModal'
+
+export function ToolsSidebarSection() {
+  const { commit } = useCurrentCommit()
+  const isLive = !!commit.mergedAt
+  const { open, onOpen, onClose } = useToggleModal()
+  const actions = useMemo(
+    () => [{ onClick: onOpen, disabled: isLive }],
+    [onOpen, isLive],
+  )
+  return (
+    <>
+      <SidebarSection title='Tools' actions={actions}>
+        TO BE LISTED
+      </SidebarSection>
+      {open ? <ConnectToolsModal onCloseModal={onClose} /> : null}
+    </>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Triggers/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Triggers/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useToggleModal } from '$/hooks/useToogleModal'
-import { SidebarSection } from '../Section'
 import { Modal } from '@latitude-data/web-ui/atoms/Modal'
 import { NewTrigger } from '$/components/TriggersManagement/NewTrigger'
 import {
@@ -18,9 +17,10 @@ import {
 } from '@latitude-data/core/schema/types'
 import { useTriggerInfo } from '$/components/TriggersManagement/hooks/useTriggerInfo'
 import { DocumentTriggerType } from '@latitude-data/constants'
-import { SectionItem } from '../SectionItem'
 import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import { useUpdateDocumentTrigger } from '$/components/TriggersManagement/EditTrigger/useUpdateDocumentTrigger'
+import { SidebarSection } from '../Section'
+import { SectionItem } from '../SectionItem'
 
 function NewTriggerModal({
   modalOpen,

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/index.tsx
@@ -6,6 +6,7 @@ import { ResolvedMetadata } from '$/workers/readMetadata'
 import { SectionLoader, SidebarSection } from './Section'
 import { SidebarHeader } from './SidebarHeader'
 import { TriggersSidebarSection, useDocumentTriggersData } from './Triggers'
+import { ToolsSidebarSection } from './Tools'
 
 function SidebarLoader() {
   return (
@@ -57,7 +58,7 @@ export function DocumentEditorSidebarArea({
             integrations={data.triggersData.integrations}
             document={data.triggersData.document}
           />
-          <SidebarSection title='Tools' actions={[{ onClick: () => {} }]} />
+          <ToolsSidebarSection />
           <SidebarSection
             title='Sub-agents'
             actions={[{ onClick: () => {} }]}

--- a/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/Pipedream/AppCard.tsx
+++ b/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/Pipedream/AppCard.tsx
@@ -7,18 +7,28 @@ import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { CollapsibleBox } from '@latitude-data/web-ui/molecules/CollapsibleBox'
 import type { App } from '@pipedream/sdk/browser'
 import Image from 'next/image'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
 import {
   PipedreamComponent,
   PipedreamComponentType,
 } from '@latitude-data/core/constants'
+import { parseMarkdownLinks } from '$/components/TriggersManagement/components/TriggerForms/IntegrationTriggerForm/usePipedreamTriggerDescription'
 
 function AppComponent({ component }: { component: PipedreamComponent }) {
+  const description = useMemo(
+    () => parseMarkdownLinks(component.description),
+    [component.description],
+  )
   return (
     <div className='flex flex-col gap-2'>
       <Text.H5>{component.name}</Text.H5>
       <Text.H6 color='foregroundMuted' wordBreak='breakWord'>
-        {component.description}
+        <div
+          className='[&>a]:underline [&>a]:text-foreground'
+          dangerouslySetInnerHTML={{
+            __html: description,
+          }}
+        />
       </Text.H6>
     </div>
   )

--- a/apps/web/src/app/(private)/settings/_components/Integrations/New/index.tsx
+++ b/apps/web/src/app/(private)/settings/_components/Integrations/New/index.tsx
@@ -19,7 +19,7 @@ import { PipedreamIntegrationConfiguration } from './_components/Configuration/P
 import { ExternalIntegrationConfiguration } from './_components/Configuration/External'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 
-type ValidIntegration = Exclude<
+export type ValidIntegration = Exclude<
   IntegrationConfiguration,
   | { type: IntegrationType.Latitude }
   | {

--- a/apps/web/src/app/api/integrations/route.ts
+++ b/apps/web/src/app/api/integrations/route.ts
@@ -17,6 +17,7 @@ export const GET = errorHandler(
       const integrations = await listIntegrations(workspace).then((r) =>
         r.unwrap(),
       )
+      console.log('Integrations:', integrations)
       return NextResponse.json(integrations, { status: 200 })
     },
   ),

--- a/apps/web/src/components/TriggersManagement/NewTrigger/IntegrationsList/utils.ts
+++ b/apps/web/src/components/TriggersManagement/NewTrigger/IntegrationsList/utils.ts
@@ -3,7 +3,11 @@ import { OptionItem as SearchableOptionItem } from '@latitude-data/web-ui/molecu
 import { type TriggerIntegrationType } from '../../types'
 import { type PipedreamIntegrationWithCounts } from '@latitude-data/core/schema/types'
 
-function pluralize(count: number, singular: string, plural: string): string {
+export function pluralize(
+  count: number,
+  singular: string,
+  plural: string,
+): string {
   return `${count} ${count === 1 ? singular : plural}`
 }
 

--- a/apps/web/src/components/TriggersManagement/components/TriggerForms/IntegrationTriggerForm/usePipedreamTriggerDescription.ts
+++ b/apps/web/src/components/TriggersManagement/components/TriggerForms/IntegrationTriggerForm/usePipedreamTriggerDescription.ts
@@ -4,7 +4,7 @@ import {
   type PipedreamComponentType,
 } from '@latitude-data/core/constants'
 
-function parseMarkdownLinks(text: string | undefined) {
+export function parseMarkdownLinks(text: string | undefined) {
   if (!text) return ''
   return text.replace(
     /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,

--- a/packages/constants/src/integrations.ts
+++ b/packages/constants/src/integrations.ts
@@ -1,8 +1,8 @@
 export enum IntegrationType {
-  Latitude = 'latitude', // For internal use only and Latte
+  Latitude = 'latitude',
   ExternalMCP = 'custom_mcp',
-  HostedMCP = 'mcp_server',
   Pipedream = 'pipedream',
+  HostedMCP = 'mcp_server', // DEPRECATED: Do not use
 }
 
 export enum HostedIntegrationType {

--- a/packages/core/src/lib/pipedream/mergeConnectedAppsBySlug.ts
+++ b/packages/core/src/lib/pipedream/mergeConnectedAppsBySlug.ts
@@ -1,0 +1,31 @@
+import {
+  PipedreamIntegration,
+  PipedreamIntegrationWithAcountCount,
+} from '../../schema/types'
+
+export function mergeConnectedAppsBySlug(
+  connectedApps: PipedreamIntegration[],
+): PipedreamIntegrationWithAcountCount[] {
+  const appMap = new Map<
+    string,
+    { app: PipedreamIntegration; accountCount: number }
+  >()
+
+  for (const app of connectedApps) {
+    const appName = app.configuration.appName
+    const existing = appMap.get(appName)
+
+    if (existing) {
+      existing.accountCount += 1
+    } else {
+      appMap.set(appName, { app, accountCount: 1 })
+    }
+  }
+
+  return Array.from(appMap.values()).map(({ app, accountCount }) => {
+    return {
+      ...app,
+      accountCount,
+    } satisfies PipedreamIntegrationWithAcountCount
+  })
+}

--- a/packages/core/src/services/integrations/connectedByAppSlug.ts
+++ b/packages/core/src/services/integrations/connectedByAppSlug.ts
@@ -1,6 +1,4 @@
 import {
-  type PipedreamIntegration,
-  type PipedreamIntegrationWithAcountCount,
   PipedreamIntegrationWithCounts,
   Workspace,
   IntegrationDto,
@@ -9,33 +7,7 @@ import { IntegrationsRepository } from '@latitude-data/core/repositories'
 import { getAllAppComponents, getPipedreamClient } from './pipedream/apps'
 import { Result } from '../../lib/Result'
 import { IntegrationType } from '@latitude-data/constants'
-
-function mergeConnectedAppsBySlug(
-  connectedApps: PipedreamIntegration[],
-): PipedreamIntegrationWithAcountCount[] {
-  const appMap = new Map<
-    string,
-    { app: PipedreamIntegration; accountCount: number }
-  >()
-
-  for (const app of connectedApps) {
-    const appName = app.configuration.appName
-    const existing = appMap.get(appName)
-
-    if (existing) {
-      existing.accountCount += 1
-    } else {
-      appMap.set(appName, { app, accountCount: 1 })
-    }
-  }
-
-  return Array.from(appMap.values()).map(({ app, accountCount }) => {
-    return {
-      ...app,
-      accountCount,
-    } satisfies PipedreamIntegrationWithAcountCount
-  })
-}
+import { mergeConnectedAppsBySlug } from '../../lib/pipedream/mergeConnectedAppsBySlug'
 
 export async function listConnectedIntegrationsByApp({
   workspace,


### PR DESCRIPTION
# What?
Layout the main work to show the connect tool sets (aka tools, aka integrations)

## TODO
- [x] Implement searchable list of tools Latitude tools + Pipedream tools
- [x] ~~Display available tools inside a tool-set under the accordion~~ Out of scope for today
- [x] Do the Pipedream connect flow
- [x] Add an callback to add the selected tool-set to the editor

### Next steps
Once we have this, we can add that selected tool set to the local sidebar editor state.

## Connect Pipedream apps from the editor
(now markdown links are links)

<img width="980" height="732" alt="image" src="https://github.com/user-attachments/assets/39436061-2265-4c70-9be0-4200ff36c8c1" />
