### PR TITLE
feat: add api-background-runs feature flag to control background execution

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.ts
@@ -56,7 +56,19 @@ export const runHandler: AppRouteHandler<RunRoute> = async (c) => {
     })
   }
 
-  if (background) {
+  // Check if background execution should happen:
+  // 1. If background prop is explicitly set, use that value
+  // 2. Otherwise, check if the feature flag is enabled for the workspace
+  const backgroundRunsFeatureEnabled = await isFeatureEnabledByName(
+    workspace.id,
+    'api-background-runs',
+  ).then((r) => r.unwrap())
+
+  const shouldRunInBackground = background !== undefined
+    ? background
+    : backgroundRunsFeatureEnabled
+
+  if (shouldRunInBackground) {
     return await handleBackgroundRun({
       c,
       workspace,

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.route.ts
@@ -27,7 +27,7 @@ export const runRoute = createRoute({
             parameters: z.record(z.string(), z.any()).optional().default({}),
             tools: z.array(z.string()).optional().default([]),
             userMessage: z.string().optional(),
-            background: z.boolean().default(false),
+            background: z.boolean().optional(),
           }),
         },
       },


### PR DESCRIPTION
## Summary
- Added feature flag `api-background-runs` to control whether runs execute in the background
- Runs now execute in background mode if either:
  - The `background` parameter is explicitly set to `true` in the request, OR
  - The `api-background-runs` feature flag is enabled for the workspace
- This allows workspaces to configure background execution as the default behavior while still allowing individual requests to override

## Test plan
- [x] Verify that runs execute in foreground when `background` is false/undefined and feature flag is disabled
- [x] Verify that runs execute in background when `background` is explicitly set to true
- [x] Verify that runs execute in background when `api-background-runs` feature flag is enabled for workspace
- [x] Verify that explicit `background: false` still executes in foreground even when feature flag is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)