### PR TITLE
Handle integrations toggle on editor sidebar

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Section/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Section/index.tsx
@@ -23,10 +23,6 @@ export function SectionLoader({ items = 3 }: { items: number }) {
   )
 }
 
-const SidebarTitle = ({ children }: { children: ReactNode }) => {
-  return <Text.H5M>{children}</Text.H5M>
-}
-
 type SectionAction = {
   iconProps?: IconProps
   onClick: () => void
@@ -37,18 +33,14 @@ const SidebarSection = ({
   title,
   actions,
 }: {
-  title: string | ReactNode
+  title: string
   children?: ReactNode
   actions?: SectionAction[]
 }) => {
   return (
     <div className='flex flex-col gap-y-2'>
       <div className='flex justify-between gap-x-3'>
-        {typeof title === 'string' ? (
-          <SidebarTitle>{title}</SidebarTitle>
-        ) : (
-          title
-        )}
+        <Text.H5M>{title}</Text.H5M>
 
         {actions ? (
           <div className='flex flex-row gap-x-2'>
@@ -69,7 +61,5 @@ const SidebarSection = ({
     </div>
   )
 }
-
-SidebarSection.Title = SidebarTitle
 
 export { SidebarSection }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/ToolList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/ToolList/index.tsx
@@ -1,0 +1,257 @@
+import { useCallback, use, useMemo, useEffect, useState, useRef } from 'react'
+import { IndentationBar } from '$/components/Sidebar/Files/IndentationBar'
+import useIntegrationTools from '$/stores/integrationTools'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
+import { SwitchToggle } from '@latitude-data/web-ui/atoms/Switch'
+import { useCurrentCommit } from '$/app/providers/CommitProvider'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Input } from '@latitude-data/web-ui/atoms/Input'
+import { ActiveIntegration } from '../../../toolsHelpers/types'
+import { ToolsContext } from '../../ToolsProvider'
+import { useActiveIntegrationsStore } from '../../hooks/useActiveIntegrationsStore'
+import { useAnimatedItems } from './useAnimatedItems'
+
+const MAX_VISIBLE_TOOLS = 10
+
+function ToolListLoader({ numberOfItems }: { numberOfItems: number }) {
+  const toolItems = useMemo(
+    () => Array.from({ length: numberOfItems }),
+    [numberOfItems],
+  )
+  return (
+    <div className='flex flex-col gap-1'>
+      {toolItems.map((_, index) => (
+        <div key={index} className='flex items-center justify-between h-6'>
+          <div className='flex items-center gap-2'>
+            <IndentationBar
+              startOnIndex={0}
+              hasChildren={false}
+              indentation={[{ isLast: index === toolItems.length - 1 }]}
+            />
+            <div className='flex items-center gap-2'>
+              <Skeleton height='h6' className='w-32' />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function checkIsActive(
+  activeTools: ActiveIntegration['tools'],
+  toolName: string,
+) {
+  if (typeof activeTools === 'boolean') {
+    return activeTools === true
+  }
+  return activeTools.includes(toolName)
+}
+
+const TOOL_EMPTY: [] = []
+export function ToolList({ integration }: { integration: ActiveIntegration }) {
+  const {
+    data: tools = TOOL_EMPTY,
+    isLoading,
+    error,
+  } = useIntegrationTools(integration)
+  const { addIntegrationTool, removeIntegrationTool } = use(ToolsContext)
+  const setIntegrationToolNames = useActiveIntegrationsStore(
+    (state) => state.setIntegrationToolNames,
+  )
+  const { commit } = useCurrentCommit()
+  const isLive = !!commit.mergedAt
+  const [showAll, setShowAll] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const toggleTool = useCallback(
+    (toolName: string) => () => {
+      if (isLive) return
+      if (!tools) return
+
+      const isActive = checkIsActive(integration.tools, toolName)
+
+      if (isActive) {
+        removeIntegrationTool({
+          integrationName: integration.name,
+          toolName,
+          allToolNames: tools.map((t) => t.name),
+        })
+      } else {
+        addIntegrationTool({
+          integrationName: integration.name,
+          toolName,
+        })
+      }
+    },
+    [tools, isLive, addIntegrationTool, removeIntegrationTool, integration],
+  )
+  // Sort tools to show active ones first (in document order), then inactive ones
+  const sortedTools = useMemo(() => {
+    if (!tools || tools.length === 0) return []
+
+    const activeToolNames = Array.isArray(integration.tools)
+      ? integration.tools
+      : []
+
+    // Split into active and inactive
+    const activeTools: typeof tools = []
+    const inactiveTools: typeof tools = []
+
+    tools.forEach((tool) => {
+      if (integration.tools === true || activeToolNames.includes(tool.name)) {
+        activeTools.push(tool)
+      } else {
+        inactiveTools.push(tool)
+      }
+    })
+
+    // Sort active tools by their position in the config
+    if (Array.isArray(integration.tools)) {
+      activeTools.sort((a, b) => {
+        const indexA = activeToolNames.indexOf(a.name)
+        const indexB = activeToolNames.indexOf(b.name)
+        return indexA - indexB
+      })
+    }
+
+    return [...activeTools, ...inactiveTools]
+  }, [tools, integration.tools])
+
+  // Filter tools based on search query
+  const filteredTools = useMemo(() => {
+    if (!searchQuery.trim()) return sortedTools
+
+    const query = searchQuery.toLowerCase()
+    return sortedTools.filter((tool) => {
+      const name = tool.name.toLowerCase()
+      const displayName = (tool.displayName ?? '').toLowerCase()
+      return name.includes(query) || displayName.includes(query)
+    })
+  }, [sortedTools, searchQuery])
+
+  useEffect(() => {
+    if (tools && tools.length > 0) {
+      setIntegrationToolNames({
+        integrationName: integration.name,
+        toolNames: tools.map((t) => t.name),
+      })
+    }
+  }, [tools, integration.name, setIntegrationToolNames])
+
+  const hasMoreTools = sortedTools.length > MAX_VISIBLE_TOOLS
+  const shouldShowSearch = sortedTools.length > MAX_VISIBLE_TOOLS
+  const visibleTools = showAll
+    ? filteredTools
+    : filteredTools.slice(0, MAX_VISIBLE_TOOLS)
+  const shouldShowMoreButton = hasMoreTools && !showAll && !searchQuery.trim()
+  useAnimatedItems({
+    containerRef,
+    isLoading,
+    sortedTools,
+    error,
+  })
+
+  if (isLoading) return <ToolListLoader numberOfItems={5} />
+
+  if (error) {
+    return (
+      <div className='w-full h-full flex flex-col gap-2 bg-destructive-muted p-4 rounded-xl'>
+        <Text.H5B color='destructiveMutedForeground'>
+          Error loading tools
+        </Text.H5B>
+        <Text.H6 color='destructiveMutedForeground'>{error.message}</Text.H6>
+        {integration.tools !== undefined && (
+          <Button
+            variant='outline'
+            className='border-destructive-muted-foreground'
+            onClick={() => {
+              removeIntegrationTool({
+                integrationName: integration.name,
+                toolName: '*',
+                allToolNames: [],
+              })
+            }}
+          >
+            <Text.H6 color='destructiveMutedForeground'>
+              Remove from prompt
+            </Text.H6>
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className='flex flex-col gap-1 min-w-0'
+      style={{ position: 'relative' }}
+    >
+      {shouldShowSearch && (
+        <div className='mb-2 mx-2'>
+          <Input
+            type='text'
+            size='small'
+            placeholder='Search tools...'
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className='w-full'
+          />
+        </div>
+      )}
+      {visibleTools.map((tool, index) => {
+        const isActive = checkIsActive(integration.tools, tool.name)
+        const isLastTool = index === visibleTools.length - 1
+        return (
+          <div
+            role='button'
+            tabIndex={0}
+            aria-disabled={isLive}
+            key={tool.name}
+            data-tool-id={tool.name}
+            onClick={toggleTool(tool.name)}
+            className='w-full flex items-center justify-between'
+          >
+            <div className='w-full flex items-center gap-2 min-w-0'>
+              <IndentationBar
+                startOnIndex={0}
+                hasChildren={false}
+                indentation={[{ isLast: isLastTool && !shouldShowMoreButton }]}
+              />
+              <div className='w-full flex justify-between items-center min-w-0 gap-x-2'>
+                <div className='flex-1 flex items-center gap-2 min-w-0'>
+                  <Text.H5 ellipsis noWrap color='foreground'>
+                    {tool.displayName ?? tool.name}
+                  </Text.H5>
+                </div>
+                <SwitchToggle
+                  checked={isActive}
+                  onClick={toggleTool(tool.name)}
+                  disabled={isLive}
+                />
+              </div>
+            </div>
+          </div>
+        )
+      })}
+      {shouldShowMoreButton && (
+        <button
+          onClick={() => setShowAll(true)}
+          className='w-full flex items-center gap-2 min-w-0 cursor-pointer hover:opacity-70'
+        >
+          <IndentationBar
+            startOnIndex={0}
+            hasChildren={false}
+            indentation={[{ isLast: true }]}
+          />
+          <Text.H5 color='accentForeground'>
+            + Show {filteredTools.length - MAX_VISIBLE_TOOLS} more
+          </Text.H5>
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/ToolList/useAnimatedItems.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/ToolList/useAnimatedItems.ts
@@ -1,0 +1,53 @@
+import { McpToolDto } from '$/stores/integrationTools'
+import { RefObject, useLayoutEffect, useRef } from 'react'
+
+export function useAnimatedItems({
+  error,
+  isLoading,
+  sortedTools,
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLElement | null>
+  error: unknown
+  isLoading: boolean
+  sortedTools: McpToolDto[]
+}) {
+  const prevPositionsRef = useRef<Map<string, DOMRect>>(new Map())
+  useLayoutEffect(() => {
+    if (isLoading || error) return
+
+    const container = containerRef.current
+    if (!container) return
+
+    const children = Array.from(
+      container.querySelectorAll('[data-tool-id]'),
+    ) as HTMLElement[]
+
+    children.forEach((child) => {
+      const id = child.dataset.toolId
+      if (!id) return
+
+      const prevRect = prevPositionsRef.current.get(id)
+      const currentRect = child.getBoundingClientRect()
+
+      if (prevRect) {
+        const deltaY = prevRect.top - currentRect.top
+
+        if (deltaY !== 0) {
+          // Invert: Move element to its previous position
+          child.style.transform = `translateY(${deltaY}px)`
+          child.style.transition = 'none'
+
+          // Play: Animate to natural position
+          requestAnimationFrame(() => {
+            child.style.transition = 'transform 0.3s ease-in-out'
+            child.style.transform = ''
+          })
+        }
+      }
+
+      // Store current position for next time
+      prevPositionsRef.current.set(id, currentRect)
+    })
+  }, [sortedTools, isLoading, error, containerRef])
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/index.tsx
@@ -1,0 +1,154 @@
+import { use, useCallback, MouseEvent, useMemo } from 'react'
+import Image from 'next/image'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { SwitchToggle } from '@latitude-data/web-ui/atoms/Switch'
+import { DropdownMenu } from '@latitude-data/web-ui/atoms/DropdownMenu'
+import { useCurrentCommit } from '$/app/providers/CommitProvider'
+import { ToolList } from './ToolList'
+import {
+  ActiveIntegration as IActiveIntegration,
+  ImageIcon,
+} from '../../toolsHelpers/types'
+import { ToolsContext } from '../ToolsProvider'
+import { useActiveIntegrationsStore } from '../hooks/useActiveIntegrationsStore'
+
+function ImageIconComponent({ imageIcon }: { imageIcon?: ImageIcon }) {
+  if (!imageIcon) return null
+  if (!imageIcon?.type) return null
+
+  if (imageIcon.type === 'image') {
+    return (
+      <Image
+        unoptimized
+        src={imageIcon.src}
+        alt={imageIcon.alt}
+        width={16}
+        height={16}
+        style={{ width: 16, height: 16 }}
+      />
+    )
+  }
+
+  return <Icon name={imageIcon.name} size='normal' />
+}
+
+export function ActiveIntegration({
+  integration,
+  onRemove,
+}: {
+  integration: IActiveIntegration
+  onRemove: (integrationName: string) => void
+}) {
+  const { addIntegrationTool, removeIntegrationTool } = use(ToolsContext)
+  const toggleIntegration = useActiveIntegrationsStore(
+    (state) => state.toggleIntegration,
+  )
+  const { commit } = useCurrentCommit()
+  const isLive = !!commit.mergedAt
+
+  const allEnabled = integration.tools === true
+  const isOpen = integration.isOpen
+
+  // Calculate tool counts from store data
+  const { totalCount, activeCount, hasToolsLoaded } = useMemo(() => {
+    const total = integration.allToolNames.length
+    const active =
+      integration.tools === true
+        ? total
+        : Array.isArray(integration.tools)
+          ? integration.tools.length
+          : 0
+    const loaded = total > 0
+
+    return { totalCount: total, activeCount: active, hasToolsLoaded: loaded }
+  }, [integration.allToolNames, integration.tools])
+
+  const toggleAllEnabled = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation()
+      if (isLive) return
+
+      if (allEnabled) {
+        removeIntegrationTool({
+          integrationName: integration.name,
+          toolName: '*',
+          allToolNames: integration.allToolNames,
+        })
+      } else {
+        addIntegrationTool({
+          integrationName: integration.name,
+          toolName: '*',
+        })
+      }
+    },
+    [
+      isLive,
+      allEnabled,
+      integration.name,
+      integration.allToolNames,
+      addIntegrationTool,
+      removeIntegrationTool,
+    ],
+  )
+
+  return (
+    <div className='flex flex-col'>
+      <div className='flex items-center justify-between gap-x-2 min-w-0 min-h-7'>
+        <div
+          role='button'
+          tabIndex={0}
+          aria-expanded={isOpen}
+          aria-controls={`integration-tools-${integration.name}`}
+          onClick={() => toggleIntegration(integration.name)}
+          className='flex items-center gap-2 min-w-0'
+        >
+          <Icon name={isOpen ? 'chevronDown' : 'chevronRight'} />
+          <ImageIconComponent imageIcon={integration.icon} />
+          <Text.H5M ellipsis noWrap>
+            {integration.name}
+          </Text.H5M>
+          <div onClick={toggleAllEnabled}>
+            <SwitchToggle
+              checked={allEnabled}
+              onClick={toggleAllEnabled}
+              disabled={isLive}
+            />
+          </div>
+        </div>
+
+        <div className='flex items-center gap-2'>
+          {hasToolsLoaded ? (
+            <Text.H6 color='foregroundMuted' noWrap>
+              {activeCount} / {totalCount} tools
+            </Text.H6>
+          ) : null}
+
+          <DropdownMenu
+            options={[
+              {
+                label: 'Remove',
+                type: 'destructive',
+                onClick: () => onRemove(integration.name),
+              },
+            ]}
+            side='bottom'
+            align='end'
+            triggerButtonProps={{
+              iconProps: { name: 'ellipsis' },
+              variant: 'ghost',
+              size: 'small',
+              disabled: isLive,
+            }}
+          />
+        </div>
+      </div>
+
+      {isOpen && (
+        <div className='flex flex-col gap-1'>
+          <ToolList integration={integration} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/ConnectPipedreamModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ConnectToolsModal/ConnectPipedreamModal/index.tsx
@@ -39,8 +39,8 @@ export function ConnectPipedreamModal({
     return errors.length ? errors : undefined
   }, [integrationName])
   const { create } = useIntegrations({
-    withTools: true,
     includeLatitudeTools: true,
+    withTools: true,
   })
   const { data: workspace } = useCurrentWorkspace()
   const { connect } = useConnectToPipedreamApp(app)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ToolsProvider/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ToolsProvider/index.tsx
@@ -1,0 +1,29 @@
+import { createContext, ReactNode } from 'react'
+import { SidebarEditorState } from '../hooks/useActiveIntegrationsStore'
+
+type IToolsContext = {
+  addIntegrationTool: (
+    args: Parameters<SidebarEditorState['addTool']>[0],
+  ) => void
+  removeIntegrationTool: (
+    args: Parameters<SidebarEditorState['removeTool']>[0],
+  ) => void
+}
+
+export const ToolsContext = createContext<IToolsContext>({} as IToolsContext)
+
+export function ToolsProvider({
+  children,
+  addIntegrationTool,
+  removeIntegrationTool,
+}: {
+  children: ReactNode
+} & IToolsContext) {
+  return (
+    <ToolsContext.Provider
+      value={{ addIntegrationTool, removeIntegrationTool }}
+    >
+      {children}
+    </ToolsContext.Provider>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrations.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrations.ts
@@ -1,0 +1,200 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { useToast } from '@latitude-data/web-ui/atoms/Toast'
+import {
+  SidebarEditorState,
+  useActiveIntegrationsStore,
+} from './useActiveIntegrationsStore'
+import { useCurrentUrl } from '$/hooks/useCurrentUrl'
+import { useNavigate } from '$/hooks/useNavigate'
+import { executeFetch } from '$/hooks/useFetcher'
+import { ROUTES } from '$/services/routes'
+import { useCurrentProject } from '$/app/providers/ProjectProvider'
+import { useCurrentCommit } from '$/app/providers/CommitProvider'
+import { useCurrentDocument } from '$/app/providers/DocumentProvider'
+import { UpdateDocumentContentResponse } from '@latitude-data/core/services/documents/updateDocumentContent/updateContent'
+import { updatePromptMetadata } from '@latitude-data/core/lib/updatePromptMetadata'
+import { updateToolsFromActiveIntegrations } from '../../toolsHelpers/updateConfigWithActiveTools'
+import { trigger } from '$/lib/events'
+import { ResolvedMetadata } from '$/workers/readMetadata'
+
+export function useActiveIntegrations() {
+  const updateController = useRef<AbortController | null>(null)
+  const { toast } = useToast()
+  const navigate = useNavigate()
+  const currentUrl = useCurrentUrl()
+  const { project } = useCurrentProject()
+  const { commit } = useCurrentCommit()
+  const { document, mutateDocumentUpdated } = useCurrentDocument()
+  const {
+    addIntegration,
+    addTool,
+    removeTool,
+    removeIntegration: removeIntegrationFromStore,
+  } = useActiveIntegrationsStore((state) => ({
+    addIntegration: state.addIntegration,
+    addTool: state.addTool,
+    removeTool: state.removeTool,
+    removeIntegration: state.removeIntegration,
+  }))
+
+  const updateDocumentContent = useCallback(
+    async ({ state }: { state: SidebarEditorState }) => {
+      if (updateController.current) {
+        updateController.current.abort()
+      }
+
+      updateController.current = new AbortController()
+
+      const updatedPrompt = updatePromptMetadata(document.content, {
+        tools: updateToolsFromActiveIntegrations({
+          currentTools: state.promptConfigTools,
+          activeIntegrations: state.integrationsMap,
+        }),
+      })
+      await executeFetch<UpdateDocumentContentResponse>({
+        method: 'POST',
+        route: ROUTES.api.projects
+          .detail(project.id)
+          .commits.detail(commit.uuid)
+          .documents.detail(document.documentUuid).updateDocumentContent.root,
+        toast,
+        abortSignal: updateController.current.signal,
+        navigate,
+        currentUrl,
+        body: { prompt: updatedPrompt },
+        serializer: (data) => data as UpdateDocumentContentResponse,
+        onSuccess: (data) => {
+          if (!data) return
+
+          mutateDocumentUpdated(data.document)
+          trigger('PromptChanged', { prompt: data.document.content })
+          trigger('PromptMetadataChanged', {
+            promptLoaded: true,
+            metadata: data.metadata as ResolvedMetadata,
+          })
+        },
+      })
+    },
+    [
+      toast,
+      navigate,
+      currentUrl,
+      project,
+      commit,
+      document,
+      mutateDocumentUpdated,
+    ],
+  )
+  const addNewIntegration = useCallback(
+    ({
+      integration,
+      toolName,
+    }: {
+      integration: Parameters<typeof addIntegration>[0]['integration']
+      toolName: string
+    }) => {
+      const updatedState = addIntegration({ integration, toolName })
+      updateDocumentContent({ state: updatedState })
+    },
+    [addIntegration, updateDocumentContent],
+  )
+
+  const addIntegrationTool = useCallback(
+    ({
+      integrationName,
+      toolName,
+    }: {
+      integrationName: string
+      toolName: string
+    }) => {
+      const updatedState = addTool({ integrationName, toolName })
+      updateDocumentContent({ state: updatedState })
+    },
+    [addTool, updateDocumentContent],
+  )
+
+  const removeIntegrationTool = useCallback(
+    ({
+      integrationName,
+      toolName,
+      allToolNames,
+    }: {
+      integrationName: string
+      toolName: string
+      allToolNames: string[]
+    }) => {
+      const updatedState = removeTool({
+        integrationName,
+        toolName,
+        allToolNames,
+      })
+      updateDocumentContent({ state: updatedState })
+    },
+    [removeTool, updateDocumentContent],
+  )
+
+  const removeIntegration = useCallback(
+    (integrationName: string) => {
+      const updatedState = removeIntegrationFromStore(integrationName)
+      updateDocumentContent({ state: updatedState })
+    },
+    [removeIntegrationFromStore, updateDocumentContent],
+  )
+
+  return useMemo(
+    () => ({
+      addNewIntegration,
+      addIntegrationTool,
+      removeIntegrationTool,
+      removeIntegration,
+    }),
+    [
+      addNewIntegration,
+      addIntegrationTool,
+      removeIntegrationTool,
+      removeIntegration,
+    ],
+  )
+}
+
+export function removeIntegrationFromActiveIntegrations({
+  activeIntegrations,
+  integrationName,
+  toolName,
+  integrationToolNames,
+}: {
+  activeIntegrations: any
+  integrationName: string
+  toolName: string
+  integrationToolNames: string[]
+}) {
+  if (!activeIntegrations[integrationName]) return activeIntegrations
+
+  if (toolName === '*') {
+    const { [integrationName]: _, ...rest } = activeIntegrations
+    return rest
+  }
+
+  if (activeIntegrations[integrationName] === true) {
+    // If it was '*', replace with all tools except the removed one
+    const remainingTools = integrationToolNames.filter((tn) => tn !== toolName)
+    if (remainingTools.length === 0) {
+      const { [integrationName]: _, ...rest } = activeIntegrations
+      return rest
+    }
+    return { ...activeIntegrations, [integrationName]: remainingTools }
+  }
+
+  if (!Array.isArray(activeIntegrations[integrationName]))
+    return activeIntegrations
+  const remaining = (activeIntegrations[integrationName] as string[]).filter(
+    (tn) => tn !== toolName,
+  )
+
+  if (remaining.length === 0) {
+    const { [integrationName]: _, ...rest } = activeIntegrations
+    return rest
+  }
+
+  return { ...activeIntegrations, [integrationName]: remaining }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrationsStore.test.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrationsStore.test.ts
@@ -1,0 +1,514 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useActiveIntegrationsStore } from './useActiveIntegrationsStore'
+import { IntegrationType } from '@latitude-data/constants'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { ActiveIntegration } from '../../toolsHelpers/types'
+
+describe('useActiveIntegrationsStore', () => {
+  // Helper to reset store state
+  const resetStore = () => {
+    const { result } = renderHook(() => useActiveIntegrationsStore())
+    act(() => {
+      result.current.buildIntegrations({ tools: [], integrations: [] })
+      result.current.setInitialized(false)
+    })
+  }
+
+  beforeEach(() => {
+    resetStore()
+  })
+
+  const mockIntegrationDto = (
+    name: string,
+    id: number = 1,
+  ): IntegrationDto => ({
+    id,
+    name,
+    type: IntegrationType.ExternalMCP,
+    configuration: { url: 'http://localhost:3000' },
+    hasTools: true,
+    hasTriggers: false,
+    workspaceId: 1,
+    authorId: 'test-author',
+    lastUsedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    mcpServerId: null,
+  })
+
+  const mockActiveIntegration = (
+    name: string,
+    tools: boolean | string[] = [],
+    id: number = 1,
+  ): ActiveIntegration => ({
+    id,
+    name,
+    type: IntegrationType.ExternalMCP,
+    configuration: null,
+    icon: { type: 'icon', name: 'mcp' },
+    tools,
+    allToolNames: [],
+    isOpen: false,
+  })
+
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+
+      expect(result.current.initialized).toBe(false)
+      expect(result.current.integrations).toEqual([])
+      expect(result.current.integrationsMap).toEqual({})
+      expect(result.current.promptConfigTools).toEqual([])
+    })
+  })
+
+  describe('buildIntegrations', () => {
+    it('should build integrations from tools config', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message'],
+          integrations,
+        })
+      })
+
+      expect(result.current.initialized).toBe(true)
+      expect(result.current.integrations).toHaveLength(2)
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[1].name).toBe('slack')
+    })
+
+    it('should preserve order of existing integrations when rebuilding', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+        mockIntegrationDto('notion', 3),
+      ]
+
+      // Initial build with google at position 0
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [integrations[0]],
+        })
+      })
+
+      // Add slack at the top
+      act(() => {
+        result.current.addIntegration({
+          integration: mockActiveIntegration('slack', [], 2),
+          toolName: '*',
+        })
+      })
+
+      // Rebuild should preserve slack at top
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['slack/*', 'google/search'],
+          integrations: [integrations[0], integrations[1]],
+        })
+      })
+
+      expect(result.current.integrations[0].name).toBe('slack')
+      expect(result.current.integrations[1].name).toBe('google')
+    })
+
+    it('should add new integrations at the end when rebuilding', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      // Initial build with google
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [integrations[0]],
+        })
+      })
+
+      // Rebuild with slack added
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message'],
+          integrations,
+        })
+      })
+
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[1].name).toBe('slack')
+    })
+
+    it('should remove integrations not in new config', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message'],
+          integrations,
+        })
+      })
+
+      expect(result.current.integrations).toHaveLength(2)
+
+      // Rebuild with only google
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [integrations[0]],
+        })
+      })
+
+      expect(result.current.integrations).toHaveLength(1)
+      expect(result.current.integrations[0].name).toBe('google')
+    })
+  })
+
+  describe('addIntegration', () => {
+    it('should add new integration at the top with isOpen: true', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      // Build with google
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [integrations[0]],
+        })
+      })
+
+      // Add slack
+      act(() => {
+        result.current.addIntegration({
+          integration: mockActiveIntegration('slack', [], 2),
+          toolName: '*',
+        })
+      })
+
+      expect(result.current.integrations).toHaveLength(2)
+      expect(result.current.integrations[0].name).toBe('slack')
+      expect(result.current.integrations[0].isOpen).toBe(true)
+      expect(result.current.integrations[0].tools).toBe(true)
+      expect(result.current.integrations[1].name).toBe('google')
+    })
+
+    it('should add integration with specific tools', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+
+      act(() => {
+        result.current.addIntegration({
+          integration: mockActiveIntegration('google'),
+          toolName: 'search',
+        })
+      })
+
+      expect(result.current.integrations[0].tools).toEqual(['search'])
+    })
+  })
+
+  describe('addTool', () => {
+    it('should add tool to existing integration and preserve order', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message'],
+          integrations,
+        })
+      })
+
+      act(() => {
+        result.current.addTool({
+          integrationName: 'google',
+          toolName: 'calendar',
+        })
+      })
+
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[0].tools).toContain('calendar')
+      expect(result.current.integrations[1].name).toBe('slack')
+    })
+
+    it('should set tools to true when adding wildcard', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [mockIntegrationDto('google')],
+        })
+      })
+
+      act(() => {
+        result.current.addTool({
+          integrationName: 'google',
+          toolName: '*',
+        })
+      })
+
+      expect(result.current.integrations[0].tools).toBe(true)
+    })
+  })
+
+  describe('removeTool', () => {
+    it('should remove tool from integration and preserve order', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'google/calendar', 'slack/message'],
+          integrations,
+        })
+      })
+
+      act(() => {
+        result.current.removeTool({
+          integrationName: 'google',
+          toolName: 'search',
+          allToolNames: ['search', 'calendar'],
+        })
+      })
+
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[0].tools).toEqual(['calendar'])
+      expect(result.current.integrations[1].name).toBe('slack')
+    })
+
+    it('should remove all tools when removing wildcard', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/*'],
+          integrations: [mockIntegrationDto('google')],
+        })
+      })
+
+      act(() => {
+        result.current.removeTool({
+          integrationName: 'google',
+          toolName: '*',
+          allToolNames: ['search', 'calendar'],
+        })
+      })
+
+      expect(result.current.integrations[0].tools).toEqual([])
+    })
+  })
+
+  describe('removeIntegration', () => {
+    it('should remove integration and preserve order of remaining', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+        mockIntegrationDto('notion', 3),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message', 'notion/page'],
+          integrations,
+        })
+      })
+
+      act(() => {
+        result.current.removeIntegration('slack')
+      })
+
+      expect(result.current.integrations).toHaveLength(2)
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[1].name).toBe('notion')
+      expect(result.current.integrationsMap.slack).toBeUndefined()
+    })
+  })
+
+  describe('setIntegrationToolNames', () => {
+    it('should set allToolNames and preserve order', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+      ]
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search', 'slack/message'],
+          integrations,
+        })
+      })
+
+      act(() => {
+        result.current.setIntegrationToolNames({
+          integrationName: 'google',
+          toolNames: ['search', 'calendar', 'drive'],
+        })
+      })
+
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[0].allToolNames).toEqual([
+        'search',
+        'calendar',
+        'drive',
+      ])
+      expect(result.current.integrations[1].name).toBe('slack')
+    })
+  })
+
+  describe('toggleIntegration', () => {
+    it('should toggle isOpen and preserve order', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [mockIntegrationDto('google')],
+        })
+      })
+
+      expect(result.current.integrations[0].isOpen).toBe(false)
+
+      act(() => {
+        result.current.toggleIntegration('google')
+      })
+
+      expect(result.current.integrations[0].name).toBe('google')
+      expect(result.current.integrations[0].isOpen).toBe(true)
+
+      act(() => {
+        result.current.toggleIntegration('google')
+      })
+
+      expect(result.current.integrations[0].isOpen).toBe(false)
+    })
+  })
+
+  describe('order preservation in complex scenarios', () => {
+    it('should maintain order through multiple operations', () => {
+      const { result } = renderHook(() => useActiveIntegrationsStore())
+      const integrations = [
+        mockIntegrationDto('google'),
+        mockIntegrationDto('slack', 2),
+        mockIntegrationDto('notion', 3),
+      ]
+
+      // 1. Build with google
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['google/search'],
+          integrations: [integrations[0]],
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual(['google'])
+
+      // 2. Add slack at top
+      act(() => {
+        result.current.addIntegration({
+          integration: mockActiveIntegration('slack', [], 2),
+          toolName: '*',
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'slack',
+        'google',
+      ])
+
+      // 3. Add notion at top
+      act(() => {
+        result.current.addIntegration({
+          integration: mockActiveIntegration('notion', [], 3),
+          toolName: 'page',
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'slack',
+        'google',
+      ])
+
+      // 4. Add tool to slack (should preserve order)
+      act(() => {
+        result.current.addTool({
+          integrationName: 'slack',
+          toolName: 'channel',
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'slack',
+        'google',
+      ])
+
+      // 5. Set tool names for notion (should preserve order)
+      act(() => {
+        result.current.setIntegrationToolNames({
+          integrationName: 'notion',
+          toolNames: ['page', 'database'],
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'slack',
+        'google',
+      ])
+
+      // 6. Toggle notion (should preserve order)
+      act(() => {
+        result.current.toggleIntegration('notion')
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'slack',
+        'google',
+      ])
+
+      // 7. Remove slack (should preserve order)
+      act(() => {
+        result.current.removeIntegration('slack')
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'google',
+      ])
+
+      // 8. Rebuild (should preserve order)
+      act(() => {
+        result.current.buildIntegrations({
+          tools: ['notion/page', 'google/search'],
+          integrations: [integrations[2], integrations[0]],
+        })
+      })
+      expect(result.current.integrations.map((i) => i.name)).toEqual([
+        'notion',
+        'google',
+      ])
+    })
+  })
+})

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrationsStore.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useActiveIntegrationsStore.ts
@@ -1,0 +1,252 @@
+import { create } from 'zustand'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { ActiveIntegration, ActiveIntegrations } from '../../toolsHelpers/types'
+import { collectTools } from '../../toolsHelpers/collectTools'
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { addTool } from '../../toolsHelpers/addTool'
+import { removeTool } from '../../toolsHelpers/removeTool'
+
+export type SidebarEditorState = {
+  initialized: boolean
+  setInitialized: (initialized: boolean) => void
+  promptConfigTools: LatitudePromptConfig['tools']
+  integrationsMap: ActiveIntegrations
+  integrations: ActiveIntegration[]
+  buildIntegrations: (args: {
+    tools: LatitudePromptConfig['tools']
+    integrations: IntegrationDto[]
+  }) => void
+  setIntegrationToolNames: (args: {
+    integrationName: string
+    toolNames: string[]
+  }) => void
+  toggleIntegration: (integrationName: string) => void
+  addIntegration: (args: {
+    integration: ActiveIntegration
+    toolName: string
+  }) => SidebarEditorState
+  addTool: (args: {
+    integrationName: string
+    toolName: string
+  }) => SidebarEditorState
+  removeTool: (args: {
+    integrationName: string
+    toolName: string
+    allToolNames: string[]
+  }) => SidebarEditorState
+  removeIntegration: (integrationName: string) => SidebarEditorState
+}
+
+export const useActiveIntegrationsStore = create<SidebarEditorState>(
+  (set, get) => ({
+    initialized: false,
+    integrationsMap: {},
+    promptConfigTools: [],
+    integrations: [],
+    setInitialized: (initialized: boolean) =>
+      set((state) => ({ ...state, initialized })),
+    buildIntegrations: ({ tools, integrations }) => {
+      const state = get()
+      const integrationsMap = collectTools({
+        tools,
+        integrations,
+        existingMap: state.integrationsMap,
+      })
+
+      // Preserve order: keep existing integrations in order, add new ones at the end
+      const existingNames = new Set(state.integrations.map((int) => int.name))
+      const newIntegrationNames = Object.keys(integrationsMap).filter(
+        (name) => !existingNames.has(name),
+      )
+
+      const updatedExisting = state.integrations
+        .filter((int) => integrationsMap[int.name]) // Remove deleted integrations
+        .map((int) => integrationsMap[int.name]) // Update with new data
+
+      const newIntegrations = newIntegrationNames.map(
+        (name) => integrationsMap[name],
+      )
+
+      const activeIntegrations = [...updatedExisting, ...newIntegrations]
+
+      set((state) => ({
+        ...state,
+        promptConfigTools: tools,
+        initialized: true,
+        integrations: activeIntegrations,
+        integrationsMap,
+      }))
+    },
+    setIntegrationToolNames: ({ integrationName, toolNames }) => {
+      const state = get()
+      const integration = state.integrationsMap[integrationName]
+      if (!integration) return
+
+      const updatedIntegration = {
+        ...integration,
+        allToolNames: toolNames,
+      }
+
+      const updatedIntegrationsMap = {
+        ...state.integrationsMap,
+        [integrationName]: updatedIntegration,
+      }
+
+      // Preserve order by mapping over existing integrations
+      const updatedIntegrations = state.integrations.map((int) =>
+        int.name === integrationName ? updatedIntegration : int,
+      )
+
+      set((state) => ({
+        ...state,
+        integrationsMap: updatedIntegrationsMap,
+        integrations: updatedIntegrations,
+      }))
+    },
+    toggleIntegration: (integrationName) => {
+      const state = get()
+      const integration = state.integrationsMap[integrationName]
+      if (!integration) return
+
+      const updatedIntegration = {
+        ...integration,
+        isOpen: !integration.isOpen,
+      }
+
+      const updatedIntegrationsMap = {
+        ...state.integrationsMap,
+        [integrationName]: updatedIntegration,
+      }
+
+      // Preserve order by mapping over existing integrations
+      const updatedIntegrations = state.integrations.map((int) =>
+        int.name === integrationName ? updatedIntegration : int,
+      )
+
+      set((state) => ({
+        ...state,
+        integrationsMap: updatedIntegrationsMap,
+        integrations: updatedIntegrations,
+      }))
+    },
+    addIntegration: ({ integration, toolName }) => {
+      const state = get()
+
+      // Create the integration with the specified tools
+      const newIntegration: ActiveIntegration = {
+        ...integration,
+        tools: toolName === '*' ? true : [toolName],
+        allToolNames: integration.allToolNames || [],
+        isOpen: true, // Open newly added integrations by default
+      }
+
+      const updatedIntegrationsMap = {
+        ...state.integrationsMap,
+        [integration.name]: newIntegration,
+      }
+
+      // Add new integration at the top of the list
+      const existingIntegrations = state.integrations.filter(
+        (int) => int.name !== integration.name,
+      )
+      const updatedIntegrations = [newIntegration, ...existingIntegrations]
+
+      const updatedState = {
+        ...state,
+        integrationsMap: updatedIntegrationsMap,
+        integrations: updatedIntegrations,
+      }
+
+      set(updatedState)
+      return updatedState
+    },
+    addTool: ({ integrationName, toolName }) => {
+      const state = get()
+      const integration = state.integrationsMap[integrationName]
+      if (!integration) return state
+
+      const updatedTools = addTool({
+        currentActiveTools: integration.tools,
+        toolName,
+      })
+
+      const updatedIntegration = {
+        ...integration,
+        tools: updatedTools,
+      }
+
+      const updatedIntegrationsMap = {
+        ...state.integrationsMap,
+        [integrationName]: updatedIntegration,
+      }
+
+      // Preserve order by mapping over existing integrations
+      const updatedIntegrations = state.integrations.map((int) =>
+        int.name === integrationName ? updatedIntegration : int,
+      )
+
+      const updatedState = {
+        ...state,
+        integrationsMap: updatedIntegrationsMap,
+        integrations: updatedIntegrations,
+      }
+
+      set(updatedState)
+      return updatedState
+    },
+    removeTool: ({ integrationName, toolName, allToolNames = [] }) => {
+      const state = get()
+      const integration = state.integrationsMap[integrationName]
+      if (!integration) return state
+
+      const updatedTools = removeTool({
+        currentActiveTools: integration.tools,
+        toolName,
+        allToolNames,
+      })
+
+      const updatedIntegration = {
+        ...integration,
+        tools: updatedTools,
+      }
+
+      const updatedIntegrationsMap = {
+        ...state.integrationsMap,
+        [integrationName]: updatedIntegration,
+      }
+
+      // Preserve order by mapping over existing integrations
+      const updatedIntegrations = state.integrations.map((int) =>
+        int.name === integrationName ? updatedIntegration : int,
+      )
+
+      const updatedState = {
+        ...state,
+        integrationsMap: updatedIntegrationsMap,
+        integrations: updatedIntegrations,
+      }
+
+      set(updatedState)
+      return updatedState
+    },
+    removeIntegration: (integrationName) => {
+      const state = get()
+      const { [integrationName]: _removed, ...remainingIntegrations } =
+        state.integrationsMap
+
+      // Preserve order by filtering out the removed integration
+      const updatedIntegrations = state.integrations.filter(
+        (int) => int.name !== integrationName,
+      )
+
+      const updatedState = {
+        ...state,
+        integrationsMap: remainingIntegrations,
+        integrations: updatedIntegrations,
+      }
+
+      set(updatedState)
+      return updatedState
+    },
+  }),
+)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useToolsData.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/useToolsData.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import useIntegrations from '$/stores/integrations'
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { useActiveIntegrationsStore } from './useActiveIntegrationsStore'
+import { useEvents } from '$/lib/events'
+
+export function useToolsData() {
+  const [promptConfig, setPromptConfig] = useState<LatitudePromptConfig>(
+    {} as LatitudePromptConfig,
+  )
+  const { buildIntegrations, setInitialized, initialized } =
+    useActiveIntegrationsStore((state) => ({
+      initialized: state.initialized,
+      setInitialized: state.setInitialized,
+      buildIntegrations: state.buildIntegrations,
+    }))
+  const { data, isLoading } = useIntegrations({
+    includeLatitudeTools: true,
+    withTools: true,
+  })
+
+  useEvents({
+    onPromptMetadataChanged: ({ promptLoaded, metadata }) => {
+      const isReady = promptLoaded && !isLoading
+      if (!metadata) return
+      if (!isReady) return
+
+      setPromptConfig(metadata?.config as LatitudePromptConfig)
+    },
+  })
+
+  useEffect(() => {
+    if (isLoading) return
+    if (!promptConfig) return
+
+    buildIntegrations({ tools: promptConfig.tools, integrations: data })
+    return () => {
+      setInitialized(false)
+    }
+  }, [isLoading, promptConfig, data, buildIntegrations, setInitialized])
+
+  return !initialized
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/hooks/utils.ts
@@ -1,0 +1,34 @@
+import { IntegrationType } from '@latitude-data/constants'
+import { INTEGRATION_TYPE_VALUES } from '$/lib/integrationTypeOptions'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { IconName } from '@latitude-data/web-ui/atoms/Icons'
+
+export function integrationOptions(integration: IntegrationDto) {
+  if (integration.type === IntegrationType.Pipedream) {
+    const imageUrl = integration.configuration.metadata?.imageUrl ?? 'unplug'
+    const label =
+      integration.configuration.metadata?.displayName ??
+      integration.configuration.appName
+    return {
+      label,
+      icon: {
+        type: 'image' as const,
+        src: imageUrl,
+        alt: label,
+      },
+    }
+  }
+
+  if (integration.type === IntegrationType.Latitude) {
+    const { label } = INTEGRATION_TYPE_VALUES[IntegrationType.Latitude]
+    return {
+      label,
+      icon: {
+        type: 'icon' as const,
+        name: 'logo' as IconName,
+      },
+    }
+  }
+  const { label, icon } = INTEGRATION_TYPE_VALUES[integration.type]
+  return { label, icon: { type: 'icon' as const, name: icon as IconName } }
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/index.tsx
@@ -3,6 +3,10 @@ import { useCurrentCommit } from '$/app/providers/CommitProvider'
 import { useToggleModal } from '$/hooks/useToogleModal'
 import { SidebarSection } from '../Section'
 import { ConnectToolsModal } from './ConnectToolsModal'
+import { useActiveIntegrations } from './hooks/useActiveIntegrations'
+import { ActiveIntegration } from './ActiveIntegration'
+import { ToolsProvider } from './ToolsProvider'
+import { useActiveIntegrationsStore } from './hooks/useActiveIntegrationsStore'
 
 export function ToolsSidebarSection() {
   const { commit } = useCurrentCommit()
@@ -12,12 +16,36 @@ export function ToolsSidebarSection() {
     () => [{ onClick: onOpen, disabled: isLive }],
     [onOpen, isLive],
   )
+  const {
+    addNewIntegration,
+    addIntegrationTool,
+    removeIntegrationTool,
+    removeIntegration,
+  } = useActiveIntegrations()
+  const { integrations } = useActiveIntegrationsStore((state) => ({
+    integrations: state.integrations,
+  }))
+
   return (
-    <>
+    <ToolsProvider
+      addIntegrationTool={addIntegrationTool}
+      removeIntegrationTool={removeIntegrationTool}
+    >
       <SidebarSection title='Tools' actions={actions}>
-        TO BE LISTED
+        {integrations.map((integration) => (
+          <ActiveIntegration
+            key={integration.id}
+            integration={integration}
+            onRemove={removeIntegration}
+          />
+        ))}
       </SidebarSection>
-      {open ? <ConnectToolsModal onCloseModal={onClose} /> : null}
-    </>
+      {open ? (
+        <ConnectToolsModal
+          onCloseModal={onClose}
+          addNewIntegration={addNewIntegration}
+        />
+      ) : null}
+    </ToolsProvider>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Triggers/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Triggers/index.tsx
@@ -83,6 +83,7 @@ function EditTriggerModal({
       }
     >
       <EditTriggerModalContent
+        canChangeDocument={false}
         isLoading={updater.isLoading}
         trigger={updater.trigger}
         document={updater.document}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/index.tsx
@@ -7,6 +7,7 @@ import { SectionLoader, SidebarSection } from './Section'
 import { SidebarHeader } from './SidebarHeader'
 import { TriggersSidebarSection, useDocumentTriggersData } from './Triggers'
 import { ToolsSidebarSection } from './Tools'
+import { useToolsData } from './Tools/hooks/useToolsData'
 
 function SidebarLoader() {
   return (
@@ -24,13 +25,14 @@ function useSidebarData({
   metadata: ResolvedMetadata | undefined
 }) {
   const triggersData = useDocumentTriggersData()
+  const isLoadingTools = useToolsData()
   return useMemo(() => {
-    const isLoading = triggersData.isLoading || !metadata
+    const isLoading = triggersData.isLoading || !metadata || isLoadingTools
     return {
       isLoading,
       triggersData,
     }
-  }, [triggersData, metadata])
+  }, [triggersData, metadata, isLoadingTools])
 }
 
 export function DocumentEditorSidebarArea({
@@ -43,28 +45,30 @@ export function DocumentEditorSidebarArea({
   const data = useSidebarData({ metadata })
 
   return (
-    <div className='flex flex-col gap-y-6'>
+    <div className='w-full relative flex flex-col gap-y-6 min-h-0 '>
       <SidebarHeader metadata={metadata} />
       <FreeRunsBanner
         isLatitudeProvider={isLatitudeProvider}
         freeRunsCount={freeRunsCount}
       />
-      {data.isLoading ? (
-        <SidebarLoader />
-      ) : (
-        <>
-          <TriggersSidebarSection
-            triggers={data.triggersData.triggers}
-            integrations={data.triggersData.integrations}
-            document={data.triggersData.document}
-          />
-          <ToolsSidebarSection />
-          <SidebarSection
-            title='Sub-agents'
-            actions={[{ onClick: () => {} }]}
-          />
-        </>
-      )}
+      <div className='flex flex-col gap-y-6 min-w-0 custom-scrollbar scrollable-indicator'>
+        {data.isLoading ? (
+          <SidebarLoader />
+        ) : (
+          <>
+            <TriggersSidebarSection
+              triggers={data.triggersData.triggers}
+              integrations={data.triggersData.integrations}
+              document={data.triggersData.document}
+            />
+            <ToolsSidebarSection />
+            <SidebarSection
+              title='Sub-agents'
+              actions={[{ onClick: () => {} }]}
+            />
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/addTool.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/addTool.ts
@@ -1,0 +1,19 @@
+import { ActiveIntegration } from './types'
+
+export function addTool({
+  currentActiveTools,
+  toolName,
+}: {
+  currentActiveTools: ActiveIntegration['tools']
+  toolName: string
+}): ActiveIntegration['tools'] {
+  if (toolName === '*') return true
+  if (!toolName) return currentActiveTools
+  if (typeof currentActiveTools === 'boolean') return currentActiveTools
+
+  // Handle undefined or empty array
+  const toolsList = currentActiveTools ?? []
+  if (toolsList.includes(toolName)) return toolsList
+
+  return [...toolsList, toolName]
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/collectTools.test.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/collectTools.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest'
+import { collectTools } from './collectTools'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { IntegrationType } from '@latitude-data/constants'
+import { ImageIcon } from './types'
+
+const integrations: IntegrationDto[] = [
+  {
+    id: 1,
+    name: 'google',
+    type: IntegrationType.ExternalMCP,
+    configuration: {},
+  } as IntegrationDto,
+  {
+    id: 2,
+    name: 'slack',
+    type: IntegrationType.Pipedream,
+    configuration: {},
+  } as IntegrationDto,
+  {
+    id: 3,
+    name: 'latitude',
+    type: IntegrationType.Latitude,
+    configuration: {},
+  } as IntegrationDto,
+]
+
+describe('collectTools', () => {
+  it('returns empty object if tools is undefined', () => {
+    expect(
+      collectTools({ integrations, tools: undefined, existingMap: {} }),
+    ).toEqual({})
+  })
+
+  it('returns empty object if tools is not an array', () => {
+    expect(
+      collectTools({ integrations, tools: 'google/search', existingMap: {} }),
+    ).toEqual({})
+  })
+
+  it('returns empty object if tools array is empty', () => {
+    expect(collectTools({ integrations, tools: [], existingMap: {} })).toEqual(
+      {},
+    )
+  })
+
+  it('ignores invalid integrations', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['unknown/search'],
+        existingMap: {},
+      }),
+    ).toEqual({})
+  })
+
+  it('handles integration with no tool (just the name)', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['slack'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      slack: { name: 'slack', tools: [], allToolNames: [] },
+    })
+  })
+
+  it('handles integration with one specific tool', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/search'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: ['search'], allToolNames: [] },
+    })
+  })
+
+  it('accumulates multiple tools for the same integration', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/search', 'google/calendar'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: {
+        name: 'google',
+        tools: ['search', 'calendar'],
+        allToolNames: [],
+      },
+    })
+  })
+
+  it('ignores duplicate tools', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/search', 'google/search', 'google/calendar'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: {
+        name: 'google',
+        tools: ['search', 'calendar'],
+        allToolNames: [],
+      },
+    })
+  })
+
+  it('sets wildcard tool (*) to true', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['slack/*'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      slack: { name: 'slack', tools: true, allToolNames: [] },
+    })
+  })
+
+  it('wildcard overrides previous specific tools (impossible state)', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: [
+          'google/search',
+          'google/search',
+          'google/calendar',
+          'google/*',
+        ],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: true, allToolNames: [] },
+    })
+  })
+
+  it('ignores additional tools after wildcard', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/*', 'google/search', 'google/calendar'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: true, allToolNames: [] },
+    })
+  })
+
+  it('handles mixed valid and invalid entries gracefully', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: [
+          'google/search',
+          'invalid/tool',
+          null,
+          123,
+          '/broken',
+          'slack/*',
+          undefined,
+        ],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: ['search'], allToolNames: [] },
+      slack: { name: 'slack', tools: true, allToolNames: [] },
+    })
+  })
+
+  it('returns empty when all entries are invalid', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: [123, {}, null, '/broken', 'invalid/tool'],
+        existingMap: {},
+      }),
+    ).toEqual({})
+  })
+
+  it('handles multiple integrations correctly', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/search', 'slack/*', 'latitude/summarize'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: ['search'], allToolNames: [] },
+      slack: { name: 'slack', tools: true, allToolNames: [] },
+      latitude: { name: 'latitude', tools: ['summarize'], allToolNames: [] },
+    })
+  })
+
+  it('handles integration names but empty tool segments (e.g. "google/")', () => {
+    expect(
+      collectTools({
+        integrations,
+        tools: ['google/', 'google/search'],
+        existingMap: {},
+      }),
+    ).toMatchObject({
+      google: { name: 'google', tools: ['search'], allToolNames: [] },
+    })
+  })
+
+  describe('with existingMap', () => {
+    it('preserves integrations from existing map with empty tools', () => {
+      const existingMap = {
+        google: {
+          id: 1,
+          name: 'google',
+          type: IntegrationType.ExternalMCP,
+          configuration: null,
+          icon: { type: 'icon', name: 'mcp' } as ImageIcon,
+          tools: ['search', 'calendar'],
+          allToolNames: ['search', 'calendar', 'drive'],
+          isOpen: false,
+        },
+      }
+
+      expect(
+        collectTools({
+          integrations,
+          tools: [],
+          existingMap,
+        }),
+      ).toMatchObject({
+        google: {
+          name: 'google',
+          tools: [],
+          allToolNames: ['search', 'calendar', 'drive'],
+        },
+      })
+    })
+
+    it('updates existing integrations with new tools', () => {
+      const existingMap = {
+        google: {
+          id: 1,
+          name: 'google',
+          type: IntegrationType.ExternalMCP,
+          configuration: null,
+          icon: { type: 'icon', name: 'mcp' } as ImageIcon,
+          tools: [],
+          allToolNames: ['search', 'calendar'],
+          isOpen: false,
+        },
+      }
+
+      expect(
+        collectTools({
+          integrations,
+          tools: ['google/search'],
+          existingMap,
+        }),
+      ).toMatchObject({
+        google: {
+          name: 'google',
+          tools: ['search'],
+          allToolNames: ['search', 'calendar'],
+        },
+      })
+    })
+
+    it('removes integrations that no longer exist in workspace', () => {
+      const existingMap = {
+        removed: {
+          id: 99,
+          name: 'removed',
+          type: IntegrationType.ExternalMCP,
+          configuration: null,
+          icon: { type: 'icon', name: 'mcp' } as ImageIcon,
+          tools: ['tool1'],
+          allToolNames: ['tool1', 'tool2'],
+          isOpen: false,
+        },
+        google: {
+          id: 1,
+          name: 'google',
+          type: IntegrationType.ExternalMCP,
+          configuration: null,
+          icon: { type: 'icon', name: 'mcp' } as ImageIcon,
+          tools: [],
+          allToolNames: ['search'],
+          isOpen: false,
+        },
+      }
+
+      const result = collectTools({
+        integrations,
+        tools: [],
+        existingMap,
+      })
+
+      expect(result.removed).toBeUndefined()
+      expect(result).toMatchObject({
+        google: { name: 'google', tools: [], allToolNames: ['search'] },
+      })
+    })
+  })
+})

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/collectTools.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/collectTools.ts
@@ -1,0 +1,118 @@
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { ActiveIntegrations } from './types'
+import { getIntegrationData } from './utils'
+
+/**
+ * Collects tools from a prompt configuration and integrates them with existing active integrations.
+ *
+ * @param integrations - Available workspace integrations
+ * @param tools - Tools from the prompt configuration
+ * @param existingMap - Existing active integrations map to preserve state
+ * @returns Updated active integrations map
+ */
+export function collectTools({
+  integrations,
+  tools,
+  existingMap,
+}: {
+  integrations: IntegrationDto[]
+  tools?: LatitudePromptConfig['tools']
+  existingMap: ActiveIntegrations
+}) {
+  const newIntegrationsMap = collectToolsFromConfig({ integrations, tools })
+
+  // Preserve integrations from existing map
+  const preservedMap = { ...existingMap }
+
+  // Update existing integrations or add new ones from the config
+  Object.entries(newIntegrationsMap).forEach(([name, integration]) => {
+    preservedMap[name] = {
+      ...integration,
+      // Preserve allToolNames and isOpen state from existing map if it exists
+      allToolNames: preservedMap[name]?.allToolNames ?? [],
+      isOpen: preservedMap[name]?.isOpen ?? false,
+    }
+  })
+
+  // For integrations in old map but not in new config, set tools to empty array
+  Object.keys(preservedMap).forEach((integrationName) => {
+    if (!newIntegrationsMap[integrationName]) {
+      // Only keep if this integration still exists in workspace
+      const stillExists = integrations.some((i) => i.name === integrationName)
+      if (stillExists) {
+        preservedMap[integrationName] = {
+          ...preservedMap[integrationName],
+          tools: [],
+          // Keep allToolNames and isOpen from existing map
+        }
+      } else {
+        // Integration was removed from workspace, delete it
+        delete preservedMap[integrationName]
+      }
+    }
+  })
+
+  return preservedMap
+}
+
+/**
+ * Internal helper to collect tools from a prompt configuration.
+ */
+function collectToolsFromConfig({
+  integrations,
+  tools,
+}: {
+  integrations: IntegrationDto[]
+  tools?: LatitudePromptConfig['tools']
+}) {
+  if (!tools) return {}
+  if (!Array.isArray(tools)) return {}
+
+  return tools.reduce((acc, tool) => {
+    if (typeof tool !== 'string') return acc
+
+    const [integrationName, toolName] = tool.split('/')
+
+    if (!integrationName) return acc
+
+    const integration = getIntegrationData({
+      integrations,
+      name: integrationName,
+    })
+
+    if (!integration) return acc
+
+    const activeIntegration = acc[integrationName]
+
+    // First time seen
+    if (!activeIntegration) {
+      acc[integrationName] = {
+        ...integration,
+        tools: toolName === '*' ? true : toolName ? [toolName] : [],
+        allToolNames: [],
+        isOpen: false, // Closed by default when loaded from config
+      }
+      return acc
+    }
+
+    // Already wildcard? skip
+    if (typeof activeIntegration.tools === 'boolean') return acc
+
+    // New wildcard? override
+    if (toolName === '*') {
+      acc[integrationName].tools = true
+      return acc
+    }
+
+    // Add tool if not duplicate (and if toolName exists)
+    if (toolName) {
+      const toolsList = activeIntegration.tools ?? []
+      if (!toolsList.includes(toolName)) {
+        acc[integrationName].tools = [...toolsList, toolName]
+      }
+    }
+
+    return acc
+  }, {} as ActiveIntegrations)
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/removeTool.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/removeTool.ts
@@ -1,0 +1,26 @@
+import { ActiveIntegration } from './types'
+
+export function removeTool({
+  currentActiveTools,
+  toolName,
+  allToolNames = [],
+}: {
+  currentActiveTools: ActiveIntegration['tools']
+  toolName: string
+  allToolNames: string[]
+}): ActiveIntegration['tools'] {
+  // Removing all tools (wildcard)
+  if (toolName === '*') return []
+
+  // If all tools are active (true), we need to create an array with all tools except the one being removed
+  if (typeof currentActiveTools === 'boolean') {
+    if (currentActiveTools) {
+      return allToolNames.filter((tn) => tn !== toolName)
+    }
+    return []
+  }
+
+  // If currentActiveTools is an array, filter out the tool
+  const toolsList = currentActiveTools ?? []
+  return toolsList.filter((tn) => tn !== toolName)
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/types.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/types.ts
@@ -1,0 +1,21 @@
+import { IntegrationType } from '@latitude-data/constants'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { IconProps } from '@latitude-data/web-ui/atoms/Icons'
+
+type ItemIcon = { type: 'icon'; name: IconProps['name'] }
+type ItemImage = { type: 'image'; src: string; alt: string }
+
+export type ImageIcon = ItemIcon | ItemImage
+export type ActiveIntegration = {
+  id: number
+  name: string
+  icon: ImageIcon
+  type: IntegrationType
+  configuration: IntegrationDto['configuration']
+  tools: boolean | string[]
+  allToolNames: string[]
+  isOpen: boolean
+}
+export type ActiveIntegrations = {
+  [key: string]: ActiveIntegration
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/updateConfigWithActiveTools.test.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/updateConfigWithActiveTools.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { updateToolsFromActiveIntegrations as updateConfig } from './updateConfigWithActiveTools'
+import { ActiveIntegrations, ActiveIntegration, ImageIcon } from './types'
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { IntegrationType } from '@latitude-data/constants'
+
+function clientTool() {
+  return {
+    customTool: {
+      description: 'Custom LLM utility',
+      parameters: {
+        type: 'object' as const,
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+      },
+    },
+  }
+}
+
+function mockIntegration(
+  name: string,
+  tools: boolean | string[],
+  id: number = 1,
+): ActiveIntegration {
+  return {
+    id,
+    name,
+    type: IntegrationType.ExternalMCP,
+    configuration: { url: 'http://localhost:3000' },
+    icon: { type: 'icon', name: 'mcp' } as ImageIcon,
+    tools,
+    allToolNames: [],
+    isOpen: false,
+  }
+}
+
+describe('updateConfig (updateToolsFromActiveIntegrations)', () => {
+  it('returns an empty array when both inputs are empty', () => {
+    expect(
+      updateConfig({
+        currentTools: [],
+        activeIntegrations: {},
+      }),
+    ).toEqual([])
+  })
+
+  it('preserves client tools when no integrations are provided', () => {
+    const result = updateConfig({
+      currentTools: [clientTool()],
+      activeIntegrations: {},
+    })
+
+    expect(result).toEqual([clientTool()])
+  })
+
+  it('adds new integration tools from active integrations', () => {
+    const activeIntegrations: ActiveIntegrations = {
+      google: mockIntegration('google', ['search', 'calendar'], 1),
+      slack: mockIntegration('slack', true, 2),
+    }
+
+    const result = updateConfig({
+      currentTools: [clientTool()],
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([
+      clientTool(),
+      'google/search',
+      'google/calendar',
+      'slack/*',
+    ])
+  })
+
+  it('replaces integrations and appends them after client tools', () => {
+    const currentTools: LatitudePromptConfig['tools'] = [
+      { some_custom_tool: { description: '...' } },
+      'slack/*',
+      { other_custom_tool: { description: '...' } },
+    ]
+
+    const activeIntegrations: ActiveIntegrations = {
+      slack: mockIntegration('slack', ['messages'], 1),
+      google: mockIntegration('google', ['search'], 2),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([
+      { some_custom_tool: { description: '...' } },
+      'slack/messages',
+      { other_custom_tool: { description: '...' } },
+      'google/search',
+    ])
+  })
+
+  it('keeps only integrations from activeIntegrations (removes others) while preserving client tools', () => {
+    const currentTools = [
+      { client_tool: { description: '...' } },
+      'notion/read',
+      'google/search',
+    ]
+    const activeIntegrations: ActiveIntegrations = {
+      slack: mockIntegration('slack', true),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([{ client_tool: { description: '...' } }, 'slack/*'])
+  })
+
+  it('handles wildcard integrations correctly', () => {
+    const currentTools = [clientTool(), 'google/search']
+    const activeIntegrations: ActiveIntegrations = {
+      google: mockIntegration('google', true),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([clientTool(), 'google/*'])
+  })
+
+  it('deduplicates integration tools', () => {
+    const currentTools = [clientTool(), 'google/search', 'google/calendar']
+    const activeIntegrations: ActiveIntegrations = {
+      google: mockIntegration('google', ['search', 'calendar']),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([clientTool(), 'google/search', 'google/calendar'])
+  })
+
+  it('handles mixed client and integration tools correctly (client tools first, integrations appended)', () => {
+    const currentTools = [
+      'google/search',
+      { llmHelper: { description: 'LLM helper tool' } },
+      'latitude/search',
+    ]
+    const activeIntegrations: ActiveIntegrations = {
+      google: mockIntegration('google', ['calendar'], 1),
+      slack: mockIntegration('slack', true, 2),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual([
+      'google/calendar',
+      { llmHelper: { description: 'LLM helper tool' } },
+      'slack/*',
+    ])
+  })
+
+  it('removes integrations not present in activeIntegrations', () => {
+    const currentTools = ['notion/read', 'google/search']
+    const activeIntegrations: ActiveIntegrations = {
+      google: mockIntegration('google', ['calendar']),
+    }
+
+    const result = updateConfig({
+      currentTools,
+      activeIntegrations,
+    })
+
+    expect(result).toEqual(['google/calendar'])
+  })
+})

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/updateConfigWithActiveTools.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/updateConfigWithActiveTools.ts
@@ -1,0 +1,83 @@
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { ActiveIntegrations } from './types'
+import { normalizeIntegrations } from './utils'
+
+/**
+ * Updates the tools config from active integrations.
+ * Preserves client tools, replaces or adds integration tools from activeIntegrations,
+ * removes outdated ones, and deduplicates results while keeping original order.
+ */
+export function updateToolsFromActiveIntegrations({
+  currentTools,
+  activeIntegrations,
+}: {
+  currentTools: LatitudePromptConfig['tools']
+  activeIntegrations: ActiveIntegrations
+}) {
+  const normalized = normalizeIntegrations(currentTools)
+
+  // Build replacements for each integration based on ActiveIntegrations
+  const replacements = new Map<string, string[]>()
+  for (const { name, tools } of Object.values(activeIntegrations)) {
+    if (tools === true) {
+      replacements.set(name, [`${name}/*`])
+    } else if (Array.isArray(tools)) {
+      replacements.set(
+        name,
+        tools.map((t) => `${name}/${t}`),
+      )
+    } else {
+      // Defensive: ignore unexpected shapes
+      replacements.set(name, [])
+    }
+  }
+
+  // Track which integrations we have already placed (in-place)
+  const placed = new Set<string>()
+
+  const result: (string | Record<string, unknown>)[] = []
+
+  for (const entry of normalized) {
+    if (typeof entry !== 'string') {
+      // Client tool: keep as is in original position
+      result.push(entry)
+      continue
+    }
+
+    const [integrationName] = entry.split('/')
+
+    if (replacements.has(integrationName)) {
+      // This integration is being managed by activeIntegrations:
+      // replace the original string IN-PLACE with its new set (once).
+      if (!placed.has(integrationName)) {
+        const rep = replacements.get(integrationName)!
+        result.push(...rep)
+        placed.add(integrationName)
+      }
+      // Skip the original string (we already replaced it)
+      continue
+    }
+
+    // Integration not present in activeIntegrations: drop it
+    // (we do not push it to result)
+  }
+
+  // Append any integrations that were NOT present in the original config
+  for (const [name, rep] of replacements.entries()) {
+    if (!placed.has(name)) {
+      result.push(...rep)
+      placed.add(name)
+    }
+  }
+
+  // Deduplicate integration strings; keep client tools as-is
+  const seen = new Set<string>()
+  const deduped = result.filter((item) => {
+    if (typeof item !== 'string') return true
+    if (seen.has(item)) return false
+    seen.add(item)
+    return true
+  })
+
+  return deduped as LatitudePromptConfig['tools']
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/utils.ts
@@ -1,0 +1,68 @@
+import { INTEGRATION_TYPE_VALUES } from '$/lib/integrationTypeOptions'
+import { IntegrationType } from '@latitude-data/constants'
+import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
+import { IntegrationDto } from '@latitude-data/core/schema/types'
+import { IconName } from '@latitude-data/web-ui/atoms/Icons'
+
+export function getIntegrationData({
+  name,
+  integrations,
+}: {
+  name: string
+  integrations: IntegrationDto[]
+}) {
+  const integration = integrations.find((i) => i.name === name)
+  if (!integration) return undefined
+
+  const commonData = {
+    id: integration.id,
+    type: integration.type,
+    name,
+    configuration: integration.configuration,
+  }
+
+  if (integration.type === IntegrationType.Pipedream) {
+    const imageUrl = integration.configuration.metadata?.imageUrl ?? 'unplug'
+    const label =
+      integration.configuration.metadata?.displayName ??
+      integration.configuration.appName
+    return {
+      ...commonData,
+      icon: {
+        type: 'image' as const,
+        src: imageUrl,
+        alt: label,
+      },
+    }
+  }
+
+  if (integration.type === IntegrationType.Latitude) {
+    return {
+      ...commonData,
+      icon: {
+        type: 'icon' as const,
+        name: 'logo' as IconName,
+      },
+    }
+  }
+
+  const { icon } = INTEGRATION_TYPE_VALUES[integration.type]
+  return {
+    ...commonData,
+    icon: {
+      type: 'icon' as const,
+      name: icon as IconName,
+    },
+  }
+}
+
+export function normalizeIntegrations(
+  tools: LatitudePromptConfig['tools'],
+): (string | Record<string, unknown>)[] {
+  if (!tools) return []
+  if (Array.isArray(tools)) return tools
+
+  return Object.entries(tools).map(([toolName, toolDefinition]) => ({
+    [toolName]: toolDefinition,
+  }))
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -78,7 +78,7 @@ export default function DocumentEditor(props: {
           />
         </div>
         {hasSidebar ? (
-          <div className='min-w-96 w-96'>
+          <div className='flex min-w-56 w-96 min-h-0'>
             <DocumentEditorSidebarArea freeRunsCount={props.freeRunsCount} />
           </div>
         ) : null}

--- a/apps/web/src/app/api/integrations/route.ts
+++ b/apps/web/src/app/api/integrations/route.ts
@@ -17,7 +17,7 @@ export const GET = errorHandler(
       const integrations = await listIntegrations(workspace).then((r) =>
         r.unwrap(),
       )
-      console.log('Integrations:', integrations)
+
       return NextResponse.json(integrations, { status: 200 })
     },
   ),

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/updateDocumentContent/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/updateDocumentContent/route.ts
@@ -1,0 +1,96 @@
+import { z, ZodSafeParseError } from 'zod'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import {
+  CommitsRepository,
+  DocumentVersionsRepository,
+} from '@latitude-data/core/repositories'
+import { NextRequest, NextResponse } from 'next/server'
+import { Workspace } from '@latitude-data/core/schema/types'
+import { updateDocumentContent } from '@latitude-data/core/services/documents/updateDocumentContent/updateContent'
+import {
+  AbortedError,
+  LatitudeErrorDetails,
+  UnprocessableEntityError,
+} from '@latitude-data/constants/errors'
+
+const inputSchema = z.object({
+  prompt: z.string().min(1, { error: 'Prompt is required' }),
+})
+type Input = z.infer<typeof inputSchema>
+
+function formatErrors(parsed: ZodSafeParseError<Input>): LatitudeErrorDetails {
+  const tree = z.treeifyError(parsed.error)
+
+  if (!tree.properties) return {}
+
+  return Object.fromEntries(
+    Object.entries(tree.properties).map(([key, value]) => [key, value?.errors]),
+  )
+}
+
+function withAbort<T>(signal: AbortSignal, work: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new AbortedError('Document update aborted'))
+    signal.addEventListener('abort', onAbort, { once: true })
+    work()
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener('abort', onAbort))
+  })
+}
+
+export const POST = errorHandler(
+  authHandler(
+    async (
+      req: NextRequest,
+      {
+        params,
+        workspace,
+      }: {
+        params: {
+          projectId: number
+          commitUuid: string
+          documentUuid: string
+        }
+        workspace: Workspace
+      },
+    ) => {
+      const { projectId, commitUuid, documentUuid } = params
+      const data = await withAbort(req.signal, async () => {
+        req.signal.throwIfAborted()
+
+        const body = await req.json()
+        const parseResult = inputSchema.safeParse(body)
+        if (!parseResult.success) {
+          throw new UnprocessableEntityError(
+            'Invalid input',
+            formatErrors(parseResult),
+          )
+        }
+
+        const commitsRepository = new CommitsRepository(workspace.id)
+        const commit = await commitsRepository
+          .getCommitByUuid({ projectId, uuid: commitUuid })
+          .then((r) => r.unwrap())
+
+        const documentsRepository = new DocumentVersionsRepository(workspace.id)
+        const document = await documentsRepository
+          .getDocumentAtCommit({
+            projectId: projectId,
+            commitUuid: commitUuid,
+            documentUuid: documentUuid,
+          })
+          .then((r) => r.unwrap())
+
+        return updateDocumentContent({
+          workspace,
+          commit,
+          document,
+          prompt: parseResult.data.prompt,
+        }).then((r) => r.unwrap())
+      })
+
+      return NextResponse.json(data, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/app/providers/DocumentProvider.tsx
+++ b/apps/web/src/app/providers/DocumentProvider.tsx
@@ -6,6 +6,7 @@ import { DocumentVersion } from '@latitude-data/core/schema/types'
 
 type DocumentVersionContext = {
   document: DocumentVersion
+  mutateDocumentUpdated: (document: DocumentVersion) => void
 }
 const DocumentContext = createContext<DocumentVersionContext>({
   document: {},
@@ -22,7 +23,7 @@ const DocumentVersionProvider = ({
   projectId: number
   commitUuid: string
 }) => {
-  const { data: documents } = useDocumentVersions({
+  const { data: documents, mutateDocumentUpdated } = useDocumentVersions({
     projectId: projectId,
     commitUuid: commitUuid,
   })
@@ -35,6 +36,7 @@ const DocumentVersionProvider = ({
   return (
     <DocumentContext.Provider
       value={{
+        mutateDocumentUpdated,
         document: document ?? fallbackDocument,
       }}
     >

--- a/apps/web/src/components/LatteSidebar/LatteChat/index.tsx
+++ b/apps/web/src/components/LatteSidebar/LatteChat/index.tsx
@@ -178,6 +178,7 @@ function LatteChatUI({
                         alt='Latte'
                         width={100}
                         height={100}
+                        style={{ width: 100, height: 100 }}
                         className={cn('select-none duration-500 h-auto', {
                           'animate-spin': animateLatte,
                         })}

--- a/apps/web/src/components/LatteSidebar/LatteLayout/index.tsx
+++ b/apps/web/src/components/LatteSidebar/LatteLayout/index.tsx
@@ -202,6 +202,7 @@ export function LatteLayout({
               alt='Latte'
               width={50}
               height={50}
+              style={{ width: 50, height: 50 }}
               className='select-none duration-500 h-auto'
               unselectable='on'
               unoptimized

--- a/apps/web/src/components/Sidebar/Files/IndentationBar/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/IndentationBar/index.tsx
@@ -18,23 +18,26 @@ export function IndentationLine({ showCurve }: { showCurve: boolean }) {
 export function IndentationBar({
   indentation,
   hasChildren,
+  startOnIndex = 1,
 }: {
   hasChildren: boolean
   indentation: IndentType[]
+  startOnIndex?: number
 }) {
   return indentation.map((indent, index) => {
-    const anyNextIndentIsNotLast = !!indentation
-      .slice(index)
-      .find((i) => !i.isLast)
-    const showBorder = anyNextIndentIsNotLast ? false : indent.isLast
-    const showCurve = !hasChildren && showBorder
+    const hasNextNonLast = indentation.slice(index + 1).some((i) => !i.isLast)
+
+    const showBorder = indent.isLast && !hasNextNonLast
+    const showCurve = showBorder && !hasChildren
+    const shouldRender = index >= startOnIndex
+
     return (
       <div key={index} className='h-6 min-w-4'>
-        {index > 0 ? (
+        {shouldRender && (
           <div className='relative w-4 h-full flex justify-center'>
             <IndentationLine showCurve={showCurve} />
           </div>
-        ) : null}
+        )}
       </div>
     )
   })

--- a/apps/web/src/components/TriggersManagement/EditTrigger/index.tsx
+++ b/apps/web/src/components/TriggersManagement/EditTrigger/index.tsx
@@ -97,6 +97,7 @@ type Props = {
   docSelection: UseUpdateDocumentTrigger['docSelection']
   setTriggerConfiguration: UseUpdateDocumentTrigger['setTriggerConfiguration']
   isUpdating: UseUpdateDocumentTrigger['isUpdating']
+  canChangeDocument?: boolean
 }
 export function EditTriggerModalContent({
   isLoading,
@@ -106,6 +107,7 @@ export function EditTriggerModalContent({
   docSelection,
   setTriggerConfiguration,
   isUpdating,
+  canChangeDocument = true,
 }: Props) {
   return (
     <>
@@ -125,6 +127,7 @@ export function EditTriggerModalContent({
                 onSelectDocument={docSelection.onSelectDocument}
                 options={docSelection.options}
                 document={docSelection.document}
+                disabled={!canChangeDocument}
               />
               <EditTriggerByType
                 trigger={trigger}

--- a/apps/web/src/components/TriggersManagement/NewTrigger/TriggerTypes/PipedreamTrigger/TriggerConfiguration/index.tsx
+++ b/apps/web/src/components/TriggersManagement/NewTrigger/TriggerTypes/PipedreamTrigger/TriggerConfiguration/index.tsx
@@ -40,6 +40,7 @@ export function TriggerConfiguration({
     onTriggerCreated,
     triggerComponent: trigger,
     payloadParameters: doc.payloadParameters,
+    initialDocument,
   })
   const canCreateTrigger = account && doc.document
   const parsedText = useParsedPipedreamTriggerDescription({

--- a/apps/web/src/hooks/useDocumentValueContext.tsx
+++ b/apps/web/src/hooks/useDocumentValueContext.tsx
@@ -25,6 +25,7 @@ import {
   DocumentVersion,
   Project,
 } from '@latitude-data/core/schema/types'
+import { useEvents } from '$/lib/events'
 
 export type updateContentFn = (
   content: string,
@@ -123,6 +124,12 @@ export function DocumentValueProvider({
     project: project,
     devMode: devMode,
     origin: origin,
+  })
+
+  useEvents({
+    onPromptChanged: ({ prompt }) => {
+      setValue(prompt)
+    },
   })
 
   return (

--- a/apps/web/src/lib/events/types/documentEvents.ts
+++ b/apps/web/src/lib/events/types/documentEvents.ts
@@ -5,4 +5,7 @@ export interface DocumentEvents {
     promptLoaded: boolean
     metadata: ResolvedMetadata
   }
+  PromptChanged: {
+    prompt: string
+  }
 }

--- a/apps/web/src/middlewares/errorHandler.ts
+++ b/apps/web/src/middlewares/errorHandler.ts
@@ -1,16 +1,38 @@
-import { LatitudeError } from '@latitude-data/constants/errors'
+import { AbortedError, LatitudeError } from '@latitude-data/constants/errors'
 import { env } from '@latitude-data/env'
 import { captureException } from '$/helpers/captureException'
 import { NextRequest, NextResponse } from 'next/server'
 import debug from '@latitude-data/core/lib/debug'
 
+interface AbortError extends DOMException {
+  name: 'AbortError'
+  reason: string
+}
+
+export function isAbortError(error: unknown): error is AbortError {
+  if (!error) return false
+  return (
+    !!error &&
+    ((error instanceof Error && error.name === 'ResponseAborted') ||
+      error instanceof AbortedError)
+  )
+}
+
 export function errorHandler(handler: any) {
+  const isDev = env.NODE_ENV === 'development'
   return async (req: NextRequest, res: any) => {
     try {
       return await handler(req, res)
     } catch (error) {
-      if (env.NODE_ENV === 'development') {
+      if (isDev) {
         debug((error as Error).message)
+      }
+
+      if (isAbortError(error)) {
+        return NextResponse.json(
+          { message: 'Request aborted by client' },
+          { status: 499 },
+        )
       }
 
       if (error instanceof LatitudeError) {

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -133,6 +133,9 @@ export const API_ROUTES = {
                   suggestions: {
                     root: `${documentRoot}/suggestions`,
                   },
+                  updateDocumentContent: {
+                    root: `${documentRoot}/updateDocumentContent`,
+                  },
                   evaluations: {
                     root: `${documentRoot}/evaluations`,
                     detail: (evaluationUuid: string) => {

--- a/apps/web/src/stores/documentVersions.ts
+++ b/apps/web/src/stores/documentVersions.ts
@@ -292,20 +292,27 @@ export default function useDocumentVersions(
       ),
     })
 
+  const mutateDocumentUpdated = useCallback(
+    (newDoc: DocumentVersion) => {
+      const prevDocuments = data || []
+
+      mutate(
+        prevDocuments.map((d) =>
+          d.documentUuid === newDoc.documentUuid ? newDoc : d,
+        ),
+      )
+    },
+    [data, mutate],
+  )
+
   const { execute: assignDataset, isPending: isAssigningDataset } =
     useLatitudeAction(assignDatasetAction, {
       onSuccess: useCallback(
         ({ data: document }: { data: DocumentVersion }) => {
           if (!document) return
-
-          const prevDocuments = data || []
-          mutate(
-            prevDocuments.map((d) =>
-              d.documentUuid === document.documentUuid ? document : d,
-            ),
-          )
+          mutateDocumentUpdated(document)
         },
-        [data, mutate],
+        [mutateDocumentUpdated],
       ),
     })
 
@@ -338,6 +345,7 @@ export default function useDocumentVersions(
       destroyFile,
       destroyFolder,
       updateContent,
+      mutateDocumentUpdated,
       isUpdatingContent,
       assignDataset,
       saveLinkedDataset,
@@ -356,6 +364,7 @@ export default function useDocumentVersions(
       destroyFile,
       destroyFolder,
       updateContent,
+      mutateDocumentUpdated,
       isUpdatingContent,
       assignDataset,
       saveLinkedDataset,

--- a/apps/web/src/stores/integrationTools.ts
+++ b/apps/web/src/stores/integrationTools.ts
@@ -4,7 +4,10 @@ import useSWR, { SWRConfiguration } from 'swr'
 import { IntegrationType, McpTool } from '@latitude-data/constants'
 import { useMemo } from 'react'
 import { AppDto } from '@latitude-data/core/constants'
-import { type IntegrationDto } from '@latitude-data/core/schema/types'
+import {
+  PipedreamIntegration,
+  type IntegrationDto,
+} from '@latitude-data/core/schema/types'
 
 const EMPTY_ARRAY: McpTool[] = []
 
@@ -21,7 +24,9 @@ type AppResponse =
   | { errorMessage: string; ok: false }
 
 export default function useIntegrationTools(
-  integration?: IntegrationDto,
+  integration?:
+    | IntegrationDto
+    | Pick<IntegrationDto, 'id' | 'name' | 'type' | 'configuration'>,
   opts?: SWRConfiguration,
 ) {
   const fetcher = useFetcher<McpTool[], ToolResponse>(
@@ -48,7 +53,7 @@ export default function useIntegrationTools(
   const displayNameFetcher = useFetcher<AppDto | undefined, AppResponse>(
     integration?.type === IntegrationType.Pipedream
       ? ROUTES.api.integrations.pipedream.detail(
-          integration.configuration.appName,
+          (integration as PipedreamIntegration).configuration.appName,
         ).root
       : undefined,
     {

--- a/apps/web/src/stores/integrations.ts
+++ b/apps/web/src/stores/integrations.ts
@@ -1,4 +1,5 @@
 'use client'
+import { useMemo } from 'react'
 import { useToast } from '@latitude-data/web-ui/atoms/Toast'
 import { createIntegrationAction } from '$/actions/integrations/create'
 import { destroyIntegrationAction } from '$/actions/integrations/destroy'
@@ -9,7 +10,6 @@ import useLatitudeAction from '$/hooks/useLatitudeAction'
 import { ROUTES } from '$/services/routes'
 import useSWR, { SWRConfiguration } from 'swr'
 import { IntegrationType } from '@latitude-data/constants'
-import { useMemo } from 'react'
 import { type IntegrationDto } from '@latitude-data/core/schema/types'
 
 const EMPTY_ARRAY: IntegrationDto[] = []

--- a/packages/constants/src/errors/constants.ts
+++ b/packages/constants/src/errors/constants.ts
@@ -10,6 +10,7 @@ export enum LatitudeErrorCodes {
   UnprocessableEntityError = 'UnprocessableEntityError',
   NotImplementedError = 'NotImplementedError',
   PaymentRequiredError = 'PaymentRequiredError',
+  AbortedError = 'AbortedError',
 }
 
 export type LatitudeErrorDetails = {

--- a/packages/constants/src/errors/latitudeError.ts
+++ b/packages/constants/src/errors/latitudeError.ts
@@ -56,6 +56,16 @@ export class OverloadedError extends LatitudeError {
   public name = LatitudeErrorCodes.OverloadedError
 }
 
+export class AbortedError extends LatitudeError {
+  public statusCode = 499
+  public reason = 'Client Closed Request'
+  public name = LatitudeErrorCodes.AbortedError
+  constructor(message: string) {
+    super(message)
+    this.reason = message
+  }
+}
+
 export class ConflictError extends LatitudeError {
   public statusCode = 409
   public name = LatitudeErrorCodes.ConflictError

--- a/packages/core/src/services/documents/updateDocumentContent/updateContent.ts
+++ b/packages/core/src/services/documents/updateDocumentContent/updateContent.ts
@@ -1,0 +1,41 @@
+import { Result, TypedResult } from '../../../lib/Result'
+import { Commit, DocumentVersion, Workspace } from '../../../schema/types'
+import { updateDocument } from '../update'
+import { validateDocumentMetadata } from './validateDocumentMetadata'
+
+type ValidatedMetadata = Awaited<ReturnType<typeof validateDocumentMetadata>>
+
+export type UpdateDocumentContentResponse = {
+  document: DocumentVersion
+  metadata: ValidatedMetadata
+}
+
+export async function updateDocumentContent({
+  workspace,
+  commit,
+  document,
+  prompt,
+}: {
+  workspace: Workspace
+  commit: Commit
+  document: DocumentVersion
+  prompt: string
+}): Promise<TypedResult<UpdateDocumentContentResponse>> {
+  const metadata = await validateDocumentMetadata({
+    workspace,
+    commit,
+    document,
+    prompt,
+  })
+  const result = await updateDocument({
+    commit,
+    document,
+    content: prompt,
+  })
+  if (result.error) return result
+
+  return Result.ok({
+    document: result.value,
+    metadata,
+  })
+}

--- a/packages/core/src/services/documents/updateDocumentContent/validateDocumentMetadata.ts
+++ b/packages/core/src/services/documents/updateDocumentContent/validateDocumentMetadata.ts
@@ -1,0 +1,125 @@
+import {
+  CompileError,
+  ConversationMetadata as PromptlConversationMetadata,
+  scan,
+} from 'promptl-ai'
+import type { AstError } from '@latitude-data/constants/promptl'
+import { AgentToolsMap, resolveRelativePath } from '@latitude-data/constants'
+import { Commit, DocumentVersion, Workspace } from '../../../schema/types'
+import { latitudePromptConfigSchema } from '@latitude-data/constants/latitudePromptSchema'
+import {
+  DocumentVersionsRepository,
+  ProviderApiKeysRepository,
+} from '../../../repositories'
+import { listIntegrations } from '../../integrations/list'
+import { getAgentToolName } from '../../agents/helpers'
+
+function readDocument(
+  document: DocumentVersion,
+  documents: DocumentVersion[],
+  prompt: string,
+) {
+  return async (refPath: string, from?: string) => {
+    const fullPath = resolveRelativePath(refPath, from)
+
+    if (fullPath === document.path) {
+      return {
+        path: fullPath,
+        content: prompt,
+      }
+    }
+
+    const content = documents.find((d) => d.path === fullPath)?.content
+    if (content === undefined) return undefined
+
+    return {
+      path: fullPath,
+      content,
+    }
+  }
+}
+
+function buildAgentsToolMap(documents: DocumentVersion[] = []) {
+  if (!documents) return {}
+
+  return documents.reduce((acc: AgentToolsMap, document) => {
+    // TODO: Remove when we remove agent type and make all documents agents
+    if (document.documentType === 'agent') {
+      acc[getAgentToolName(document.path)] = document.path
+    }
+    return acc
+  }, {})
+}
+
+async function getProvderNames({ workspace }: { workspace: Workspace }) {
+  const scope = new ProviderApiKeysRepository(workspace.id)
+  const providers = await scope.findAll().then((r) => r.unwrap())
+  return providers.map((provider) => provider.name)
+}
+
+function parseMetadataErrors({
+  metadata,
+}: {
+  metadata: PromptlConversationMetadata
+}) {
+  const { setConfig: _, errors: rawErrors, ...returnedMetadata } = metadata
+  const errors = rawErrors.map((error: CompileError) => {
+    return {
+      startIndex: error.startIndex,
+      endIndex: error.endIndex,
+      start: {
+        line: error.start?.line ?? 0,
+        column: error.start?.column ?? 0,
+      },
+      end: {
+        line: error.end?.line ?? 0,
+        column: error.end?.column ?? 0,
+      },
+      message: error.message,
+      name: error.name,
+    } satisfies AstError
+  })
+
+  return {
+    ...(returnedMetadata as PromptlConversationMetadata),
+    errors,
+  }
+}
+
+export async function validateDocumentMetadata({
+  commit,
+  document,
+  workspace,
+  prompt,
+}: {
+  workspace: Workspace
+  commit: Commit
+  document: DocumentVersion
+  prompt: string
+}) {
+  const docsScope = new DocumentVersionsRepository(workspace.id)
+  const documents = await docsScope
+    .getDocumentsAtCommit(commit)
+    .then((r) => r.unwrap())
+  const agentToolsMap = buildAgentsToolMap(documents)
+  const providerNames = await getProvderNames({ workspace })
+  const integrations = await listIntegrations(workspace).then((r) => r.unwrap())
+  const integrationNames = integrations.map((i) => i.name)
+  const referenceFn = readDocument(document, documents, prompt)
+  const configSchema = latitudePromptConfigSchema({
+    providerNames,
+    integrationNames,
+    fullPath: document?.path,
+    agentToolsMap,
+  })
+  const scanParams = {
+    prompt,
+    fullPath: document?.path,
+    referenceFn,
+    requireConfig: true,
+    configSchema,
+  }
+  const metadata = await scan(scanParams)
+
+  return parseMetadataErrors({ metadata })
+}

--- a/packages/web-ui/src/ds/molecules/SearchableList/index.tsx
+++ b/packages/web-ui/src/ds/molecules/SearchableList/index.tsx
@@ -143,6 +143,7 @@ export function ImageIcon({
     </div>
   )
 }
+
 function DefaultItemPresenter<T extends ItemType = 'item'>({
   item,
   textSize,
@@ -290,7 +291,7 @@ function Heading({
     <div className='flex items-center justify-between mb-2'>
       <Text.H5M display='block'>{label}</Text.H5M>
       {loading ? (
-        <div className='flex flex-row justify-center gap-x-2'>
+        <div className='flex flex-row items-center justify-center gap-x-2 overflow-hidden'>
           <Text.H6 color='foregroundMuted'>Loading...</Text.H6>
           <Icon
             name='loader'
@@ -337,14 +338,16 @@ function renderItem<T extends ItemType = 'no_type'>({
 type GroupWrapperProps = {
   children: ReactNode
   style: 'border' | 'onlySeparators'
+  hidden?: boolean
 }
-function GroupWrapper({ children, style }: GroupWrapperProps) {
+function GroupWrapper({ children, style, hidden }: GroupWrapperProps) {
   return (
     <div
       className={cn('border-border', {
-        'rounded-2xl overflow-hidden border divide-border divide-y':
-          style === 'border',
-        ' divide-border divide-y border-b': style === 'onlySeparators',
+        'rounded-2xl overflow-hidden ': style === 'border',
+        ' divide-border divide-y border-b':
+          style === 'onlySeparators' && !hidden,
+        'divide-y divide-borde border': style === 'border' && !hidden,
       })}
     >
       {children}
@@ -367,12 +370,19 @@ function renderGroup<T extends ItemType = 'no_type'>({
   onSelectValue?: OnSelectValue<T>
   selectedValue?: string | undefined
 }) {
+  const hasItems = group.items && group.items.length > 0
   return (
     <Command.Group
       key={idx}
-      heading={<Heading loading={group.loading} label={group.label} />}
+      heading={
+        !group.loading && !hasItems ? (
+          <></>
+        ) : (
+          <Heading loading={group.loading} label={group.label} />
+        )
+      }
     >
-      <GroupWrapper style={groupStyle}>
+      <GroupWrapper style={groupStyle} hidden={!hasItems && !group.loading}>
         {!group.loading
           ? group.items.map((item, idx) =>
               renderItem({
@@ -539,7 +549,7 @@ export function SearchableList<T extends ItemType>({
                 selectedValue={selectedValue}
               />
             ) : (
-              <GroupWrapper style={groupStyle}>
+              <GroupWrapper style={groupStyle} hidden={items.length === 0}>
                 {(items as OptionItem<T>[]).map((item, idx) => (
                   <Item
                     key={idx}


### PR DESCRIPTION
# What?
Manage state of what integrations, custom tools and sub-agents the document has enabled with the editor sidebar.

### TODO
- [x] Handle active integrations on a zustand state 
- [x] When changing tools from old toolbar or editing the prompt update editor sidebar
- [x] List used integrations on the prompt
- [x] Avoid re-computing the sidebar when a change on the prompt comes from the sidebar toggle
- [x] Toggle all button on active tool-set
- [x] Keep the tool set visible when unchecked all
- [x] Add to active tool-set from connect modal
- [x] 🔥 tool-set option remove
- [x] 🐛 Annoying visual bug while loading tools on modal
- [x] Search typeahead with more than > 10 tools

## NEXT
- [ ] Add sub-agents
- [ ] Add custom-tools
- [ ] Create sub-agents typeahead popover
- [ ] Enable agent behaviour for everyone
- [ ] Enable feature flag