### PR TITLE
fix: specify schema for subscriptions table in SQL migration

### DIFF
--- a/packages/core/drizzle/0070_shiny_midnight.sql
+++ b/packages/core/drizzle/0070_shiny_midnight.sql
@@ -2,7 +2,7 @@
 BEGIN;
 
 -- Update the created_at column in the subscriptions table
-UPDATE subscriptions
+UPDATE "latitude"."subscriptions"
 SET created_at = workspaces.created_at
 FROM workspaces
 WHERE subscriptions.id = workspaces.current_subscription_id;


### PR DESCRIPTION
This pull request addresses the issue related to #1092.

When initiating a new deployment in the Kubernetes cluster using Helm, the migration pod failed with an error. This update aims to resolve that problem and ensure the migration runs successfully during deployment.