### PR TITLE
fix(core): clean active run if no job is found

### DIFF
--- a/packages/core/src/services/runs/stop.test.ts
+++ b/packages/core/src/services/runs/stop.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { publisher } from '../../events/publisher'
+import { queues } from '../../jobs/queues'
+import { UnprocessableEntityError } from '../../lib/errors'
+import { Result } from '../../lib/Result'
+import { RunsRepository } from '../../repositories'
+import { Project, Workspace } from '../../schema/types'
+
+import { stopRun } from './stop'
+
+vi.mock('../../jobs/queues')
+vi.mock('../../events/publisher')
+vi.mock('../../repositories')
+
+describe('stopRun', () => {
+  const mockWorkspace = { id: 1 } as Workspace
+  const mockProject = { id: 1 } as Project
+  const mockRun = {
+    uuid: 'test-uuid',
+    endedAt: null,
+  } as any
+
+  const mockQueue = {
+    getJob: vi.fn(),
+  }
+
+  const mockJob = {
+    id: 'job-123',
+    getState: vi.fn(),
+    waitUntilFinished: vi.fn(),
+    remove: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(queues).mockResolvedValue({
+      runsQueue: mockQueue as any,
+    } as any)
+  })
+
+  describe('when run has already ended', () => {
+    it('returns UnprocessableEntityError', async () => {
+      // @ts-expect-error - mock
+      const endedRun = { ...mockRun, endedAt: new Date() } as Run
+
+      const result = await stopRun({
+        run: endedRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(result.error).toBeInstanceOf(UnprocessableEntityError)
+      expect(result.error?.message).toBe('Run already ended')
+      expect(mockQueue.getJob).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when job is not found', () => {
+    it('handles stale run cleanup when run exists in repository', async () => {
+      mockQueue.getJob.mockResolvedValueOnce(null)
+
+      const mockRepo = {
+        get: vi.fn().mockResolvedValueOnce(Result.ok(mockRun)),
+        delete: vi.fn().mockResolvedValueOnce(Result.ok(undefined)),
+      }
+      vi.mocked(RunsRepository).mockImplementationOnce(() => mockRepo as any)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mockRepo.delete).toHaveBeenCalledWith({ runUuid: mockRun.uuid })
+    })
+
+    it('handles repository delete failure gracefully', async () => {
+      mockQueue.getJob.mockResolvedValueOnce(null)
+
+      const mockRepo = {
+        get: vi.fn().mockResolvedValueOnce(Result.ok(mockRun)),
+        delete: vi
+          .fn()
+          .mockResolvedValueOnce(Result.error(new Error('Delete failed'))),
+      }
+      vi.mocked(RunsRepository).mockImplementationOnce(() => mockRepo as any)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('when job is found', () => {
+    beforeEach(() => {
+      mockQueue.getJob.mockResolvedValueOnce(mockJob)
+    })
+
+    it('publishes cancelJob event when job is not finished', async () => {
+      mockJob.getState.mockResolvedValueOnce('active')
+      mockJob.waitUntilFinished.mockResolvedValueOnce(undefined)
+      mockJob.remove.mockResolvedValueOnce(undefined)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(publisher.publish).toHaveBeenCalledWith('cancelJob', {
+        jobId: mockJob.id,
+      })
+      expect(result.ok).toBe(true)
+    })
+
+    it('does not publish cancelJob event when job is already finished', async () => {
+      mockJob.getState.mockResolvedValueOnce('completed')
+      mockJob.remove.mockResolvedValueOnce(undefined)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(publisher.publish).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+    })
+
+    it('handles job state check failure', async () => {
+      mockJob.getState.mockRejectedValueOnce(new Error('State check failed'))
+      mockJob.remove.mockResolvedValueOnce(undefined)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(publisher.publish).not.toHaveBeenCalled()
+      expect(result.ok).toBe(true)
+    })
+
+    it('handles waitUntilFinished timeout gracefully', async () => {
+      mockJob.getState.mockResolvedValueOnce('active')
+      mockJob.waitUntilFinished.mockRejectedValueOnce(new Error('Timeout'))
+      mockJob.remove.mockResolvedValueOnce(undefined)
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(publisher.publish).toHaveBeenCalledWith('cancelJob', {
+        jobId: mockJob.id,
+      })
+      expect(result.ok).toBe(true)
+    })
+
+    it('handles job remove failure gracefully', async () => {
+      mockJob.getState.mockResolvedValueOnce('active')
+      mockJob.waitUntilFinished.mockResolvedValueOnce(undefined)
+      mockJob.remove.mockRejectedValueOnce(new Error('Remove failed'))
+
+      const result = await stopRun({
+        run: mockRun,
+        project: mockProject,
+        workspace: mockWorkspace,
+      })
+
+      expect(result.ok).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/services/runs/stop.ts
+++ b/packages/core/src/services/runs/stop.ts
@@ -1,13 +1,16 @@
 import { Run } from '../../constants'
 import { publisher } from '../../events/publisher'
 import { queues } from '../../jobs/queues'
-import { NotFoundError, UnprocessableEntityError } from '../../lib/errors'
+import { UnprocessableEntityError } from '../../lib/errors'
 import { Result } from '../../lib/Result'
+import { RunsRepository } from '../../repositories'
 import { Project, Workspace } from '../../schema/types'
 import { JOB_FINISHED_STATES, subscribeQueue } from './shared'
 
 export async function stopRun({
   run,
+  project,
+  workspace,
 }: {
   run: Run
   project: Project
@@ -20,13 +23,21 @@ export async function stopRun({
   const { runsQueue } = await queues()
   const job = await runsQueue.getJob(run.uuid)
   if (!job?.id) {
-    return Result.error(
-      new NotFoundError(`Active run job with uuid ${run.uuid} not found`),
-    )
+    const runsRepo = new RunsRepository(workspace.id, project.id)
+    const result = await runsRepo.delete({ runUuid: run.uuid })
+    if (!Result.isOk(result)) return result
+
+    return Result.nil()
   }
 
-  const state = await job.getState()
-  if (!JOB_FINISHED_STATES.includes(state)) {
+  let state: string | undefined
+  try {
+    state = await job.getState()
+  } catch {
+    /* No-op */
+  }
+
+  if (state && !JOB_FINISHED_STATES.includes(state)) {
     publisher.publish('cancelJob', { jobId: job.id })
 
     try {


### PR DESCRIPTION
The active runs and job state can get desynced in unexpected conditions. The stop service should clean up the state in that case.

Added tests.