### PR TITLE
feat: file cache

### DIFF
--- a/apps/web/src/app/api/files/file/route.test.ts
+++ b/apps/web/src/app/api/files/file/route.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { downloadWithCache } from '@latitude-data/core/lib/downloadWithCache'
+import { GET } from './route'
+
+// Mock the downloadWithCache function and env
+vi.mock('@latitude-data/core/lib/downloadWithCache', () => ({
+  downloadWithCache: vi.fn(),
+}))
+
+// Mock the env module to control FILE_CACHE behavior
+vi.mock('@latitude-data/env', () => ({
+  env: {
+    FILE_CACHE: true,
+  },
+}))
+
+describe('GET /api/files/file', () => {
+  const mockDownloadWithCache = downloadWithCache as unknown as ReturnType<
+    typeof vi.fn
+  >
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return 400 when URL parameter is missing', async () => {
+    const request = new NextRequest('http://localhost:3000/api/files/file')
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data).toEqual({ error: 'URL parameter is required' })
+  })
+
+  it('should return 400 when URL format is invalid', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=invalid-url',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data).toEqual({ error: 'Invalid URL format' })
+  })
+
+  it('should return 400 when URL protocol is not allowed', async () => {
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=ftp://example.com/file.txt',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data).toEqual({ error: 'Only HTTP and HTTPS protocols are allowed' })
+  })
+
+  it('should successfully download and return file content', async () => {
+    const mockData = new Uint8Array([1, 2, 3, 4, 5])
+    const mockMediaType = 'text/plain'
+
+    mockDownloadWithCache.mockResolvedValueOnce({
+      data: mockData,
+      mediaType: mockMediaType,
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=https://example.com/file.txt',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe(mockMediaType)
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600')
+
+    const responseData = await response.arrayBuffer()
+    expect(new Uint8Array(responseData)).toEqual(mockData)
+
+    expect(mockDownloadWithCache).toHaveBeenCalledWith(
+      new URL('https://example.com/file.txt'),
+    )
+  })
+
+  it('should handle download errors gracefully', async () => {
+    mockDownloadWithCache.mockRejectedValueOnce(new Error('Network error'))
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=https://example.com/file.txt',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(500)
+    const data = await response.json()
+    expect(data).toEqual({ error: 'Failed to download file' })
+  })
+
+  it('should use default content type when media type is undefined', async () => {
+    const mockData = new Uint8Array([1, 2, 3, 4, 5])
+
+    mockDownloadWithCache.mockResolvedValueOnce({
+      data: mockData,
+      mediaType: undefined,
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=https://example.com/file.txt',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/octet-stream',
+    )
+  })
+
+  it('should handle special characters in URL', async () => {
+    const mockData = new Uint8Array([1, 2, 3, 4, 5])
+    const testUrl =
+      'https://example.com/file with spaces.txt?param=value&other=123'
+
+    mockDownloadWithCache.mockResolvedValueOnce({
+      data: mockData,
+      mediaType: 'text/plain',
+    })
+
+    const request = new NextRequest(
+      `http://localhost:3000/api/files/file?url=${encodeURIComponent(testUrl)}`,
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(mockDownloadWithCache).toHaveBeenCalledWith(new URL(testUrl))
+  })
+
+  it('should work when FILE_CACHE is disabled', async () => {
+    // Mock env with FILE_CACHE disabled
+    vi.doMock('@latitude-data/env', () => ({
+      env: {
+        FILE_CACHE: false,
+      },
+    }))
+
+    const mockData = new Uint8Array([1, 2, 3, 4, 5])
+    const mockMediaType = 'text/plain'
+
+    mockDownloadWithCache.mockResolvedValueOnce({
+      data: mockData,
+      mediaType: mockMediaType,
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=https://example.com/file.txt',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe(mockMediaType)
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600')
+
+    const responseData = await response.arrayBuffer()
+    expect(new Uint8Array(responseData)).toEqual(mockData)
+
+    expect(mockDownloadWithCache).toHaveBeenCalledWith(
+      new URL('https://example.com/file.txt'),
+    )
+  })
+
+  it('should work when FILE_CACHE is enabled', async () => {
+    // Mock env with FILE_CACHE enabled (default in our mock)
+    const mockData = new Uint8Array([1, 2, 3, 4, 5])
+    const mockMediaType = 'application/json'
+
+    mockDownloadWithCache.mockResolvedValueOnce({
+      data: mockData,
+      mediaType: mockMediaType,
+    })
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/files/file?url=https://api.example.com/data.json',
+    )
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe(mockMediaType)
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600')
+
+    const responseData = await response.arrayBuffer()
+    expect(new Uint8Array(responseData)).toEqual(mockData)
+
+    expect(mockDownloadWithCache).toHaveBeenCalledWith(
+      new URL('https://api.example.com/data.json'),
+    )
+  })
+})

--- a/apps/web/src/app/api/files/file/route.ts
+++ b/apps/web/src/app/api/files/file/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { errorHandler } from '$/middlewares/errorHandler'
+import { downloadWithCache } from '@latitude-data/core/lib/downloadWithCache'
+
+export const GET = errorHandler(async (request: NextRequest) => {
+  const { searchParams } = new URL(request.url)
+  const url = searchParams.get('url')
+
+  if (!url) {
+    return NextResponse.json(
+      { error: 'URL parameter is required' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    // Validate URL to prevent security issues
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(url)
+    } catch {
+      return NextResponse.json({ error: 'Invalid URL format' }, { status: 400 })
+    }
+
+    // Only allow HTTP/HTTPS protocols
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return NextResponse.json(
+        { error: 'Only HTTP and HTTPS protocols are allowed' },
+        { status: 400 },
+      )
+    }
+
+    const result = await downloadWithCache(parsedUrl)
+
+    // Create response with proper headers
+    const response = new NextResponse(Buffer.from(result.data), {
+      status: 200,
+      headers: {
+        'Content-Type': result.mediaType || 'application/octet-stream',
+        'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+      },
+    })
+
+    return response
+  } catch (error) {
+    console.error('Error downloading file:', error)
+
+    return NextResponse.json(
+      { error: 'Failed to download file' },
+      { status: 500 },
+    )
+  }
+})

--- a/apps/web/src/components/ChatWrapper/Message/index.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/index.tsx
@@ -24,6 +24,7 @@ import { cn } from '@latitude-data/web-ui/utils'
 import type { Components } from 'react-markdown'
 import { roleToString, roleVariant } from '..'
 import { ToolCallContent } from './ToolCall'
+import { ROUTES } from '$/services/routes'
 
 export { roleToString, roleVariant } from './helpers'
 
@@ -539,7 +540,7 @@ function FileComponent({ src }: { src: string }) {
 
   return (
     <a
-      href={src}
+      href={ROUTES.api.files.file(src)}
       target='_blank'
       rel='noopener noreferrer'
       className={cn(

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -4,6 +4,9 @@ import { type DocumentLogFilterOptions } from '@latitude-data/core/constants'
 type PaginationParameters = { page: number; pageSize: number }
 
 export const API_ROUTES = {
+  files: {
+    file: (url: string) => `/api/files/file?url=${url}`,
+  },
   workspaces: {
     current: '/api/workspaces/current',
     available: '/api/workspaces/available',

--- a/packages/core/src/lib/downloadWithCache.test.ts
+++ b/packages/core/src/lib/downloadWithCache.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetch = vi.fn()
+
+global.fetch = mockFetch as any
+
+describe('downloadWithCache', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+  })
+
+  it('should download and return data with correct structure', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+    const testData = 'Hello World'
+    const arrayBuffer = new TextEncoder().encode(testData).buffer
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+      headers: {
+        get: (key: string) => (key === 'content-type' ? 'text/plain' : null),
+      },
+    })
+
+    const testUrl = new URL('https://example.com/test.txt')
+    const result = await downloadWithCache(testUrl)
+
+    expect(result).toHaveProperty('data')
+    expect(result).toHaveProperty('mediaType')
+    expect(result.data).toBeInstanceOf(Uint8Array)
+    expect(result.mediaType).toBe('text/plain')
+
+    const text = new TextDecoder().decode(result.data)
+    expect(text).toBe(testData)
+
+    expect(mockFetch).toHaveBeenCalledWith(testUrl)
+  })
+
+  it('should throw error on HTTP error responses', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+    })
+
+    const errorUrl = new URL('https://example.com/notfound')
+
+    await expect(downloadWithCache(errorUrl)).rejects.toThrow(
+      'HTTP error! status: 404',
+    )
+  })
+
+  it('should handle different content types', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+    const jsonData = { key: 'value' }
+    const arrayBuffer = new TextEncoder().encode(
+      JSON.stringify(jsonData),
+    ).buffer
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+      headers: {
+        get: (key: string) =>
+          key === 'content-type' ? 'application/json' : null,
+      },
+    })
+
+    const jsonUrl = new URL('https://example.com/data.json')
+    const result = await downloadWithCache(jsonUrl)
+
+    expect(result.mediaType).toBe('application/json')
+
+    const text = new TextDecoder().decode(result.data)
+    const parsed = JSON.parse(text)
+    expect(parsed).toEqual(jsonData)
+  })
+
+  it('should handle missing content-type header', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+    const testData = 'Data without content type'
+    const arrayBuffer = new TextEncoder().encode(testData).buffer
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+      headers: {
+        get: () => null,
+      },
+    })
+
+    const testUrl = new URL('https://example.com/noheader')
+    const result = await downloadWithCache(testUrl)
+
+    expect(result.mediaType).toBeUndefined()
+    const text = new TextDecoder().decode(result.data)
+    expect(text).toBe(testData)
+  })
+
+  it('should handle binary data correctly', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+    const binaryData = new Uint8Array([1, 2, 3, 4, 5])
+    const arrayBuffer = binaryData.buffer
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+      headers: {
+        get: (key: string) =>
+          key === 'content-type' ? 'application/octet-stream' : null,
+      },
+    })
+
+    const testUrl = new URL('https://example.com/binary.dat')
+    const result = await downloadWithCache(testUrl)
+
+    expect(result.mediaType).toBe('application/octet-stream')
+    expect(result.data).toEqual(binaryData)
+  })
+
+  it('should handle large text data', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+    const largeText = 'X'.repeat(10000)
+    const arrayBuffer = new TextEncoder().encode(largeText).buffer
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(arrayBuffer),
+      headers: {
+        get: (key: string) => (key === 'content-type' ? 'text/plain' : null),
+      },
+    })
+
+    const testUrl = new URL('https://example.com/large.txt')
+    const result = await downloadWithCache(testUrl)
+
+    const text = new TextDecoder().decode(result.data)
+    expect(text.length).toBe(10000)
+    expect(text).toBe(largeText)
+  })
+
+  it('should handle different HTTP status errors correctly', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+
+    const testCases = [
+      { status: 400, message: 'HTTP error! status: 400' },
+      { status: 403, message: 'HTTP error! status: 403' },
+      { status: 500, message: 'HTTP error! status: 500' },
+    ]
+
+    for (const testCase of testCases) {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: testCase.status,
+      })
+
+      const testUrl = new URL('https://example.com/error')
+
+      await expect(downloadWithCache(testUrl)).rejects.toThrow(testCase.message)
+    }
+  })
+
+  it('should handle network errors', async () => {
+    const { downloadWithCache } = await import('./downloadWithCache')
+
+    mockFetch.mockRejectedValue(new Error('Network error'))
+
+    const testUrl = new URL('https://example.com/network-error')
+
+    await expect(downloadWithCache(testUrl)).rejects.toThrow('Network error')
+  })
+})

--- a/packages/core/src/lib/downloadWithCache.ts
+++ b/packages/core/src/lib/downloadWithCache.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'crypto'
+
+import { diskFactory } from './disk'
+import { env } from '@latitude-data/env'
+
+export async function downloadWithCache(url: URL): Promise<{
+  data: Uint8Array<ArrayBufferLike>
+  mediaType: string | undefined
+}> {
+  let disk, urlHash, cacheKey
+  if (env.FILE_CACHE) disk = diskFactory('private')
+
+  // Try to get from cache first
+  if (disk) {
+    urlHash = createHash('sha256').update(url.toString()).digest('hex')
+    cacheKey = `${urlHash}`
+
+    let cached
+    try {
+      cached = await disk.get(cacheKey)
+    } catch {
+      // do nothing
+    }
+
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached)
+        return {
+          data: new Uint8Array(Buffer.from(parsed.data, 'base64')),
+          mediaType: parsed.mediaType,
+        }
+      } catch (error) {
+        // If cache is corrupted, delete it and proceed with fresh download
+        await disk.delete(cacheKey)
+
+        // TODO: Capture exception but do not throw
+      }
+    }
+  }
+
+  // Download fresh
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download file. Response status: ${response.status} for URL: ${url}`,
+    )
+  }
+  const arrayBuffer = await response.arrayBuffer()
+  const contentType = response.headers.get('content-type')
+  const result = {
+    data: new Uint8Array(arrayBuffer),
+    mediaType: contentType || undefined,
+  }
+
+  // Cache the result asynchronously - don't wait for completion
+  const cacheData = {
+    data: Buffer.from(arrayBuffer).toString('base64'),
+    mediaType: result.mediaType,
+  }
+  if (disk && cacheKey) {
+    disk.put(cacheKey, JSON.stringify(cacheData)).catch(() => {
+      // TODO: capture exception but do not throw
+    })
+  }
+
+  return result
+}

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -26,6 +26,7 @@ import { handleAICallAPIError } from './handleError'
 import { createProvider } from './helpers'
 import { Providers } from '@latitude-data/constants'
 import { applyAllRules } from './providers/rules'
+import { downloadWithCache } from '../../lib/downloadWithCache'
 
 const DEFAULT_AI_SDK_PROVIDER = {
   streamText: originalStreamText,
@@ -171,6 +172,17 @@ export async function ai({
       experimental_output: useSchema
         ? Output.object({ schema: jsonSchema(schema) })
         : undefined,
+      experimental_download: async (
+        options: { url: URL; isUrlSupportedByModel: boolean }[],
+      ) => {
+        try {
+          return Promise.all(options.map(({ url }) => downloadWithCache(url)))
+        } catch (error) {
+          throw new Error(
+            `Failed to download: ${error instanceof Error ? error.message : String(error)}`,
+          )
+        }
+      },
     })
 
     return Result.ok({

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -267,6 +267,12 @@ export const env = createEnv({
       .default('709a3398-ed26-4e77-beef-90ed288cdd0a'),
 
     RELEASE_VERSION: z.string().optional(),
+
+    // Controls whether message contents of type file should be cached in
+    // Latitude's object storage for later retrieval. Allows customers to share
+    // long-lived URIs with LLM providers at the expense of duplicating data in
+    // Latitude's object storage.
+    FILE_CACHE: z.coerce.boolean().optional().default(false),
   },
   runtimeEnv: {
     ...process.env,


### PR DESCRIPTION
Implements a file cache for file downloads in object storage. Disabled by default. This allows self-hosted customers to easily expose private files via publicly signed URLs with short TTLs and do not worry about ttl expiration in long-running conversations.