### PR TITLE
Fix validation error issue in dataset modal

### DIFF
--- a/packages/core/src/lib/zodUtils.test.ts
+++ b/packages/core/src/lib/zodUtils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { flattenErrors } from './zodUtils'
+import { z } from 'zod'
+import { type ZodSafeParseResult } from 'zod'
+
+describe('flattenErrors', () => {
+  let validation: ZodSafeParseResult<any>
+
+  it('should flatten with only one layer of errors', async () => {
+    const schema = z.object({
+      name: z.string().min(1, 'Name is required'),
+      email: z.string().email('Invalid email'),
+    })
+
+    const data = {
+      name: '',
+      email: 'invalid-email',
+    }
+
+    validation = await schema.safeParseAsync(data)
+    if (!validation.success) {
+      const result = flattenErrors(validation)
+      expect(result).toEqual({
+        name: ['Name is required'],
+        email: ['Invalid email'],
+      })
+    }
+  })
+
+  it('should flatten with multiple layers of errors', async () => {
+    const schema = z.object({
+      age: z
+        .number()
+        .min(18, 'Must be 18 or older')
+        .max(100, 'Must be 100 or younger')
+        .int('Must be a whole number'),
+      name: z
+        .string()
+        .min(1, 'Name is required')
+        .max(10, 'Name must be short!!')
+        .regex(/^[a-z]+$/, 'Name must contain only lowercase letters'),
+    })
+
+    const data = {
+      age: 15.75,
+      name: 'ESTERNOCLEIDOMASTOIDEO',
+    }
+
+    validation = await schema.safeParseAsync(data)
+    if (!validation.success) {
+      const result = flattenErrors(validation)
+      expect(result).toEqual({
+        name: [
+          'Name must be short!!',
+          'Name must contain only lowercase letters',
+        ],
+        age: ['Must be 18 or older', 'Must be a whole number'],
+      })
+    }
+  })
+})

--- a/packages/core/src/lib/zodUtils.ts
+++ b/packages/core/src/lib/zodUtils.ts
@@ -8,8 +8,8 @@ type ErrorTree = {
 
 // Recursively map schema T into error strings
 type FlattenErrorTree<T> = T extends object
-  ? { [K in keyof T]?: FlattenErrorTree<T[K]> | string }
-  : string
+  ? { [K in keyof T]?: FlattenErrorTree<T[K]> | string[] }
+  : string[]
 
 export function flattenErrors<T>(
   error: ZodSafeParseError<T>,
@@ -23,7 +23,6 @@ export function flattenErrors<T>(
         Extract<keyof U, string>,
         ErrorTree | undefined,
       ][]
-
       for (const [key, child] of entries) {
         if (child) {
           ;(result as Record<string, unknown>)[key] = walk(child)
@@ -32,7 +31,7 @@ export function flattenErrors<T>(
       return result
     }
 
-    return (node.errors[0] ?? '') as FlattenErrorTree<U>
+    return (node.errors ?? []) as FlattenErrorTree<U>
   }
 
   return walk<T>(tree)


### PR DESCRIPTION
The first letter of the errors was appearing when a validation error occurred when creating datasets. 

<img width="612" height="607" alt="image" src="https://github.com/user-attachments/assets/71ceb8b0-4a4a-405e-94d1-318f4ec9c84d" />

This was due to how we were flattening zod validation errors in the API, where we returned a key value record, where the value were strings instead of array of strings. 

We could have left it returning a string and modify frontend logic, however as our input atoms ask for an array of strings, and zod can return multiple validation errors for a single attribute, its more extendable to modifying the flattening logic to return an array of strings as a value, as we can reuse this logic for more forms.

This PR adds this new logic.