### PR TITLE
Fix/web captureexception typo

### DIFF
--- a/apps/web/src/helpers/captureException.ts
+++ b/apps/web/src/helpers/captureException.ts
@@ -73,7 +73,7 @@ export const captureMessage = (
       level,
       message,
       timestamp: new Date().toISOString(),
-      service: 'latitude-web',
+      service: 'latitude-llm-web',
       ...tags,
     }),
   )


### PR DESCRIPTION
We have an inconsistency of names between the `captureException` and the `intrumentation.ts` file, where here we call the service `latitude-web` while in the `instrumentation.ts`, where we're initializing the DD tracer, its `latitude-llm-web`.

