### PR TITLE
fix: Refresh Websockets listener

### DIFF
--- a/apps/web/src/actions/user/refreshWebsocketTokenAction.ts
+++ b/apps/web/src/actions/user/refreshWebsocketTokenAction.ts
@@ -6,7 +6,7 @@ import { cookies } from 'next/headers'
 
 import { authProcedure } from '../procedures'
 
-export const refreshWebesocketTokenAction = authProcedure.action(
+export const refreshWebsocketTokenAction = authProcedure.action(
   async ({ ctx: { user, workspace } }) => {
     const cks = await cookies()
     const refreshWebsocketCookie = cks.get('websocketRefresh')


### PR DESCRIPTION
When opening a Latitude tab that has been open for a while, the user can sometimes see constant "The action was completed successfully" toasts appearing in the screen. Dozens each second. Opening the Network tab shows that these are unknown actions being sent over and over and over again really fast.

The issue apparently was with the WebSocket provider, which was adding a new `onError` event callback ON EVERY RENDER. This means that, after a few hundred or thousand renders, when there is finally a connection error with the websockets server, ALL CALLBACKS fire at the same time. Since each callback contains an action execution, thousands of actions requests get fired.

This fix changes the hook's logic to only have 1 single callback for the event, re-defining it if anything changed.
