### PR TITLE
Include Source Data in Tool Calls

### DIFF
--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -27,7 +27,8 @@
     "./latte": "./src/latte/index.ts",
     "./promptl": "./src/promptl.ts",
     "./trigger": "./src/trigger.ts",
-    "./documentTriggers": "./src/documentTriggers/schema.ts"
+    "./documentTriggers": "./src/documentTriggers/schema.ts",
+    "./toolSources": "./src/toolSources.ts"
   },
   "devDependencies": {
     "@latitude-data/eslint-config": "workspace:*",

--- a/packages/constants/src/ai/vercelSdkV5ToV4.ts
+++ b/packages/constants/src/ai/vercelSdkV5ToV4.ts
@@ -1,5 +1,6 @@
 import { ToolResultPart, ModelMessage as VercelV5Message } from 'ai'
 import { AssistantMessage, ToolMessage } from '../legacyCompiler'
+import { ToolSourceData } from '../toolSources'
 
 export type ReplaceTextDelta<T> = T extends {
   type: 'text-delta'
@@ -10,7 +11,10 @@ export type ReplaceTextDelta<T> = T extends {
   : T extends {
         type: 'tool-call'
       }
-    ? Omit<T, 'input'> & { args: Record<string, unknown> }
+    ? Omit<T, 'input'> & {
+        args: Record<string, unknown>
+        _sourceData?: ToolSourceData
+      }
     : T extends {
           type: 'tool-result'
         }

--- a/packages/constants/src/legacyCompiler.ts
+++ b/packages/constants/src/legacyCompiler.ts
@@ -1,4 +1,5 @@
 import { LegacyVercelSDKToolResultPart as ToolResultPart } from './ai'
+import { ToolSourceData } from './toolSources'
 
 export enum MessageRole {
   system = 'system',
@@ -50,6 +51,7 @@ export type ToolRequestContent = {
   toolCallId: string
   toolName: string
   args: Record<string, unknown>
+  _sourceData?: ToolSourceData
 }
 export type MessageContent =
   | FileContent
@@ -88,6 +90,7 @@ export type ToolCall = {
   id: string
   name: string
   arguments: Record<string, unknown>
+  _sourceData?: ToolSourceData
 }
 
 export type Message =

--- a/packages/constants/src/mcp.ts
+++ b/packages/constants/src/mcp.ts
@@ -2,6 +2,7 @@ import { JSONSchema7 } from 'json-schema'
 
 export type McpTool = {
   name: string
+  displayName?: string
   description?: string
   inputSchema: {
     type: 'object'

--- a/packages/constants/src/toolSources.ts
+++ b/packages/constants/src/toolSources.ts
@@ -1,0 +1,45 @@
+import { Providers } from '.'
+import { LatitudeTool } from './config'
+
+export enum ToolSource {
+  Client = 'client',
+  Latitude = 'latitude',
+  Agent = 'agentAsTool',
+  Integration = 'integration',
+  ProviderTool = 'providerTool',
+}
+
+type BaseToolSourceData<T extends ToolSource> = {
+  source: T
+}
+
+type ClientToolSourceData = BaseToolSourceData<ToolSource.Client>
+
+type LatitudeToolSourceData = BaseToolSourceData<ToolSource.Latitude> & {
+  latitudeTool: LatitudeTool
+}
+
+type AgentAsToolSourceData = BaseToolSourceData<ToolSource.Agent> & {
+  agentPath: string
+  documentUuid: string
+  documentLogUuid?: string
+}
+
+type IntegrationToolSourceData = BaseToolSourceData<ToolSource.Integration> & {
+  integrationId: number
+  toolLabel?: string // Human-readable tool label
+  imageUrl?: string // For Pipedream integrations
+}
+
+type ProviderToolSourceData = BaseToolSourceData<ToolSource.ProviderTool> & {
+  provider: Providers
+}
+
+// prettier-ignore
+export type ToolSourceData<T extends ToolSource = ToolSource> =
+  T extends ToolSource.Client ? ClientToolSourceData :
+  T extends ToolSource.Latitude ? LatitudeToolSourceData : 
+  T extends ToolSource.Agent ? AgentAsToolSourceData :
+  T extends ToolSource.Integration ? IntegrationToolSourceData :
+  T extends ToolSource.ProviderTool ? ProviderToolSourceData :
+  never

--- a/packages/core/src/lib/streamManager/chainStreamManager.ts
+++ b/packages/core/src/lib/streamManager/chainStreamManager.ts
@@ -86,6 +86,7 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
         schema: chain.schema,
         source: this.source,
         workspace: this.workspace,
+        resolvedTools: toolsBySource,
       })
 
       this.updateStateFromResponse({

--- a/packages/core/src/lib/streamManager/defaultStreamManager.ts
+++ b/packages/core/src/lib/streamManager/defaultStreamManager.ts
@@ -77,6 +77,7 @@ export class DefaultStreamManager
           schema: this.schema,
           source: this.source,
           workspace: this.workspace,
+          resolvedTools: toolsBySource,
         })
 
       this.updateStateFromResponse({

--- a/packages/core/src/lib/streamManager/resolveTools/agentsAsTools.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/agentsAsTools.ts
@@ -2,7 +2,11 @@ import { resolveRelativePath } from '@latitude-data/constants'
 import { BadRequestError, LatitudeError, NotFoundError } from '../../errors'
 import { PromisedResult } from '../../Transaction'
 import { Result, TypedResult } from '../../Result'
-import { ResolvedTools, ToolSource, ToolSourceData } from './types'
+import { ResolvedTools } from './types'
+import {
+  ToolSource,
+  ToolSourceData,
+} from '@latitude-data/constants/toolSources'
 import { type DocumentVersion } from '../../../schema/models/types/DocumentVersion'
 import { DocumentVersionsRepository } from '../../../repositories'
 import { getToolDefinitionFromDocument } from '../../../services/agents/agentsAsTools'
@@ -100,7 +104,7 @@ export async function resolveAgentsAsTools({
   const agentDocs = agentDocsResult.unwrap()
   const resolvedToolsEntries: [
     string,
-    { definition: Tool; sourceData: ToolSourceData },
+    { definition: Tool; sourceData: ToolSourceData<ToolSource.Agent> },
   ][] = await Promise.all(
     agentDocs.map(async (doc) => {
       const { name, toolDefinition } = await getToolDefinitionFromDocument({
@@ -117,8 +121,9 @@ export async function resolveAgentsAsTools({
         {
           definition: toolDefinition,
           sourceData: {
-            source: ToolSource.AgentAsTool,
+            source: ToolSource.Agent,
             agentPath: doc.path,
+            documentUuid: doc.documentUuid,
           },
         },
       ]

--- a/packages/core/src/lib/streamManager/resolveTools/clientTools.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/clientTools.ts
@@ -5,7 +5,8 @@ import {
 } from '@latitude-data/constants'
 import { LatitudeError } from '../../errors'
 import { Result, TypedResult } from '../../Result'
-import { ResolvedTools, ToolSource } from './types'
+import { ResolvedTools } from './types'
+import { ToolSource } from '@latitude-data/constants/toolSources'
 import {
   AI_PROVIDERS_WITH_BUILTIN_TOOLS,
   LatitudePromptConfig,

--- a/packages/core/src/lib/streamManager/resolveTools/latitudeTools.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/latitudeTools.ts
@@ -8,9 +8,10 @@ import {
 import { TelemetryContext } from '../../../telemetry'
 import { BadRequestError, LatitudeError, NotFoundError } from '../../errors'
 import { Result, TypedResult } from '../../Result'
-import { ResolvedTools, ToolSource } from './types'
+import { ResolvedTools } from './types'
 import { publisher } from '../../../events/publisher'
 import { Tool } from 'ai'
+import { ToolSource } from '@latitude-data/constants/toolSources'
 
 export function resolveLatitudeTools({
   config,

--- a/packages/core/src/lib/streamManager/resolveTools/resolveProviderTools.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/resolveProviderTools.ts
@@ -4,7 +4,7 @@ import {
   openAIToolsList,
 } from '@latitude-data/constants/latitudePromptSchema'
 import { Result, TypedResult } from '../../Result'
-import { ResolvedProviderTool, ResolvedTools, ToolSource } from './types'
+import { ResolvedProviderTool, ResolvedTools } from './types'
 import {
   LatitudeError,
   NotFoundError,
@@ -12,6 +12,7 @@ import {
 } from '../../errors'
 import { openai } from '@ai-sdk/openai'
 import { Providers, VercelProviderTool } from '@latitude-data/constants'
+import { ToolSource } from '@latitude-data/constants/toolSources'
 
 function resolveOpenAITools(openAITools: OpenAIToolList) {
   const result = openAIToolsList.safeParse(openAITools)

--- a/packages/core/src/lib/streamManager/resolveTools/types.ts
+++ b/packages/core/src/lib/streamManager/resolveTools/types.ts
@@ -1,63 +1,13 @@
+import { Providers, VercelProviderTool } from '@latitude-data/constants'
 import {
-  LatitudeTool,
-  Providers,
-  VercelProviderTool,
-} from '@latitude-data/constants'
+  ToolSource,
+  ToolSourceData,
+} from '@latitude-data/constants/toolSources'
 import { Tool } from 'ai'
 
-export enum ToolSource {
-  Client = 'client',
-  Latitude = 'latitude',
-  AgentReturn = 'agentReturn',
-  AgentAsTool = 'agentAsTool',
-  Integration = 'integration',
-  ProviderTool = 'providerTool',
-}
-
-interface BaseToolSourceData {
-  source: ToolSource
-}
-
-interface ClientToolSourceData extends BaseToolSourceData {
-  source: ToolSource.Client
-}
-
-interface LatitudeToolSourceData extends BaseToolSourceData {
-  source: ToolSource.Latitude
-  latitudeTool: LatitudeTool
-}
-
-interface AgentReturnToolSourceData extends BaseToolSourceData {
-  source: ToolSource.AgentReturn
-}
-
-interface AgentAsToolSourceData extends BaseToolSourceData {
-  source: ToolSource.AgentAsTool
-  agentPath: string
-}
-
-interface IntegrationToolSourceData extends BaseToolSourceData {
-  source: ToolSource.Integration
-  integrationName: string
-  toolName: string
-}
-
-interface ProviderToolSourceData extends BaseToolSourceData {
-  source: ToolSource.ProviderTool
-  provider: Providers
-}
-
-export type ToolSourceData =
-  | ClientToolSourceData
-  | LatitudeToolSourceData
-  | AgentReturnToolSourceData
-  | AgentAsToolSourceData
-  | IntegrationToolSourceData
-  | ProviderToolSourceData
-
-type ResolvedTool = {
+type ResolvedTool<T extends ToolSource = ToolSource> = {
   definition: Tool
-  sourceData: ToolSourceData
+  sourceData: ToolSourceData<T>
 }
 
 export type ResolvedProviderTool = {
@@ -68,4 +18,7 @@ export type ResolvedProviderTool = {
   }
 }
 
-export type ResolvedTools = Record<string, ResolvedTool | ResolvedProviderTool>
+export type ResolvedTools<T extends ToolSource = ToolSource> = Record<
+  string,
+  T extends ToolSource.ProviderTool ? ResolvedProviderTool : ResolvedTool<T>
+>

--- a/packages/core/src/lib/streamManager/step/streamAIResponse.ts
+++ b/packages/core/src/lib/streamManager/step/streamAIResponse.ts
@@ -22,6 +22,7 @@ import { checkValidStream } from '../checkValidStream'
 import { isAbortError } from '../../isAbortError'
 import { createFakeProviderLog } from '../utils/createFakeProviderLog'
 import { handleAIError } from './handleAIError'
+import { ResolvedTools } from '../resolveTools/types'
 
 export type ExecuteStepArgs = {
   controller: ReadableStreamDefaultController
@@ -50,6 +51,7 @@ export async function streamAIResponse({
   schema,
   output,
   abortSignal,
+  resolvedTools,
 }: {
   context: TelemetryContext
   controller: ReadableStreamDefaultController
@@ -62,6 +64,7 @@ export async function streamAIResponse({
   schema?: JSONSchema7
   output?: Output
   abortSignal?: AbortSignal
+  resolvedTools?: ResolvedTools
 }): Promise<{
   response: ChainStepResponse<StreamType>
   messages: LegacyMessage[]
@@ -90,6 +93,7 @@ export async function streamAIResponse({
       controller,
       result: aiResult,
       accumulatedText,
+      resolvedTools,
     })
     chunkError = resultStream.error
   } catch (error) {
@@ -114,6 +118,7 @@ export async function streamAIResponse({
   const processedResponse = await processResponse({
     aiResult,
     documentLogUuid,
+    resolvedTools,
   })
 
   let finishReason

--- a/packages/core/src/services/integrations/pipedream/helpers/ComponentConverter.ts
+++ b/packages/core/src/services/integrations/pipedream/helpers/ComponentConverter.ts
@@ -10,6 +10,7 @@ export function pipedreamComponentToToolDefinition(
 ): McpTool {
   return {
     name: component.key,
+    displayName: component.name,
     description: component.description,
     inputSchema: propsToJSONSchema(component.configurableProps),
   }


### PR DESCRIPTION
When running an Agent, we compute all tools and build a "source" object, where we know exactly where tools are coming from, independently of their name, ids, and any other attributes. This source is used to know what callback to execute when a Tool Call is received.

We can include this source to the Tool Call data we send to the stream and store as a Provider Log! This way, we can apply the same logic and print different components based on the tool origin, independently of the tool's actual name.

Before this change, we could only detect if a tool came from an integration if it started with a custom prefix we always added. And even then, we could not know what integration it was even coming from.

Now, since all source data is included in the Tool Call itself, we don't need prefixes. All we need to do is check the source, which contains a `type` (client, integration, subagent, latitude tool...), and relevant information depending on its type, such as its integration id for integration tools, or the document uuid for subagent requests!