### PR TITLE
Fix latte text area cutoff and header commit title max width issue

### DIFF
--- a/apps/web/src/components/LatteSidebar/LatteChat/LatteChatInput.tsx
+++ b/apps/web/src/components/LatteSidebar/LatteChat/LatteChatInput.tsx
@@ -1,5 +1,6 @@
 import { useCurrentDocumentMaybe } from '$/app/providers/DocumentProvider'
 import { useLatteChangeActions } from '$/hooks/latte/useLatteChangeActions'
+import { useLatteDebugMode } from '$/hooks/latte/useLatteDebugMode'
 import { useDocumentValueMaybe } from '$/hooks/useDocumentValueContext'
 import { useNavigate } from '$/hooks/useNavigate'
 import { ROUTES } from '$/services/routes'
@@ -71,6 +72,7 @@ export function LatteChatInput({
     threadUuid,
     commitId: commit.id,
   })
+  const { enabled: debugModeEnabled, data: debugData } = useLatteDebugMode()
   const checkpoint = useMemo(() => {
     return checkpoints?.find((cp) => cp.documentUuid === document.documentUuid)
   }, [checkpoints, document])
@@ -80,6 +82,9 @@ export function LatteChatInput({
   const [value, setValue] = useState('')
   const [action, setAction] = useState<'accept' | 'undo'>('accept')
   const feedbackRequested = !!latteActionsFeedbackUuid
+
+  const isDebugSelectorVisible =
+    !inConversation && debugModeEnabled && debugData.length > 0
   const handleValueChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       const newValue = e.target.value
@@ -160,10 +165,11 @@ export function LatteChatInput({
       <TextArea
         ref={inputRef}
         className={cn(
-          'bg-background w-full px-3 pt-3 pb-14 resize-none text-sm border-none',
+          'bg-background w-full px-3 pt-3 resize-none text-sm border-none',
           'shadow-sm text-muted-foreground',
           'ring-0 focus-visible:ring-0 outline-none focus-visible:outline-none',
           'focus-visible:animate-glow focus-visible:glow-latte custom-scrollbar scrollable-indicator',
+          isDebugSelectorVisible ? 'pb-18' : 'pb-14',
         )}
         placeholder={
           inConversation

--- a/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/Versions/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/Versions/index.tsx
@@ -49,9 +49,11 @@ export function CommitBreadcrumbItems({
           <BreadcrumbItemSkeleton className='pl-3' />
         ) : (
           <div className='flex flex-row w-full justify-between overflow-hidden pl-3'>
-            <Text.H5 color='foregroundMuted' noWrap ellipsis>
-              {currentCommit?.title ?? commitUuid}
-            </Text.H5>
+            <div className='flex flex-row overflow-hidden max-w-[200px] sm:max-w-[300px] md:max-w-[400px] lg:max-w-[500px] xl:max-w-[600px]'>
+              <Text.H5 color='foregroundMuted' noWrap ellipsis>
+                {currentCommit?.title ?? commitUuid}
+              </Text.H5>
+            </div>
             <ClickToCopy
               copyValue={currentCommit?.uuid ?? commitUuid}
               tooltipContent='Click to copy the version UUID'

--- a/packages/web-ui/tailwind.config.js
+++ b/packages/web-ui/tailwind.config.js
@@ -19,6 +19,9 @@ export default {
       mono: ['var(--font-mono)'],
     },
     extend: {
+      spacing: {
+        18: '72px',
+      },
       colors: {
         border: 'hsl(var(--border) / <alpha-value>)',
         input: 'hsl(var(--input) / <alpha-value>)',


### PR DESCRIPTION
The text area of latte's chat input would cutoff when debug mode was on, and the commit title would break the header when it was too long as well. This small PR fixes these issues