### PR TITLE
feat: add over-capacity middleware to limit concurrent requests to 30

### DIFF
--- a/apps/gateway/src/middlewares/overCapacity.ts
+++ b/apps/gateway/src/middlewares/overCapacity.ts
@@ -1,0 +1,22 @@
+import { createMiddleware } from 'hono/factory'
+import { RateLimitError } from '@latitude-data/constants/errors'
+import { cloudWatchMetrics } from '../services/cloudwatchMetrics'
+
+const MAX_INFLIGHT_REQUESTS = 30
+
+export const overCapacityMiddleware = () =>
+  createMiddleware(async (_c, next) => {
+    const currentInflight = cloudWatchMetrics.getInflightRequests()
+
+    if (currentInflight >= MAX_INFLIGHT_REQUESTS) {
+      throw new RateLimitError(
+        'Server is at capacity. Too many concurrent requests.',
+        1, // retry after 1 second
+        MAX_INFLIGHT_REQUESTS,
+        0, // no remaining requests available
+        Date.now() + 1000, // reset in 1 second
+      )
+    }
+
+    await next()
+  })

--- a/apps/gateway/src/routes/app.ts
+++ b/apps/gateway/src/routes/app.ts
@@ -4,6 +4,7 @@ import authMiddleware from '$/middlewares/auth'
 import { rateLimitMiddleware } from '$/middlewares/rateLimit'
 import errorHandlerMiddleware from '$/middlewares/errorHandler'
 import { inflightRequestsMiddleware } from '$/middlewares/inflightRequests'
+import { overCapacityMiddleware } from '$/middlewares/overCapacity'
 
 import createApp from '$/openApi/createApp'
 import configureOpenAPI from '$/openApi/configureOpenAPI'
@@ -33,6 +34,7 @@ app.use(rateLimitMiddleware())
 app.use(authMiddleware())
 
 if (env.AWS_ACCESS_KEY && env.AWS_ACCESS_SECRET) {
+  app.use(overCapacityMiddleware())
   app.use(inflightRequestsMiddleware())
 }
 


### PR DESCRIPTION
## Summary
- Create overCapacityMiddleware that checks current inflight request count
- Limit concurrent requests to 30 maximum using existing cloudWatchMetrics
- Return RateLimitError with 429 status when capacity is exceeded
- Integrate middleware before inflight tracking in the request pipeline
- Only enable when AWS credentials are available (same as inflight tracking)
- Provides server-level protection against overload while maintaining existing per-workspace rate limits

This adds a second layer of protection at the server level to prevent overload, complementing the existing per-workspace rate limiting. When the server reaches 30 concurrent requests, new requests will be rejected with a 429 status code and appropriate rate limit headers.