### PR TITLE
Chat input on playground with no parameters

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/ToolBar/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/ToolBar/index.tsx
@@ -24,12 +24,14 @@ export function ToolBar({
   disabledSubmit = false,
   disabledBack = false,
   onBackLabel = 'Edit',
+  onSubmitLabel = 'Send',
 }: {
   onSubmit?: () => void
   onBack?: () => void
   onBackLabel?: string
   disabledSubmit?: boolean
   disabledBack?: boolean
+  onSubmitLabel?: string
 }) {
   return (
     <ToolBarWrapper>
@@ -59,7 +61,7 @@ export function ToolBar({
           roundy={true}
           userSelect={false}
         >
-          Send
+          {onSubmitLabel}
         </Button>
       )}
     </ToolBarWrapper>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/index.tsx
@@ -1,7 +1,7 @@
 import { ToolMessage } from '@latitude-data/constants/legacyCompiler'
 import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
 import { cn } from '@latitude-data/web-ui/utils'
-import { KeyboardEvent, useCallback, useState } from 'react'
+import { ChangeEvent, KeyboardEvent, useCallback, useState } from 'react'
 import { ToolBar } from './ToolBar'
 
 type OnSubmitWithTools = (value: string | ToolMessage[]) => void
@@ -11,28 +11,34 @@ function SimpleTextArea({
   placeholder,
   onSubmit,
   onBack,
+  onChange,
   onBackLabel,
+  onSubmitLabel,
   minRows = 1,
   maxRows = 10,
   disabledSubmit = false,
   disabledBack = false,
+  canSubmitWithEmptyValue = false,
 }: {
   placeholder: string
   minRows?: number
   maxRows?: number
   onSubmit?: (value: string) => void
   onBack?: () => void
+  onChange?: (value: string) => void
   onBackLabel?: string
+  onSubmitLabel?: string
   disabledSubmit?: boolean
   disabledBack?: boolean
+  canSubmitWithEmptyValue?: boolean
 }) {
   const [value, setValue] = useState('')
   const onSubmitHandler = useCallback(() => {
     if (disabledSubmit) return
-    if (value === '') return
+    if (value === '' && !canSubmitWithEmptyValue) return
     setValue('')
     onSubmit?.(value)
-  }, [value, onSubmit, disabledSubmit])
+  }, [value, onSubmit, disabledSubmit, canSubmitWithEmptyValue])
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
@@ -41,6 +47,13 @@ function SimpleTextArea({
       }
     },
     [onSubmitHandler],
+  )
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      setValue(e.target.value)
+      onChange?.(e.target.value)
+    },
+    [onChange],
   )
   return (
     <div className='flex flex-col w-full'>
@@ -54,7 +67,7 @@ function SimpleTextArea({
         )}
         placeholder={placeholder}
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={handleChange}
         onKeyDown={handleKeyDown}
         minRows={minRows}
         maxRows={maxRows}
@@ -65,6 +78,7 @@ function SimpleTextArea({
           onSubmit={onSubmitHandler}
           onBack={onBack}
           onBackLabel={onBackLabel}
+          onSubmitLabel={onSubmitLabel}
           disabledSubmit={disabledSubmit}
           disabledBack={disabledBack}
         />
@@ -78,10 +92,13 @@ export function ChatTextArea({
   onSubmit,
   onBack,
   onBackLabel,
+  onSubmitLabel,
   disabledSubmit = false,
   disabledBack = false,
   minRows = 1,
   maxRows = 10,
+  onChange,
+  canSubmitWithEmptyValue,
 }: {
   placeholder: string
   minRows?: number
@@ -89,8 +106,11 @@ export function ChatTextArea({
   onSubmit?: OnSubmit | OnSubmitWithTools
   onBack?: () => void
   onBackLabel?: string
+  onSubmitLabel?: string
   disabledSubmit?: boolean
   disabledBack?: boolean
+  onChange?: (value: string) => void
+  canSubmitWithEmptyValue?: boolean
 }) {
   return (
     <div className='flex relative w-full'>
@@ -100,9 +120,12 @@ export function ChatTextArea({
         placeholder={placeholder}
         onSubmit={onSubmit}
         onBack={onBack}
+        onSubmitLabel={onSubmitLabel}
+        onChange={onChange}
         onBackLabel={onBackLabel}
         disabledSubmit={disabledSubmit}
         disabledBack={disabledBack}
+        canSubmitWithEmptyValue={canSubmitWithEmptyValue}
       />
     </div>
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ContentArea/hooks/usePlaygroundLogic.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ContentArea/hooks/usePlaygroundLogic.ts
@@ -111,6 +111,7 @@ export function useEditorCallbacks({
   isPlaygroundOpen,
   togglePlaygroundOpen,
   setSelectedTab,
+  setUserMessage,
 }: {
   playground: ReturnType<typeof usePlaygroundChat>
   isPlaygroundOpen: boolean
@@ -118,6 +119,7 @@ export function useEditorCallbacks({
   resetChat: () => void
   source: (typeof INPUT_SOURCE)[keyof typeof INPUT_SOURCE]
   setSelectedTab: ReactStateDispatch<TabValue>
+  setUserMessage: ReactStateDispatch<string>
 }) {
   const runPromptButtonHandler = useCallback(() => {
     if (!isPlaygroundOpen) {
@@ -126,7 +128,14 @@ export function useEditorCallbacks({
     } else {
       playground.start()
     }
-  }, [playground, togglePlaygroundOpen, isPlaygroundOpen, setSelectedTab])
+    setUserMessage('')
+  }, [
+    playground,
+    togglePlaygroundOpen,
+    isPlaygroundOpen,
+    setSelectedTab,
+    setUserMessage,
+  ])
 
   return useMemo(
     () => ({

--- a/apps/web/src/components/ChatWrapper/Message/Content/Text.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/Text.tsx
@@ -116,7 +116,7 @@ export function TextMessageContent({
       size={size}
       text={text}
       parameters={parameters}
-      sourceMap={sourceMap}
+      sourceMap={debugMode ? sourceMap : undefined}
     />
   )
 }


### PR DESCRIPTION
The Playground's parameters UI is really confusing if you have not added any parameter to your prompt.
To solve this, if you have not added any parameter, we'll display a Chat Input instead


https://github.com/user-attachments/assets/a698b0aa-edee-4e63-b539-33dd79095adb


