### PR TITLE
Fix Experiment diff editor

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentRefinement/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentRefinement/index.tsx
@@ -15,11 +15,11 @@ import { useCallback, useRef, useState } from 'react'
 import { Step1 } from './Step1'
 import { Step2 } from './Step2'
 import { Step3 } from './Step3'
-import { useLatteDiff } from '$/hooks/useLatteDiff'
 
 import { EvaluationV2 } from '@latitude-data/core/constants'
 
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+import { useDocumentValue } from '$/hooks/useDocumentValueContext'
 export function DocumentRefinement({
   project,
   commit,
@@ -38,7 +38,7 @@ export function DocumentRefinement({
   refinementEnabled: boolean
 }) {
   const router = useRouter()
-  const { diff: latteDiff } = useLatteDiff()
+  const { diffOptions } = useDocumentValue()
 
   const { playgroundAction, resetPlaygroundAction } = usePlaygroundAction({
     action: PlaygroundAction.RefinePrompt,
@@ -97,6 +97,7 @@ export function DocumentRefinement({
       setDiff({
         newValue: refinement.prompt,
         description: refinement.summary,
+        source: 'refine',
         onAccept: async (prompt) => {
           const [result, error] = await refineApply({ prompt })
           if (error) return
@@ -223,7 +224,7 @@ export function DocumentRefinement({
 
   const isDisabled = !refinementEnabled || !!diff
 
-  if (latteDiff) return null
+  if (diffOptions) return null
   if (!refinementEnabled) return null
   if (document.promptlVersion === 0) return null
 

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentSuggestions/SuggestionItem.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentSuggestions/SuggestionItem.tsx
@@ -58,6 +58,7 @@ export function SuggestionItem({
     setDiff({
       newValue: patchedPrompt,
       description: suggestion.summary,
+      source: 'suggestion',
       onAccept: async (prompt) => {
         const [result, error] = await apply({ suggestionId: suggestion.id, prompt }) // prettier-ignore
         if (error) return

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentSuggestions/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/DocumentSuggestions/index.tsx
@@ -13,8 +13,8 @@ import type { ICommitContextType } from '$/app/providers/CommitProvider'
 import type { IProjectContextType } from '$/app/providers/ProjectProvider'
 import { useCallback, useEffect, useState } from 'react'
 import { SuggestionItem } from './SuggestionItem'
-import { useLatteDiff } from '$/hooks/useLatteDiff'
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+import { useDocumentValue } from '$/hooks/useDocumentValueContext'
 
 const useDocumentSuggestionsSocket = ({
   document,
@@ -75,7 +75,7 @@ export function DocumentSuggestions({
   setDiff: (value?: DiffOptions) => void
   setPrompt: (prompt: string) => void
 }) {
-  const { diff: latteDiff } = useLatteDiff()
+  const { diffOptions } = useDocumentValue()
   const [isOpen, setIsOpen] = useState(false)
   const close = useCallback(() => setIsOpen(false), [setIsOpen])
   const [notifier, setNotifier] = useState<Notifier>({ isOpen: false })
@@ -108,7 +108,7 @@ export function DocumentSuggestions({
 
   const isDisabled = isLoading || !!diff
 
-  if (latteDiff) return null
+  if (diffOptions) return null
   if (!suggestions.length) return null
 
   return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/TextEditor/LatteDiffManager.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/TextEditor/LatteDiffManager.tsx
@@ -73,9 +73,9 @@ export function LatteDiffManager() {
           .detail({ id: project.id })
           .commits.detail({ uuid: commit.uuid }).documents.root,
       )
-    } else if (updateDocumentContent) {
+    } else {
       // Optimistically update the document value to the previous value
-      updateDocumentContent(diff?.oldValue, { origin: 'latteCopilot' })
+      updateDocumentContent?.(diff?.oldValue, { origin: 'latteCopilot' })
     }
   }, [
     discardPartialChanges,
@@ -91,7 +91,16 @@ export function LatteDiffManager() {
     acceptPartialChanges({
       documentUuids: [document.documentUuid],
     })
-  }, [acceptPartialChanges, document.documentUuid])
+
+    if (diff?.newValue) {
+      updateDocumentContent?.(diff?.newValue, { origin: 'latteCopilot' })
+    }
+  }, [
+    acceptPartialChanges,
+    document.documentUuid,
+    diff?.newValue,
+    updateDocumentContent,
+  ])
 
   const handleReviewNextFile = useCallback(() => {
     handleNavigateToCheckpoint('next')

--- a/apps/web/src/hooks/usePlaygroundAction.ts
+++ b/apps/web/src/hooks/usePlaygroundAction.ts
@@ -6,7 +6,7 @@ import {
   useLocalStorage,
 } from '@latitude-data/web-ui/hooks/useLocalStorage'
 import { omit } from 'lodash-es'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useCallback, useState } from 'react'
 
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
@@ -49,8 +49,6 @@ export function usePlaygroundAction<
   commit: Pick<Commit, 'uuid'>
   document?: Pick<DocumentVersion, 'commitId' | 'documentUuid'>
 }) {
-  const navigate = useRouter()
-
   const base = ROUTES.projects
     .detail({ id: project.id })
     .commits.detail({ uuid: commit.uuid })
@@ -89,7 +87,8 @@ export function usePlaygroundAction<
         },
       })
       const query = new URLSearchParams({ actionId })
-      navigate.push(`${route}?${query.toString()}`)
+      const newUrl = `${route}?${query.toString()}`
+      window.history.pushState(null, '', newUrl)
     },
     [
       playgroundActions,
@@ -98,7 +97,6 @@ export function usePlaygroundAction<
       project,
       commit,
       document,
-      navigate,
       route,
     ],
   )
@@ -107,14 +105,13 @@ export function usePlaygroundAction<
     const clean = !!action && !!actionId
     setAction(undefined)
     if (clean) setPlaygroundActions(omit(playgroundActions, actionId))
-    navigate.replace(route)
+    window.history.replaceState(null, '', route) // We are not using react's navigate because that will trigger a full page reload, which reset Providers state
   }, [
     action,
     actionId,
     setAction,
     playgroundActions,
     setPlaygroundActions,
-    navigate,
     route,
   ])
 
@@ -126,8 +123,6 @@ export function usePlaygroundAction<
 }
 
 export function useDeferredPlaygroundAction() {
-  const navigate = useRouter()
-
   const { value: playgroundActions, setValue: setPlaygroundActions } =
     useLocalStorage<PlaygroundActions>({
       key: AppLocalStorage.playgroundActions,
@@ -166,9 +161,10 @@ export function useDeferredPlaygroundAction() {
         ? base.documents.detail({ uuid: document.documentUuid }).root
         : base.home.root
       const query = new URLSearchParams({ actionId })
-      navigate.push(`${route}?${query.toString()}`)
+      const newUrl = `${route}?${query.toString()}`
+      window.history.pushState(null, '', newUrl)
     },
-    [playgroundActions, setPlaygroundActions, navigate],
+    [playgroundActions, setPlaygroundActions],
   )
 
   return {

--- a/packages/web-ui/src/ds/molecules/DocumentTextEditor/types.ts
+++ b/packages/web-ui/src/ds/molecules/DocumentTextEditor/types.ts
@@ -6,6 +6,7 @@ export type DiffOptions = {
   oldValue?: string
   newValue: string
   description?: string
+  source: 'latte' | 'refine' | 'suggestion' | 'experiment'
   onAccept?: (newValue: string) => void
   onReject?: () => void
 }


### PR DESCRIPTION
When clicking on "Use this prompt" in an experiment, it should display a diff in the editor with the experiment's prompt. It does not.

Fixed the logic for managing the editor's Diff state, for Experiments, Suggestions and Latte changes.