### PR TITLE
Assign issue from failed annotation

### DIFF
--- a/apps/web/src/actions/evaluationsV2/issues/assignIssue.ts
+++ b/apps/web/src/actions/evaluationsV2/issues/assignIssue.ts
@@ -1,0 +1,38 @@
+'use server'
+
+import {
+  EvaluationResultsV2Repository,
+  IssuesRepository,
+} from '@latitude-data/core/repositories'
+import { assignIssue } from '@latitude-data/core/services/issues/assignIssue'
+import { z } from 'zod'
+import { withEvaluation, withEvaluationSchema } from '../../procedures'
+
+export const assignIssueAction = withEvaluation
+  .inputSchema(
+    withEvaluationSchema.extend({
+      issueId: z.number(),
+      evaluationResultUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const issue = await new IssuesRepository(ctx.workspace.id)
+      .find(parsedInput.issueId)
+      .then((r) => r.unwrap())
+    const evaluationResult = await new EvaluationResultsV2Repository(
+      ctx.workspace.id,
+    )
+      .findByUuid(parsedInput.evaluationResultUuid)
+      .then((r) => r.unwrap())
+
+    const result = await assignIssue({
+      workspace: ctx.workspace,
+      project: ctx.project,
+      commit: ctx.commit,
+      evaluation: ctx.evaluation,
+      evaluationResult,
+      issue,
+    }).then((r) => r.unwrap())
+
+    return result
+  })

--- a/apps/web/src/actions/evaluationsV2/issues/createIssue.ts
+++ b/apps/web/src/actions/evaluationsV2/issues/createIssue.ts
@@ -1,0 +1,37 @@
+'use server'
+
+import { z } from 'zod'
+import { EvaluationResultsV2Repository } from '@latitude-data/core/repositories'
+import { createAndAssignIssue } from '@latitude-data/core/services/issues/createAndAssignIssue'
+import { withEvaluation, withEvaluationSchema } from '../../procedures'
+
+export const createIssueAction = withEvaluation
+  .inputSchema(
+    withEvaluationSchema.extend({
+      evaluationResultUuid: z.string(),
+      title: z.string().trim().min(1, { message: 'Title cannot be empty' }),
+      description: z
+        .string()
+        .trim()
+        .min(1, { message: 'Description cannot be empty' }),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const evaluationResult = await new EvaluationResultsV2Repository(
+      ctx.workspace.id,
+    )
+      .findByUuid(parsedInput.evaluationResultUuid)
+      .then((r) => r.unwrap())
+
+    const result = await createAndAssignIssue({
+      workspace: ctx.workspace,
+      project: ctx.project,
+      commit: ctx.commit,
+      evaluation: ctx.evaluation,
+      evaluationResult,
+      title: parsedInput.title,
+      description: parsedInput.description,
+    }).then((r) => r.unwrap())
+
+    return result
+  })

--- a/apps/web/src/actions/evaluationsV2/issues/unAssignIssue.ts
+++ b/apps/web/src/actions/evaluationsV2/issues/unAssignIssue.ts
@@ -1,0 +1,29 @@
+'use server'
+
+import { z } from 'zod'
+import { EvaluationResultsV2Repository } from '@latitude-data/core/repositories'
+import { unAssignIssue } from '@latitude-data/core/services/issues/unAssignIssue'
+import { withEvaluation, withEvaluationSchema } from '../../procedures'
+
+export const unAssignIssueAction = withEvaluation
+  .inputSchema(
+    withEvaluationSchema.extend({
+      evaluationResultUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const evaluationResult = await new EvaluationResultsV2Repository(
+      ctx.workspace.id,
+    )
+      .findByUuid(parsedInput.evaluationResultUuid)
+      .then((r) => r.unwrap())
+
+    const result = await unAssignIssue({
+      workspace: ctx.workspace,
+      project: ctx.project,
+      commit: ctx.commit,
+      evaluationResult,
+    }).then((r) => r.unwrap())
+
+    return result
+  })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/logs/_components/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/logs/_components/index.tsx
@@ -177,16 +177,13 @@ export function DocumentLogsPage({
     return aggregationsNormal
   }, [limitedView, aggregationsNormal])
 
-  const {
-    data: evaluationResults,
-    isLoading: isEvaluationResultsV2Loading,
-    mutate: mutateEvaluationResultsV2,
-  } = useEvaluationResultsV2ByDocumentLogs({
-    project: project,
-    commit: commit,
-    document: document,
-    documentLogUuids: documentLogs.map((l) => l.uuid),
-  })
+  const { data: evaluationResults, isLoading: isEvaluationResultsV2Loading } =
+    useEvaluationResultsV2ByDocumentLogs({
+      project: project,
+      commit: commit,
+      document: document,
+      documentLogUuids: documentLogs.map((l) => l.uuid),
+    })
 
   const {
     data: evaluations,
@@ -266,7 +263,6 @@ export function DocumentLogsPage({
             aggregations={aggregations}
             isAggregationsLoading={isAggregationsLoading}
             evaluationResults={evaluationResults}
-            mutateEvaluationResults={mutateEvaluationResultsV2}
             isEvaluationsLoading={isEvaluationsLoading}
             evaluations={evaluations}
             annotateEvaluation={annotateEvaluation}

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/issues/[issueId]/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/issues/[issueId]/route.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import {
+  ProjectsRepository,
+  IssuesRepository,
+} from '@latitude-data/core/repositories'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { NextRequest, NextResponse } from 'next/server'
+
+const paramsSchema = z.object({
+  projectId: z.coerce.number(),
+  commitUuid: z.string(),
+  issueId: z.coerce.number(),
+})
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      _r: NextRequest,
+      {
+        params,
+        workspace,
+      }: {
+        params: {
+          projectId: string
+          commitUuid: string
+          issueId: string
+        }
+        workspace: Workspace
+      },
+    ) => {
+      const { projectId, issueId } = paramsSchema.parse({
+        projectId: params.projectId,
+        commitUuid: params.commitUuid,
+        issueId: params.issueId,
+      })
+      const projectsRepo = new ProjectsRepository(workspace.id)
+      const project = await projectsRepo.find(projectId).then((r) => r.unwrap())
+      const issuesRepo = new IssuesRepository(workspace.id)
+      const issue = await issuesRepo.findById({
+        project,
+        issueId,
+      })
+
+      if (!issue) {
+        return NextResponse.json(
+          { message: 'Issue not found' },
+          { status: 404 },
+        )
+      }
+
+      return NextResponse.json(issue, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/issues/search/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/issues/search/route.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import {
+  ProjectsRepository,
+  IssuesRepository,
+  CommitsRepository,
+  DocumentVersionsRepository,
+} from '@latitude-data/core/repositories'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { NextRequest, NextResponse } from 'next/server'
+
+export type SearchIssueResponse = Awaited<
+  ReturnType<IssuesRepository['findByTitle']>
+>
+
+const paramsSchema = z.object({
+  projectId: z.coerce.number(),
+  commitUuid: z.string(),
+  documentUuid: z.string(),
+})
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      request: NextRequest,
+      {
+        params,
+        workspace,
+      }: {
+        params: {
+          projectId: string
+          commitUuid: string
+        }
+        workspace: Workspace
+      },
+    ) => {
+      const query = request.nextUrl.searchParams
+      const { projectId, commitUuid, documentUuid } = paramsSchema.parse({
+        projectId: params.projectId,
+        commitUuid: params.commitUuid,
+        documentUuid: query.get('documentUuid'),
+      })
+      const title = query.get('query')
+      const projectsRepo = new ProjectsRepository(workspace.id)
+      const project = await projectsRepo.find(projectId).then((r) => r.unwrap())
+      const commitsRepo = new CommitsRepository(workspace.id)
+      const commit = await commitsRepo
+        .getCommitByUuid({
+          projectId,
+          uuid: commitUuid,
+        })
+        .then((r) => r.unwrap())
+      const docsScope = new DocumentVersionsRepository(workspace.id)
+      const document = await docsScope
+        .getDocumentByUuid({
+          documentUuid,
+          commitUuid: commit?.uuid ?? undefined,
+        })
+        .then((r) => r.unwrap())
+      const issuesRepo = new IssuesRepository(workspace.id)
+      const result = await issuesRepo.findByTitle({
+        project,
+        document,
+        title,
+      })
+
+      return NextResponse.json(result, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/NewIssueModal/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/NewIssueModal/index.tsx
@@ -1,0 +1,112 @@
+import { useCallback, FormEvent, use, useState } from 'react'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Modal, CloseTrigger } from '@latitude-data/web-ui/atoms/Modal'
+import { useCurrentProject } from '$/app/providers/ProjectProvider'
+import { useIssue } from '$/stores/issues/issue'
+import { Input } from '@latitude-data/web-ui/atoms/Input'
+import useEvaluationResultsV2ByDocumentLogs from '$/stores/evaluationResultsV2/byDocumentLogs'
+import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
+import { AnnotationContext } from '../../../FormWrapper'
+import { updateEvaluationResultInstance } from '../updateEvaluationResultInstance'
+
+export function NewIssueModal({ onClose }: { onClose: () => void }) {
+  const [errors, setErrors] = useState<
+    Record<'title' | 'description', string[] | undefined>
+  >({
+    title: undefined,
+    description: undefined,
+  })
+  const { project } = useCurrentProject()
+  const { documentLog, evaluation, result, commit } = use(AnnotationContext)
+  const { mutate: mutateResults } = useEvaluationResultsV2ByDocumentLogs({
+    project,
+    commit,
+    document: {
+      commitId: commit.id,
+      documentUuid: documentLog.documentUuid,
+    },
+    documentLogUuids: [documentLog.uuid],
+  })
+  const { createIssue, isCreating: isCreatingIssue } = useIssue({
+    projectId: project.id,
+    commitUuid: commit.uuid,
+    issueId: result?.issueId,
+    onIssueAssigned: ({ data: { evaluationResult } }) => {
+      mutateResults((results) => {
+        return updateEvaluationResultInstance({
+          prev: results,
+          documentLogUuid: documentLog.uuid,
+          updatedResultWithEvaluation: {
+            evaluation,
+            result: evaluationResult,
+          },
+        })
+      })
+      onClose()
+    },
+  })
+
+  const onSubmit = useCallback(
+    async (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      if (!result) return
+
+      const formData = new FormData(e.currentTarget)
+      const title = formData.get('title')?.toString() ?? ''
+      const description = formData.get('description')?.toString() ?? ''
+
+      const [_, actionErrors] = await createIssue({
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuid: evaluation.documentUuid,
+        evaluationUuid: evaluation.uuid,
+        evaluationResultUuid: result.uuid,
+        title,
+        description,
+      })
+
+      if (actionErrors) {
+        setErrors({
+          title: actionErrors.fieldErrors?.title,
+          description: actionErrors.fieldErrors?.description,
+        })
+      } else {
+        onClose()
+      }
+    },
+    [createIssue, evaluation, project.id, commit.uuid, result, onClose],
+  )
+  return (
+    <Modal
+      open
+      onOpenChange={onClose}
+      title='Create new issue'
+      description='Create a new issue to track this problem. We will assign it to the current evaluation.'
+      dismissible
+      footer={
+        <>
+          <CloseTrigger />
+          <Button
+            fancy
+            disabled={isCreatingIssue}
+            type='submit'
+            form='new-issue-form'
+          >
+            {isCreatingIssue ? 'Creating...' : 'Create Issue'}
+          </Button>
+        </>
+      }
+    >
+      <form onSubmit={onSubmit} className='space-y-4' id='new-issue-form'>
+        <Input name='title' label='Title' errors={errors.title} />
+        <TextArea
+          name='description'
+          label='Description'
+          errors={errors.description}
+        />
+      </form>
+    </Modal>
+  )
+}

--- a/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/index.tsx
@@ -1,0 +1,187 @@
+import { use, useCallback, useMemo, useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+import { Select, SelectOption } from '@latitude-data/web-ui/atoms/Select'
+import { useIssue } from '$/stores/issues/issue'
+import { useSearchIssues } from '$/stores/issues/selectorIssues'
+import { AnnotationContext, AnnotationFormWrapper } from '../../FormWrapper'
+import useEvaluationResultsV2ByDocumentLogs from '$/stores/evaluationResultsV2/byDocumentLogs'
+import { useCurrentProject } from '$/app/providers/ProjectProvider'
+import useFeature from '$/stores/useFeature'
+import { useToggleModal } from '$/hooks/useToogleModal'
+import { updateEvaluationResultInstance } from './updateEvaluationResultInstance'
+import { NewIssueModal } from './NewIssueModal'
+
+export function IssuesSelector() {
+  const issuesFeature = useFeature('issues')
+  const newIssueModal = useToggleModal()
+  const { project } = useCurrentProject()
+  const { documentLog, evaluation, result, commit, documentUuid } =
+    use(AnnotationContext)
+  const [query, setQuery] = useState('')
+  const [open, setOpen] = useState(false)
+  const projectId = project.id
+  const { mutate: mutateResults } = useEvaluationResultsV2ByDocumentLogs({
+    project,
+    commit,
+    document: {
+      commitId: commit.id,
+      documentUuid: documentLog.documentUuid,
+    },
+    documentLogUuids: [documentLog.uuid],
+  })
+  const {
+    data: resultIssue,
+    assignIssue,
+    unAssignIssue,
+    isAssigningIssue,
+    isUnAssigningIssue,
+    isLoading: isLoadingIssue,
+  } = useIssue({
+    projectId,
+    commitUuid: commit.uuid,
+    issueId: result?.issueId,
+    onIssueAssigned: ({ data: { evaluationResult } }) => {
+      mutateResults((results) => {
+        return updateEvaluationResultInstance({
+          prev: results,
+          documentLogUuid: documentLog.uuid,
+          updatedResultWithEvaluation: {
+            evaluation,
+            result: evaluationResult,
+          },
+        })
+      })
+    },
+    onIssueUnAssigned: ({ data: evaluationResult }) => {
+      mutateResults((results) => {
+        return updateEvaluationResultInstance({
+          prev: results,
+          documentLogUuid: documentLog.uuid,
+          updatedResultWithEvaluation: {
+            evaluation,
+            result: evaluationResult,
+          },
+        })
+      })
+    },
+  })
+
+  const { data: serachIssues, isLoading: isSearchingIssues } = useSearchIssues({
+    projectId,
+    commitUuid: commit.uuid,
+    documentUuid,
+    query,
+  })
+  const isLoading =
+    isLoadingIssue ||
+    isSearchingIssues ||
+    isAssigningIssue ||
+    isUnAssigningIssue
+  const onSearch = useDebouncedCallback(async (value: string) => {
+    setQuery(value)
+  }, 500)
+  const options = useMemo<SelectOption<number>[]>(() => {
+    const list = serachIssues.map((issue) => ({
+      label: issue.title,
+      value: issue.id,
+    }))
+
+    // Put in the list evaluation result assigned issue if not present
+    if (resultIssue) {
+      const exists = list.find((item) => item.value === resultIssue.id)
+
+      if (!exists) {
+        list.unshift({
+          label: resultIssue.title,
+          value: resultIssue.id,
+        })
+      }
+    }
+
+    return list
+  }, [serachIssues, resultIssue])
+  const onOpenChange = useCallback((open: boolean) => {
+    setOpen(open)
+    if (open) {
+      setQuery('')
+    }
+  }, [])
+
+  const onChange = useCallback(
+    (issueId: number | undefined) => {
+      if (!result) return
+
+      if (issueId === undefined) {
+        unAssignIssue({
+          projectId,
+          documentUuid: documentLog.documentUuid,
+          commitUuid: commit.uuid,
+          evaluationUuid: evaluation.uuid,
+          evaluationResultUuid: result.uuid,
+        })
+      } else {
+        assignIssue({
+          projectId,
+          documentUuid: documentLog.documentUuid,
+          commitUuid: commit.uuid,
+          evaluationUuid: evaluation.uuid,
+          evaluationResultUuid: result.uuid,
+          issueId,
+        })
+      }
+    },
+    [
+      assignIssue,
+      unAssignIssue,
+      projectId,
+      commit.uuid,
+      documentLog.documentUuid,
+      evaluation.uuid,
+      result,
+    ],
+  )
+  const onClickCreate = useCallback(() => {
+    setOpen(false)
+    newIssueModal.onOpen()
+  }, [newIssueModal])
+
+  if (!issuesFeature.isEnabled) return null
+
+  const hasReason = Boolean(
+    result?.metadata && 'reason' in result.metadata && result.metadata.reason,
+  )
+
+  if (!result || result.hasPassed || !hasReason) return null
+
+  return (
+    <>
+      <AnnotationFormWrapper.Body>
+        <Select<number>
+          searchable
+          removable
+          width='auto'
+          open={open}
+          onOpenChange={onOpenChange}
+          options={options}
+          name='annotation-issue'
+          disabled={isLoading}
+          placeholder='Auto-discover issue'
+          searchPlaceholder='Search existing issues...'
+          placeholderIcon='sparkles'
+          onChange={onChange}
+          onSearch={onSearch}
+          value={resultIssue?.id}
+          footerAction={{
+            label: 'Create New Issue',
+            icon: 'plus',
+            onClick: onClickCreate,
+          }}
+        />
+      </AnnotationFormWrapper.Body>
+
+      {newIssueModal.open ? (
+        <NewIssueModal onClose={newIssueModal.onClose} />
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/updateEvaluationResultInstance.ts
+++ b/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/updateEvaluationResultInstance.ts
@@ -1,0 +1,46 @@
+import { ResultWithEvaluationV2 } from '@latitude-data/core/schema/types'
+
+/**
+ * Check in local collection of evaluation results stored by
+ * document log uuuid if there is an evaluation result for
+ * evaluation result instance to update, and update it
+ * with new issue assignment
+ *
+ * TODO: This is super complicated, we have a local collection
+ * that couple evaluation with evaluation results by document log uuid.
+ * This makes things hard to follow. And also we need to change all of
+ * this now that we're moving document logs to traces.
+ */
+export function updateEvaluationResultInstance({
+  prev,
+  documentLogUuid,
+  updatedResultWithEvaluation,
+}: {
+  prev: Record<string, ResultWithEvaluationV2[]> | undefined
+  documentLogUuid: string
+  updatedResultWithEvaluation: ResultWithEvaluationV2
+}): Record<string, ResultWithEvaluationV2[]> {
+  const existingResults = prev ?? {}
+  const byDocumentLogUuid = existingResults[documentLogUuid] ?? []
+  const existingIndex = byDocumentLogUuid.findIndex(
+    ({ evaluation, result }) =>
+      evaluation.uuid === updatedResultWithEvaluation.evaluation.uuid &&
+      result.id === updatedResultWithEvaluation.result.id,
+  )
+  let updatedResultsForDocumentLogUuid: ResultWithEvaluationV2[]
+
+  if (existingIndex !== -1) {
+    updatedResultsForDocumentLogUuid = [...byDocumentLogUuid]
+    updatedResultsForDocumentLogUuid[existingIndex] =
+      updatedResultWithEvaluation
+  } else {
+    updatedResultsForDocumentLogUuid = [
+      ...byDocumentLogUuid,
+      updatedResultWithEvaluation,
+    ]
+  }
+  return {
+    ...existingResults,
+    [documentLogUuid]: updatedResultsForDocumentLogUuid,
+  }
+}

--- a/apps/web/src/components/evaluations/Annotation/Form/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/index.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react'
 import { EvaluationMetric, EvaluationType } from '@latitude-data/core/constants'
 import { EVALUATION_SPECIFICATIONS } from '../..'
 import { AnnotationProvider } from '../FormWrapper'
 import { FormProps } from '../types'
 import { useAnnotationForm } from '../useAnnotationForm'
+import { IssuesSelector } from './IssuesSelector'
+import { cn } from '@latitude-data/web-ui/utils'
 
 export function AnnotationForm<
   T extends EvaluationType,
@@ -28,15 +31,50 @@ export function AnnotationForm<
     commit,
   })
 
+  // Start expanded if there's already a result
+  const [isExpanded, setIsExpanded] = useState(!!result)
+
   if (!spec.AnnotationForm) return null
 
   return (
-    <AnnotationProvider onSubmit={onSubmit} isSubmitting={isSubmitting}>
-      <spec.AnnotationForm
-        metric={evaluation.metric}
-        evaluation={evaluation}
-        result={result}
-      />
+    <AnnotationProvider
+      commit={commit}
+      documentLog={documentLog}
+      evaluation={evaluation}
+      documentUuid={documentLog.documentUuid}
+      result={result}
+      onSubmit={onSubmit}
+      isSubmitting={isSubmitting}
+      isExpanded={isExpanded}
+      setIsExpanded={setIsExpanded}
+    >
+      <div
+        className={cn(
+          'bg-background dark:bg-backgroundCode',
+          'flex flex-col ',
+          'transition-all duration-300 ease-in-out',
+          'origin-bottom-left',
+          'overflow-hidden',
+          {
+            'border border-border rounded-xl': isExpanded,
+            'focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2':
+              isExpanded,
+            'w-full': isExpanded,
+            'w-fit': !isExpanded,
+          },
+        )}
+      >
+        {isExpanded && (
+          <div className='animate-in fade-in slide-in-from-top-2 duration-300'>
+            <IssuesSelector />
+          </div>
+        )}
+        <spec.AnnotationForm
+          metric={evaluation.metric}
+          evaluation={evaluation}
+          result={result}
+        />
+      </div>
     </AnnotationProvider>
   )
 }

--- a/apps/web/src/components/evaluations/Annotation/ThumbsUpDownInput/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/ThumbsUpDownInput/index.tsx
@@ -1,43 +1,57 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 
 export function ThumbsUpDownInput({
   thumbsUp,
   onThumbsClick,
+  isSubmitting = false,
+  hasPassed,
 }: {
   thumbsUp: boolean | null
   onThumbsClick: (thumbsUp: boolean) => void
   onChange?: (_value: boolean | null) => void
+  isSubmitting?: boolean
+  hasPassed?: boolean
 }) {
-  const [isThumbsUp, setIsThumbsUp] = useState<boolean | null>(thumbsUp)
-
   const onThumbsUpClick = useCallback(() => {
-    setIsThumbsUp(true)
     onThumbsClick(true)
   }, [onThumbsClick])
 
   const onThumbsDownClick = useCallback(() => {
-    setIsThumbsUp(false)
     onThumbsClick(false)
   }, [onThumbsClick])
 
-  useEffect(() => {
-    setIsThumbsUp(thumbsUp)
-  }, [thumbsUp])
+  const thumbsUpVariant =
+    thumbsUp !== true
+      ? 'ghost'
+      : isSubmitting
+        ? 'secondary'
+        : hasPassed
+          ? 'successMuted'
+          : 'destructiveMuted'
+
+  const thumbsDownVariant =
+    thumbsUp !== false
+      ? 'ghost'
+      : isSubmitting
+        ? 'secondary'
+        : hasPassed
+          ? 'successMuted'
+          : 'destructiveMuted'
 
   return (
     <div className='flex gap-x-2'>
       <Button
         type='button'
         size='small'
-        variant={isThumbsUp === true ? 'successMuted' : 'ghost'}
+        variant={thumbsUpVariant}
         iconProps={{ name: 'thumbsUp' }}
         onClick={onThumbsUpClick}
       />
       <Button
         size='small'
         type='button'
-        variant={isThumbsUp === false ? 'destructiveMuted' : 'ghost'}
+        variant={thumbsDownVariant}
         iconProps={{ name: 'thumbsDown' }}
         onClick={onThumbsDownClick}
       />

--- a/apps/web/src/components/evaluations/Annotation/useAnnotationForm.ts
+++ b/apps/web/src/components/evaluations/Annotation/useAnnotationForm.ts
@@ -57,6 +57,7 @@ export function useAnnotationForm<
           resultScore: score,
           resultMetadata,
         })
+
         if (errors) return
 
         const { result } = annotationResult

--- a/apps/web/src/components/evaluations/composite/Weighted.tsx
+++ b/apps/web/src/components/evaluations/composite/Weighted.tsx
@@ -99,7 +99,7 @@ function ConfigurationSimpleForm({
                 {evaluationOptions[uuid].label}
               </Label>
               <NumberInput
-                value={configuration.weights?.[uuid] ?? undefined}
+                defaultValue={configuration.weights?.[uuid] ?? undefined}
                 name={`weights[${uuid}]`}
                 placeholder='25%'
                 min={0}

--- a/apps/web/src/components/evaluations/composite/index.tsx
+++ b/apps/web/src/components/evaluations/composite/index.tsx
@@ -120,7 +120,7 @@ function ConfigurationSimpleForm<M extends CompositeEvaluationMetric>({
         description='The minimum and maximum score threshold of the response'
       >
         <NumberInput
-          value={configuration.minThreshold ?? undefined}
+          defaultValue={configuration.minThreshold ?? undefined}
           name='minThreshold'
           label='Minimum threshold'
           placeholder='No minimum'
@@ -135,7 +135,7 @@ function ConfigurationSimpleForm<M extends CompositeEvaluationMetric>({
           required
         />
         <NumberInput
-          value={configuration.maxThreshold ?? undefined}
+          defaultValue={configuration.maxThreshold ?? undefined}
           name='maxThreshold'
           label='Maximum threshold'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/llm/Comparison.tsx
+++ b/apps/web/src/components/evaluations/llm/Comparison.tsx
@@ -99,7 +99,7 @@ function ConfigurationAdvancedForm({
         description='The minimum and maximum percentage of criteria met of the response'
       >
         <NumberInput
-          value={configuration.minThreshold ?? undefined}
+          defaultValue={configuration.minThreshold ?? undefined}
           name='minThreshold'
           label='Minimum threshold'
           placeholder='No minimum'
@@ -114,7 +114,7 @@ function ConfigurationAdvancedForm({
           required
         />
         <NumberInput
-          value={configuration.maxThreshold ?? undefined}
+          defaultValue={configuration.maxThreshold ?? undefined}
           name='maxThreshold'
           label='Maximum threshold'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/llm/Custom.tsx
+++ b/apps/web/src/components/evaluations/llm/Custom.tsx
@@ -126,7 +126,7 @@ ${
         description='The minimum and maximum score of the response'
       >
         <NumberInput
-          value={configuration.minScore ?? undefined}
+          defaultValue={configuration.minScore ?? undefined}
           name='minScore'
           label='Minimum score'
           placeholder='0'
@@ -140,7 +140,7 @@ ${
           required
         />
         <NumberInput
-          value={configuration.maxScore ?? undefined}
+          defaultValue={configuration.maxScore ?? undefined}
           name='maxScore'
           label='Maximum score'
           placeholder='5'
@@ -171,7 +171,7 @@ function ConfigurationAdvancedForm({
         description='The minimum and maximum score threshold of the response'
       >
         <NumberInput
-          value={configuration.minThreshold ?? undefined}
+          defaultValue={configuration.minThreshold ?? undefined}
           name='minThreshold'
           label='Minimum threshold'
           placeholder='No minimum'
@@ -186,7 +186,7 @@ function ConfigurationAdvancedForm({
           required
         />
         <NumberInput
-          value={configuration.maxThreshold ?? undefined}
+          defaultValue={configuration.maxThreshold ?? undefined}
           name='maxThreshold'
           label='Maximum threshold'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/llm/Rating.tsx
+++ b/apps/web/src/components/evaluations/llm/Rating.tsx
@@ -55,7 +55,7 @@ function ConfigurationSimpleForm({
         description='Additional guidelines describing when the response should be rated low'
       >
         <NumberInput
-          value={configuration.minRating ?? undefined}
+          defaultValue={configuration.minRating ?? undefined}
           name='minRating'
           placeholder='0'
           onChange={(value) => {
@@ -90,7 +90,7 @@ function ConfigurationSimpleForm({
         description='Additional guidelines describing when the response should be rated high'
       >
         <NumberInput
-          value={configuration.maxRating ?? undefined}
+          defaultValue={configuration.maxRating ?? undefined}
           name='maxRating'
           placeholder='5'
           onChange={(value) => {
@@ -136,7 +136,7 @@ function ConfigurationAdvancedForm({
         description='The minimum and maximum rating threshold of the response'
       >
         <NumberInput
-          value={configuration.minThreshold ?? undefined}
+          defaultValue={configuration.minThreshold ?? undefined}
           name='minThreshold'
           label='Minimum threshold'
           placeholder='No minimum'
@@ -151,7 +151,7 @@ function ConfigurationAdvancedForm({
           required
         />
         <NumberInput
-          value={configuration.maxThreshold ?? undefined}
+          defaultValue={configuration.maxThreshold ?? undefined}
           name='maxThreshold'
           label='Maximum threshold'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/rule/LengthCount.tsx
+++ b/apps/web/src/components/evaluations/rule/LengthCount.tsx
@@ -59,7 +59,7 @@ function ConfigurationSimpleForm({
         description='The minimum and maximum length of the response'
       >
         <NumberInput
-          value={configuration.minLength ?? undefined}
+          defaultValue={configuration.minLength ?? undefined}
           name='minLength'
           label='Minimum length'
           placeholder='No minimum'
@@ -73,7 +73,7 @@ function ConfigurationSimpleForm({
           required
         />
         <NumberInput
-          value={configuration.maxLength ?? undefined}
+          defaultValue={configuration.maxLength ?? undefined}
           name='maxLength'
           label='Maximum length'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/rule/LexicalOverlap.tsx
+++ b/apps/web/src/components/evaluations/rule/LexicalOverlap.tsx
@@ -58,7 +58,7 @@ function ConfigurationSimpleForm({
         description='The minimum and maximum percentage of overlap of the response'
       >
         <NumberInput
-          value={configuration.minOverlap ?? undefined}
+          defaultValue={configuration.minOverlap ?? undefined}
           name='minOverlap'
           label='Minimum overlap'
           placeholder='No minimum'
@@ -73,7 +73,7 @@ function ConfigurationSimpleForm({
           required
         />
         <NumberInput
-          value={configuration.maxOverlap ?? undefined}
+          defaultValue={configuration.maxOverlap ?? undefined}
           name='maxOverlap'
           label='Maximum overlap'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/rule/NumericSimilarity.tsx
+++ b/apps/web/src/components/evaluations/rule/NumericSimilarity.tsx
@@ -46,7 +46,7 @@ function ConfigurationSimpleForm({
         description='The minimum and maximum percentage of similarity of the response'
       >
         <NumberInput
-          value={configuration.minSimilarity ?? undefined}
+          defaultValue={configuration.minSimilarity ?? undefined}
           name='minSimilarity'
           label='Minimum similarity'
           placeholder='No minimum'
@@ -61,7 +61,7 @@ function ConfigurationSimpleForm({
           required
         />
         <NumberInput
-          value={configuration.maxSimilarity ?? undefined}
+          defaultValue={configuration.maxSimilarity ?? undefined}
           name='maxSimilarity'
           label='Maximum similarity'
           placeholder='No maximum'

--- a/apps/web/src/components/evaluations/rule/SemanticSimilarity.tsx
+++ b/apps/web/src/components/evaluations/rule/SemanticSimilarity.tsx
@@ -46,7 +46,7 @@ function ConfigurationSimpleForm({
         description='The minimum and maximum percentage of similarity of the response'
       >
         <NumberInput
-          value={configuration.minSimilarity ?? undefined}
+          defaultValue={configuration.minSimilarity ?? undefined}
           name='minSimilarity'
           label='Minimum similarity'
           placeholder='No minimum'
@@ -61,7 +61,7 @@ function ConfigurationSimpleForm({
           required
         />
         <NumberInput
-          value={configuration.maxSimilarity ?? undefined}
+          defaultValue={configuration.maxSimilarity ?? undefined}
           name='maxSimilarity'
           label='Maximum similarity'
           placeholder='No maximum'

--- a/apps/web/src/hooks/annotations/useUIAnnotations.ts
+++ b/apps/web/src/hooks/annotations/useUIAnnotations.ts
@@ -1,0 +1,121 @@
+import { Project } from '@latitude-data/core/schema/models/types/Project'
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { ProviderLogDto } from '@latitude-data/core/schema/types'
+import { getEvaluationMetricSpecification } from '$/components/evaluations'
+import { useEvaluationsV2 } from '$/stores/evaluationsV2'
+import { useMemo } from 'react'
+import {
+  EvaluationConfiguration,
+  EvaluationResultV2,
+  EvaluationType,
+  HumanEvaluationMetric,
+} from '@latitude-data/constants'
+import useEvaluationResultsV2ByDocumentLogs from '$/stores/evaluationResultsV2/byDocumentLogs'
+
+export type UseUIAnnotationsProps = {
+  project: Project
+  commit: Commit
+  documentLog: { uuid: string; documentUuid: string }
+  providerLog: ProviderLogDto | undefined
+}
+
+/**
+ * Get the evaluations that are configured for annotating on Latitude UI.
+ * These are human evaluations with configuration `enableControls: true`.
+ */
+export function useUIAnnotations({
+  commit,
+  project,
+  documentLog,
+  providerLog,
+}: UseUIAnnotationsProps) {
+  const {
+    data: evaluations,
+    isLoading: isLoadingEvaluations,
+    annotateEvaluation,
+    isAnnotatingEvaluation,
+  } = useEvaluationsV2({
+    project,
+    commit,
+    document: {
+      commitId: commit.id,
+      documentUuid: documentLog.documentUuid,
+    },
+  })
+  const {
+    data: results,
+    isLoading: isLoadingResults,
+    mutate: mutateResults,
+  } = useEvaluationResultsV2ByDocumentLogs({
+    project: project,
+    commit: commit,
+    document: {
+      commitId: commit.id,
+      documentUuid: documentLog.documentUuid,
+    },
+    documentLogUuids: [documentLog.uuid],
+  })
+  const manualEvaluations = useMemo(
+    () =>
+      evaluations.filter((e) => {
+        const supportManual =
+          getEvaluationMetricSpecification(e).supportsManualEvaluation
+
+        if (!supportManual) return false
+
+        const config = e.configuration as EvaluationConfiguration<
+          EvaluationType.Human,
+          HumanEvaluationMetric
+        >
+        return config.enableControls === true
+      }),
+    [evaluations],
+  )
+
+  const manualEvaluation = manualEvaluations[0]
+  const manualResult = useMemo(() => {
+    if (!results[documentLog.uuid]) return {}
+
+    return results[documentLog.uuid].reduce<Record<string, EvaluationResultV2>>(
+      (acc, r) => {
+        const e = manualEvaluations.find((e) => r.evaluation.uuid === e.uuid)
+
+        if (e) acc[r.evaluation.uuid] = r.result
+
+        return acc
+      },
+      {},
+    )
+  }, [results, documentLog.uuid, manualEvaluations])
+
+  const isLoading = isLoadingEvaluations || isLoadingResults
+  return useMemo(
+    () => ({
+      annotations: {
+        bottom:
+          !isLoading && providerLog && manualEvaluation && manualResult
+            ? {
+                evaluation: manualEvaluation,
+                result: manualResult[manualEvaluation?.uuid],
+                providerLog,
+              }
+            : undefined,
+      },
+      evaluationResults: results,
+      mutateResults,
+      isLoading,
+      annotateEvaluation,
+      isAnnotatingEvaluation,
+    }),
+    [
+      results,
+      manualEvaluation,
+      manualResult,
+      annotateEvaluation,
+      isAnnotatingEvaluation,
+      mutateResults,
+      providerLog,
+      isLoading,
+    ],
+  )
+}

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -135,6 +135,12 @@ export const API_ROUTES = {
             },
             issues: {
               root: `${projectRoot}/commits/${commitUuid}/issues`,
+              search: `${projectRoot}/commits/${commitUuid}/issues/search`,
+              detail: (issueId: number) => {
+                return {
+                  root: `${projectRoot}/commits/${commitUuid}/issues/${issueId}`,
+                }
+              },
             },
             documents: {
               root: `${projectRoot}/commits/${commitUuid}/documents`,

--- a/apps/web/src/stores/evaluationsV2.ts
+++ b/apps/web/src/stores/evaluationsV2.ts
@@ -262,11 +262,8 @@ export function useEvaluationsV2(
     execute: executeAnnotateEvaluationV2,
     isPending: isAnnotatingEvaluation,
   } = useLatitudeAction(annotateEvaluationV2Action, {
-    onSuccess: async ({ data: { result } }) => {
-      toast({
-        title: 'Evaluation annotated successfully',
-        description: `Evaluation annotated successfully with a ${result.hasPassed ? 'passed' : 'failed'} result`,
-      })
+    onSuccess: async () => {
+      // no-op
     },
     onError: async (error) => {
       if (error.code === 'ERROR') {

--- a/apps/web/src/stores/issues/issue.ts
+++ b/apps/web/src/stores/issues/issue.ts
@@ -1,0 +1,76 @@
+import { useMemo } from 'react'
+import useSWR, { SWRConfiguration } from 'swr'
+import { ROUTES } from '$/services/routes'
+import useFetcher from '$/hooks/useFetcher'
+import { Issue } from '@latitude-data/core/schema/models/types/Issue'
+import { EvaluationResultV2 } from '@latitude-data/constants'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { assignIssueAction } from '$/actions/evaluationsV2/issues/assignIssue'
+import { unAssignIssueAction } from '$/actions/evaluationsV2/issues/unAssignIssue'
+import { createIssueAction } from '$/actions/evaluationsV2/issues/createIssue'
+
+export function useIssue(
+  {
+    projectId,
+    commitUuid,
+    issueId,
+    onIssueAssigned,
+    onIssueUnAssigned,
+  }: {
+    projectId: number
+    commitUuid: string
+    issueId?: number | null
+    onIssueAssigned?: (_args: {
+      data: {
+        issue: Issue
+        evaluationResult: EvaluationResultV2
+      }
+    }) => void
+    onIssueUnAssigned?: (_args: { data: EvaluationResultV2 }) => void
+  },
+  swrConfig?: SWRConfiguration<Issue, any>,
+) {
+  const base = ROUTES.api.projects.detail(projectId).commits.detail(commitUuid)
+  const route = issueId ? base.issues.detail(issueId).root : undefined
+  const fetcher = useFetcher<Issue>(route ? route : undefined, {
+    fallback: null,
+  })
+  const { data, isLoading } = useSWR<Issue>(
+    ['issueByProject', projectId, commitUuid, issueId],
+    fetcher,
+    swrConfig,
+  )
+
+  const { execute: assignIssue, isPending: isAssigningIssue } =
+    useLatitudeAction(assignIssueAction, { onSuccess: onIssueAssigned })
+
+  const { execute: unAssignIssue, isPending: isUnAssigningIssue } =
+    useLatitudeAction(unAssignIssueAction, { onSuccess: onIssueUnAssigned })
+
+  const { execute: createIssue, isPending: isCreating } = useLatitudeAction(
+    createIssueAction,
+    { onSuccess: onIssueAssigned },
+  )
+  return useMemo(
+    () => ({
+      data,
+      isLoading,
+      assignIssue,
+      isAssigningIssue,
+      unAssignIssue,
+      isUnAssigningIssue,
+      createIssue,
+      isCreating,
+    }),
+    [
+      data,
+      isLoading,
+      assignIssue,
+      isAssigningIssue,
+      unAssignIssue,
+      isUnAssigningIssue,
+      createIssue,
+      isCreating,
+    ],
+  )
+}

--- a/apps/web/src/stores/issues/selectorIssues.ts
+++ b/apps/web/src/stores/issues/selectorIssues.ts
@@ -1,0 +1,54 @@
+import useSWR, { SWRConfiguration } from 'swr'
+import { ROUTES } from '$/services/routes'
+import useFetcher from '$/hooks/useFetcher'
+import { Issue } from '@latitude-data/core/schema/models/types/Issue'
+import { useMemo } from 'react'
+import { SearchIssueResponse } from '$/app/api/projects/[projectId]/commits/[commitUuid]/issues/search/route'
+
+export function createSearchIssuesKey({
+  projectId,
+  commitUuid,
+  documentUuid,
+  query,
+}: {
+  projectId: number
+  commitUuid: string
+  documentUuid: string
+  query?: string
+}) {
+  const base = ['searchIssues', projectId, commitUuid, documentUuid]
+
+  if (!query) return base
+
+  return [...base, query]
+}
+
+const EMPTY_LIST: Issue[] = []
+
+export function useSearchIssues(
+  {
+    projectId,
+    commitUuid,
+    documentUuid,
+    query,
+  }: {
+    projectId: number
+    commitUuid: string
+    documentUuid: string
+    query?: string
+  },
+  swrConfig?: SWRConfiguration<SearchIssueResponse, any>,
+) {
+  const base = ROUTES.api.projects.detail(projectId).commits.detail(commitUuid)
+  const route = base.issues.search
+  const fetcher = useFetcher<SearchIssueResponse>(route, {
+    searchParams: { documentUuid, query: query ?? '' },
+  })
+  const { data = EMPTY_LIST, isLoading } = useSWR<SearchIssueResponse>(
+    createSearchIssuesKey({ projectId, commitUuid, documentUuid, query }),
+    fetcher,
+    swrConfig,
+  )
+
+  return useMemo(() => ({ data, isLoading }), [data, isLoading])
+}

--- a/packages/core/src/repositories/commitsRepository/index.ts
+++ b/packages/core/src/repositories/commitsRepository/index.ts
@@ -138,6 +138,9 @@ export class CommitsRepository extends RepositoryLegacy<
   /**
    * Get all the commits that are merged before our commit
    * and also include our commit even it's not merged yet
+   *
+   * Draft commit has mergedAt = null and it is considered as the latest commit
+   * so it's the first in the history
    */
   async getCommitsHistory({ commit }: { commit: Commit }) {
     const condition = commit.mergedAt
@@ -147,14 +150,11 @@ export class CommitsRepository extends RepositoryLegacy<
         )
       : or(isNotNull(this.scope.mergedAt), eq(this.scope.id, commit.id))
 
-    return (
-      this.db
-        .select()
-        .from(this.scope)
-        .where(and(eq(this.scope.projectId, commit.projectId), condition))
-        // TODO:: Is draft on top or bottom?
-        .orderBy(desc(this.scope.mergedAt))
-    )
+    return this.db
+      .select()
+      .from(this.scope)
+      .where(and(eq(this.scope.projectId, commit.projectId), condition))
+      .orderBy(desc(this.scope.mergedAt))
   }
 
   getCommitsWithDocumentChanges({

--- a/packages/core/src/services/evaluationsV2/annotate.ts
+++ b/packages/core/src/services/evaluationsV2/annotate.ts
@@ -31,19 +31,19 @@ export async function annotateEvaluationV2<
   M extends EvaluationMetric<T>,
 >(
   {
+    workspace,
+    commit,
+    providerLog,
+    evaluation,
     resultScore,
     resultMetadata,
-    evaluation,
-    providerLog,
-    commit,
-    workspace,
   }: {
+    workspace: Workspace
+    commit: Commit
+    providerLog: ProviderLogDto
+    evaluation: EvaluationV2<T, M>
     resultScore: number
     resultMetadata?: Partial<EvaluationResultMetadata<T, M>>
-    evaluation: EvaluationV2<T, M>
-    providerLog: ProviderLogDto
-    commit: Commit
-    workspace: Workspace
   },
   db = database,
 ) {
@@ -159,22 +159,19 @@ export async function annotateEvaluationV2<
     value = { error: { message: (error as Error).message } }
   }
 
-  // TODO: Validate the result is not passed and not errored before assigning issue
-  // TODO: Check issue belongs to document
-  // TODO: upsert histogram add or remove a count
-
   // TODO: We are stepping out of the db instance. This service should accept an instance of Transaction instead.
   const transaction = new Transaction()
   return await transaction.call(
     async () => {
       let result
+
       if (existingResult.ok) {
         const { result: updatedResult } = await updateEvaluationResultV2(
           {
+            workspace,
+            commit,
             result: existingResult.unwrap(),
-            commit: commit,
             value: value as EvaluationResultValue<T, M>,
-            workspace: workspace,
           },
           transaction,
         ).then((r) => r.unwrap())

--- a/packages/core/src/services/evaluationsV2/results/update.ts
+++ b/packages/core/src/services/evaluationsV2/results/update.ts
@@ -11,21 +11,24 @@ import Transaction from '../../../lib/Transaction'
 import { evaluationResultsV2 } from '../../../schema/models/evaluationResultsV2'
 import { type Commit } from '../../../schema/models/types/Commit'
 import { type Workspace } from '../../../schema/models/types/Workspace'
+import { Issue } from '../../../schema/models/types/Issue'
 
 export async function updateEvaluationResultV2<
   T extends EvaluationType,
   M extends EvaluationMetric<T>,
 >(
   {
-    result: { uuid },
-    commit,
-    value,
     workspace,
+    commit,
+    result: { uuid },
+    value,
+    issue,
   }: {
-    result: EvaluationResultV2<T, M>
-    commit: Commit
-    value: Partial<EvaluationResultValue<T, M>>
     workspace: Workspace
+    commit: Commit
+    result: EvaluationResultV2<T, M>
+    value?: Partial<EvaluationResultValue<T, M>>
+    issue?: Issue | null
   },
   transaction = new Transaction(),
 ) {
@@ -35,7 +38,12 @@ export async function updateEvaluationResultV2<
         .update(evaluationResultsV2)
         .set({
           commitId: commit.id,
-          ...value,
+          ...(value ? { ...value } : {}),
+          ...(issue
+            ? { issueId: issue.id }
+            : issue === null
+              ? { issueId: null }
+              : {}),
           updatedAt: new Date(),
         })
         .where(

--- a/packages/core/src/services/issueHistograms/create.ts
+++ b/packages/core/src/services/issueHistograms/create.ts
@@ -1,0 +1,36 @@
+import { format } from 'date-fns'
+import { type Issue } from '../../schema/models/types/Issue'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { issueHistograms } from '../../schema/models/issueHistograms'
+import { Commit } from '../../schema/models/types/Commit'
+
+export async function createHistogram(
+  {
+    commit,
+    issue,
+    date,
+    initialCount = 1,
+  }: {
+    commit: Commit
+    issue: Issue
+    date: Date
+    initialCount?: number
+  },
+  transaction = new Transaction(),
+) {
+  return transaction.call(async (tx) => {
+    const result = await tx
+      .insert(issueHistograms)
+      .values({
+        workspaceId: issue.workspaceId,
+        commitId: commit.id,
+        issueId: issue.id,
+        date: format(date, 'yyyy-MM-dd'),
+        count: initialCount,
+      })
+      .returning()
+
+    return Result.ok(result[0]!)
+  })
+}

--- a/packages/core/src/services/issueHistograms/decrementHistogram.ts
+++ b/packages/core/src/services/issueHistograms/decrementHistogram.ts
@@ -1,0 +1,33 @@
+import { type Issue } from '../../schema/models/types/Issue'
+import Transaction from '../../lib/Transaction'
+import { Commit } from '../../schema/models/types/Commit'
+import { IssueHistogramsRepository } from '../../repositories/issueHistogramsRepository'
+import { updateHistogram } from './update'
+import { Result } from '../../lib/Result'
+
+export async function decrementHistogram(
+  {
+    commit,
+    issue,
+    date,
+  }: {
+    commit: Commit
+    issue: Issue
+    date: Date
+  },
+  transaction = new Transaction(),
+) {
+  const histogramRepo = new IssueHistogramsRepository(issue.workspaceId)
+  const histogram = await histogramRepo.findHistogram({
+    commit,
+    issue,
+    date,
+  })
+
+  if (!histogram) return Result.ok(null)
+
+  return updateHistogram(
+    { histogram, count: 1, direction: 'decrement' },
+    transaction,
+  )
+}

--- a/packages/core/src/services/issueHistograms/update.ts
+++ b/packages/core/src/services/issueHistograms/update.ts
@@ -1,0 +1,33 @@
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { issueHistograms } from '../../schema/models/issueHistograms'
+import { IssueHistogram } from '../../schema/models/types/IssueHistogram'
+import { eq } from 'drizzle-orm'
+
+export async function updateHistogram(
+  {
+    histogram,
+    count = 1,
+    direction = 'increment',
+  }: {
+    histogram: IssueHistogram
+    count?: number
+    direction?: 'increment' | 'decrement'
+  },
+  transaction = new Transaction(),
+) {
+  return transaction.call(async (tx) => {
+    const result = await tx
+      .update(issueHistograms)
+      .set({
+        count:
+          direction === 'increment'
+            ? histogram.count + count
+            : Math.max(0, histogram.count - count),
+      })
+      .where(eq(issueHistograms.id, histogram.id))
+      .returning()
+
+    return Result.ok(result[0]!)
+  })
+}

--- a/packages/core/src/services/issueHistograms/upsert.ts
+++ b/packages/core/src/services/issueHistograms/upsert.ts
@@ -1,0 +1,35 @@
+import { type Issue } from '../../schema/models/types/Issue'
+import Transaction from '../../lib/Transaction'
+import { Commit } from '../../schema/models/types/Commit'
+import { IssueHistogramsRepository } from '../../repositories/issueHistogramsRepository'
+import { updateHistogram } from './update'
+import { createHistogram } from './create'
+
+export async function upsertHistogram(
+  {
+    commit,
+    issue,
+    date,
+  }: {
+    commit: Commit
+    issue: Issue
+    date: Date
+  },
+  transaction = new Transaction(),
+) {
+  const histogramRepo = new IssueHistogramsRepository(issue.workspaceId)
+  const existing = await histogramRepo.findHistogram({
+    commit,
+    issue,
+    date,
+  })
+
+  if (existing) {
+    return updateHistogram(
+      { histogram: existing, count: 1, direction: 'increment' },
+      transaction,
+    )
+  }
+
+  return createHistogram({ commit, issue, date }, transaction)
+}

--- a/packages/core/src/services/issues/assignIssue.ts
+++ b/packages/core/src/services/issues/assignIssue.ts
@@ -1,0 +1,80 @@
+import { EvaluationResultV2, EvaluationV2 } from '@latitude-data/constants'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { Issue } from '../../schema/models/types/Issue'
+import { upsertHistogram } from '../issueHistograms/upsert'
+import { Commit } from '../../schema/models/types/Commit'
+import { Workspace } from '../../schema/models/types/Workspace'
+import { updateEvaluationResultV2 } from '../evaluationsV2/results/update'
+import { IssuesRepository } from '../../repositories'
+import { Project } from '../../schema/models/types/Project'
+import { decrementHistogram } from '../issueHistograms/decrementHistogram'
+
+export async function assignIssue(
+  {
+    workspace,
+    project,
+    commit,
+    evaluation,
+    evaluationResult,
+    issue,
+  }: {
+    workspace: Workspace
+    project: Project
+    commit: Commit
+    evaluation: EvaluationV2
+    evaluationResult: EvaluationResultV2
+    issue: Issue
+  },
+  transaction = new Transaction(),
+) {
+  const documentUuid = evaluation.documentUuid
+
+  if (documentUuid !== issue.documentUuid) {
+    return Result.error(
+      new Error(
+        `Issue document UUID (${issue.documentUuid}) does not match the provided document version UUID (${documentUuid})`,
+      ),
+    )
+  }
+
+  if (evaluation.uuid !== evaluationResult.evaluationUuid) {
+    return Result.error(
+      new Error(
+        `Evaluation UUID (${evaluation.uuid}) does not match the provided evaluation result's evaluation UUID (${evaluationResult.evaluationUuid})`,
+      ),
+    )
+  }
+  const issuesRepo = new IssuesRepository(workspace.id)
+  const oldIssue = await issuesRepo.findById({
+    project,
+    issueId: evaluationResult.issueId,
+  })
+
+  const date = new Date()
+  return transaction.call(async (_tx) => {
+    const { result } = await updateEvaluationResultV2(
+      {
+        workspace,
+        commit,
+        result: evaluationResult,
+        issue,
+      },
+      transaction,
+    ).then((r) => r.unwrap())
+
+    if (oldIssue && oldIssue.id !== issue.id) {
+      // TODO: missing delete issue if histogram count reaches 0 for old issue.
+      await decrementHistogram(
+        { commit, issue: oldIssue, date },
+        transaction,
+      ).then((r) => r.unwrap())
+    }
+
+    await upsertHistogram({ commit, issue, date }, transaction).then((r) =>
+      r.unwrap(),
+    )
+
+    return Result.ok({ issue, evaluationResult: result })
+  })
+}

--- a/packages/core/src/services/issues/createAndAssignIssue.ts
+++ b/packages/core/src/services/issues/createAndAssignIssue.ts
@@ -1,0 +1,67 @@
+import { EvaluationResultV2, EvaluationV2 } from '@latitude-data/constants'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { upsertHistogram } from '../issueHistograms/upsert'
+import { Commit } from '../../schema/models/types/Commit'
+import { Project } from '../../schema/models/types/Project'
+import { Workspace } from '../../schema/models/types/Workspace'
+import { updateEvaluationResultV2 } from '../evaluationsV2/results/update'
+import { createIssue } from './create'
+
+export async function createAndAssignIssue(
+  {
+    workspace,
+    project,
+    commit,
+    evaluation,
+    evaluationResult,
+    title,
+    description,
+  }: {
+    workspace: Workspace
+    project: Project
+    commit: Commit
+    evaluation: EvaluationV2
+    evaluationResult: EvaluationResultV2
+    title: string
+    description: string
+  },
+  transaction = new Transaction(),
+) {
+  if (evaluation.uuid !== evaluationResult.evaluationUuid) {
+    return Result.error(
+      new Error(
+        `Evaluation UUID (${evaluation.uuid}) does not match the provided evaluation result's evaluation UUID (${evaluationResult.evaluationUuid})`,
+      ),
+    )
+  }
+
+  return transaction.call(async (_tx) => {
+    const issue = await createIssue(
+      {
+        workspace,
+        project,
+        documentUuid: evaluation.documentUuid,
+        title,
+        description,
+      },
+      transaction,
+    ).then((r) => r.unwrap())
+    const { result } = await updateEvaluationResultV2(
+      {
+        workspace,
+        commit,
+        result: evaluationResult,
+        issue,
+      },
+      transaction,
+    ).then((r) => r.unwrap())
+
+    await upsertHistogram(
+      { commit, issue, date: new Date() },
+      transaction,
+    ).then((r) => r.unwrap())
+
+    return Result.ok({ issue, evaluationResult: result })
+  })
+}

--- a/packages/core/src/services/issues/unAssignIssue.ts
+++ b/packages/core/src/services/issues/unAssignIssue.ts
@@ -1,0 +1,53 @@
+import { EvaluationResultV2 } from '@latitude-data/constants'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { Commit } from '../../schema/models/types/Commit'
+import { Workspace } from '../../schema/models/types/Workspace'
+import { updateEvaluationResultV2 } from '../evaluationsV2/results/update'
+import { IssuesRepository } from '../../repositories'
+import { Project } from '../../schema/models/types/Project'
+import { decrementHistogram } from '../issueHistograms/decrementHistogram'
+
+export async function unAssignIssue(
+  {
+    workspace,
+    project,
+    commit,
+    evaluationResult,
+  }: {
+    workspace: Workspace
+    project: Project
+    commit: Commit
+    evaluationResult: EvaluationResultV2
+  },
+  transaction = new Transaction(),
+) {
+  const issuesRepo = new IssuesRepository(workspace.id)
+  const assignedIssue = await issuesRepo.findById({
+    project,
+    issueId: evaluationResult.issueId,
+  })
+
+  if (!assignedIssue) return Result.ok(evaluationResult)
+
+  const date = new Date()
+  return transaction.call(async (_tx) => {
+    const { result } = await updateEvaluationResultV2(
+      {
+        workspace,
+        commit,
+        result: evaluationResult,
+        issue: null,
+      },
+      transaction,
+    ).then((r) => r.unwrap())
+
+    // TODO: missing delete issue if histogram count reaches 0 for old issue.
+    await decrementHistogram(
+      { commit, issue: assignedIssue, date },
+      transaction,
+    ).then((r) => r.unwrap())
+
+    return Result.ok(result)
+  })
+}

--- a/packages/web-ui/src/ds/atoms/Button/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Button/index.tsx
@@ -87,7 +87,7 @@ const buttonVariants = cva(
         outlineDestructive:
           'border border-destructive text-destructive-foreground dark:text-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground group-hover:bg-secondary/80',
+          'border border-transparent bg-secondary text-secondary-foreground group-hover:bg-secondary/80',
         ghost:
           'border border-transparent shadow-none bg-transparent text-muted-foreground',
         link: 'shadow-none underline-offset-4 group-hover:underline text-accent-foreground',

--- a/packages/web-ui/src/ds/atoms/NumberInput/index.tsx
+++ b/packages/web-ui/src/ds/atoms/NumberInput/index.tsx
@@ -12,7 +12,8 @@ type Props = NumberInputProps &
 
 const NumberInput = forwardRef<HTMLInputElement, Props>(function NumberInput(
   {
-    value: defaultValue,
+    value,
+    defaultValue,
     onChange,
     min = -Infinity,
     max = Infinity,
@@ -30,7 +31,8 @@ const NumberInput = forwardRef<HTMLInputElement, Props>(function NumberInput(
 ) {
   const ni = useNumberInput({
     ref,
-    value: defaultValue,
+    value,
+    defaultValue,
     onChange,
     min,
     max,

--- a/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/Primitives/index.tsx
@@ -75,9 +75,11 @@ const SelectValue = ({
   selected,
   options,
   placeholder,
+  placeholderIcon,
 }: {
   options: SelectOption[] | SelectOptionGroup[]
   placeholder?: string
+  placeholderIcon?: IconName
   selected: unknown
 }) => {
   const flatOptions = useMemo(() => flattenOption(options), [options])
@@ -86,12 +88,20 @@ const SelectValue = ({
     setOption(findSelected(flatOptions, selected))
   }, [selected, flatOptions])
 
-  if (!option)
+  if (!option) {
+    if (placeholderIcon) {
+      return (
+        <SelectValueWithIcon icon={placeholderIcon}>
+          {placeholder}
+        </SelectValueWithIcon>
+      )
+    }
     return (
       <SelectValuePrimitive placeholder={placeholder} className='opacity-50'>
         {placeholder}
       </SelectValuePrimitive>
     )
+  }
 
   return (
     <SelectValueWithIcon icon={option.icon}>{option.label}</SelectValueWithIcon>
@@ -231,7 +241,7 @@ const SelectContent = forwardRef<
         ref={ref}
         position={position}
         className={cn(
-          'min-w-52 relative z-50 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-md',
+          'min-w-64 relative z-50 overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-md',
           'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
           'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,

--- a/packages/web-ui/src/ds/atoms/Select/SearchableList/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/SearchableList/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import {
   Command,
   CommandEmpty,
@@ -14,29 +14,49 @@ import { Icon, IconName } from '../../Icons'
 export function SearchableSelectList<V extends unknown = unknown>({
   options,
   onChange,
+  onSearchChange,
+  searchableEmptyMessage = 'No results found.',
+  searchPlaceholder = 'Search...',
+  selectedValue,
 }: {
   options: SelectOption<V>[]
+  onSearchChange?: (query: string) => void
   onChange?: (value: string) => void
+  searchableEmptyMessage?: string
+  searchPlaceholder?: string
+  selectedValue?: V
 }) {
   const [searchQuery, setSearchQuery] = useState('')
+  const onValueChange = useCallback(
+    (value: string) => {
+      setSearchQuery(value)
+      onSearchChange?.(value)
+    },
+    [onSearchChange],
+  )
   return (
     <>
       <Command>
         <CommandInput
           autoFocus
-          placeholder='Search...'
+          placeholder={searchPlaceholder}
           value={searchQuery}
-          onValueChange={setSearchQuery}
+          onValueChange={onValueChange}
         />
         <CommandList>
           <CommandEmpty>
-            <Text.H6>No results found.</Text.H6>
+            <Text.H6>{searchableEmptyMessage}</Text.H6>
           </CommandEmpty>
           <CommandGroup>
             {options
-              .filter((option) =>
-                option.label.toLowerCase().includes(searchQuery.toLowerCase()),
-              )
+              .filter((option) => {
+                const matchesSearch = option.label
+                  .toLowerCase()
+                  .includes(searchQuery.toLowerCase())
+                const isSelected =
+                  selectedValue !== undefined && option.value === selectedValue
+                return matchesSearch || isSelected
+              })
               .map((option) => (
                 <CommandItem
                   key={option.label}

--- a/packages/web-ui/src/ds/atoms/Select/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/index.tsx
@@ -47,6 +47,7 @@ export type SelectProps<V extends unknown = unknown> = Omit<
     value?: V
     trigger?: ReactNode
     placeholder?: string
+    placeholderIcon?: IconName
     loading?: boolean
     disabled?: boolean
     required?: boolean
@@ -55,6 +56,9 @@ export type SelectProps<V extends unknown = unknown> = Omit<
     size?: 'small' | 'default'
     removable?: boolean
     searchable?: boolean
+    searchPlaceholder?: string
+    searchableEmptyMessage?: string
+    onSearch?: (search: string) => void
     open?: boolean
     onOpenChange?: (open: boolean) => void
     footerAction?: {
@@ -72,6 +76,7 @@ export function Select<V extends unknown = unknown>({
   autoFocus,
   trigger,
   placeholder,
+  placeholderIcon,
   options,
   defaultValue,
   value,
@@ -85,6 +90,9 @@ export function Select<V extends unknown = unknown>({
   required = false,
   removable = false,
   searchable = false,
+  searchableEmptyMessage,
+  onSearch,
+  searchPlaceholder,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   footerAction,
@@ -119,7 +127,12 @@ export function Select<V extends unknown = unknown>({
     >
       <div className={width === 'full' ? 'w-full' : 'w-auto'}>
         {loading ? (
-          <Skeleton className='w-full h-8 rounded-md' />
+          <Skeleton
+            className={cn('h-8 rounded-md', {
+              'min-w-28': width === 'auto',
+              'w-full': width === 'full',
+            })}
+          />
         ) : (
           <SelectRoot
             open={isOpen}
@@ -147,6 +160,7 @@ export function Select<V extends unknown = unknown>({
                   selected={selectedValue}
                   options={options}
                   placeholder={placeholder ?? 'Select an option'}
+                  placeholderIcon={placeholderIcon}
                 />
               </SelectTrigger>
             )}
@@ -155,6 +169,10 @@ export function Select<V extends unknown = unknown>({
                 <SearchableSelectList<V>
                   options={options}
                   onChange={_onChange}
+                  onSearchChange={onSearch}
+                  searchPlaceholder={searchPlaceholder}
+                  searchableEmptyMessage={searchableEmptyMessage}
+                  selectedValue={selectedValue}
                 />
               ) : (
                 <SelectGroup>
@@ -167,7 +185,7 @@ export function Select<V extends unknown = unknown>({
                     onClick={footerAction.onClick}
                     className={cn(
                       'cursor-pointer flex items-center justify-center',
-                      'gap-2 py-1.5 px-2 w-full rounded-sm hover:bg-muted',
+                      'gap-2 py-1.5 px-2 w-full rounded-b-lg bg-muted hover:bg-accent',
                     )}
                   >
                     {footerAction.icon ? (

--- a/packages/web-ui/src/ds/atoms/StepperNumberInput/index.tsx
+++ b/packages/web-ui/src/ds/atoms/StepperNumberInput/index.tsx
@@ -14,30 +14,42 @@ const BUTTON_BASE_CLASSES = cn(
 type Props = Omit<HtmlHTMLAttributes<HTMLInputElement>, 'onChange'> &
   NumberInputProps & {
     ref?: Ref<HTMLInputElement>
+    variant?: 'default' | 'success' | 'destructive'
   }
 export function StepperNumberInput({
   ref,
   name,
-  value: defaultValue,
+  value,
   onChange,
   min = -Infinity,
   max = Infinity,
   disabled,
+  variant = 'default',
 }: Props) {
   const badge = useNumberInput({
     ref,
-    value: defaultValue,
+    value,
     onChange,
     min,
     max,
   })
+
+  const containerClassName = cn(
+    'inline-flex items-center rounded-xl',
+    'focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-0',
+    'bg-muted border border-muted',
+    {
+      // TODO: Discuss with design about these variants
+      'bg-muted border-muted': variant === 'default',
+      // 'bg-success-muted dark:bg-transparent dark:shadow-[inset_0_0_0_1px_hsl(var(--success))]':
+      //   variant === 'success',
+      // 'bg-destructive-muted dark:bg-transparent dark:shadow-[inset_0_0_0_1px_hsl(var(--destructive))]':
+      //   variant === 'destructive',
+    },
+  )
+
   return (
-    <div
-      className={cn(
-        'inline-flex items-center rounded-xl bg-muted',
-        'focus-within:ring-1 focus-within:ring-ring focus-within:ring-offset-0',
-      )}
-    >
+    <div className={containerClassName}>
       {/* Decrement Button */}
       <button
         tabIndex={-1}


### PR DESCRIPTION
# What?
When users annotate an evaluation result, let them assign 

## TODO
- [x] Fuzzy search of issues by document on the annotation form shown when evaluation is not passing.
- [x] **Assign** issue when selected from the list
- [x] **UnAssign** issue when **was** a selected issue
- [x] Implement action to set the `issueId` in the evaluation result when selected from the list of existing issues
- [x] Update the color green or red of the annotation control depending if the eval result is passing or not
- [x] Review document logs and use new `useUIAnnotations` hook, Should be able to work as in runs. 
- [x] All interactions on annotations are without 'save' button
- [x] Allow users create issue from annotation description
- [x] Decrement histograms from old assigned issue when selecting a new issue 
- [x] QA that create issue from scratch works and is assigned to the evaluation result.
- [x] Do not display annotation form just the annotation widget until user annotates the eval result.

## Next
- [x] Redesign issues dashboard list to have histogram column with last 14 days of data. Put there also the concept of `escalating`. Remove escalating tag, convert status column into `resolved` and `ignored` tags. So we have title with tags and histogram columns
- [x] Talk with product about what to do on issues details panel. Some ideas 👇 
- [x] Add annotations widget on playground (Talk with @neoxelox)

## Dashboard issue detail
- [x] A panel like in logs 
- [x] title, description, selector with tags for linked evaluations
- [x] List of evaluation results (not paginated. A link to eval results)