### PR TITLE
Filter runs

### DIFF
--- a/apps/web/src/app/(private)/_data-access/index.ts
+++ b/apps/web/src/app/(private)/_data-access/index.ts
@@ -23,6 +23,7 @@ import {
   EvaluationV2,
   PROJECT_STATS_CACHE_KEY,
   LAST_LATTE_THREAD_CACHE_KEY,
+  RunSourceGroup,
 } from '@latitude-data/core/constants'
 import { DocumentLogsLimitedView } from '@latitude-data/core/schema/models/types/DocumentLog'
 import { ProjectLimitedView } from '@latitude-data/core/schema/models/types/Project'
@@ -374,15 +375,21 @@ export const listActiveRunsCached = cache(
     projectId,
     page,
     pageSize,
+    sourceGroup,
   }: {
     projectId: number
     page?: number
     pageSize?: number
+    sourceGroup?: RunSourceGroup
   }) => {
     const { workspace } = await getCurrentUserOrRedirect()
     const repository = new RunsRepository(workspace.id, projectId)
     const runs = await repository
-      .listActive({ page, pageSize })
+      .listActive({
+        page,
+        pageSize,
+        sourceGroup,
+      })
       .then((r) => r.unwrap())
 
     return runs
@@ -394,15 +401,17 @@ export const listCompletedRunsCached = cache(
     projectId,
     page,
     pageSize,
+    sourceGroup,
   }: {
     projectId: number
     page?: number
     pageSize?: number
+    sourceGroup?: RunSourceGroup
   }) => {
     const { workspace } = await getCurrentUserOrRedirect()
     const repository = new RunsRepository(workspace.id, projectId)
     const runs = await repository
-      .listCompleted({ page, pageSize })
+      .listCompleted({ page, pageSize, sourceGroup })
       .then((r) => r.unwrap())
 
     return runs

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/Item.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/Item.tsx
@@ -47,7 +47,7 @@ export const RunsListItem = memo(
               else setSelectedRunUuid(run.uuid)
             }}
           >
-            <div className='min-w-0 min-h-7 flex items-center justify-start gap-2.5 truncate'>
+            <div className='min-w-0 min-h-8 flex items-center justify-start gap-2.5 truncate'>
               {run.endedAt ? (
                 <Icon
                   name={

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/SourceSelector.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/SourceSelector.tsx
@@ -1,0 +1,121 @@
+import { formatCount } from '$/lib/formatCount'
+import {
+  LogSources,
+  RUN_SOURCES,
+  RunSourceGroup,
+} from '@latitude-data/constants'
+import { Badge } from '@latitude-data/web-ui/atoms/Badge'
+import { Icon, IconName } from '@latitude-data/web-ui/atoms/Icons'
+import {
+  TabSelect,
+  TabSelectOption,
+} from '@latitude-data/web-ui/molecules/TabSelect'
+import {
+  BackgroundColor,
+  colors,
+  TextColor,
+} from '@latitude-data/web-ui/tokens'
+import { cn } from '@latitude-data/web-ui/utils'
+import { useCallback, useMemo } from 'react'
+
+const SOURCE_OPTIONS: Record<
+  RunSourceGroup,
+  {
+    label: string
+    icon: IconName
+    backgroundColor: BackgroundColor
+    foregroundColor: TextColor
+  }
+> = {
+  [RunSourceGroup.Production]: {
+    label: 'Production',
+    icon: 'radio',
+    backgroundColor: 'warningMuted',
+    foregroundColor: 'warningMutedForeground',
+  },
+  [RunSourceGroup.Playground]: {
+    label: 'Playground',
+    icon: 'lab',
+    backgroundColor: 'accent',
+    foregroundColor: 'accentForeground',
+  },
+} as const
+
+export function RunSourceSelector({
+  value,
+  setValue,
+  countBySource,
+}: {
+  value: RunSourceGroup
+  setValue: (value: RunSourceGroup) => void
+  countBySource?: Record<LogSources, number>
+}) {
+  const onChange = useCallback(
+    (newValue: RunSourceGroup) => {
+      if (value === newValue) return
+      setValue(newValue)
+    },
+    [setValue, value],
+  )
+
+  const options = useMemo<TabSelectOption<RunSourceGroup>[]>(
+    () =>
+      Object.entries(SOURCE_OPTIONS).map(
+        ([group, { label, icon, backgroundColor, foregroundColor }]) => {
+          const count = Object.entries(countBySource ?? {})
+            .filter(([source]) =>
+              RUN_SOURCES[group as RunSourceGroup].includes(
+                source as LogSources,
+              ),
+            )
+            .reduce((acc, [_, count]) => acc + count, 0)
+
+          const selected = value === (group as RunSourceGroup)
+
+          return {
+            value: group as RunSourceGroup,
+            label,
+            icon: (
+              <div
+                className={cn(
+                  'flex items-center justify-center w-6 h-6 rounded-full',
+                  {
+                    [colors.backgrounds[backgroundColor]]: selected,
+                  },
+                )}
+              >
+                <Icon
+                  name={icon}
+                  color={selected ? foregroundColor : 'foregroundMuted'}
+                />
+              </div>
+            ),
+            suffix:
+              count > 0 ? (
+                <Badge shape='rounded' variant='noBorderMuted' ellipsis noWrap>
+                  <div className='flex items-center justify-center gap-1'>
+                    <Icon
+                      name='loader'
+                      color='foregroundMuted'
+                      size='small'
+                      className='animate-spin'
+                    />
+                    {formatCount(count)}
+                  </div>
+                </Badge>
+              ) : undefined,
+          }
+        },
+      ),
+    [countBySource, value],
+  )
+
+  return (
+    <TabSelect
+      value={value}
+      name='source'
+      options={options}
+      onChange={onChange}
+    />
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/index.tsx
@@ -3,20 +3,28 @@
 import { RealtimeToggle } from '$/components/RealtimeToggle'
 import { LogicTablePaginationFooter } from '$/components/TablePaginationFooter/LogicTablePaginationFooter'
 import { useActiveRuns } from '$/stores/runs/activeRuns'
-import { ActiveRun, CompletedRun, Run } from '@latitude-data/constants'
+import {
+  ActiveRun,
+  CompletedRun,
+  LogSources,
+  Run,
+  RunSourceGroup,
+} from '@latitude-data/constants'
 import { Pagination } from '@latitude-data/core/helpers'
 import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { RunsListItem } from './Item'
+import { RunSourceSelector } from './SourceSelector'
 
 type RunsProps<R extends Run> = {
   runs: R[]
   search: Pagination
   setSearch: (search: Pagination) => void
   next: number
-  count: number
   isLoading?: boolean
+  countBySource?: Record<LogSources, number>
+  totalCount?: number
 }
 
 export function RunsList({
@@ -28,6 +36,8 @@ export function RunsList({
   isStoppingRun,
   realtime,
   setRealtime,
+  sourceGroup,
+  setSourceGroup,
 }: {
   active: RunsProps<ActiveRun>
   completed: RunsProps<CompletedRun>
@@ -37,6 +47,8 @@ export function RunsList({
   isStoppingRun: boolean
   realtime: boolean
   setRealtime: (realtime: boolean) => void
+  sourceGroup: RunSourceGroup
+  setSourceGroup: (sourceGroup: RunSourceGroup) => void
 }) {
   const timerRef = useRef<number | null>(null)
   const [timerNow, setTimerNow] = useState<number>(0)
@@ -72,7 +84,14 @@ export function RunsList({
             <Text.H4M>In progress</Text.H4M>
             <Text.H6 color='foregroundMuted'>Runs currently processing</Text.H6>
           </div>
-          <RealtimeToggle enabled={realtime} setEnabled={setRealtime} />
+          <div className='flex flex-row items-center gap-4'>
+            <RunSourceSelector
+              value={sourceGroup}
+              setValue={setSourceGroup}
+              countBySource={active.countBySource}
+            />
+            <RealtimeToggle enabled={realtime} setEnabled={setRealtime} />
+          </div>
         </div>
         {active.isLoading ? (
           <div className='w-full h-full flex items-center justify-center gap-2 py-9 px-4 border border-border border-dashed rounded-xl'>
@@ -103,7 +122,7 @@ export function RunsList({
                 <LogicTablePaginationFooter
                   page={active.search.page ?? 1}
                   pageSize={active.search.pageSize ?? 25}
-                  count={active.count ?? 0}
+                  count={active.totalCount ?? 0}
                   countLabel={(count) => `${count} runs`}
                   onPageChange={(page) =>
                     active.setSearch({ ...active.search, page })
@@ -152,7 +171,7 @@ export function RunsList({
                 <LogicTablePaginationFooter
                   page={completed.search.page ?? 1}
                   pageSize={completed.search.pageSize ?? 25}
-                  count={completed.count ?? 0}
+                  count={completed.totalCount ?? 0}
                   countLabel={(count) => `${count} runs`}
                   onPageChange={(page) =>
                     completed.setSearch({ ...completed.search, page })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/page.tsx
@@ -5,7 +5,10 @@ import {
   listActiveRunsCached,
   listCompletedRunsCached,
 } from '$/app/(private)/_data-access'
-import { LIMITED_VIEW_THRESHOLD } from '@latitude-data/core/constants'
+import {
+  LIMITED_VIEW_THRESHOLD,
+  RunSourceGroup,
+} from '@latitude-data/core/constants'
 import { QueryParams } from '@latitude-data/core/lib/pagination/buildPaginatedUrl'
 import { RunsPage as ClientRunsPage } from './_components/RunsPage'
 
@@ -17,21 +20,30 @@ export default async function RunsPage({
   searchParams: Promise<QueryParams>
 }) {
   const { projectId: _projectId } = await params
-  const { activePage, activePageSize, completedPage, completedPageSize } =
-    await searchParams
+  const {
+    activePage,
+    activePageSize,
+    sourceGroup,
+    completedPage,
+    completedPageSize,
+  } = await searchParams
+
+  const defaultSourceGroup = RunSourceGroup.Production
 
   const projectId = Number(_projectId)
   const activeSearch = {
     page: activePage ? Number(activePage) : undefined,
     pageSize: activePageSize ? Number(activePageSize) : undefined,
+    sourceGroup: (sourceGroup as RunSourceGroup) ?? defaultSourceGroup,
   }
   const completedSearch = {
     page: completedPage ? Number(completedPage) : undefined,
     pageSize: completedPageSize ? Number(completedPageSize) : undefined,
+    sourceGroup: (sourceGroup as RunSourceGroup) ?? defaultSourceGroup,
   }
 
-  const activeRuns = await listActiveRunsCached({ projectId, ...activeSearch}) // prettier-ignore
-  const completedRuns = await listCompletedRunsCached({ projectId, ...completedSearch}) // prettier-ignore
+  const activeRuns = await listActiveRunsCached({ projectId, ...activeSearch }) // prettier-ignore
+  const completedRuns = await listCompletedRunsCached({ projectId, ...completedSearch }) // prettier-ignore
 
   let limitedView = undefined
   const approximatedCount = await getDocumentLogsApproximatedCountByProjectCached(projectId) // prettier-ignore
@@ -44,6 +56,7 @@ export default async function RunsPage({
       active={{ runs: activeRuns, search: activeSearch }}
       completed={{ runs: completedRuns, search: completedSearch }}
       limitedView={limitedView}
+      defaultSourceGroup={(sourceGroup as RunSourceGroup) ?? defaultSourceGroup}
     />
   )
 }

--- a/apps/web/src/app/api/projects/[projectId]/runs/active/count/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/runs/active/count/route.ts
@@ -22,9 +22,11 @@ export const GET = errorHandler(
       const { projectId } = params
 
       const repository = new RunsRepository(workspace.id, projectId)
-      const count = await repository.countActive().then((r) => r.unwrap())
+      const countBySource = await repository
+        .countActiveBySource()
+        .then((r) => r.unwrap())
 
-      return NextResponse.json({ count }, { status: 200 })
+      return NextResponse.json({ countBySource }, { status: 200 })
     },
   ),
 )

--- a/apps/web/src/app/api/projects/[projectId]/runs/active/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/runs/active/route.ts
@@ -1,6 +1,7 @@
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 
+import { RunSourceGroup } from '@latitude-data/constants'
 import { RunsRepository } from '@latitude-data/core/repositories'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { NextRequest, NextResponse } from 'next/server'
@@ -20,15 +21,19 @@ export const GET = errorHandler(
       },
     ) => {
       const { projectId } = params
-      const { page, pageSize } = Object.fromEntries(
-        request.nextUrl.searchParams.entries(),
-      )
+      const searchParams = request.nextUrl.searchParams
+      const page = searchParams.get('page')
+      const pageSize = searchParams.get('pageSize')
+      const sourceGroup = searchParams.get('sourceGroup') as
+        | RunSourceGroup
+        | undefined
 
       const repository = new RunsRepository(workspace.id, projectId)
       const runs = await repository
         .listActive({
           page: page ? Number(page) : undefined,
           pageSize: pageSize ? Number(pageSize) : undefined,
+          sourceGroup,
         })
         .then((r) => r.unwrap())
 

--- a/apps/web/src/app/api/projects/[projectId]/runs/completed/count/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/runs/completed/count/route.ts
@@ -22,9 +22,11 @@ export const GET = errorHandler(
       const { projectId } = params
 
       const repository = new RunsRepository(workspace.id, projectId)
-      const count = await repository.countCompleted().then((r) => r.unwrap())
+      const countBySource = await repository
+        .countCompletedBySource()
+        .then((r) => r.unwrap())
 
-      return NextResponse.json({ count }, { status: 200 })
+      return NextResponse.json({ countBySource }, { status: 200 })
     },
   ),
 )

--- a/apps/web/src/app/api/projects/[projectId]/runs/completed/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/runs/completed/route.ts
@@ -1,6 +1,7 @@
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 
+import { RunSourceGroup } from '@latitude-data/constants'
 import { RunsRepository } from '@latitude-data/core/repositories'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { NextRequest, NextResponse } from 'next/server'
@@ -20,15 +21,19 @@ export const GET = errorHandler(
       },
     ) => {
       const { projectId } = params
-      const { page, pageSize } = Object.fromEntries(
-        request.nextUrl.searchParams.entries(),
-      )
+      const searchParams = request.nextUrl.searchParams
+      const page = searchParams.get('page')
+      const pageSize = searchParams.get('pageSize')
+      const sourceGroup = searchParams.get('sourceGroup') as
+        | RunSourceGroup
+        | undefined
 
       const repository = new RunsRepository(workspace.id, projectId)
       const runs = await repository
         .listCompleted({
           page: page ? Number(page) : undefined,
           pageSize: pageSize ? Number(pageSize) : undefined,
+          sourceGroup,
         })
         .then((r) => r.unwrap())
 

--- a/apps/web/src/components/ChatWrapper/Message/Content/Text.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/Text.tsx
@@ -46,7 +46,8 @@ const ContentText = memo(
       <TextComponent
         color={color}
         whiteSpace='preWrap'
-        wordBreak='breakAll'
+        wordBreak='breakWord'
+        ellipsis
         key={`${index}-group-${groupIndex}`}
       >
         {group.length > 0

--- a/apps/web/src/components/ChatWrapper/Message/UserMessage.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/UserMessage.tsx
@@ -19,6 +19,7 @@ export function UserMessage({
         className={cn(
           'flex flex-col gap-1 items-start',
           'px-4 py-3 bg-primary-muted rounded-2xl',
+          'max-w-full overflow-hidden',
           {
             'animate-pulse': animatePulse,
           },

--- a/packages/constants/src/runs.ts
+++ b/packages/constants/src/runs.ts
@@ -40,3 +40,21 @@ export const ACTIVE_RUN_CACHE_TTL = 1 * 3 * 60 * 60 * 1000 // 3 hours
 export const ACTIVE_RUN_STREAM_KEY = (runUuid: string) =>
   `run:active:${runUuid}:stream`
 export const ACTIVE_RUN_STREAM_CAP = 100_000
+
+export enum RunSourceGroup {
+  Production = 'production',
+  Playground = 'playground',
+}
+
+export const RUN_SOURCES: Record<RunSourceGroup, LogSources[]> = {
+  [RunSourceGroup.Production]: [
+    LogSources.API,
+    LogSources.Copilot,
+    LogSources.EmailTrigger,
+    LogSources.IntegrationTrigger,
+    LogSources.ScheduledTrigger,
+    LogSources.SharedPrompt,
+    LogSources.User,
+  ],
+  [RunSourceGroup.Playground]: [LogSources.Playground, LogSources.Experiment],
+} as const

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -153,6 +153,7 @@ import {
   SquareDashed,
   Brush,
   ShieldAlertIcon,
+  FlaskConical,
 } from 'lucide-react'
 import { MouseEvent } from 'react'
 
@@ -306,6 +307,7 @@ const Icons = {
   intercom: Intercom,
   intercomChat: IntercomChat,
   jira: Jira,
+  lab: FlaskConical,
   letterText: LetterText,
   lightBulb: Lightbulb,
   linear: Linear,

--- a/packages/web-ui/src/ds/molecules/TabSelect/index.tsx
+++ b/packages/web-ui/src/ds/molecules/TabSelect/index.tsx
@@ -21,6 +21,7 @@ export type TabSelectOption<V extends unknown = unknown> = {
   label: string
   value: V
   icon?: ReactNode | IconName
+  suffix?: ReactNode
 }
 
 export function TabSelect<V extends unknown = unknown>({
@@ -182,6 +183,7 @@ export function TabSelect<V extends unknown = unknown>({
                         {option.label}
                       </span>
                     </Text.H5M>
+                    {option.suffix}
                   </span>
                 </Button>
               </div>


### PR DESCRIPTION
New Tab filters in "Runs", to group "Production" runs (API, SDK, Triggers...) and "Playground" runs (Playground, Experiments...)

<img width="1129" height="639" alt="image" src="https://github.com/user-attachments/assets/41e0b58f-7e16-4f0a-950f-f4b24dfcc3d1" />
