### PR TITLE
Fix: Getting Stuck with Latte panel being too large

### DIFF
--- a/apps/web/src/components/LatteSidebar/LatteLayout/index.tsx
+++ b/apps/web/src/components/LatteSidebar/LatteLayout/index.tsx
@@ -32,12 +32,21 @@ const MIN_WIDTH = 400
 function LatteLayoutContent({
   initialThreadUuid,
   initialProviderLog,
+  containerRef,
 }: {
   initialThreadUuid?: string
   initialProviderLog?: ProviderLogDto
+  containerRef?: RefObject<HTMLDivElement | null>
 }) {
-  const { isOpen, setIsOpen, localWidth, setWidth, inputRef } =
-    useLatteSidebar()
+  const {
+    isOpen,
+    setIsOpen,
+    localWidth,
+    width,
+    setWidth,
+    setLocalWidth,
+    inputRef,
+  } = useLatteSidebar()
 
   const openBadgeRef = useRef<HTMLDivElement>(null)
   const sidebarRef = useRef<HTMLDivElement>(null)
@@ -70,6 +79,27 @@ function LatteLayoutContent({
       openBadge.removeEventListener('mouseleave', onMouseLeave)
     }
   }, [])
+
+  useEffect(() => {
+    if (!containerRef?.current) return
+    const container = containerRef.current
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const containerWidth = entry.contentRect.width
+        if (width > containerWidth) {
+          setWidth(containerWidth)
+          setLocalWidth(containerWidth)
+        }
+      }
+    })
+
+    resizeObserver.observe(container)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
+  }, [width, setLocalWidth, setWidth, containerRef])
 
   return (
     <>
@@ -181,13 +211,19 @@ export function LatteLayout({
   initialThreadUuid?: string
   initialProviderLog?: ProviderLogDto
 }) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
   return (
     <LatteLayoutProvider>
-      <div className='w-full h-full relative overflow-hidden pr-6'>
+      <div
+        className='w-full h-full relative overflow-hidden pr-6'
+        ref={containerRef}
+      >
         {children}
         <LatteLayoutContent
           initialThreadUuid={initialThreadUuid}
           initialProviderLog={initialProviderLog}
+          containerRef={containerRef}
         />
       </div>
     </LatteLayoutProvider>


### PR DESCRIPTION
You can change Latte's sidebar width to your desired size, and it will be stored in LocalStorage. However, this change can only be made from the edge of the sidebar.

When switching to a smaller screen, issues may arise if the previously set sidebar width exceeds the new screen size. In such cases, the sidebar overflows, making it impossible to access the edge and adjust its size.

To resolve this issue, the sidebar now adapts automatically to the screen width. As you move to a smaller screen, the sidebar will shrink accordingly, ensuring it remains accessible and adjustable.