### PR TITLE
Redirect onboarding to playground runs

### DIFF
--- a/apps/web/src/actions/workspaceOnboarding/complete.ts
+++ b/apps/web/src/actions/workspaceOnboarding/complete.ts
@@ -8,6 +8,7 @@ import { ROUTES } from '$/services/routes'
 import { z } from 'zod'
 import { isFeatureEnabledByName } from '@latitude-data/core/services/workspaceFeatures/isFeatureEnabledByName'
 import { Result } from '@latitude-data/core/lib/Result'
+import { RunSourceGroup } from '@latitude-data/core/constants'
 
 /**
  * Mark onboarding as complete
@@ -56,7 +57,10 @@ export const completeOnboardingAction = authProcedure
       return frontendRedirect(
         ROUTES.projects
           .detail({ id: projectId })
-          .commits.detail({ uuid: commitUuid }).runs.root,
+          .commits.detail({ uuid: commitUuid })
+          .runs.root({
+            sourceGroup: RunSourceGroup.Playground,
+          }),
       )
     }
 

--- a/apps/web/src/app/(onboarding)/onboarding-dataset/paste-your-prompt/_components/PasteYourPrompt/index.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding-dataset/paste-your-prompt/_components/PasteYourPrompt/index.tsx
@@ -13,7 +13,12 @@ import { fromAstToBlocks } from '$/components/BlocksEditor/Editor/state/promptlT
 import { useDatasetOnboarding } from '$/app/(onboarding)/onboarding-dataset/datasetOnboarding'
 import { ROUTES } from '$/services/routes'
 import { useNavigate } from '$/hooks/useNavigate'
-import { SAMPLE_PROMPT, DEFAULT_PROMPT_CONFIGURATION } from '../../constants'
+import {
+  SAMPLE_PROMPT,
+  DEFAULT_PROMPT_CONFIGURATION,
+  DEFAULT_PARAMETER_NAME,
+  DEFAULT_DATASET_NAME,
+} from '../../constants'
 import { toast } from 'node_modules/@latitude-data/web-ui/src/ds/atoms/Toast/useToast'
 
 export function PasteYourPromptBody() {
@@ -40,7 +45,8 @@ export function PasteYourPromptBody() {
 
     // We need max speed here, so we don't want to use the useMetadata hook to get the metadata.ast or parameters
     const metadata = await scan({ prompt: value })
-    if (Object.keys(metadata.config).length === 0) {
+    const noConfiguration = Object.keys(metadata.config).length === 0
+    if (noConfiguration) {
       const promptWithConfiguration = DEFAULT_PROMPT_CONFIGURATION + value
       const metadataWithConfiguration = await scan({
         prompt: promptWithConfiguration,
@@ -56,16 +62,15 @@ export function PasteYourPromptBody() {
       setInitialValue(fromAstToBlocks({ ast: metadata.ast, prompt: value }))
     }
 
-    // If the user doesnt add any parameters, we default to 'message'
     const documentParameters =
       Array.from(metadata.parameters).length > 0
         ? Array.from(metadata.parameters)
-        : ['message']
+        : [DEFAULT_PARAMETER_NAME]
     setDocumentParameters(documentParameters)
 
     const latestDatasetName = datasets?.[datasets.length - 1]
-      ? `Dataset Onboarding ${datasets.length}`
-      : 'Dataset Onboarding'
+      ? `${DEFAULT_DATASET_NAME} ${datasets.length}`
+      : DEFAULT_DATASET_NAME
     setLatestDatasetName(latestDatasetName)
 
     runGenerateOnboardingAction({

--- a/apps/web/src/app/(onboarding)/onboarding-dataset/paste-your-prompt/constants.ts
+++ b/apps/web/src/app/(onboarding)/onboarding-dataset/paste-your-prompt/constants.ts
@@ -10,6 +10,10 @@ export type SamplePromptParameters = Record<
   string | number
 >
 
+const DEFAULT_PARAMETER_NAME = 'message'
+
+const DEFAULT_DATASET_NAME = 'Dataset Onboarding'
+
 const DEFAULT_PROMPT_CONFIGURATION = `
 ---
 provider: ${envClient.NEXT_PUBLIC_DEFAULT_PROVIDER_NAME}
@@ -103,4 +107,6 @@ export {
   SAMPLE_PROMPT_DATASET,
   SAMPLE_PROMPT,
   DEFAULT_PROMPT_CONFIGURATION,
+  DEFAULT_DATASET_NAME,
+  DEFAULT_PARAMETER_NAME,
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ProjectSection/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ProjectSection/index.tsx
@@ -116,7 +116,8 @@ export default function ProjectSection({
           label: 'Runs',
           route: ROUTES.projects
             .detail({ id: project.id })
-            .commits.detail({ uuid: commit.uuid }).runs.root,
+            .commits.detail({ uuid: commit.uuid })
+            .runs.root(),
           iconName: 'logs',
           notifications: {
             count: disableRunsNotifications ? 0 : activeCount,

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsPage.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsPage.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
+import { useCurrentCommit } from '$/app/providers/CommitProvider'
+import { ROUTES } from '$/services/routes'
 import { useActiveRuns, useActiveRunsCount } from '$/stores/runs/activeRuns'
 import {
   useCompletedRuns,
@@ -84,6 +86,7 @@ export function RunsPage({
   defaultSourceGroup: RunSourceGroup
 }) {
   const { project } = useCurrentProject()
+  const { commit } = useCurrentCommit()
 
   const [sourceGroup, setSourceGroup] =
     useState<RunSourceGroup>(defaultSourceGroup)
@@ -108,21 +111,28 @@ export function RunsPage({
   })
 
   useEffect(() => {
-    const currentUrl = window.location.origin + window.location.pathname
+    const runsRoute = ROUTES.projects
+      .detail({ id: project.id })
+      .commits.detail({ uuid: commit.uuid })
+      .runs.root({
+        activePage: debouncedActiveSearch.page,
+        activePageSize: debouncedActiveSearch.pageSize,
+        completedPage: debouncedCompletedSearch.page,
+        completedPageSize: debouncedCompletedSearch.pageSize,
+        sourceGroup: debouncedSourceGroup,
+      })
 
-    const params = new URLSearchParams()
-    if (debouncedActiveSearch.page) params.set('activePage', String(debouncedActiveSearch.page)) // prettier-ignore
-    if (debouncedActiveSearch.pageSize) params.set('activePageSize', String(debouncedActiveSearch.pageSize)) // prettier-ignore
-    if (debouncedCompletedSearch.page) params.set('completedPage', String(debouncedCompletedSearch.page)) // prettier-ignore
-    if (debouncedCompletedSearch.pageSize) params.set('completedPageSize', String(debouncedCompletedSearch.pageSize)) // prettier-ignore
-    if (debouncedSourceGroup) params.set('sourceGroup', String(debouncedSourceGroup)) // prettier-ignore
-    const queryParams = params.toString()
-
-    const targetUrl = `${currentUrl}${queryParams ? `?${queryParams}` : ''}`
+    const targetUrl = `${window.location.origin}${runsRoute}`
     if (targetUrl !== window.location.href) {
-      window.history.replaceState(null, '', targetUrl)
+      window.history.replaceState(null, '', runsRoute)
     }
-  }, [debouncedActiveSearch, debouncedCompletedSearch, debouncedSourceGroup])
+  }, [
+    project.id,
+    commit.uuid,
+    debouncedActiveSearch,
+    debouncedCompletedSearch,
+    debouncedSourceGroup,
+  ])
 
   const [realtime, setRealtime] = useState(!limitedView)
 

--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -253,7 +253,26 @@ export const ROUTES = {
                 },
               },
               runs: {
-                root: `${root}/runs`,
+                root: (params?: {
+                  activePage?: number
+                  activePageSize?: number
+                  sourceGroup?: string
+                  completedPage?: number
+                  completedPageSize?: number
+                }) => {
+                  const base = `${root}/runs`
+                  if (!params) return base
+
+                  const searchParams = new URLSearchParams()
+                  if (params.activePage !== undefined) searchParams.set('activePage', String(params.activePage)) // prettier-ignore
+                  if (params.activePageSize !== undefined) searchParams.set('activePageSize', String(params.activePageSize)) // prettier-ignore
+                  if (params.sourceGroup !== undefined) searchParams.set('sourceGroup', params.sourceGroup) // prettier-ignore
+                  if (params.completedPage !== undefined) searchParams.set('completedPage', String(params.completedPage)) // prettier-ignore
+                  if (params.completedPageSize !== undefined) searchParams.set('completedPageSize', String(params.completedPageSize)) // prettier-ignore
+
+                  const query = searchParams.toString()
+                  return query ? `${base}?${query}` : base
+                },
                 detail: ({ uuid }: { uuid: string }) => ({
                   root: `${root}/runs/${uuid}`,
                 }),


### PR DESCRIPTION
With the new addition of the Playground/Production runs, we are redirecting the onboarding users to the runs page and they see no logs, as they are in the Playground tab.

<img width="1714" height="1080" alt="image" src="https://github.com/user-attachments/assets/2b069ac2-7143-4724-96c3-6ab9cbd22ce4" />


This PR redirects users to the playground tab