### PR TITLE
Get analytics from annotations and nicer annotation icon on runs

### DIFF
--- a/apps/web/src/actions/evaluationsV2/annotate.ts
+++ b/apps/web/src/actions/evaluationsV2/annotate.ts
@@ -47,6 +47,7 @@ export const annotateEvaluationV2Action = withEvaluation
       span: { ...span, metadata } as SpanWithDetails<SpanType.Prompt>,
       commit: ctx.commit,
       workspace: ctx.workspace,
+      currentUser: ctx.user,
     }).then((r) => r.unwrap())
 
     return result

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunsList/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { RealtimeToggle } from '$/components/RealtimeToggle'
 import { LogicTablePaginationFooter } from '$/components/TablePaginationFooter/LogicTablePaginationFooter'
 import { SimpleKeysetTablePaginationFooter } from '$/components/TablePaginationFooter/SimpleKeysetTablePaginationFooter'

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -454,11 +454,13 @@ export type EvaluationV2AnnotatedEvent = LatitudeEventGeneric<
   'evaluationV2Annotated',
   {
     workspaceId: number
+    isNew: boolean
     evaluation: EvaluationV2
     result: EvaluationResultV2
     commit: Commit
     spanId: string
     traceId: string
+    userEmail?: string | null
   }
 >
 


### PR DESCRIPTION
# What
☝️ Handle product feedback on the issues dashboard

## TODO
- [x] Display thumbs up and down in runs table
- [x] Add to analytics annotate event

