### PR TITLE
Align lock duration to backgroundJob potential timeout

### DIFF
--- a/apps/workers/src/workers/worker-definitions/runsWorker.ts
+++ b/apps/workers/src/workers/worker-definitions/runsWorker.ts
@@ -1,5 +1,6 @@
 import * as jobs from '@latitude-data/core/jobs/definitions'
 import { Queues } from '@latitude-data/core/queues/types'
+import { env } from '@latitude-data/env'
 import { WORKER_CONNECTION_CONFIG } from '../utils/connectionConfig'
 import { createWorker } from '../utils/createWorker'
 
@@ -8,8 +9,12 @@ const jobMappings = {
 }
 
 export function startRunsWorker() {
+  // Set lockDuration to account for stream processing (10min), additional processing after streaming (experiment handling, cleanup, etc.), and a safety buffer.
+  const lockDuration = Math.round(env.KEEP_ALIVE_TIMEOUT * 1.5) // 15 minutes total
+
   return createWorker(Queues.runsQueue, jobMappings, {
     concurrency: 100,
     connection: WORKER_CONNECTION_CONFIG,
+    lockDuration,
   })
 }


### PR DESCRIPTION
We have a grace period of streaming processing in the backgroundJob of 10 minutes, but were using the default BullMQ lock duration of 30 seconds. 

So if a backgroundJob takes 5 minutes, after 30 it gets considered stalled in BullMQ and moves to waiting for another worker to get it. In the meantime, its still executing, and if another worker later on gets it, it will start executing the job again, creating potential duplicates. 

To solve this, we can match the lock duration of the runs queue to the grace period of streaming, plus an additional buffer for post processing (if its an experiment, etc.).