### PR TITLE
fix: Running prompts with custom tools from SDK and API

### DIFF
--- a/apps/gateway/src/routes/api/v3/conversations/chat/chat.handler.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/chat/chat.handler.ts
@@ -11,6 +11,7 @@ import { BACKGROUND, telemetry } from '@latitude-data/core/telemetry'
 import { streamSSE } from 'hono/streaming'
 import { LogSources } from '@latitude-data/core/constants'
 import { ProviderApiKeysRepository } from '@latitude-data/core/repositories'
+import { BadRequestError } from '@latitude-data/constants/errors'
 
 // @ts-expect-error: streamSSE has type issues
 export const chatHandler: AppRouteHandler<ChatRoute> = async (c) => {
@@ -23,6 +24,10 @@ export const chatHandler: AppRouteHandler<ChatRoute> = async (c) => {
     __internal,
   } = c.req.valid('json')
   const workspace = c.get('workspace')
+
+  if (tools.length > 0 && !useSSE) {
+    throw new BadRequestError('You must enable Stream to use custom tools')
+  }
 
   const result = (
     await addMessages({

--- a/packages/core/src/lib/streamManager/defaultStreamManager.ts
+++ b/packages/core/src/lib/streamManager/defaultStreamManager.ts
@@ -58,21 +58,23 @@ export class DefaultStreamManager
   }
 
   async step(): Promise<void> {
-    this.setMessages(this.messages)
-    this.startStep()
-    this.startProviderStep({
-      config: this.config,
-      messages: this.messages,
-      provider: this.provider,
-    })
-
-    const toolsBySource = await this.getToolsBySource().then((r) => r.unwrap())
-    const config = this.transformPromptlToVercelToolDeclarations(
-      applyAgentRule(this.config),
-      toolsBySource,
-    )
-
     try {
+      this.setMessages(this.messages)
+      this.startStep()
+      this.startProviderStep({
+        config: this.config,
+        messages: this.messages,
+        provider: this.provider,
+      })
+
+      const toolsBySource = await this.getToolsBySource().then((r) =>
+        r.unwrap(),
+      )
+      const config = this.transformPromptlToVercelToolDeclarations(
+        applyAgentRule(this.config),
+        toolsBySource,
+      )
+
       const { response, messages, tokenUsage, finishReason } =
         await streamAIResponse({
           config,

--- a/packages/sdks/python/pyproject.toml
+++ b/packages/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-sdk"
-version = "5.3.0"
+version = "5.3.1"
 description = "Latitude SDK for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/sdks/python/src/latitude_sdk/sdk/prompts.py
+++ b/packages/sdks/python/src/latitude_sdk/sdk/prompts.py
@@ -198,7 +198,7 @@ class Prompts:
                     path=path,
                     parameters=options.parameters,
                     custom_identifier=options.custom_identifier,
-                    tools=list(options.tools.keys()) if options.tools and options.stream else None,
+                    tools=list(options.tools.keys()) if options.tools else None,
                     stream=options.stream,
                     background=options.background,
                 ),
@@ -247,7 +247,7 @@ class Prompts:
                 ),
                 body=ChatPromptRequestBody(
                     messages=messages,
-                    tools=list(options.tools.keys()) if options.tools and options.stream else None,
+                    tools=list(options.tools.keys()) if options.tools else None,
                     stream=options.stream,
                 ),
                 stream=options.stream,

--- a/packages/sdks/python/tests/prompts/chat_test.py
+++ b/packages/sdks/python/tests/prompts/chat_test.py
@@ -79,6 +79,7 @@ class TestChatPromptSync(TestCase):
             endpoint=chat_endpoint,
             body={
                 "messages": [json.loads(message.model_dump_json()) for message in messages],
+                "tools": list((options.tools or {}).keys()),
                 "stream": options.stream,
             },
         )

--- a/packages/sdks/python/tests/prompts/run_test.py
+++ b/packages/sdks/python/tests/prompts/run_test.py
@@ -170,6 +170,7 @@ class TestRunPromptSync(TestCase):
                 "path": path,
                 "customIdentifier": options.custom_identifier,
                 "parameters": options.parameters,
+                "tools": list((options.tools or {}).keys()),
                 "stream": options.stream,
                 "background": options.background,
             },

--- a/packages/sdks/typescript/CHANGELOG.md
+++ b/packages/sdks/typescript/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.2] - 2025-11-13
+
+- Fixed `prompts.chat()` method was not including custom tools in the request
+
 ## [5.2.1] - 2025-10-15
 
 - Exports MessageRole enum instead of the type only

--- a/packages/sdks/typescript/package.json
+++ b/packages/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/sdk",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Latitude SDK for Typescript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/sdks/typescript/src/tests/run.test.ts
+++ b/packages/sdks/typescript/src/tests/run.test.ts
@@ -173,6 +173,36 @@ describe('/run', () => {
     )
 
     it(
+      'sends tools names in request body when provided',
+      server.boundary(async () => {
+        const { mockBody } = mockRequest({
+          server,
+          apiVersion: 'v3',
+          version: 'SOME_UUID',
+          projectId: '123',
+        })
+        await sdk.prompts.run('path/to/document', {
+          projectId,
+          versionUuid: 'SOME_UUID',
+          parameters: { foo: 'bar' },
+          tools: {
+            get_weather: async () => 'sunny',
+            get_time: async () => '12:00',
+          },
+          stream: true,
+        })
+        expect(mockBody).toHaveBeenCalledWith({
+          path: 'path/to/document',
+          parameters: { foo: 'bar' },
+          tools: ['get_weather', 'get_time'],
+          stream: true,
+          background: false,
+          __internal: { source: LogSources.API },
+        })
+      }),
+    )
+
+    it(
       'send data onMessage callback',
       server.boundary(async () => {
         const onMessageMock = vi.fn()
@@ -398,6 +428,37 @@ data: ${JSON.stringify({
           stream: false,
           background: false,
           tools: [],
+          __internal: { source: LogSources.API },
+        })
+      }),
+    )
+
+    it(
+      'sends tools names in request body when provided (non-streaming)',
+      server.boundary(async () => {
+        const { mockBody } = mockRequest({
+          server,
+          apiVersion: 'v3',
+          version: 'SOME_UUID',
+          projectId: '123',
+          fakeResponse: RUN_TEXT_RESPONSE,
+        })
+        await sdk.prompts.run('path/to/document', {
+          projectId,
+          versionUuid: 'SOME_UUID',
+          parameters: { foo: 'bar' },
+          tools: {
+            get_weather: async () => 'sunny',
+            get_time: async () => '12:00',
+          },
+          stream: false,
+        })
+        expect(mockBody).toHaveBeenCalledWith({
+          path: 'path/to/document',
+          parameters: { foo: 'bar' },
+          tools: ['get_weather', 'get_time'],
+          stream: false,
+          background: false,
           __internal: { source: LogSources.API },
         })
       }),

--- a/packages/sdks/typescript/src/utils/syncRun.ts
+++ b/packages/sdks/typescript/src/utils/syncRun.ts
@@ -1,5 +1,6 @@
 import { LatitudeApiError } from '$sdk/utils/errors'
 import { makeRequest } from '$sdk/utils/request'
+import { waitForTools } from '$sdk/utils/streamRun'
 import {
   GenerationResponse,
   HandlerType,
@@ -24,6 +25,7 @@ export async function syncRun<
     projectId,
     versionUuid,
     parameters,
+    tools,
     customIdentifier,
     userMessage,
     onFinished,
@@ -60,7 +62,7 @@ export async function syncRun<
       path,
       parameters,
       customIdentifier,
-      tools: [],
+      tools: waitForTools(tools),
       userMessage,
     },
   })


### PR DESCRIPTION
Fixes:
 - Running /run or /chat with custom tools and background=true did not fail.
 - Running /run or /chat endpoint with custom tools and stream=false failed with a confusing error message.
 - Running /chat with custom tools and stream=true was not working but did not show an error either.