### PR TITLE
feat: results from draft versions do not modify issue centroid

### DIFF
--- a/packages/constants/src/issues/constants.ts
+++ b/packages/constants/src/issues/constants.ts
@@ -95,6 +95,6 @@ export const ISSUE_GENERATION_CACHE_KEY = (hash: string) =>
   `issues:generations:${hash}`
 
 export const ISSUE_JOBS_MAX_ATTEMPTS = 3
-export const ISSUE_JOBS_GENERATE_DETAILS_DEBOUNCE = 6 * 60 * 60 * 1000 // 6 hours
-export const ISSUE_JOBS_MERGE_COMMON_DEBOUNCE = 24 * 60 * 60 * 1000 // 1 day
+export const ISSUE_JOBS_GENERATE_DETAILS_THROTTLE = 6 * 60 * 60 * 1000 // 6 hours
+export const ISSUE_JOBS_MERGE_COMMON_THROTTLE = 24 * 60 * 60 * 1000 // 1 day
 export const ISSUE_JOBS_DISCOVER_RESULT_DELAY = 60 * 1000 // 1 minute

--- a/packages/core/src/jobs/job-definitions/issues/mergeCommonIssuesJob.ts
+++ b/packages/core/src/jobs/job-definitions/issues/mergeCommonIssuesJob.ts
@@ -1,7 +1,7 @@
 // TODO(AO): implement this
 
 /*
-- This job is debounced (leading), only runs (with mutual exclusion) max 1 every day (THIS IS ALREADY DONE WHEN ENQUEUING THE JOB in add/remove result from issue services)
+- This job is throttled (leading), only runs (with mutual exclusion) max 1 every day (THIS IS ALREADY DONE WHEN ENQUEUING THE JOB in add/remove result from issue services)
 - Find the existing issue by id in the database. This job executing means that this issue is ongoing currently and could be deviating towards another existing issue/s.
 - Call mergeIssues service
 

--- a/packages/core/src/services/issues/results/remove.ts
+++ b/packages/core/src/services/issues/results/remove.ts
@@ -2,9 +2,10 @@ import {
   EvaluationMetric,
   EvaluationResultSuccessValue,
   EvaluationType,
-  ISSUE_JOBS_GENERATE_DETAILS_DEBOUNCE,
+  ISSUE_JOBS_GENERATE_DETAILS_THROTTLE,
   ISSUE_JOBS_MAX_ATTEMPTS,
-  ISSUE_JOBS_MERGE_COMMON_DEBOUNCE,
+  ISSUE_JOBS_MERGE_COMMON_THROTTLE,
+  IssueCentroid,
 } from '../../../constants'
 import { generateIssueDetailsJobKey } from '../../../jobs/job-definitions/issues/generateIssueDetailsJob'
 import { mergeCommonIssuesJobKey } from '../../../jobs/job-definitions/issues/mergeCommonIssuesJob'
@@ -25,11 +26,10 @@ import { deleteIssue } from '../delete'
 import { decrementIssueHistogram } from '../histograms/decrement'
 import { embedReason, updateCentroid } from '../shared'
 import { updateIssue } from '../update'
+import { containsResultsFromOtherCommits } from './add'
 import { validateResultForIssue } from './validate'
 
-// TODO(AO): IMPORTANT! Evaluation results from draft versions
-// should not modify issues that appeared in production. If the
-// issue only appeared in draft versions its okay
+// TODO(AO): Add tests
 export async function removeResultFromIssue<
   T extends EvaluationType,
   M extends EvaluationMetric<T>,
@@ -80,6 +80,17 @@ export async function removeResultFromIssue<
     embedding = embedying.value
   }
 
+  // Issue centroids' are only updated when the annotation is from a live
+  // commit, it's a new issue, or the issue has only received annotations from
+  // the same commit. This ensures the centroid is only updated when it makes
+  // sense to do it.
+  const canUpdateCentroid = commit.mergedAt
+    ? true
+    : !(await containsResultsFromOtherCommits({
+        issue,
+        commitId: result.commitId,
+      }))
+
   return await transaction.call(
     async (tx) => {
       const issuesRepository = new IssuesRepository(workspace.id, tx)
@@ -107,12 +118,15 @@ export async function removeResultFromIssue<
         return Result.error(validating.error)
       }
 
-      const centroid = updateCentroid(
-        { ...issue.centroid, updatedAt: issue.updatedAt },
-        { embedding, type: evaluation.type, createdAt: result.createdAt },
-        'remove',
-        timestamp,
-      )
+      let centroid: IssueCentroid | undefined
+      if (canUpdateCentroid) {
+        centroid = updateCentroid(
+          { ...issue.centroid, updatedAt: issue.updatedAt },
+          { embedding, type: evaluation.type, createdAt: result.createdAt },
+          'remove',
+          timestamp,
+        )
+      }
 
       const updatingre = await updateEvaluationResultV2(
         { issue: null, result, commit, workspace },
@@ -169,7 +183,7 @@ export async function removeResultFromIssue<
           attempts: ISSUE_JOBS_MAX_ATTEMPTS,
           deduplication: {
             id: generateIssueDetailsJobKey(payload),
-            ttl: ISSUE_JOBS_GENERATE_DETAILS_DEBOUNCE,
+            ttl: ISSUE_JOBS_GENERATE_DETAILS_THROTTLE,
           },
         })
 
@@ -177,7 +191,7 @@ export async function removeResultFromIssue<
           attempts: ISSUE_JOBS_MAX_ATTEMPTS,
           deduplication: {
             id: mergeCommonIssuesJobKey(payload),
-            ttl: ISSUE_JOBS_MERGE_COMMON_DEBOUNCE,
+            ttl: ISSUE_JOBS_MERGE_COMMON_THROTTLE,
           },
         })
       }


### PR DESCRIPTION
This will keep results assigned to the proper issue but ensure we don't add noise to the issue's centroid.