### PR TITLE
Added an optional generic type to API routes to enforce the return type

### DIFF
--- a/apps/web/src/app/api/projects/[projectId]/runs/completed/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/runs/completed/route.ts
@@ -1,12 +1,16 @@
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 
-import { RunSourceGroup, SpanType } from '@latitude-data/constants'
+import {
+  CompletedRun,
+  RunSourceGroup,
+  SpanType,
+} from '@latitude-data/constants'
 import { listCompletedRuns } from '@latitude-data/core/services/runs/completed/listCompleted'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { NextRequest, NextResponse } from 'next/server'
 
-export const GET = errorHandler(
+export const GET = errorHandler<CompletedRun[]>(
   authHandler(
     async (
       request: NextRequest,
@@ -43,7 +47,7 @@ export const GET = errorHandler(
         next: runs.next ? JSON.stringify(runs.next) : null,
       }
 
-      return NextResponse.json(response, { status: 200 })
+      return NextResponse.json(response.items, { status: 200 })
     },
   ),
 )

--- a/apps/web/src/middlewares/adminHandler.ts
+++ b/apps/web/src/middlewares/adminHandler.ts
@@ -1,8 +1,9 @@
 import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
 import { notFound } from 'next/navigation'
 import { NextRequest } from 'next/server'
+import { RouteHandler } from './types'
 
-export function adminHandler(handler: any) {
+export function adminHandler<T>(handler: RouteHandler<T>) {
   return async (
     req: NextRequest,
     { params, ...rest }: { params?: Promise<Record<string, string>> } = {},

--- a/apps/web/src/middlewares/authHandler.ts
+++ b/apps/web/src/middlewares/authHandler.ts
@@ -1,7 +1,8 @@
 import { getDataFromSession } from '$/data-access'
 import { NextRequest, NextResponse } from 'next/server'
+import { RouteHandler } from './types'
 
-export function authHandler(handler: any) {
+export function authHandler<T>(handler: RouteHandler<T>) {
   return async (
     req: NextRequest,
     {

--- a/apps/web/src/middlewares/errorHandler.ts
+++ b/apps/web/src/middlewares/errorHandler.ts
@@ -3,6 +3,7 @@ import { env } from '@latitude-data/env'
 import { captureException } from '$/helpers/captureException'
 import { NextRequest, NextResponse } from 'next/server'
 import debug from '@latitude-data/core/lib/debug'
+import { RouteHandler } from './types'
 
 interface AbortError extends DOMException {
   name: 'AbortError'
@@ -18,7 +19,7 @@ export function isAbortError(error: unknown): error is AbortError {
   )
 }
 
-export function errorHandler(handler: any) {
+export function errorHandler<T>(handler: RouteHandler<T>) {
   const isDev = env.NODE_ENV === 'development'
   return async (req: NextRequest, res: any) => {
     try {

--- a/apps/web/src/middlewares/types.ts
+++ b/apps/web/src/middlewares/types.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+type ApiMessageResponse = {
+  message: string
+}
+
+type ApiErrorResponse = {
+  error: string
+}
+
+export type RouteHandler<T> = (
+  req: NextRequest,
+  res: any,
+) => Promise<
+  | NextResponse<T>
+  | NextResponse<ApiErrorResponse>
+  | NextResponse<ApiMessageResponse>
+>

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -399,18 +399,6 @@ export const API_ROUTES = {
           completed: {
             root: `${projectRoot}/runs/completed`,
             count: `${projectRoot}/runs/completed/count`,
-            detail: ({
-              limit,
-              sourceGroup,
-            }: {
-              limit?: number
-              sourceGroup?: RunSourceGroup
-            } = {}) => {
-              const params = new URLSearchParams()
-              if (limit) params.set('limit', limit.toString())
-              if (sourceGroup) params.set('sourceGroup', sourceGroup)
-              return `${projectRoot}/runs/completed?${params.toString()}`
-            },
           },
           detail: (uuid: string) => ({
             root: `${projectRoot}/runs/${uuid}`,

--- a/apps/web/src/stores/runs/completedRuns.ts
+++ b/apps/web/src/stores/runs/completedRuns.ts
@@ -15,6 +15,7 @@ import {
 
 import { useCallback, useMemo } from 'react'
 import useSWR, { SWRConfiguration } from 'swr'
+import { compactObject } from '@latitude-data/core/lib/compactObject'
 
 export function useCompletedRuns(
   {
@@ -32,7 +33,13 @@ export function useCompletedRuns(
   opts?: SWRConfiguration,
 ) {
   const fetcher = useFetcher<CompletedRun[]>(
-    ROUTES.api.projects.detail(project.id).runs.completed.detail(search),
+    ROUTES.api.projects.detail(project.id).runs.completed.root,
+    {
+      searchParams: compactObject({
+        limit: search?.limit ? search.limit.toString() : undefined,
+        sourceGroup: search?.sourceGroup,
+      }) as Record<string, string>,
+    },
   )
 
   const {


### PR DESCRIPTION
The returned type from an API route and the expected type from a fetcher have nothing to do and could change without warning.

Although this does not completely fix that, it does improve the type safety by adding an optional type enforcement.

Let me explain with an example:

Let's say you have a hook with the following fetcher:
```ts
const fetcher = useFetcher<CompletedRuns[]>(CUSTOM_ROUTE)
```
You are expecting the route to return a response with the `CompletedRuns[]` type.

However, if the route logic changes at any point and you forget to update all hooks that use this route, you will not notice it!

Now, you can add this same type to the route, to enforce the return!
```ts
// apps/web/src/api/.../route.ts

export const GET = errorHandler<CompletedRuns[]>(
  authHandler(
    async(...) => {
      ...
      return NextResponse.json(result, { status: 200 })
    }
  )
)
```

> [!TIP]
> You can add the generic type in any `errorHandler`, `authHandler` or `adminHandler`. You can even add it to all of them at the same time!

Now that you have added the `CompletedRuns[]` type to the handler, it will display a typecheck error if the `result` object does not match this defined type.

So now, you can improve the dev exp by using the same type both on the route definition and useFetcher implementation!