### PR TITLE
feat: fetch the last completion span from the span tree

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/EditorHeader/PromptIntegrations/IntegrationsList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/[evaluationUuid]/editor/_components/EvaluationEditor/EditorHeader/PromptIntegrations/IntegrationsList.tsx
@@ -12,6 +12,7 @@ import { integrationOptions } from '$/lib/integrationTypeOptions'
 import { BlankSlate } from '@latitude-data/web-ui/molecules/BlankSlate'
 import { useNavigate } from '$/hooks/useNavigate'
 import { IntegrationDto } from '@latitude-data/core/schema/models/types/Integration'
+import Image from 'next/image'
 
 export function IntegrationsList({
   disabled,
@@ -47,7 +48,7 @@ export function IntegrationsList({
             label,
             icon:
               icon.type === 'image' ? (
-                <img
+                <Image
                   src={icon.src}
                   alt={icon.alt}
                   width={16}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunPanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/runs/_components/RunPanel/index.tsx
@@ -32,11 +32,11 @@ import { useToolContentMap } from '@latitude-data/web-ui/hooks/useToolContentMap
 import Link from 'next/link'
 import { RunPanelStats } from './Stats'
 import { useTrace } from '$/stores/traces'
-import { findFirstSpanOfType } from '@latitude-data/core/services/tracing/spans/findFirstSpanOfType'
 import { Message } from '@latitude-data/constants/legacyCompiler'
 import { sum } from 'lodash-es'
 import { useCompletedRunsKeysetPaginationStore } from '$/stores/completedRunsKeysetPagination'
 import { useAnnotationBySpan } from '$/hooks/useAnnotationsBySpan'
+import { findLastSpanOfType } from '@latitude-data/core/services/tracing/spans/findLastSpanOfType'
 
 export function RunPanel({
   run,
@@ -98,7 +98,7 @@ function CompletedRunPanel({
   const { data: trace, isLoading: isLoadingTrace } = useTrace({
     traceId: run.span.traceId,
   })
-  const completionSpan = findFirstSpanOfType(
+  const completionSpan = findLastSpanOfType(
     trace?.children ?? [],
     SpanType.Completion,
   )

--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -14,6 +14,7 @@ import { AnnotationForms } from './AnnotationForms'
 import { TraceEvaluations } from './TraceEvaluations'
 import { MetadataInfoTabs } from '../MetadataInfoTabs'
 import { useMemo } from 'react'
+import { findLastSpanOfType } from '@latitude-data/core/services/tracing/spans/findLastSpanOfType'
 
 export const DEFAULT_TABS = [
   { label: 'Metadata', value: 'metadata' },
@@ -99,7 +100,7 @@ function TraceMetadata({
 
 function TraceMessages({ traceId }: { traceId: string | null }) {
   const { data: trace } = useTrace({ traceId })
-  const completionSpan = findFirstSpanOfType(
+  const completionSpan = findLastSpanOfType(
     trace?.children ?? [],
     SpanType.Completion,
   )

--- a/packages/core/src/services/evaluationsV2/annotate.test.ts
+++ b/packages/core/src/services/evaluationsV2/annotate.test.ts
@@ -110,8 +110,8 @@ describe('annotateEvaluationV2', () => {
     )
 
     vi.spyOn(
-      await import('../tracing/spans/findFirstSpanOfType'),
-      'findFirstSpanOfType',
+      await import('../tracing/spans/findLastSpanOfType'),
+      'findLastSpanOfType',
     ).mockReturnValue({
       id: 'completion-span-id',
       traceId: 'trace-id',
@@ -157,8 +157,8 @@ describe('annotateEvaluationV2', () => {
   it('fails when evaluating a log that does not end with an assistant message', async () => {
     // Mock the span to return a conversation that doesn't end with assistant message
     vi.spyOn(
-      await import('../tracing/spans/findFirstSpanOfType'),
-      'findFirstSpanOfType',
+      await import('../tracing/spans/findLastSpanOfType'),
+      'findLastSpanOfType',
     ).mockReturnValue({
       id: 'completion-span-id',
       traceId: 'trace-id',

--- a/packages/core/src/services/evaluationsV2/annotate.ts
+++ b/packages/core/src/services/evaluationsV2/annotate.ts
@@ -21,12 +21,12 @@ import {
 import { type Commit } from '../../schema/models/types/Commit'
 import { type Workspace } from '../../schema/models/types/Workspace'
 import { type User } from '../../schema/models/types/User'
-import { findFirstSpanOfType } from '../tracing/spans/findFirstSpanOfType'
 import { assembleTrace } from '../tracing/traces/assemble'
 import { extractActualOutput } from './outputs/extract'
 import { createEvaluationResultV2 } from './results/create'
 import { updateEvaluationResultV2 } from './results/update'
 import { EVALUATION_SPECIFICATIONS } from './specifications'
+import { findLastSpanOfType } from '../tracing/spans/findLastSpanOfType'
 
 export async function annotateEvaluationV2<
   T extends EvaluationType,
@@ -84,7 +84,7 @@ export async function annotateEvaluationV2<
     workspace,
   }).then((r) => r.value)
   if (assembledtrace) {
-    const completionSpan = findFirstSpanOfType(
+    const completionSpan = findLastSpanOfType(
       assembledtrace.trace.children,
       SpanType.Completion,
     )

--- a/packages/core/src/services/evaluationsV2/llm/binary.ts
+++ b/packages/core/src/services/evaluationsV2/llm/binary.ts
@@ -20,7 +20,7 @@ import {
 } from '../shared'
 import { buildEvaluationParameters, promptTask, runPrompt } from './shared'
 import { assembleTrace } from '../../tracing/traces/assemble'
-import { findFirstSpanOfType } from '../../tracing/spans/findFirstSpanOfType'
+import { findLastSpanOfType } from '../../tracing/spans/findLastSpanOfType'
 
 export const LlmEvaluationBinarySpecification = {
   ...specification,
@@ -163,7 +163,7 @@ async function run(
     db,
   ).then((r) => r.value)
   if (assembledtrace) {
-    completionSpan = findFirstSpanOfType(
+    completionSpan = findLastSpanOfType(
       assembledtrace.trace.children,
       SpanType.Completion,
     )

--- a/packages/core/src/services/evaluationsV2/llm/comparison.ts
+++ b/packages/core/src/services/evaluationsV2/llm/comparison.ts
@@ -20,7 +20,7 @@ import {
 } from '../shared'
 import { buildEvaluationParameters, promptTask, runPrompt } from './shared'
 import { assembleTrace } from '../../tracing/traces/assemble'
-import { findFirstSpanOfType } from '../../tracing/spans/findFirstSpanOfType'
+import { findLastSpanOfType } from '../../tracing/spans/findLastSpanOfType'
 
 export const LlmEvaluationComparisonSpecification = {
   ...specification,
@@ -219,7 +219,7 @@ async function run(
     db,
   ).then((r) => r.value)
   if (assembledTrace) {
-    completionSpan = findFirstSpanOfType(
+    completionSpan = findLastSpanOfType(
       assembledTrace.trace.children,
       SpanType.Completion,
     )

--- a/packages/core/src/services/evaluationsV2/llm/custom.ts
+++ b/packages/core/src/services/evaluationsV2/llm/custom.ts
@@ -18,7 +18,7 @@ import {
 } from '../shared'
 import { buildEvaluationParameters, runPrompt } from './shared'
 import { assembleTrace } from '../../tracing/traces/assemble'
-import { findFirstSpanOfType } from '../../tracing/spans/findFirstSpanOfType'
+import { findLastSpanOfType } from '../../tracing/spans/findLastSpanOfType'
 
 export const LlmEvaluationCustomSpecification = {
   ...specification,
@@ -212,7 +212,7 @@ async function run(
     db,
   ).then((r) => r.value)
   if (assembledtrace) {
-    completionSpan = findFirstSpanOfType(
+    completionSpan = findLastSpanOfType(
       assembledtrace.trace.children,
       SpanType.Completion,
     )

--- a/packages/core/src/services/evaluationsV2/llm/rating.ts
+++ b/packages/core/src/services/evaluationsV2/llm/rating.ts
@@ -20,7 +20,7 @@ import {
 } from '../shared'
 import { buildEvaluationParameters, promptTask, runPrompt } from './shared'
 import { assembleTrace } from '../../tracing/traces/assemble'
-import { findFirstSpanOfType } from '../../tracing/spans/findFirstSpanOfType'
+import { findLastSpanOfType } from '../../tracing/spans/findLastSpanOfType'
 
 export const LlmEvaluationRatingSpecification = {
   ...specification,
@@ -224,7 +224,7 @@ async function run(
     db,
   ).then((r) => r.value)
   if (assembledtrace) {
-    completionSpan = findFirstSpanOfType(
+    completionSpan = findLastSpanOfType(
       assembledtrace.trace.children,
       SpanType.Completion,
     )

--- a/packages/core/src/services/evaluationsV2/run.ts
+++ b/packages/core/src/services/evaluationsV2/run.ts
@@ -30,9 +30,9 @@ import { type Workspace } from '../../schema/models/types/Workspace'
 import { extractActualOutput, extractExpectedOutput } from './outputs/extract'
 import { createEvaluationResultV2 } from './results/create'
 import { EVALUATION_SPECIFICATIONS } from './specifications'
-import { findFirstSpanOfType } from '../tracing/spans/findFirstSpanOfType'
 import { assembleTrace } from '../tracing/traces/assemble'
 import { LegacyMessage } from '../../lib/vercelSdkFromV5ToV4/convertResponseMessages'
+import { findLastSpanOfType } from '../tracing/spans/findLastSpanOfType'
 
 export async function runEvaluationV2<
   T extends EvaluationType,
@@ -128,7 +128,7 @@ export async function runEvaluationV2<
   if (!assembledSpan) {
     return Result.error(new UnprocessableEntityError('Cannot assemble trace'))
   }
-  const completionSpan = findFirstSpanOfType(
+  const completionSpan = findLastSpanOfType(
     assembledSpan.trace.children,
     SpanType.Completion,
   )


### PR DESCRIPTION
We were fetching the first one which was correct in most circumstances except when a prompt had multiple promptl steps.