### PR TITLE
Update posthog dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -71,7 +71,7 @@
     "oslo": "1.2.0",
     "pdfjs-dist": "4.9.155",
     "pg": "catalog:",
-    "posthog-js": "1.252.1",
+    "posthog-js": "1.298.0",
     "promptl-ai": "catalog:",
     "rate-limiter-flexible": "5.0.3",
     "react": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -188,7 +188,7 @@
     "officeparser": "5.1.1",
     "pdfjs-dist": "4.9.155",
     "pg": "catalog:",
-    "posthog-node": "4.2.0",
+    "posthog-node": "5.14.0",
     "promptl-ai": "catalog:",
     "rate-limiter-flexible": "5.0.3",
     "react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: 'catalog:'
         version: 8.16.0
       posthog-js:
-        specifier: 1.252.1
-        version: 1.252.1
+        specifier: 1.298.0
+        version: 1.298.0
       promptl-ai:
         specifier: 'catalog:'
         version: 0.9.4(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
@@ -919,8 +919,8 @@ importers:
         specifier: 'catalog:'
         version: 8.16.0
       posthog-node:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 5.14.0
+        version: 5.14.0
       promptl-ai:
         specifier: 'catalog:'
         version: 0.9.4(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
@@ -4443,6 +4443,9 @@ packages:
   '@poppinss/utils@6.10.1':
     resolution: {integrity: sha512-da+MMyeXhBaKtxQiWPfy7+056wk3lVIhioJnXHXkJ2/OHDaZfFcyKHNl1R06sdYO8lIRXcXdoZ6LO2ARmkAREA==}
     engines: {node: '>=18.16.0'}
+
+  '@posthog/core@1.6.0':
+    resolution: {integrity: sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==}
 
   '@prisma/instrumentation@6.11.1':
     resolution: {integrity: sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==}
@@ -11505,20 +11508,12 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-js@1.252.1:
-    resolution: {integrity: sha512-EkUCULWJqonMAvzE6CRX9MQupKG18X+r81+hYp3CBRcvbZG5gkbwR39t6p1347wBZJEsC1cKrjRnklc4w7XAUw==}
-    peerDependencies:
-      '@rrweb/types': 2.0.0-alpha.17
-      rrweb-snapshot: 2.0.0-alpha.17
-    peerDependenciesMeta:
-      '@rrweb/types':
-        optional: true
-      rrweb-snapshot:
-        optional: true
+  posthog-js@1.298.0:
+    resolution: {integrity: sha512-Zwzsf7TO8qJ6DFLuUlQSsT/5OIOcxSBZlKOSk3satkEnwKdmnBXUuxgVXRHrvq1kj7OB2PVAPgZiQ8iHHj9DRA==}
 
-  posthog-node@4.2.0:
-    resolution: {integrity: sha512-hgyCYMyzMvuF3qWMw6JvS8gT55v7Mtp5wKWcnDrw+nu39D0Tk9BXD7I0LOBp0lGlHEPaXCEVYUtviNKrhMALGA==}
-    engines: {node: '>=15.0.0'}
+  posthog-node@5.14.0:
+    resolution: {integrity: sha512-cKY2Wdtjx5wlIWL9/Im5/FT+zeKaYjtG94rfrIFKTVoCdwV7S9PaU8frLD/8TpGx1SwOFgw7QTjhpa/vnxTlww==}
+    engines: {node: '>=20'}
 
   pprof-format@2.2.1:
     resolution: {integrity: sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==}
@@ -12136,9 +12131,6 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  rusha@0.8.14:
-    resolution: {integrity: sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==}
 
   rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -18499,6 +18491,10 @@ snapshots:
       flattie: 1.1.1
       safe-stable-stringify: 2.5.0
       secure-json-parse: 4.0.0
+
+  '@posthog/core@1.6.0':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -26798,19 +26794,17 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-js@1.252.1:
+  posthog-js@1.298.0:
     dependencies:
+      '@posthog/core': 1.6.0
       core-js: 3.45.1
       fflate: 0.4.8
       preact: 10.27.2
       web-vitals: 4.2.4
 
-  posthog-node@4.2.0:
+  posthog-node@5.14.0:
     dependencies:
-      axios: 1.12.2(debug@4.4.3)
-      rusha: 0.8.14
-    transitivePeerDependencies:
-      - debug
+      '@posthog/core': 1.6.0
 
   pprof-format@2.2.1: {}
 
@@ -27701,8 +27695,6 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rusha@0.8.14: {}
 
   rxjs@6.6.7:
     dependencies:


### PR DESCRIPTION
# What?
We need to update Posthog. I'm jumping in `posthog-node` from `4.2.0` to `5.14.9` Doesn't look there are breaking changes that affect us

## Posthog Node
https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md

## My only concern is this
https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md#breaking-changes