### PR TITLE
fix: Experiment status updates

### DIFF
--- a/apps/web/src/stores/experimentComparison.ts
+++ b/apps/web/src/stores/experimentComparison.ts
@@ -319,7 +319,12 @@ export function useExperimentComparison(
       const { documentLogWithMetadata } = message
       if (!documentLogWithMetadata) return
 
+      let alreadyRegistered = false
       setExperimentsWithScores((prev) => {
+        // Prevent StrictMode double rendering
+        if (alreadyRegistered) return prev
+        alreadyRegistered = true
+
         if (!prev) return prev
 
         // Find the experiment that was updated

--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.test.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.test.ts
@@ -45,6 +45,7 @@ vi.spyOn(progressTracker, 'ProgressTracker').mockImplementation(() => ({
   evaluationError: evaluationErrorSpy,
   // @ts-expect-error - mock
   getProgress: vi.fn(() => Promise.resolve({ completed: 1, total: 1 })),
+  disconnect: vi.fn().mockReturnValue(Promise.resolve()),
   cleanup: vi.fn().mockReturnValue(Promise.resolve()),
 }))
 

--- a/packages/core/src/jobs/utils/progressTracker.ts
+++ b/packages/core/src/jobs/utils/progressTracker.ts
@@ -133,6 +133,13 @@ export class ProgressTracker {
     }
   }
 
+  async disconnect() {
+    if (this.redis) {
+      await this.redis.quit()
+      this.redis = null
+    }
+  }
+
   async cleanup() {
     if (this.redis) {
       // Delete all keys associated with this batch

--- a/packages/core/src/services/experiments/updateStatus.ts
+++ b/packages/core/src/services/experiments/updateStatus.ts
@@ -22,6 +22,10 @@ export async function updateExperimentStatus(
     const progress = await progressTracker.getProgress()
 
     if (progress.completed >= progress.total) {
+      await progressTracker.cleanup().catch(() => {
+        // Silently ignore cleanup errors to not mask the original error
+      })
+
       const completeResult = await completeExperiment(experiment)
       if (!Result.isOk(completeResult)) {
         return completeResult as ErrorResult<LatitudeError>
@@ -43,7 +47,7 @@ export async function updateExperimentStatus(
     return Result.nil()
   } finally {
     // CRITICAL: Always cleanup Redis connection to prevent memory leaks
-    await progressTracker.cleanup().catch(() => {
+    await progressTracker.disconnect().catch(() => {
       // Silently ignore cleanup errors to not mask the original error
     })
   }
@@ -80,7 +84,7 @@ export async function initializeExperimentStatus({
     return Result.nil()
   } finally {
     // CRITICAL: Always cleanup Redis connection to prevent memory leaks
-    await progressTracker.cleanup().catch(() => {
+    await progressTracker.disconnect().catch(() => {
       // Silently ignore cleanup errors to not mask the original error
     })
   }


### PR DESCRIPTION
Fixes:
 - Realtime count of experiment status is broken. Status was only really being updated through polling, websockets were always being reset with every update.
 - The "See X Logs" button in experiment displayed the double of the exected value (due to StrictMode)
