### PR TITLE
Fix issue search API route missing histogram table

### DIFF
--- a/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/IssuesSelector/index.tsx
@@ -69,6 +69,7 @@ export function IssuesSelector() {
   const { data: searchIssues, isLoading: isSearchingIssues } = useSearchIssues({
     projectId,
     documentUuid,
+    commitUuid: commit.uuid,
     query,
     group: ISSUE_GROUP.activeWithResolved,
   })

--- a/apps/web/src/components/evaluations/ConfigurationForm.tsx
+++ b/apps/web/src/components/evaluations/ConfigurationForm.tsx
@@ -114,6 +114,7 @@ export function ConfigurationAdvancedForm<
   const { data: issues, isLoading: isLoadingIssues } = useSearchIssues({
     projectId: project.id,
     documentUuid: document.documentUuid,
+    commitUuid: commit.uuid,
     query,
     group: ISSUE_GROUP.active,
   })

--- a/apps/web/src/stores/issues/selectorIssues.ts
+++ b/apps/web/src/stores/issues/selectorIssues.ts
@@ -38,12 +38,14 @@ export function useSearchIssues(
   {
     projectId,
     documentUuid,
+    commitUuid,
     query,
     statuses,
     group,
   }: {
     projectId: number
     documentUuid: string
+    commitUuid: string
     query?: string
     statuses?: IssueStatuses[]
     group?: IssueGroup
@@ -58,6 +60,7 @@ export function useSearchIssues(
   const fetcher = useFetcher<SearchIssueResponse>(route, {
     searchParams: {
       documentUuid,
+      commitUuid,
       query: query ?? '',
       statuses: issueStatusesQueryParam ?? '',
       group: group ?? '',

--- a/packages/core/src/repositories/issuesRepository.test.ts
+++ b/packages/core/src/repositories/issuesRepository.test.ts
@@ -204,6 +204,7 @@ describe('IssuesRepository - Group Filtering', () => {
       const issues = await repository.findByTitleAndStatuses({
         project,
         document,
+        commitId: commit.id,
         title: null,
         group: ISSUE_GROUP.activeWithResolved,
       })


### PR DESCRIPTION
After the commit #1974,  the `useIssuesSearch` API endpoint was breaking when entering a setting of an existing evaluation.

This was due to the `findByTitleAndStatuses` missing the join of the histogram table, useful when searching for the inactive group. 

This PR adds the necessary join