### PR TITLE
Fix: Evaluation "issues" confused with errors

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangesList/EvaluationItem.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/ChangesList/EvaluationItem.tsx
@@ -58,7 +58,6 @@ export function EvaluationChangeItem({
   }, [evaluation])
 
   const iconColor = useMemo<TextColor>(() => {
-    if (change.hasIssues) return 'destructive'
     return MODIFICATION_COLORS[change.changeType]
   }, [change])
 
@@ -77,7 +76,6 @@ export function EvaluationChangeItem({
       }
       label={change.name}
       changeType={change.changeType}
-      hasIssues={change.hasIssues}
       href={
         ROUTES.projects
           .detail({ id: projectId })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
@@ -49,10 +49,6 @@ function confirmDescription({
     return `There are triggers that needs to be configured before publishing.`
   }
 
-  if (changes.evaluations.hasIssues) {
-    return 'Some evaluations have issues. Please review the evaluations with issues before publishing.'
-  }
-
   return 'Publishing a new version is reversible and doesnt remove previous versions! You can always go back to use previous version if needed.'
 }
 

--- a/apps/web/src/stores/commitChanges.ts
+++ b/apps/web/src/stores/commitChanges.ts
@@ -21,10 +21,7 @@ const NO_CHANGES = {
     pending: [],
   },
   evaluations: {
-    hasIssues: false,
     all: [],
-    clean: [],
-    withIssues: [],
   },
 } satisfies CommitChanges
 

--- a/packages/constants/src/history.ts
+++ b/packages/constants/src/history.ts
@@ -29,7 +29,6 @@ export type ChangedEvaluation = {
   name: string
   type: EvaluationType
   changeType: ModifiedDocumentType
-  hasIssues: boolean
 }
 
 export type CommitChanges = {
@@ -49,9 +48,6 @@ export type CommitChanges = {
     pending: ChangedTrigger[]
   }
   evaluations: {
-    hasIssues: boolean
     all: ChangedEvaluation[]
-    clean: ChangedEvaluation[]
-    withIssues: ChangedEvaluation[]
   }
 }

--- a/packages/core/src/services/commits/getChanges.ts
+++ b/packages/core/src/services/commits/getChanges.ts
@@ -173,16 +173,9 @@ export async function getCommitChanges(
     )
 
     const allEvaluations = evaluationChangesResult.value
-    const cleanEvaluations = allEvaluations.filter(
-      (evaluation) => !evaluation.hasIssues,
-    )
-    const evaluationsWithIssues = allEvaluations.filter(
-      (evaluation) => evaluation.hasIssues,
-    )
 
     const hasErrors = documentsWithErrors.length > 0
     const hasPending = pendingTriggers.length > 0
-    const hasEvaluationIssues = evaluationsWithIssues.length > 0
 
     const anyChanges =
       allTriggers.length > 0 ||
@@ -192,7 +185,7 @@ export async function getCommitChanges(
 
     return Result.ok({
       anyChanges,
-      hasIssues: hasErrors || hasPending || hasEvaluationIssues,
+      hasIssues: hasErrors || hasPending,
       mainDocumentUuid: mainDocumentChanged
         ? commit.mainDocumentUuid // new main document uuid (or null if it was removed)
         : undefined, // no change
@@ -209,10 +202,7 @@ export async function getCommitChanges(
         pending: pendingTriggers,
       },
       evaluations: {
-        hasIssues: hasEvaluationIssues,
         all: allEvaluations,
-        clean: cleanEvaluations,
-        withIssues: evaluationsWithIssues,
       },
     })
   })

--- a/packages/core/src/services/evaluationsV2/changes/getEvaluationChanges.test.ts
+++ b/packages/core/src/services/evaluationsV2/changes/getEvaluationChanges.test.ts
@@ -77,7 +77,6 @@ describe('getCommitEvaluationChanges', () => {
         name: evaluation.name,
         type: evaluation.type,
         changeType: ModifiedDocumentType.Created,
-        hasIssues: false,
       })
     })
 
@@ -114,7 +113,6 @@ describe('getCommitEvaluationChanges', () => {
         name: 'Updated evaluation',
         type: evaluation.type,
         changeType: ModifiedDocumentType.Updated,
-        hasIssues: false,
       })
     })
 
@@ -148,7 +146,6 @@ describe('getCommitEvaluationChanges', () => {
         name: evaluation.name,
         type: evaluation.type,
         changeType: ModifiedDocumentType.Deleted,
-        hasIssues: false,
       })
     })
 
@@ -214,7 +211,6 @@ describe('getCommitEvaluationChanges', () => {
         name: 'New Evaluation',
         type: newEval.type,
         changeType: ModifiedDocumentType.Created,
-        hasIssues: false,
       })
 
       const updatedChange = changes.find(
@@ -226,7 +222,6 @@ describe('getCommitEvaluationChanges', () => {
         name: 'Updated Name',
         type: updatedEval.type,
         changeType: ModifiedDocumentType.Updated,
-        hasIssues: false,
       })
 
       const deletedChange = changes.find(
@@ -238,7 +233,6 @@ describe('getCommitEvaluationChanges', () => {
         name: 'Deleted Evaluation',
         type: deletedEval.type,
         changeType: ModifiedDocumentType.Deleted,
-        hasIssues: false,
       })
     })
   })
@@ -282,7 +276,6 @@ describe('getCommitEvaluationChanges', () => {
         name: 'Updated in draft',
         type: evaluation.type,
         changeType: ModifiedDocumentType.Updated,
-        hasIssues: false,
       })
     })
 

--- a/packages/core/src/services/evaluationsV2/changes/getEvaluationChanges.ts
+++ b/packages/core/src/services/evaluationsV2/changes/getEvaluationChanges.ts
@@ -80,22 +80,14 @@ export function evaluationChangesPresenter({
   currentCommitEvaluations: EvaluationV2[]
   previousCommitEvaluations: EvaluationV2[]
 }) {
-  const changes = currentCommitEvaluations.map((changedEvaluation) => {
+  return currentCommitEvaluations.map((changedEvaluation) => {
     return {
       evaluationUuid: changedEvaluation.uuid,
       documentUuid: changedEvaluation.documentUuid,
       name: changedEvaluation.name,
       type: changedEvaluation.type,
       changeType: getChangeType(changedEvaluation, previousCommitEvaluations),
-      hasIssues: !!changedEvaluation.issueId,
     } satisfies ChangedEvaluation
-  })
-
-  // Sort by hasIssues (evaluations with issues first)
-  return changes.sort((a, b) => {
-    const aHasIssues = a.hasIssues ? 1 : 0
-    const bHasIssues = b.hasIssues ? 1 : 0
-    return bHasIssues - aHasIssues
   })
 }
 


### PR DESCRIPTION
ChangesPresenter has an "issues" property, which represents errors within changed items. Evaluation issues have been added to this property due to semantic similarity but they are, in fact, not errors.