### PR TITLE
Weekly email issues resume

### DIFF
--- a/packages/core/src/data-access/weeklyEmail/issues/index.test.ts
+++ b/packages/core/src/data-access/weeklyEmail/issues/index.test.ts
@@ -1,0 +1,368 @@
+import { eq } from 'drizzle-orm'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { createWorkspace } from '../../../tests/factories'
+import { Workspace } from '../../../schema/models/types/Workspace'
+import { getIssuesData } from './index'
+import { createProject } from '../../../tests/factories/projects'
+import { Project } from '../../../schema/models/types/Project'
+import { createIssue } from '../../../tests/factories/issues'
+import { Commit } from '../../../schema/models/types/Commit'
+import { DocumentVersion } from '../../../schema/models/types/DocumentVersion'
+import { issues } from '../../../schema/models/issues'
+import { database } from '../../../client'
+
+// Static date for testing: Monday, January 8, 2024 at 10:00 AM UTC
+const STATIC_TEST_DATE = new Date('2024-01-08T10:00:00Z')
+
+// Date range for testing (last week): Sunday Jan 7, 2024 to Sunday Jan 14, 2024
+const LAST_WEEK_START = new Date('2024-01-07T00:00:00Z')
+const LAST_WEEK_END = new Date('2024-01-14T00:00:00Z')
+
+let workspace: Workspace
+let project: Project
+let commit: Commit
+let document: DocumentVersion
+
+describe('getIssuesData', () => {
+  beforeAll(async () => {
+    const { workspace: ws } = await createWorkspace()
+    workspace = ws
+
+    const {
+      project: p,
+      commit: c,
+      documents,
+    } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    project = p
+    commit = c
+    document = documents[0]!
+  })
+
+  describe('when workspace has never created issues', () => {
+    it('returns hasIssues: false with zero counts', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+
+      const result = await getIssuesData({
+        workspace: freshWorkspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result).toEqual({
+        hasIssues: false,
+        issuesCount: 0,
+        newIssuesCount: 0,
+        escalatedIssuesCount: 0,
+        resolvedIssuesCount: 0,
+        ignoredIssuesCount: 0,
+        regressedIssuesCount: 0,
+        topProjects: [],
+      })
+    })
+  })
+
+  describe('when workspace has issues but none in last week', () => {
+    it('returns hasIssues: true with zero counts for last week', async () => {
+      const { project, commit, documents } = await createProject({
+        workspace,
+        documents: { 'test-doc': 'test content' },
+      })
+
+      const outsideRange = new Date('2024-01-01T10:00:00Z')
+
+      // Create issue with histogram outside the date range
+      await createIssue({
+        workspace,
+        project,
+        document: documents[0]!,
+        createdAt: outsideRange,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: outsideRange,
+            count: 5,
+          },
+        ],
+      })
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result).toEqual({
+        hasIssues: true,
+        issuesCount: 0,
+        newIssuesCount: 0,
+        escalatedIssuesCount: 0,
+        resolvedIssuesCount: 0,
+        ignoredIssuesCount: 0,
+        regressedIssuesCount: 0,
+        topProjects: [],
+      })
+    })
+  })
+
+  describe('when workspace has issues in last week', () => {
+    it('counts issues correctly', async () => {
+      for (let i = 0; i < 3; i++) {
+        await createIssue({
+          workspace,
+          project,
+          document,
+          createdAt: STATIC_TEST_DATE,
+          histograms: [
+            {
+              commitId: commit.id,
+              date: STATIC_TEST_DATE,
+              count: 5,
+            },
+          ],
+        })
+      }
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.hasIssues).toBe(true)
+      expect(result.issuesCount).toBe(3)
+      expect(result.newIssuesCount).toBe(3) // All created in range
+      expect(result.topProjects).toHaveLength(1)
+      expect(result.topProjects[0]?.issuesCount).toBe(3)
+    })
+
+    it('counts new issues created in date range', async () => {
+      const oldDate = new Date('2023-12-01T10:00:00Z')
+
+      // Create old issue (not new) but with histogram in range
+      await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: oldDate,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: STATIC_TEST_DATE,
+            count: 5,
+          },
+        ],
+      })
+
+      // Create new issue in range
+      await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: STATIC_TEST_DATE,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: STATIC_TEST_DATE,
+            count: 3,
+          },
+        ],
+      })
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.issuesCount).toBe(2)
+      expect(result.newIssuesCount).toBe(1) // Only the one created in range
+    })
+
+    it('counts escalated issues in date range', async () => {
+      await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: STATIC_TEST_DATE,
+        escalatingAt: STATIC_TEST_DATE,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: STATIC_TEST_DATE,
+            count: 5,
+          },
+        ],
+      })
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.issuesCount).toBe(1)
+      expect(result.escalatedIssuesCount).toBe(1)
+    })
+
+    it('counts resolved issues in date range', async () => {
+      const resolvedDate = STATIC_TEST_DATE
+
+      const { issue } = await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: resolvedDate,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: STATIC_TEST_DATE,
+            count: 5,
+          },
+        ],
+      })
+
+      await database
+        .update(issues)
+        .set({ resolvedAt: resolvedDate })
+        .where(eq(issues.id, issue.id))
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.issuesCount).toEqual(1)
+      expect(result.resolvedIssuesCount).toEqual(1)
+    })
+
+    it('counts regressed issues (resolved but had occurrences after resolution)', async () => {
+      const resolvedDate = new Date('2024-01-06T10:00:00Z')
+      const { issue } = await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: resolvedDate,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: resolvedDate,
+            count: 5,
+          },
+          {
+            commitId: commit.id,
+            date: STATIC_TEST_DATE, // After resolution
+            count: 3,
+          },
+        ],
+      })
+
+      await database
+        .update(issues)
+        .set({ resolvedAt: resolvedDate })
+        .where(eq(issues.id, issue.id))
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.issuesCount).toBe(1)
+      expect(result.regressedIssuesCount).toBe(1)
+    })
+
+    it('respects custom date range when provided', async () => {
+      const customRangeStart = new Date('2024-01-08T00:00:00Z')
+      const customRangeEnd = new Date('2024-01-11T00:00:00Z')
+      const dateInRange = new Date('2024-01-09T10:00:00Z')
+      const dateOutOfRange = new Date('2024-01-15T10:00:00Z')
+
+      // Issue with histogram in custom range
+      await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: dateInRange,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: dateInRange,
+            count: 5,
+          },
+        ],
+      })
+
+      await createIssue({
+        workspace,
+        project,
+        document,
+        createdAt: dateOutOfRange,
+        histograms: [
+          {
+            commitId: commit.id,
+            date: dateOutOfRange,
+            count: 3,
+          },
+        ],
+      })
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: {
+          from: customRangeStart,
+          to: customRangeEnd,
+        },
+      })
+
+      expect(result.issuesCount).toBe(1) // Only the one in range
+      expect(result.topProjects[0]?.issuesCount).toBe(1)
+    })
+  })
+
+  describe('top projects', () => {
+    it('returns top 10 projects ordered by issue count', async () => {
+      for (let i = 0; i < 12; i++) {
+        const {
+          project: p,
+          commit: c,
+          documents,
+        } = await createProject({
+          workspace,
+          documents: { [`doc-${i}`]: 'content' },
+        })
+
+        const issueCount = 12 - i // Descending counts: 12, 11, 10, ..., 1
+
+        for (let j = 0; j < issueCount; j++) {
+          await createIssue({
+            workspace,
+            project: p,
+            document: documents[0]!,
+            createdAt: STATIC_TEST_DATE,
+            histograms: [
+              {
+                commitId: c.id,
+                date: STATIC_TEST_DATE,
+                count: 1,
+              },
+            ],
+          })
+        }
+      }
+
+      const result = await getIssuesData({
+        workspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      // Should return only top 10
+      expect(result.topProjects).toHaveLength(10)
+
+      // Should be ordered by issue count descending
+      expect(result.topProjects[0]?.issuesCount).toBe(12)
+      expect(result.topProjects[1]?.issuesCount).toBe(11)
+      expect(result.topProjects[9]?.issuesCount).toBe(3)
+
+      // Global count should include all 12 projects
+      const totalIssues = ((12 + 1) * 12) / 2 // Sum from 1 to 12
+      expect(result.issuesCount).toBe(totalIssues)
+    })
+  })
+})

--- a/packages/core/src/data-access/weeklyEmail/issues/index.ts
+++ b/packages/core/src/data-access/weeklyEmail/issues/index.ts
@@ -1,0 +1,227 @@
+import { and, between, count, desc, eq, isNotNull, sql } from 'drizzle-orm'
+import { format } from 'date-fns'
+import { database } from '../../../client'
+import { DateRange, SureDateRange } from '../../../constants'
+import { issueHistograms } from '../../../schema/models/issueHistograms'
+import { issues } from '../../../schema/models/issues'
+import { projects } from '../../../schema/models/projects'
+import { Workspace } from '../../../schema/models/types/Workspace'
+import { getDateRangeOrLastWeekRange } from '../utils'
+
+async function getAllTimesIssuesCount(
+  { workspace }: { workspace: Workspace },
+  db = database,
+) {
+  return db
+    .select({ count: count() })
+    .from(issues)
+    .where(eq(issues.workspaceId, workspace.id))
+    .then((r) => r[0].count)
+}
+
+function buildHistogramSubquery(
+  {
+    workspace,
+    fromDate,
+    toDate,
+  }: {
+    workspace: Workspace
+    fromDate: string
+    toDate: string
+  },
+  db = database,
+) {
+  return db
+    .select({
+      issueId: issueHistograms.issueId,
+    })
+    .from(issueHistograms)
+    .where(
+      and(
+        eq(issueHistograms.workspaceId, workspace.id),
+        between(issueHistograms.date, fromDate, toDate),
+      ),
+    )
+    .groupBy(issueHistograms.issueId)
+    .as('histogramSubquery')
+}
+
+function buildRegressedSubquery(
+  {
+    workspace,
+    fromDate,
+    toDate,
+  }: {
+    workspace: Workspace
+    fromDate: string
+    toDate: string
+  },
+  db = database,
+) {
+  return db
+    .select({
+      issueId: issueHistograms.issueId,
+    })
+    .from(issueHistograms)
+    .innerJoin(issues, eq(issueHistograms.issueId, issues.id))
+    .where(
+      and(
+        eq(issueHistograms.workspaceId, workspace.id),
+        isNotNull(issues.resolvedAt),
+        sql`${issueHistograms.date} > ${issues.resolvedAt}`,
+        between(issueHistograms.date, fromDate, toDate),
+      ),
+    )
+    .groupBy(issueHistograms.issueId)
+    .as('regressedSubquery')
+}
+
+async function getGlobalIssuesStats(
+  {
+    workspace,
+    range,
+  }: {
+    workspace: Workspace
+    range: SureDateRange
+  },
+  db = database,
+) {
+  const fromDate = format(range.from, 'yyyy-MM-dd')
+  const toDate = format(range.to, 'yyyy-MM-dd')
+
+  const histogramSubquery = buildHistogramSubquery(
+    { workspace, fromDate, toDate },
+    db,
+  )
+  const regressedSubquery = buildRegressedSubquery(
+    { workspace, fromDate, toDate },
+    db,
+  )
+
+  const stats = await db
+    .select({
+      issuesCount: sql<number>`COUNT(DISTINCT ${issues.id})`,
+      newIssuesCount: sql<number>`SUM(CASE WHEN ${issues.createdAt} BETWEEN ${range.from} AND ${range.to} THEN 1 ELSE 0 END)`,
+      escalatedIssuesCount: sql<number>`SUM(CASE WHEN ${issues.escalatingAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.escalatingAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      resolvedIssuesCount: sql<number>`SUM(CASE WHEN ${issues.resolvedAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.resolvedAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      ignoredIssuesCount: sql<number>`SUM(CASE WHEN ${issues.ignoredAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.ignoredAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      regressedIssuesCount: sql<number>`SUM(CASE WHEN ${regressedSubquery.issueId} IS NOT NULL THEN 1 ELSE 0 END)`,
+    })
+    .from(issues)
+    .innerJoin(histogramSubquery, eq(issues.id, histogramSubquery.issueId))
+    .leftJoin(regressedSubquery, eq(issues.id, regressedSubquery.issueId))
+    .where(eq(issues.workspaceId, workspace.id))
+    .then((r) => r[0])
+
+  // If no issues found, return zeros
+  if (!stats || Number(stats.issuesCount) === 0) {
+    return {
+      issuesCount: 0,
+      newIssuesCount: 0,
+      escalatedIssuesCount: 0,
+      resolvedIssuesCount: 0,
+      ignoredIssuesCount: 0,
+      regressedIssuesCount: 0,
+    }
+  }
+
+  return {
+    issuesCount: Number(stats.issuesCount),
+    newIssuesCount: Number(stats.newIssuesCount),
+    escalatedIssuesCount: Number(stats.escalatedIssuesCount),
+    resolvedIssuesCount: Number(stats.resolvedIssuesCount),
+    ignoredIssuesCount: Number(stats.ignoredIssuesCount),
+    regressedIssuesCount: Number(stats.regressedIssuesCount),
+  }
+}
+
+async function getTopProjectsIssuesStats(
+  {
+    workspace,
+    range,
+  }: {
+    workspace: Workspace
+    range: SureDateRange
+  },
+  db = database,
+) {
+  const fromDate = format(range.from, 'yyyy-MM-dd')
+  const toDate = format(range.to, 'yyyy-MM-dd')
+
+  const histogramSubquery = buildHistogramSubquery(
+    { workspace, fromDate, toDate },
+    db,
+  )
+  const regressedSubquery = buildRegressedSubquery(
+    { workspace, fromDate, toDate },
+    db,
+  )
+
+  const projectStats = await db
+    .select({
+      projectId: projects.id,
+      projectName: projects.name,
+      issuesCount: sql<number>`COUNT(DISTINCT ${issues.id})`,
+      newIssuesCount: sql<number>`SUM(CASE WHEN ${issues.createdAt} BETWEEN ${range.from} AND ${range.to} THEN 1 ELSE 0 END)`,
+      escalatedIssuesCount: sql<number>`SUM(CASE WHEN ${issues.escalatingAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.escalatingAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      resolvedIssuesCount: sql<number>`SUM(CASE WHEN ${issues.resolvedAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.resolvedAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      ignoredIssuesCount: sql<number>`SUM(CASE WHEN ${issues.ignoredAt} BETWEEN ${range.from} AND ${range.to} AND ${issues.ignoredAt} IS NOT NULL THEN 1 ELSE 0 END)`,
+      regressedIssuesCount: sql<number>`SUM(CASE WHEN ${regressedSubquery.issueId} IS NOT NULL THEN 1 ELSE 0 END)`,
+    })
+    .from(issues)
+    .innerJoin(histogramSubquery, eq(issues.id, histogramSubquery.issueId))
+    .innerJoin(projects, eq(issues.projectId, projects.id))
+    .leftJoin(regressedSubquery, eq(issues.id, regressedSubquery.issueId))
+    .where(eq(issues.workspaceId, workspace.id))
+    .groupBy(projects.id, projects.name)
+    .orderBy(desc(sql`COUNT(DISTINCT ${issues.id})`))
+    .limit(10)
+
+  return projectStats.map((project) => ({
+    projectId: project.projectId,
+    projectName: project.projectName,
+    issuesCount: Number(project.issuesCount),
+    newIssuesCount: Number(project.newIssuesCount),
+    escalatedIssuesCount: Number(project.escalatedIssuesCount),
+    resolvedIssuesCount: Number(project.resolvedIssuesCount),
+    ignoredIssuesCount: Number(project.ignoredIssuesCount),
+    regressedIssuesCount: Number(project.regressedIssuesCount),
+  }))
+}
+
+export async function getIssuesData(
+  {
+    workspace,
+    dateRange,
+  }: {
+    workspace: Workspace
+    dateRange?: DateRange
+  },
+  db = database,
+) {
+  const allTimesIssuesCount = await getAllTimesIssuesCount({ workspace }, db)
+  const hasIssues = allTimesIssuesCount > 0
+
+  if (!hasIssues) {
+    return {
+      hasIssues: false,
+      issuesCount: 0,
+      newIssuesCount: 0,
+      escalatedIssuesCount: 0,
+      resolvedIssuesCount: 0,
+      ignoredIssuesCount: 0,
+      regressedIssuesCount: 0,
+      topProjects: [],
+    }
+  }
+
+  const range = getDateRangeOrLastWeekRange(dateRange)
+  const globalStats = await getGlobalIssuesStats({ workspace, range }, db)
+  const topProjects = await getTopProjectsIssuesStats({ workspace, range }, db)
+
+  return {
+    hasIssues: true,
+    ...globalStats,
+    topProjects,
+  }
+}

--- a/packages/core/src/data-access/weeklyEmail/logs/index.test.ts
+++ b/packages/core/src/data-access/weeklyEmail/logs/index.test.ts
@@ -36,6 +36,7 @@ describe('getLogsData', () => {
         logsCount: 0,
         tokensSpent: 0,
         tokensCost: 0,
+        topProjects: [],
       })
     })
   })
@@ -61,6 +62,7 @@ describe('getLogsData', () => {
         logsCount: 0,
         tokensSpent: 0,
         tokensCost: 0,
+        topProjects: [],
       })
     })
   })
@@ -119,13 +121,13 @@ describe('getLogsData', () => {
       // Call without dateRange - should use default last week range
       const result = await getLogsData({ workspace: freshWorkspace })
 
-      expect(result.usedInProduction).toBe(true)
+      expect(result.usedInProduction).toEqual(true)
       // Should only count the recent trace, not the old one
-      expect(result.logsCount).toBe(1)
+      expect(result.logsCount).toEqual(1)
       // Should only count tokens from recent completion span
-      expect(result.tokensSpent).toBe(300) // 100 + 200
+      expect(result.tokensSpent).toEqual(300) // 100 + 200
       // Should only count cost from recent completion span
-      expect(result.tokensCost).toBe(10) // 1000 / 100
+      expect(result.tokensCost).toEqual(10) // 1000 / 100
     })
   })
 
@@ -175,8 +177,8 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.logsCount).toBe(3) // 3 distinct trace IDs (all sources)
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.logsCount).toEqual(3) // 3 distinct trace IDs (all sources)
     })
 
     it('sums tokens from completion spans only (all sources)', async () => {
@@ -226,9 +228,9 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
+      expect(result.usedInProduction).toEqual(true)
       // Total: (100 + 200 + 50 + 25) + (150 + 250 + 75 + 30) = 375 + 505 = 880
-      expect(result.tokensSpent).toBe(880)
+      expect(result.tokensSpent).toEqual(880)
     })
 
     it('sums cost from completion spans only and converts from cents (all sources)', async () => {
@@ -269,9 +271,9 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
+      expect(result.usedInProduction).toEqual(true)
       // Total: (1234 + 5678) / 100 = 6912 / 100 = 69.12
-      expect(result.tokensCost).toBe(69.12)
+      expect(result.tokensCost).toEqual(69.12)
     })
 
     it('handles null/undefined token and cost values', async () => {
@@ -305,9 +307,9 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.tokensSpent).toBe(100)
-      expect(result.tokensCost).toBe(5)
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.tokensSpent).toEqual(100)
+      expect(result.tokensCost).toEqual(5)
     })
 
     it('counts all sources for logs/tokens/cost', async () => {
@@ -363,10 +365,10 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.logsCount).toBe(4) // 4 distinct traces: prod-trace-1, shared-trace-id, playground-trace-1, experiment-trace-1
-      expect(result.tokensSpent).toBe(600) // 100 + 500
-      expect(result.tokensCost).toBe(60) // (1000 + 5000) / 100
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.logsCount).toEqual(4) // 4 distinct traces: prod-trace-1, shared-trace-id, playground-trace-1, experiment-trace-1
+      expect(result.tokensSpent).toEqual(600) // 100 + 500
+      expect(result.tokensCost).toEqual(60) // (1000 + 5000) / 100
     })
 
     it('respects custom date range when provided', async () => {
@@ -401,8 +403,8 @@ describe('getLogsData', () => {
         },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.logsCount).toBe(1) // Only trace-in-range
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.logsCount).toEqual(1) // Only trace-in-range
     })
 
     it('handles all source types', async () => {
@@ -434,8 +436,8 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.logsCount).toBe(allSources.length)
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.logsCount).toEqual(allSources.length)
     })
   })
 
@@ -456,10 +458,13 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(false) // No prompt spans = never used in production
-      expect(result.logsCount).toBe(0)
-      expect(result.tokensSpent).toBe(0)
-      expect(result.tokensCost).toBe(0)
+      expect(result).toEqual({
+        usedInProduction: false,
+        logsCount: 0,
+        tokensSpent: 0,
+        tokensCost: 0,
+        topProjects: [],
+      })
     })
 
     it('handles very large token and cost values', async () => {
@@ -486,9 +491,13 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.tokensSpent).toBe(3_000_000)
-      expect(result.tokensCost).toBe(99_999.99)
+      expect(result).toEqual({
+        usedInProduction: true,
+        logsCount: expect.any(Number),
+        tokensSpent: 3_000_000,
+        tokensCost: 99_999.99,
+        topProjects: expect.any(Array),
+      })
     })
 
     it('handles zero cost and zero tokens', async () => {
@@ -514,9 +523,274 @@ describe('getLogsData', () => {
         dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
       })
 
-      expect(result.usedInProduction).toBe(true)
-      expect(result.tokensSpent).toBe(0)
-      expect(result.tokensCost).toBe(0)
+      expect(result.usedInProduction).toEqual(true)
+      expect(result.tokensSpent).toEqual(0)
+      expect(result.tokensCost).toEqual(0)
+    })
+  })
+
+  describe('top projects', () => {
+    it('returns top 10 projects ordered by logs count', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+      const { createProject } = await import(
+        '../../../tests/factories/projects'
+      )
+
+      // Enable production usage (outside date range to not affect counts)
+      const outsideRange = new Date('2024-01-01T10:00:00Z')
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: outsideRange,
+      })
+
+      // Create 12 projects with different log counts
+      for (let i = 0; i < 12; i++) {
+        const { project } = await createProject({
+          workspace: freshWorkspace,
+          documents: { [`doc-${i}`]: 'content' },
+        })
+
+        const logsCount = 12 - i // Descending counts: 12, 11, 10, ..., 1
+
+        for (let j = 0; j < logsCount; j++) {
+          const traceId = `project-${project.id}-trace-${j}`
+
+          // Create prompt span for the trace
+          await createSpan({
+            workspaceId: freshWorkspace.id,
+            projectId: project.id,
+            traceId,
+            type: SpanType.Prompt,
+            source: LogSources.API,
+            startedAt: STATIC_TEST_DATE,
+          })
+
+          // Create completion span for tokens and cost
+          await createSpan({
+            workspaceId: freshWorkspace.id,
+            projectId: project.id,
+            traceId,
+            type: SpanType.Completion,
+            source: LogSources.API,
+            startedAt: STATIC_TEST_DATE,
+            tokensPrompt: 10,
+            tokensCompletion: 20,
+            cost: 100, // $1.00 per trace
+          })
+        }
+      }
+
+      const result = await getLogsData({
+        workspace: freshWorkspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      // Should return only top 10
+      expect(result.topProjects).toHaveLength(10)
+
+      // Should be ordered by logs count descending
+      expect(result.topProjects[0]?.logsCount).toEqual(12)
+      expect(result.topProjects[1]?.logsCount).toEqual(11)
+      expect(result.topProjects[9]?.logsCount).toEqual(3)
+
+      // Check tokens and cost for first project (12 traces)
+      expect(result.topProjects[0]?.tokensSpent).toEqual(12 * 30) // 12 traces * 30 tokens
+      expect(result.topProjects[0]?.tokensCost).toEqual(12 * 1) // 12 traces * $1.00
+
+      // Global count should include all 12 projects
+      const totalLogs = ((12 + 1) * 12) / 2 // Sum from 1 to 12
+      expect(result.logsCount).toEqual(totalLogs)
+    })
+
+    it('includes project name in top projects', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+      const { createProject } = await import(
+        '../../../tests/factories/projects'
+      )
+
+      // Enable production usage (outside date range to not affect counts)
+      const outsideRange = new Date('2024-01-01T10:00:00Z')
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: outsideRange,
+      })
+
+      const { project } = await createProject({
+        workspace: freshWorkspace,
+        name: 'Test Project Name',
+        documents: { doc: 'content' },
+      })
+
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: project.id,
+        traceId: 'test-trace',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: STATIC_TEST_DATE,
+      })
+
+      const result = await getLogsData({
+        workspace: freshWorkspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.topProjects).toHaveLength(1)
+      expect(result.topProjects[0]?.projectId).toEqual(project.id)
+      expect(result.topProjects[0]?.projectName).toEqual('Test Project Name')
+    })
+
+    it('excludes spans without projectId from top projects', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+      const { createProject } = await import(
+        '../../../tests/factories/projects'
+      )
+
+      // Enable production usage (outside date range to not affect counts)
+      const outsideRange = new Date('2024-01-01T10:00:00Z')
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: outsideRange,
+      })
+
+      const { project } = await createProject({
+        workspace: freshWorkspace,
+        documents: { doc: 'content' },
+      })
+
+      // Create spans with projectId
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: project.id,
+        traceId: 'with-project',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: STATIC_TEST_DATE,
+      })
+
+      // Create spans without projectId (should not appear in top projects)
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: undefined,
+        traceId: 'without-project',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: STATIC_TEST_DATE,
+      })
+
+      const result = await getLogsData({
+        workspace: freshWorkspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      // Global count includes both
+      expect(result.logsCount).toEqual(2)
+
+      // Top projects only includes the one with projectId
+      expect(result.topProjects).toHaveLength(1)
+      expect(result.topProjects[0]?.projectId).toEqual(project.id)
+    })
+
+    it('handles projects with no completion spans (zero tokens/cost)', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+      const { createProject } = await import(
+        '../../../tests/factories/projects'
+      )
+
+      // Enable production usage (outside date range to not affect counts)
+      const outsideRange = new Date('2024-01-01T10:00:00Z')
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: outsideRange,
+      })
+
+      const { project } = await createProject({
+        workspace: freshWorkspace,
+        documents: { doc: 'content' },
+      })
+
+      // Create only prompt span (no completion span)
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: project.id,
+        traceId: 'test-trace',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: STATIC_TEST_DATE,
+      })
+
+      const result = await getLogsData({
+        workspace: freshWorkspace,
+        dateRange: { from: LAST_WEEK_START, to: LAST_WEEK_END },
+      })
+
+      expect(result.topProjects).toHaveLength(1)
+      expect(result.topProjects[0]?.logsCount).toEqual(1)
+      expect(result.topProjects[0]?.tokensSpent).toEqual(0)
+      expect(result.topProjects[0]?.tokensCost).toEqual(0)
+    })
+
+    it('respects date range for top projects', async () => {
+      const { workspace: freshWorkspace } = await createWorkspace()
+      const { createProject } = await import(
+        '../../../tests/factories/projects'
+      )
+
+      // Enable production usage (outside date range to not affect counts)
+      const enableProductionDate = new Date('2024-01-01T10:00:00Z')
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: enableProductionDate,
+      })
+
+      const { project } = await createProject({
+        workspace: freshWorkspace,
+        documents: { doc: 'content' },
+      })
+
+      const dateInRange = new Date('2024-01-09T10:00:00Z')
+      const dateOutOfRange = new Date('2024-01-15T10:00:00Z')
+
+      // Create span in range
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: project.id,
+        traceId: 'in-range',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: dateInRange,
+      })
+
+      // Create span out of range
+      await createSpan({
+        workspaceId: freshWorkspace.id,
+        projectId: project.id,
+        traceId: 'out-of-range',
+        type: SpanType.Prompt,
+        source: LogSources.API,
+        startedAt: dateOutOfRange,
+      })
+
+      const result = await getLogsData({
+        workspace: freshWorkspace,
+        dateRange: {
+          from: new Date('2024-01-08T00:00:00Z'),
+          to: new Date('2024-01-11T00:00:00Z'),
+        },
+      })
+
+      expect(result.topProjects).toHaveLength(1)
+      expect(result.topProjects[0]?.logsCount).toEqual(1) // Only the one in range
     })
   })
 })

--- a/packages/core/src/repositories/issuesRepository.test.ts
+++ b/packages/core/src/repositories/issuesRepository.test.ts
@@ -40,7 +40,6 @@ describe('IssuesRepository - Group Filtering', () => {
       createdAt: new Date(),
       histograms: [
         {
-          issue: null as any,
           commitId: commit.id,
           date: new Date(),
           count: 1,
@@ -56,7 +55,6 @@ describe('IssuesRepository - Group Filtering', () => {
       createdAt: new Date(),
       histograms: [
         {
-          issue: null as any,
           commitId: commit.id,
           date: new Date(),
           count: 1,
@@ -77,7 +75,6 @@ describe('IssuesRepository - Group Filtering', () => {
       createdAt: new Date(),
       histograms: [
         {
-          issue: null as any,
           commitId: commit.id,
           date: new Date(),
           count: 1,
@@ -94,7 +91,6 @@ describe('IssuesRepository - Group Filtering', () => {
       createdAt: new Date(),
       histograms: [
         {
-          issue: null as any,
           commitId: commit.id,
           date: new Date(),
           count: 1,
@@ -108,7 +104,6 @@ describe('IssuesRepository - Group Filtering', () => {
       createdAt: new Date(),
       histograms: [
         {
-          issue: null as any,
           commitId: commit.id,
           date: new Date(),
           count: 1,

--- a/packages/core/src/tests/factories/issues.ts
+++ b/packages/core/src/tests/factories/issues.ts
@@ -13,7 +13,6 @@ import Transaction from '../../lib/Transaction'
 import { issueHistograms } from '../../schema/models/issueHistograms'
 
 export type IssueHistogramData = {
-  issue: Issue
   commitId: number
   date: Date
   count: number
@@ -25,7 +24,7 @@ async function createIssueHistogramsBulk(
     histograms,
   }: {
     workspace: Workspace
-    histograms: IssueHistogramData[]
+    histograms: (IssueHistogramData & { issue: Issue })[]
   },
   transaction = new Transaction(),
 ) {


### PR DESCRIPTION
# What?
Get the data to sent in the weekly email for the issues created for each project. We need to sort by most issues and only display the top 10 of the projects. Otherwise the email will be super long.

## TODO
- [x] Issues weekly query
- [x] Fix spans query to also be grouped by project. 