### PR TITLE
feat: Add UI and API for shadow and A/B testing

### DIFF
--- a/apps/gateway/src/presenters/runPresenter.ts
+++ b/apps/gateway/src/presenters/runPresenter.ts
@@ -1,19 +1,17 @@
 import { captureException } from '$/common/tracer'
 import {
   AssertedStreamType,
-  ChainStepObjectResponse,
-  ChainStepTextResponse,
+  ChainStepResponse,
   RunSyncAPIResponse,
+  StreamType,
 } from '@latitude-data/constants'
 import { LatitudeError } from '@latitude-data/constants/errors'
 import { Result, TypedResult } from '@latitude-data/core/lib/Result'
 import { ProviderApiKey } from '@latitude-data/core/schema/models/types/ProviderApiKey'
 import { estimateCost } from '@latitude-data/core/services/ai/estimateCost/index'
 
-type DocumentResponse = ChainStepObjectResponse | ChainStepTextResponse
-
 export function v2RunPresenter(
-  response: DocumentResponse,
+  response: ChainStepResponse<StreamType>,
 ): TypedResult<
   Omit<RunSyncAPIResponse<AssertedStreamType>, 'toolRequests'>,
   LatitudeError
@@ -51,7 +49,7 @@ export function runPresenter({
   response,
   provider,
 }: {
-  response: DocumentResponse
+  response: ChainStepResponse<StreamType>
   provider: ProviderApiKey
 }): TypedResult<RunSyncAPIResponse<AssertedStreamType>, LatitudeError> {
   const conversation = response.providerLog?.messages

--- a/apps/web/src/actions/deploymentTests/create.ts
+++ b/apps/web/src/actions/deploymentTests/create.ts
@@ -1,0 +1,49 @@
+'use server'
+
+import { withProject, withProjectSchema } from '../procedures'
+import { createDeploymentTest } from '@latitude-data/core/services/deploymentTests/create'
+import { startDeploymentTest } from '@latitude-data/core/services/deploymentTests/start'
+import { CommitsRepository } from '@latitude-data/core/repositories'
+import { z } from 'zod'
+
+export const createDeploymentTestAction = withProject
+  .inputSchema(
+    withProjectSchema.extend({
+      challengerCommitUuid: z.string(),
+      testType: z.enum(['shadow', 'ab']),
+      trafficPercentage: z.number().min(0).max(100).optional(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const { challengerCommitUuid, testType, trafficPercentage } = parsedInput
+
+    // Fetch challenger commit
+    const commitsRepo = new CommitsRepository(ctx.workspace.id)
+    const challengerCommitResult = await commitsRepo.getCommitByUuid({
+      uuid: challengerCommitUuid,
+      projectId: ctx.project.id,
+    })
+    const challengerCommit = challengerCommitResult.unwrap()
+
+    // Create the deployment test (baseline is always the head commit)
+    const deploymentTestResult = await createDeploymentTest({
+      workspaceId: ctx.workspace.id,
+      projectId: ctx.project.id,
+      challengerCommitId: challengerCommit.id,
+      testType,
+      trafficPercentage:
+        testType === 'ab'
+          ? (trafficPercentage ?? 50)
+          : (trafficPercentage ?? 100),
+      createdByUserId: ctx.user.id,
+    })
+    const deploymentTest = deploymentTestResult.unwrap()
+
+    // Start the test
+    const startResult = await startDeploymentTest({
+      test: deploymentTest,
+    })
+    startResult.unwrap()
+
+    return deploymentTest
+  })

--- a/apps/web/src/actions/deploymentTests/destroy.ts
+++ b/apps/web/src/actions/deploymentTests/destroy.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { z } from 'zod'
+import { authProcedure } from '../procedures'
+import { destroyDeploymentTest } from '@latitude-data/core/services/deploymentTests/destroy'
+import { DeploymentTestsRepository } from '@latitude-data/core/repositories/deploymentTestsRepository'
+
+export const destroyDeploymentTestAction = authProcedure
+  .inputSchema(
+    z.object({
+      testUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const { testUuid } = parsedInput
+
+    // Fetch the test by UUID to get its ID
+    const repo = new DeploymentTestsRepository(ctx.workspace.id)
+    const testResult = await repo.findByUuid(testUuid)
+    const test = testResult.unwrap()
+
+    const result = await destroyDeploymentTest({
+      test,
+    })
+
+    return result.unwrap()
+  })

--- a/apps/web/src/actions/deploymentTests/pause.ts
+++ b/apps/web/src/actions/deploymentTests/pause.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { z } from 'zod'
+import { authProcedure } from '../procedures'
+import { pauseDeploymentTest } from '@latitude-data/core/services/deploymentTests/pause'
+import { DeploymentTestsRepository } from '@latitude-data/core/repositories/deploymentTestsRepository'
+
+export const pauseDeploymentTestAction = authProcedure
+  .inputSchema(
+    z.object({
+      testUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const { testUuid } = parsedInput
+
+    // Fetch the test by UUID to get its ID
+    const repo = new DeploymentTestsRepository(ctx.workspace.id)
+    const testResult = await repo.findByUuid(testUuid)
+    const test = testResult.unwrap()
+
+    const result = await pauseDeploymentTest({
+      test,
+    })
+
+    return result.unwrap()
+  })

--- a/apps/web/src/actions/deploymentTests/resume.ts
+++ b/apps/web/src/actions/deploymentTests/resume.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { z } from 'zod'
+import { authProcedure } from '../procedures'
+import { startDeploymentTest } from '@latitude-data/core/services/deploymentTests/start'
+import { DeploymentTestsRepository } from '@latitude-data/core/repositories/deploymentTestsRepository'
+
+export const resumeDeploymentTestAction = authProcedure
+  .inputSchema(
+    z.object({
+      testUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const { testUuid } = parsedInput
+
+    // Fetch the test by UUID
+    const repo = new DeploymentTestsRepository(ctx.workspace.id)
+    const testResult = await repo.findByUuid(testUuid)
+    const test = testResult.unwrap()
+
+    const result = await startDeploymentTest({
+      test,
+    })
+
+    return result.unwrap()
+  })

--- a/apps/web/src/actions/deploymentTests/stop.ts
+++ b/apps/web/src/actions/deploymentTests/stop.ts
@@ -1,0 +1,27 @@
+'use server'
+
+import { z } from 'zod'
+import { authProcedure } from '../procedures'
+import { stopDeploymentTest } from '@latitude-data/core/services/deploymentTests/stop'
+import { DeploymentTestsRepository } from '@latitude-data/core/repositories/deploymentTestsRepository'
+
+export const stopDeploymentTestAction = authProcedure
+  .inputSchema(
+    z.object({
+      testUuid: z.string(),
+    }),
+  )
+  .action(async ({ ctx, parsedInput }) => {
+    const { testUuid } = parsedInput
+
+    // Fetch the test by UUID to get its ID
+    const repo = new DeploymentTestsRepository(ctx.workspace.id)
+    const testResult = await repo.findByUuid(testUuid)
+    const test = testResult.unwrap()
+
+    const result = await stopDeploymentTest({
+      test,
+    })
+
+    return result.unwrap()
+  })

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/ActiveCommitsList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/ActiveCommitsList.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { compact } from 'lodash-es'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+
+import { CommitItem } from './CommitItem'
+import { CommitItemsWrapper } from './CommitItemsWrapper'
+
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+import { DeploymentTest } from '@latitude-data/core/schema/models/types/DeploymentTest'
+
+export type CommitTestInfo =
+  | {
+      type: 'ab'
+      isBaseline: boolean
+      trafficPercentage: number
+    }
+  | {
+      type: 'shadow'
+    }
+  | null
+
+export function getCommitTestInfo(
+  commitId: number,
+  headCommitId: number | undefined,
+  activeTests: DeploymentTest[],
+): CommitTestInfo {
+  // Baseline is always the head commit, challenger is stored in the test
+  const isBaseline = headCommitId === commitId
+
+  // First, check for A/B tests (prioritize showing traffic percentage)
+  for (const test of activeTests) {
+    if (test.testType === 'ab') {
+      const isChallenger = test.challengerCommitId === commitId
+      if (isBaseline || isChallenger) {
+        // Baseline gets remaining traffic (100 - challenger %), challenger gets its assigned %
+        const trafficPercentage = isBaseline
+          ? 100 - (test.trafficPercentage ?? 50)
+          : (test.trafficPercentage ?? 50)
+        return {
+          type: 'ab',
+          isBaseline,
+          trafficPercentage,
+        }
+      }
+    }
+  }
+
+  // Then check for shadow tests
+  for (const test of activeTests) {
+    if (test.testType === 'shadow') {
+      const isChallenger = test.challengerCommitId === commitId
+      if (isBaseline || isChallenger) {
+        return { type: 'shadow' }
+      }
+    }
+  }
+
+  return null
+}
+
+export function ActiveCommitsList({
+  currentDocument,
+  headCommit,
+  commitsInActiveTests,
+  activeTests,
+  onCommitPublish,
+  onCommitDelete,
+}: {
+  currentDocument?: DocumentVersion
+  headCommit?: Commit
+  commitsInActiveTests: Commit[]
+  activeTests: DeploymentTest[]
+  onCommitPublish: React.Dispatch<React.SetStateAction<number | null>>
+  onCommitDelete: React.Dispatch<React.SetStateAction<number | null>>
+}) {
+  const activeCommits = useMemo(() => {
+    const commits = new Map<number, Commit>()
+
+    // Add head commit if it exists
+    if (headCommit) {
+      commits.set(headCommit.id, headCommit)
+    }
+
+    // Add commits in active test deployments
+    commitsInActiveTests.forEach((commit) => {
+      commits.set(commit.id, commit)
+    })
+
+    return Array.from(commits.values())
+  }, [headCommit, commitsInActiveTests])
+
+  if (activeCommits.length === 0) {
+    return (
+      <Text.H6 color='foregroundMuted'>
+        There are no active versions on this project yet.
+      </Text.H6>
+    )
+  }
+
+  return (
+    <CommitItemsWrapper>
+      {compact(activeCommits).map((commit) => {
+        const testInfo = getCommitTestInfo(
+          commit.id,
+          headCommit?.id,
+          activeTests,
+        )
+        return (
+          <li key={commit.id}>
+            <CommitItem
+              commit={commit}
+              currentDocument={currentDocument}
+              headCommitId={headCommit?.id}
+              testInfo={testInfo}
+              onCommitPublish={onCommitPublish}
+              onCommitDelete={onCommitDelete}
+            />
+          </li>
+        )
+      })}
+    </CommitItemsWrapper>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/ArchivedCommitsList.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/ArchivedCommitsList.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { useCommits } from '$/stores/commitsStore'
 
-import { CommitItem, CommitItemSkeleton, SimpleUser } from './CommitItem'
+import { CommitItem, CommitItemSkeleton } from './CommitItem'
 import { CommitItemsWrapper } from './CommitItemsWrapper'
 
 import { CommitStatus } from '@latitude-data/core/constants'
@@ -14,11 +14,9 @@ import { DocumentVersion } from '@latitude-data/core/schema/models/types/Documen
 export function ArchivedCommitsList({
   currentDocument,
   headCommit,
-  usersById,
 }: {
   currentDocument?: DocumentVersion
   headCommit?: Commit
-  usersById: Record<string, SimpleUser>
 }) {
   const { data, isLoading } = useCommits({
     commitStatus: CommitStatus.Merged,
@@ -51,11 +49,7 @@ export function ArchivedCommitsList({
     <CommitItemsWrapper>
       {commits.map((commit) => (
         <li key={commit.id}>
-          <CommitItem
-            commit={commit}
-            currentDocument={currentDocument}
-            user={usersById[commit.userId]}
-          />
+          <CommitItem commit={commit} currentDocument={currentDocument} />
         </li>
       ))}
     </CommitItemsWrapper>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CommitItem/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CommitItem/index.tsx
@@ -1,10 +1,12 @@
 'use client'
+
 import { useMemo } from 'react'
 
 import { ROUTES } from '$/services/routes'
 import { Badge } from '@latitude-data/web-ui/atoms/Badge'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { Tooltip } from '@latitude-data/web-ui/atoms/Tooltip'
 import { ReactStateDispatch } from '@latitude-data/web-ui/commonTypes'
 import { useCurrentCommit } from '$/app/providers/CommitProvider'
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
@@ -16,6 +18,7 @@ import { HEAD_COMMIT } from '@latitude-data/core/constants'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
 import { User } from '@latitude-data/core/schema/models/types/User'
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+import type { CommitTestInfo } from '../ActiveCommitsList'
 export type SimpleUser = Omit<User, 'encryptedPassword'>
 
 export enum BadgeType {
@@ -27,19 +30,47 @@ export enum BadgeType {
 export function BadgeCommit({
   commit,
   isLive,
+  testInfo,
 }: {
   commit?: Commit
   isLive: boolean
+  testInfo?: CommitTestInfo | null
 }) {
-  const text = isLive
-    ? 'Live'
-    : commit?.mergedAt
-      ? `v${commit?.version}`
-      : 'Draft'
+  // Head commit always shows "Live" label regardless of tests
+  if (isLive) {
+    return (
+      <Badge variant='accent' className='min-w-0 flex-shrink-0'>
+        Live
+      </Badge>
+    )
+  }
+
+  // If there's test info for non-head commits, show test badge
+  if (testInfo) {
+    if (testInfo.type === 'shadow') {
+      return (
+        <Badge variant='purple' className='flex-shrink-0'>
+          Shadow test
+        </Badge>
+      )
+    }
+    if (testInfo.type === 'ab') {
+      // Challenger gets warning badge
+      const variant = 'warningMuted'
+      return (
+        <Badge variant={variant} className='flex-shrink-0'>
+          A/B test: {testInfo.trafficPercentage}%
+        </Badge>
+      )
+    }
+  }
+
+  // Default badge behavior for non-head commits
+  const text = commit?.mergedAt ? `v${commit?.version}` : 'Draft'
   return (
     <Badge
       variant={commit?.mergedAt ? 'accent' : 'muted'}
-      className='flex-shrink-0'
+      className='min-w-0 flex-shrink-0'
     >
       {text}
     </Badge>
@@ -50,14 +81,14 @@ export function CommitItem({
   commit,
   currentDocument,
   headCommitId,
-  user,
+  testInfo,
   onCommitPublish,
   onCommitDelete,
 }: {
   commit?: Commit
   currentDocument?: DocumentVersion
   headCommitId?: number
-  user?: SimpleUser
+  testInfo?: CommitTestInfo | null
   onCommitPublish?: ReactStateDispatch<number | null>
   onCommitDelete?: ReactStateDispatch<number | null>
 }) {
@@ -88,47 +119,79 @@ export function CommitItem({
 
   if (!commit || !commitPath) return null
 
+  const hasViewButton = currentCommit.uuid !== commit.uuid
+  const hasDraftButtons = isDraft && onCommitPublish && onCommitDelete
+  const hasAnyButton = hasViewButton || hasDraftButtons
+
   return (
     <div
       className={cn('flex flex-col p-4 gap-y-2', {
         'bg-accent/50': commit.id === currentCommit.id,
       })}
     >
-      <div className='flex flex-col gap-y-1'>
-        <div className='flex items-center justify-between'>
+      <div className='flex flex-row items-center justify-between'>
+        <div className='flex flex-col gap-2'>
           <Text.H5>{commit.title}</Text.H5>
-          <BadgeCommit commit={commit} isLive={commit.id === headCommitId} />
+          <div>
+            <BadgeCommit
+              commit={commit}
+              isLive={commit.id === headCommitId}
+              testInfo={testInfo}
+            />
+          </div>
         </div>
-        <Text.H6 color='foregroundMuted'>
-          {user ? user.name : 'Unknown user'}
-        </Text.H6>
-      </div>
-      <div className='flex flex-row items-center gap-x-4'>
-        {currentCommit.uuid !== commit.uuid && (
-          <Link href={commitPath}>
-            <Button variant='link' size='none'>
-              View
-            </Button>
-          </Link>
+        {hasAnyButton && (
+          <div className='flex flex-row items-center gap-x-4'>
+            <div className='flex flex-row items-center gap-4 px-2 py-0 border rounded-xl'>
+              {hasViewButton && (
+                <Tooltip
+                  asChild
+                  trigger={
+                    <Link href={commitPath}>
+                      <Button
+                        iconProps={{
+                          name: 'arrowRight',
+                          color: 'foregroundMuted',
+                        }}
+                        variant='nope'
+                      />
+                    </Link>
+                  }
+                >
+                  View version
+                </Tooltip>
+              )}
+              {hasDraftButtons && (
+                <>
+                  <Tooltip
+                    asChild
+                    trigger={
+                      <Button
+                        iconProps={{ name: 'split', color: 'foregroundMuted' }}
+                        variant='nope'
+                        onClick={() => onCommitPublish(commit.id)}
+                      />
+                    }
+                  >
+                    Deploy version
+                  </Tooltip>
+                  <Tooltip
+                    asChild
+                    trigger={
+                      <Button
+                        iconProps={{ name: 'trash', color: 'foregroundMuted' }}
+                        variant='nope'
+                        onClick={() => onCommitDelete(commit.id)}
+                      />
+                    }
+                  >
+                    Delete version
+                  </Tooltip>
+                </>
+              )}
+            </div>
+          </div>
         )}
-        {isDraft && onCommitPublish && onCommitDelete ? (
-          <>
-            <Button
-              variant='link'
-              size='none'
-              onClick={() => onCommitPublish(commit.id)}
-            >
-              Publish
-            </Button>
-            <Button
-              variant='link'
-              size='none'
-              onClick={() => onCommitDelete(commit.id)}
-            >
-              Delete
-            </Button>
-          </>
-        ) : null}
       </div>
     </div>
   )

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/TestingSection.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/TestingSection.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { SwitchInput } from '@latitude-data/web-ui/atoms/Switch'
+import { TabSelector } from '$/components/TabSelector'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { Slider } from '@latitude-data/web-ui/atoms/Slider'
+import { FormWrapper } from '@latitude-data/web-ui/atoms/FormWrapper'
+
+interface TestingSectionProps {
+  enabled: boolean
+  testType: 'shadow' | 'ab' | null
+  trafficPercentage: number
+  onEnabledChange: (enabled: boolean) => void
+  onTestTypeChange: (testType: 'shadow' | 'ab') => void
+  onTrafficPercentageChange: (percentage: number) => void
+}
+
+export function TestingSection({
+  enabled,
+  testType,
+  trafficPercentage,
+  onEnabledChange,
+  onTestTypeChange,
+  onTrafficPercentageChange,
+}: TestingSectionProps) {
+  return (
+    <div className='flex flex-col gap-y-4'>
+      <div className='flex justify-end'>
+        <SwitchInput
+          checked={enabled}
+          onCheckedChange={onEnabledChange}
+          label='Testing'
+          fullWidth={false}
+          inverted
+        />
+      </div>
+      <div className={`flex flex-col gap-y-4 ${enabled ? '' : 'opacity-50'}`}>
+        <div className='flex flex-col gap-y-2'>
+          <TabSelector
+            options={[
+              { label: 'Shadow Test', value: 'shadow' },
+              { label: 'A/B Test', value: 'ab' },
+            ]}
+            selected={testType || undefined}
+            onSelect={(value) => onTestTypeChange(value as 'shadow' | 'ab')}
+            disabled={!enabled}
+            fullWidth
+          />
+          {testType && (
+            <Text.H6 color='foregroundMuted'>
+              {testType === 'shadow'
+                ? 'Run the new version alongside production without affecting users'
+                : 'Split traffic between the current version and the new version'}
+            </Text.H6>
+          )}
+        </div>
+        <FormWrapper>
+          {testType && (
+            <div className='flex flex-col gap-y-4'>
+              <div className='flex flex-col gap-y-2'>
+                <Text.H5M>Traffic percentage</Text.H5M>
+                <Text.H6 color='foregroundMuted'>
+                  {testType === 'shadow'
+                    ? 'Percentage of traffic to shadow test'
+                    : 'Percentage of traffic to route to the new version'}
+                </Text.H6>
+              </div>
+              <div className='flex flex-row items-center gap-4 px-2'>
+                <Text.H6
+                  color={
+                    trafficPercentage === 0
+                      ? 'accentForeground'
+                      : 'foregroundMuted'
+                  }
+                >
+                  0%
+                </Text.H6>
+                <div className='relative flex-grow min-w-0'>
+                  <Slider
+                    showMiddleRange
+                    disabled={!enabled}
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={[trafficPercentage]}
+                    onValueChange={(value) =>
+                      onTrafficPercentageChange(value[0]!)
+                    }
+                  />
+                </div>
+                <Text.H6
+                  color={
+                    trafficPercentage === 100
+                      ? 'accentForeground'
+                      : 'foregroundMuted'
+                  }
+                >
+                  100%
+                </Text.H6>
+              </div>
+              <div className='flex justify-center'>
+                <Text.H4M color='accentForeground'>
+                  {trafficPercentage}%
+                </Text.H4M>
+              </div>
+            </div>
+          )}
+        </FormWrapper>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/PublishDraftCommitModal/index.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
-import { ConfirmModal } from '@latitude-data/web-ui/atoms/Modal'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+} from 'react'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { CloseTrigger, Modal } from '@latitude-data/web-ui/atoms/Modal'
 import { FormWrapper } from '@latitude-data/web-ui/atoms/FormWrapper'
 import { Input } from '@latitude-data/web-ui/atoms/Input'
 import { ReactStateDispatch } from '@latitude-data/web-ui/commonTypes'
@@ -11,53 +18,28 @@ import { ROUTES } from '$/services/routes'
 import { useCommits } from '$/stores/commitsStore'
 import { useRouter } from 'next/navigation'
 import { useCommitsChanges } from '$/stores/commitChanges'
+import useFeature from '$/stores/useFeature'
 import { ChangedDocument, type CommitChanges } from '@latitude-data/constants'
 import { ChangesList } from './ChangesList'
 import { ChangeDiff } from './ChangeDiff'
 import { CommitStatus } from '@latitude-data/core/constants'
 import { MainDocumentChange } from './MainDocumentChange'
 import useDocumentVersions from '$/stores/documentVersions'
-
-function BlankSlateSelection() {
-  return (
-    <div className='flex flex-grow bg-secondary w-full rounded-md items-center justify-center'>
-      <Text.H6 color='foregroundMuted'>
-        Select a prompt to view the diff
-      </Text.H6>
-    </div>
-  )
-}
-
-function confirmDescription({
-  isLoading,
-  changes,
-  title,
-}: {
-  changes: CommitChanges
-  isLoading: boolean
-  title: string
-}) {
-  if (isLoading) return undefined
-  if (!changes.anyChanges) return 'No changes to publish.'
-  if (!title.trim()) return 'Please provide a version name.'
-
-  if (changes.documents.hasErrors) {
-    return 'Some documents have errors, please click on those documents to see the errors.'
-  }
-
-  if (changes.triggers.hasPending) {
-    return `There are triggers that needs to be configured before publishing.`
-  }
-
-  return 'Publishing a new version is reversible and doesnt remove previous versions! You can always go back to use previous version if needed.'
-}
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { TestingSection } from './TestingSection'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { createDeploymentTestAction } from '$/actions/deploymentTests/create'
+import useDeploymentTests from '$/stores/deploymentTests'
+import type { DeploymentTest } from '@latitude-data/core/schema/models/types/DeploymentTest'
 
 export default function PublishDraftCommitModal({
   commitId,
   onClose,
+  headCommit,
 }: {
   commitId: number | null
   onClose: ReactStateDispatch<number | null>
+  headCommit?: Commit
 }) {
   const { toast } = useToast()
   const { data, publishDraft, isPublishing } = useCommits({
@@ -84,9 +66,80 @@ export default function PublishDraftCommitModal({
   const [selectedDocumentChange, setSelectedDocumentChange] = useState<
     ChangedDocument | undefined
   >(undefined)
+  const { isEnabled: testVersionEnabled } = useFeature('testing')
+  const [testingEnabled, setTestingEnabled] = useState(false)
+  const [testType, setTestType] = useState<'shadow' | 'ab' | null>('shadow')
+  const [trafficPercentage, setTrafficPercentage] = useState(100)
   const { data: changes, isLoading: isLoadingChanges } = useCommitsChanges({
     commit,
   })
+  const { data: documents, isLoading: isLoadingDocuments } =
+    useDocumentVersions({
+      projectId: project.id,
+      commitUuid: commit?.uuid,
+    })
+  const { data: deploymentTests, isLoading: isDeploymentTests } =
+    useDeploymentTests({
+      projectId: project.id,
+    })
+  const { execute: createTest, isPending: isCreatingTest } = useLatitudeAction(
+    createDeploymentTestAction,
+    {
+      onSuccess: () => {
+        toast({
+          title: 'Success',
+          description: 'Deployment test created successfully',
+        })
+
+        if (commit) {
+          router.push(
+            ROUTES.projects
+              .detail({ id: project.id })
+              .commits.detail({ uuid: commit?.uuid }).root,
+          )
+        }
+      },
+      onError: (error) => {
+        toast({
+          title: 'Error',
+          description: error.message,
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+  const isLoading = isLoadingDocuments || isDeploymentTests
+  const isPublishingOrCreating = isPublishing || isCreatingTest
+
+  const { commitInActiveDeployment, hasBothTestTypesActive } =
+    useDeploymentTestsState(deploymentTests, commit?.id)
+
+  const shouldShowTestingSection = useTestingSectionVisibility(
+    testVersionEnabled,
+    headCommit,
+    commit,
+    isLoading,
+    commitInActiveDeployment,
+    hasBothTestTypesActive,
+  )
+
+  const {
+    anyChanges,
+    hasErrors,
+    disabled: formDisabled,
+  } = usePublishFormState(
+    changes,
+    isLoadingChanges,
+    isPublishing,
+    isCreatingTest,
+    testingEnabled,
+    headCommit,
+    commit,
+    title,
+  )
+
+  const disabled = formDisabled || (testingEnabled && !testType)
+
   useEffect(() => {
     if (commit) {
       setTitle(commit.title || '')
@@ -94,29 +147,36 @@ export default function PublishDraftCommitModal({
     }
   }, [commit])
 
-  const { data: documents, isLoading: isLoadingDocuments } =
-    useDocumentVersions({
-      projectId: project.id,
-      commitUuid: commit?.uuid,
-    })
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
 
-  const isLoading = isLoadingChanges || isLoadingDocuments
+      if (testingEnabled && testVersionEnabled) {
+        if (!headCommit) {
+          toast({
+            title: 'Error',
+            description: 'No published version found to use as baseline',
+            variant: 'destructive',
+          })
+          return
+        }
 
-  const anyChanges = changes.anyChanges
-  const hasErrors = (!isLoadingChanges && changes.hasIssues) || !anyChanges
+        if (!testType || !commit) {
+          toast({
+            title: 'Error',
+            description: 'Please complete all required fields',
+            variant: 'destructive',
+          })
+          return
+        }
 
-  return (
-    <ConfirmModal
-      size='xl'
-      height='screen'
-      scrollable={false}
-      dismissible={!isPublishing}
-      type={hasErrors ? 'destructive' : 'default'}
-      open={!!commit}
-      title='Publish new version'
-      description='Publish a new version of the project to create a checkpoint of the current state of the project, including all prompts and triggers.'
-      onOpenChange={() => onClose(null)}
-      onConfirm={() =>
+        await createTest({
+          projectId: project.id,
+          challengerCommitUuid: commit.uuid,
+          testType,
+          trafficPercentage,
+        })
+      } else {
         publishDraft({
           projectId: project.id,
           id: commitId!,
@@ -124,50 +184,110 @@ export default function PublishDraftCommitModal({
           description,
         })
       }
-      confirm={{
-        label: isLoading ? 'Validating...' : 'Publish new version',
-        description: confirmDescription({ isLoading, changes, title }),
-        disabled:
-          isLoading ||
-          !changes.anyChanges ||
-          changes.hasIssues ||
-          !title.trim(),
-        isConfirming: isPublishing,
-      }}
+    },
+    [
+      testingEnabled,
+      testVersionEnabled,
+      headCommit,
+      testType,
+      commit,
+      trafficPercentage,
+      createTest,
+      project.id,
+      publishDraft,
+      commitId,
+      title,
+      description,
+      toast,
+    ],
+  )
+
+  return (
+    <Modal
+      size='xl'
+      height='screen'
+      scrollable={false}
+      dismissible={!isPublishingOrCreating}
+      open={!!commit}
+      title='Deploy'
+      onOpenChange={() => onClose(null)}
+      description={confirmDescription({ isLoading, changes, title })}
+      footer={
+        <>
+          <CloseTrigger />
+          <Button
+            fancy
+            variant={hasErrors ? 'destructive' : 'default'}
+            disabled={disabled}
+            type='submit'
+            form='publish-commit-form'
+            isLoading={isPublishingOrCreating}
+            iconProps={{
+              name: 'arrowUp',
+              placement: 'right',
+            }}
+          >
+            {isLoading
+              ? 'Validating...'
+              : isPublishingOrCreating
+                ? testingEnabled && testVersionEnabled
+                  ? 'Deploying test...'
+                  : 'Deploying...'
+                : testingEnabled && testVersionEnabled
+                  ? 'Deploy test'
+                  : 'Deploy'}
+          </Button>
+        </>
+      }
     >
       <div className='flex flex-row gap-4 h-full divide-x divide-border'>
-        <div className='flex flex-col gap-4 min-w-64 max-w-64 h-full'>
-          <FormWrapper>
-            <Input
-              required
-              label='Version name'
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder='Enter version name'
+        <div className='flex flex-col gap-8 min-w-[368px] h-full'>
+          <form id='publish-commit-form' onSubmit={handleSubmit}>
+            <FormWrapper>
+              <Input
+                required
+                label='Version name'
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder='Enter version name'
+              />
+              <TextArea
+                label='Description'
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder='Enter version description'
+                minRows={2}
+                className='resize-none'
+              />
+            </FormWrapper>
+          </form>
+          {shouldShowTestingSection && (
+            <TestingSection
+              enabled={testingEnabled}
+              testType={testType}
+              trafficPercentage={trafficPercentage}
+              onEnabledChange={setTestingEnabled}
+              onTestTypeChange={setTestType}
+              onTrafficPercentageChange={setTrafficPercentage}
             />
-            <TextArea
-              label='Description'
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder='Enter version description'
-              minRows={2}
-              className='resize-none'
-            />
-          </FormWrapper>
-          {commit && changes.mainDocumentUuid !== undefined && (
-            <MainDocumentChange commit={commit!} />
           )}
-          <ChangesList
-            anyChanges={anyChanges}
-            selected={selectedDocumentChange}
-            onSelect={setSelectedDocumentChange}
-            projectId={project.id}
-            commit={commit}
-            documents={documents}
-            isLoading={isLoading}
-            changes={changes}
-            onClose={onClose}
-          />
+          <div className='flex flex-col gap-4'>
+            <Text.H5M>Changes</Text.H5M>
+            {commit && changes.mainDocumentUuid !== undefined && (
+              <MainDocumentChange commit={commit!} />
+            )}
+            <ChangesList
+              anyChanges={anyChanges}
+              selected={selectedDocumentChange}
+              onSelect={setSelectedDocumentChange}
+              projectId={project.id}
+              commit={commit}
+              documents={documents}
+              isLoading={isLoading}
+              changes={changes}
+              onClose={onClose}
+            />
+          </div>
         </div>
 
         <div className='pl-4 flex flex-col w-full'>
@@ -178,6 +298,131 @@ export default function PublishDraftCommitModal({
           )}
         </div>
       </div>
-    </ConfirmModal>
+    </Modal>
   )
+}
+
+function BlankSlateSelection() {
+  return (
+    <div className='flex flex-grow bg-secondary w-full rounded-md items-center justify-center'>
+      <Text.H6 color='foregroundMuted'>
+        Select a prompt to view the diff
+      </Text.H6>
+    </div>
+  )
+}
+
+function useDeploymentTestsState(
+  deploymentTests: DeploymentTest[],
+  commitId?: number,
+) {
+  return useMemo(() => {
+    const currentCommitTests = deploymentTests.filter(
+      (test) => test.challengerCommitId === commitId,
+    )
+
+    const commitInActiveDeployment = currentCommitTests.some(
+      (test) => test.status === 'pending' || test.status === 'running',
+    )
+
+    const activeTestTypes = new Set(
+      deploymentTests
+        .filter(
+          (test) => test.status === 'pending' || test.status === 'running',
+        )
+        .map((test) => test.testType),
+    )
+
+    const hasBothTestTypesActive =
+      activeTestTypes.has('ab') && activeTestTypes.has('shadow')
+
+    return { commitInActiveDeployment, hasBothTestTypesActive }
+  }, [deploymentTests, commitId])
+}
+
+function useTestingSectionVisibility(
+  testVersionEnabled: boolean,
+  headCommit: Commit | undefined,
+  commit: Commit | undefined,
+  isLoading: boolean,
+  commitInActiveDeployment: boolean,
+  hasBothTestTypesActive: boolean,
+) {
+  return useMemo(
+    () =>
+      testVersionEnabled &&
+      headCommit &&
+      commit &&
+      !isLoading &&
+      !commitInActiveDeployment &&
+      !hasBothTestTypesActive,
+    [
+      testVersionEnabled,
+      headCommit,
+      commit,
+      isLoading,
+      commitInActiveDeployment,
+      hasBothTestTypesActive,
+    ],
+  )
+}
+
+function usePublishFormState(
+  changes: CommitChanges,
+  isLoadingChanges: boolean,
+  isPublishing: boolean,
+  isCreatingTest: boolean,
+  testingEnabled: boolean,
+  headCommit: Commit | undefined,
+  commit: Commit | undefined,
+  title: string,
+) {
+  const anyChanges = changes.anyChanges
+  const hasErrors = !isLoadingChanges && changes.hasIssues
+
+  const disabled = useMemo(
+    () =>
+      isPublishing ||
+      isCreatingTest ||
+      !changes.anyChanges ||
+      changes.hasIssues ||
+      !title.trim() ||
+      (testingEnabled && (!headCommit || !commit)),
+    [
+      isPublishing,
+      isCreatingTest,
+      changes.anyChanges,
+      changes.hasIssues,
+      title,
+      testingEnabled,
+      headCommit,
+      commit,
+    ],
+  )
+
+  return { anyChanges, hasErrors, disabled }
+}
+
+function confirmDescription({
+  isLoading,
+  changes,
+  title,
+}: {
+  changes: CommitChanges
+  isLoading: boolean
+  title: string
+}) {
+  if (isLoading) return undefined
+  if (!changes.anyChanges) return 'No changes to publish.'
+  if (!title.trim()) return 'Please provide a version name.'
+
+  if (changes.documents.hasErrors) {
+    return 'Some documents have errors, please click on those documents to see the errors.'
+  }
+
+  if (changes.triggers.hasPending) {
+    return `There are triggers that needs to be configured before publishing.`
+  }
+
+  return 'Publishing a new version is reversible and doesnt remove previous versions! You can always go back to use previous version if needed.'
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/Filters/TestDeploymentFilter.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/Filters/TestDeploymentFilter.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo } from 'react'
+import { DeploymentTest } from '@latitude-data/core/schema/models/types/DeploymentTest'
+
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Checkbox } from '@latitude-data/web-ui/atoms/Checkbox'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { useFilterButtonColor, FilterButton } from '$/components/FilterButton'
+
+function TestDeploymentCheckbox({
+  test,
+  selectedTestIds,
+  onSelectTests,
+}: {
+  test: DeploymentTest
+  selectedTestIds: number[]
+  onSelectTests: (selectedTestIds: number[]) => void
+}) {
+  const isSelected = useMemo(
+    () => selectedTestIds.includes(test.id),
+    [selectedTestIds, test],
+  )
+
+  const onSelect = useCallback(() => {
+    onSelectTests(
+      isSelected
+        ? selectedTestIds.filter((id) => id !== test.id)
+        : [...selectedTestIds, test.id],
+    )
+  }, [selectedTestIds, test, isSelected, onSelectTests])
+
+  return (
+    <Checkbox
+      checked={isSelected}
+      onClick={onSelect}
+      label={
+        <div className='flex flex-col gap-1'>
+          <Text.H5 noWrap ellipsis>
+            {test.testType === 'ab' ? 'A/B Test' : 'Shadow Test'}
+          </Text.H5>
+        </div>
+      }
+    />
+  )
+}
+
+function TestDeploymentsList({
+  tests,
+  selectedTestIds,
+  onSelectTests,
+}: {
+  tests: DeploymentTest[]
+  selectedTestIds: number[]
+  onSelectTests: (selectedTestIds: number[]) => void
+}) {
+  return (
+    <div className='flex flex-col gap-2 w-full'>
+      <Text.H5B>Test Deployments</Text.H5B>
+      <ul className='flex flex-col gap-2 w-full'>
+        {tests.map((test) => (
+          <li key={test.id}>
+            <TestDeploymentCheckbox
+              test={test}
+              selectedTestIds={selectedTestIds}
+              onSelectTests={onSelectTests}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export function TestDeploymentFilter({
+  selectedTestIds,
+  onSelectTests,
+  isDefault,
+  reset,
+  disabled,
+  tests,
+}: {
+  selectedTestIds: number[]
+  onSelectTests: (selectedTestIds: number[]) => void
+  isDefault: boolean
+  reset: () => void
+  disabled?: boolean
+  tests: DeploymentTest[]
+}) {
+  const sortedTests = useMemo(
+    () =>
+      [...tests].sort((a, b) => {
+        const aTime =
+          a.createdAt instanceof Date
+            ? a.createdAt.getTime()
+            : a.createdAt
+              ? new Date(a.createdAt).getTime()
+              : 0
+        const bTime =
+          b.createdAt instanceof Date
+            ? b.createdAt.getTime()
+            : b.createdAt
+              ? new Date(b.createdAt).getTime()
+              : 0
+        return bTime - aTime
+      }),
+    [tests],
+  )
+
+  const filterLabel = useMemo(() => {
+    if (isDefault) return 'All tests'
+    if (selectedTestIds.length === 0) return 'No tests selected'
+    if (selectedTestIds.length > 1) {
+      return `${selectedTestIds.length} tests`
+    }
+    const selectedTest = tests.find((test) => test.id === selectedTestIds[0])
+    return selectedTest
+      ? `${selectedTest.testType === 'ab' ? 'A/B' : 'Shadow'} Test`
+      : '1 test'
+  }, [isDefault, selectedTestIds, tests])
+
+  const filterColor = useFilterButtonColor({
+    isDefault,
+    isSelected: selectedTestIds.length > 0,
+  })
+
+  return (
+    <FilterButton
+      label={filterLabel}
+      color={filterColor.color}
+      darkColor={filterColor.darkColor}
+    >
+      <div className='flex flex-row gap-4 w-full flex-nowrap justify-end'>
+        <Button
+          size='none'
+          variant='link'
+          onClick={reset}
+          disabled={disabled || isDefault}
+        >
+          Reset
+        </Button>
+      </div>
+      <div className='flex flex-col gap-4'>
+        <TestDeploymentsList
+          tests={sortedTests}
+          selectedTestIds={selectedTestIds}
+          onSelectTests={onSelectTests}
+        />
+      </div>
+    </FilterButton>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/TracePanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/TracePanel/index.tsx
@@ -25,6 +25,7 @@ export function TracePanel({
   const ref = useRef<HTMLDivElement>(null)
   const scrollableArea = usePanelDomRef({ selfRef: ref.current })
   const beacon = panelRef?.current
+
   useStickyNested({
     scrollableArea,
     beacon,
@@ -32,6 +33,7 @@ export function TracePanel({
     targetContainer: panelContainerRef?.current,
     offset: DETAILS_OFFSET,
   })
+
   return (
     <div ref={panelContainerRef} className='h-full'>
       {children({ ref })}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/page.tsx
@@ -38,6 +38,7 @@ export default async function TracesPage({
     spanId: validatedFilters?.spanId,
     commitUuids: validatedFilters?.commitUuids,
     experimentUuids: validatedFilters?.experimentUuids,
+    testDeploymentIds: validatedFilters?.testDeploymentIds,
     createdAt: validatedFilters?.createdAt,
   }
   const commit = await commitsRepo

--- a/apps/web/src/app/api/deployment-tests/route.ts
+++ b/apps/web/src/app/api/deployment-tests/route.ts
@@ -1,0 +1,52 @@
+'use server'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { authHandler } from '$/middlewares/authHandler'
+import { DeploymentTestsRepository } from '@latitude-data/core/repositories/deploymentTestsRepository'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { BadRequestError } from '@latitude-data/core/lib/errors'
+
+export const GET = errorHandler(
+  authHandler(
+    async (
+      req: NextRequest,
+      {
+        workspace,
+      }: {
+        workspace: Workspace
+      },
+    ) => {
+      const searchParams = req.nextUrl.searchParams
+      const projectIdParam = searchParams.get('projectId')
+      const commitIdParam = searchParams.get('commitId')
+      const statusParams = searchParams.getAll('status')
+
+      if (!projectIdParam) {
+        throw new BadRequestError('projectId query parameter is required')
+      }
+
+      const projectId = Number(projectIdParam)
+      if (isNaN(projectId)) {
+        throw new BadRequestError('Invalid project ID')
+      }
+
+      let commitId: number | undefined
+      if (commitIdParam) {
+        commitId = Number(commitIdParam)
+        if (isNaN(commitId)) {
+          throw new BadRequestError('Invalid commit ID')
+        }
+      }
+
+      const repo = new DeploymentTestsRepository(workspace.id)
+      const result = await repo.filterByProjectAndCommitAndStatus(
+        projectId,
+        commitId,
+        statusParams.length > 0 ? statusParams : undefined,
+      )
+
+      return NextResponse.json(result, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/hooks/spanFilters/useProcessSpanFilters.ts
+++ b/apps/web/src/hooks/spanFilters/useProcessSpanFilters.ts
@@ -67,6 +67,14 @@ export function useProcessSpanFilters({
     )
   }, [filterOptions.experimentUuids])
 
+  const isTestDeploymentsDefault = useMemo(() => {
+    // Default is when no test deployment filter is set (undefined or empty array)
+    return (
+      !filterOptions.testDeploymentIds ||
+      filterOptions.testDeploymentIds.length === 0
+    )
+  }, [filterOptions.testDeploymentIds])
+
   const onSelectCommits = useCallback(
     (selectedCommitUuids: string[] | undefined) => {
       // Remove commitUuids from filter if undefined (all commits selected)
@@ -189,11 +197,42 @@ export function useProcessSpanFilters({
     [onFiltersChanged, setSearchParams, filterOptions],
   )
 
+  const onSelectTestDeployments = useCallback(
+    (selectedTestDeploymentIds: number[] | undefined) => {
+      // Remove testDeploymentIds from filter if undefined (all tests selected)
+      if (!selectedTestDeploymentIds) {
+        const { testDeploymentIds: _, ...restFilters } = filterOptions
+        onFiltersChanged(restFilters)
+
+        // If no filters remain, remove the filters param entirely
+        if (Object.keys(restFilters).length === 0) {
+          setSearchParams('filters', undefined)
+        } else {
+          setSearchParams('filters', JSON.stringify(restFilters))
+        }
+      } else {
+        onFiltersChanged((currentFilters) => ({
+          ...currentFilters,
+          testDeploymentIds: selectedTestDeploymentIds,
+        }))
+
+        const updatedFilters: SpansFilters = {
+          ...filterOptions,
+          testDeploymentIds: selectedTestDeploymentIds,
+        }
+        setSearchParams('filters', JSON.stringify(updatedFilters))
+      }
+    },
+    [onFiltersChanged, setSearchParams, filterOptions],
+  )
+
   return {
     isCommitsDefault,
     isExperimentsDefault,
+    isTestDeploymentsDefault,
     onSelectCommits,
     onSelectExperiments,
+    onSelectTestDeployments,
     onCreatedAtChange,
     onTraceIdChange,
   }

--- a/apps/web/src/hooks/useDocumentValueContext.tsx
+++ b/apps/web/src/hooks/useDocumentValueContext.tsx
@@ -101,7 +101,8 @@ export function DocumentValueProvider({
       if (error) {
         toast({
           title: 'Error saving document',
-          description: 'There was an error saving the document.',
+          description:
+            error.message ?? 'There was an error saving the document.',
           variant: 'destructive',
         })
 

--- a/apps/web/src/hooks/useFetcher.ts
+++ b/apps/web/src/hooks/useFetcher.ts
@@ -182,7 +182,7 @@ export default function useFetcher<
   return useCallback(async () => {
     if (!route) return fallback as R
 
-    const response = executeFetch<R, I, Raw>({
+    const response = await executeFetch<R, I, Raw>({
       route,
       searchParams,
       toast,

--- a/apps/web/src/lib/schemas/filters.ts
+++ b/apps/web/src/lib/schemas/filters.ts
@@ -6,6 +6,7 @@ export const spansFiltersSchema = z
     spanId: z.string().optional(),
     commitUuids: z.array(z.string()).optional(),
     experimentUuids: z.array(z.string()).optional(),
+    testDeploymentIds: z.array(z.coerce.number()).optional(),
     createdAt: z
       .object({
         from: z.coerce.date().optional(),

--- a/apps/web/src/stores/deploymentTests.ts
+++ b/apps/web/src/stores/deploymentTests.ts
@@ -1,0 +1,264 @@
+'use client'
+
+import { DeploymentTest } from '@latitude-data/core/schema/models/types/DeploymentTest'
+import { useCallback, useMemo } from 'react'
+import useFetcher from '$/hooks/useFetcher'
+import { createDeploymentTestAction } from '$/actions/deploymentTests/create'
+import { pauseDeploymentTestAction } from '$/actions/deploymentTests/pause'
+import { resumeDeploymentTestAction } from '$/actions/deploymentTests/resume'
+import { stopDeploymentTestAction } from '$/actions/deploymentTests/stop'
+import { destroyDeploymentTestAction } from '$/actions/deploymentTests/destroy'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { useToast } from '@latitude-data/web-ui/atoms/Toast'
+import useSWR, { SWRConfiguration } from 'swr'
+
+const EMPTY_DATA = [] as DeploymentTest[]
+
+export default function useDeploymentTests(
+  {
+    projectId,
+    commitId,
+    status,
+  }: {
+    projectId?: number
+    commitId?: number
+    status?: string
+  } = {},
+  opts: SWRConfiguration & {
+    onSuccessCreate?: (test: DeploymentTest) => void
+  } = {},
+) {
+  const { toast } = useToast()
+  const { onSuccessCreate } = opts
+  const enabled = !!projectId
+
+  const queryParams = new URLSearchParams()
+  if (projectId) {
+    queryParams.set('projectId', String(projectId))
+  }
+  if (commitId) {
+    queryParams.set('commitId', String(commitId))
+  }
+  if (status) {
+    queryParams.set('status', status)
+  }
+  const queryString = queryParams.toString()
+  const url = enabled
+    ? `/api/deployment-tests${queryString ? `?${queryString}` : ''}`
+    : undefined
+
+  const fetcher = useFetcher<DeploymentTest[]>(url, {
+    fallback: EMPTY_DATA,
+  })
+
+  const {
+    mutate,
+    data = EMPTY_DATA,
+    isValidating,
+    isLoading,
+    error: swrError,
+  } = useSWR<DeploymentTest[]>(
+    enabled ? ['deploymentTests', projectId, commitId, status] : undefined,
+    fetcher,
+    opts,
+  )
+
+  const { execute: executeCreate, isPending: isCreating } = useLatitudeAction(
+    createDeploymentTestAction,
+    {
+      onSuccess: ({ data: test }) => {
+        toast({
+          title: 'Test created',
+          description: `Deployment test has been created and started`,
+        })
+        onSuccessCreate?.(test)
+        mutate()
+      },
+      onError: () => {
+        toast({
+          title: 'Error creating test',
+          description: 'Failed to create deployment test',
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+
+  const { execute: executePause, isPending: isPausing } = useLatitudeAction(
+    pauseDeploymentTestAction,
+    {
+      onSuccess: ({ data: updatedTest }) => {
+        mutate(
+          (prev) =>
+            (prev ?? data)?.map((test) =>
+              test.id === updatedTest.id ? updatedTest : test,
+            ) ?? [],
+          { revalidate: false },
+        )
+        toast({
+          title: 'Test paused',
+          description: 'Deployment test has been paused',
+        })
+      },
+      onError: () => {
+        toast({
+          title: 'Error pausing test',
+          description: 'Failed to pause deployment test',
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+
+  const { execute: executeResume, isPending: isResuming } = useLatitudeAction(
+    resumeDeploymentTestAction,
+    {
+      onSuccess: ({ data: updatedTest }) => {
+        mutate(
+          (prev) =>
+            (prev ?? data)?.map((test) =>
+              test.id === updatedTest.id ? updatedTest : test,
+            ) ?? [],
+          { revalidate: false },
+        )
+        toast({
+          title: 'Test resumed',
+          description: 'Deployment test has been resumed',
+        })
+      },
+      onError: () => {
+        toast({
+          title: 'Error resuming test',
+          description: 'Failed to resume deployment test',
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+
+  const { execute: executeStop, isPending: isStopping } = useLatitudeAction(
+    stopDeploymentTestAction,
+    {
+      onSuccess: ({ data: updatedTest }) => {
+        mutate(
+          (prev) =>
+            (prev ?? data)?.map((test) =>
+              test.id === updatedTest.id ? updatedTest : test,
+            ) ?? [],
+          { revalidate: false },
+        )
+        toast({
+          title: 'Test stopped',
+          description: 'Deployment test has been completed',
+        })
+      },
+      onError: () => {
+        toast({
+          title: 'Error stopping test',
+          description: 'Failed to stop deployment test',
+          variant: 'destructive',
+        })
+      },
+    },
+  )
+
+  const { execute: executeDestroy, isPending: isDestroying } =
+    useLatitudeAction(destroyDeploymentTestAction, {
+      onSuccess: () => {
+        toast({
+          title: 'Test deleted',
+          description: 'Deployment test has been deleted',
+        })
+        mutate()
+      },
+      onError: () => {
+        toast({
+          title: 'Error deleting test',
+          description: 'Failed to delete deployment test',
+          variant: 'destructive',
+        })
+      },
+    })
+
+  const create = useCallback(
+    (input: Parameters<typeof executeCreate>[0]) => {
+      return executeCreate(input)
+    },
+    [executeCreate],
+  )
+
+  const pause = useCallback(
+    (testUuid: string) => {
+      return executePause({ testUuid })
+    },
+    [executePause],
+  )
+
+  const resume = useCallback(
+    (testUuid: string) => {
+      return executeResume({ testUuid })
+    },
+    [executeResume],
+  )
+
+  const stop = useCallback(
+    (testUuid: string) => {
+      return executeStop({ testUuid })
+    },
+    [executeStop],
+  )
+
+  const destroy = useCallback(
+    (testUuid: string) => {
+      return executeDestroy({ testUuid })
+    },
+    [executeDestroy],
+  )
+
+  return useMemo(
+    () => ({
+      data,
+      isLoading,
+      isValidating,
+      error: swrError,
+      mutate,
+      create: {
+        execute: create,
+        isPending: isCreating,
+      },
+      pause: {
+        execute: pause,
+        isPending: isPausing,
+      },
+      resume: {
+        execute: resume,
+        isPending: isResuming,
+      },
+      stop: {
+        execute: stop,
+        isPending: isStopping,
+      },
+      destroy: {
+        execute: destroy,
+        isPending: isDestroying,
+      },
+    }),
+    [
+      data,
+      isLoading,
+      isValidating,
+      swrError,
+      mutate,
+      create,
+      isCreating,
+      pause,
+      isPausing,
+      resume,
+      isResuming,
+      stop,
+      isStopping,
+      destroy,
+      isDestroying,
+    ],
+  )
+}

--- a/apps/workers/src/workers/worker-definitions/eventsWorker.ts
+++ b/apps/workers/src/workers/worker-definitions/eventsWorker.ts
@@ -50,6 +50,7 @@ const eventHandlersJobMappings = {
   generateDetailsForMergedIssue: jobs.generateDetailsForMergedIssue,
   notifyClientOfCommitUpdated: jobs.notifyClientOfCommitUpdated,
   unlockIssuesDashboardOnAnnotation: jobs.unlockIssuesDashboardOnAnnotation,
+  stopDeploymentTestsForCommitHandler: jobs.stopDeploymentTestsForCommitHandler,
 }
 
 export function startEventsWorker() {

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -45,6 +45,7 @@ export type Events =
   | 'commitCreated'
   | 'commitPublished'
   | 'commitMerged'
+  | 'commitDeleted'
   | 'documentCreated'
   | 'documentRunRequested'
   | 'publicDocumentRunRequested'
@@ -95,6 +96,7 @@ export type Events =
   | 'weeklyEmailPreferenceUpdated'
   | 'escalatingIssuesEmailPreferenceUpdated'
   | 'workspaceIssuesDashboardUnlocked'
+  | 'deploymentTestCreated'
 
 export type LatitudeEventGeneric<
   U extends Events,
@@ -304,6 +306,14 @@ export type CommitMergedEvent = LatitudeEventGeneric<
   {
     commit: Commit
     userEmail: string
+    workspaceId: number
+  }
+>
+
+export type CommitDeletedEvent = LatitudeEventGeneric<
+  'commitDeleted',
+  {
+    commit: Commit
     workspaceId: number
   }
 >
@@ -871,6 +881,15 @@ export type WorkspaceIssuesDashboardUnlockedEvent = LatitudeEventGeneric<
   }
 >
 
+export type DeploymentTestCreatedEvent = LatitudeEventGeneric<
+  'deploymentTestCreated',
+  {
+    deploymentTestId: number
+    workspaceId: number
+    userEmail: string | null
+  }
+>
+
 export type LatitudeEvent =
   | MembershipCreatedEvent
   | UserCreatedEvent
@@ -894,6 +913,7 @@ export type LatitudeEvent =
   | CommitCreatedEvent
   | CommitPublishedEvent
   | CommitMergedEvent
+  | CommitDeletedEvent
   | DocumentCreatedEvent
   | DocumentRunRequestedEvent
   | PublicDocumentRunRequestedEvent
@@ -954,6 +974,7 @@ export type LatitudeEvent =
   | WeeklyEmailPreferenceUpdatedEvent
   | EscalatingIssuesEmailPreferenceUpdatedEvent
   | WorkspaceIssuesDashboardUnlockedEvent
+  | DeploymentTestCreatedEvent
 
 export interface IEventsHandlers {
   magicLinkTokenCreated: EventHandler<MagicLinkTokenCreated>[]
@@ -978,6 +999,7 @@ export interface IEventsHandlers {
   commitCreated: EventHandler<CommitCreatedEvent>[]
   commitPublished: EventHandler<CommitPublishedEvent>[]
   commitMerged: EventHandler<CommitMergedEvent>[]
+  commitDeleted: EventHandler<CommitDeletedEvent>[]
   documentCreated: EventHandler<DocumentCreatedEvent>[]
   documentRunRequested: EventHandler<DocumentRunRequestedEvent>[]
   publicDocumentRunRequested: EventHandler<PublicDocumentRunRequestedEvent>[]
@@ -1038,4 +1060,5 @@ export interface IEventsHandlers {
   weeklyEmailPreferenceUpdated: EventHandler<WeeklyEmailPreferenceUpdatedEvent>[]
   escalatingIssuesEmailPreferenceUpdated: EventHandler<EscalatingIssuesEmailPreferenceUpdatedEvent>[]
   workspaceIssuesDashboardUnlocked: EventHandler<WorkspaceIssuesDashboardUnlockedEvent>[]
+  deploymentTestCreated: EventHandler<DeploymentTestCreatedEvent>[]
 }

--- a/packages/core/src/events/handlers/index.ts
+++ b/packages/core/src/events/handlers/index.ts
@@ -33,6 +33,7 @@ import { generateDetailsForMergedIssue } from './generateDetailsForMergedIssue'
 import { unlockIssuesDashboardOnAnnotation } from './unlockIssuesDashboardOnAnnotation'
 import { notifyClientOfRunStatusByDocument } from './notifyClientOfRunStatusByDocument'
 import { enqueueShadowTestChallengerHandler } from './enqueueShadowTestChallenger'
+import { stopDeploymentTestsForCommitHandler } from './stopDeploymentTestsForCommitHandler'
 
 export const EventHandlers: IEventsHandlers = {
   claimReferralInvitations: [createClaimInvitationReferralJob],
@@ -95,7 +96,8 @@ export const EventHandlers: IEventsHandlers = {
   documentTriggerEventCreated: [notifyClientOfDocumentTriggerEventCreated],
   promocodeClaimed: [],
   subscriptionUpdated: [],
-  commitMerged: [],
+  commitMerged: [stopDeploymentTestsForCommitHandler],
+  commitDeleted: [stopDeploymentTestsForCommitHandler],
   documentRunQueued: [notifyClientOfRunStatusByDocument],
   documentRunStarted: [
     notifyClientOfRunStatusByDocument,
@@ -127,4 +129,5 @@ export const EventHandlers: IEventsHandlers = {
   weeklyEmailPreferenceUpdated: [],
   escalatingIssuesEmailPreferenceUpdated: [],
   workspaceIssuesDashboardUnlocked: [],
+  deploymentTestCreated: [],
 }

--- a/packages/core/src/events/handlers/stopDeploymentTestsForCommitHandler.ts
+++ b/packages/core/src/events/handlers/stopDeploymentTestsForCommitHandler.ts
@@ -1,0 +1,25 @@
+import { DeploymentTestsRepository } from '../../repositories'
+import { stopDeploymentTest } from '../../services/deploymentTests/stop'
+import { captureException } from '../../utils/datadogCapture'
+import { CommitMergedEvent, CommitDeletedEvent } from '../events'
+
+export async function stopDeploymentTestsForCommitHandler({
+  data: event,
+}: {
+  data: CommitMergedEvent | CommitDeletedEvent
+}): Promise<void> {
+  const { commit, workspaceId } = event.data
+
+  try {
+    const deploymentTestsRepo = new DeploymentTestsRepository(workspaceId)
+    const activeTest = await deploymentTestsRepo.findActiveForCommit(
+      commit.projectId,
+      commit.id,
+    )
+    if (!activeTest) return
+
+    await stopDeploymentTest({ test: activeTest }).then((r) => r.unwrap())
+  } catch (error) {
+    captureException(error as Error)
+  }
+}

--- a/packages/core/src/jobs/job-definitions/index.ts
+++ b/packages/core/src/jobs/job-definitions/index.ts
@@ -33,6 +33,7 @@ export * from '../../events/handlers/removeMergedIssueVectors'
 export * from '../../events/handlers/generateDetailsForMergedIssue'
 export * from '../../events/handlers/notifyClientOfCommitUpdated'
 export * from '../../events/handlers/unlockIssuesDashboardOnAnnotation'
+export * from '../../events/handlers/stopDeploymentTestsForCommitHandler'
 
 // Jobs
 export * from './actions/generateProjectNameJob'

--- a/packages/core/src/schema/models/deploymentTests.ts
+++ b/packages/core/src/schema/models/deploymentTests.ts
@@ -16,7 +16,10 @@ import { workspaces } from './workspaces'
 import { projects } from './projects'
 import { commits } from './commits'
 import { timestamps } from '../schemaHelpers'
-import { DeploymentTestStatus } from './types/DeploymentTest'
+import {
+  DeploymentTestStatus,
+  DeploymentTestType,
+} from './types/DeploymentTest'
 
 export const deploymentTests = latitudeSchema.table(
   'deployment_tests',
@@ -37,8 +40,9 @@ export const deploymentTests = latitudeSchema.table(
       .references(() => commits.id),
     testType: varchar('test_type', {
       length: 20,
-      enum: ['shadow', 'ab'],
-    }).notNull(),
+    })
+      .$type<DeploymentTestType>()
+      .notNull(),
     trafficPercentage: integer('traffic_percentage').default(50),
     status: varchar('status', { length: 20 })
       .$type<DeploymentTestStatus>()

--- a/packages/core/src/schema/models/types/DeploymentTest.ts
+++ b/packages/core/src/schema/models/types/DeploymentTest.ts
@@ -2,7 +2,6 @@ import { deploymentTests } from '../deploymentTests'
 
 export type DeploymentTest = typeof deploymentTests.$inferSelect
 export type DeploymentTestInsert = typeof deploymentTests.$inferInsert
-
 export type DeploymentTestStatus =
   | 'pending'
   | 'running'
@@ -11,3 +10,4 @@ export type DeploymentTestStatus =
   | 'cancelled'
 export type DeploymentTestType = 'shadow' | 'ab'
 export type RoutedTo = 'baseline' | 'challenger'
+export const ACTIVE_DEPLOYMENT_STATUSES = ['pending', 'running']

--- a/packages/core/src/services/commits/delete.ts
+++ b/packages/core/src/services/commits/delete.ts
@@ -9,54 +9,82 @@ import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
 import { commits } from '../../schema/models/commits'
 import { pingProjectUpdate } from '../projects'
-import { assertCanEditCommit } from '../../lib/assertCanEditCommit'
+import { findWorkspaceFromCommit } from '../../data-access/workspaces'
+import { publisher } from '../../events/publisher'
+import { captureException } from '../../utils/datadogCapture'
+import { assertCommitIsDraft } from '../../lib/assertCommitIsDraft'
 
 export async function deleteCommitDraft(
   commit: Commit,
   transaction = new Transaction(),
 ) {
-  return transaction.call<Commit>(async (tx) => {
-    const assertionResult = await assertCanEditCommit(commit, tx)
-    if (assertionResult.error) return assertionResult
+  return transaction.call<Commit>(
+    async (tx) => {
+      const assertionResult = assertCommitIsDraft(commit)
+      if (assertionResult.error) return assertionResult
 
-    try {
-      const projectCommits = await unsafelyFindCommitsByProjectId(
-        commit.projectId,
-        tx,
-      )
-      if (projectCommits.length === 1) {
-        return Result.error(
-          new BadRequestError('Cannot delete the only version in a project'),
+      try {
+        const projectCommits = await unsafelyFindCommitsByProjectId(
+          commit.projectId,
+          tx,
         )
+        if (projectCommits.length === 1) {
+          return Result.error(
+            new BadRequestError('Cannot delete the only version in a project'),
+          )
+        }
+
+        const deleted = await tx
+          .update(commits)
+          .set({ deletedAt: new Date() })
+          .where(eq(commits.id, commit.id))
+          .returning()
+
+        const deletedCommit = deleted[0]!
+
+        await pingProjectUpdate(
+          {
+            projectId: commit.projectId,
+          },
+          transaction,
+        ).then((r) => r.unwrap())
+
+        return Result.ok(deletedCommit)
+      } catch (error) {
+        if (
+          error instanceof DatabaseError &&
+          error.code === databaseErrorCodes.foreignKeyViolation
+        ) {
+          throw new BadRequestError(
+            'Cannot delete this version because there are logs or evaluations associated with it.',
+          )
+        } else {
+          throw error
+        }
       }
+    },
+    async (deletedCommit) => {
+      try {
+        const workspace = await findWorkspaceFromCommit(deletedCommit)
+        if (!workspace) {
+          captureException(
+            new Error(
+              `Workspace not found for deleted commit ${deletedCommit.id}`,
+            ),
+          )
+          return
+        }
 
-      const deleted = await tx
-        .update(commits)
-        .set({ deletedAt: new Date() })
-        .where(eq(commits.id, commit.id))
-        .returning()
-
-      const deletedCommit = deleted[0]!
-
-      await pingProjectUpdate(
-        {
-          projectId: commit.projectId,
-        },
-        transaction,
-      ).then((r) => r.unwrap())
-
-      return Result.ok(deletedCommit)
-    } catch (error) {
-      if (
-        error instanceof DatabaseError &&
-        error.code === databaseErrorCodes.foreignKeyViolation
-      ) {
-        throw new BadRequestError(
-          'Cannot delete this version because there are logs or evaluations associated with it.',
-        )
-      } else {
-        throw error
+        await publisher.publishLater({
+          type: 'commitDeleted',
+          data: {
+            commit: deletedCommit,
+            workspaceId: workspace.id,
+          },
+        })
+      } catch (error) {
+        captureException(error as Error)
       }
-    }
-  })
+    },
+  )
 }

--- a/packages/core/src/services/documents/recomputeChanges/index.ts
+++ b/packages/core/src/services/documents/recomputeChanges/index.ts
@@ -23,7 +23,6 @@ import { inheritDocumentRelations } from '../inheritRelations'
 import { getHeadDocumentsAndDraftDocumentsForCommit } from './getHeadDocumentsAndDraftDocuments'
 import { getMergedAndDraftDocuments } from './getMergedAndDraftDocuments'
 import { latitudePromptConfigSchema } from '@latitude-data/constants/latitudePromptSchema'
-import { assertCanEditCommit } from '../../../lib/assertCanEditCommit'
 
 async function resolveDocumentChanges({
   originalDocuments,
@@ -217,8 +216,6 @@ export async function recomputeChanges(
   transaction = new Transaction(),
 ): Promise<TypedResult<RecomputedChanges, Error>> {
   return transaction.call(async (tx) => {
-    await assertCanEditCommit(draft, tx).then((r) => r.unwrap())
-
     const commitsRepository = new CommitsRepository(workspace.id, tx)
     const previousCommit = await commitsRepository.getPreviousCommit(draft)
 

--- a/packages/core/src/services/runs/enqueue.ts
+++ b/packages/core/src/services/runs/enqueue.ts
@@ -16,7 +16,7 @@ import { SimulationSettings } from '../../../../constants/src/simulation'
 import { cache as redis, Cache } from '../../cache'
 import { DeploymentTest } from '../../schema/models/types/DeploymentTest'
 
-type EnqueueRunProps = {
+export type EnqueueRunProps = {
   activeDeploymentTest?: DeploymentTest
   cache?: Cache
   commit: Commit

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -163,6 +163,7 @@ import {
   Video,
   Volume2,
   MessageSquareTextIcon,
+  Split,
 } from 'lucide-react'
 import { MouseEvent } from 'react'
 
@@ -436,6 +437,7 @@ const Icons = {
   sigma: SigmaIcon,
   wandSparkles: WandSparkles,
   cornerDownRight: CornerDownRightIcon,
+  split: Split,
 }
 
 export type IconName = keyof typeof Icons

--- a/packages/web-ui/src/ds/atoms/Switch/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Switch/index.tsx
@@ -96,6 +96,7 @@ type Props = ToogleProps &
     defaultChecked?: boolean
     fullWidth?: boolean
     innerClassName?: string
+    inverted?: boolean
   }
 function SwitchInput({
   className,
@@ -107,6 +108,7 @@ function SwitchInput({
   defaultChecked,
   fullWidth = true,
   innerClassName,
+  inverted = false,
   ...rest
 }: Props) {
   const error = errors?.[0]
@@ -133,6 +135,14 @@ function SwitchInput({
       aria-invalid={!!error}
     >
       <div className='flex flex-row items-center gap-x-2 w-full'>
+        {inverted && label ? (
+          <Label
+            variant={error ? 'destructive' : 'default'}
+            htmlFor={formItemId}
+          >
+            {label}
+          </Label>
+        ) : null}
         <FormControl
           error={error}
           formItemId={formItemId}
@@ -154,7 +164,7 @@ function SwitchInput({
             />
           </div>
         </FormControl>
-        {label ? (
+        {!inverted && label ? (
           <Label
             variant={error ? 'destructive' : 'default'}
             htmlFor={formItemId}


### PR DESCRIPTION
This PR adds the UI and API layer for shadow and A/B testing functionality.

## Changes
- Add deployment test actions (create, destroy, pause, resume, stop)
- Add deployment test stores and hooks (`deploymentTests.ts`, `useActiveDeploymentTest.ts`)
- Add UI components for testing section in publish modal
- Add active commits list and drafts commits list components
- Add test deployment filter for traces
- Add API route for active test status (`/api/projects/[projectId]/active-test`)
- Update gateway handler to support deployment tests
- Update commit selector UI
- Add comprehensive documentation for shadow and A/B testing

## Dependencies
- Depends on: Core services PR (must be merged first)

## Related PRs
- Previous: Core services PR
- This completes the shadow and A/B testing feature implementation