### PR TITLE
Fix collect project Id when bulk processing spans

### DIFF
--- a/apps/web/src/actions/admin/weeklyEmail/enqueueWeeklyEmail.ts
+++ b/apps/web/src/actions/admin/weeklyEmail/enqueueWeeklyEmail.ts
@@ -22,12 +22,25 @@ export const enqueueWeeklyEmailAction = withAdmin
           .filter((e) => e.length > 0)
       : undefined
 
+    // Create date range from 7 days ago (start of day) to now (end of day)
+    const now = new Date()
+    const to = new Date(now)
+    to.setHours(23, 59, 59, 999) // End of today
+
+    const from = new Date(now)
+    from.setDate(from.getDate() - 7)
+    from.setHours(0, 0, 0, 0) // Start of 7 days ago
+
     const { maintenanceQueue } = await queues()
     await maintenanceQueue.add(
       'sendWeeklyEmailJob',
       {
         workspaceId,
         emails: emailList,
+        dateRange: {
+          from: from.toISOString(),
+          to: to.toISOString(),
+        },
       },
       {
         jobId: `weekly-email-manual-${workspaceId}-${Date.now()}`,

--- a/packages/core/src/data-access/weeklyEmail/logs/index.tsx
+++ b/packages/core/src/data-access/weeklyEmail/logs/index.tsx
@@ -162,16 +162,6 @@ export async function getLogsData(
   )
   const usedInProduction = allTimesProductionSpansCount > 0
 
-  if (!usedInProduction) {
-    return {
-      usedInProduction: false,
-      logsCount: 0,
-      tokensSpent: 0,
-      tokensCost: 0,
-      topProjects: [],
-    }
-  }
-
   const range = getDateRangeOrLastWeekRange(dateRange)
 
   const globalStats = await getGlobalLogsStats({ workspace, range }, db)
@@ -181,7 +171,7 @@ export async function getLogsData(
   )
 
   return {
-    usedInProduction: true,
+    usedInProduction,
     ...globalStats,
     topProjects,
   }

--- a/packages/core/src/services/commits/foregroundRun.test.ts
+++ b/packages/core/src/services/commits/foregroundRun.test.ts
@@ -4,7 +4,7 @@ import { Result } from '../../lib/Result'
 import { createProject, helpers } from '../../tests/factories'
 import { Providers } from '@latitude-data/constants'
 import { DeploymentTest } from '../../schema/models/types/DeploymentTest'
-import type { Workspace } from '../../schema/models/types/Workspace'
+import type { WorkspaceDto } from '../../schema/models/types/Workspace'
 import type { Project } from '../../schema/models/types/Project'
 import type { Commit } from '../../schema/models/types/Commit'
 import type { DocumentVersion } from '../../schema/models/types/DocumentVersion'
@@ -18,7 +18,7 @@ vi.spyOn(publisherModule.publisher, 'publishLater')
 vi.spyOn(ProviderApiKeysRepository.prototype, 'find')
 
 describe('runForegroundDocument', () => {
-  let workspace: Workspace
+  let workspace: WorkspaceDto
   let project: Project
   let commit: Commit
   let document: DocumentVersion

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -5,7 +5,11 @@ import { WorkspaceDto } from '../../schema/models/types/Workspace'
 import { LogSources } from '../../constants'
 import { generateUUIDIdentifier } from '../../lib/generateUUID'
 import { Result } from '../../lib/Result'
-import { telemetry, TelemetryContext } from '../../telemetry'
+import {
+  type LatitudeTelemetry,
+  telemetry as realTelemetry,
+  TelemetryContext,
+} from '../../telemetry'
 import { runChain } from '../chains/run'
 import { createDocumentLog } from '../documentLogs/create'
 import { getResolvedContent } from '../documents'
@@ -33,23 +37,26 @@ export type RunDocumentAtCommitArgs = {
   testDeploymentId?: number
 }
 
-export async function runDocumentAtCommit({
-  context,
-  workspace,
-  document,
-  parameters,
-  commit,
-  customIdentifier,
-  source,
-  customPrompt,
-  experiment,
-  errorableUuid,
-  userMessage,
-  abortSignal,
-  tools = {},
-  simulationSettings,
-  testDeploymentId,
-}: RunDocumentAtCommitArgs) {
+export async function runDocumentAtCommit(
+  {
+    context,
+    workspace,
+    document,
+    parameters,
+    commit,
+    customIdentifier,
+    source,
+    customPrompt,
+    experiment,
+    errorableUuid,
+    userMessage,
+    abortSignal,
+    tools = {},
+    simulationSettings,
+    testDeploymentId,
+  }: RunDocumentAtCommitArgs,
+  telemetry: LatitudeTelemetry = realTelemetry,
+) {
   errorableUuid = errorableUuid ?? generateUUIDIdentifier()
   const providersMap = await buildProvidersMap({
     workspaceId: workspace.id,
@@ -71,6 +78,7 @@ export async function runDocumentAtCommit({
     promptUuid: document.documentUuid,
     template: result.value,
     versionUuid: commit.uuid,
+    projectId: commit.projectId,
     source,
   })
 

--- a/packages/core/src/services/documentLogs/addMessages/index.test.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Providers } from '@latitude-data/constants'
+import { LogSources } from '../../../constants'
+import { MessageRole } from '@latitude-data/constants/legacyCompiler'
+import { Result } from '../../../lib/Result'
+import {
+  createDocumentLog,
+  createProject,
+  createProviderLog,
+} from '../../../tests/factories'
+import {
+  telemetry as realTelemetry,
+  type LatitudeTelemetry,
+} from '../../../telemetry'
+import { addMessages } from './index'
+
+const mocks = {
+  runAi: vi.fn(async () => {
+    const fullStream = new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    return Result.ok({
+      type: 'text',
+      text: Promise.resolve('Fake AI generated text'),
+      providerLog: Promise.resolve({ uuid: 'fake-provider-log-uuid' }),
+      usage: Promise.resolve({
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      }),
+      toolCalls: Promise.resolve([]),
+      response: Promise.resolve({ messages: [] }),
+      fullStream,
+    })
+  }),
+}
+
+const aiSpy = vi.spyOn(await import('../../ai'), 'ai')
+
+describe('addMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // @ts-expect-error - we are mocking the function
+    aiSpy.mockImplementation(mocks.runAi)
+  })
+
+  it('calls telemetry.prompt with projectId and all required parameters', async () => {
+    const { workspace, project, documents, commit, providers } =
+      await createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          doc1: `
+---
+provider: openai
+model: gpt-4o
+---
+Hello world
+`,
+        },
+      })
+
+    const document = documents[0]!
+    const provider = providers[0]!
+
+    const { documentLog } = await createDocumentLog({
+      document,
+      commit,
+    })
+
+    await createProviderLog({
+      workspace,
+      documentLogUuid: documentLog.uuid,
+      providerId: provider.id,
+      providerType: provider.provider,
+    })
+
+    const mockPrompt = vi
+      .fn()
+      .mockImplementation(realTelemetry.prompt.bind(realTelemetry))
+    const mockTelemetry = {
+      ...realTelemetry,
+      prompt: mockPrompt,
+    } as unknown as LatitudeTelemetry
+
+    const result = await addMessages(
+      {
+        workspace,
+        documentLogUuid: documentLog.uuid,
+        messages: [
+          {
+            role: MessageRole.user,
+            content: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+        source: LogSources.API,
+      },
+      mockTelemetry,
+    )
+
+    expect(result.ok).toBe(true)
+
+    expect(mockPrompt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        documentLogUuid: documentLog.uuid,
+        name: document.path.split('/').at(-1),
+        promptUuid: document.documentUuid,
+        template: document.content,
+        versionUuid: commit.uuid,
+        projectId: project.id,
+      }),
+    )
+  })
+})

--- a/packages/core/src/services/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.ts
@@ -14,7 +14,12 @@ import {
   ProviderLogsRepository,
 } from '../../../repositories'
 import { WorkspaceDto } from '../../../schema/models/types/Workspace'
-import { BACKGROUND, telemetry, TelemetryContext } from '../../../telemetry'
+import {
+  BACKGROUND,
+  type LatitudeTelemetry,
+  telemetry as realTelemetry,
+  TelemetryContext,
+} from '../../../telemetry'
 import { getInputSchema, getOutputType } from '../../chains/ChainValidator'
 import { scanDocumentContent } from '../../documents'
 import { isErrorRetryable } from '../../evaluationsV2/run'
@@ -31,16 +36,19 @@ type AddMessagesArgs = {
   testDeploymentId?: number
 }
 
-export async function addMessages({
-  workspace,
-  documentLogUuid,
-  messages,
-  source,
-  abortSignal,
-  tools = {},
-  context = BACKGROUND({ workspaceId: workspace.id }),
-  testDeploymentId,
-}: AddMessagesArgs) {
+export async function addMessages(
+  {
+    workspace,
+    documentLogUuid,
+    messages,
+    source,
+    abortSignal,
+    tools = {},
+    context = BACKGROUND({ workspaceId: workspace.id }),
+    testDeploymentId,
+  }: AddMessagesArgs,
+  telemetry: LatitudeTelemetry = realTelemetry,
+) {
   if (!documentLogUuid) {
     return Result.error(new Error('documentLogUuid is required'))
   }
@@ -59,6 +67,7 @@ export async function addMessages({
     promptUuid: document.documentUuid,
     template: document.content,
     versionUuid: commit.uuid,
+    projectId: commit.projectId,
   })
 
   if (!providerLog.providerId) {

--- a/packages/core/src/services/evaluationsV2/llm/buildStreamEvaluationRun.ts
+++ b/packages/core/src/services/evaluationsV2/llm/buildStreamEvaluationRun.ts
@@ -8,7 +8,11 @@ import {
 import { Result, TypedResult } from '../../../lib/Result'
 import { generateUUIDIdentifier } from '../../../lib/generateUUID'
 import { WorkspaceDto } from '../../../schema/models/types/Workspace'
-import { BACKGROUND, telemetry } from '../../../telemetry'
+import {
+  BACKGROUND,
+  type LatitudeTelemetry,
+  telemetry as realTelemetry,
+} from '../../../telemetry'
 import { runChain } from '../../chains/run'
 import { buildProvidersMap } from '../../providerApiKeys/buildMap'
 import { buildLlmEvaluationRunFunction } from './shared'
@@ -16,7 +20,7 @@ import { buildLlmEvaluationRunFunction } from './shared'
 const buildStreamHandler =
   (
     stream: ReadableStream<ChainEvent>,
-    $span: ReturnType<typeof telemetry.prompt>,
+    $span: ReturnType<typeof realTelemetry.prompt>,
   ) =>
   async ({
     signal,
@@ -70,10 +74,12 @@ export async function buildStreamEvaluationRun({
   workspace,
   evaluation,
   parameters,
+  telemetry = realTelemetry,
 }: {
   workspace: WorkspaceDto
   evaluation: EvaluationV2<EvaluationType.Llm, LlmEvaluationMetricAnyCustom>
   parameters: Record<string, unknown>
+  telemetry?: LatitudeTelemetry
 }): Promise<TypedResult<{ streamHandler: StreamHandler }, Error>> {
   const resultUuid = generateUUIDIdentifier()
   const result = await buildLlmEvaluationRunFunction({

--- a/packages/core/src/services/evaluationsV2/llm/shared.ts
+++ b/packages/core/src/services/evaluationsV2/llm/shared.ts
@@ -21,7 +21,11 @@ import { ProviderLogsRepository } from '../../../repositories'
 import { type Commit } from '../../../schema/models/types/Commit'
 import { type ProviderApiKey } from '../../../schema/models/types/ProviderApiKey'
 import { WorkspaceDto } from '../../../schema/models/types/Workspace'
-import { BACKGROUND, telemetry } from '../../../telemetry'
+import {
+  BACKGROUND,
+  type LatitudeTelemetry,
+  telemetry as realTelemetry,
+} from '../../../telemetry'
 import { runChain } from '../../chains/run'
 import { parsePrompt } from '../../documents/parse'
 
@@ -168,6 +172,7 @@ export async function runPrompt<
     providers,
     commit,
     workspace,
+    telemetry = realTelemetry,
   }: {
     prompt: string
     parameters?: Record<string, unknown>
@@ -177,6 +182,7 @@ export async function runPrompt<
     providers: Map<string, ProviderApiKey>
     commit: Commit
     workspace: WorkspaceDto
+    telemetry?: LatitudeTelemetry
   },
   db = database,
 ) {
@@ -194,6 +200,7 @@ export async function runPrompt<
     documentLogUuid: resultUuid,
     versionUuid: commit.uuid,
     promptUuid: evaluation.uuid,
+    projectId: commit.projectId,
     template: prompt,
     parameters: parameters,
     source: LogSources.Evaluation,

--- a/packages/telemetry/typescript/src/instrumentations/manual.ts
+++ b/packages/telemetry/typescript/src/instrumentations/manual.ts
@@ -127,7 +127,7 @@ export type PromptSpanOptions = StartSpanOptions & {
   documentLogUuid?: string // TODO(tracing): temporal related log, remove when observability is ready
   versionUuid?: string // Alias for commitUuid
   promptUuid: string // Alias for documentUuid
-  projectId?: string
+  projectId?: number
   experimentUuid?: string
   testDeploymentId?: number
   externalId?: string


### PR DESCRIPTION
# What?
While testing the weekly email I noticed we're not rendering top projects with traces, but we have traces for the time period. I saw in DB we're not collecting project id, so the query to filter spans by project ID will not work