### PR TITLE
Make more chill weekly email sending of notifications. (too many - too fast)

### DIFF
--- a/apps/workers/src/workers/index.ts
+++ b/apps/workers/src/workers/index.ts
@@ -10,6 +10,7 @@ import { startGenerateEvaluationWorker } from './worker-definitions/generateEval
 import { startIssuesWorker } from './worker-definitions/issuesWorker'
 import { startLatteWorker } from './worker-definitions/latteWorker'
 import { startMaintenanceWorker } from './worker-definitions/maintenanceWorker'
+import { startNotificationsWorker } from './worker-definitions/notificationsWorker'
 import { startRunsWorker } from './worker-definitions/runsWorker'
 import { startTracingWorker } from './worker-definitions/tracingWorker'
 import { startWebhooksWorker } from './worker-definitions/webhooksWorker'
@@ -21,6 +22,7 @@ export async function startWorkers() {
   const eventHandlersWorker = startEventHandlersWorker()
   const latteWorker = startLatteWorker()
   const maintenanceWorker = startMaintenanceWorker()
+  const notificationsWorker = startNotificationsWorker()
   const webhooksWorker = startWebhooksWorker()
   const documentsWorker = startDocumentsWorker()
   const documentSuggestionsWorker = startDocumentSuggestionsWorker()
@@ -36,6 +38,7 @@ export async function startWorkers() {
     eventHandlersWorker,
     latteWorker,
     maintenanceWorker,
+    notificationsWorker,
     webhooksWorker,
     documentsWorker,
     documentSuggestionsWorker,

--- a/apps/workers/src/workers/worker-definitions/maintenanceWorker.ts
+++ b/apps/workers/src/workers/worker-definitions/maintenanceWorker.ts
@@ -16,7 +16,6 @@ const jobMappings = {
   scaleDownMcpServerJob: jobs.scaleDownMcpServerJob,
   updateMcpServerLastUsedJob: jobs.updateMcpServerLastUsedJob,
   scheduleWeeklyEmailJobs: jobs.scheduleWeeklyEmailJobs,
-  sendWeeklyEmailJob: jobs.sendWeeklyEmailJob,
 }
 
 export function startMaintenanceWorker() {

--- a/apps/workers/src/workers/worker-definitions/notificationsWorker.ts
+++ b/apps/workers/src/workers/worker-definitions/notificationsWorker.ts
@@ -1,0 +1,24 @@
+import * as jobs from '@latitude-data/core/jobs/definitions'
+import { Queues } from '@latitude-data/core/queues/types'
+import { createWorker } from '../utils/createWorker'
+import { WORKER_OPTIONS } from '../utils/connectionConfig'
+
+const jobMappings = {
+  sendWeeklyEmailJob: jobs.sendWeeklyEmailJob,
+}
+
+/**
+ * Notifications worker with rate limiting for Mailgun.
+ *
+ * Rate limit: 90 jobs/minute (~91 emails/minute)
+ * This keeps us safely under Mailgun's limits while allowing fast processing.
+ */
+export function startNotificationsWorker() {
+  return createWorker(Queues.notificationsQueue, jobMappings, {
+    ...WORKER_OPTIONS,
+    limiter: {
+      max: 90,
+      duration: 60_000,
+    },
+  })
+}

--- a/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.test.ts
+++ b/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.test.ts
@@ -12,7 +12,7 @@ describe('scheduleWeeklyEmailJobs', () => {
   beforeEach(() => {
     mockAdd = vi.fn()
     vi.spyOn(queuesModule, 'queues').mockResolvedValue({
-      maintenanceQueue: { add: mockAdd },
+      notificationsQueue: { add: mockAdd },
       eventsQueue: { add: vi.fn() },
       webhooksQueue: { add: vi.fn() },
     } as any)

--- a/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.ts
+++ b/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.ts
@@ -11,15 +11,16 @@ export type ScheduleWeeklyEmailJobsData = Record<string, never>
  * 1. Finds all workspaces with prompt span activity in the last 4 weeks
  * 2. Excludes workspaces marked as big accounts (isBigAccount = true)
  * 3. Enqueues individual sendWeeklyEmailJob for each active workspace
+ *    on the notifications queue (rate-limited to 90/minute for Mailgun)
  */
 export const scheduleWeeklyEmailJobs = async (
   _: Job<ScheduleWeeklyEmailJobsData>,
 ) => {
-  const { maintenanceQueue } = await queues()
+  const { notificationsQueue } = await queues()
   const activeWorkspaces = await getActiveWorkspacesForWeeklyEmail()
 
   for (const workspace of activeWorkspaces) {
-    await maintenanceQueue.add(
+    await notificationsQueue.add(
       'sendWeeklyEmailJob',
       { workspaceId: workspace.id },
       { attempts: 3 },

--- a/packages/core/src/jobs/queues/index.ts
+++ b/packages/core/src/jobs/queues/index.ts
@@ -12,6 +12,7 @@ let _queues:
       eventHandlersQueue: Queue
       eventsQueue: Queue
       maintenanceQueue: Queue
+      notificationsQueue: Queue
       tracingQueue: Queue
       webhooksQueue: Queue
       latteQueue: Queue
@@ -59,6 +60,7 @@ export async function queues() {
     eventHandlersQueue: new Queue(Queues.eventHandlersQueue, options),
     eventsQueue: new Queue(Queues.eventsQueue, options),
     maintenanceQueue: new Queue(Queues.maintenanceQueue, options),
+    notificationsQueue: new Queue(Queues.notificationsQueue, options),
     tracingQueue: new Queue(Queues.tracingQueue, options),
     webhooksQueue: new Queue(Queues.webhooksQueue, options),
     latteQueue: new Queue(Queues.latteQueue, options),

--- a/packages/core/src/jobs/queues/types.ts
+++ b/packages/core/src/jobs/queues/types.ts
@@ -5,6 +5,7 @@ export enum Queues {
   eventHandlersQueue = 'eventHandlers',
   eventsQueue = 'events',
   maintenanceQueue = 'maintenance',
+  notificationsQueue = 'notifications',
   webhooksQueue = 'webhooks',
   documentsQueue = 'documentsQueue',
   documentSuggestionsQueue = 'documentSuggestionsQueue',


### PR DESCRIPTION
# What?
I did not add the rate limit, and our email provider gave us a warning. Now we can enqueue a maximum of 90 jobs/minute, so it's a bit more relaxed