### PR TITLE
Eval icon in issue updates IRL

### DIFF
--- a/apps/web/src/stores/activeEvaluations.ts
+++ b/apps/web/src/stores/activeEvaluations.ts
@@ -47,7 +47,10 @@ export function useActiveEvaluations(
               opts.onEvaluationEnded(args.evaluation)
               if (!args.evaluation?.error) {
                 globalMutate(
-                  (key) => Array.isArray(key) && key[0] === 'issueEvaluations',
+                  (key) =>
+                    Array.isArray(key) &&
+                    key[0] === 'issueEvaluations' &&
+                    key[1] === project.id,
                 )
               }
             }
@@ -76,7 +79,7 @@ export function useActiveEvaluations(
         { revalidate: false },
       )
     },
-    [mutate, opts, globalMutate],
+    [mutate, opts, globalMutate, project.id],
   )
   useSockets({ event: 'evaluationStatus', onMessage })
   return { data, isLoading }

--- a/apps/web/src/stores/evaluationsV2.ts
+++ b/apps/web/src/stores/evaluationsV2.ts
@@ -78,6 +78,13 @@ export function useEvaluationsV2(
   } = useLatitudeAction(createEvaluationV2Action, {
     onSuccess: async ({ data: { evaluation } }) => {
       mutate((prev) => [evaluation, ...(prev ?? [])])
+      globalMutate(
+        (key) =>
+          Array.isArray(key) &&
+          key[0] === 'issueEvaluations' &&
+          key[1] === project.id &&
+          key[2] === commit.uuid,
+      )
       toast({
         title: 'Evaluation created successfully',
         description: `Evaluation ${evaluation.name} created successfully`,
@@ -129,7 +136,13 @@ export function useEvaluationsV2(
             return evaluation
           }) ?? [],
       )
-      globalMutate((key) => Array.isArray(key) && key[0] === 'issueEvaluations')
+      globalMutate(
+        (key) =>
+          Array.isArray(key) &&
+          key[0] === 'issueEvaluations' &&
+          key[1] === project.id &&
+          key[2] === commit.uuid,
+      )
       if (!notifyUpdate) return
       toast({
         title: 'Evaluation updated successfully',


### PR DESCRIPTION
As the evaluation generated within an issue uses a different store with a different SWR key than the one used when detecting which issues have evaluations in the dashboard page, when we generated an evaluation or deleted one from an issue, the icon would still be cached in the other SWR key. 

This PR fixes that by mutating the other store if these two actions occur