### PR TITLE
fix: evaluation results repository

### DIFF
--- a/apps/web/src/actions/evaluationsV2/create.ts
+++ b/apps/web/src/actions/evaluationsV2/create.ts
@@ -1,4 +1,5 @@
 'use server'
+
 import { createEvaluationV2 } from '@latitude-data/core/services/evaluationsV2/create'
 import { returnValidationErrors } from 'next-safe-action'
 import { z } from 'zod'

--- a/apps/web/src/app/api/evaluations/route.ts
+++ b/apps/web/src/app/api/evaluations/route.ts
@@ -4,6 +4,7 @@ import { EvaluationsV2Repository } from '@latitude-data/core/repositories'
 import { NextRequest, NextResponse } from 'next/server'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { z } from 'zod'
+import { HEAD_COMMIT } from '@latitude-data/constants'
 
 const searchParamsSchema = z.object({
   projectId: z.string().optional(),
@@ -29,7 +30,7 @@ export const GET = errorHandler(
       const evaluations = await evaluationsRepository
         .list({
           projectId: projectIdParam ? Number(projectIdParam) : undefined,
-          commitUuid,
+          commitUuid: commitUuid || HEAD_COMMIT,
           documentUuid,
         })
         .then((r) => r.unwrap())

--- a/packages/core/src/repositories/evaluationsV2Repository.test.ts
+++ b/packages/core/src/repositories/evaluationsV2Repository.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { type Workspace } from '../schema/models/types/Workspace'
+import { mergeCommit } from '../services/commits'
 import * as factories from '../tests/factories'
+import { deleteEvaluationV2 } from '../services/evaluationsV2/delete'
 import { EvaluationsV2Repository } from './evaluationsV2Repository'
 
 describe('EvaluationsV2Repository', () => {
@@ -15,88 +17,28 @@ describe('EvaluationsV2Repository', () => {
   })
 
   describe('list', () => {
-    it('returns all evaluations for the workspace when no filters are provided', async () => {
-      const { commit, documents } = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test' },
-      })
-
-      const document1 = documents[0]!
-      const document2 =
-        documents[1] ||
-        (
-          await factories.createProject({
-            workspace,
-            documents: { prompt: 'test' },
-          })
-        ).documents[0]!
-
-      const evaluation1 = await factories.createEvaluationV2({
-        document: document1,
-        commit,
-        workspace,
-      })
-
-      const evaluation2 = await factories.createEvaluationV2({
-        document: document2,
-        commit,
-        workspace,
-      })
-
-      const result = await repository.list({})
-      const evaluations = result.unwrap()
-
-      expect(evaluations.length).toBeGreaterThanOrEqual(2)
-      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
-      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(true)
-    })
-
-    it('filters by projectId when only projectId is provided', async () => {
-      const project1 = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test1' },
-      })
-      const project2 = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test2' },
-      })
-
-      const evaluation1 = await factories.createEvaluationV2({
-        document: project1.documents[0]!,
-        commit: project1.commit,
-        workspace,
-      })
-
-      const evaluation2 = await factories.createEvaluationV2({
-        document: project2.documents[0]!,
-        commit: project2.commit,
-        workspace,
-      })
-
-      const result = await repository.list({
-        projectId: project1.project.id,
-      })
-      const evaluations = result.unwrap()
-
-      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
-      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
-    })
-
     it('returns empty array when projectId has no commits', async () => {
       const project = await factories.createProject({
         workspace,
         skipMerge: true,
       })
 
+      // Create a commit for this test since commitUuid is now mandatory
+      const { commit } = await factories.createProject({
+        workspace,
+        documents: { prompt: 'test' },
+      })
+
       const result = await repository.list({
         projectId: project.project.id,
+        commitUuid: commit.uuid,
       })
       const evaluations = result.unwrap()
 
       expect(evaluations).toEqual([])
     })
 
-    it('filters by commitUuid when commitUuid and projectId are provided', async () => {
+    it('filters by commitUuid when commitUuid is provided', async () => {
       const project = await factories.createProject({
         workspace,
         documents: { prompt: 'test' },
@@ -121,42 +63,6 @@ describe('EvaluationsV2Repository', () => {
       const result = await repository.list({
         projectId: project.project.id,
         commitUuid: project.commit.uuid,
-      })
-      const evaluations = result.unwrap()
-
-      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
-      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
-    })
-
-    it('filters by documentUuid when only documentUuid is provided', async () => {
-      const project = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test' },
-      })
-      const document1 = project.documents[0]!
-      const document2 =
-        project.documents[1] ||
-        (
-          await factories.createProject({
-            workspace,
-            documents: { prompt: 'test' },
-          })
-        ).documents[0]!
-
-      const evaluation1 = await factories.createEvaluationV2({
-        document: document1,
-        commit: project.commit,
-        workspace,
-      })
-
-      const evaluation2 = await factories.createEvaluationV2({
-        document: document2,
-        commit: project.commit,
-        workspace,
-      })
-
-      const result = await repository.list({
-        documentUuid: document1.documentUuid,
       })
       const evaluations = result.unwrap()
 
@@ -192,34 +98,12 @@ describe('EvaluationsV2Repository', () => {
       const result = await repository.list({
         projectId: project1.project.id,
         documentUuid: document1.documentUuid,
+        commitUuid: project1.commit.uuid,
       })
       const evaluations = result.unwrap()
 
       expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
       expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
-    })
-
-    it('uses history merging logic when commitUuid, documentUuid, and projectId are provided', async () => {
-      const project = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test' },
-      })
-      const document = project.documents[0]!
-
-      const evaluation = await factories.createEvaluationV2({
-        document,
-        commit: project.commit,
-        workspace,
-      })
-
-      const result = await repository.list({
-        projectId: project.project.id,
-        commitUuid: project.commit.uuid,
-        documentUuid: document.documentUuid,
-      })
-      const evaluations = result.unwrap()
-
-      expect(evaluations.some((e) => e.uuid === evaluation.uuid)).toBe(true)
     })
 
     it('only returns evaluations from the correct workspace', async () => {
@@ -249,6 +133,7 @@ describe('EvaluationsV2Repository', () => {
 
       const result = await repository.list({
         projectId: project1.project.id,
+        commitUuid: project1.commit.uuid,
       })
       const evaluations = result.unwrap()
 
@@ -256,57 +141,7 @@ describe('EvaluationsV2Repository', () => {
       expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
     })
 
-    it('combines multiple filters correctly', async () => {
-      const project = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test' },
-      })
-      const document1 = project.documents[0]!
-      const document2 =
-        project.documents[1] ||
-        (
-          await factories.createProject({
-            workspace,
-            documents: { prompt: 'test' },
-          })
-        ).documents[0]!
-
-      const { commit: commit2 } = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test2' },
-      })
-
-      const evaluation1 = await factories.createEvaluationV2({
-        document: document1,
-        commit: project.commit,
-        workspace,
-      })
-
-      const evaluation2 = await factories.createEvaluationV2({
-        document: document2,
-        commit: project.commit,
-        workspace,
-      })
-
-      const evaluation3 = await factories.createEvaluationV2({
-        document: document1,
-        commit: commit2,
-        workspace,
-      })
-
-      const result = await repository.list({
-        projectId: project.project.id,
-        commitUuid: project.commit.uuid,
-        documentUuid: document1.documentUuid,
-      })
-      const evaluations = result.unwrap()
-
-      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
-      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
-      expect(evaluations.some((e) => e.uuid === evaluation3.uuid)).toBe(false)
-    })
-
-    it('ignores commitUuid when projectId is not provided and filters by documentUuid only', async () => {
+    it('includes evaluation versions from merged commits even if deleted in unmerged draft', async () => {
       const project = await factories.createProject({
         workspace,
         documents: { prompt: 'test' },
@@ -320,57 +155,215 @@ describe('EvaluationsV2Repository', () => {
       })
 
       const evaluation2 = await factories.createEvaluationV2({
-        document:
-          project.documents[1] ||
-          (
-            await factories.createProject({
-              workspace,
-              documents: { prompt: 'test' },
-            })
-          ).documents[0]!,
+        document,
         commit: project.commit,
         workspace,
       })
 
+      // Delete one evaluation in a draft commit (not merged yet)
+      const { commit: draft } = await factories.createDraft({
+        project: project.project,
+        user: project.user,
+      })
+      await deleteEvaluationV2({
+        evaluation: evaluation1,
+        commit: draft,
+        workspace,
+      }).then((r) => r.unwrap())
+
+      // List evaluations at the original merged commit - deleted one should still appear
+      // because the deletion is only in a draft commit, not merged yet
       const result = await repository.list({
+        projectId: project.project.id,
         commitUuid: project.commit.uuid,
         documentUuid: document.documentUuid,
       })
       const evaluations = result.unwrap()
 
       expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
-      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(false)
+      expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(true)
     })
 
-    it('ignores commitUuid when projectId is not provided and returns all evaluations', async () => {
-      const project1 = await factories.createProject({
+    it('excludes deleted evaluation versions when merging history', async () => {
+      const project = await factories.createProject({
         workspace,
-        documents: { prompt: 'test1' },
+        documents: { prompt: 'test' },
       })
-      const project2 = await factories.createProject({
-        workspace,
-        documents: { prompt: 'test2' },
-      })
+      const document = project.documents[0]!
 
+      // Create an evaluation in the first commit
       const evaluation1 = await factories.createEvaluationV2({
-        document: project1.documents[0]!,
-        commit: project1.commit,
+        document,
+        commit: project.commit,
         workspace,
       })
 
       const evaluation2 = await factories.createEvaluationV2({
-        document: project2.documents[0]!,
-        commit: project2.commit,
+        document,
+        commit: project.commit,
         workspace,
       })
 
+      // Create a new commit and delete one evaluation
+      const { commit: draft } = await factories.createDraft({
+        project: project.project,
+        user: project.user,
+      })
+      await deleteEvaluationV2({
+        evaluation: evaluation1,
+        commit: draft,
+        workspace,
+      }).then((r) => r.unwrap())
+
+      const commit2 = await mergeCommit(draft).then((r) => r.unwrap())
+
+      // List at commit 2 - deleted evaluation should not appear
+      const resultAtCommit2 = await repository.list({
+        projectId: project.project.id,
+        commitUuid: commit2.uuid,
+        documentUuid: document.documentUuid,
+      })
+      const evaluationsAtCommit2 = resultAtCommit2.unwrap()
+
+      expect(
+        evaluationsAtCommit2.some((e) => e.uuid === evaluation1.uuid),
+      ).toBe(false)
+      expect(
+        evaluationsAtCommit2.some((e) => e.uuid === evaluation2.uuid),
+      ).toBe(true)
+
+      // List at commit 1 - evaluation should still appear (not deleted there)
+      const resultAtCommit1 = await repository.list({
+        projectId: project.project.id,
+        commitUuid: project.commit.uuid,
+        documentUuid: document.documentUuid,
+      })
+      const evaluationsAtCommit1 = resultAtCommit1.unwrap()
+
+      expect(
+        evaluationsAtCommit1.some((e) => e.uuid === evaluation1.uuid),
+      ).toBe(true)
+      expect(
+        evaluationsAtCommit1.some((e) => e.uuid === evaluation2.uuid),
+      ).toBe(true)
+    })
+
+    it('excludes deleted evaluation versions from head commit when fetching from draft commit', async () => {
+      const project = await factories.createProject({
+        workspace,
+        documents: { prompt: 'test' },
+      })
+      const document = project.documents[0]!
+
+      // Create evaluations in the head commit
+      const evaluation1 = await factories.createEvaluationV2({
+        document,
+        commit: project.commit,
+        workspace,
+      })
+
+      const evaluation2 = await factories.createEvaluationV2({
+        document,
+        commit: project.commit,
+        workspace,
+      })
+
+      // Delete one evaluation in a draft and merge it (so it's deleted in head)
+      const { commit: draft1 } = await factories.createDraft({
+        project: project.project,
+        user: project.user,
+      })
+      await deleteEvaluationV2({
+        evaluation: evaluation1,
+        commit: draft1,
+        workspace,
+      }).then((r) => r.unwrap())
+
+      await mergeCommit(draft1).then((r) => r.unwrap())
+
+      // Create a new draft commit
+      const { commit: draft2 } = await factories.createDraft({
+        project: project.project,
+        user: project.user,
+      })
+
+      // Fetch evaluations from the draft commit - deleted evaluation should not appear
       const result = await repository.list({
-        commitUuid: project1.commit.uuid,
+        projectId: project.project.id,
+        commitUuid: draft2.uuid,
+        documentUuid: document.documentUuid,
       })
       const evaluations = result.unwrap()
 
-      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(true)
+      expect(evaluations.some((e) => e.uuid === evaluation1.uuid)).toBe(false)
       expect(evaluations.some((e) => e.uuid === evaluation2.uuid)).toBe(true)
+    })
+
+    it('includes evaluations created in draft commit along with evaluations from head commit', async () => {
+      const project = await factories.createProject({
+        workspace,
+        documents: { prompt: 'test' },
+      })
+      const document = project.documents[0]!
+
+      // Create evaluations in the merged head commit
+      const evaluationInHead1 = await factories.createEvaluationV2({
+        document,
+        commit: project.commit,
+        workspace,
+      })
+
+      const evaluationInHead2 = await factories.createEvaluationV2({
+        document,
+        commit: project.commit,
+        workspace,
+      })
+
+      // Create a draft commit
+      const { commit: draft } = await factories.createDraft({
+        project: project.project,
+        user: project.user,
+      })
+
+      // Create NEW evaluations in the draft commit
+      const evaluationInDraft1 = await factories.createEvaluationV2({
+        document,
+        commit: draft,
+        workspace,
+      })
+
+      const evaluationInDraft2 = await factories.createEvaluationV2({
+        document,
+        commit: draft,
+        workspace,
+      })
+
+      // Fetch evaluations from the draft commit - should include both head and draft evaluations
+      const result = await repository.list({
+        projectId: project.project.id,
+        commitUuid: draft.uuid,
+        documentUuid: document.documentUuid,
+      })
+      const evaluations = result.unwrap()
+
+      // Should include evaluations from head commit
+      expect(evaluations.some((e) => e.uuid === evaluationInHead1.uuid)).toBe(
+        true,
+      )
+      expect(evaluations.some((e) => e.uuid === evaluationInHead2.uuid)).toBe(
+        true,
+      )
+
+      // Should include evaluations created in draft commit
+      expect(evaluations.some((e) => e.uuid === evaluationInDraft1.uuid)).toBe(
+        true,
+      )
+      expect(evaluations.some((e) => e.uuid === evaluationInDraft2.uuid)).toBe(
+        true,
+      )
+
+      // Should have all 4 evaluations
+      expect(evaluations.length).toBe(4)
     })
   })
 })

--- a/packages/core/src/repositories/evaluationsV2Repository.ts
+++ b/packages/core/src/repositories/evaluationsV2Repository.ts
@@ -4,7 +4,6 @@ import {
   desc,
   eq,
   getTableColumns,
-  inArray,
   isNotNull,
   isNull,
   lt,
@@ -44,24 +43,49 @@ export class EvaluationsV2Repository extends Repository<EvaluationV2> {
       .$dynamic()
   }
 
-  private async getCommitByUuid({
+  async getAtCommitByDocument({
     projectId,
     commitUuid,
+    documentUuid,
+    evaluationUuid,
   }: {
     projectId?: number
     commitUuid: string
+    documentUuid?: string
+    evaluationUuid: string
+  }) {
+    const evaluations = await this.list({
+      projectId: projectId,
+      commitUuid: commitUuid,
+      documentUuid: documentUuid,
+    }).then((r) => r.unwrap())
+
+    const evaluation = evaluations.find((e) => e.uuid === evaluationUuid)
+    if (!evaluation) {
+      return Result.error(new NotFoundError('Evaluation not found'))
+    }
+
+    return Result.ok<EvaluationV2>(evaluation)
+  }
+
+  async list({
+    projectId,
+    commitUuid,
+    documentUuid,
+  }: {
+    projectId?: number
+    commitUuid: string
+    documentUuid?: string
   }) {
     const commitsRepository = new CommitsRepository(this.workspaceId, this.db)
-    return commitsRepository
+    const commit = await commitsRepository
       .getCommitByUuid({
-        projectId,
+        projectId: projectId,
         uuid: commitUuid,
       })
       .then((r) => r.unwrap())
-  }
 
-  private createHistoryCTE(commit: Commit) {
-    return this.db.$with('history').as(
+    const history = this.db.$with('history').as(
       this.db
         .select({
           id: commits.id,
@@ -80,51 +104,38 @@ export class EvaluationsV2Repository extends Repository<EvaluationV2> {
           ),
         ),
     )
-  }
 
-  private async getHistoryVersions(
-    history: ReturnType<typeof this.createHistoryCTE>,
-    documentUuid?: string,
-  ) {
-    const historyWhereConditions = [
-      eq(evaluationVersions.workspaceId, this.workspaceId),
-      isNull(evaluationVersions.deletedAt),
-    ]
-    if (documentUuid) {
-      historyWhereConditions.push(
-        eq(evaluationVersions.documentUuid, documentUuid),
-      )
-    }
-
-    return this.db
+    const historyVersions = await this.db
       .with(history)
       .selectDistinctOn([evaluationVersions.evaluationUuid], tt)
       .from(evaluationVersions)
       .innerJoin(history, eq(history.id, evaluationVersions.commitId))
-      .where(and(...historyWhereConditions))
-      .orderBy(desc(evaluationVersions.evaluationUuid), desc(history.mergedAt))
-  }
-
-  private async getCurrentVersions(commit: Commit, documentUuid?: string) {
-    const currentWhereConditions = [eq(evaluationVersions.commitId, commit.id)]
-    if (documentUuid) {
-      currentWhereConditions.push(
-        eq(evaluationVersions.documentUuid, documentUuid),
+      .where(
+        and(
+          eq(evaluationVersions.workspaceId, this.workspaceId),
+          ...(documentUuid
+            ? [eq(evaluationVersions.documentUuid, documentUuid)]
+            : []),
+        ),
       )
-    }
+      .orderBy(desc(evaluationVersions.evaluationUuid), desc(history.mergedAt))
 
-    return this.scope.where(and(...currentWhereConditions))
-  }
+    const currentVersions = await this.scope.where(
+      and(
+        eq(evaluationVersions.workspaceId, this.workspaceId),
+        eq(evaluationVersions.commitId, commit.id),
+        ...(documentUuid
+          ? [eq(evaluationVersions.documentUuid, documentUuid)]
+          : []),
+      ),
+    )
 
-  private mergeAndSortEvaluations(
-    currentVersions: EvaluationV2[],
-    historyVersions: EvaluationV2[],
-  ) {
     let evaluations = currentVersions.concat(
       historyVersions.filter(
         (oldVersion) =>
           !currentVersions.find(
-            (newVersion) => newVersion.uuid === oldVersion.uuid,
+            (newVersion) =>
+              newVersion.evaluationUuid === oldVersion.evaluationUuid,
           ),
       ),
     )
@@ -133,32 +144,7 @@ export class EvaluationsV2Repository extends Repository<EvaluationV2> {
       differenceInMilliseconds(b.createdAt, a.createdAt),
     )
 
-    return evaluations
-  }
-
-  async getAtCommitByDocument({
-    projectId,
-    commitUuid,
-    documentUuid,
-    evaluationUuid,
-  }: {
-    projectId?: number
-    commitUuid: string
-    documentUuid: string
-    evaluationUuid: string
-  }) {
-    const evaluations = await this.list({
-      projectId: projectId,
-      commitUuid: commitUuid,
-      documentUuid: documentUuid,
-    }).then((r) => r.unwrap())
-
-    const evaluation = evaluations.find((e) => e.uuid === evaluationUuid)
-    if (!evaluation) {
-      return Result.error(new NotFoundError('Evaluation not found'))
-    }
-
-    return Result.ok<EvaluationV2>(evaluation)
+    return Result.ok<EvaluationV2[]>(evaluations)
   }
 
   async existsAnotherVersion({
@@ -211,75 +197,6 @@ export class EvaluationsV2Repository extends Repository<EvaluationV2> {
           eq(evaluationVersions.issueId, issueId),
         ),
       )
-  }
-
-  async list({
-    projectId,
-    commitUuid,
-    documentUuid,
-  }: {
-    projectId?: number
-    commitUuid?: string
-    documentUuid?: string
-  }) {
-    // If commitUuid is provided, use history merging logic
-    if (commitUuid && projectId) {
-      const commit = await this.getCommitByUuid({ projectId, commitUuid })
-      const history = this.createHistoryCTE(commit)
-      const historyVersions = await this.getHistoryVersions(
-        history,
-        documentUuid,
-      )
-      const currentVersions = await this.getCurrentVersions(
-        commit,
-        documentUuid,
-      )
-      const evaluations = this.mergeAndSortEvaluations(
-        currentVersions,
-        historyVersions,
-      )
-
-      return Result.ok<EvaluationV2[]>(evaluations)
-    }
-
-    // Fallback to simple filtering when commitUuid is not provided
-    const additionalFilters = []
-
-    if (projectId) {
-      const projectCommits = await this.db
-        .select({ id: commits.id })
-        .from(commits)
-        .innerJoin(projects, eq(projects.id, commits.projectId))
-        .where(
-          and(
-            eq(projects.workspaceId, this.workspaceId),
-            eq(projects.id, projectId),
-            isNull(projects.deletedAt),
-            isNull(commits.deletedAt),
-          ),
-        )
-
-      const commitIds = projectCommits.map((c) => c.id)
-      if (commitIds.length === 0) {
-        return Result.ok<EvaluationV2[]>([])
-      }
-      additionalFilters.push(inArray(evaluationVersions.commitId, commitIds))
-    }
-
-    if (documentUuid) {
-      additionalFilters.push(eq(evaluationVersions.documentUuid, documentUuid))
-    }
-
-    if (additionalFilters.length === 0) {
-      const evaluations = await this.scope.then((r) => r)
-      return Result.ok<EvaluationV2[]>(evaluations)
-    }
-
-    const combinedFilter = and(this.scopeFilter, ...additionalFilters)
-
-    const evaluations = await this.scope.where(combinedFilter).then((r) => r)
-
-    return Result.ok<EvaluationV2[]>(evaluations)
   }
 
   async getDefaultCompositeTarget({


### PR DESCRIPTION
- The repository did not filter deleted evals
- The repository required projectid to filter by commit uuid, now it does not and it will fail if you pass a HEAD_COMMIT without projectid