### PR TITLE
fix: dedup spans by eval results

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/issues/_components/IssueDetailPanel/TracesList/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/issues/_components/IssueDetailPanel/TracesList/index.tsx
@@ -1,16 +1,13 @@
-import { useState } from 'react'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
-import { LimitedTablePaginationFooter } from '$/components/TablePaginationFooter/LimitedTablePaginationFooter'
+import { SimpleKeysetTablePaginationFooter } from '$/components/TablePaginationFooter/SimpleKeysetTablePaginationFooter'
 import { Issue } from '@latitude-data/core/schema/models/types/Issue'
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
 import { useCurrentCommit } from '$/app/providers/CommitProvider'
 import { useIssueSpans } from '$/stores/issues/spans'
 import { IssueSpansTable } from '../../IssueSpansTable'
-import { Span } from '@latitude-data/constants'
+import { Span, SpanType } from '@latitude-data/constants'
 import { TableSkeleton } from '@latitude-data/web-ui/molecules/TableSkeleton'
 import { BlankSlate } from '@latitude-data/web-ui/molecules/BlankSlate'
-
-const PAGE_SIZE = 25
 
 export function TracesList({
   issue,
@@ -21,33 +18,35 @@ export function TracesList({
 }) {
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
-  const [page, setPage] = useState(1)
   const {
     data: spans,
-    hasNextPage,
+    hasNext,
+    hasPrev,
     isLoading,
+    goToNextPage,
+    goToPrevPage,
   } = useIssueSpans({
     projectId: project.id,
     commitUuid: commit.uuid,
     issueId: issue.id,
-    page,
-    pageSize: PAGE_SIZE,
   })
   return (
     <>
-      <Text.H5M>Logs</Text.H5M>
+      <Text.H5M>Traces</Text.H5M>
       {isLoading ? (
         <TableSkeleton rows={8} cols={3} maxHeight={320} />
       ) : spans.length > 0 ? (
         <IssueSpansTable
-          spans={spans}
+          spans={spans as Span<SpanType.Prompt>[]}
           showPagination
           onView={onView}
           PaginationFooter={
-            <LimitedTablePaginationFooter
-              page={page}
-              nextPage={hasNextPage}
-              onPageChange={setPage}
+            <SimpleKeysetTablePaginationFooter
+              hasNext={hasNext}
+              hasPrev={hasPrev}
+              setNext={goToNextPage}
+              setPrev={goToPrevPage}
+              isLoading={isLoading}
             />
           }
         />

--- a/apps/web/src/stores/useCursorPagination.ts
+++ b/apps/web/src/stores/useCursorPagination.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * Generic cursor-based pagination hook
+ * Manages cursor state, history, and navigation for keyset pagination
+ */
+export interface UseCursorPaginationReturn {
+  currentCursor: string | null
+  goToNextPage: (nextCursor: string) => void
+  goToPrevPage: () => void
+  reset: () => void
+  hasPrev: boolean
+  cursorHistoryLength: number
+}
+
+/**
+ * Hook for managing cursor-based pagination state
+ *
+ * @returns Pagination state and navigation functions
+ */
+export function useCursorPagination(): UseCursorPaginationReturn {
+  const [cursorHistory, setCursorHistory] = useState<(string | null)[]>([])
+  const [currentCursor, setCurrentCursor] = useState<string | null>(null)
+
+  const goToNextPage = useCallback(
+    (nextCursor: string) => {
+      if (!nextCursor) return
+      setCursorHistory((prev) => [...prev, currentCursor])
+      setCurrentCursor(nextCursor)
+    },
+    [currentCursor],
+  )
+
+  const goToPrevPage = useCallback(() => {
+    if (cursorHistory.length === 0) return
+    const previousCursor = cursorHistory[cursorHistory.length - 1]
+    if (previousCursor !== undefined) {
+      setCursorHistory((prev) => prev.slice(0, -1))
+      setCurrentCursor(previousCursor)
+    }
+  }, [cursorHistory])
+
+  const reset = useCallback(() => {
+    setCursorHistory([])
+    setCurrentCursor(null)
+  }, [])
+
+  return useMemo(
+    () => ({
+      currentCursor,
+      goToNextPage,
+      goToPrevPage,
+      reset,
+      hasPrev: cursorHistory.length > 0,
+      cursorHistoryLength: cursorHistory.length,
+    }),
+    [currentCursor, goToNextPage, goToPrevPage, reset, cursorHistory.length],
+  )
+}

--- a/packages/core/src/repositories/spansRepository.ts
+++ b/packages/core/src/repositories/spansRepository.ts
@@ -434,20 +434,33 @@ export class SpansRepository extends Repository<Span> {
         ),
       )
 
+    return this.orderSpansByEvaluationResults(
+      evaluationResults,
+      fetchedSpans as Span[],
+    )
+  }
+
+  private orderSpansByEvaluationResults(
+    evaluationResults: Pick<
+      EvaluationResultV2,
+      'evaluatedSpanId' | 'evaluatedTraceId'
+    >[],
+    spansList: Span[],
+  ) {
     const spanMap = new Map<string, Span>()
-    for (const span of fetchedSpans) {
-      const key = `${span.id}:${span.traceId}`
-      spanMap.set(key, span as Span)
+    for (const span of spansList) {
+      spanMap.set(this.buildSpanKey(span.id, span.traceId), span)
     }
 
-    const orderedSpans = evaluationResults
-      .map((result) => {
-        const key = `${result.evaluatedSpanId}:${result.evaluatedTraceId}`
-        return spanMap.get(key)
-      })
+    return evaluationResults
+      .map(({ evaluatedSpanId, evaluatedTraceId }) =>
+        spanMap.get(this.buildSpanKey(evaluatedSpanId!, evaluatedTraceId!)),
+      )
       .filter((span): span is Span => span !== undefined)
+  }
 
-    return orderedSpans
+  private buildSpanKey(spanId: string, traceId: string) {
+    return `${spanId}:${traceId}`
   }
 }
 


### PR DESCRIPTION
The list of spans in the issue details panel was duplicated a span can have multiple eval results. This commit fixes this.