### PR TITLE
fix: NumberInput controlled mode and min/max bounds enforcement

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/[evaluationUuid]/_components/EvaluationActions.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/[evaluationUuid]/_components/EvaluationActions.tsx
@@ -271,6 +271,7 @@ function EditEvaluation<
         Settings
       </TableWithHeader.Button>
       <ConfirmModal
+        dismissible
         size='medium'
         open={openUpdateModal}
         icon={metricSpecification.icon}

--- a/apps/web/src/components/evaluations/llm/Custom.tsx
+++ b/apps/web/src/components/evaluations/llm/Custom.tsx
@@ -130,10 +130,13 @@ ${
           name='minScore'
           label='Minimum score'
           placeholder='0'
-          onChange={(value) => {
-            if (value === undefined) return
-            setConfiguration({ ...configuration, minScore: value })
-          }}
+          max={configuration.maxScore}
+          onChange={(value) =>
+            setConfiguration({
+              ...configuration,
+              minScore: value as number,
+            })
+          }
           errors={errors?.['minScore']}
           className='w-full'
           disabled={disabled}
@@ -144,10 +147,13 @@ ${
           name='maxScore'
           label='Maximum score'
           placeholder='5'
-          onChange={(value) => {
-            if (value === undefined) return
-            setConfiguration({ ...configuration, maxScore: value })
-          }}
+          min={configuration.minScore}
+          onChange={(value) =>
+            setConfiguration({
+              ...configuration,
+              maxScore: value as number,
+            })
+          }
           errors={errors?.['maxScore']}
           className='w-full'
           disabled={disabled}

--- a/packages/web-ui/src/ds/atoms/NumberInput/useNumberInput.ts
+++ b/packages/web-ui/src/ds/atoms/NumberInput/useNumberInput.ts
@@ -35,42 +35,37 @@ export function useNumberInput({
   min = -Infinity,
   max = Infinity,
 }: NumberInputProps & { ref?: Ref<HTMLInputElement> }) {
-  const isControlledRef = useRef(controlledValue !== undefined)
-  if (controlledValue !== undefined) {
-    isControlledRef.current = true
-  }
-  const isControlled = isControlledRef.current
   const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue)
-  const currentValue = isControlled ? controlledValue : uncontrolledValue
+  const rawValue =
+    controlledValue !== undefined ? controlledValue : uncontrolledValue
+  const currentValue = buildValue(rawValue, min, max)
 
   const onChangeRef = useRef(onChange)
-  useEffect(() => {
-    onChangeRef.current = onChange
-  }, [onChange])
+  onChangeRef.current = onChange
+
+  const minRef = useRef(min)
+  const maxRef = useRef(max)
+  minRef.current = min
+  maxRef.current = max
 
   const internalRef = useRef<HTMLInputElement>(null)
   const [focused, setFocused] = useState(false)
 
-  const updateValue = useCallback(
-    (next: number | undefined) => {
-      const bounded = buildValue(next, min, max)
-      if (!isControlled) {
-        setUncontrolledValue(bounded)
-      }
-      onChangeRef.current?.(bounded)
-    },
-    [isControlled, min, max],
-  )
+  const updateValue = useCallback((next: number | undefined) => {
+    const bounded = buildValue(next, minRef.current, maxRef.current)
+    setUncontrolledValue(bounded)
+    onChangeRef.current?.(bounded)
+  }, [])
 
   const increment = useCallback(() => {
-    const next = Math.min((currentValue ?? 0) + 1, max)
+    const next = Math.min((currentValue ?? 0) + 1, maxRef.current)
     updateValue(next)
-  }, [currentValue, max, updateValue])
+  }, [currentValue, updateValue])
 
   const decrement = useCallback(() => {
-    const next = Math.max((currentValue ?? 0) - 1, min)
+    const next = Math.max((currentValue ?? 0) - 1, minRef.current)
     updateValue(next)
-  }, [currentValue, min, updateValue])
+  }, [currentValue, updateValue])
 
   const onFocus = useCallback(() => setFocused(true), [])
   const onBlur = useCallback(() => {


### PR DESCRIPTION
Fix multiple issues with the NumberInput component:

- Fix controlled input not calling onChange: The hook incorrectly detected controlled vs uncontrolled mode based on initial value being undefined, causing onChange to not fire when value started as undefined

- Fix stale closure issue with min/max bounds: Callbacks captured old min/max values from previous renders. Now uses refs (minRef/maxRef) to always read current values at execution time

- Always clamp displayed value to min/max bounds: currentValue now uses buildValue() to ensure the displayed value respects bounds even if parent passes an out-of-bounds value

- Update onChangeRef synchronously instead of in useEffect to prevent stale callback references

- Add missing min/max constraints to Custom evaluation score fields: minScore now has max={maxScore}, maxScore now has min={minScore}

- Remove guards that prevented clearing number inputs (allow undefined during editing, validate on submit)

- Add dismissible prop to evaluation settings modal