### PR TITLE
fix: unoptimized traces

### DIFF
--- a/apps/gateway/src/routes/api/v3/conversations/annotate/annotate.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/annotate/annotate.handler.test.ts
@@ -16,18 +16,19 @@ import {
   helpers,
 } from '@latitude-data/core/factories'
 import { generateUUIDIdentifier } from '@latitude-data/core/lib/generateUUID'
+import { Result } from '@latitude-data/core/lib/Result'
 import { ApiKey } from '@latitude-data/core/schema/models/types/ApiKey'
 import { describe, expect, it, vi } from 'vitest'
 
 // Mock SpanMetadatasRepository
-const mockGet = vi.fn().mockResolvedValue({ value: null })
+const mockGet = vi.fn().mockResolvedValue(Result.ok(null))
 vi.mock('@latitude-data/core/repositories', async () => {
   const actual = await vi.importActual('@latitude-data/core/repositories')
   return {
     ...actual,
     SpanMetadatasRepository: vi.fn().mockImplementation(() => ({
       get: mockGet,
-      invalidate: vi.fn().mockResolvedValue({ value: null }),
+      invalidate: vi.fn().mockResolvedValue(Result.ok(null)),
     })),
   }
 })
@@ -171,7 +172,7 @@ describe('POST /conversations/:conversationUuid/evaluations/:evaluationUuid/anno
     // Mock the get method to return different metadata based on spanId
     mockGet.mockImplementation(({ spanId: requestedSpanId }) => {
       if (requestedSpanId === spanId) {
-        return Promise.resolve({ value: mockPromptSpanMetadata })
+        return Promise.resolve(Result.ok(mockPromptSpanMetadata))
       }
       // For completion spans, return completion metadata
       const mockCompletionSpanMetadata = {
@@ -203,7 +204,7 @@ describe('POST /conversations/:conversationUuid/evaluations/:evaluationUuid/anno
           completion: 15,
         },
       }
-      return Promise.resolve({ value: mockCompletionSpanMetadata })
+      return Promise.resolve(Result.ok(mockCompletionSpanMetadata))
     })
   }
 

--- a/apps/web/src/app/api/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/conversations/[conversationId]/route.ts
@@ -3,7 +3,7 @@ import { errorHandler } from '$/middlewares/errorHandler'
 import { AssembledTrace } from '@latitude-data/core/constants'
 import { SpansRepository } from '@latitude-data/core/repositories'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
-import { assembleTrace } from '@latitude-data/core/services/tracing/traces/assemble'
+import { assembleTraceStructure } from '@latitude-data/core/services/tracing/traces/assemble'
 import { NextRequest, NextResponse } from 'next/server'
 
 export type ConversationTracesResponse = {
@@ -35,7 +35,7 @@ export const GET = errorHandler(
 
       const traces: AssembledTrace[] = []
       for (const traceId of traceIds) {
-        const result = await assembleTrace({ traceId, workspace })
+        const result = await assembleTraceStructure({ traceId, workspace })
         if (result.ok && result.value) {
           traces.push(result.value.trace)
         }

--- a/apps/web/src/app/api/traces/[traceId]/route.ts
+++ b/apps/web/src/app/api/traces/[traceId]/route.ts
@@ -1,6 +1,6 @@
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
-import { assembleTrace } from '@latitude-data/core/services/tracing/traces/assemble'
+import { assembleTraceStructure } from '@latitude-data/core/services/tracing/traces/assemble'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -19,7 +19,7 @@ export const GET = errorHandler(
       },
     ) => {
       const { traceId } = params
-      const { trace } = await assembleTrace({
+      const { trace } = await assembleTraceStructure({
         traceId: traceId,
         workspace: workspace,
       }).then((r) => r.unwrap())

--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -1,12 +1,7 @@
 import { Ref, useMemo } from 'react'
 import { DetailsPanel } from '$/components/tracing/spans/DetailsPanel'
 import { useLastTrace } from '$/stores/conversations'
-import {
-  AssembledSpan,
-  AssembledTrace,
-  SpanType,
-  SpanWithDetails,
-} from '@latitude-data/constants'
+import { SpanType, SpanWithDetails } from '@latitude-data/constants'
 import { LoadingText } from '@latitude-data/web-ui/molecules/LoadingText'
 import { MessageList } from '$/components/ChatWrapper'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
@@ -17,25 +12,7 @@ import { useCurrentProject } from '$/app/providers/ProjectProvider'
 import { AnnotationForms } from './AnnotationForms'
 import { TraceEvaluations } from './TraceEvaluations'
 import { MetadataInfoTabs } from '../MetadataInfoTabs'
-import {
-  adaptCompletionSpanMessagesToLegacy,
-  findCompletionSpanFromTrace,
-} from '@latitude-data/core/services/tracing/spans/findCompletionSpanFromTrace'
-
-const MAIN_SPAN_TYPES = new Set([
-  SpanType.Prompt,
-  SpanType.Chat,
-  SpanType.External,
-])
-
-function findMainSpan(
-  trace: AssembledTrace | undefined,
-): AssembledSpan | undefined {
-  if (!trace) return undefined
-  return trace.children.find((span) =>
-    MAIN_SPAN_TYPES.has(span.type as SpanType),
-  )
-}
+import { adaptCompletionSpanMessagesToLegacy } from '@latitude-data/core/services/tracing/spans/findCompletionSpanFromTrace'
 
 export const DEFAULT_TABS = [
   { label: 'Metadata', value: 'metadata' },
@@ -136,12 +113,10 @@ function TraceMessages({
 }: {
   documentLogUuid: string | null
 }) {
-  const { trace, isLoading } = useLastTrace({ documentLogUuid })
-
-  const mainSpan = findMainSpan(trace ?? undefined)
-  const mainMetadata = mainSpan?.metadata
-  const completionSpan = findCompletionSpanFromTrace(trace ?? undefined)
-  const messages = adaptCompletionSpanMessagesToLegacy(completionSpan)
+  const { completionSpan, isLoading } = useLastTrace({ documentLogUuid })
+  const messages = adaptCompletionSpanMessagesToLegacy(
+    completionSpan ?? undefined,
+  )
 
   if (isLoading) {
     return <LoadingText alignX='center' />
@@ -155,10 +130,5 @@ function TraceMessages({
     )
   }
 
-  const parameters =
-    mainMetadata && 'parameters' in mainMetadata
-      ? Object.keys(mainMetadata.parameters as Record<string, unknown>)
-      : undefined
-
-  return <MessageList debugMode messages={messages} parameters={parameters} />
+  return <MessageList debugMode messages={messages} />
 }

--- a/apps/web/src/stores/conversations.ts
+++ b/apps/web/src/stores/conversations.ts
@@ -54,7 +54,12 @@ export function useLastTrace(
   } = useSWR<LastTraceResponse>(route, fetcher, opts)
 
   return useMemo(
-    () => ({ trace: data?.trace ?? null, mutate, isLoading }),
+    () => ({
+      trace: data?.trace ?? null,
+      completionSpan: data?.completionSpan ?? null,
+      mutate,
+      isLoading,
+    }),
     [data, mutate, isLoading],
   )
 }

--- a/packages/core/src/data-access/issues/getSpanMessagesBySpans.ts
+++ b/packages/core/src/data-access/issues/getSpanMessagesBySpans.ts
@@ -1,8 +1,7 @@
 import { Workspace } from '../../schema/models/types/Workspace'
 import { Span } from '../../constants'
 import { Result } from '../../lib/Result'
-import { assembleTrace } from '../../services/tracing/traces/assemble'
-import { findCompletionSpanFromTrace } from '../../services/tracing/spans/findCompletionSpanFromTrace'
+import { assembleTraceWithMessages } from '../../services/tracing/traces/assemble'
 import { adaptCompletionSpanMessagesToLegacy } from '../../services/tracing/spans/findCompletionSpanFromTrace'
 import { Message as LegacyMessage } from '@latitude-data/constants/legacyCompiler'
 
@@ -16,20 +15,16 @@ export async function getSpanMessagesBySpans({
   const messagesAndEvaluationResults: LegacyMessage[] = []
 
   for (const span of spans) {
-    // Assemble the trace to get the completion span
-    const assembledTrace = await assembleTrace({
+    const assembledTraceResult = await assembleTraceWithMessages({
       traceId: span.traceId,
       workspace: workspace,
     })
 
-    if (!Result.isOk(assembledTrace)) {
+    if (!Result.isOk(assembledTraceResult)) {
       continue
     }
 
-    const completionSpan = findCompletionSpanFromTrace(
-      assembledTrace.value.trace,
-    )
-
+    const { completionSpan } = assembledTraceResult.unwrap()
     if (!completionSpan) {
       continue
     }

--- a/packages/core/src/services/evaluationsV2/llm/binary.ts
+++ b/packages/core/src/services/evaluationsV2/llm/binary.ts
@@ -18,8 +18,7 @@ import {
   normalizeScore,
 } from '../shared'
 import { buildEvaluationParameters, promptTask, runPrompt } from './shared'
-import { assembleTrace } from '../../tracing/traces/assemble'
-import { findCompletionSpanFromTrace } from '../../tracing/spans/findCompletionSpanFromTrace'
+import { assembleTraceWithMessages } from '../../tracing/traces/assemble'
 
 export const LlmEvaluationBinarySpecification = {
   ...specification,
@@ -156,14 +155,14 @@ async function run(
     throw new BadRequestError('Provider is required')
   }
 
-  let completionSpan
-  const assembledtrace = await assembleTrace(
+  const assembledTraceResult = await assembleTraceWithMessages(
     { traceId: span.traceId, workspace },
     db,
-  ).then((r) => r.value)
-  if (assembledtrace) {
-    completionSpan = findCompletionSpanFromTrace(assembledtrace.trace)
+  )
+  if (!Result.isOk(assembledTraceResult)) {
+    return Result.error(new BadRequestError('Could not assemble trace'))
   }
+  const { completionSpan } = assembledTraceResult.unwrap()
 
   let result
   try {

--- a/packages/core/src/services/evaluationsV2/llm/comparison.ts
+++ b/packages/core/src/services/evaluationsV2/llm/comparison.ts
@@ -18,8 +18,7 @@ import {
   normalizeScore,
 } from '../shared'
 import { buildEvaluationParameters, promptTask, runPrompt } from './shared'
-import { assembleTrace } from '../../tracing/traces/assemble'
-import { findCompletionSpanFromTrace } from '../../tracing/spans/findCompletionSpanFromTrace'
+import { assembleTraceWithMessages } from '../../tracing/traces/assemble'
 
 export const LlmEvaluationComparisonSpecification = {
   ...specification,
@@ -212,14 +211,14 @@ async function run(
     throw new BadRequestError('Provider is required')
   }
 
-  let completionSpan
-  const assembledTrace = await assembleTrace(
+  const assembledTraceResult = await assembleTraceWithMessages(
     { traceId: span.traceId, workspace },
     db,
-  ).then((r) => r.value)
-  if (assembledTrace) {
-    completionSpan = findCompletionSpanFromTrace(assembledTrace.trace)
+  )
+  if (!Result.isOk(assembledTraceResult)) {
+    return Result.error(new BadRequestError('Could not assemble trace'))
   }
+  const { completionSpan } = assembledTraceResult.unwrap()
 
   let result
   try {

--- a/packages/core/src/services/evaluationsV2/run.test.ts
+++ b/packages/core/src/services/evaluationsV2/run.test.ts
@@ -132,12 +132,11 @@ value1,value2,value3
       },
     } as any)
 
-    // Also mock the assembleTrace function to return a Result with the trace
     vi.spyOn(
       await import('../tracing/traces/assemble'),
-      'assembleTrace',
-    ).mockResolvedValue({
-      unwrap: () => ({
+      'assembleTraceWithMessages',
+    ).mockResolvedValue(
+      Result.ok({
         trace: {
           id: span.traceId,
           children: [
@@ -166,8 +165,17 @@ value1,value2,value3
           startedAt: new Date(),
           endedAt: new Date(),
         },
-      }),
-    } as any)
+        completionSpan: {
+          id: 'completion-span-id',
+          traceId: span.traceId,
+          type: SpanType.Completion,
+          metadata: {
+            input: [{ role: 'user', content: 'test input' }],
+            output: [{ role: 'assistant', content: 'test output' }],
+          },
+        },
+      }) as any,
+    )
   })
 
   it('fails when evaluating a log that is already evaluated for this evaluation', async () => {

--- a/packages/core/src/services/tracing/traces/assemble.test.ts
+++ b/packages/core/src/services/tracing/traces/assemble.test.ts
@@ -1,0 +1,462 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  SpanType,
+  SpanStatus,
+  CompletionSpanMetadata,
+} from '../../../constants'
+import * as factories from '../../../tests/factories'
+import { Workspace } from '../../../schema/models/types/Workspace'
+import { assembleTraceStructure, assembleTraceWithMessages } from './assemble'
+import { SpanMetadatasRepository } from '../../../repositories'
+import { Result } from '../../../lib/Result'
+
+let workspace: Workspace
+
+describe('assembleTraceStructure', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { workspace: ws } = await factories.createWorkspace()
+    workspace = ws
+  })
+
+  it('returns error for empty trace', async () => {
+    const result = await assembleTraceStructure({
+      traceId: 'non-existent-trace',
+      workspace,
+    })
+
+    expect(result.error).toBeDefined()
+    expect(result.error?.message).toContain('Cannot assemble an empty trace')
+  })
+
+  it('assembles a single span trace', async () => {
+    const span = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-1',
+      type: SpanType.Prompt,
+      name: 'root-span',
+      duration: 1000,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: span.traceId,
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.id).toBe('trace-1')
+    expect(result.value?.trace.children).toHaveLength(1)
+
+    const firstSpan = result.value?.trace.children[0]
+    expect(firstSpan?.id).toBe(span.id)
+    expect(firstSpan?.name).toBe('root-span')
+    expect(firstSpan?.depth).toBe(0)
+    expect(firstSpan?.metadata).toBeUndefined()
+  })
+
+  it('assembles a trace with parent-child relationships', async () => {
+    const startTime = new Date()
+    const parentSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-2',
+      type: SpanType.Prompt,
+      name: 'parent',
+      startedAt: startTime,
+      duration: 2000,
+    })
+
+    const childSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-2',
+      parentId: parentSpan.id,
+      type: SpanType.Completion,
+      name: 'child',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 500,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-2',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.children).toHaveLength(1)
+
+    const parent = result.value?.trace.children[0]
+    expect(parent?.id).toBe(parentSpan.id)
+    expect(parent?.depth).toBe(0)
+    expect(parent?.children).toHaveLength(1)
+
+    const child = parent?.children[0]
+    expect(child?.id).toBe(childSpan.id)
+    expect(child?.depth).toBe(1)
+  })
+
+  it('assembles a trace with multiple root spans', async () => {
+    const startTime = new Date()
+    const span1 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-3',
+      type: SpanType.Prompt,
+      name: 'first',
+      startedAt: startTime,
+      duration: 1000,
+    })
+
+    const span2 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-3',
+      type: SpanType.Prompt,
+      name: 'second',
+      startedAt: new Date(startTime.getTime() + 2000),
+      duration: 1000,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-3',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.children).toHaveLength(2)
+    expect(result.value?.trace.children[0]?.id).toBe(span1.id)
+    expect(result.value?.trace.children[1]?.id).toBe(span2.id)
+  })
+
+  it('calculates trace duration correctly', async () => {
+    const startTime = new Date('2024-01-01T00:00:00.000Z')
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-4',
+      type: SpanType.Prompt,
+      startedAt: startTime,
+      endedAt: new Date(startTime.getTime() + 3000),
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-4',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.duration).toBe(3000)
+    expect(result.value?.trace.startedAt.getTime()).toBe(startTime.getTime())
+  })
+
+  it('calculates span offsets correctly', async () => {
+    const startTime = new Date('2024-01-01T00:00:00.000Z')
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-5',
+      type: SpanType.Prompt,
+      startedAt: new Date(startTime.getTime() + 500),
+      endedAt: new Date(startTime.getTime() + 1500),
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-5',
+      type: SpanType.Prompt,
+      startedAt: startTime,
+      endedAt: new Date(startTime.getTime() + 500),
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-5',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const spans = result.value?.trace.children ?? []
+    expect(spans[0]?.startOffset).toBe(0)
+    expect(spans[0]?.endOffset).toBe(500)
+    expect(spans[1]?.startOffset).toBe(500)
+    expect(spans[1]?.endOffset).toBe(1500)
+  })
+
+  it('does not fetch metadata for any spans', async () => {
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-6',
+      type: SpanType.Prompt,
+      name: 'parent',
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-6',
+      type: SpanType.Completion,
+      name: 'completion',
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-6',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const allSpans = result.value?.trace.children ?? []
+    for (const span of allSpans) {
+      expect(span.metadata).toBeUndefined()
+      for (const child of span.children ?? []) {
+        expect(child.metadata).toBeUndefined()
+      }
+    }
+  })
+})
+
+describe('assembleTraceWithMessages', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { workspace: ws } = await factories.createWorkspace()
+    workspace = ws
+  })
+
+  it('returns trace structure even when no completion span exists', async () => {
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-no-completion',
+      type: SpanType.Prompt,
+      name: 'prompt-only',
+    })
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-no-completion',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.children).toHaveLength(1)
+    expect(result.value?.completionSpan).toBeUndefined()
+  })
+
+  it('finds and returns the completion span from the trace', async () => {
+    const startTime = new Date()
+    const promptSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-with-completion',
+      type: SpanType.Prompt,
+      name: 'prompt',
+      startedAt: startTime,
+      duration: 2000,
+    })
+
+    const completionSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-with-completion',
+      parentId: promptSpan.id,
+      type: SpanType.Completion,
+      name: 'completion',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 1000,
+    })
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-with-completion',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.completionSpan).toBeDefined()
+    expect(result.value?.completionSpan?.id).toBe(completionSpan.id)
+    expect(result.value?.completionSpan?.type).toBe(SpanType.Completion)
+  })
+
+  it('attaches metadata to the completion span in the tree', async () => {
+    const mockMetadata = {
+      input: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
+      output: [
+        { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] },
+      ],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+    } as unknown as CompletionSpanMetadata
+
+    vi.spyOn(SpanMetadatasRepository.prototype, 'get').mockResolvedValue(
+      Result.ok(mockMetadata),
+    )
+
+    const startTime = new Date()
+    const promptSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-with-metadata',
+      type: SpanType.Prompt,
+      name: 'prompt',
+      startedAt: startTime,
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-with-metadata',
+      parentId: promptSpan.id,
+      type: SpanType.Completion,
+      name: 'completion',
+      startedAt: new Date(startTime.getTime() + 100),
+    })
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-with-metadata',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.completionSpan?.metadata).toBeDefined()
+    expect(result.value?.completionSpan?.metadata?.input).toEqual([
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ])
+    expect(result.value?.completionSpan?.metadata?.output).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] },
+    ])
+  })
+})
+
+describe('assembleTraceStructure - deep nesting', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { workspace: ws } = await factories.createWorkspace()
+    workspace = ws
+  })
+
+  it('handles deeply nested spans correctly', async () => {
+    const startTime = new Date()
+    const root = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-deep',
+      type: SpanType.Prompt,
+      name: 'root',
+      startedAt: startTime,
+      duration: 5000,
+    })
+
+    const level1 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-deep',
+      parentId: root.id,
+      type: SpanType.Step,
+      name: 'level1',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 4000,
+    })
+
+    const level2 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-deep',
+      parentId: level1.id,
+      type: SpanType.Tool,
+      name: 'level2',
+      startedAt: new Date(startTime.getTime() + 200),
+      duration: 3000,
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-deep',
+      parentId: level2.id,
+      type: SpanType.Completion,
+      name: 'level3',
+      startedAt: new Date(startTime.getTime() + 300),
+      duration: 2000,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-deep',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.spans).toBe(4)
+
+    const rootSpan = result.value?.trace.children[0]
+    expect(rootSpan?.depth).toBe(0)
+    expect(rootSpan?.children).toHaveLength(1)
+
+    const l1Span = rootSpan?.children[0]
+    expect(l1Span?.depth).toBe(1)
+    expect(l1Span?.children).toHaveLength(1)
+
+    const l2Span = l1Span?.children[0]
+    expect(l2Span?.depth).toBe(2)
+    expect(l2Span?.children).toHaveLength(1)
+
+    const l3Span = l2Span?.children[0]
+    expect(l3Span?.depth).toBe(3)
+    expect(l3Span?.children).toHaveLength(0)
+  })
+
+  it('handles sibling spans at the same level', async () => {
+    const startTime = new Date()
+    const root = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-siblings',
+      type: SpanType.Prompt,
+      name: 'root',
+      startedAt: startTime,
+      duration: 5000,
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-siblings',
+      parentId: root.id,
+      type: SpanType.Tool,
+      name: 'sibling1',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 1000,
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-siblings',
+      parentId: root.id,
+      type: SpanType.Tool,
+      name: 'sibling2',
+      startedAt: new Date(startTime.getTime() + 1200),
+      duration: 1000,
+    })
+
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-siblings',
+      parentId: root.id,
+      type: SpanType.Completion,
+      name: 'sibling3',
+      startedAt: new Date(startTime.getTime() + 2300),
+      duration: 1000,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-siblings',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const rootSpan = result.value?.trace.children[0]
+    expect(rootSpan?.children).toHaveLength(3)
+    expect(rootSpan?.children[0]?.name).toBe('sibling1')
+    expect(rootSpan?.children[1]?.name).toBe('sibling2')
+    expect(rootSpan?.children[2]?.name).toBe('sibling3')
+  })
+
+  it('handles spans with error status', async () => {
+    await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-error',
+      type: SpanType.Prompt,
+      name: 'error-span',
+      status: SpanStatus.Error,
+      message: 'Something went wrong',
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-error',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    const span = result.value?.trace.children[0]
+    expect(span?.status).toBe(SpanStatus.Error)
+    expect(span?.message).toBe('Something went wrong')
+  })
+})


### PR DESCRIPTION
`assembleTrace` is used on several different parts of the code to fetch and build the **structure** of a trace. In some of the cases, we will also get the list of messages from the metadata of the last generation span.

Previously, we were fetching the metadata from every single span when assembling the trace, which is VERY EXPENSIVE since we're accessing S3 N times.

Now, instead, the method has been changed to `assembleTraceStructure`, which does not perform any access to S3 storage, and only THEN accessing the last storage span's metadata to obtain the list of messages