### PR TITLE
Do not update centroid when eval result is from an experiment

### DIFF
--- a/packages/core/src/services/issues/results/canUpdateCentroid.test.ts
+++ b/packages/core/src/services/issues/results/canUpdateCentroid.test.ts
@@ -1,0 +1,388 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Providers, SpanType, EvaluationV2 } from '@latitude-data/constants'
+import { type Commit } from '../../../schema/models/types/Commit'
+import { type DocumentVersion } from '../../../schema/models/types/DocumentVersion'
+import { type Issue } from '../../../schema/models/types/Issue'
+import { type Project } from '../../../schema/models/types/Project'
+import { type Workspace } from '../../../schema/models/types/Workspace'
+import { type User } from '../../../schema/models/types/User'
+import * as factories from '../../../tests/factories'
+import { canUpdateCentroid } from './canUpdateCentroid'
+
+const MOCK_EMBEDDING = [0.1, 0.2, 0.3]
+
+describe('canUpdateCentroid', () => {
+  let workspace: Workspace
+  let project: Project
+  let commit: Commit
+  let document: DocumentVersion
+  let evaluation: EvaluationV2
+  let issue: Issue
+  let user: User
+
+  beforeEach(async () => {
+    const setup = await factories.createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      documents: {
+        doc1: factories.helpers.createPrompt({
+          provider: 'openai',
+          content: 'Test prompt',
+        }),
+      },
+    })
+
+    workspace = setup.workspace
+    project = setup.project
+    commit = setup.commit
+    document = setup.documents[0]!
+    user = setup.user
+
+    evaluation = await factories.createEvaluationV2({
+      workspace,
+      document,
+      commit,
+    })
+
+    const issueResult = await factories.createIssue({
+      workspace,
+      project,
+      document,
+    })
+    issue = issueResult.issue
+  })
+
+  describe('when embedding is undefined', () => {
+    it('returns false regardless of other conditions', async () => {
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const evaluationResult = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const result = await canUpdateCentroid({
+        result: evaluationResult,
+        commit,
+        issue,
+        embedding: undefined,
+        issueWasNew: true,
+      })
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('when result is from an experiment', () => {
+    it('returns false regardless of commit merge status', async () => {
+      const { experiment } = await factories.createExperiment({
+        workspace,
+        user,
+        document,
+        commit,
+        evaluations: [evaluation],
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const experimentResult = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        experiment,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const result = await canUpdateCentroid({
+        result: experimentResult,
+        commit,
+        issue,
+        embedding: MOCK_EMBEDDING,
+        issueWasNew: false,
+      })
+
+      expect(result).toBe(false)
+    })
+
+    it('returns false even when issue is new', async () => {
+      const { experiment } = await factories.createExperiment({
+        workspace,
+        user,
+        document,
+        commit,
+        evaluations: [evaluation],
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const experimentResult = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        experiment,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const result = await canUpdateCentroid({
+        result: experimentResult,
+        commit,
+        issue,
+        embedding: MOCK_EMBEDDING,
+        issueWasNew: true,
+      })
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('when result is NOT from an experiment', () => {
+    describe('when commit is merged (live)', () => {
+      it('returns true', async () => {
+        const span = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const evaluationResult = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit,
+          span,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        const result = await canUpdateCentroid({
+          result: evaluationResult,
+          commit,
+          issue,
+          embedding: MOCK_EMBEDDING,
+          issueWasNew: false,
+        })
+
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('when issue is new', () => {
+      it('returns true even if commit is not merged', async () => {
+        const { commit: draft } = await factories.createDraft({ project, user })
+
+        const span = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: draft.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const evaluationResult = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit: draft,
+          span,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        const result = await canUpdateCentroid({
+          result: evaluationResult,
+          commit: draft,
+          issue,
+          embedding: MOCK_EMBEDDING,
+          issueWasNew: true,
+        })
+
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('when commit is not merged and issue is not new', () => {
+      it('returns true when issue has no results from other commits', async () => {
+        const { commit: draft } = await factories.createDraft({ project, user })
+
+        const span = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: draft.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const evaluationResult = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit: draft,
+          span,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        const result = await canUpdateCentroid({
+          result: evaluationResult,
+          commit: draft,
+          issue,
+          embedding: MOCK_EMBEDDING,
+          issueWasNew: false,
+        })
+
+        expect(result).toBe(true)
+      })
+
+      it('returns false when issue has results from other commits', async () => {
+        const { commit: draft } = await factories.createDraft({ project, user })
+
+        const spanFromMerged = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const resultFromMerged = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit,
+          span: spanFromMerged,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        await factories.createIssueEvaluationResult({
+          workspace,
+          issue,
+          evaluationResult: resultFromMerged,
+        })
+
+        const spanFromDraft = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: draft.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const resultFromDraft = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit: draft,
+          span: spanFromDraft,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        const result = await canUpdateCentroid({
+          result: resultFromDraft,
+          commit: draft,
+          issue,
+          embedding: MOCK_EMBEDDING,
+          issueWasNew: false,
+        })
+
+        expect(result).toBe(false)
+      })
+
+      it('returns true when issue only has results from the same commit', async () => {
+        const { commit: draft } = await factories.createDraft({ project, user })
+
+        const spanFromDraft1 = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: draft.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const resultFromDraft1 = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit: draft,
+          span: spanFromDraft1,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        await factories.createIssueEvaluationResult({
+          workspace,
+          issue,
+          evaluationResult: resultFromDraft1,
+        })
+
+        const spanFromDraft2 = await factories.createSpan({
+          workspaceId: workspace.id,
+          commitUuid: draft.uuid,
+          type: SpanType.Prompt,
+        })
+
+        const resultFromDraft2 = await factories.createEvaluationResultV2({
+          workspace,
+          evaluation,
+          commit: draft,
+          span: spanFromDraft2,
+          score: 0,
+          normalizedScore: 0,
+          hasPassed: false,
+        })
+
+        const result = await canUpdateCentroid({
+          result: resultFromDraft2,
+          commit: draft,
+          issue,
+          embedding: MOCK_EMBEDDING,
+          issueWasNew: false,
+        })
+
+        expect(result).toBe(true)
+      })
+    })
+  })
+
+  describe('issueWasNew default value', () => {
+    it('defaults to false when not provided', async () => {
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const evaluationResult = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const result = await canUpdateCentroid({
+        result: evaluationResult,
+        commit,
+        issue,
+        embedding: MOCK_EMBEDDING,
+      })
+
+      expect(result).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/services/issues/results/canUpdateCentroid.ts
+++ b/packages/core/src/services/issues/results/canUpdateCentroid.ts
@@ -1,0 +1,80 @@
+import { eq, and, ne } from 'drizzle-orm'
+import {
+  EvaluationMetric,
+  EvaluationResultV2,
+  EvaluationType,
+} from '../../../constants'
+import { Issue } from '../../../schema/models/types/Issue'
+import { Commit } from '../../../schema/models/types/Commit'
+import { database } from '../../../client'
+import { evaluationResultsV2 } from '../../../schema/models/evaluationResultsV2'
+import { issueEvaluationResults } from '../../../schema/models/issueEvaluationResults'
+
+async function containsResultsFromOtherCommits(
+  {
+    issue,
+    commitId,
+  }: {
+    issue: Issue
+    commitId: number
+  },
+  db = database,
+) {
+  const commitIds = await db
+    .selectDistinct({ commitId: evaluationResultsV2.commitId })
+    .from(issueEvaluationResults)
+    .innerJoin(
+      evaluationResultsV2,
+      eq(issueEvaluationResults.evaluationResultId, evaluationResultsV2.id),
+    )
+    .where(
+      and(
+        eq(issueEvaluationResults.workspaceId, issue.workspaceId),
+        eq(issueEvaluationResults.issueId, issue.id),
+        ne(evaluationResultsV2.commitId, commitId),
+      ),
+    )
+    .limit(1)
+
+  return commitIds.length > 0
+}
+/**
+ * Determines whether the issue centroid should be updated when adding or
+ * removing a result.
+ *
+ * The centroid is only updated when:
+ * 1. The embedding is provided
+ * 2. The result is NOT from an experiment (experiment results should be added
+ *    to issues, but not move the centroid)
+ * 3. AND one of the following:
+ *    - The commit is merged (live)
+ *    - The issue is new (for add operations)
+ *    - The issue has only received results from the same commit
+ */
+export async function canUpdateCentroid<
+  T extends EvaluationType,
+  M extends EvaluationMetric<T>,
+>({
+  result,
+  commit,
+  issue,
+  embedding,
+  issueWasNew = false,
+}: {
+  result: EvaluationResultV2<T, M>
+  commit: Commit
+  issue: Issue
+  embedding: number[] | undefined
+  issueWasNew?: boolean
+}): Promise<boolean> {
+  if (!embedding) return false
+  if (result.experimentId) return false
+  if (commit.mergedAt || issueWasNew) return true
+
+  const resultsFromOtherCommits = await containsResultsFromOtherCommits({
+    issue,
+    commitId: result.commitId,
+  })
+
+  return !resultsFromOtherCommits
+}


### PR DESCRIPTION
# What?
We want to add to the issue the result from experiments but we don't want to influence centroid