### PR TITLE
Fix billing period calculations

### DIFF
--- a/packages/core/src/services/copilot/latte/credits/usage.test.ts
+++ b/packages/core/src/services/copilot/latte/credits/usage.test.ts
@@ -1,5 +1,13 @@
 import { addMonths, startOfDay, subMonths } from 'date-fns'
-import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockInstance,
+  vi,
+} from 'vitest'
 import { type LatteThread } from '../../../../schema/models/types/LatteThread'
 import { type Project } from '../../../../schema/models/types/Project'
 import { type Workspace } from '../../../../schema/models/types/Workspace'
@@ -17,6 +25,8 @@ const SubscriptionPlansMock = {
   },
 }
 
+const MOCK_DATE = new Date('2025-01-15T12:00:00Z')
+
 describe('usageLatteCredits', () => {
   let mocks: {
     cache: {
@@ -31,9 +41,9 @@ describe('usageLatteCredits', () => {
   let thread: LatteThread
 
   beforeEach(async () => {
-    vi.resetAllMocks()
-    vi.clearAllMocks()
-    vi.restoreAllMocks()
+    // Set the system time to a fixed date for consistent testing (avoids date issues with subMonths)
+    vi.useFakeTimers()
+    vi.setSystemTime(MOCK_DATE)
 
     vi.spyOn(plans, 'SubscriptionPlans', 'get').mockReturnValue(
       SubscriptionPlansMock as any,
@@ -121,6 +131,10 @@ describe('usageLatteCredits', () => {
         set: setCacheMock,
       },
     }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('succeeds when no requests', async () => {

--- a/packages/core/src/services/grants/quota.test.ts
+++ b/packages/core/src/services/grants/quota.test.ts
@@ -1,6 +1,6 @@
 import { addMonths, startOfDay, subMonths } from 'date-fns'
 import { eq } from 'drizzle-orm'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { database } from '../../client'
 import { GrantSource, QuotaType } from '../../constants'
 import * as plans from '../../plans'
@@ -20,14 +20,16 @@ const SubscriptionPlansMock = {
   },
 }
 
+const MOCK_DATE = new Date('2025-01-15T12:00:00Z')
+
 describe('computeQuota', () => {
   let now: Date
   let workspace: Workspace
 
   beforeEach(async () => {
-    vi.resetAllMocks()
-    vi.clearAllMocks()
-    vi.restoreAllMocks()
+    // Set the system time to a fixed date for consistent testing (avoids date issues with subMonths)
+    vi.useFakeTimers()
+    vi.setSystemTime(MOCK_DATE)
 
     vi.spyOn(plans, 'SubscriptionPlans', 'get').mockReturnValue(
       SubscriptionPlansMock as any,
@@ -102,6 +104,10 @@ describe('computeQuota', () => {
       workspace: workspace,
       expiresAt: subMonths(now, 2),
     })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('succeeds when no grants', async () => {

--- a/packages/core/src/services/workspaces/utils/calculateRenewalDate.test.ts
+++ b/packages/core/src/services/workspaces/utils/calculateRenewalDate.test.ts
@@ -55,4 +55,64 @@ describe('getLatestRenewalDate', () => {
 
     expect(result).toEqual(new Date(2023, 11, 12))
   })
+
+  it('clamps day 31 to day 28 when renewal falls in February (non-leap year)', () => {
+    const firstRenewalDate = new Date(2024, 0, 31) // Jan 31
+    const targetDate = new Date(2025, 2, 15) // March 15, 2025
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be Feb 28, 2025 (not March 3 which would happen without clamping)
+    expect(result).toEqual(new Date(2025, 1, 28))
+  })
+
+  it('clamps day 31 to day 29 when renewal falls in February (leap year)', () => {
+    const firstRenewalDate = new Date(2024, 0, 31) // Jan 31
+    const targetDate = new Date(2024, 2, 15) // March 15, 2024 (leap year)
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be Feb 29, 2024 (leap year)
+    expect(result).toEqual(new Date(2024, 1, 29))
+  })
+
+  it('clamps day 31 to day 30 when renewal falls in a 30-day month', () => {
+    const firstRenewalDate = new Date(2024, 0, 31) // Jan 31
+    const targetDate = new Date(2024, 4, 15) // May 15, 2024
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be April 30 (April has 30 days)
+    expect(result).toEqual(new Date(2024, 3, 30))
+  })
+
+  it('does not clamp when renewal day exists in the target month', () => {
+    const firstRenewalDate = new Date(2024, 0, 31) // Jan 31
+    const targetDate = new Date(2024, 7, 15) // Aug 15, 2024
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be July 31 (July has 31 days)
+    expect(result).toEqual(new Date(2024, 6, 31))
+  })
+
+  it('clamps day 30 to day 28 when renewal falls in February (non-leap year)', () => {
+    const firstRenewalDate = new Date(2024, 3, 30) // Apr 30
+    const targetDate = new Date(2025, 2, 15) // March 15, 2025
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be Feb 28, 2025
+    expect(result).toEqual(new Date(2025, 1, 28))
+  })
+
+  it('clamps day 29 to day 28 when renewal falls in February (non-leap year)', () => {
+    const firstRenewalDate = new Date(2024, 0, 29) // Jan 29
+    const targetDate = new Date(2025, 2, 15) // March 15, 2025
+
+    const result = getLatestRenewalDate(firstRenewalDate, targetDate)
+
+    // Should be Feb 28, 2025
+    expect(result).toEqual(new Date(2025, 1, 28))
+  })
 })

--- a/packages/core/src/services/workspaces/utils/calculateRenewalDate.ts
+++ b/packages/core/src/services/workspaces/utils/calculateRenewalDate.ts
@@ -33,5 +33,10 @@ export function getLatestRenewalDate(firstRenewalDate: Date, targetDate: Date) {
   const adjustedMonth =
     (targetMonth - (targetDay < renewalDay ? 1 : 0) + 12) % 12
 
-  return new Date(adjustedYear, adjustedMonth, renewalDay)
+  // Clamp renewalDay to the last valid day of the adjusted month
+  // This handles edge cases like Jan 31 -> Feb (which only has 28/29 days)
+  const lastDayOfMonth = new Date(adjustedYear, adjustedMonth + 1, 0).getDate()
+  const clampedDay = Math.min(renewalDay, lastDayOfMonth)
+
+  return new Date(adjustedYear, adjustedMonth, clampedDay)
 }


### PR DESCRIPTION
Fixes incorrect billing period calculations for subscriptions created on days 29-31 when the renewal falls in a shorter month (e.g., Feb). 

Previously, JavaScript's Date constructor would roll over to the next month (e.g., Feb 31 → Mar 3), causing usage/quota calculations to be off by several days.

Example when it could occur:
- Workspace created on the 31st (or 30th/29th for Feb)
- User uses Latitude during a short month (Feb, Apr, Jun, Sep, Nov)

What would happen:
- Subscription created Jan 31
- User uses Latitude on March 15 (usage is calculated in dashboard)
- Code calculates last renewal as "Feb 31"
- JavaScript makes it March 3 instead
- Usage/quota numbers would be slightly off (counting ~3 extra days)
