### PR TITLE
Improve active weekly workspaces query

### DIFF
--- a/apps/web/src/actions/workspaceOnboarding/skip.ts
+++ b/apps/web/src/actions/workspaceOnboarding/skip.ts
@@ -17,4 +17,3 @@ export const skipOnboardingAction = authProcedure.action(async ({ ctx }) => {
 
   return frontendRedirect(ROUTES.dashboard.root)
 })
-

--- a/apps/web/src/app/(onboarding)/onboarding/install/_lib/OnboardingInstallProvider.tsx
+++ b/apps/web/src/app/(onboarding)/onboarding/install/_lib/OnboardingInstallProvider.tsx
@@ -34,4 +34,3 @@ export function useOnboardingInstall() {
   }
   return context
 }
-

--- a/packages/core/src/data-access/weeklyEmail/activeWorkspaces/index.test.ts
+++ b/packages/core/src/data-access/weeklyEmail/activeWorkspaces/index.test.ts
@@ -37,7 +37,7 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: workspace.id,
+            id: String(workspace.id),
           }),
         ]),
       )
@@ -61,7 +61,7 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       expect(result).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: oldWorkspace.id,
+            id: String(oldWorkspace.id),
           }),
         ]),
       )
@@ -91,7 +91,7 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       expect(result).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: nonPromptWorkspace.id,
+            id: String(nonPromptWorkspace.id),
           }),
         ]),
       )
@@ -133,15 +133,15 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       // Should include common workspace and workspace2
       expect(result).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: workspace.id }),
-          expect.objectContaining({ id: workspace2.id }),
+          expect.objectContaining({ id: String(workspace.id) }),
+          expect.objectContaining({ id: String(workspace2.id) }),
         ]),
       )
 
       // Should not include workspace3
       expect(result).not.toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: workspace3.id }),
+          expect.objectContaining({ id: String(workspace3.id) }),
         ]),
       )
     })
@@ -171,8 +171,9 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
 
       const result = await getActiveWorkspacesForWeeklyEmail()
 
-      // Should include workspace only once
-      const workspaceCount = result.filter((w) => w.id === workspace.id).length
+      const workspaceCount = result.filter(
+        (w) => w.id === String(workspace.id),
+      ).length
       expect(workspaceCount).toEqual(1)
     })
   })
@@ -207,7 +208,7 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       // Should include regular workspace
       expect(result).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: regularWorkspace.id }),
+          expect.objectContaining({ id: String(regularWorkspace.id) }),
         ]),
       )
 
@@ -254,15 +255,15 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       // Should include common workspace and regularWorkspace (not big accounts)
       expect(result).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: workspace.id }),
-          expect.objectContaining({ id: regularWorkspace.id }),
+          expect.objectContaining({ id: String(workspace.id) }),
+          expect.objectContaining({ id: String(regularWorkspace.id) }),
         ]),
       )
 
       // Should not include bigWorkspace (big account)
       expect(result).not.toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: bigWorkspace.id }),
+          expect.objectContaining({ id: String(bigWorkspace.id) }),
         ]),
       )
     })
@@ -285,7 +286,7 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       expect(result).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: edgeCaseWorkspace.id,
+            id: String(edgeCaseWorkspace.id),
           }),
         ]),
       )
@@ -307,28 +308,10 @@ describe('getActiveWorkspacesForWeeklyEmail', () => {
       expect(result).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            id: tooOldWorkspace.id,
+            id: String(tooOldWorkspace.id),
           }),
         ]),
       )
-    })
-
-    it('returns full workspace objects with all fields', async () => {
-      const threeDaysAgo = new Date()
-      threeDaysAgo.setDate(threeDaysAgo.getDate() - 3)
-
-      await createSpan({
-        workspaceId: workspace.id,
-        type: SpanType.Prompt,
-        startedAt: threeDaysAgo,
-      })
-
-      const result = await getActiveWorkspacesForWeeklyEmail()
-
-      const foundWorkspace = result.find((w) => w.id === workspace.id)
-      expect(foundWorkspace).toBeDefined()
-      expect(foundWorkspace?.name).toBeDefined()
-      expect(foundWorkspace?.createdAt).toBeDefined()
     })
   })
 })

--- a/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.test.ts
+++ b/packages/core/src/jobs/job-definitions/weeklyEmail/scheduleWeeklyEmailJobs.test.ts
@@ -48,12 +48,12 @@ describe('scheduleWeeklyEmailJobs', () => {
 
     expect(mockAdd).toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: workspace1.id },
+      { workspaceId: String(workspace1.id) },
       { attempts: 3 },
     )
     expect(mockAdd).toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: workspace2.id },
+      { workspaceId: String(workspace2.id) },
       { attempts: 3 },
     )
   })
@@ -73,7 +73,7 @@ describe('scheduleWeeklyEmailJobs', () => {
     await scheduleWeeklyEmailJobs({} as Job)
     expect(mockAdd).not.toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: workspace.id },
+      { workspaceId: String(workspace.id) },
       expect.any(Object),
     )
   })
@@ -96,7 +96,7 @@ describe('scheduleWeeklyEmailJobs', () => {
 
     expect(mockAdd).not.toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: bigWorkspace.id },
+      { workspaceId: String(bigWorkspace.id) },
       expect.any(Object),
     )
   })
@@ -135,18 +135,18 @@ describe('scheduleWeeklyEmailJobs', () => {
 
     expect(mockAdd).toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: activeWorkspace.id },
+      { workspaceId: String(activeWorkspace.id) },
       { attempts: 3 },
     )
 
     expect(mockAdd).not.toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: bigWorkspace.id },
+      { workspaceId: String(bigWorkspace.id) },
       expect.any(Object),
     )
     expect(mockAdd).not.toHaveBeenCalledWith(
       'sendWeeklyEmailJob',
-      { workspaceId: inactiveWorkspace.id },
+      { workspaceId: String(inactiveWorkspace.id) },
       expect.any(Object),
     )
   })


### PR DESCRIPTION
# What?
We have a weekly email newsletter where we show each workspace activity. This is failing because we query the `spans` table which is huge. I changed this query to try to fix it

## WIP
I'm not sure this is going to fix the problem. I have 3 ideas

## Idea 1: add a combined index
Add an index by `started_at` + `type` + `workspace_id`. This is my last resort. I want to try the other ideas first

## Idea 2: Move span query to individual job
Instead of filtering workspaces by activity in the master job, do the filtering in the individual workspace job. Is more work but might be the solution.

## Idea 3: Improve this Query
This is what I'm trying in this PR. I want to see if starting the query from workspaces table which is smaller would improve the full query on spans. **WIP**


## RESULT
I'll go with Idea (3). I think is good enough. Doing `EXPLAIN ANALYZE` it does this this code:
  | Metric | Before | After |
  |--------|--------|-------|
  | Execution time | 30+ seconds (timeout) | ~2.5 seconds |
  | Strategy | Hash aggregate over 20M+ spans | Nested loop with LATERAL
  (22k workspace lookups) |

  The LATERAL join forces PostgreSQL to:
  1. Iterate over workspaces (22k rows)
  2. For each workspace, use index to find ONE matching span
  3. Stop immediately when found (LIMIT 1)
