### PR TITLE
Do not allow resolve or ignore merged issues

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/issues/_components/IssueItemActions/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/issues/_components/IssueItemActions/index.tsx
@@ -34,20 +34,21 @@ const UNDO_MESSAGES = {
   },
 }
 
+type IssueActionsProps = {
+  issue: SerializedIssue
+  placement: 'item' | 'details'
+  onOptimisticAction?: () => void
+}
 /**
  * The way this works is tha optimistic updates are performed immediately on the SWR cache,
  * and a toast with an "Undo" action is shown. If the user clicks "Undo", the cache is reverted.
  * If the timeout elapses without an undo, the backend call is made to perform the action.
  */
-export function IssueItemActions({
+function RealIssueItemActions({
   issue,
   placement,
   onOptimisticAction,
-}: {
-  issue: SerializedIssue
-  placement: 'item' | 'details'
-  onOptimisticAction?: () => void
-}) {
+}: IssueActionsProps) {
   const { mutate } = useSWRConfig()
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
@@ -324,5 +325,21 @@ export function IssueItemActions({
         evaluations={issueEvaluations}
       />
     </>
+  )
+}
+
+export function IssueItemActions({
+  issue,
+  placement,
+  onOptimisticAction,
+}: IssueActionsProps) {
+  if (issue.isMerged) return null
+
+  return (
+    <RealIssueItemActions
+      issue={issue}
+      placement={placement}
+      onOptimisticAction={onOptimisticAction}
+    />
   )
 }

--- a/packages/core/src/services/issues/ignore.ts
+++ b/packages/core/src/services/issues/ignore.ts
@@ -18,6 +18,12 @@ export async function ignoreIssue(
   },
   transaction = new Transaction(),
 ) {
+  if (issue.mergedAt) {
+    return Result.error(
+      new UnprocessableEntityError('Cannot ignore a merged issue'),
+    )
+  }
+
   if (issue.resolvedAt) {
     return Result.error(
       new UnprocessableEntityError('Cannot ignore a resolved issue'),

--- a/packages/core/src/services/issues/resolve.ts
+++ b/packages/core/src/services/issues/resolve.ts
@@ -20,6 +20,12 @@ export async function resolveIssue(
   },
   transaction = new Transaction(),
 ) {
+  if (issue.mergedAt) {
+    return Result.error(
+      new UnprocessableEntityError('Cannot resolve a merged issue'),
+    )
+  }
+
   if (issue.ignoredAt) {
     return Result.error(
       new UnprocessableEntityError('Cannot resolve an ignored issue'),

--- a/packages/core/src/services/issues/unignore.ts
+++ b/packages/core/src/services/issues/unignore.ts
@@ -18,14 +18,18 @@ export async function unignoreIssue(
   },
   transaction = new Transaction(),
 ) {
-  // Check if the issue is resolved
+  if (issue.mergedAt) {
+    return Result.error(
+      new UnprocessableEntityError('Cannot unignore a merged issue'),
+    )
+  }
+
   if (issue.resolvedAt) {
     return Result.error(
       new UnprocessableEntityError('Cannot unignore a resolved issue'),
     )
   }
 
-  // Check if the issue is not ignored
   if (!issue.ignoredAt) {
     return Result.error(new UnprocessableEntityError('Issue is not ignored'))
   }

--- a/packages/core/src/services/issues/unresolve.ts
+++ b/packages/core/src/services/issues/unresolve.ts
@@ -18,14 +18,18 @@ export async function unresolveIssue(
   },
   transaction = new Transaction(),
 ) {
-  // Check if the issue is ignored
+  if (issue.mergedAt) {
+    return Result.error(
+      new UnprocessableEntityError('Cannot unresolve a merged issue'),
+    )
+  }
+
   if (issue.ignoredAt) {
     return Result.error(
       new UnprocessableEntityError('Cannot unresolve an ignored issue'),
     )
   }
 
-  // Check if the issue is not resolved
   if (!issue.resolvedAt) {
     return Result.error(new UnprocessableEntityError('Issue is not resolved'))
   }


### PR DESCRIPTION
# What?
Merged issues should not be resolved or ignored. Already are inactive

## TODO
- [x] Hide in the frontend UI for ignoring or resolving the issue
- [x] Change core services to fail if trying to ignore or resolve a merged issue