### PR TITLE
Do not update issues details when centroid is not updated

### DIFF
--- a/packages/core/src/repositories/evaluationResultsV2Repository.ts
+++ b/packages/core/src/repositories/evaluationResultsV2Repository.ts
@@ -812,6 +812,7 @@ export class EvaluationResultsV2Repository extends Repository<EvaluationResultV2
       eq(issueEvaluationResults.issueId, issueId),
       isNotNull(commits.mergedAt),
       isNull(evaluationResultsV2.error),
+      isNull(evaluationResultsV2.experimentId),
       sql`${evaluationResultsV2.hasPassed} IS NOT TRUE`,
     ]
 

--- a/packages/core/src/services/issues/results/add.test.ts
+++ b/packages/core/src/services/issues/results/add.test.ts
@@ -1,0 +1,334 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env } from '@latitude-data/env'
+import { Providers, SpanType } from '@latitude-data/constants'
+import { eq } from 'drizzle-orm'
+import { database } from '../../../client'
+import { issues } from '../../../schema/models/issues'
+import * as factories from '../../../tests/factories'
+import { waitForTransactionCallbacks } from '../../../tests/helpers'
+import { addResultToIssue } from './add'
+import { queues } from '../../../jobs/queues'
+
+vi.mock('../../../jobs/queues')
+
+const originalWeaviateKey = env.WEAVIATE_API_KEY
+
+beforeAll(() => {
+  ;(env as any).WEAVIATE_API_KEY = undefined
+})
+
+afterAll(() => {
+  ;(env as any).WEAVIATE_API_KEY = originalWeaviateKey
+})
+
+async function makeIssueNotNew(issueId: number) {
+  const pastDate = new Date(Date.now() - 1000 * 60 * 60)
+  await database
+    .update(issues)
+    .set({ createdAt: pastDate })
+    .where(eq(issues.id, issueId))
+}
+
+describe('addResultToIssue', () => {
+  let mockIssuesQueue: { add: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIssuesQueue = { add: vi.fn() }
+    vi.mocked(queues).mockResolvedValue({
+      issuesQueue: mockIssuesQueue,
+    } as any)
+  })
+
+  describe('generateIssueDetailsJob', () => {
+    it('queues generateIssueDetailsJob when result is NOT from an experiment', async () => {
+      const { workspace, documents, commit } = await factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          prompt: factories.helpers.createPrompt({
+            provider: 'openai',
+            model: 'gpt-4o',
+          }),
+        },
+      })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      const addResult = await addResultToIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      expect(addResult.ok).toBe(true)
+
+      await waitForTransactionCallbacks()
+
+      const generateDetailsCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'generateIssueDetailsJob',
+      )
+      expect(generateDetailsCall).toBeDefined()
+    })
+
+    it('does NOT queue generateIssueDetailsJob when result is from an experiment', async () => {
+      const { workspace, documents, commit, user } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            prompt: factories.helpers.createPrompt({
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const { experiment } = await factories.createExperiment({
+        workspace,
+        user,
+        document,
+        commit,
+        evaluations: [evaluation],
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        experiment,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        document,
+      })
+
+      await addResultToIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      const generateDetailsCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'generateIssueDetailsJob',
+      )
+      expect(generateDetailsCall).toBeUndefined()
+    })
+
+    it('does NOT queue mergeCommonIssuesJob when result is from an experiment', async () => {
+      const { workspace, documents, commit, user } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            prompt: factories.helpers.createPrompt({
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const { experiment } = await factories.createExperiment({
+        workspace,
+        user,
+        document,
+        commit,
+        evaluations: [evaluation],
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        experiment,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      await addResultToIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      const mergeCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'mergeCommonIssuesJob',
+      )
+      expect(mergeCall).toBeUndefined()
+    })
+
+    it('queues mergeCommonIssuesJob when result is NOT from an experiment', async () => {
+      const { workspace, documents, commit } = await factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          prompt: factories.helpers.createPrompt({
+            provider: 'openai',
+            model: 'gpt-4o',
+          }),
+        },
+      })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      await addResultToIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      const mergeCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'mergeCommonIssuesJob',
+      )
+      expect(mergeCall).toBeDefined()
+    })
+
+    it('does NOT queue any jobs when embedding is not provided', async () => {
+      const { workspace, documents, commit } = await factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          prompt: factories.helpers.createPrompt({
+            provider: 'openai',
+            model: 'gpt-4o',
+          }),
+        },
+      })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        document,
+      })
+
+      await addResultToIssue({
+        result: { result, evaluation, embedding: undefined },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      expect(mockIssuesQueue.add).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/services/issues/results/add.ts
+++ b/packages/core/src/services/issues/results/add.ts
@@ -145,6 +145,8 @@ export async function addResultToIssue<
       return Result.ok({ issue, histogram, result })
     },
     async ({ issue }) => {
+      if (!shouldUpdateCentroid) return
+
       const payload = { workspaceId: workspace.id, issueId: issue.id }
       const { issuesQueue } = await queues()
 

--- a/packages/core/src/services/issues/results/remove.test.ts
+++ b/packages/core/src/services/issues/results/remove.test.ts
@@ -1,0 +1,270 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { env } from '@latitude-data/env'
+import { Providers, SpanType } from '@latitude-data/constants'
+import { eq } from 'drizzle-orm'
+import { database } from '../../../client'
+import { issues } from '../../../schema/models/issues'
+import { issueHistograms } from '../../../schema/models/issueHistograms'
+import * as factories from '../../../tests/factories'
+import { waitForTransactionCallbacks } from '../../../tests/helpers'
+import { removeResultFromIssue } from './remove'
+import { queues } from '../../../jobs/queues'
+
+vi.mock('../../../jobs/queues')
+
+const originalWeaviateKey = env.WEAVIATE_API_KEY
+
+beforeAll(() => {
+  ;(env as any).WEAVIATE_API_KEY = undefined
+})
+
+afterAll(() => {
+  ;(env as any).WEAVIATE_API_KEY = originalWeaviateKey
+})
+
+async function makeIssueNotNew(issueId: number) {
+  const pastDate = new Date(Date.now() - 1000 * 60 * 60)
+  await database
+    .update(issues)
+    .set({ createdAt: pastDate })
+    .where(eq(issues.id, issueId))
+}
+
+describe('removeResultFromIssue', () => {
+  let mockIssuesQueue: { add: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIssuesQueue = { add: vi.fn() }
+    vi.mocked(queues).mockResolvedValue({
+      issuesQueue: mockIssuesQueue,
+    } as any)
+  })
+
+  describe('generateIssueDetailsJob', () => {
+    it('queues generateIssueDetailsJob when result is NOT from an experiment', async () => {
+      const { workspace, project, documents, commit } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            prompt: factories.helpers.createPrompt({
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      await factories.createIssueEvaluationResult({
+        workspace,
+        issue,
+        evaluationResult: result,
+      })
+
+      await database.insert(issueHistograms).values({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        issueId: issue.id,
+        commitId: commit.id,
+        date: new Date().toISOString().split('T')[0]!,
+        count: 2,
+      })
+
+      await removeResultFromIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      const generateDetailsCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'generateIssueDetailsJob',
+      )
+      expect(generateDetailsCall).toBeDefined()
+    })
+
+    it('does NOT queue any jobs when result is from an experiment', async () => {
+      const { workspace, project, documents, commit, user } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            prompt: factories.helpers.createPrompt({
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const { experiment } = await factories.createExperiment({
+        workspace,
+        user,
+        document,
+        commit,
+        evaluations: [evaluation],
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        experiment,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      await factories.createIssueEvaluationResult({
+        workspace,
+        issue,
+        evaluationResult: result,
+      })
+
+      await database.insert(issueHistograms).values({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        issueId: issue.id,
+        commitId: commit.id,
+        date: new Date().toISOString().split('T')[0]!,
+        count: 2,
+      })
+
+      await removeResultFromIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      expect(mockIssuesQueue.add).not.toHaveBeenCalled()
+    })
+
+    it('queues mergeCommonIssuesJob when result is NOT from an experiment', async () => {
+      const { workspace, project, documents, commit } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            prompt: factories.helpers.createPrompt({
+              provider: 'openai',
+              model: 'gpt-4o',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const evaluation = await factories.createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await factories.createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await factories.createEvaluationResultV2({
+        workspace,
+        evaluation,
+        commit,
+        span,
+        score: 0,
+        normalizedScore: 0,
+        hasPassed: false,
+      })
+
+      const { issue } = await factories.createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await makeIssueNotNew(issue.id)
+
+      await factories.createIssueEvaluationResult({
+        workspace,
+        issue,
+        evaluationResult: result,
+      })
+
+      await database.insert(issueHistograms).values({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        issueId: issue.id,
+        commitId: commit.id,
+        date: new Date().toISOString().split('T')[0]!,
+        count: 2,
+      })
+
+      await removeResultFromIssue({
+        result: { result, evaluation, embedding: [0.1, 0.2, 0.3] },
+        issue,
+        workspace,
+      })
+
+      await waitForTransactionCallbacks()
+
+      const mergeCall = mockIssuesQueue.add.mock.calls.find(
+        (call) => call[0] === 'mergeCommonIssuesJob',
+      )
+      expect(mergeCall).toBeDefined()
+    })
+  })
+})

--- a/packages/core/src/services/issues/results/remove.ts
+++ b/packages/core/src/services/issues/results/remove.ts
@@ -177,26 +177,26 @@ export async function removeResultFromIssue<
       return Result.ok({ issue, histogram, result })
     },
     async ({ issue }) => {
-      if (!issueWasLast) {
-        const payload = { workspaceId: workspace.id, issueId: issue.id }
-        const { issuesQueue } = await queues()
+      if (issueWasLast || !shouldUpdateCentroid) return
 
-        await issuesQueue.add('generateIssueDetailsJob', payload, {
-          attempts: ISSUE_JOBS_MAX_ATTEMPTS,
-          deduplication: {
-            id: generateIssueDetailsJobKey(payload),
-            ttl: ISSUE_JOBS_GENERATE_DETAILS_THROTTLE,
-          },
-        })
+      const payload = { workspaceId: workspace.id, issueId: issue.id }
+      const { issuesQueue } = await queues()
 
-        await issuesQueue.add('mergeCommonIssuesJob', payload, {
-          attempts: ISSUE_JOBS_MAX_ATTEMPTS,
-          deduplication: {
-            id: mergeCommonIssuesJobKey(payload),
-            ttl: ISSUE_JOBS_MERGE_COMMON_THROTTLE,
-          },
-        })
-      }
+      await issuesQueue.add('generateIssueDetailsJob', payload, {
+        attempts: ISSUE_JOBS_MAX_ATTEMPTS,
+        deduplication: {
+          id: generateIssueDetailsJobKey(payload),
+          ttl: ISSUE_JOBS_GENERATE_DETAILS_THROTTLE,
+        },
+      })
+
+      await issuesQueue.add('mergeCommonIssuesJob', payload, {
+        attempts: ISSUE_JOBS_MAX_ATTEMPTS,
+        deduplication: {
+          id: mergeCommonIssuesJobKey(payload),
+          ttl: ISSUE_JOBS_MERGE_COMMON_THROTTLE,
+        },
+      })
     },
   )
 }

--- a/packages/core/src/tests/helpers.ts
+++ b/packages/core/src/tests/helpers.ts
@@ -5,6 +5,18 @@ import { mergeCommit } from '../services/commits'
 import * as factories from './factories'
 import { env } from '@latitude-data/env'
 
+/**
+ * Waits for async Transaction success callbacks to complete.
+ *
+ * The Transaction class calls success callbacks without awaiting them
+ * (see Transaction.ts). When callbacks are async, they start executing
+ * but the Transaction.call() returns before they complete. This helper
+ * gives the event loop time to process those pending promises.
+ */
+export function waitForTransactionCallbacks() {
+  return new Promise((resolve) => setTimeout(resolve, 100))
+}
+
 export async function testConsumeStream(stream: ReadableStream) {
   const reader = stream.getReader()
 


### PR DESCRIPTION
# What?
Some updates on issue details re-generation

## TODO
- [x] Results that shouldn't move the centroid also shouldn't trigger issue details re-generation
- [x] results from experiments are excluded for issue details job generation