### PR TITLE
fix: keep focus on playground input after sending message

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/ChatTextArea/index.tsx
@@ -1,7 +1,14 @@
 import { ToolMessage } from '@latitude-data/constants/legacyCompiler'
 import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
 import { cn } from '@latitude-data/web-ui/utils'
-import { ChangeEvent, KeyboardEvent, useCallback, useState } from 'react'
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { ToolBar } from './ToolBar'
 
 type OnSubmitWithTools = (value: string | ToolMessage[]) => void
@@ -32,7 +39,17 @@ function SimpleTextArea({
   disabledBack?: boolean
   canSubmitWithEmptyValue?: boolean
 }) {
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
+  const wasDisabledRef = useRef(disabledSubmit)
   const [value, setValue] = useState('')
+
+  useEffect(() => {
+    if (wasDisabledRef.current && !disabledSubmit) {
+      textAreaRef.current?.focus()
+    }
+    wasDisabledRef.current = disabledSubmit
+  }, [disabledSubmit])
+
   const onSubmitHandler = useCallback(() => {
     if (disabledSubmit) return
     if (value === '' && !canSubmitWithEmptyValue) return
@@ -58,6 +75,7 @@ function SimpleTextArea({
   return (
     <div className='flex flex-col w-full'>
       <TextArea
+        ref={textAreaRef}
         disabled={disabledSubmit}
         className={cn(
           'bg-background w-full p-3 resize-none text-sm rounded-2xl',

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ChatInputBox/index.tsx
@@ -19,7 +19,7 @@ export const ChatInputBox = memo(function ChatInputBox({
   playground: ReturnType<typeof usePlaygroundChat>
 }) {
   return (
-    <div className='flex relative flex-row w-full items-center justify-center px-4'>
+    <div className='relative w-full'>
       <StatusIndicator
         playground={playground}
         resetChat={resetChat}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ContentArea/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/ContentArea/index.tsx
@@ -182,7 +182,7 @@ export function DocumentEditorContentArea({
             </div>
             <div
               className={cn(
-                'sticky bottom-2 flex flex-row items-center justify-center',
+                'sticky bottom-2 flex flex-row items-center justify-center px-4',
               )}
             >
               {playground.mode === 'preview' &&

--- a/apps/web/src/components/PlaygroundCommon/StatusIndicator/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/StatusIndicator/index.tsx
@@ -28,7 +28,7 @@ export function StatusIndicator({
   return (
     <div
       className={cn(
-        'absolute bg-background rounded-xl flex items-center justify-center flex-row',
+        'absolute left-1/2 -translate-x-1/2 bg-background rounded-xl flex items-center justify-center flex-row',
         'gap-2 border border-border px-3 py-2 shadow-sm !select-none',
         position === 'bottom' ? '' : '-top-14',
         { '-top-[5.5rem]': !canChat && position === 'top' },

--- a/packages/web-ui/tailwind.config.js
+++ b/packages/web-ui/tailwind.config.js
@@ -147,15 +147,15 @@ export default {
         glow: {
           '0%': {
             boxShadow:
-              '0 0 20px 4px var(--from-glow-color, hsl(var(--primary) / 0.15))',
+              '0 0 8px 2px var(--from-glow-color, hsl(var(--primary) / 0.15))',
           },
           '50%': {
             boxShadow:
-              '0 0 30px 8px var(--to-glow-color, hsl(var(--primary) / 0.3))',
+              '0 0 12px 4px var(--to-glow-color, hsl(var(--primary) / 0.3))',
           },
           '100%': {
             boxShadow:
-              '0 0 20px 4px var(--from-glow-color, hsl(var(--primary) / 0.15))',
+              '0 0 8px 2px var(--from-glow-color, hsl(var(--primary) / 0.15))',
           },
         },
       },


### PR DESCRIPTION
## Summary

Fixed an issue where the playground input would lose focus after sending a message, requiring users to manually refocus to send another message.

## Changes

- Add `useEffect` to refocus textarea when it transitions from disabled to enabled state
- Reduce glow animation size to prevent visual clipping in containers with overflow
- Add consistent padding to input containers in both preview and chat modes
- Center the StatusIndicator using absolute positioning (`left-1/2 -translate-x-1/2`)

## Testing

1. Open the prompt playground
2. Send a message
3. After the response completes, verify the input is automatically focused
4. Verify the glow effect is not clipped on the sides