### PR TITLE
Filter issues from deleted documents in issues dashboard

### DIFF
--- a/apps/workers/src/workers/worker-definitions/eventsWorker.ts
+++ b/apps/workers/src/workers/worker-definitions/eventsWorker.ts
@@ -55,6 +55,7 @@ const eventHandlersJobMappings = {
   notifyClientOfEvaluationV2AlignmentUpdated:
     jobs.notifyClientOfEvaluationV2AlignmentUpdated,
   notifyClientOfOptimizationStatus: jobs.notifyClientOfOptimizationStatus,
+  unassignIssuesOnDocumentsDeleted: jobs.unassignIssuesOnDocumentsDeleted,
 }
 
 export function startEventsWorker() {

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -50,6 +50,7 @@ export type Events =
   | 'commitMerged'
   | 'commitDeleted'
   | 'documentCreated'
+  | 'documentsDeleted'
   | 'documentRunRequested'
   | 'publicDocumentRunRequested'
   | 'chatMessageRequested'
@@ -335,6 +336,18 @@ export type DocumentCreatedEvent = LatitudeEventGeneric<
     document: DocumentVersion
     workspaceId: number
     userEmail?: string
+  }
+>
+
+export type DocumentsDeletedEvent = LatitudeEventGeneric<
+  'documentsDeleted',
+  {
+    workspaceId: number
+    projectId: number
+    commitUuid: string
+    documentUuids: string[]
+    softDeletedDocumentUuids: string[]
+    hardDeletedDocumentUuids: string[]
   }
 >
 
@@ -1020,6 +1033,7 @@ export type LatitudeEvent =
   | CommitMergedEvent
   | CommitDeletedEvent
   | DocumentCreatedEvent
+  | DocumentsDeletedEvent
   | DocumentRunRequestedEvent
   | PublicDocumentRunRequestedEvent
   | ChatMessageRequestedEvent
@@ -1114,6 +1128,7 @@ export interface IEventsHandlers {
   commitMerged: EventHandler<CommitMergedEvent>[]
   commitDeleted: EventHandler<CommitDeletedEvent>[]
   documentCreated: EventHandler<DocumentCreatedEvent>[]
+  documentsDeleted: EventHandler<DocumentsDeletedEvent>[]
   documentRunRequested: EventHandler<DocumentRunRequestedEvent>[]
   publicDocumentRunRequested: EventHandler<PublicDocumentRunRequestedEvent>[]
   chatMessageRequested: EventHandler<ChatMessageRequestedEvent>[]

--- a/packages/core/src/events/handlers/index.ts
+++ b/packages/core/src/events/handlers/index.ts
@@ -36,6 +36,7 @@ import { touchProviderApiKeyJob } from './touchProviderApiKeyJob'
 import { undeployDocumentTriggerJob } from './undeployDocumentTriggerJob'
 import { unlockIssuesDashboardOnAnnotation } from './unlockIssuesDashboardOnAnnotation'
 import { updateWebhookLastTriggeredAt } from './webhooks'
+import { unassignIssuesOnDocumentsDeleted } from './unassignIssuesOnDocumentsDeleted'
 
 export const EventHandlers: IEventsHandlers = {
   claimReferralInvitations: [createClaimInvitationReferralJob],
@@ -44,6 +45,7 @@ export const EventHandlers: IEventsHandlers = {
   datasetCreated: [],
   datasetUploaded: [createDatasetRowsJob],
   documentCreated: [],
+  documentsDeleted: [unassignIssuesOnDocumentsDeleted],
   documentLogCreated: [notifyToClientDocumentLogCreatedJob],
   experimentVariantsCreated: [],
   documentSuggestionCreated: [

--- a/packages/core/src/events/handlers/unassignIssuesOnDocumentsDeleted.test.ts
+++ b/packages/core/src/events/handlers/unassignIssuesOnDocumentsDeleted.test.ts
@@ -1,0 +1,348 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { database } from '../../client'
+import { issueEvaluationResults } from '../../schema/models/issueEvaluationResults'
+import { issueHistograms } from '../../schema/models/issueHistograms'
+import { issues } from '../../schema/models/issues'
+import { createEvaluationResultV2 } from '../../tests/factories/evaluationResultsV2'
+import { createEvaluationV2 } from '../../tests/factories/evaluationsV2'
+import { createIssueEvaluationResult } from '../../tests/factories/issueEvaluationResults'
+import { createIssue } from '../../tests/factories/issues'
+import { createProject } from '../../tests/factories/projects'
+import { createSpan } from '../../tests/factories/spans'
+import { createWorkspace } from '../../tests/factories/workspaces'
+import { DocumentsDeletedEvent } from '../events'
+import { unassignIssuesOnDocumentsDeleted } from './unassignIssuesOnDocumentsDeleted'
+
+describe('unassignIssuesOnDocumentsDeleted', () => {
+  it('does nothing when documentUuids is empty', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project } = await createProject({ workspace })
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: 'some-uuid',
+        documentUuids: [],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [],
+      },
+    }
+
+    await expect(
+      unassignIssuesOnDocumentsDeleted({ data: event }),
+    ).resolves.not.toThrow()
+  })
+
+  it('does nothing when commit is not found', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    const document = documents[0]!
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: 'non-existent-uuid',
+        documentUuids: [document.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [],
+      },
+    }
+
+    await expect(
+      unassignIssuesOnDocumentsDeleted({ data: event }),
+    ).resolves.not.toThrow()
+  })
+
+  it('unassigns issueEvaluationResults for deleted documents in the commit', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents, commit } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    const document = documents[0]!
+
+    const { issue } = await createIssue({
+      workspace,
+      project,
+      document,
+    })
+
+    const evaluation = await createEvaluationV2({
+      workspace,
+      document,
+      commit,
+    })
+
+    const span = await createSpan({
+      workspaceId: workspace.id,
+      documentUuid: document.documentUuid,
+      commitUuid: commit.uuid,
+      projectId: project.id,
+    })
+
+    const evalResult = await createEvaluationResultV2({
+      workspace,
+      evaluation,
+      span,
+      commit,
+    })
+
+    await createIssueEvaluationResult({
+      workspace,
+      issue,
+      evaluationResult: evalResult,
+    })
+
+    const beforeDelete = await database
+      .select()
+      .from(issueEvaluationResults)
+      .where(eq(issueEvaluationResults.issueId, issue.id))
+    expect(beforeDelete).toHaveLength(1)
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuids: [document.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [document.documentUuid],
+      },
+    }
+
+    await unassignIssuesOnDocumentsDeleted({ data: event })
+
+    const afterDelete = await database
+      .select()
+      .from(issueEvaluationResults)
+      .where(eq(issueEvaluationResults.issueId, issue.id))
+    expect(afterDelete).toHaveLength(0)
+  })
+
+  it('deletes histograms for issues in the commit where documents are deleted', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents, commit } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    const document = documents[0]!
+
+    const histogramData = {
+      commitId: commit.id,
+      date: new Date(),
+      count: 5,
+    }
+
+    const { issue, histograms } = await createIssue({
+      workspace,
+      project,
+      document,
+      histograms: [histogramData],
+    })
+
+    expect(histograms).toHaveLength(1)
+
+    const beforeDelete = await database
+      .select()
+      .from(issueHistograms)
+      .where(
+        and(
+          eq(issueHistograms.issueId, issue.id),
+          eq(issueHistograms.commitId, commit.id),
+        ),
+      )
+    expect(beforeDelete).toHaveLength(1)
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuids: [document.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [document.documentUuid],
+      },
+    }
+
+    await unassignIssuesOnDocumentsDeleted({ data: event })
+
+    const afterDelete = await database
+      .select()
+      .from(issueHistograms)
+      .where(
+        and(
+          eq(issueHistograms.issueId, issue.id),
+          eq(issueHistograms.commitId, commit.id),
+        ),
+      )
+    expect(afterDelete).toHaveLength(0)
+  })
+
+  it('updates escalating status for affected issues', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents, commit } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    const document = documents[0]!
+
+    const histogramData = {
+      commitId: commit.id,
+      date: new Date(),
+      count: 10,
+    }
+
+    const { issue } = await createIssue({
+      workspace,
+      project,
+      document,
+      histograms: [histogramData],
+      escalatingAt: new Date(),
+    })
+
+    expect(issue.escalatingAt).not.toBeNull()
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuids: [document.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [document.documentUuid],
+      },
+    }
+
+    await unassignIssuesOnDocumentsDeleted({ data: event })
+
+    const updatedIssue = await database
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issue.id))
+      .then((r) => r[0])
+
+    expect(updatedIssue?.escalatingAt).toBeNull()
+  })
+
+  it('handles multiple documents and issues', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents, commit } = await createProject({
+      workspace,
+      documents: {
+        'doc-1': 'content 1',
+        'doc-2': 'content 2',
+      },
+    })
+    const doc1 = documents[0]!
+    const doc2 = documents[1]!
+
+    const { issue: issue1 } = await createIssue({
+      workspace,
+      project,
+      document: doc1,
+      histograms: [{ commitId: commit.id, date: new Date(), count: 3 }],
+    })
+
+    const { issue: issue2 } = await createIssue({
+      workspace,
+      project,
+      document: doc2,
+      histograms: [{ commitId: commit.id, date: new Date(), count: 5 }],
+    })
+
+    const beforeDelete = await database
+      .select()
+      .from(issueHistograms)
+      .where(
+        and(
+          inArray(issueHistograms.issueId, [issue1.id, issue2.id]),
+          eq(issueHistograms.commitId, commit.id),
+        ),
+      )
+    expect(beforeDelete).toHaveLength(2)
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: commit.uuid,
+        documentUuids: [doc1.documentUuid, doc2.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [doc1.documentUuid, doc2.documentUuid],
+      },
+    }
+
+    await unassignIssuesOnDocumentsDeleted({ data: event })
+
+    const afterDelete = await database
+      .select()
+      .from(issueHistograms)
+      .where(
+        and(
+          inArray(issueHistograms.issueId, [issue1.id, issue2.id]),
+          eq(issueHistograms.commitId, commit.id),
+        ),
+      )
+    expect(afterDelete).toHaveLength(0)
+  })
+
+  it('only deletes histograms for the specific commit', async () => {
+    const { workspace } = await createWorkspace({ features: ['issues'] })
+    const { project, documents, commit: commit1 } = await createProject({
+      workspace,
+      documents: { 'test-doc': 'test content' },
+    })
+    const document = documents[0]!
+
+    const { commit: commit2 } = await createProject({
+      workspace,
+      documents: { 'other-doc': 'other content' },
+    })
+
+    const { issue, histograms } = await createIssue({
+      workspace,
+      project,
+      document,
+      histograms: [
+        { commitId: commit1.id, date: new Date(), count: 5 },
+        { commitId: commit2.id, date: new Date(), count: 3 },
+      ],
+    })
+
+    expect(histograms).toHaveLength(2)
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId: workspace.id,
+        projectId: project.id,
+        commitUuid: commit1.uuid,
+        documentUuids: [document.documentUuid],
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [document.documentUuid],
+      },
+    }
+
+    await unassignIssuesOnDocumentsDeleted({ data: event })
+
+    const remainingHistograms = await database
+      .select()
+      .from(issueHistograms)
+      .where(eq(issueHistograms.issueId, issue.id))
+
+    expect(remainingHistograms).toHaveLength(1)
+    expect(remainingHistograms[0]!.commitId).toBe(commit2.id)
+  })
+})

--- a/packages/core/src/events/handlers/unassignIssuesOnDocumentsDeleted.ts
+++ b/packages/core/src/events/handlers/unassignIssuesOnDocumentsDeleted.ts
@@ -1,0 +1,119 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { Database } from '../../client'
+import { Result } from '../../lib/Result'
+import Transaction from '../../lib/Transaction'
+import { CommitsRepository, IssuesRepository } from '../../repositories'
+import { evaluationResultsV2 } from '../../schema/models/evaluationResultsV2'
+import { issueEvaluationResults } from '../../schema/models/issueEvaluationResults'
+import { issueHistograms } from '../../schema/models/issueHistograms'
+import { issues } from '../../schema/models/issues'
+import { Commit } from '../../schema/models/types/Commit'
+import { updateEscalatingIssue } from '../../services/issues/updateEscalating'
+import { DocumentsDeletedEvent } from '../events'
+
+async function unassignIssueEvaluationResults({
+  documentUuids,
+  commit,
+  db,
+}: {
+  documentUuids: string[]
+  commit: Commit
+  db: Database
+}) {
+  const issueIdsSubquery = db
+    .select({ id: issues.id })
+    .from(issues)
+    .where(inArray(issues.documentUuid, documentUuids))
+
+  const evalResultIdsSubquery = db
+    .select({ id: evaluationResultsV2.id })
+    .from(evaluationResultsV2)
+    .where(eq(evaluationResultsV2.commitId, commit.id))
+
+  await db.delete(issueEvaluationResults).where(
+    and(
+      inArray(issueEvaluationResults.issueId, issueIdsSubquery),
+      inArray(issueEvaluationResults.evaluationResultId, evalResultIdsSubquery),
+    ),
+  )
+}
+
+async function deleteHistogramsAndUpdateEscalation({
+  workspaceId,
+  documentUuids,
+  commit,
+  db,
+  transaction,
+}: {
+  workspaceId: number
+  documentUuids: string[]
+  commit: Commit
+  db: Database
+  transaction: Transaction
+}) {
+  const issuesRepo = new IssuesRepository(workspaceId, db)
+  const affectedIssues = await db
+    .select({ id: issues.id })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.workspaceId, workspaceId),
+        inArray(issues.documentUuid, documentUuids),
+      ),
+    )
+
+  if (affectedIssues.length === 0) return
+
+  const issueIds = affectedIssues.map((i) => i.id)
+
+  await db.delete(issueHistograms).where(
+    and(
+      eq(issueHistograms.workspaceId, workspaceId),
+      eq(issueHistograms.commitId, commit.id),
+      inArray(issueHistograms.issueId, issueIds),
+    ),
+  )
+
+  for (const { id } of affectedIssues) {
+    const issue = await issuesRepo.find(id).then((r) => r.unwrap())
+    await updateEscalatingIssue({ issue }, transaction).then((r) => r.unwrap())
+  }
+}
+
+export async function unassignIssuesOnDocumentsDeleted({
+  data: event,
+}: {
+  data: DocumentsDeletedEvent
+}) {
+  const { workspaceId, projectId, commitUuid, documentUuids } = event.data
+
+  if (documentUuids.length === 0) return
+
+  const commitsRepo = new CommitsRepository(workspaceId)
+  const commitResult = await commitsRepo.getCommitByUuid({
+    projectId,
+    uuid: commitUuid,
+  })
+  if (commitResult.error) return
+
+  const commit = commitResult.value
+  const transaction = new Transaction()
+
+  await transaction.call(async (tx) => {
+    await unassignIssueEvaluationResults({
+      documentUuids,
+      commit,
+      db: tx,
+    })
+
+    await deleteHistogramsAndUpdateEscalation({
+      workspaceId,
+      documentUuids,
+      commit,
+      db: tx,
+      transaction,
+    })
+
+    return Result.ok(true)
+  })
+}

--- a/packages/core/src/jobs/job-definitions/index.ts
+++ b/packages/core/src/jobs/job-definitions/index.ts
@@ -37,6 +37,7 @@ export * from '../../events/handlers/unlockIssuesDashboardOnAnnotation'
 export * from '../../events/handlers/stopDeploymentTestsForCommitHandler'
 export * from '../../events/handlers/enqueueShadowTestChallenger'
 export * from '../../events/handlers/notifyClientOfOptimizationStatus'
+export * from '../../events/handlers/unassignIssuesOnDocumentsDeleted'
 
 // Jobs
 export * from './actions/generateProjectNameJob'

--- a/packages/core/src/services/documents/destroyOrSoftDeleteDocuments.ts
+++ b/packages/core/src/services/documents/destroyOrSoftDeleteDocuments.ts
@@ -3,6 +3,7 @@ import { omit } from 'lodash-es'
 import { and, eq, inArray, ne } from 'drizzle-orm'
 
 import { database } from '../../client'
+import { publisher } from '../../events/publisher'
 import { Result, TypedResult } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
 import { EvaluationsV2Repository } from '../../repositories'
@@ -141,79 +142,106 @@ export async function destroyOrSoftDeleteDocuments(
   },
   transaction = new Transaction(),
 ): Promise<TypedResult<boolean, Error>> {
-  return transaction.call(async (tx) => {
-    const repository = new EvaluationsV2Repository(workspace.id, tx)
+  let softDeletedDocumentUuids: string[] = []
+  let hardDeletedDocumentUuids: string[] = []
 
-    await Promise.all(
-      documents.map(async (document) => {
-        const evaluations = await repository
-          .listAtCommitByDocument({
-            commitUuid: commit.uuid,
-            documentUuid: document.documentUuid,
-          })
-          .then((r) => r.unwrap())
+  return transaction.call(
+    async (tx) => {
+      const repository = new EvaluationsV2Repository(workspace.id, tx)
 
-        await Promise.all(
-          evaluations.map((evaluation) =>
-            deleteEvaluationV2(
-              { evaluation, commit, workspace },
-              transaction,
-            ).then((r) => r.unwrap()),
-          ),
-        )
-      }),
-    )
-    const deleteAllTriggerDocumentsResult =
-      await deleteDocumentTriggersFromDocuments(
-        {
-          commit,
-          workspace,
-          documents,
-        },
-        transaction,
+      await Promise.all(
+        documents.map(async (document) => {
+          const evaluations = await repository
+            .listAtCommitByDocument({
+              commitUuid: commit.uuid,
+              documentUuid: document.documentUuid,
+            })
+            .then((r) => r.unwrap())
+
+          await Promise.all(
+            evaluations.map((evaluation) =>
+              deleteEvaluationV2(
+                { evaluation, commit, workspace },
+                transaction,
+              ).then((r) => r.unwrap()),
+            ),
+          )
+        }),
       )
-
-    if (!Result.isOk(deleteAllTriggerDocumentsResult)) {
-      return deleteAllTriggerDocumentsResult
-    }
-
-    // If main document has been deleted, set it to null
-    if (
-      commit.mainDocumentUuid &&
-      documents.map((d) => d.documentUuid).includes(commit.mainDocumentUuid)
-    ) {
-      const commitUpdateResult = await updateCommit(
-        {
-          workspace,
-          commit,
-          data: {
-            mainDocumentUuid: null,
+      const deleteAllTriggerDocumentsResult =
+        await deleteDocumentTriggersFromDocuments(
+          {
+            commit,
+            workspace,
+            documents,
           },
-        },
-        transaction,
+          transaction,
+        )
+
+      if (!Result.isOk(deleteAllTriggerDocumentsResult)) {
+        return deleteAllTriggerDocumentsResult
+      }
+
+      // If main document has been deleted, set it to null
+      if (
+        commit.mainDocumentUuid &&
+        documents.map((d) => d.documentUuid).includes(commit.mainDocumentUuid)
+      ) {
+        const commitUpdateResult = await updateCommit(
+          {
+            workspace,
+            commit,
+            data: {
+              mainDocumentUuid: null,
+            },
+          },
+          transaction,
+        )
+
+        if (commitUpdateResult.error) return commitUpdateResult
+      }
+
+      const existingUuids = await findUuidsInOtherCommits({
+        tx: tx,
+        documents: documents,
+        commit: commit,
+      })
+      const toBeSoftDeleted = getToBeSoftDeleted({ documents, existingUuids })
+      const toBeCreated = toBeSoftDeleted.filter(
+        (d) => d.commitId !== commit.id,
+      )
+      const toBeUpdated = toBeSoftDeleted.filter(
+        (d) => d.commitId === commit.id,
       )
 
-      if (commitUpdateResult.error) return commitUpdateResult
-    }
+      hardDeletedDocumentUuids = documents
+        .filter((d) => !existingUuids.includes(d.documentUuid))
+        .map((d) => d.documentUuid)
+      softDeletedDocumentUuids = toBeSoftDeleted.map((d) => d.documentUuid)
 
-    const existingUuids = await findUuidsInOtherCommits({
-      tx: tx,
-      documents: documents,
-      commit: commit,
-    })
-    const toBeSoftDeleted = getToBeSoftDeleted({ documents, existingUuids })
-    const toBeCreated = toBeSoftDeleted.filter((d) => d.commitId !== commit.id)
-    const toBeUpdated = toBeSoftDeleted.filter((d) => d.commitId === commit.id)
+      await Promise.all([
+        hardDestroyDocuments({ documents, existingUuids, tx }),
+        createDocumentsAsSoftDeleted({ toBeCreated, commit, tx }),
+        updateDocumentsAsSoftDeleted({ toBeUpdated, commit, tx }),
+      ])
 
-    await Promise.all([
-      hardDestroyDocuments({ documents, existingUuids, tx }),
-      createDocumentsAsSoftDeleted({ toBeCreated, commit, tx }),
-      updateDocumentsAsSoftDeleted({ toBeUpdated, commit, tx }),
-    ])
+      await invalidateDocumentsCacheInCommit(commit.id, tx)
+      await pingProjectUpdate({ projectId: commit.projectId }, transaction)
 
-    await invalidateDocumentsCacheInCommit(commit.id, tx)
-    await pingProjectUpdate({ projectId: commit.projectId }, transaction)
-
-    return Result.ok(true)
-  })
+      return Result.ok(true)
+    },
+    () => {
+      publisher.publishLater({
+        type: 'documentsDeleted',
+        data: {
+          workspaceId: workspace.id,
+          projectId: commit.projectId,
+          commitUuid: commit.uuid,
+          documentUuids: documents.map((d) => d.documentUuid),
+          softDeletedDocumentUuids,
+          hardDeletedDocumentUuids,
+        },
+      })
+    },
+  )
 }


### PR DESCRIPTION
# What?
Issues from deleted documents in current commit should not be visible in the issues dashboard.

## TODO
- [x] Filter issues from deleted documents in the current commit the user is seing
- [x] Unassign the ocurrences to that issue from the commit the document is deleted