### PR TITLE
Use correct resultReason method when fetching eval reason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ __testing__
 # New spans
 apps/web/ingest
 apps/workers/workspaces/*/traces
+provider-logs/*
+workspaces/*
 
 # Helm chart secrets (do not commit)
 charts/latitude/values.secrets.yaml

--- a/packages/core/src/data-access/issues/getSpanMessagesAndEvaluationResultsByIssue.test.ts
+++ b/packages/core/src/data-access/issues/getSpanMessagesAndEvaluationResultsByIssue.test.ts
@@ -221,6 +221,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -256,6 +257,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -283,6 +285,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -307,6 +310,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -337,6 +341,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -366,6 +371,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(false)
@@ -379,6 +385,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -426,6 +433,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
       workspace,
       commit,
       issue,
+      existingEvaluations: [evaluation],
     })
 
     expect(result.ok).toBe(true)
@@ -535,6 +543,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
         workspace,
         commit: commit2,
         issue,
+        existingEvaluations: [evaluation],
       })
 
       expect(result.ok).toBe(true)
@@ -642,6 +651,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
         workspace,
         commit: draftCommit,
         issue,
+        existingEvaluations: [evaluation],
       })
 
       expect(result.ok).toBe(true)
@@ -733,6 +743,7 @@ describe('getSpanMessagesAndEvaluationResultsByIssue', () => {
         workspace,
         commit,
         issue,
+        existingEvaluations: [evaluation],
       })
 
       expect(result.ok).toBe(true)


### PR DESCRIPTION
We used to do a quickfix to get the reason, now we implemented the improved version using the correct resultReason method