### PR TITLE
Improve composite evaluation creation form validation

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/_components/EvaluationsActions.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/_components/EvaluationsActions.tsx
@@ -340,6 +340,7 @@ function CombineEvaluations({
         Combine evaluations
       </TableWithHeader.Button>
       <ConfirmModal
+        dismissible
         size='medium'
         open={openCreateModal}
         title='Create a new composite score'


### PR DESCRIPTION
When existing evaluations don't meet the criteria we need to create a composite evaluation no evaluations are sent and we were returning a toast message which dissapear and is hard to understand what's happening. Now we display the error message inline in the sub evaluations selector.

<img width="784" height="397" alt="image" src="https://github.com/user-attachments/assets/a23cf21f-e594-4d79-8358-469d7a1222e3" />
