### PR TITLE
Fix resize header in datagrid (datasets table)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,14 @@
     "datadog:sourcemaps:server": "datadog-ci sourcemaps upload .next/server --service=latitude-llm-web --minified-path-prefix=/app/apps/web/.next/server/ --release-version=${RELEASE_VERSION:-unknown} --disable-git --max-concurrency=20",
     "datadog:sourcemaps": "pnpm datadog:sourcemaps:client && pnpm datadog:sourcemaps:server"
   },
+  "browserslist": [
+    "Chrome >= 89",
+    "Edge >= 89",
+    "Firefox >= 66",
+    "Safari >= 15",
+    "iOS >= 15",
+    "Opera >= 76"
+  ],
   "dependencies": {
     "@ai-sdk/rsc": "^1.0.44",
     "@aws-sdk/client-s3": "3.850.0",
@@ -76,7 +84,7 @@
     "promptl-ai": "catalog:",
     "rate-limiter-flexible": "5.0.3",
     "react": "catalog:",
-    "react-data-grid": "7.0.0-beta.51",
+    "react-data-grid": "catalog:",
     "react-dom": "catalog:",
     "react-infinite-scroll-component": "^6.1.1",
     "require-in-the-middle": "7.5.2",

--- a/apps/web/src/app/(private)/datasets/[datasetId]/DatasetDetailTable/DataGrid/index.tsx
+++ b/apps/web/src/app/(private)/datasets/[datasetId]/DatasetDetailTable/DataGrid/index.tsx
@@ -8,7 +8,7 @@ import useDatasets from '$/stores/datasets'
 import { ClientPagination } from '@latitude-data/core/lib/pagination/buildPagination'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import type {
-  CellClickArgs,
+  CellMouseArgs,
   CellMouseEvent,
   Props as DataGridProps,
   RenderCellProps,
@@ -164,7 +164,7 @@ export default function DataGrid({
     return [SelectColumn, ...dataColumns]
   }, [dataset.columns, backgroundCssClasses])
   const onCellClick = useCallback(
-    (args: CellClickArgs<ClientDatasetRow>, event: CellMouseEvent) => {
+    (args: CellMouseArgs<ClientDatasetRow>, event: CellMouseEvent) => {
       event.preventGridDefault()
       args.selectCell(true)
     },

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -305,7 +305,7 @@
     "monaco-editor": "^0.50.0",
     "next-themes": "^0.3.0",
     "react": "catalog:",
-    "react-data-grid": "7.0.0-beta.51",
+    "react-data-grid": "catalog:",
     "react-day-picker": "8.10.1",
     "react-dom": "catalog:",
     "react-markdown": "^9.1.0",

--- a/packages/web-ui/src/ds/atoms/DataGrid/index.tsx
+++ b/packages/web-ui/src/ds/atoms/DataGrid/index.tsx
@@ -10,7 +10,7 @@ export type {
   RenderCellProps,
   RenderEditCellProps,
   RenderHeaderCellProps,
-  CellClickArgs,
+  CellMouseArgs,
   CellMouseEvent,
   RowsChangeData,
   DataGridProps,

--- a/packages/web-ui/styles.css
+++ b/packages/web-ui/styles.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 @layer utilities {
+
   /* Chrome, Safari and Opera */
   .no-scrollbar::-webkit-scrollbar {
     display: none;
@@ -22,12 +23,9 @@
       linear-gradient(hsl(var(--background)) 30%, hsl(var(--background) / 0)),
       linear-gradient(hsl(var(--background)), hsl(var(--background)) 0%) 0 100%,
       radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.1), transparent),
-      radial-gradient(
-          farthest-side at 50% 100%,
-          hsl(var(--background-shadow) / 0.1),
-          rgba(0, 0, 0, 0)
-        )
-        0 100%;
+      radial-gradient(farthest-side at 50% 100%,
+        hsl(var(--background-shadow) / 0.1),
+        rgba(0, 0, 0, 0)) 0 100%;
     background-repeat: no-repeat;
     background-color: hsl(var(--background));
     background-size:
@@ -295,6 +293,7 @@
       --rdg-row-selected-background-color: hsl(var(--accent));
       --rdg-row-selected-hover-background-color: hsl(var(--accent));
       --rdg-checkbox-focus-color: hsl(var(--accent-button));
+
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     react:
       specifier: 19.1.4
       version: 19.1.4
+    react-data-grid:
+      specifier: 7.0.0-beta.59
+      version: 7.0.0-beta.59
     react-dom:
       specifier: 19.1.4
       version: 19.1.4
@@ -400,8 +403,8 @@ importers:
         specifier: 'catalog:'
         version: 19.1.4
       react-data-grid:
-        specifier: 7.0.0-beta.51
-        version: 7.0.0-beta.51(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        specifier: 'catalog:'
+        version: 7.0.0-beta.59(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       react-dom:
         specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
@@ -1401,8 +1404,8 @@ importers:
         specifier: 'catalog:'
         version: 19.1.4
       react-data-grid:
-        specifier: 7.0.0-beta.51
-        version: 7.0.0-beta.51(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        specifier: 'catalog:'
+        version: 7.0.0-beta.59(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       react-day-picker:
         specifier: 8.10.1
         version: 8.10.1(date-fns@3.6.0)(react@19.1.4)
@@ -11771,11 +11774,11 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-data-grid@7.0.0-beta.51:
-    resolution: {integrity: sha512-SRzMbVqC6er9z/XYSgrjnM6s7mythMZXxIsVsTt+4spD2PhChotFnF/9rQKK8xynKSBb4GK1VNDsjkq1Hr0B6g==}
+  react-data-grid@7.0.0-beta.59:
+    resolution: {integrity: sha512-iAp/UYWjfmXYFsyKDtGDMP1IvhwtQSjCP6G/wFEbMNuumWGOEZF8Ut1S2Bp4XxVpOrBkEVKXn+QC3rs14AcB7A==}
     peerDependencies:
-      react: ^19.0
-      react-dom: ^19.0
+      react: ^19.2
+      react-dom: ^19.2
 
   react-day-picker@8.10.1:
     resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
@@ -21358,7 +21361,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
       eslint-config-prettier: 9.1.2(eslint@8.57.1)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
@@ -23273,7 +23276,7 @@ snapshots:
       eslint-plugin-turbo: 2.5.8(eslint@8.57.1)(turbo@2.5.8)
       turbo: 2.5.8
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)):
     dependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
 
@@ -27410,9 +27413,8 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-data-grid@7.0.0-beta.51(react-dom@19.1.4(react@19.1.4))(react@19.1.4):
+  react-data-grid@7.0.0-beta.59(react-dom@19.1.4(react@19.1.4))(react@19.1.4):
     dependencies:
-      clsx: 2.1.1
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,3 +28,4 @@ catalog:
   '@opentelemetry/baggage-span-processor': 0.3.1
   '@opentelemetry/semantic-conventions': 1.34.0
   '@datadog/datadog-ci': ^3.0.0
+  'react-data-grid': 7.0.0-beta.59


### PR DESCRIPTION
# What?
I updated react-data-grid dependency and put under catalog because is used in `packages/web-ui` and `apps/web`. But this was not the issue. The issue is that generated CSS was not generating logical properties which are used by Data grid package. In our case we are only LTR (Left To Right) so resize handle on data grid header is always on the right side.