### PR TITLE
fix(core): exclude deleted projects when checking integration references

### DIFF
--- a/packages/core/src/repositories/documentIntegrationReferencesRepository.ts
+++ b/packages/core/src/repositories/documentIntegrationReferencesRepository.ts
@@ -67,7 +67,12 @@ export class DocumentIntegrationReferencesRepository extends Repository<Document
         ),
       )
       .innerJoin(projects, eq(projects.id, commits.projectId))
-      .where(eq(projects.workspaceId, this.workspaceId))
+      .where(
+        and(
+          eq(projects.workspaceId, this.workspaceId),
+          isNull(projects.deletedAt),
+        ),
+      )
       .as('documentVersionsScope')
   }
 
@@ -82,11 +87,13 @@ export class DocumentIntegrationReferencesRepository extends Repository<Document
         commits,
         eq(commits.id, documentIntegrationReferences.commitId),
       )
+      .innerJoin(projects, eq(projects.id, commits.projectId))
       .where(
         and(
           isNull(commits.mergedAt),
           eq(documentIntegrationReferences.workspaceId, this.workspaceId),
           isNull(commits.deletedAt),
+          isNull(projects.deletedAt),
         ),
       )
 


### PR DESCRIPTION
When deleting an integration, the system was still finding references from prompts in deleted projects, preventing the deletion. This fix adds `isNull(projects.deletedAt)` filter to both
DocumentIntegrationReferencesRepository and DocumentTriggersRepository queries to properly exclude soft-deleted projects.