### PR TITLE
Investigate latitude-dev error in latitude-llm repository

### DIFF
--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.ts
@@ -5,7 +5,10 @@ import { ExperimentsRepository } from '../../../repositories'
 import { updateExperimentStatus } from '../../../services/experiments/updateStatus'
 import { captureException } from '../../../utils/datadogCapture'
 import { queues } from '../../queues'
-import { RunEvaluationV2JobData } from './runEvaluationV2Job'
+import {
+  runEvaluationV2JobKey,
+  RunEvaluationV2JobData,
+} from './runEvaluationV2Job'
 import { LatitudeError } from '@latitude-data/constants/errors'
 
 export type RunEvaluationForExperimentJobData = {
@@ -77,7 +80,9 @@ export async function runEvaluationForExperimentJob(
     ...rest,
   }
 
-  evaluationsQueue.add('runEvaluationV2Job', payload)
+  evaluationsQueue.add('runEvaluationV2Job', payload, {
+    deduplication: { id: runEvaluationV2JobKey(payload) },
+  })
 }
 
 /**


### PR DESCRIPTION
Two changes to fix the "Cannot evaluate a log that is already evaluated" error:

1. In evaluateLiveLogJob, use span.source (from database) instead of spanMetadata.source (from disk storage). The span object already has the source field which is more reliable and immediately available. This ensures experiment spans (source=experiment) are correctly filtered out from live evaluation.

2. Add deduplication to runEvaluationForExperimentJob using the same runEvaluationV2JobKey as other evaluation job enqueuers. This prevents duplicate evaluation jobs even if somehow the same evaluation is requested multiple times.