### PR TITLE
Display icon for deprecated Hosted MCP

### DIFF
--- a/apps/web/src/components/Integrations/IntegrationIcon.tsx
+++ b/apps/web/src/components/Integrations/IntegrationIcon.tsx
@@ -47,7 +47,13 @@ export function IntegrationIcon({
 
   // @ts-expect-error HostedMCP is not supported as type but we validate on runtime
   if (integration.type === IntegrationType.HostedMCP) {
-    throw new Error('HostedMCP integration type is not supported here')
+    return (
+      <Icon
+        name='mcp'
+        size={size === 16 ? 'normal' : 'large'}
+        className={className}
+      />
+    )
   }
 
   // Standard integration types: use INTEGRATION_TYPE_VALUES

--- a/apps/web/src/lib/integrationTypeOptions.tsx
+++ b/apps/web/src/lib/integrationTypeOptions.tsx
@@ -51,7 +51,11 @@ export function integrationOptions(
 
   // @ts-expect-error HostedMCP is not supported as type but we validate on runtime
   if (integration.type === IntegrationType.HostedMCP) {
-    throw new Error('HostedMCP integration type is not supported here')
+    return {
+      // @ts-expect-error HostedMCP is not supported as type but we validate on runtime
+      label: `${integration.name} DEPRECATED: Hosted MCP Server`,
+      icon: { type: 'icon', name: 'mcp' },
+    }
   }
 
   return INTEGRATION_TYPE_VALUES[integration.type]


### PR DESCRIPTION
I was to aggressive an throw an error where I should have just display the icon