### PR TITLE
Trace graph: bugfixes

### DIFF
--- a/apps/gateway/src/routes/api/v3/conversations/get/get.handler.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/get/get.handler.ts
@@ -21,6 +21,7 @@ export const getHandler: AppRouteHandler<GetRoute> = async (context) => {
   const assembledResult = await assembleTraceWithMessages({
     traceId: mainSpan.traceId,
     workspace,
+    spanId: mainSpan.id,
   })
 
   const messages = assembledResult.ok

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
@@ -16,11 +16,8 @@ import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { useToolContentMap } from '@latitude-data/web-ui/hooks/useToolContentMap'
 import Link from 'next/link'
-import { useTrace } from '$/stores/traces'
-import {
-  findCompletionSpanFromTrace,
-  adaptCompletionSpanMessagesToLegacy,
-} from '@latitude-data/core/services/tracing/spans/fetching/findCompletionSpanFromTrace'
+import { useTraceWithMessages } from '$/stores/traces'
+import { adaptCompletionSpanMessagesToLegacy } from '@latitude-data/core/services/tracing/spans/fetching/findCompletionSpanFromTrace'
 import { Message } from '@latitude-data/constants/legacyCompiler'
 import { sum } from 'lodash-es'
 import { RunPanelStats } from '$/components/RunPanelStats'
@@ -37,15 +34,15 @@ export function AnnotationsPanel({
 }) {
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
-  const { data: trace, isLoading: isLoadingTrace } = useTrace({
+  const {
+    completionSpan,
+    isLoading: isLoadingTrace,
+  } = useTraceWithMessages({
     traceId: span.traceId,
+    spanId: span.id,
   })
-  const completionSpan = useMemo(
-    () => findCompletionSpanFromTrace(trace),
-    [trace],
-  )
   const conversation = useMemo(
-    () => adaptCompletionSpanMessagesToLegacy(completionSpan),
+    () => adaptCompletionSpanMessagesToLegacy(completionSpan ?? undefined),
     [completionSpan],
   )
   const toolContentMap = useToolContentMap(conversation as unknown as Message[])

--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -16,7 +16,7 @@ import {
 import useEvaluationResultsV2BySpans from '$/stores/evaluationResultsV2/bySpans'
 import { useSpan } from '$/stores/spans'
 import { TraceEvaluations } from './TraceEvaluations'
-import { useLastTrace } from '$/stores/conversations'
+import { useTraceWithMessages } from '$/stores/traces'
 import { adaptCompletionSpanMessagesToLegacy } from '@latitude-data/core/services/tracing/spans/fetching/findCompletionSpanFromTrace'
 import { AnnotationFormWithoutContext } from '../ChatWrapper/AnnotationFormWithoutContext'
 
@@ -68,7 +68,7 @@ export function TraceInfoPanel({
             <TraceMetadata isLoading={isLoading} span={span} />
           )}
           {selectedTab === 'messages' && (
-            <TraceMessages span={span} documentLogUuid={documentLogUuid} />
+            <TraceMessages span={span} />
           )}
           {selectedTab === 'evaluations' && (
             <TraceEvaluations
@@ -118,14 +118,15 @@ function TraceMetadata({
 
 function TraceMessages({
   span,
-  documentLogUuid,
 }: {
   span?: SpanWithDetails
-  documentLogUuid: string | null
 }) {
   const { commit } = useCurrentCommit()
   const { project } = useCurrentProject()
-  const { trace, completionSpan, isLoading } = useLastTrace({ documentLogUuid })
+  const { trace, completionSpan, isLoading } = useTraceWithMessages({
+    traceId: span?.traceId ?? null,
+    spanId: span?.id ?? null,
+  })
   const mainSpan = findMainSpan(trace ?? undefined)
   const mainMetadata = mainSpan?.metadata
   const messages = adaptCompletionSpanMessagesToLegacy(

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -15,6 +15,7 @@ export const API_ROUTES = {
       spans: {
         detail: (spanId: string) => ({
           root: `/api/traces/${traceId}/spans/${spanId}`,
+          messages: `/api/traces/${traceId}/spans/${spanId}/messages`,
         }),
       },
     }),
@@ -348,9 +349,6 @@ export const API_ROUTES = {
         root: conversationRoot,
         traceIds: {
           root: `${conversationRoot}/trace-ids`,
-        },
-        lastTrace: {
-          root: `${conversationRoot}/last-trace`,
         },
         spans: {
           detail: (spanId: string) => ({

--- a/apps/web/src/stores/conversations.ts
+++ b/apps/web/src/stores/conversations.ts
@@ -5,7 +5,6 @@ import useSWR, { SWRConfiguration } from 'swr'
 import useFetcher from '$/hooks/useFetcher'
 import { ROUTES } from '$/services/routes'
 import { ConversationTracesResponse } from '$/app/api/conversations/[conversationId]/route'
-import { LastTraceResponse } from '$/app/api/conversations/[conversationId]/last-trace/route'
 
 export function useConversation(
   {
@@ -29,37 +28,6 @@ export function useConversation(
 
   return useMemo(
     () => ({ traces: data?.traces ?? [], mutate, isLoading }),
-    [data, mutate, isLoading],
-  )
-}
-
-export function useLastTrace(
-  {
-    documentLogUuid,
-  }: {
-    documentLogUuid?: string | null
-  },
-  opts?: SWRConfiguration,
-) {
-  const route = documentLogUuid
-    ? ROUTES.api.conversations.detail(documentLogUuid).lastTrace.root
-    : undefined
-  const fetcher = useFetcher<LastTraceResponse>(route, {
-    fallback: undefined,
-  })
-  const {
-    data = undefined,
-    mutate,
-    isLoading,
-  } = useSWR<LastTraceResponse>(route, fetcher, opts)
-
-  return useMemo(
-    () => ({
-      trace: data?.trace ?? null,
-      completionSpan: data?.completionSpan ?? null,
-      mutate,
-      isLoading,
-    }),
     [data, mutate, isLoading],
   )
 }

--- a/apps/web/src/stores/traces.ts
+++ b/apps/web/src/stores/traces.ts
@@ -5,6 +5,7 @@ import { ROUTES } from '$/services/routes'
 import { useMemo } from 'react'
 import useSWR, { SWRConfiguration } from 'swr'
 import { AssembledTrace } from '@latitude-data/core/constants'
+import { SpanMessagesResponse } from '$/app/api/traces/[traceId]/spans/[spanId]/messages/route'
 
 export function useTrace(
   {
@@ -26,4 +27,39 @@ export function useTrace(
   } = useSWR<AssembledTrace>(traceId, fetcher, opts)
 
   return useMemo(() => ({ data, isLoading, mutate }), [data, isLoading, mutate])
+}
+
+export function useTraceWithMessages(
+  {
+    traceId,
+    spanId,
+  }: {
+    traceId?: string | null
+    spanId?: string | null
+  },
+  opts?: SWRConfiguration,
+) {
+  const route =
+    traceId && spanId
+      ? ROUTES.api.traces.detail(traceId).spans.detail(spanId).messages
+      : undefined
+  const fetcher = useFetcher<SpanMessagesResponse>(route, {
+    fallback: undefined,
+  })
+
+  const {
+    data = undefined,
+    mutate,
+    isLoading,
+  } = useSWR<SpanMessagesResponse>(route, fetcher, opts)
+
+  return useMemo(
+    () => ({
+      trace: data?.trace ?? null,
+      completionSpan: data?.completionSpan ?? null,
+      mutate,
+      isLoading,
+    }),
+    [data, mutate, isLoading],
+  )
 }

--- a/packages/constants/src/tracing/span.ts
+++ b/packages/constants/src/tracing/span.ts
@@ -307,3 +307,7 @@ export const MAIN_SPAN_TYPES = new Set([
 export function isMainSpan(span: Span | SpanWithDetails | AssembledSpan) {
   return MAIN_SPAN_TYPES.has(span.type)
 }
+
+export function isCompletionSpan(span: Span | SpanWithDetails | AssembledSpan): span is AssembledSpan<SpanType.Completion> {
+  return span.type === SpanType.Completion
+}

--- a/packages/core/src/data-access/evaluations/buildEvaluatedSpan.ts
+++ b/packages/core/src/data-access/evaluations/buildEvaluatedSpan.ts
@@ -67,6 +67,7 @@ export async function buildEvaluatedSpan({
   const assembledTraceResult = await assembleTraceWithMessages({
     traceId: span.traceId,
     workspace,
+    spanId: span.id,
   })
 
   if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/evaluationsV2/annotate.ts
+++ b/packages/core/src/services/evaluationsV2/annotate.ts
@@ -72,6 +72,7 @@ export async function annotateEvaluationV2<
   const assembledTraceResult = await assembleTraceWithMessages({
     traceId: span.traceId,
     workspace,
+    spanId: span.id,
   })
   if (!Result.isOk(assembledTraceResult)) {
     return Result.error(new BadRequestError('Could not assemble trace'))

--- a/packages/core/src/services/evaluationsV2/llm/binary.ts
+++ b/packages/core/src/services/evaluationsV2/llm/binary.ts
@@ -156,7 +156,7 @@ async function run(
   }
 
   const assembledTraceResult = await assembleTraceWithMessages(
-    { traceId: span.traceId, workspace },
+    { traceId: span.traceId, workspace, spanId: span.id },
     db,
   )
   if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/evaluationsV2/llm/comparison.ts
+++ b/packages/core/src/services/evaluationsV2/llm/comparison.ts
@@ -227,7 +227,7 @@ async function run(
   }
 
   const assembledTraceResult = await assembleTraceWithMessages(
-    { traceId: span.traceId, workspace },
+    { traceId: span.traceId, workspace, spanId: span.id },
     db,
   )
   if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/evaluationsV2/llm/custom.ts
+++ b/packages/core/src/services/evaluationsV2/llm/custom.ts
@@ -220,7 +220,7 @@ async function run(
   )
 
   const assembledTraceResult = await assembleTraceWithMessages(
-    { traceId: span.traceId, workspace },
+    { traceId: span.traceId, workspace, spanId: span.id },
     db,
   )
   if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/evaluationsV2/llm/rating.ts
+++ b/packages/core/src/services/evaluationsV2/llm/rating.ts
@@ -232,7 +232,7 @@ async function run(
   }
 
   const assembledTraceResult = await assembleTraceWithMessages(
-    { traceId: span.traceId, workspace },
+    { traceId: span.traceId, workspace, spanId: span.id },
     db,
   )
   if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/evaluationsV2/run.ts
+++ b/packages/core/src/services/evaluationsV2/run.ts
@@ -119,6 +119,7 @@ export async function runEvaluationV2<
   const assembledTraceResult = await assembleTraceWithMessages({
     traceId: span.traceId,
     workspace,
+    spanId: span.id,
   })
   if (!Result.isOk(assembledTraceResult)) {
     return Result.error(new UnprocessableEntityError('Cannot assemble trace'))

--- a/packages/core/src/services/issues/results/getOrSetEnrichedReason.ts
+++ b/packages/core/src/services/issues/results/getOrSetEnrichedReason.ts
@@ -80,11 +80,17 @@ export async function getOrSetEnrichedReason<
       new BadRequestError('Evaluation result does not have a trace ID'),
     )
   }
+  if (!result.evaluatedSpanId) {
+    return Result.error(
+      new BadRequestError('Evaluation result does not have a span ID'),
+    )
+  }
 
   const workspace = await unsafelyFindWorkspace(result.workspaceId)
   const assembledTraceResult = await assembleTraceWithMessages({
     traceId: result.evaluatedTraceId,
     workspace,
+    spanId: result.evaluatedSpanId,
   })
   if (!Result.isOk(assembledTraceResult)) {
     return Result.error(

--- a/packages/core/src/services/spans/buildSpanMessagesWithReasons.ts
+++ b/packages/core/src/services/spans/buildSpanMessagesWithReasons.ts
@@ -49,6 +49,7 @@ export async function buildSpanMessagesWithReasons({
     const assembledTraceResult = await assembleTraceWithMessages({
       traceId: span.traceId,
       workspace,
+      spanId: span.id,
     })
 
     if (!Result.isOk(assembledTraceResult)) {

--- a/packages/core/src/services/tracing/spans/fetching/findCompletionSpanForSpan.test.ts
+++ b/packages/core/src/services/tracing/spans/fetching/findCompletionSpanForSpan.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AssembledSpan,
+  AssembledTrace,
+  SpanType,
+  SpanKind,
+  SpanStatus,
+} from '../../../../constants'
+import { findCompletionSpanForSpan } from './findCompletionSpanForSpan'
+
+function createMockSpan<T extends SpanType>(
+  type: T,
+  id: string,
+  children: AssembledSpan[] = [],
+): AssembledSpan<T> {
+  return {
+    id,
+    traceId: 'trace-1',
+    parentId: undefined,
+    workspaceId: 1,
+    apiKeyId: 1,
+    name: `${type}-span`,
+    kind: SpanKind.Internal,
+    type,
+    status: SpanStatus.Ok,
+    duration: 100,
+    startedAt: new Date(),
+    endedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    conversationId: undefined,
+    children,
+    depth: 0,
+    startOffset: 0,
+    endOffset: 100,
+  } as AssembledSpan<T>
+}
+
+function createMockTrace(children: AssembledSpan[]): AssembledTrace {
+  return {
+    id: 'trace-1',
+    children,
+    spans: children.length,
+    duration: 100,
+    startedAt: new Date(),
+    endedAt: new Date(),
+  }
+}
+
+describe('findCompletionSpanForSpan', () => {
+  it('returns undefined for undefined span', () => {
+    const trace = createMockTrace([])
+    const result = findCompletionSpanForSpan(undefined, trace)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined for undefined trace', () => {
+    const span = createMockSpan(SpanType.Prompt, 'span-1')
+    const result = findCompletionSpanForSpan(span, undefined)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when no main span found', () => {
+    const tool = createMockSpan(SpanType.Tool, 'tool-1')
+    const http = createMockSpan(SpanType.Http, 'http-1')
+    const trace = createMockTrace([tool, http])
+    const result = findCompletionSpanForSpan(tool, trace)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('finds completion span for a main span with direct completion child', () => {
+    const completion = createMockSpan(SpanType.Completion, 'completion-1')
+    const prompt = createMockSpan(SpanType.Prompt, 'prompt-1', [completion])
+    const trace = createMockTrace([prompt])
+
+    const result = findCompletionSpanForSpan(prompt, trace)
+
+    expect(result).toBe(completion)
+    expect(result?.id).toBe('completion-1')
+  })
+
+  it('finds the last completion span when multiple completion spans exist', () => {
+    const completion1 = createMockSpan(SpanType.Completion, 'completion-1')
+    const completion2 = createMockSpan(SpanType.Completion, 'completion-2')
+    const prompt = createMockSpan(SpanType.Prompt, 'prompt-1', [
+      completion1,
+      completion2,
+    ])
+    const trace = createMockTrace([prompt])
+
+    const result = findCompletionSpanForSpan(prompt, trace)
+
+    expect(result).toBe(completion2)
+    expect(result?.id).toBe('completion-2')
+  })
+
+  it('finds completion span for a child span within a main span', () => {
+    const completion = createMockSpan(SpanType.Completion, 'completion-1')
+    const tool = createMockSpan(SpanType.Tool, 'tool-1')
+    const prompt = createMockSpan(SpanType.Prompt, 'prompt-1', [
+      completion,
+      tool,
+    ])
+    const trace = createMockTrace([prompt])
+
+    // Selecting the tool span should find the parent's completion
+    const result = findCompletionSpanForSpan(tool, trace)
+
+    expect(result).toBe(completion)
+    expect(result?.id).toBe('completion-1')
+  })
+
+  it('stops searching when encountering a child main span', () => {
+    // Parent (Prompt) -> Completion -> Tool -> Child (Prompt) -> Completion
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion')
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const tool = createMockSpan(SpanType.Tool, 'tool-1', [childPrompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      tool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // Selecting the parent prompt should find its own completion, not the child's
+    const result = findCompletionSpanForSpan(parentPrompt, trace)
+
+    expect(result).toBe(parentCompletion)
+    expect(result?.id).toBe('parent-completion')
+  })
+
+  it('finds child agent completion when selecting child agent span', () => {
+    // Parent (Prompt) -> Completion -> Tool -> Child (Prompt) -> Completion
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion')
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const tool = createMockSpan(SpanType.Tool, 'tool-1', [childPrompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      tool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // Selecting the child prompt should find its own completion
+    const result = findCompletionSpanForSpan(childPrompt, trace)
+
+    expect(result).toBe(childCompletion)
+    expect(result?.id).toBe('child-completion')
+  })
+
+  it('finds child agent completion when selecting a span within child agent', () => {
+    // Parent (Prompt) -> Completion -> Tool -> Child (Prompt) -> Completion -> Tool
+    const childTool = createMockSpan(SpanType.Tool, 'child-tool')
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion', [
+      childTool,
+    ])
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const parentTool = createMockSpan(SpanType.Tool, 'parent-tool', [childPrompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      parentTool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // Selecting a tool within the child agent should find the child's completion
+    const result = findCompletionSpanForSpan(childTool, trace)
+
+    expect(result).toBe(childCompletion)
+    expect(result?.id).toBe('child-completion')
+  })
+
+  it('handles nested agents: parent -> child1 -> child2', () => {
+    // Parent (Prompt) -> Completion -> Tool -> Child1 (Prompt) -> Completion -> Tool -> Child2 (Prompt) -> Completion
+    const child2Completion = createMockSpan(
+      SpanType.Completion,
+      'child2-completion',
+    )
+    const child2Prompt = createMockSpan(SpanType.Prompt, 'child2-prompt', [
+      child2Completion,
+    ])
+    const child1Tool = createMockSpan(SpanType.Tool, 'child1-tool', [child2Prompt])
+    const child1Completion = createMockSpan(SpanType.Completion, 'child1-completion', [
+      child1Tool,
+    ])
+    const child1Prompt = createMockSpan(SpanType.Prompt, 'child1-prompt', [
+      child1Completion,
+    ])
+    const parentTool = createMockSpan(SpanType.Tool, 'parent-tool', [child1Prompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      parentTool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // Selecting parent should find parent's completion
+    const parentResult = findCompletionSpanForSpan(parentPrompt, trace)
+    expect(parentResult?.id).toBe('parent-completion')
+
+    // Selecting child1 should find child1's completion (not child2's)
+    const child1Result = findCompletionSpanForSpan(child1Prompt, trace)
+    expect(child1Result?.id).toBe('child1-completion')
+
+    // Selecting child2 should find child2's completion
+    const child2Result = findCompletionSpanForSpan(child2Prompt, trace)
+    expect(child2Result?.id).toBe('child2-completion')
+  })
+
+  it('handles multiple child agents with same parent', () => {
+    // Parent (Prompt) -> Completion -> Tool1 -> Child1 (Prompt) -> Completion
+    //                              -> Tool2 -> Child1 (Prompt) -> Completion -> Tool -> Child2 (Prompt) -> Completion
+    const child2Completion = createMockSpan(
+      SpanType.Completion,
+      'child2-completion',
+    )
+    const child2Prompt = createMockSpan(SpanType.Prompt, 'child2-prompt', [
+      child2Completion,
+    ])
+    const secondChild1Tool = createMockSpan(SpanType.Tool, 'child1-tool-2', [
+      child2Prompt,
+    ])
+    const secondChild1Completion = createMockSpan(
+      SpanType.Completion,
+      'child1-completion-2',
+      [secondChild1Tool],
+    )
+    const secondChild1Prompt = createMockSpan(SpanType.Prompt, 'child1-prompt-2', [
+      secondChild1Completion,
+    ])
+    const firstChild1Completion = createMockSpan(
+      SpanType.Completion,
+      'child1-completion-1',
+    )
+    const firstChild1Prompt = createMockSpan(SpanType.Prompt, 'child1-prompt-1', [
+      firstChild1Completion,
+    ])
+    const tool1 = createMockSpan(SpanType.Tool, 'tool-1', [firstChild1Prompt])
+    const tool2 = createMockSpan(SpanType.Tool, 'tool-2', [secondChild1Prompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      tool1,
+      tool2,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // Selecting parent should find parent's completion
+    const parentResult = findCompletionSpanForSpan(parentPrompt, trace)
+    expect(parentResult?.id).toBe('parent-completion')
+
+    // Selecting first Child1 should find first Child1's completion
+    const firstChild1Result = findCompletionSpanForSpan(firstChild1Prompt, trace)
+    expect(firstChild1Result?.id).toBe('child1-completion-1')
+
+    // Selecting second Child1 should find second Child1's completion (not Child2's)
+    const secondChild1Result = findCompletionSpanForSpan(secondChild1Prompt, trace)
+    expect(secondChild1Result?.id).toBe('child1-completion-2')
+
+    // Selecting Child2 should find Child2's completion
+    const child2Result = findCompletionSpanForSpan(child2Prompt, trace)
+    expect(child2Result?.id).toBe('child2-completion')
+  })
+
+  it('returns undefined when main span has no completion children', () => {
+    const tool = createMockSpan(SpanType.Tool, 'tool-1')
+    const prompt = createMockSpan(SpanType.Prompt, 'prompt-1', [tool])
+    const trace = createMockTrace([prompt])
+
+    const result = findCompletionSpanForSpan(prompt, trace)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('works with External span type as main span', () => {
+    const completion = createMockSpan(SpanType.Completion, 'completion-1')
+    const external = createMockSpan(SpanType.External, 'external-1', [completion])
+    const trace = createMockTrace([external])
+
+    const result = findCompletionSpanForSpan(external, trace)
+
+    expect(result).toBe(completion)
+    expect(result?.id).toBe('completion-1')
+  })
+
+  it('works with Chat span type as main span', () => {
+    const completion = createMockSpan(SpanType.Completion, 'completion-1')
+    const chat = createMockSpan(SpanType.Chat, 'chat-1', [completion])
+    const trace = createMockTrace([chat])
+
+    const result = findCompletionSpanForSpan(chat, trace)
+
+    expect(result).toBe(completion)
+    expect(result?.id).toBe('completion-1')
+  })
+
+  it('handles completion span before child main span', () => {
+    // Main span has: Completion, then Tool with Child Prompt
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion')
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const tool = createMockSpan(SpanType.Tool, 'tool-1', [childPrompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      parentCompletion,
+      tool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    const result = findCompletionSpanForSpan(parentPrompt, trace)
+
+    expect(result).toBe(parentCompletion)
+    expect(result?.id).toBe('parent-completion')
+  })
+
+  it('handles completion span after child main span', () => {
+    // Main span has: Tool with Child Prompt, then Completion
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion')
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const tool = createMockSpan(SpanType.Tool, 'tool-1', [childPrompt])
+    const parentCompletion = createMockSpan(SpanType.Completion, 'parent-completion')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      tool,
+      parentCompletion,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    // The completion span is a sibling of the tool (not nested inside it),
+    // so it should be found even though it comes after the child main span
+    const result = findCompletionSpanForSpan(parentPrompt, trace)
+
+    expect(result).toBe(parentCompletion)
+    expect(result?.id).toBe('parent-completion')
+  })
+
+  it('handles multiple completion spans before child main span', () => {
+    const childCompletion = createMockSpan(SpanType.Completion, 'child-completion')
+    const childPrompt = createMockSpan(SpanType.Prompt, 'child-prompt', [
+      childCompletion,
+    ])
+    const tool = createMockSpan(SpanType.Tool, 'tool-1', [childPrompt])
+    const completion1 = createMockSpan(SpanType.Completion, 'completion-1')
+    const completion2 = createMockSpan(SpanType.Completion, 'completion-2')
+    const parentPrompt = createMockSpan(SpanType.Prompt, 'parent-prompt', [
+      completion1,
+      completion2,
+      tool,
+    ])
+    const trace = createMockTrace([parentPrompt])
+
+    const result = findCompletionSpanForSpan(parentPrompt, trace)
+
+    // Should find the last completion before the child main span
+    expect(result).toBe(completion2)
+    expect(result?.id).toBe('completion-2')
+  })
+})

--- a/packages/core/src/services/tracing/spans/fetching/findCompletionSpanForSpan.ts
+++ b/packages/core/src/services/tracing/spans/fetching/findCompletionSpanForSpan.ts
@@ -1,0 +1,105 @@
+import {
+  AssembledSpan,
+  AssembledTrace,
+  isCompletionSpan,
+  isMainSpan,
+  SpanType,
+} from '../../../../constants'
+
+/**
+ * Builds a parent map by traversing the trace tree.
+ * Returns a map from span ID to its parent span.
+ */
+function buildParentMap(trace: AssembledTrace): Map<string, AssembledSpan> {
+  const parentMap = new Map<string, AssembledSpan>()
+
+  function traverse(span: AssembledSpan, parent?: AssembledSpan) {
+    if (parent) {
+      parentMap.set(span.id, parent)
+    }
+
+    for (const child of span.children || []) {
+      traverse(child, span)
+    }
+  }
+
+  for (const rootSpan of trace.children) {
+    traverse(rootSpan)
+  }
+
+  return parentMap
+}
+
+/**
+ * Finds the nearest parent span of type Prompt, External, or Chat.
+ * Returns the span itself if it's already one of those types.
+ */
+function findNearestMainSpan(
+  span: AssembledSpan,
+  trace: AssembledTrace,
+): AssembledSpan | undefined {
+  // If the span itself is a main span, return it
+  if (isMainSpan(span)) {
+    return span
+  }
+
+  // Build parent map to traverse up
+  const parentMap = buildParentMap(trace)
+
+  // Traverse up the tree to find the nearest main span
+  let current: AssembledSpan | undefined = span
+  while (current) {
+    if (isMainSpan(current)) {
+      return current
+    }
+    current = parentMap.get(current.id)
+  }
+
+  return undefined
+}
+
+function findLatestCompletionSpan(span: AssembledSpan): AssembledSpan<SpanType.Completion> | undefined {
+  if (!span.children) return undefined
+  const reversedChildren = [...span.children].reverse()
+  
+  for (const child of reversedChildren) {
+    if (isMainSpan(child)) continue
+    if (isCompletionSpan(child)) return child
+
+    const innerCompletion = findLatestCompletionSpan(child)
+    if (innerCompletion) return innerCompletion
+  }
+
+  return undefined
+}
+
+/**
+ * Finds the completion span containing the conversation for a specific span.
+ *
+ * This works by:
+ * 1. Finding the nearest parent span of type Prompt, External, or Chat
+ * 2. Finding that parent's completion span (stopping before any child main spans)
+ * 3. Returning that completion span
+ *
+ * This allows viewing subagent conversations independently from the parent
+ * agent's global conversation.
+ *
+ * @param span - The span to find the conversation for
+ * @param trace - The assembled trace containing the span
+ * @returns The completion span containing the conversation, or undefined if not found
+ */
+export function findCompletionSpanForSpan(
+  span: AssembledSpan | undefined,
+  trace: AssembledTrace | undefined,
+): AssembledSpan<SpanType.Completion> | undefined {
+  if (!span || !trace) return undefined
+  
+  if (span.type === SpanType.Completion) {
+    return span as AssembledSpan<SpanType.Completion>;
+  }
+
+  const mainSpan = findNearestMainSpan(span, trace)
+  if (!mainSpan) return undefined
+
+  return findLatestCompletionSpan(mainSpan)
+}

--- a/packages/core/src/services/tracing/traces/assemble.test.ts
+++ b/packages/core/src/services/tracing/traces/assemble.test.ts
@@ -214,7 +214,7 @@ describe('assembleTraceWithMessages', () => {
   })
 
   it('returns trace structure even when no completion span exists', async () => {
-    await factories.createSpan({
+    const promptSpan = await factories.createSpan({
       workspaceId: workspace.id,
       traceId: 'trace-no-completion',
       type: SpanType.Prompt,
@@ -224,6 +224,7 @@ describe('assembleTraceWithMessages', () => {
     const result = await assembleTraceWithMessages({
       traceId: 'trace-no-completion',
       workspace,
+      spanId: promptSpan.id,
     })
 
     expect(result.ok).toBe(true)
@@ -255,6 +256,7 @@ describe('assembleTraceWithMessages', () => {
     const result = await assembleTraceWithMessages({
       traceId: 'trace-with-completion',
       workspace,
+      spanId: promptSpan.id,
     })
 
     expect(result.ok).toBe(true)
@@ -299,6 +301,7 @@ describe('assembleTraceWithMessages', () => {
     const result = await assembleTraceWithMessages({
       traceId: 'trace-with-metadata',
       workspace,
+      spanId: promptSpan.id,
     })
 
     expect(result.ok).toBe(true)

--- a/packages/core/src/utils/promptlAdapter.ts
+++ b/packages/core/src/utils/promptlAdapter.ts
@@ -80,10 +80,12 @@ export function adaptPromptlMessageToLegacy(
               type: 'tool-call',
               toolCallId: contentItem.toolCallId,
               toolName: contentItem.toolName,
-              // @ts-expect-error - TODO: What is happening here? promptl
-              // messages are supposed to have a toolArguments property yet in
-              // truth this has a .args argument
-              args: contentItem.args,
+              // Handle both args and toolArguments for compatibility
+              // promptl messages use toolArguments, but some sources may use args
+              args:
+                (contentItem as any).args ??
+                (contentItem as any).toolArguments ??
+                {},
             }
           default:
             return contentItem
@@ -103,7 +105,7 @@ export function adaptPromptlMessageToLegacy(
         (toolCall): LegacyToolCall => ({
           id: toolCall.toolCallId,
           name: toolCall.toolName,
-          arguments: toolCall.args,
+          arguments: toolCall.args ?? {},
           _sourceData: undefined, // promptl doesn't have source data
         }),
       )


### PR DESCRIPTION
This PR fixes the following bugs:

**Trace closes when clicking on different spans**
Clicking on a different span works (at first), but doing it again closes the trace

https://github.com/user-attachments/assets/cb7c4632-06e6-4b93-babc-accb6d3d4cbf

---

**No tool calls**
The "messages" tab does not include any tool call in the conversation, not even the tool for calling subagents

---

**Incorrect Messages**
When selecting a subagent span, the "Messages" tab still shows the conversation from the parent, not from itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces span-scoped conversation assembly and updates APIs/UI to fix trace graph issues and missing tool calls.
> 
> - Core: `assembleTraceWithMessages` now accepts `spanId` and resolves the appropriate completion span via new `findCompletionSpanForSpan`; falls back to global completion span. Added comprehensive unit tests.
> - API: New endpoint `GET /api/traces/{traceId}/spans/{spanId}/messages` returning `trace` and `completionSpan`; routes and SWR hook `useTraceWithMessages` added. Removed legacy `lastTrace` usage.
> - UI: Annotation panel and trace messages switch to `useTraceWithMessages` (pass `traceId` + `spanId`), ensuring correct messages for selected subagent. Trace selection logic preserves parent `documentLogUuid` and keeps parent expanded when selecting subagent spans, preventing unintended collapse.
> - Gateway: Conversation fetch includes `spanId` for accurate message assembly.
> - Evaluations/Issues: All evaluation flows and reason enrichment pass `spanId` to assemble messages consistently.
> - Utils: `promptlAdapter` now maps tool call args robustly, restoring tool call display in conversations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 664435643a31cab33359b4e5a772ad1954688255. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->