### PR TITLE
feat(ci): add dependency check and post-publish verification for SDKs

### DIFF
--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -76,11 +76,47 @@ jobs:
         if: steps.check_version.outputs.should_publish == 'true'
         run: pnpm exec turbo run test --filter=@latitude-data/sdk...
 
+      - name: Check for internal dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: node tools/check-sdk-dependencies.js packages/sdks/typescript/package.json
+
       - name: Publish to npm
         if: steps.check_version.outputs.should_publish == 'true'
         run: pnpm publish --access public --filter=@latitude-data/sdk --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify npm installation
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          echo "Waiting for npm registry to update..."
+          sleep 30
+
+          # Create a temporary directory for testing
+          TEST_DIR=$(mktemp -d)
+          cd "$TEST_DIR"
+
+          # Initialize a new project
+          npm init -y
+
+          # Install the published package
+          echo "Installing @latitude-data/sdk@${{ steps.get_version.outputs.version }}..."
+          npm install @latitude-data/sdk@${{ steps.get_version.outputs.version }}
+
+          # Verify the package can be imported
+          echo "Verifying package import..."
+          node -e "
+            const sdk = require('@latitude-data/sdk');
+            if (!sdk.Latitude) {
+              console.error('ERROR: Latitude class not found in package exports');
+              process.exit(1);
+            }
+            console.log('SUCCESS: Package installed and imports correctly');
+          "
+
+          # Cleanup
+          cd -
+          rm -rf "$TEST_DIR"
 
       - name: Extract changelog for current version
         if: steps.check_version.outputs.should_publish == 'true'

--- a/.github/workflows/publish-typescript-telemetry.yml
+++ b/.github/workflows/publish-typescript-telemetry.yml
@@ -74,8 +74,44 @@ jobs:
         if: steps.check_version.outputs.should_publish == 'true'
         run: pnpm exec turbo run test --filter=@latitude-data/telemetry...
 
+      - name: Check for internal dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: node tools/check-sdk-dependencies.js packages/telemetry/typescript/package.json
+
       - name: Publish to npm
         if: steps.check_version.outputs.should_publish == 'true'
         run: pnpm publish --access public --filter=@latitude-data/telemetry --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify npm installation
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: |
+          echo "Waiting for npm registry to update..."
+          sleep 30
+
+          # Create a temporary directory for testing
+          TEST_DIR=$(mktemp -d)
+          cd "$TEST_DIR"
+
+          # Initialize a new project
+          npm init -y
+
+          # Install the published package
+          echo "Installing @latitude-data/telemetry@${{ steps.get_version.outputs.version }}..."
+          npm install @latitude-data/telemetry@${{ steps.get_version.outputs.version }}
+
+          # Verify the package can be imported
+          echo "Verifying package import..."
+          node -e "
+            const telemetry = require('@latitude-data/telemetry');
+            if (!telemetry.LatitudeTelemetry) {
+              console.error('ERROR: LatitudeTelemetry class not found in package exports');
+              process.exit(1);
+            }
+            console.log('SUCCESS: Package installed and imports correctly');
+          "
+
+          # Cleanup
+          cd -
+          rm -rf "$TEST_DIR"

--- a/tools/check-sdk-dependencies.js
+++ b/tools/check-sdk-dependencies.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * Checks that a package.json file does not contain any @latitude-data/*
+ * packages in regular dependencies. Dev dependencies and peer dependencies
+ * are allowed.
+ *
+ * Usage: node check-sdk-dependencies.js <path-to-package.json>
+ */
+
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const packageJsonPath = process.argv[2]
+
+if (!packageJsonPath) {
+  console.error('Usage: node check-sdk-dependencies.js <path-to-package.json>')
+  process.exit(1)
+}
+
+const absolutePath = resolve(packageJsonPath)
+let packageJson
+
+try {
+  const content = readFileSync(absolutePath, 'utf-8')
+  packageJson = JSON.parse(content)
+} catch (error) {
+  console.error(`Failed to read package.json at ${absolutePath}:`, error.message)
+  process.exit(1)
+}
+
+const dependencies = packageJson.dependencies || {}
+const latitudePackages = Object.keys(dependencies).filter((dep) =>
+  dep.startsWith('@latitude-data/')
+)
+
+if (latitudePackages.length > 0) {
+  console.error(
+    '\nError: Found @latitude-data/* packages in regular dependencies:'
+  )
+  latitudePackages.forEach((pkg) => {
+    console.error(`  - ${pkg}: ${dependencies[pkg]}`)
+  })
+  console.error(
+    '\nThese internal packages should not be published as dependencies.'
+  )
+  console.error(
+    'Move them to devDependencies or peerDependencies if needed.\n'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `✓ No @latitude-data/* packages found in dependencies of ${packageJson.name}`
+)
+process.exit(0)


### PR DESCRIPTION
## Summary
- Add `check-sdk-dependencies.js` script that prevents `@latitude-data/*` packages from being added as regular dependencies in published SDKs
- Add post-publish step to verify npm installation works correctly after publishing
- Apply changes to both TypeScript SDK and Telemetry package workflows

## Test plan
- [x] Verify the dependency check script runs correctly in CI
- [x] Verify post-publish installation test runs after a successful publish

🤖 Generated with [Claude Code](https://claude.ai/code)