### PR TITLE
MCP Integration: Custom Headers UI

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/hooks/useRunPlaygroundPrompt.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/Playground/hooks/useRunPlaygroundPrompt.ts
@@ -9,6 +9,7 @@ import { DocumentVersion } from '@latitude-data/core/schema/models/types/Documen
 import { TraceContext } from '@latitude-data/constants'
 import type { ICommitContextType } from '$/app/providers/CommitProvider'
 import { useCallback, useMemo } from 'react'
+import { useAllCustomMcpHeaders } from '$/stores/customMcpHeaders'
 
 export function useRunPlaygroundPrompt({
   commit,
@@ -29,6 +30,8 @@ export function useRunPlaygroundPrompt({
     hasActiveStream,
     createAbortController,
   } = useStreamHandler()
+  const { data: mcpHeaders } = useAllCustomMcpHeaders()
+
   const runPromptFn = useCallback(async () => {
     const signal = createAbortController()
 
@@ -47,6 +50,7 @@ export function useRunPlaygroundPrompt({
           parameters: parameters ?? {},
           stream: true, // Explicitly request streaming
           userMessage,
+          mcpHeaders,
         }),
         signal: signal,
       },
@@ -60,6 +64,7 @@ export function useRunPlaygroundPrompt({
     commit.uuid,
     parameters,
     userMessage,
+    mcpHeaders,
     createAbortController,
     createStreamHandler,
   ])

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/CustomMcpHeaders/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/CustomMcpHeaders/index.tsx
@@ -1,0 +1,182 @@
+import { IntegrationType } from "@latitude-data/constants";
+import { ActiveIntegration } from "../../../toolsHelpers/types";
+import { Tooltip } from "@latitude-data/web-ui/atoms/Tooltip";
+import { Button } from "@latitude-data/web-ui/atoms/Button";
+import { useCustomMcpHeaders } from "$/stores/customMcpHeaders";
+import { Modal } from "@latitude-data/web-ui/atoms/Modal";
+import { useCallback, useState } from "react";
+import { Input } from "@latitude-data/web-ui/atoms/Input";
+import { cn } from "@latitude-data/web-ui/utils";
+
+function CustomMcpHeadersModal({ integrationName, open, onOpenChange }: { integrationName: string, open: boolean, onOpenChange: (open: boolean) => void }) {
+  const { data: initialHeaders, update: updateHeaders, remove: removeHeaders } = useCustomMcpHeaders(integrationName)
+
+  const [headers, setHeaders] = useState<[string, string][]>([...Object.entries(initialHeaders ?? {}), ['', '']])
+  const [errors, setErrors] = useState<Record<number, string>>({})
+
+  const validateHeaders = useCallback((headersToValidate: [string, string][]) => {
+    const newErrors: Record<number, string> = {}
+    
+    headersToValidate.forEach(([key, value], idx) => {
+      if (!key.trim() && value.trim()) {
+        newErrors[idx] = 'Header key is required when value is provided'
+      }
+    })
+    
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }, [])
+
+  const handleUpdateHeaderKey = useCallback((idx: number, key: string) => {
+    setHeaders((prev) => {
+      const newHeaders = [...prev]
+      newHeaders[idx][0] = key
+
+      // Add a new empty row if we are editing the last row
+      if (idx === newHeaders.length - 1) {
+        newHeaders.push(['', ''])
+      }
+
+      return newHeaders
+    })
+    setErrors((prev) => {
+      const newErrors = { ...prev }
+      delete newErrors[idx]
+      return newErrors
+    })
+  }, [setHeaders])
+
+  const handleUpdateHeaderValue = useCallback((idx: number, value: string) => {
+    setHeaders((prev) => {
+      const newHeaders = [...prev]
+      newHeaders[idx][1] = value
+
+      // Add a new empty row if we are editing the last row
+      if (idx === newHeaders.length - 1) {
+        newHeaders.push(['', ''])
+      }
+
+      return newHeaders
+    })
+    setErrors((prev) => {
+      const newErrors = { ...prev }
+      delete newErrors[idx]
+      return newErrors
+    })
+  }, [setHeaders])
+
+  const handleRemoveHeader = useCallback((idx: number) => {
+    setHeaders((prev) => {
+      const newHeaders = [...prev]
+      newHeaders.splice(idx, 1)
+
+      // Add a new empty row if there is no rows left
+      if (newHeaders.length === 0) {
+        newHeaders.push(['', ''])
+      }
+
+      return newHeaders
+    })
+    setErrors((prev) => {
+      const newErrors = { ...prev }
+      delete newErrors[idx]
+      return newErrors
+    })
+  }, [setHeaders])
+
+  const handleSave = useCallback(() => {
+    const filteredHeaders = headers.filter(([key, value]) => key.trim() || value.trim())
+    
+    if (!validateHeaders(filteredHeaders)) {
+      return
+    }
+    
+    const headersToSave = filteredHeaders.filter(([key, value]) => key.trim() && value.trim())
+
+    if (headersToSave.length === 0) {
+      removeHeaders()
+    } else {
+      updateHeaders(Object.fromEntries(headersToSave))
+    }
+
+    onOpenChange(false)
+  }, [headers, updateHeaders, validateHeaders, onOpenChange, removeHeaders])
+
+  const handleRemoveAll = useCallback(() => {
+    removeHeaders()
+    onOpenChange(false)
+  }, [removeHeaders, onOpenChange])
+
+  return (
+    <Modal
+      title='Custom headers'
+      description='Add custom headers to the MCP requests'
+      dismissible
+      open={open}
+      onOpenChange={onOpenChange}
+      footer={
+        <div className="flex items-center gap-2">
+          <Button variant='destructive' fancy onClick={handleRemoveAll}>Remove all</Button>
+          <Button variant='default' fancy onClick={handleSave}>Save</Button>
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-4 py-1">
+        {headers.map(([key, value], idx) => (
+          <div key={idx} className="flex flex-col gap-1">
+            <div className={cn("flex items-center gap-2", { 'opacity-75': idx === headers.length - 1 })}>
+              <Input
+                value={key}
+                onChange={(e) => handleUpdateHeaderKey(idx, e.target.value)}
+                errors={errors[idx] ? [errors[idx]] : undefined}
+                placeholder="Key"
+                errorStyle="tooltip"
+              />
+              <Input
+                value={value}
+                onChange={(e) => handleUpdateHeaderValue(idx, e.target.value)}
+                placeholder="Value"
+              />
+              <Button
+                variant='ghost'
+                className='p-0'
+                onClick={() => handleRemoveHeader(idx)}
+                iconProps={{ name: 'trash' }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Modal>
+  )
+}
+
+export function CustomMcpHeadersButton({ integration }: { integration: ActiveIntegration }) {
+  const { data: headers } = useCustomMcpHeaders(integration.name)
+  const hasHeaders = !!headers && Object.keys(headers).length > 0
+  const [open, setOpen] = useState(false)
+
+  if (integration.type !== IntegrationType.ExternalMCP) return null
+
+  return (
+    <>
+    <Tooltip
+    trigger={
+      <Button
+        variant={hasHeaders ? 'primaryMuted' : 'ghost'}
+        size='small'
+        iconProps={{ name: 'key' }} 
+        onClick={() => setOpen(true)}
+      />
+    }
+    >
+      Custom headers
+    </Tooltip>
+    <CustomMcpHeadersModal
+      integrationName={integration.name}
+      open={open}
+      onOpenChange={setOpen}
+    />
+    </>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/index.tsx
@@ -19,6 +19,7 @@ import { IntegrationType } from '@latitude-data/constants'
 import { INTEGRATION_TYPE_VALUES } from '$/lib/integrationTypeOptions'
 import { usePipedreamApp } from '$/stores/pipedreamApp'
 import { parseMarkdownLinks } from '$/components/Pipedream/utils'
+import { CustomMcpHeadersButton } from './CustomMcpHeaders'
 
 function ImageIconComponent({ imageIcon }: { imageIcon?: ImageIcon }) {
   if (!imageIcon) return null
@@ -216,6 +217,10 @@ export function ActiveIntegration({
               ) : null}
             </Text.H6>
           ) : null}
+
+          <CustomMcpHeadersButton
+            integration={integration}
+          />
 
           {!isClientTools && (
             <DropdownMenu

--- a/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
+++ b/apps/web/src/app/api/documents/[documentUuid]/run/route.ts
@@ -32,6 +32,7 @@ const inputSchema = z.object({
   stream: z.boolean().default(true),
   userMessage: z.string().optional(),
   aiParameters: z.boolean().optional(),
+  mcpHeaders: z.record(z.string(), z.record(z.string(), z.string())).optional(),
 })
 
 export const POST = errorHandler(
@@ -54,6 +55,7 @@ export const POST = errorHandler(
           parameters: _parameters,
           userMessage,
           aiParameters,
+          mcpHeaders,
         } = inputSchema.parse(body)
         const projectId = Number(body.projectId)
         const commitsScope = new CommitsRepository(workspace.id)
@@ -111,6 +113,7 @@ export const POST = errorHandler(
             versionUuid: commitUuid,
             parameters,
             userMessage,
+            mcpHeaders,
           })
           if (!result?.uuid) throw new Error('Failed to create run')
 

--- a/apps/web/src/stores/customMcpHeaders.ts
+++ b/apps/web/src/stores/customMcpHeaders.ts
@@ -1,0 +1,43 @@
+import { AppLocalStorage, useLocalStorage } from "@latitude-data/web-ui/hooks/useLocalStorage";
+import { useCallback, useMemo } from "react";
+
+type CustomMcpHeaders = Record<string, Record<string, string>>;
+
+export function useAllCustomMcpHeaders() {
+  const { value, setValue } = useLocalStorage<CustomMcpHeaders>({
+    key: AppLocalStorage.customMcpHeaders,
+    defaultValue: {},
+  })
+
+  return {
+    data: value,
+    update: setValue,
+  }
+}
+
+export function useCustomMcpHeaders(integrationName: string) {
+  const { data: record, update: updateRecord } = useAllCustomMcpHeaders()
+
+  const data = useMemo(() => record[integrationName] ?? undefined, [record, integrationName])
+
+  const update = useCallback((headers: Record<string, string>) => {
+    updateRecord((prev) => ({
+      ...prev,
+      [integrationName]: headers,
+    }))
+  }, [updateRecord, integrationName])
+
+  const remove = useCallback(() => {
+    updateRecord((prev) => {
+      const { [integrationName]: _, ...rest } = prev
+      return rest
+    })
+  }, [updateRecord, integrationName])
+
+  
+  return {
+    data,
+    update,
+    remove,
+  }
+}

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -171,6 +171,7 @@ import {
   GraduationCap,
   Bell,
   CreditCardIcon,
+  KeyRound,
 } from 'lucide-react'
 import { MouseEvent } from 'react'
 
@@ -334,6 +335,7 @@ const Icons = {
   intercom: Intercom,
   intercomChat: IntercomChat,
   jira: Jira,
+  key: KeyRound,
   lab: FlaskConical,
   letterText: LetterText,
   lightBulb: Lightbulb,

--- a/packages/web-ui/src/lib/hooks/useLocalStorage.ts
+++ b/packages/web-ui/src/lib/hooks/useLocalStorage.ts
@@ -23,6 +23,7 @@ export enum AppLocalStorage {
   replayOnboarding = 'replayOnboarding',
   lastRunTab = 'lastRunTab',
   onboardingState = 'onboardingState',
+  customMcpHeaders = 'customMcpHeaders',
 }
 
 export const isLocalStorageAvailable = (() => {


### PR DESCRIPTION
Since #2131 , you can run prompts from SDK adding custom headers to MCP Integrations being used by the agent.

This PR focuses on bringing the same feature to the Playground UI. Now, you can configure and store custom Headers to any MCP Integration when running a prompt, which are also stored locally in the browser.

https://github.com/user-attachments/assets/56ea6865-641b-49f9-b9ab-585e081b3c4c

