### PR TITLE
fix: use correct GTM snippet

### DIFF
--- a/apps/web/src/components/Providers/GoogleTagManager/index.tsx
+++ b/apps/web/src/components/Providers/GoogleTagManager/index.tsx
@@ -10,19 +10,23 @@ export function GoogleTagManager() {
 
   return (
     <>
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${gtmId}`}
-        strategy='afterInteractive'
-      />
-      <Script id='gtm-init' strategy='afterInteractive'>
+      <Script id='gtm-head' strategy='afterInteractive'>
         {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', '${gtmId}');
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','${gtmId}');
         `}
       </Script>
+      <noscript>
+        <iframe
+          src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+          height='0'
+          width='0'
+          style={{ display: 'none', visibility: 'hidden' }}
+        />
+      </noscript>
     </>
   )
 }
-


### PR DESCRIPTION
Fixes the Google Tag Manager integration to use the proper GTM container snippet instead of gtag.js.

## Changes
- Replace gtag.js script with the official GTM container snippet
- Add noscript fallback iframe for users with JavaScript disabled

## Note
The GTM ID also changed from `AW-*` (Google Ads) to `GTM-*` (Tag Manager container).