### PR TITLE
Add extra fields in stripe checkout

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -198,7 +198,7 @@
     "react-dom": "catalog:",
     "safe-regex": "2.1.1",
     "socket.io-client": "4.7.5",
-    "stripe": "18.1.0",
+    "stripe": "20.1.0",
     "uuid": "11.1.0",
     "voyageai": "0.0.8",
     "weaviate-client": "3.9.0",

--- a/packages/core/src/lib/stripe.ts
+++ b/packages/core/src/lib/stripe.ts
@@ -29,6 +29,7 @@ export function getStripe({
   }
 
   stripeInstance = new Stripe(secret, {
+    apiVersion: '2025-12-15.clover',
     typescript: true,
   })
 

--- a/packages/core/src/services/billing/createCheckoutSession.test.ts
+++ b/packages/core/src/services/billing/createCheckoutSession.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BillingError } from '@latitude-data/constants/errors'
+import { SubscriptionPlan, SubscriptionPlans } from '../../plans'
+import { createCheckoutSession } from './createCheckoutSession'
+import * as stripeModule from '../../lib/stripe'
+import { Result } from '../../lib/Result'
+
+const mockSessionsCreate = vi.fn()
+
+const mockStripe = {
+  checkout: {
+    sessions: {
+      create: mockSessionsCreate,
+    },
+  },
+}
+
+vi.mock('../../lib/stripe', () => ({
+  getStripe: vi.fn(),
+}))
+
+describe('createCheckoutSession', () => {
+  const defaultParams = {
+    plan: SubscriptionPlan.TeamV4,
+    workspaceId: 123,
+    userEmail: 'test@example.com',
+    successUrl: 'https://example.com/success',
+    cancelUrl: 'https://example.com/cancel',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(stripeModule.getStripe).mockReturnValue(Result.ok(mockStripe as any))
+  })
+
+  describe('successful checkout session creation', () => {
+    it('returns checkout session URL on success', async () => {
+      const expectedUrl = 'https://checkout.stripe.com/session123'
+      mockSessionsCreate.mockResolvedValue({ url: expectedUrl })
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(true)
+      expect(result.unwrap()).toEqual({ url: expectedUrl })
+    })
+
+    it('passes correct parameters to Stripe', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/session' })
+
+      await createCheckoutSession(defaultParams)
+
+      expect(mockSessionsCreate).toHaveBeenCalledWith({
+        mode: 'subscription',
+        customer_email: 'test@example.com',
+        line_items: [
+          { price: SubscriptionPlans[SubscriptionPlan.TeamV4].stripePriceId, quantity: 1 },
+        ],
+        subscription_data: {
+          metadata: {
+            workspaceId: '123',
+          },
+        },
+        allow_promotion_codes: true,
+        billing_address_collection: 'required',
+        name_collection: {
+          individual: { enabled: true },
+          business: { enabled: true },
+        },
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+      })
+    })
+
+    it('uses correct price ID for TeamV3 plan', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/session' })
+
+      await createCheckoutSession({
+        ...defaultParams,
+        plan: SubscriptionPlan.TeamV3,
+      })
+
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: [
+            { price: SubscriptionPlans[SubscriptionPlan.TeamV3].stripePriceId, quantity: 1 },
+          ],
+        }),
+      )
+    })
+
+    it('uses correct price ID for ProV2 plan', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/session' })
+
+      await createCheckoutSession({
+        ...defaultParams,
+        plan: SubscriptionPlan.ProV2,
+      })
+
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          line_items: [
+            { price: SubscriptionPlans[SubscriptionPlan.ProV2].stripePriceId, quantity: 1 },
+          ],
+        }),
+      )
+    })
+
+    it('converts workspaceId to string in metadata', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/session' })
+
+      await createCheckoutSession({
+        ...defaultParams,
+        workspaceId: 456789,
+      })
+
+      expect(mockSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription_data: {
+            metadata: {
+              workspaceId: '456789',
+            },
+          },
+        }),
+      )
+    })
+  })
+
+  describe('error cases', () => {
+    it('returns error when Stripe is not configured', async () => {
+      const stripeError = new BillingError('Stripe not configured')
+      vi.mocked(stripeModule.getStripe).mockReturnValue(Result.error(stripeError))
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe(stripeError)
+      expect(mockSessionsCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns error when session URL is null', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: null })
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeInstanceOf(BillingError)
+      expect(result.error!.message).toContain('no redirect URL was returned')
+    })
+
+    it('returns error when session URL is undefined', async () => {
+      mockSessionsCreate.mockResolvedValue({})
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeInstanceOf(BillingError)
+      expect(result.error!.message).toContain('no redirect URL was returned')
+    })
+
+    it('returns error when Stripe API throws', async () => {
+      mockSessionsCreate.mockRejectedValue(new Error('Stripe API error'))
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeInstanceOf(BillingError)
+      expect(result.error!.message).toContain('Failed to create checkout session')
+      expect(result.error!.message).toContain('Stripe API error')
+    })
+
+    it('returns error when Stripe throws rate limit error', async () => {
+      mockSessionsCreate.mockRejectedValue(new Error('Rate limit exceeded'))
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeInstanceOf(BillingError)
+      expect(result.error!.message).toContain('Rate limit exceeded')
+    })
+
+    it('returns error when Stripe throws invalid price error', async () => {
+      mockSessionsCreate.mockRejectedValue(
+        new Error('No such price: price_invalid'),
+      )
+
+      const result = await createCheckoutSession(defaultParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBeInstanceOf(BillingError)
+      expect(result.error!.message).toContain('No such price')
+    })
+  })
+
+  describe('getStripe call', () => {
+    it('passes tags to getStripe for error context', async () => {
+      mockSessionsCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/session' })
+
+      await createCheckoutSession(defaultParams)
+
+      expect(stripeModule.getStripe).toHaveBeenCalledWith({
+        tags: {
+          workspaceId: 123,
+          userEmail: 'test@example.com',
+          plan: SubscriptionPlan.TeamV4,
+        },
+      })
+    })
+  })
+})

--- a/packages/core/src/services/billing/createCheckoutSession.ts
+++ b/packages/core/src/services/billing/createCheckoutSession.ts
@@ -42,6 +42,12 @@ export async function createCheckoutSession({
           workspaceId: String(workspaceId),
         },
       },
+      allow_promotion_codes: true,
+      billing_address_collection: 'required',
+      name_collection: {
+        individual: { enabled: true },
+        business: { enabled: true },
+      },
       success_url: successUrl,
       cancel_url: cancelUrl,
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,8 +964,8 @@ importers:
         specifier: 4.7.5
         version: 4.7.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       stripe:
-        specifier: 18.1.0
-        version: 18.1.0(@types/node@22.18.8)
+        specifier: 20.1.0
+        version: 20.1.0(@types/node@22.18.8)
       uuid:
         specifier: 11.1.0
         version: 11.1.0
@@ -12763,6 +12763,15 @@ packages:
       '@types/node':
         optional: true
 
+  stripe@20.1.0:
+    resolution: {integrity: sha512-o1VNRuMkY76ZCq92U3EH3/XHm/WHp7AerpzDs4Zyo8uE5mFL4QUcv/2SudWsSnhBSp4moO2+ZoGCZ7mT8crPmQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
@@ -16268,7 +16277,7 @@ snapshots:
       '@azure/arm-appservice': 16.0.0
       '@azure/arm-resources': 6.1.0
       '@azure/identity': 4.12.0
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       chalk: 3.0.0
       fast-deep-equal: 3.1.3
     transitivePeerDependencies:
@@ -16310,7 +16319,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-deployment@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       simple-git: 3.16.0
@@ -16320,7 +16329,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-dora@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       simple-git: 3.16.0
@@ -16330,7 +16339,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-gate@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       '@types/uuid': 9.0.8
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
@@ -16382,7 +16391,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-sarif@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       axios: 1.12.2(debug@4.4.3)
@@ -16397,7 +16406,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-sbom@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       axios: 1.12.2(debug@4.4.3)
@@ -16414,14 +16423,14 @@ snapshots:
       '@aws-sdk/client-cloudwatch-logs': 3.901.0
       '@aws-sdk/client-iam': 3.901.0
       '@aws-sdk/client-sfn': 3.901.0
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       deep-object-diff: 1.1.9
     transitivePeerDependencies:
       - aws-crt
 
   '@datadog/datadog-ci-plugin-synthetics@3.21.4(@datadog/datadog-ci-base@3.21.4)(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       debug: 4.4.3
@@ -28894,7 +28903,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.19
 
-  stripe@18.1.0(@types/node@22.18.8):
+  stripe@20.1.0(@types/node@22.18.8):
     dependencies:
       qs: 6.14.0
     optionalDependencies:


### PR DESCRIPTION
# What?
I updated Stripe to latest version to be able to add to Stripe session these fields: `Customer Name`, `Bussines name` and `Bussiness address`. Also the option to use promo codes.

## TODO
- [x] Update stripe to latest version. I tried in sandbox to do a full buy and it worked.
- [x] Add fields
- [x] Tests
