### PR TITLE
Sync default composite when issues' linked evaluations change

### DIFF
--- a/packages/core/src/services/evaluationsV2/create.ts
+++ b/packages/core/src/services/evaluationsV2/create.ts
@@ -103,7 +103,7 @@ export async function createEvaluationV2<
       // Note: failing silently.
       // We don't want to block evaluation creation
       await syncDefaultCompositeTarget(
-        { evaluation, issueId, document, commit, workspace },
+        { document, commit, workspace },
         transaction,
       )
     }

--- a/packages/core/src/services/evaluationsV2/delete.ts
+++ b/packages/core/src/services/evaluationsV2/delete.ts
@@ -83,7 +83,7 @@ export async function deleteEvaluationV2<
       // Note: if the deleted evaluation had an issue linked,
       // we treat it as if the issue was being unlinked
       await syncDefaultCompositeTarget(
-        { evaluation, issueId: null, document, commit, workspace },
+        { document, commit, workspace },
         transaction,
       )
     }

--- a/packages/core/src/services/evaluationsV2/update.ts
+++ b/packages/core/src/services/evaluationsV2/update.ts
@@ -155,7 +155,7 @@ export async function updateEvaluationV2<
       if (issueId !== undefined) {
         // issueId === null means un-assign the issue.
         await syncDefaultCompositeTarget(
-          { evaluation, issueId, document, commit, workspace },
+          { document, commit, workspace },
           transaction,
         )
       }


### PR DESCRIPTION
Simplifies the `syncDefaultCompositeTarget` service to use a state-based approach rather than requiring callers to specify which evaluation changed and how.

**Before:** Callers had to pass the specific `evaluation` and `issueId` being changed, and the service would determine whether to add/remove that evaluation from the composite.

**After:** The service now only requires to specify the document and commit, and the service will automatically sync the composite based on the current state of all issue-linked evaluations in the database.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks `syncDefaultCompositeTarget` to be state-based, removing the need for callers to pass `evaluation`/`issueId`. The service now fetches the latest document and all evaluations at a commit, filters by `issueId`, and creates/updates/deletes the default composite accordingly.
> 
> - Adds `generateCompositeEvaluationSettings` and `updateCompositeEvaluation`; removes per-evaluation add/remove paths
> - Always resets composite config to default values on sync (e.g., name, thresholds, evaluation list)
> - Updates `create.ts`, `update.ts`, and `delete.ts` to call `syncDefaultCompositeTarget({ document, commit, workspace })`
> - Expands tests to cover: no issue-linked evaluations (noop/delete), creation, updates to include all issue-linked evals, exclusion of non-issue evals, removal when issues are unlinked, config reset, and merged-commit scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94e6d11b4165e24133ea51e2c2781565e5f3be0a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->