### PR TITLE
Improve Completion span generation

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationGraph.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationGraph.tsx
@@ -88,13 +88,6 @@ const GraphItem = memo(
     ])
 
     const colorScheme = useMemo(() => {
-      if (isSelected) {
-        return {
-          background: 'bg-accent',
-          border: 'border-accent-foreground',
-        }
-      }
-
       if (span.status === SpanStatus.Error) {
         return {
           background: colors.backgrounds[SPAN_COLORS.red.background],
@@ -106,16 +99,16 @@ const GraphItem = memo(
         background: colors.backgrounds[specification.color.background],
         border: colors.borderColors[specification.color.border],
       }
-    }, [isSelected, span.status, specification.color])
+    }, [span.status, specification.color])
 
     return (
       <div className='relative w-full h-full'>
         <div
           className={cn(
-            'absolute h-5 rounded-md cursor-pointer border top-1 hover:opacity-80',
+            'absolute h-5 rounded-md cursor-pointer border top-1 hover:opacity-80 transition-opacity',
             colorScheme.background,
-            colorScheme.border +
-              (isSelected || isCollapsed ? ' border-2' : '/10'),
+            colorScheme.border + (isSelected ? ' border-2' : '/10'),
+            isCollapsed && 'border-dashed opacity-80',
           )}
           style={barStyle}
           onClick={() => {

--- a/apps/web/src/components/tracing/spans/Completion.tsx
+++ b/apps/web/src/components/tracing/spans/Completion.tsx
@@ -7,12 +7,11 @@ import { MetadataItem } from '$/components/MetadataItem'
 import { Message } from '@latitude-data/constants/legacyCompiler'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { CodeBlock } from '@latitude-data/web-ui/atoms/CodeBlock'
-import { IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { Modal } from '@latitude-data/web-ui/atoms/Modal'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { Tooltip } from '@latitude-data/web-ui/atoms/Tooltip'
 import { useState } from 'react'
-import { DetailsPanelProps, SPAN_COLORS } from './shared'
+import { DetailsPanelProps, SPAN_COLORS, SpanFrontendSpecification } from './shared'
 import {
   FINISH_REASON_DETAILS,
   SPAN_SPECIFICATIONS,
@@ -23,10 +22,10 @@ import { cn } from '@latitude-data/web-ui/utils'
 const specification = SPAN_SPECIFICATIONS[SpanType.Completion]
 export default {
   ...specification,
-  icon: 'brain' as IconName,
+  icon: 'messageCircle',
   color: SPAN_COLORS.blue,
   DetailsPanel: DetailsPanel,
-}
+} satisfies SpanFrontendSpecification<SpanType.Completion>
 
 function MessagesDetails({
   input,

--- a/apps/web/src/components/tracing/spans/Tool.tsx
+++ b/apps/web/src/components/tracing/spans/Tool.tsx
@@ -1,20 +1,19 @@
 import { MetadataItem } from '$/components/MetadataItem'
 import { Alert } from '@latitude-data/web-ui/atoms/Alert'
 import { CodeBlock } from '@latitude-data/web-ui/atoms/CodeBlock'
-import { IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { TextArea } from '@latitude-data/web-ui/atoms/TextArea'
 import { ClickToCopy } from '@latitude-data/web-ui/molecules/ClickToCopy'
-import { DetailsPanelProps, SPAN_COLORS } from './shared'
+import { DetailsPanelProps, SPAN_COLORS, SpanFrontendSpecification } from './shared'
 import { SPAN_SPECIFICATIONS, SpanType } from '@latitude-data/core/constants'
 
 const specification = SPAN_SPECIFICATIONS[SpanType.Tool]
 export default {
   ...specification,
-  icon: 'blocks' as IconName,
+  icon: 'wrench',
   color: SPAN_COLORS.green,
   DetailsPanel: DetailsPanel,
-}
+} satisfies SpanFrontendSpecification<SpanType.Tool>
 
 function DetailsPanel({ span }: DetailsPanelProps<SpanType.Tool>) {
   return (

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -205,6 +205,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "2.0.0",
     "@faker-js/faker": "^8.4.1",
     "@types/blessed": "^0.1.25",
     "@types/diff-match-patch": "^1.0.36",

--- a/packages/core/src/lib/streamManager/chainStreamManager.ts
+++ b/packages/core/src/lib/streamManager/chainStreamManager.ts
@@ -62,8 +62,6 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
       this.startStep()
       this.startProviderStep({
         config: chain.config,
-        messages: chain.messages,
-        provider: chain.provider,
       })
 
       const toolsBySource = await this.getToolsBySource(chain).then((r) =>
@@ -81,7 +79,7 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
         finishReason,
       } = await streamAIResponse({
         config,
-        context: this.$completion!.context,
+        context: this.$context,
         abortSignal: this.abortSignal,
         controller: this.controller!,
         documentLogUuid: this.uuid,
@@ -92,6 +90,7 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
         source: this.source,
         workspace: this.workspace,
         resolvedTools: toolsBySource,
+        telemetryOptions: this.telemetryOptions,
       })
 
       this.updateStateFromResponse({
@@ -101,7 +100,6 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
         finishReason,
       })
       this.endProviderStep({
-        responseMessages,
         tokenUsage,
         response,
         finishReason,

--- a/packages/core/src/lib/streamManager/defaultStreamManager.ts
+++ b/packages/core/src/lib/streamManager/defaultStreamManager.ts
@@ -63,8 +63,6 @@ export class DefaultStreamManager
       this.startStep()
       this.startProviderStep({
         config: this.config,
-        messages: this.messages,
-        provider: this.provider,
       })
 
       const toolsBySource = await this.getToolsBySource().then((r) =>
@@ -78,7 +76,7 @@ export class DefaultStreamManager
       const { response, messages, tokenUsage, finishReason } =
         await streamAIResponse({
           config,
-          context: this.$completion!.context,
+          context: this.$context,
           abortSignal: this.abortSignal,
           controller: this.controller!,
           documentLogUuid: this.uuid,
@@ -89,6 +87,7 @@ export class DefaultStreamManager
           source: this.source,
           workspace: this.workspace,
           resolvedTools: toolsBySource,
+          telemetryOptions: this.telemetryOptions,
         })
 
       this.updateStateFromResponse({
@@ -98,7 +97,6 @@ export class DefaultStreamManager
         finishReason,
       })
       this.endProviderStep({
-        responseMessages: messages,
         tokenUsage,
         response,
         finishReason,

--- a/packages/core/src/lib/streamManager/step/streamAIResponse.ts
+++ b/packages/core/src/lib/streamManager/step/streamAIResponse.ts
@@ -9,7 +9,7 @@ import { JSONSchema7 } from 'json-schema'
 import { LogSources } from '../../../constants'
 import { type ProviderApiKey } from '../../../schema/models/types/ProviderApiKey'
 import { WorkspaceDto } from '../../../schema/models/types/Workspace'
-import { ai, AIReturn } from '../../../services/ai'
+import { ai, AIReturn, CompletionTelemetryOptions } from '../../../services/ai'
 import { processResponse } from '../../../services/chains/ProviderProcessor'
 import { buildProviderLogDto } from '../../../services/chains/ProviderProcessor/saveOrPublishProviderLogs'
 import { createProviderLog } from '../../../services/providerLogs/create'
@@ -46,6 +46,7 @@ export async function streamAIResponse({
   output,
   abortSignal,
   resolvedTools,
+  telemetryOptions,
 }: {
   context: TelemetryContext
   controller: ReadableStreamDefaultController
@@ -59,6 +60,7 @@ export async function streamAIResponse({
   output?: Output
   abortSignal?: AbortSignal
   resolvedTools?: ResolvedToolsDict
+  telemetryOptions?: CompletionTelemetryOptions
 }): Promise<{
   response: ChainStepResponse<StreamType>
   messages: LegacyMessage[]
@@ -77,6 +79,7 @@ export async function streamAIResponse({
     output,
     abortSignal,
     onError: handleAIError,
+    telemetryOptions,
   }).then((r) => r.unwrap())
 
   const checkResult = checkValidStream({ type: aiResult.type })

--- a/packages/core/src/services/ai/getLanguageModel.test.ts
+++ b/packages/core/src/services/ai/getLanguageModel.test.ts
@@ -6,6 +6,7 @@ import * as factories from '../../tests/factories'
 import { getLanguageModel } from './getLanguageModel'
 import { LlmProvider } from './helpers'
 import { VercelConfigWithProviderRules } from './providers/rules'
+import { TelemetryContext } from '@latitude-data/telemetry'
 
 const GetLanguageModelMock = vi.hoisted(() => vi.fn())
 const GetChatLanguageModelMock = vi.hoisted(() => vi.fn())
@@ -60,6 +61,7 @@ describe('getLanguageModel', () => {
       llmProvider: MockLlmProvider,
       config,
       customLanguageModel,
+      context: {} as TelemetryContext,
     })
 
     expect(model).toEqual({ model: 'im_custom' })
@@ -71,6 +73,7 @@ describe('getLanguageModel', () => {
       model: 'gpt-4o',
       llmProvider: MockLlmProvider,
       config,
+      context: {} as TelemetryContext,
     })
 
     expect(GetChatLanguageModelMock).toHaveBeenCalledWith('gpt-4o', {
@@ -86,6 +89,7 @@ describe('getLanguageModel', () => {
       model: 'gpt-4o',
       llmProvider: MockLlmProvider,
       config,
+      context: {} as TelemetryContext,
     })
 
     expect(GetLanguageModelMock).toHaveBeenCalledWith('gpt-4o', {
@@ -105,6 +109,7 @@ describe('getLanguageModel', () => {
         provider: Providers.Anthropic,
         model: 'claude-3-5-sonnet',
       },
+      context: {} as TelemetryContext,
     })
 
     expect(GetLanguageModelMock).toHaveBeenCalledWith('claude-3-5-sonnet', {

--- a/packages/core/src/services/ai/helpers.test.ts
+++ b/packages/core/src/services/ai/helpers.test.ts
@@ -4,11 +4,9 @@ import { Providers } from '@latitude-data/constants'
 import { type User } from '../../schema/models/types/User'
 import { type Workspace } from '../../schema/models/types/Workspace'
 import { Result } from '../../lib/Result'
-import { TelemetryContext } from '../../telemetry'
 import * as factories from '../../tests/factories'
 import { createProvider as createProviderGlobal } from './helpers'
 
-let context: TelemetryContext
 let workspace: Workspace
 let user: User
 
@@ -18,7 +16,6 @@ describe('createProvider', () => {
 
     user = userData
     workspace = w
-    context = factories.createTelemetryContext({ workspace })
 
     vi.resetModules()
   })
@@ -32,7 +29,6 @@ describe('createProvider', () => {
     })
 
     const result = createProviderGlobal({
-      context,
       provider,
       apiKey: provider.token,
       url: undefined,
@@ -75,7 +71,6 @@ describe('createProvider', () => {
     const mod = await import('./helpers')
     const createProvider = mod.createProvider
     const result = createProvider({
-      context,
       provider,
       apiKey: provider.token,
       url: undefined,
@@ -127,7 +122,6 @@ describe('createProvider', () => {
     const mod = await import('./helpers')
     const createProvider = mod.createProvider
     const result = createProvider({
-      context,
       provider,
       apiKey: provider.token,
       url: undefined,

--- a/packages/core/src/services/ai/helpers.ts
+++ b/packages/core/src/services/ai/helpers.ts
@@ -16,7 +16,6 @@ import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai'
 import { createPerplexity, PerplexityProvider } from '@ai-sdk/perplexity'
 import { createXai, XaiProvider } from '@ai-sdk/xai'
 import { ChainError, RunErrorCodes } from '@latitude-data/constants/errors'
-import { TelemetryContext } from '../../telemetry'
 
 import { Providers } from '@latitude-data/constants'
 import { Result, TypedResult } from '../../lib/Result'
@@ -36,7 +35,6 @@ export { type PartialPromptConfig as PartialConfig } from '@latitude-data/consta
 const GROQ_API_URL = 'https://api.groq.com/openai/v1'
 
 function createAmazonBedrockProvider(
-  context: TelemetryContext,
   config: AmazonBedrockConfiguration,
   name: string,
 ) {
@@ -53,7 +51,7 @@ function createAmazonBedrockProvider(
 
   return Result.ok(
     createAmazonBedrock({
-      fetch: instrumentedFetch({ context }),
+      fetch: instrumentedFetch(),
       region: config.region,
       accessKeyId: config.accessKeyId,
       secretAccessKey: config.secretAccessKey,
@@ -104,13 +102,11 @@ export type LlmProvider =
   | PerplexityProvider
 
 export function createProvider({
-  context,
   provider,
   apiKey,
   url,
   config,
 }: {
-  context: TelemetryContext
   provider: ProviderApiKey
   apiKey: string
   url?: string
@@ -124,14 +120,14 @@ export function createProvider({
     case Providers.OpenAI:
       return Result.ok(
         createOpenAI({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.Groq:
       return Result.ok(
         createOpenAI({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
           baseURL: GROQ_API_URL,
         }),
@@ -139,21 +135,21 @@ export function createProvider({
     case Providers.Anthropic:
       return Result.ok(
         createAnthropic({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.Mistral:
       return Result.ok(
         createMistral({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.Azure:
       return Result.ok(
         createAzure({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
           ...(config?.azure ?? {}),
         }),
@@ -161,7 +157,7 @@ export function createProvider({
     case Providers.Google: {
       return Result.ok(
         createGoogleGenerativeAI({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
@@ -176,7 +172,7 @@ export function createProvider({
 
       return Result.ok(
         createVertex({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           ...vertexConfig,
         }),
       )
@@ -192,7 +188,7 @@ export function createProvider({
 
       return Result.ok(
         createVertexAnthropic({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           ...vertexConfig,
         }),
       )
@@ -200,35 +196,34 @@ export function createProvider({
     case Providers.XAI:
       return Result.ok(
         createXai({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.DeepSeek:
       return Result.ok(
         createDeepSeek({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.Perplexity:
       return Result.ok(
         createPerplexity({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
         }),
       )
     case Providers.Custom:
       return Result.ok(
         createOpenAI({
-          fetch: instrumentedFetch({ context }),
+          fetch: instrumentedFetch(),
           apiKey,
           baseURL: url,
         }),
       )
     case Providers.AmazonBedrock:
       return createAmazonBedrockProvider(
-        context,
         provider.configuration as AmazonBedrockConfiguration,
         provider.name,
       )

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -74,6 +74,12 @@ function getStopWhen({ maxSteps }: { maxSteps?: number | undefined }) {
 
 export type OnErrorParameters = Parameters<StreamTextOnErrorCallback>[0]
 
+export type CompletionTelemetryOptions = {
+  promptUuid?: string
+  versionUuid?: string
+  experimentUuid?: string
+}
+
 export async function ai({
   context,
   provider,
@@ -84,6 +90,7 @@ export async function ai({
   output,
   aiSdkProvider,
   abortSignal,
+  telemetryOptions,
 }: {
   context: TelemetryContext
   provider: ProviderApiKey
@@ -94,6 +101,7 @@ export async function ai({
   output?: ObjectOutput
   aiSdkProvider?: Partial<AISDKProvider>
   abortSignal?: AbortSignal
+  telemetryOptions?: CompletionTelemetryOptions
 }): Promise<
   TypedResult<
     AIReturn<StreamType>,
@@ -132,7 +140,6 @@ export async function ai({
     const model = config.model
     const tools = config.tools
     const providerAdapterResult = createProvider({
-      context,
       provider: provider,
       apiKey,
       url: url ?? undefined,
@@ -146,6 +153,8 @@ export async function ai({
       provider,
       config,
       model,
+      context,
+      telemetryOptions,
     })
 
     const toolsResult = buildTools(tools)

--- a/packages/core/src/services/ai/streamConsumer.test.ts
+++ b/packages/core/src/services/ai/streamConsumer.test.ts
@@ -1,0 +1,742 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createStreamConsumer,
+  buildOutputMessages,
+  extractGenerateResultContent,
+  CapturedStreamResult,
+} from './streamConsumer'
+
+describe('createStreamConsumer', () => {
+  function createMockStream(chunks: unknown[]) {
+    return new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(chunk)
+        }
+        controller.close()
+      },
+    })
+  }
+
+  async function consumeStream(stream: ReadableStream) {
+    const reader = stream.getReader()
+    const chunks: unknown[] = []
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+    }
+    return chunks
+  }
+
+  it('captures text-delta chunks', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [
+      { type: 'text-delta', delta: 'Hello, ' },
+      { type: 'text-delta', delta: 'world!' },
+      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5 } },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    const consumedChunks = await consumeStream(wrappedStream)
+
+    expect(consumedChunks).toEqual(mockChunks)
+    expect(onConsumed).toHaveBeenCalledWith({
+      text: 'Hello, world!',
+      reasoning: '',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: {
+        prompt: 10,
+        completion: 5,
+        cached: undefined,
+        reasoning: undefined,
+      },
+    })
+  })
+
+  it('captures reasoning chunks', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [
+      { type: 'reasoning-delta', delta: 'Let me think...' },
+      { type: 'reasoning-delta', delta: ' I should respond with hello.' },
+      { type: 'text-delta', delta: 'Hello!' },
+      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 8 } },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    await consumeStream(wrappedStream)
+
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Hello!',
+        reasoning: 'Let me think... I should respond with hello.',
+        files: [],
+      }),
+    )
+  })
+
+  it('captures tool-call chunks', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [
+      { type: 'text-delta', delta: 'Let me search...' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-123',
+        toolName: 'web_search',
+        input: { query: 'latest news' },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-456',
+        toolName: 'calculator',
+        input: { expression: '2 + 2' },
+      },
+      { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 15, outputTokens: 10 } },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    await consumeStream(wrappedStream)
+
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Let me search...',
+        files: [],
+        toolCalls: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-123',
+            toolName: 'web_search',
+            args: { query: 'latest news' },
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-456',
+            toolName: 'calculator',
+            args: { expression: '2 + 2' },
+          },
+        ],
+        finishReason: 'tool-calls',
+      }),
+    )
+  })
+
+  it('captures cached and reasoning tokens', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [
+      { type: 'text-delta', delta: 'Hello' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 5,
+          cachedInputTokens: 8,
+          reasoningTokens: 3,
+        },
+      },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    await consumeStream(wrappedStream)
+
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [],
+        tokens: {
+          prompt: 10,
+          completion: 5,
+          cached: 8,
+          reasoning: 3,
+        },
+      }),
+    )
+  })
+
+  it('defaults finishReason to unknown when no finish chunk', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [{ type: 'text-delta', delta: 'Hello' }]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    await consumeStream(wrappedStream)
+
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: [],
+        finishReason: 'unknown',
+      }),
+    )
+  })
+
+  it('ignores unknown chunk types', async () => {
+    const onConsumed = vi.fn()
+    const mockChunks = [
+      { type: 'unknown-type', data: 'whatever' },
+      { type: 'text-delta', delta: 'Hello' },
+      { type: 'another-unknown', foo: 'bar' },
+      { type: 'finish', finishReason: 'stop', usage: {} },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    const consumedChunks = await consumeStream(wrappedStream)
+
+    expect(consumedChunks).toEqual(mockChunks)
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Hello',
+        files: [],
+      }),
+    )
+  })
+
+  it('captures file chunks', async () => {
+    const onConsumed = vi.fn()
+    const imageData = new Uint8Array([1, 2, 3, 4])
+    const pdfData = new ArrayBuffer(8)
+    const mockChunks = [
+      { type: 'text-delta', delta: 'Here is an image: ' },
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        data: imageData,
+      },
+      { type: 'text-delta', delta: ' and a PDF: ' },
+      {
+        type: 'file',
+        mediaType: 'application/pdf',
+        data: pdfData,
+      },
+      { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5 } },
+    ]
+
+    const stream = createMockStream(mockChunks)
+    const wrappedStream = stream.pipeThrough(createStreamConsumer(onConsumed))
+    await consumeStream(wrappedStream)
+
+    expect(onConsumed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Here is an image:  and a PDF: ',
+        files: [
+          {
+            type: 'file',
+            mediaType: 'image/png',
+            data: imageData,
+          },
+          {
+            type: 'file',
+            mediaType: 'application/pdf',
+            data: pdfData,
+          },
+        ],
+      }),
+    )
+  })
+})
+
+describe('buildOutputMessages', () => {
+  it('builds message with text content', () => {
+    const result: CapturedStreamResult = {
+      text: 'Hello, world!',
+      reasoning: '',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: { prompt: 10, completion: 5 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello, world!' }],
+        toolCalls: [],
+      },
+    ])
+  })
+
+  it('builds message with text and reasoning', () => {
+    const result: CapturedStreamResult = {
+      text: 'The answer is 42.',
+      reasoning: 'Let me calculate...',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: { prompt: 10, completion: 15 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'Let me calculate...' },
+          { type: 'text', text: 'The answer is 42.' },
+        ],
+        toolCalls: [],
+      },
+    ])
+  })
+
+  it('builds message with tool calls', () => {
+    const result: CapturedStreamResult = {
+      text: 'I will search for that.',
+      reasoning: '',
+      files: [],
+      toolCalls: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-123',
+          toolName: 'web_search',
+          args: { query: 'news' },
+        },
+      ],
+      finishReason: 'tool-calls',
+      tokens: { prompt: 10, completion: 8 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'I will search for that.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-123',
+            toolName: 'web_search',
+            args: { query: 'news' },
+          },
+        ],
+        toolCalls: [
+          {
+            id: 'call-123',
+            name: 'web_search',
+            arguments: { query: 'news' },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('builds message with text, reasoning, and tool calls', () => {
+    const result: CapturedStreamResult = {
+      text: 'Searching now.',
+      reasoning: 'The user wants current news.',
+      files: [],
+      toolCalls: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-789',
+          toolName: 'web_search',
+          args: { query: 'latest news' },
+        },
+      ],
+      finishReason: 'tool-calls',
+      tokens: { prompt: 15, completion: 20 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'The user wants current news.' },
+          { type: 'text', text: 'Searching now.' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-789',
+            toolName: 'web_search',
+            args: { query: 'latest news' },
+          },
+        ],
+        toolCalls: [
+          {
+            id: 'call-789',
+            name: 'web_search',
+            arguments: { query: 'latest news' },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('returns empty array when no content', () => {
+    const result: CapturedStreamResult = {
+      text: '',
+      reasoning: '',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: { prompt: 5, completion: 0 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [],
+      },
+    ])
+  })
+
+  it('builds message with image files', () => {
+    const imageData = new Uint8Array([1, 2, 3, 4])
+    const result: CapturedStreamResult = {
+      text: 'Here is an image.',
+      reasoning: '',
+      files: [
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: imageData,
+        },
+        {
+          type: 'file',
+          mediaType: 'image/jpeg',
+          data: imageData,
+        },
+      ],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: { prompt: 10, completion: 5 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Here is an image.' },
+          { type: 'image', image: imageData },
+          { type: 'image', image: imageData },
+        ],
+        toolCalls: [],
+      },
+    ])
+  })
+
+  it('builds message with non-image files', () => {
+    const pdfData = new ArrayBuffer(8)
+    const result: CapturedStreamResult = {
+      text: 'Here is a PDF.',
+      reasoning: '',
+      files: [
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: pdfData,
+        },
+        {
+          type: 'file',
+          mediaType: 'text/plain',
+          data: 'text content',
+        },
+      ],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: { prompt: 10, completion: 5 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Here is a PDF.' },
+          { type: 'file', file: pdfData, mimeType: 'application/pdf' },
+          { type: 'file', file: 'text content', mimeType: 'text/plain' },
+        ],
+        toolCalls: [],
+      },
+    ])
+  })
+
+  it('builds message with mixed content including files', () => {
+    const imageData = new Uint8Array([1, 2, 3])
+    const pdfData = new ArrayBuffer(4)
+    const result: CapturedStreamResult = {
+      text: 'Mixed content.',
+      reasoning: 'Some reasoning.',
+      files: [
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: imageData,
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: pdfData,
+        },
+      ],
+      toolCalls: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-1',
+          toolName: 'search',
+          args: { query: 'test' },
+        },
+      ],
+      finishReason: 'tool-calls',
+      tokens: { prompt: 15, completion: 10 },
+    }
+
+    const messages = buildOutputMessages(result)
+
+    expect(messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'Some reasoning.' },
+          { type: 'text', text: 'Mixed content.' },
+          { type: 'image', image: imageData },
+          { type: 'file', file: pdfData, mimeType: 'application/pdf' },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'search',
+            args: { query: 'test' },
+          },
+        ],
+        toolCalls: [
+          {
+            id: 'call-1',
+            name: 'search',
+            arguments: { query: 'test' },
+          },
+        ],
+      },
+    ])
+  })
+})
+
+describe('extractGenerateResultContent', () => {
+  it('extracts text from content array', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'text', text: 'world!' },
+      ],
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 5 },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured).toEqual({
+      text: 'Hello world!',
+      reasoning: '',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: {
+        prompt: 10,
+        completion: 5,
+        cached: undefined,
+        reasoning: undefined,
+      },
+    })
+  })
+
+  it('extracts reasoning from content array', () => {
+    const result = {
+      content: [
+        { type: 'reasoning', text: 'Thinking...' },
+        { type: 'text', text: 'Answer.' },
+      ],
+      finishReason: 'stop',
+      usage: { inputTokens: 15, outputTokens: 10, reasoningTokens: 5 },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured).toEqual(
+      expect.objectContaining({
+        text: 'Answer.',
+        reasoning: 'Thinking...',
+        files: [],
+        tokens: expect.objectContaining({
+          reasoning: 5,
+        }),
+      }),
+    )
+  })
+
+  it('extracts tool calls from content array', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'Calling tool.' },
+        {
+          type: 'tool-call',
+          toolCallId: 'call-abc',
+          toolName: 'calculator',
+          args: { expression: '1+1' },
+        },
+      ],
+      finishReason: 'tool-calls',
+      usage: { inputTokens: 12, outputTokens: 8 },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured).toEqual(
+      expect.objectContaining({
+        text: 'Calling tool.',
+        files: [],
+        toolCalls: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-abc',
+            toolName: 'calculator',
+            args: { expression: '1+1' },
+          },
+        ],
+        finishReason: 'tool-calls',
+      }),
+    )
+  })
+
+  it('handles non-array content', () => {
+    const result = {
+      content: 'just a string',
+      finishReason: 'stop',
+      usage: {},
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured).toEqual({
+      text: '',
+      reasoning: '',
+      files: [],
+      toolCalls: [],
+      finishReason: 'stop',
+      tokens: {
+        prompt: undefined,
+        completion: undefined,
+        cached: undefined,
+        reasoning: undefined,
+      },
+    })
+  })
+
+  it('handles cached input tokens', () => {
+    const result = {
+      content: [{ type: 'text', text: 'Cached response.' }],
+      finishReason: 'stop',
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        cachedInputTokens: 8,
+      },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured.files).toEqual([])
+    expect(captured.tokens).toEqual({
+      prompt: 10,
+      completion: 5,
+      cached: 8,
+      reasoning: undefined,
+    })
+  })
+
+  it('extracts files from content array', () => {
+    const imageData = new Uint8Array([1, 2, 3])
+    const pdfData = new ArrayBuffer(4)
+    const result = {
+      content: [
+        { type: 'text', text: 'With files.' },
+        {
+          type: 'file',
+          mediaType: 'image/png',
+          data: imageData,
+        },
+        {
+          type: 'file',
+          mediaType: 'application/pdf',
+          data: pdfData,
+        },
+      ],
+      finishReason: 'stop',
+      usage: { inputTokens: 20, outputTokens: 10 },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured.text).toBe('With files.')
+    expect(captured.files).toEqual([
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        data: imageData,
+      },
+      {
+        type: 'file',
+        mediaType: 'application/pdf',
+        data: pdfData,
+      },
+    ])
+    expect(captured.toolCalls).toEqual([])
+  })
+
+  it('ignores unknown content types', () => {
+    const result = {
+      content: [
+        { type: 'image', image: 'base64...' },
+        { type: 'text', text: 'With text.' },
+        { type: 'unknown', data: 'whatever' },
+      ],
+      finishReason: 'stop',
+      usage: { inputTokens: 20, outputTokens: 10 },
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured.text).toBe('With text.')
+    expect(captured.files).toEqual([])
+    expect(captured.toolCalls).toEqual([])
+  })
+
+  it('handles tool-call missing args', () => {
+    const result = {
+      content: [
+        {
+          type: 'tool-call',
+          toolCallId: 'call-xyz',
+          toolName: 'no_args_tool',
+        },
+      ],
+      finishReason: 'tool-calls',
+      usage: {},
+    }
+
+    const captured = extractGenerateResultContent(result)
+
+    expect(captured.files).toEqual([])
+    expect(captured.toolCalls).toEqual([
+      {
+        type: 'tool-call',
+        toolCallId: 'call-xyz',
+        toolName: 'no_args_tool',
+        args: undefined,
+      },
+    ])
+  })
+})

--- a/packages/core/src/services/ai/streamConsumer.ts
+++ b/packages/core/src/services/ai/streamConsumer.ts
@@ -1,0 +1,267 @@
+/**
+ * Stream consumer utilities for AI SDK streams.
+ * Provides a TransformStream that captures all content from the stream
+ * without consuming it, passing through all chunks unchanged.
+ */
+
+import type { LanguageModelV2StreamPart } from '@ai-sdk/provider'
+import { Message, MessageContent, MessageRole, ToolCall } from '@latitude-data/constants/legacyCompiler'
+
+/**
+ * Represents a tool call captured from the stream
+ */
+export type CapturedToolCall = {
+  type: 'tool-call'
+  toolCallId: string
+  toolName: string
+  args: unknown
+}
+
+export type CapturedFile = {
+  type: 'file'
+  mediaType: string
+  data: string | Uint8Array | ArrayBuffer
+}
+
+/**
+ * Token usage information captured from the stream
+ */
+export type CapturedTokenUsage = {
+  prompt?: number
+  completion?: number
+  cached?: number
+  reasoning?: number
+}
+
+/**
+ * Complete stream result captured from consuming the stream
+ */
+export type CapturedStreamResult = {
+  text: string
+  reasoning: string
+  files: CapturedFile[]
+  toolCalls: CapturedToolCall[]
+  finishReason: string
+  tokens: CapturedTokenUsage
+}
+
+/**
+ * Callback invoked when the stream is fully consumed
+ */
+export type StreamConsumedCallback = (result: CapturedStreamResult) => void
+
+/**
+ * Creates a TransformStream that captures all content from an AI SDK stream
+ * while passing through all chunks unchanged.
+ *
+ * Captures:
+ * - text-delta: Accumulated into full text
+ * - reasoning: Accumulated into full reasoning text
+ * - tool-call: Complete tool calls with id, name, and args
+ * - finish: finishReason and token usage (including cached and reasoning tokens)
+ *
+ * @param onConsumed - Callback invoked when the stream is fully consumed (in flush)
+ * @returns TransformStream that can be piped through
+ */
+export function createStreamConsumer(
+  onConsumed: StreamConsumedCallback,
+): TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart> {
+  let finishReason: string | undefined
+  let promptTokens: number | undefined
+  let completionTokens: number | undefined
+  let cachedTokens: number | undefined
+  let reasoningTokens: number | undefined
+
+  const textParts: string[] = []
+  const reasoningParts: string[] = []
+  const files: CapturedFile[] = []
+  const toolCalls: CapturedToolCall[] = []
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      switch (chunk.type) {
+        case 'text-delta':
+          textParts.push(chunk.delta)
+          break
+
+        case 'reasoning-delta':
+          reasoningParts.push(chunk.delta)
+          break
+
+        case 'file':
+          files.push({
+            type: 'file',
+            mediaType: chunk.mediaType,
+            data: chunk.data,
+          })
+          break
+
+        case 'tool-call':
+          toolCalls.push({
+            type: 'tool-call',
+            toolCallId: chunk.toolCallId,
+            toolName: chunk.toolName,
+            args: chunk.input,
+          })
+          break
+
+        case 'finish':
+          finishReason = chunk.finishReason
+          promptTokens = chunk.usage?.inputTokens
+          completionTokens = chunk.usage?.outputTokens
+          cachedTokens = chunk.usage?.cachedInputTokens
+          reasoningTokens = chunk.usage?.reasoningTokens
+          break
+      }
+
+      controller.enqueue(chunk)
+    },
+
+    flush() {
+      onConsumed({
+        text: textParts.join(''),
+        reasoning: reasoningParts.join(''),
+        files,
+        toolCalls,
+        finishReason: finishReason ?? 'unknown',
+        tokens: {
+          prompt: promptTokens,
+          completion: completionTokens,
+          cached: cachedTokens,
+          reasoning: reasoningTokens,
+        },
+      })
+    },
+  })
+}
+
+/**
+ * Builds output messages array from captured stream result.
+ * Formats the result into the message structure expected by telemetry.
+ */
+export function buildOutputMessages(
+  result: CapturedStreamResult,
+): Message[] {
+  const content: MessageContent[] = []
+
+  if (result.reasoning) {
+    content.push({ type: 'reasoning', text: result.reasoning })
+  }
+  
+  if (result.text) {
+    content.push({ type: 'text', text: result.text })
+  }
+
+  for (const file of result.files) {
+
+    if (file.mediaType.startsWith('image/')) {
+      content.push({
+        type: 'image',
+        image: file.data,
+      })
+    } else {
+      content.push({
+        type: 'file',
+        file: file.data,
+        mimeType: file.mediaType,
+      })
+    }
+  }
+
+  for (const tc of result.toolCalls) {
+    content.push({
+      type: 'tool-call',
+      toolCallId: tc.toolCallId,
+      toolName: tc.toolName,
+      args: tc.args as Record<string, unknown>,
+    })
+  }
+
+  const toolCalls: ToolCall[] = result.toolCalls.map((tc) => ({
+    id: tc.toolCallId,
+    name: tc.toolName,
+    arguments: tc.args as Record<string, unknown>,
+  }))
+
+  return [{ role: MessageRole.assistant, content, toolCalls }]
+}
+
+/**
+ * Extracts content from a non-streaming (generate) result.
+ * Handles text, reasoning, and tool calls from the result content array.
+ */
+export function extractGenerateResultContent(result: {
+  content: unknown
+  finishReason: string
+  usage?: {
+    inputTokens?: number
+    outputTokens?: number
+    cachedInputTokens?: number
+    reasoningTokens?: number
+  }
+}): CapturedStreamResult {
+  const textParts: string[] = []
+  const reasoningParts: string[] = []
+  const files: CapturedFile[] = []
+  const toolCalls: CapturedToolCall[] = []
+
+  if (Array.isArray(result.content)) {
+    for (const part of result.content) {
+      if (typeof part !== 'object' || part === null) continue
+
+      const partType = (part as Record<string, unknown>).type
+
+      switch (partType) {
+        case 'text':
+          if ('text' in part && typeof part.text === 'string') {
+            textParts.push(part.text)
+          }
+          break
+
+        case 'reasoning':
+          if ('text' in part && typeof part.text === 'string') {
+            reasoningParts.push(part.text)
+          }
+          break
+
+        case 'file':
+          files.push({
+            type: 'file',
+            mediaType: part.mediaType,
+            data: part.data,
+          })
+          break
+
+        case 'tool-call':
+          if (
+            'toolCallId' in part &&
+            'toolName' in part &&
+            typeof part.toolCallId === 'string' &&
+            typeof part.toolName === 'string'
+          ) {
+            toolCalls.push({
+              type: 'tool-call',
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              args: 'args' in part ? part.args : undefined,
+            })
+          }
+          break
+      }
+    }
+  }
+
+  return {
+    text: textParts.join(''),
+    reasoning: reasoningParts.join(''),
+    files,
+    toolCalls,
+    finishReason: result.finishReason,
+    tokens: {
+      prompt: result.usage?.inputTokens,
+      completion: result.usage?.outputTokens,
+      cached: result.usage?.cachedInputTokens,
+      reasoning: result.usage?.reasoningTokens,
+    },
+  }
+}

--- a/packages/core/src/services/ai/telemetryMiddleware.test.ts
+++ b/packages/core/src/services/ai/telemetryMiddleware.test.ts
@@ -1,0 +1,729 @@
+import { describe, expect, it, vi, beforeEach, type TaskContext } from 'vitest'
+import { context as otelContext, ROOT_CONTEXT } from '@opentelemetry/api'
+import { createTelemetryMiddleware } from './telemetryMiddleware'
+import type { TelemetryContext } from '../../telemetry'
+import type { LanguageModelMiddleware } from 'ai'
+
+type TelemetryMocks = TaskContext & {
+  mocks: {
+    telemetry: {
+      sdk: ReturnType<typeof vi.spyOn>
+      exporter: { spans: unknown[] }
+      processor: unknown
+    }
+  }
+}
+
+type WrapGenerateParams = Parameters<
+  NonNullable<LanguageModelMiddleware['wrapGenerate']>
+>[0]
+type WrapStreamParams = Parameters<
+  NonNullable<LanguageModelMiddleware['wrapStream']>
+>[0]
+
+describe('createTelemetryMiddleware', () => {
+  const mockContext = ROOT_CONTEXT as TelemetryContext
+  const providerName = 'openai'
+  const model = 'gpt-4o'
+
+  let mockSpanEnd: ReturnType<typeof vi.fn>
+  let mockSpanFail: ReturnType<typeof vi.fn>
+  let mockSpanContext: TelemetryContext
+  let mockCompletion: ReturnType<typeof vi.fn>
+
+  beforeEach((ctx: TelemetryMocks) => {
+    mockSpanContext = ROOT_CONTEXT as TelemetryContext
+    mockSpanEnd = vi.fn()
+    mockSpanFail = vi.fn()
+
+    const mockCompletionSpan = {
+      context: mockSpanContext,
+      end: mockSpanEnd,
+      fail: mockSpanFail,
+    }
+
+    mockCompletion = vi.fn(() => mockCompletionSpan)
+
+    const mockTelemetry = {
+      span: {
+        completion: mockCompletion,
+      },
+    }
+
+    ctx.mocks.telemetry.sdk.mockReturnValue(mockTelemetry)
+  })
+
+  describe('wrapGenerate', () => {
+    it('creates a completion span and calls doGenerate', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockResult = {
+        content: [{ type: 'text', text: 'Hello, world!' }],
+        usage: { inputTokens: 10, outputTokens: 5 },
+        finishReason: 'stop',
+      }
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      const params = {
+        prompt: [{ role: 'user', content: 'Hi' }],
+      }
+
+      const result = await middleware.wrapGenerate!({
+        doGenerate,
+        params,
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        {
+          provider: providerName,
+          model,
+          input: [{ role: 'user', content: 'Hi' }],
+          configuration: {
+            model,
+            prompt: [{ role: 'user', content: 'Hi' }],
+          },
+          promptUuid: undefined,
+          versionUuid: undefined,
+          experimentUuid: undefined,
+        },
+        mockContext,
+      )
+      expect(doGenerate).toHaveBeenCalled()
+      expect(mockSpanEnd).toHaveBeenCalledWith({
+        output: [{ role: 'assistant', content: [{ type: 'text', text: 'Hello, world!' }], toolCalls: [] }],
+        tokens: {
+          prompt: 10,
+          completion: 5,
+          cached: undefined,
+          reasoning: undefined,
+        },
+        finishReason: 'stop',
+      })
+      expect(result).toBe(mockResult)
+    })
+
+    it('passes optional uuids to completion span', async () => {
+      const promptUuid = 'prompt-123'
+      const versionUuid = 'version-456'
+      const experimentUuid = 'experiment-789'
+
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+        promptUuid,
+        versionUuid,
+        experimentUuid,
+      })
+
+      const mockResult = {
+        content: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+        finishReason: 'stop',
+      }
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      await middleware.wrapGenerate!({
+        doGenerate,
+        params: { prompt: [] },
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptUuid,
+          versionUuid,
+          experimentUuid,
+        }),
+        mockContext,
+      )
+    })
+
+    it('handles errors and fails the span', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const error = new Error('API Error')
+      const doGenerate = vi.fn().mockRejectedValue(error)
+
+      await expect(
+        middleware.wrapGenerate!({
+          doGenerate,
+          params: { prompt: [] },
+          model: {} as WrapGenerateParams['model'],
+        } as unknown as WrapGenerateParams),
+      ).rejects.toThrow('API Error')
+
+      expect(mockSpanFail).toHaveBeenCalledWith(error)
+      expect(mockSpanEnd).not.toHaveBeenCalled()
+    })
+
+    it('handles empty content in result', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockResult = {
+        content: [],
+        usage: { inputTokens: 5, outputTokens: 0 },
+        finishReason: 'stop',
+      }
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      await middleware.wrapGenerate!({
+        doGenerate,
+        params: { prompt: [] },
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(mockSpanEnd).toHaveBeenCalledWith({
+        output: [{ role: 'assistant', content: [], toolCalls: [] }],
+        tokens: {
+          prompt: 5,
+          completion: 0,
+          cached: undefined,
+          reasoning: undefined,
+        },
+        finishReason: 'stop',
+      })
+    })
+
+    it('handles non-array prompts', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockResult = {
+        content: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+        finishReason: 'stop',
+      }
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      await middleware.wrapGenerate!({
+        doGenerate,
+        params: { prompt: 'just a string' },
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: undefined,
+        }),
+        mockContext,
+      )
+    })
+
+    it('handles primitive values in prompt array', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockResult = {
+        content: [],
+        usage: { inputTokens: 0, outputTokens: 0 },
+        finishReason: 'stop',
+      }
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      await middleware.wrapGenerate!({
+        doGenerate,
+        params: { prompt: ['string message', 123, null] },
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [
+            { content: 'string message' },
+            { content: '123' },
+            { content: 'null' },
+          ],
+        }),
+        mockContext,
+      )
+    })
+
+    it('runs doGenerate within otel context', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockResult = {
+        content: [],
+        usage: {},
+        finishReason: 'stop',
+      }
+
+      const otelContextSpy = vi.spyOn(otelContext, 'with')
+      const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+      await middleware.wrapGenerate!({
+        doGenerate,
+        params: { prompt: [] },
+        model: {} as WrapGenerateParams['model'],
+      } as unknown as WrapGenerateParams)
+
+      expect(otelContextSpy).toHaveBeenCalledWith(
+        mockSpanContext,
+        expect.any(Function),
+      )
+    })
+  })
+
+  describe('wrapStream', () => {
+    function createMockStream(chunks: unknown[]) {
+      return new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) {
+            controller.enqueue(chunk)
+          }
+          controller.close()
+        },
+      })
+    }
+
+    async function consumeStream(stream: ReadableStream) {
+      const reader = stream.getReader()
+      const chunks: unknown[] = []
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        chunks.push(value)
+      }
+      return chunks
+    }
+
+    it('creates a completion span and streams response', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockChunks = [
+        { type: 'text-delta', delta: 'Hello, ' },
+        { type: 'text-delta', delta: 'world!' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 2 } },
+      ]
+
+      const mockStream = createMockStream(mockChunks)
+      const doStream = vi.fn().mockResolvedValue({ stream: mockStream })
+
+      const result = await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [{ role: 'user', content: 'Hi' }] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: providerName,
+          model,
+          input: [{ role: 'user', content: 'Hi' }],
+        }),
+        mockContext,
+      )
+
+      const consumedChunks = await consumeStream(result.stream)
+
+      // Wait a bit for the stream consumer callback to be invoked
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(consumedChunks).toEqual(mockChunks)
+      expect(mockSpanEnd).toHaveBeenCalledWith({
+        output: [{ role: 'assistant', content: [{ type: 'text', text: 'Hello, world!' }], toolCalls: [] }],
+        tokens: {
+          prompt: 10,
+          completion: 2,
+          cached: undefined,
+          reasoning: undefined,
+        },
+        finishReason: 'stop',
+      })
+    })
+
+    it('handles stream without text content', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockChunks = [
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 0 } },
+      ]
+
+      const mockStream = createMockStream(mockChunks)
+      const doStream = vi.fn().mockResolvedValue({ stream: mockStream })
+
+      const result = await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      await consumeStream(result.stream)
+
+      // Wait a bit for the stream consumer callback to be invoked
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(mockSpanEnd).toHaveBeenCalledWith({
+        output: [{ role: 'assistant', content: [], toolCalls: [] }],
+        tokens: {
+          prompt: 5,
+          completion: 0,
+          cached: undefined,
+          reasoning: undefined,
+        },
+        finishReason: 'stop',
+      })
+    })
+
+    it('defaults finishReason to unknown when not provided', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockChunks = [
+        { type: 'text-delta', delta: 'Hello' },
+      ]
+
+      const mockStream = createMockStream(mockChunks)
+      const doStream = vi.fn().mockResolvedValue({ stream: mockStream })
+
+      const result = await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      await consumeStream(result.stream)
+
+      // Wait a bit for the stream consumer callback to be invoked
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(mockSpanEnd).toHaveBeenCalledWith(
+        expect.objectContaining({
+          finishReason: 'unknown',
+        }),
+      )
+    })
+
+    it('handles errors during stream creation and fails the span', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const error = new Error('Stream Error')
+      const doStream = vi.fn().mockRejectedValue(error)
+
+      await expect(
+        middleware.wrapStream!({
+          doStream,
+          params: { prompt: [] },
+          model: {} as WrapStreamParams['model'],
+        } as unknown as WrapStreamParams),
+      ).rejects.toThrow('Stream Error')
+
+      expect(mockSpanFail).toHaveBeenCalledWith(error)
+      expect(mockSpanEnd).not.toHaveBeenCalled()
+    })
+
+    it('passes optional uuids to completion span for streams', async () => {
+      const promptUuid = 'prompt-123'
+      const versionUuid = 'version-456'
+      const experimentUuid = 'experiment-789'
+
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+        promptUuid,
+        versionUuid,
+        experimentUuid,
+      })
+
+      const mockStream = createMockStream([
+        { type: 'finish', finishReason: 'stop', usage: {} },
+      ])
+      const doStream = vi.fn().mockResolvedValue({ stream: mockStream })
+
+      const result = await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      await consumeStream(result.stream)
+
+      // Wait a bit for the stream consumer callback to be invoked
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      expect(mockCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptUuid,
+          versionUuid,
+          experimentUuid,
+        }),
+        mockContext,
+      )
+    })
+
+    it('runs doStream within otel context', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockStream = createMockStream([])
+      const doStream = vi.fn().mockResolvedValue({ stream: mockStream })
+
+      const otelContextSpy = vi.spyOn(otelContext, 'with')
+
+      await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      expect(otelContextSpy).toHaveBeenCalledWith(
+        mockSpanContext,
+        expect.any(Function),
+      )
+    })
+
+    it('preserves other properties from stream result', async () => {
+      const middleware = createTelemetryMiddleware({
+        context: mockContext,
+        providerName,
+        model,
+      })
+
+      const mockStream = createMockStream([])
+      const extraProp = { someData: 'value' }
+      const doStream = vi.fn().mockResolvedValue({
+        stream: mockStream,
+        extra: extraProp,
+      })
+
+      const result = await middleware.wrapStream!({
+        doStream,
+        params: { prompt: [] },
+        model: {} as WrapStreamParams['model'],
+      } as unknown as WrapStreamParams)
+
+      expect((result as unknown as { extra: typeof extraProp }).extra).toBe(extraProp)
+    })
+  })
+})
+
+describe('convertPromptToMessages (indirect)', () => {
+  const mockContext = ROOT_CONTEXT as TelemetryContext
+
+  let mockSpanEnd: ReturnType<typeof vi.fn>
+  let mockSpanFail: ReturnType<typeof vi.fn>
+  let mockCompletion: ReturnType<typeof vi.fn>
+
+  beforeEach((ctx: TelemetryMocks) => {
+    mockSpanEnd = vi.fn()
+    mockSpanFail = vi.fn()
+
+    const mockCompletionSpan = {
+      context: ROOT_CONTEXT as TelemetryContext,
+      end: mockSpanEnd,
+      fail: mockSpanFail,
+    }
+
+    mockCompletion = vi.fn(() => mockCompletionSpan)
+
+    const mockTelemetry = {
+      span: {
+        completion: mockCompletion,
+      },
+    }
+
+    ctx.mocks.telemetry.sdk.mockReturnValue(mockTelemetry)
+  })
+
+  it('converts object prompts to messages', async () => {
+    const middleware = createTelemetryMiddleware({
+      context: mockContext,
+      providerName: 'test',
+      model: 'test-model',
+    })
+
+    const mockResult = { content: [], usage: {}, finishReason: 'stop' }
+    const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+    const complexPrompt = [
+      { role: 'system', content: 'You are helpful' },
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ]
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: { prompt: complexPrompt },
+      model: {} as WrapGenerateParams['model'],
+    } as unknown as WrapGenerateParams)
+
+    expect(mockCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: complexPrompt,
+      }),
+      mockContext,
+    )
+  })
+})
+
+describe('extractTextFromContent (indirect)', () => {
+  const mockContext = ROOT_CONTEXT as TelemetryContext
+
+  let mockSpanEnd: ReturnType<typeof vi.fn>
+  let mockSpanFail: ReturnType<typeof vi.fn>
+  let mockCompletion: ReturnType<typeof vi.fn>
+
+  beforeEach((ctx: TelemetryMocks) => {
+    mockSpanEnd = vi.fn()
+    mockSpanFail = vi.fn()
+
+    const mockCompletionSpan = {
+      context: ROOT_CONTEXT as TelemetryContext,
+      end: mockSpanEnd,
+      fail: mockSpanFail,
+    }
+
+    mockCompletion = vi.fn(() => mockCompletionSpan)
+
+    const mockTelemetry = {
+      span: {
+        completion: mockCompletion,
+      },
+    }
+
+    ctx.mocks.telemetry.sdk.mockReturnValue(mockTelemetry)
+  })
+
+  it('extracts text from content array with text parts', async () => {
+    const middleware = createTelemetryMiddleware({
+      context: mockContext,
+      providerName: 'test',
+      model: 'test-model',
+    })
+
+    const mockResult = {
+      content: [
+        { type: 'text', text: 'Part 1 ' },
+        { type: 'text', text: 'Part 2' },
+      ],
+      usage: {},
+      finishReason: 'stop',
+    }
+    const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: { prompt: [] },
+      model: {} as WrapGenerateParams['model'],
+    } as unknown as WrapGenerateParams)
+
+    expect(mockSpanEnd).toHaveBeenCalledWith({
+      output: [{ role: 'assistant', content: [{ type: 'text', text: 'Part 1 Part 2' }], toolCalls: [] }],
+      tokens: {
+        cached: undefined,
+        completion: undefined,
+        prompt: undefined,
+        reasoning: undefined,
+      },
+      finishReason: 'stop',
+    })
+  })
+
+  it('handles non-text content parts', async () => {
+    const middleware = createTelemetryMiddleware({
+      context: mockContext,
+      providerName: 'test',
+      model: 'test-model',
+    })
+
+    const mockResult = {
+      content: [
+        { type: 'image', image: 'base64...' },
+        { type: 'text', text: 'With text' },
+      ],
+      usage: {},
+      finishReason: 'stop',
+    }
+    const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: { prompt: [] },
+      model: {} as WrapGenerateParams['model'],
+    } as unknown as WrapGenerateParams)
+
+    expect(mockSpanEnd).toHaveBeenCalledWith({
+      output: [{ role: 'assistant', content: [{ type: 'text', text: 'With text' }], toolCalls: [] }],
+      tokens: {
+        cached: undefined,
+        completion: undefined,
+        prompt: undefined,
+        reasoning: undefined,
+      },
+      finishReason: 'stop',
+    })
+  })
+
+  it('returns empty output for non-array content', async () => {
+    const middleware = createTelemetryMiddleware({
+      context: mockContext,
+      providerName: 'test',
+      model: 'test-model',
+    })
+
+    const mockResult = {
+      content: 'just a string',
+      usage: {},
+      finishReason: 'stop',
+    }
+    const doGenerate = vi.fn().mockResolvedValue(mockResult)
+
+    await middleware.wrapGenerate!({
+      doGenerate,
+      params: { prompt: [] },
+      model: {} as WrapGenerateParams['model'],
+    } as unknown as WrapGenerateParams)
+
+    expect(mockSpanEnd).toHaveBeenCalledWith({
+      output: [{ role: 'assistant', content: [], toolCalls: [] }],
+      tokens: {
+        cached: undefined,
+        completion: undefined,
+        prompt: undefined,
+        reasoning: undefined,
+      },
+      finishReason: 'stop',
+    })
+  })
+})

--- a/packages/core/src/services/ai/telemetryMiddleware.ts
+++ b/packages/core/src/services/ai/telemetryMiddleware.ts
@@ -1,0 +1,115 @@
+import type { LanguageModelMiddleware } from 'ai'
+import { context as otelContext } from '@opentelemetry/api'
+import { telemetry, TelemetryContext } from '../../telemetry'
+import {
+  createStreamConsumer,
+  buildOutputMessages,
+  extractGenerateResultContent,
+} from './streamConsumer'
+
+function convertPromptToMessages(
+  prompt: unknown,
+): Record<string, unknown>[] | undefined {
+  if (!Array.isArray(prompt)) return undefined
+
+  return prompt.map((item) => {
+    if (typeof item === 'object' && item !== null) {
+      return item as Record<string, unknown>
+    }
+    return { content: String(item) }
+  })
+}
+
+export function createTelemetryMiddleware(
+  { context, providerName, model, promptUuid, versionUuid, experimentUuid }: {
+    context: TelemetryContext
+    providerName: string
+    model: string
+    promptUuid?: string
+    versionUuid?: string
+    experimentUuid?: string
+  },
+): LanguageModelMiddleware {
+  return {
+    wrapGenerate: async ({ doGenerate, params }) => {
+      const inputMessages = convertPromptToMessages(params.prompt)
+
+      const $completion = telemetry.span.completion(
+        {
+          provider: providerName,
+          model,
+          input: inputMessages,
+          configuration: {
+            model,
+            ...((params as Record<string, unknown>) ?? {}),
+          },
+          promptUuid,
+          versionUuid,
+          experimentUuid,
+        },
+        context,
+      )
+
+      try {
+        // Run doGenerate within the completion span's context so HTTP spans become children
+        const result = await otelContext.with($completion.context, () => doGenerate())
+
+        const captured = extractGenerateResultContent(result)
+        const outputMessages = buildOutputMessages(captured)
+
+        $completion.end({
+          output: outputMessages,
+          tokens: captured.tokens,
+          finishReason: captured.finishReason,
+        })
+
+        return result
+      } catch (error) {
+        $completion.fail(error as Error)
+        throw error
+      }
+    },
+
+    wrapStream: async ({ doStream, params }) => {
+      const inputMessages = convertPromptToMessages(params.prompt)
+
+      const $completion = telemetry.span.completion(
+        {
+          provider: providerName,
+          model,
+          input: inputMessages,
+          configuration: {
+            model,
+            ...((params as Record<string, unknown>) ?? {}),
+          },
+          promptUuid,
+          versionUuid,
+          experimentUuid,
+        },
+        context,
+      )
+
+      try {
+        // Run doStream within the completion span's context so HTTP spans become children
+        const result = await otelContext.with($completion.context, () => doStream())
+
+        const wrappedStream = result.stream.pipeThrough(
+          createStreamConsumer((captured) => {
+            const outputMessages = buildOutputMessages(captured)
+
+            $completion.end({
+              output: outputMessages,
+              tokens: captured.tokens,
+              finishReason: captured.finishReason,
+            })
+          }),
+        )
+
+        return { ...result, stream: wrappedStream }
+      } catch (error) {
+        $completion.fail(error as Error)
+        throw error
+      }
+    },
+  }
+}

--- a/packages/core/src/services/documents/tools/resolve/agentsAsTools.ts
+++ b/packages/core/src/services/documents/tools/resolve/agentsAsTools.ts
@@ -48,8 +48,8 @@ export async function resolveAgentAsToolDefinition({
   toolManifest: ToolManifest<ToolSource.Agent>
   streamManager: StreamManager
 }): PromisedResult<Tool, LatitudeError> {
-  const { $completion, workspace, promptSource } = streamManager
-  const context = $completion!.context
+  const { $context, workspace, promptSource } = streamManager
+  const context = $context
 
   if (!('commit' in promptSource)) {
     return Result.error(

--- a/packages/core/src/services/documents/tools/resolve/clientTools.ts
+++ b/packages/core/src/services/documents/tools/resolve/clientTools.ts
@@ -82,7 +82,7 @@ export function resolveClientToolDefinition({
       ...toolManifest.definition,
       execute: instrumentToolHandler(awaitClientToolResult, {
         workspaceId: streamManager.workspace.id,
-        context: streamManager.$completion!.context,
+        context: streamManager.$context,
         toolManifest,
         toolName,
       }),
@@ -95,7 +95,7 @@ export function resolveClientToolDefinition({
       ...toolManifest.definition,
       execute: instrumentToolHandler(toolHandler, {
         workspaceId: streamManager.workspace.id,
-        context: streamManager.$completion!.context,
+        context: streamManager.$context,
         toolName,
         toolManifest,
       }),

--- a/packages/core/src/services/documents/tools/resolve/index.ts
+++ b/packages/core/src/services/documents/tools/resolve/index.ts
@@ -84,7 +84,7 @@ async function resolveToolDefinition({
   if (isSimulated) {
     return Result.ok(
       simulatedToolDefinition({
-        context: streamManager.$completion!.context,
+        context: streamManager.$context,
         toolName,
         toolManifest,
         simulationInstructions:

--- a/packages/core/src/services/documents/tools/resolve/integrationTools.ts
+++ b/packages/core/src/services/documents/tools/resolve/integrationTools.ts
@@ -39,7 +39,7 @@ export async function resolveIntegrationToolDefinition({
             arguments: args,
           },
         },
-        streamManager.$completion!.context,
+        streamManager.$context,
       )
 
       publisher.publishLater({

--- a/packages/core/src/services/documents/tools/resolve/latitudeTools.ts
+++ b/packages/core/src/services/documents/tools/resolve/latitudeTools.ts
@@ -27,7 +27,7 @@ export function resolveLatitudeToolDefinition({
     )
   }
 
-  const context = streamManager.$completion!.context
+  const context = streamManager.$context
   const definition = toolDefinition.definition(context)!
 
   return Result.ok({

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -172,6 +172,7 @@ import {
   Bell,
   CreditCardIcon,
   KeyRound,
+  MessageCircle,
 } from 'lucide-react'
 import { MouseEvent } from 'react'
 
@@ -355,6 +356,7 @@ const Icons = {
   mapPin: MapPin,
   maximize: Maximize2,
   mcp: MCP,
+  messageCircle: MessageCircle,
   minimize: Minimize2,
   mintlify: Mintlify,
   minus: MinusIcon,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -979,6 +979,9 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8
     devDependencies:
+      '@ai-sdk/provider':
+        specifier: 2.0.0
+        version: 2.0.0
       '@faker-js/faker':
         specifier: ^8.4.1
         version: 8.4.1
@@ -16277,7 +16280,7 @@ snapshots:
       '@azure/arm-appservice': 16.0.0
       '@azure/arm-resources': 6.1.0
       '@azure/identity': 4.12.0
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       chalk: 3.0.0
       fast-deep-equal: 3.1.3
     transitivePeerDependencies:
@@ -16319,7 +16322,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-deployment@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       simple-git: 3.16.0
@@ -16329,7 +16332,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-dora@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       simple-git: 3.16.0
@@ -16339,7 +16342,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-gate@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       '@types/uuid': 9.0.8
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
@@ -16391,7 +16394,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-sarif@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       axios: 1.12.2(debug@4.4.3)
@@ -16406,7 +16409,7 @@ snapshots:
 
   '@datadog/datadog-ci-plugin-sbom@3.21.4(@datadog/datadog-ci-base@3.21.4)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       axios: 1.12.2(debug@4.4.3)
@@ -16423,14 +16426,14 @@ snapshots:
       '@aws-sdk/client-cloudwatch-logs': 3.901.0
       '@aws-sdk/client-iam': 3.901.0
       '@aws-sdk/client-sfn': 3.901.0
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       deep-object-diff: 1.1.9
     transitivePeerDependencies:
       - aws-crt
 
   '@datadog/datadog-ci-plugin-synthetics@3.21.4(@datadog/datadog-ci-base@3.21.4)(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
     dependencies:
-      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@20.19.19)
+      '@datadog/datadog-ci-base': 3.21.4(@datadog/datadog-ci-plugin-aas@3.21.4)(@datadog/datadog-ci-plugin-cloud-run@3.21.4)(@datadog/datadog-ci-plugin-deployment@3.21.4)(@datadog/datadog-ci-plugin-dora@3.21.4)(@datadog/datadog-ci-plugin-gate@3.21.4)(@datadog/datadog-ci-plugin-lambda@3.21.4)(@datadog/datadog-ci-plugin-sarif@3.21.4)(@datadog/datadog-ci-plugin-sbom@3.21.4)(@datadog/datadog-ci-plugin-stepfunctions@3.21.4)(@datadog/datadog-ci-plugin-synthetics@3.21.4)(@types/node@22.18.8)
       axios: 1.12.2(debug@4.4.3)
       chalk: 3.0.0
       debug: 4.4.3


### PR DESCRIPTION
Now Completion spans generated in Latitude only contain the HTTP! 
Tool Calls are SIBLINGS to completions, not children!!!

An agent: first generates tool calls, them executes them, and finally generates another response!

<img width="1643" height="319" alt="image" src="https://github.com/user-attachments/assets/c495ba49-503e-469c-a01d-117322e88062" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes completion telemetry and stream handling.
> 
> - **Telemetry refactor**: Remove per-request `$completion` spans from `StreamManager`; add `CompletionTelemetryOptions` and wrap language models with `telemetryMiddleware` via `wrapLanguageModel`. HTTP calls now use the active OTEL context (`instrumentedFetch`). Tool calls are emitted as sibling spans, not children.
> - **Stream pipeline**: Pass `telemetryOptions` from `StreamManager` → `ai` → `getLanguageModel`. New `streamConsumer` captures text/reasoning/tool-calls/tokens from streams to finalize completion spans. Provider step APIs simplified (drop unused params).
> - **Tools resolution**: Replace `$completion.context` with `$context` across agent/client/integration/latitude tools.
> - **UI tweaks**: Conversation graph styling improvements (transition, collapsed state), change Completion icon to `pencilLine` and Tool icon to `wrench`; register new icon.
> - **Dependencies & tests**: Add `@ai-sdk/provider`; extensive tests for model selection, telemetry middleware, and stream consumer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03557e0960abe84fc45a4ec9aca19d42203ec52d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->