### PR TITLE
Fix error evaluation evaluated this log already

### DIFF
--- a/packages/core/src/services/evaluationsV2/run.ts
+++ b/packages/core/src/services/evaluationsV2/run.ts
@@ -62,7 +62,7 @@ export async function runEvaluationV2<
     evaluatedTraceId: span.traceId,
     evaluationUuid: evaluation.uuid,
   })
-  if (found) {
+  if (found && !dry) {
     return Result.error(
       new UnprocessableEntityError(
         'Cannot evaluate a log that is already evaluated for this evaluation',


### PR DESCRIPTION
We were seeing this error a lot in our exceptions. The hypothesis behind this fix is: 

If a user manually attaches an issueId to an already generated evaluation, we will start calculating its alignment daily using the daily alignment recalculation job. If this evaluation was running before attaching the issue, it might have evaluated a trace/span combo that a user annotated (non-dry run, saving it in the db). Therefore, when trying to calculate the alignment, its going to try to run the evaluation against those same spans (dry, but running them) that the user annotated, and the error will appear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> - In `run.ts`, only block re-evaluation if an existing result is found and `dry` is false (`found && !dry`). This enables dry-run re-evaluations without persisting or publishing.
> 
> **Tests**
> - Rename/clarify test to assert failure in non-dry mode and pass `dry: false` explicitly.
> - Add test verifying dry-run succeeds when a result already exists (alignment recalculation scenario) and does not publish events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 799745f567f173163e39122c2e6bd4166b203a27. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->