### PR TITLE
Improve production banner performance

### DIFF
--- a/apps/web/src/app/api/spans/has-production-spans/route.ts
+++ b/apps/web/src/app/api/spans/has-production-spans/route.ts
@@ -1,0 +1,28 @@
+import { authHandler } from '$/middlewares/authHandler'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { hasProductionTraces } from '@latitude-data/core/data-access/traces/hasProductionTraces'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+const searchParamsSchema = z.object({
+  projectId: z.coerce.number(),
+})
+
+export const GET = errorHandler(
+  authHandler(
+    async (request: NextRequest, { workspace }: { workspace: Workspace }) => {
+      const searchParams = request.nextUrl.searchParams
+      const { projectId } = searchParamsSchema.parse({
+        projectId: searchParams.get('projectId'),
+      })
+
+      const hasTraces = await hasProductionTraces({
+        workspaceId: workspace.id,
+        projectId,
+      })
+
+      return NextResponse.json({ hasProductionSpans: hasTraces }, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -305,6 +305,9 @@ export const API_ROUTES = {
     downloadSpans: {
       root: `/api/spans/download-spans`,
     },
+    hasProductionSpans: {
+      root: '/api/spans/has-production-spans',
+    },
   },
   workspaceFeatures: {
     root: '/api/workspaceFeatures',

--- a/packages/core/src/data-access/traces/hasProductionTraces.ts
+++ b/packages/core/src/data-access/traces/hasProductionTraces.ts
@@ -1,0 +1,33 @@
+import { and, eq, inArray, sql, SQL } from 'drizzle-orm'
+import { database } from '../../client'
+import { RUN_SOURCES, RunSourceGroup, SpanType } from '../../constants'
+import { spans } from '../../schema/models/spans'
+
+export async function hasProductionTraces(
+  {
+    workspaceId,
+    projectId,
+  }: {
+    workspaceId: number
+    projectId?: number
+  },
+  db = database,
+): Promise<boolean> {
+  const conditions: SQL<unknown>[] = [
+    eq(spans.workspaceId, workspaceId),
+    inArray(spans.type, [SpanType.Prompt, SpanType.External]),
+    inArray(spans.source, RUN_SOURCES[RunSourceGroup.Production]),
+  ]
+
+  if (projectId !== undefined) {
+    conditions.push(eq(spans.projectId, projectId))
+  }
+
+  const result = await db
+    .select({ exists: sql<number>`1` })
+    .from(spans)
+    .where(and(...conditions))
+    .limit(1)
+
+  return result.length > 0
+}


### PR DESCRIPTION
# What?
We were using a query that's too heavy to be on the sidebar. I replaced it with the same query we use on the weekly email to check if the project has traces in production

<img width="371" height="214" alt="image" src="https://github.com/user-attachments/assets/09c83114-de05-468a-9ea0-c5f357f553dd" />

<img width="594" height="147" alt="image" src="https://github.com/user-attachments/assets/1f48225a-8acd-4c04-8977-75e9a0948563" />
