### PR TITLE
Do not notify Latitude web app when a run start on foreground

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.0.8",
         "@anthropic-ai/sdk": "^0.32.1",
-        "@latitude-data/sdk": "5.2.1",
+        "@latitude-data/sdk": "5.3.1",
         "@pinecone-database/pinecone": "^6.0.1",
         "@vercel/otel": "^1.10.0",
         "ai": "^4.0.18",
@@ -574,11 +574,12 @@
       "license": "MIT"
     },
     "node_modules/@latitude-data/sdk": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@latitude-data/sdk/-/sdk-5.2.1.tgz",
-      "integrity": "sha512-GIUtjbllfix9Og0XRVpemozLO81U6RIdmrhLfhtvmT5F13nLALImQOuMjsoyTG+uN9FYZ6WJlqMwGcFbgf/Kew==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@latitude-data/sdk/-/sdk-5.3.1.tgz",
+      "integrity": "sha512-aNo/uyzrDVUAFImjnoJMwZgg/t4KD0cdJRzRUk2E4aWejwznTWU6jHflZa/WQAWRDscrDNV0xfa2JloRvpaR5w==",
       "license": "MIT",
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.34.0",
         "eventsource-parser": "^2.0.1",
         "node-fetch": "2.7.0",
         "promptl-ai": "^0.9.4",
@@ -586,6 +587,15 @@
       },
       "peerDependencies": {
         "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@latitude-data/sdk/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.34.0.tgz",
+      "integrity": "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@latitude-data/sdk/node_modules/zod": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.0.8",
     "@anthropic-ai/sdk": "^0.32.1",
-    "@latitude-data/sdk": "5.2.1",
+    "@latitude-data/sdk": "5.3.1",
     "@pinecone-database/pinecone": "^6.0.1",
     "@vercel/otel": "^1.10.0",
     "ai": "^4.0.18",

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -643,6 +643,7 @@ type DocumentRunStatusEventData = {
   documentUuid: string
   commitUuid: string
   run: ActiveRun
+  eventContext: 'foreground' | 'background'
   activeDeploymentTest?: DeploymentTest
   parameters?: Record<string, unknown>
   customIdentifier?: string | null

--- a/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.test.ts
+++ b/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { notifyClientOfRunStatusByDocument } from './notifyClientOfRunStatusByDocument'
+import { WebsocketClient } from '../../websockets/workers'
+import { LogSources } from '@latitude-data/constants'
+import { DocumentRunStatusEvent } from '../events'
+
+vi.mock('../../websockets/workers', () => ({
+  WebsocketClient: {
+    sendEvent: vi.fn(),
+  },
+}))
+
+describe('notifyClientOfRunStatusByDocument', () => {
+  const baseEventData = {
+    workspaceId: 1,
+    projectId: 2,
+    documentUuid: 'doc-uuid-123',
+    commitUuid: 'commit-uuid-456',
+    run: {
+      uuid: 'run-uuid-789',
+      queuedAt: new Date('2025-01-01T00:00:00Z'),
+      documentUuid: 'doc-uuid-123',
+      commitUuid: 'commit-uuid-456',
+      source: LogSources.API,
+    },
+    eventContext: 'background' as const,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should not send event when eventContext is foreground', async () => {
+    const event = {
+      type: 'documentRunQueued',
+      data: {
+        ...baseEventData,
+        eventContext: 'foreground' as const,
+      },
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).not.toHaveBeenCalled()
+  })
+
+  it('should send documentRunStatus event for documentRunQueued', async () => {
+    const event = {
+      type: 'documentRunQueued',
+      data: baseEventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: baseEventData.workspaceId,
+        data: {
+          event: 'documentRunQueued',
+          eventContext: 'background',
+          workspaceId: baseEventData.workspaceId,
+          projectId: baseEventData.projectId,
+          documentUuid: baseEventData.documentUuid,
+          commitUuid: baseEventData.commitUuid,
+          run: baseEventData.run,
+        },
+      },
+    )
+  })
+
+  it('should send documentRunStatus event for documentRunStarted', async () => {
+    const eventData = {
+      ...baseEventData,
+      run: {
+        ...baseEventData.run,
+        startedAt: new Date('2025-01-01T00:00:01Z'),
+      },
+    }
+    const event = {
+      type: 'documentRunStarted',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunStarted',
+          eventContext: 'background',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+        },
+      },
+    )
+  })
+
+  it('should send documentRunStatus event for documentRunProgress', async () => {
+    const eventData = {
+      ...baseEventData,
+      run: {
+        ...baseEventData.run,
+        startedAt: new Date('2025-01-01T00:00:01Z'),
+        caption: 'Processing...',
+      },
+    }
+    const event = {
+      type: 'documentRunProgress',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunProgress',
+          eventContext: 'background',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+        },
+      },
+    )
+  })
+
+  it('should send documentRunStatus event for documentRunEnded', async () => {
+    const eventData = {
+      ...baseEventData,
+      run: {
+        ...baseEventData.run,
+        startedAt: new Date('2025-01-01T00:00:01Z'),
+        caption: 'Completed',
+      },
+    }
+    const event = {
+      type: 'documentRunEnded',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunEnded',
+          eventContext: 'background',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+        },
+      },
+    )
+  })
+
+  it('should include optional fields when present', async () => {
+    const eventData = {
+      ...baseEventData,
+      parameters: { key: 'value' },
+      customIdentifier: 'custom-id',
+      tools: ['tool1', 'tool2'],
+      userMessage: 'Hello',
+    }
+    const event = {
+      type: 'documentRunQueued',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunQueued',
+          eventContext: 'background',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+        },
+      },
+    )
+  })
+})

--- a/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.ts
+++ b/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.ts
@@ -10,7 +10,16 @@ export const notifyClientOfRunStatusByDocument = async ({
 }: {
   data: DocumentRunStatusEvent
 }) => {
-  const { workspaceId, projectId, documentUuid, commitUuid, run } = event.data
+  const {
+    workspaceId,
+    projectId,
+    documentUuid,
+    commitUuid,
+    run,
+    eventContext,
+  } = event.data
+
+  if (eventContext === 'foreground') return
 
   await WebsocketClient.sendEvent('documentRunStatus', {
     workspaceId,
@@ -21,6 +30,7 @@ export const notifyClientOfRunStatusByDocument = async ({
       documentUuid,
       commitUuid,
       run,
+      eventContext,
     },
   })
 }

--- a/packages/core/src/services/commits/foregroundRun.ts
+++ b/packages/core/src/services/commits/foregroundRun.ts
@@ -78,6 +78,7 @@ export async function runForegroundDocument(
   await publisher.publishLater({
     type: 'documentRunStarted',
     data: {
+      eventContext: 'foreground',
       workspaceId: workspace.id,
       projectId: project.id,
       documentUuid: document.documentUuid,

--- a/packages/core/src/services/runs/end.ts
+++ b/packages/core/src/services/runs/end.ts
@@ -27,7 +27,14 @@ export async function endRun({
 
   await publisher.publishLater({
     type: 'documentRunEnded',
-    data: { projectId, workspaceId, documentUuid, commitUuid, run },
+    data: {
+      projectId,
+      workspaceId,
+      documentUuid,
+      commitUuid,
+      run,
+      eventContext: 'background',
+    },
   })
 
   return deleteResult

--- a/packages/core/src/services/runs/enqueue.test.ts
+++ b/packages/core/src/services/runs/enqueue.test.ts
@@ -378,6 +378,7 @@ describe('enqueueRun', () => {
           workspaceId: mockWorkspace.id,
           documentUuid: mockDocument.documentUuid,
           commitUuid: mockCommit.uuid,
+          eventContext: 'background',
         },
       })
     })

--- a/packages/core/src/services/runs/enqueue.ts
+++ b/packages/core/src/services/runs/enqueue.ts
@@ -118,6 +118,7 @@ export async function enqueueRun({
   await publisher.publishLater({
     type: 'documentRunQueued',
     data: {
+      eventContext: 'background',
       projectId: project.id,
       workspaceId: workspace.id,
       documentUuid: document.documentUuid,

--- a/packages/core/src/services/runs/start.ts
+++ b/packages/core/src/services/runs/start.ts
@@ -40,6 +40,7 @@ export async function startRun({
   await publisher.publishLater({
     type: 'documentRunStarted',
     data: {
+      eventContext: 'background',
       projectId,
       workspaceId,
       documentUuid,

--- a/packages/core/src/services/runs/update.ts
+++ b/packages/core/src/services/runs/update.ts
@@ -32,7 +32,14 @@ export async function updateRun({
 
   await publisher.publishLater({
     type: 'documentRunProgress',
-    data: { projectId, workspaceId, documentUuid, commitUuid, run },
+    data: {
+      projectId,
+      workspaceId,
+      documentUuid,
+      commitUuid,
+      run,
+      eventContext: 'background',
+    },
   })
 
   return updateResult


### PR DESCRIPTION
# What?
We are emiting the same event in foreground and background `documentRunStarted` and our UI start showing active runs row in traces section but is not an active run. Active runs only happen when run is run in backgroud