### PR TITLE
Improve traces page re-renders

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ActiveRuns/ActiveRunRow/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ActiveRuns/ActiveRunRow/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { use, useEffect, useMemo, useState } from 'react'
+import { memo, use, useEffect, useMemo, useState } from 'react'
 import { ActiveRun } from '@latitude-data/constants'
 import { TableCell, TableRow } from '@latitude-data/web-ui/atoms/Table'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
@@ -8,10 +8,14 @@ import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 import { cn } from '@latitude-data/web-ui/utils'
 import { formatDuration } from '$/app/_lib/formatUtils'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
-import { TraceSpanSelectionContext } from '../../TraceSpanSelectionContext'
+import { TraceSpanSelectionActionsContext } from '../../TraceSpanSelectionContext'
 
-export function ActiveRunRow({ run }: { run: ActiveRun }) {
-  const { onClickTraceRow } = use(TraceSpanSelectionContext)
+export const ActiveRunRow = memo(function ActiveRunRow({
+  run,
+}: {
+  run: ActiveRun
+}) {
+  const { onClickTraceRow } = use(TraceSpanSelectionActionsContext)
   const [duration, setDuration] = useState<number>(0)
 
   const message = useMemo(() => {
@@ -79,4 +83,4 @@ export function ActiveRunRow({ run }: { run: ActiveRun }) {
       </TableCell>
     </TableRow>
   )
-}
+})

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationTimeline.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationTimeline.tsx
@@ -7,7 +7,10 @@ import { AssembledSpan, AssembledTrace } from '@latitude-data/core/constants'
 import { useConversation } from '$/stores/conversations'
 import { use, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TimelineScale } from '$/components/tracing/traces/Timeline/Scale'
-import { TraceSpanSelectionContext } from './TraceSpanSelectionContext'
+import {
+  TraceSpanSelectionActionsContext,
+  TraceSpanSelectionStateContext,
+} from './TraceSpanSelectionContext'
 import { ConversationTree } from './ConversationTree'
 import { ConversationGraph } from './ConversationGraph'
 
@@ -81,7 +84,8 @@ function findSpanByIdInTraces(
 }
 
 function UnifiedTimeline({ traces }: { traces: AssembledTrace[] }) {
-  const { selection, selectSpan } = use(TraceSpanSelectionContext)
+  const { selection } = use(TraceSpanSelectionStateContext)
+  const { selectSpan } = use(TraceSpanSelectionActionsContext)
   const selectedSpan = findSpanByIdInTraces(traces, selection.spanId)
   const treeRef = useRef<HTMLDivElement>(null)
   const [treeWidth, setTreeWidth] = useState(0)

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/DocumentTraces.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/DocumentTraces.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from '@latitude-data/web-ui/atoms/Table'
-import { TraceSpanSelectionContext } from './TraceSpanSelectionContext'
+import { TraceSpanSelectionStateContext } from './TraceSpanSelectionContext'
 import { SpanRow } from './SpanRow'
 import { ActiveRunRow } from './ActiveRuns/ActiveRunRow'
 import { SimpleKeysetTablePaginationFooter } from '$/components/TablePaginationFooter/SimpleKeysetTablePaginationFooter'
@@ -16,11 +16,13 @@ import { useCurrentCommit } from '$/app/providers/CommitProvider'
 import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
 import { useSpansKeysetPaginationStore } from '$/stores/spansKeysetPagination'
-import { ActiveRun, PromptSpan } from '@latitude-data/constants'
+import { ActiveRun, EvaluationResultV2, PromptSpan } from '@latitude-data/constants'
 import { type SelectableRowsHook } from '$/hooks/useSelectableRows'
 import { Checkbox } from '@latitude-data/web-ui/atoms/Checkbox'
 import { useEvaluationResultsV2ByTraces } from '$/stores/evaluationResultsV2'
 import { useSpanCreatedListener } from './useSpanCreatedListener'
+
+const EMPTY_EVALUATION_RESULTS: EvaluationResultV2[] = []
 
 export function DocumentTraces({
   ref,
@@ -33,7 +35,7 @@ export function DocumentTraces({
   selectableState: SelectableRowsHook
   ref?: Ref<HTMLTableElement>
 }) {
-  const { selection } = use(TraceSpanSelectionContext)
+  const { selection } = use(TraceSpanSelectionStateContext)
   const { project } = useCurrentProject()
   const { commit } = useCurrentCommit()
   const { document } = useCurrentDocument()
@@ -91,13 +93,15 @@ export function DocumentTraces({
             key={span.id}
             span={span as PromptSpan}
             toggleRow={selectableState.toggleRow}
-            isSelected={selectableState.isSelected}
+            isRowSelected={selectableState.isSelected(span.id)}
             isExpanded={
               selection.documentLogUuid !== null &&
               (selection.documentLogUuid === span.documentLogUuid ||
                 selection.expandedDocumentLogUuid === span.documentLogUuid)
             }
-            evaluationResults={evaluationResultsByTraceId[span.traceId] || []}
+            evaluationResults={
+              evaluationResultsByTraceId[span.traceId] ?? EMPTY_EVALUATION_RESULTS
+            }
             isEvaluationResultsLoading={isEvaluationResultsLoading}
           />
         ))}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/DocumentTracesPage.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/DocumentTracesPage.tsx
@@ -24,7 +24,7 @@ import { SpanFilters } from './Filters'
 import { SelectionTracesBanner } from './SelectionTracesBanner'
 import { TracePanel } from './TracePanel'
 import { TracesOverTime } from './TracesOverTime'
-import { TraceSpanSelectionContext } from './TraceSpanSelectionContext'
+import { TraceSpanSelectionActionsContext } from './TraceSpanSelectionContext'
 import { useTraceSelection } from './useTraceSelection'
 
 export function DocumentTracesPage({
@@ -34,7 +34,7 @@ export function DocumentTracesPage({
   initialSpans: Span[]
   initialSpanFilterOptions: SpansFilters
 }) {
-  const { clearSelection } = use(TraceSpanSelectionContext)
+  const { clearSelection } = use(TraceSpanSelectionActionsContext)
   const panelContainerRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLTableElement>(null)
   const { document } = useCurrentDocument()

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/SpanRow.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/SpanRow.tsx
@@ -6,11 +6,11 @@ import { EvaluationResultV2, PromptSpan } from '@latitude-data/constants'
 import { TableCell, TableRow } from '@latitude-data/web-ui/atoms/Table'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { cn } from '@latitude-data/web-ui/utils'
-import { Fragment, use, useMemo } from 'react'
+import { Fragment, memo, useContext, useMemo } from 'react'
 import { ConversationTimeline } from './ConversationTimeline'
-import { TraceSpanSelectionContext } from './TraceSpanSelectionContext'
-import { useCommits } from '$/stores/commitsStore'
+import { TraceSpanSelectionActionsContext } from './TraceSpanSelectionContext'
 import { useSelectableRows } from '$/hooks/useSelectableRows'
+import { useCommits } from '$/stores/commitsStore'
 import { Checkbox } from '@latitude-data/web-ui/atoms/Checkbox'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
 import { useEvaluationsV2 } from '$/stores/evaluationsV2'
@@ -24,10 +24,10 @@ import { Badge } from '@latitude-data/web-ui/atoms/Badge'
 type SpanRowProps = {
   span: PromptSpan
   toggleRow: ReturnType<typeof useSelectableRows>['toggleRow']
-  isSelected: ReturnType<typeof useSelectableRows>['isSelected']
+  isRowSelected: boolean
   isExpanded: boolean
-  evaluationResults?: EvaluationResultV2[]
-  isEvaluationResultsLoading?: boolean
+  evaluationResults: EvaluationResultV2[]
+  isEvaluationResultsLoading: boolean
 }
 
 function EvaluationsColumn({
@@ -95,15 +95,15 @@ function EvaluationsColumn({
   )
 }
 
-export function SpanRow({
+export const SpanRow = memo(function SpanRow({
   span,
   toggleRow,
-  isSelected,
+  isRowSelected,
   isExpanded,
-  evaluationResults = [],
-  isEvaluationResultsLoading = false,
+  evaluationResults,
+  isEvaluationResultsLoading,
 }: SpanRowProps) {
-  const { onClickTraceRow } = use(TraceSpanSelectionContext)
+  const { onClickTraceRow } = useContext(TraceSpanSelectionActionsContext)
   const { data: commits } = useCommits()
   const commit = commits?.find((c) => c.uuid === span.commitUuid)
   const hasError = span.status === 'error'
@@ -128,10 +128,10 @@ export function SpanRow({
           preventDefault
           align='left'
           onClick={() => {
-            toggleRow(span.id, !isSelected(span.id))
+            toggleRow(span.id, !isRowSelected)
           }}
         >
-          <Checkbox fullWidth={false} checked={isSelected(span.id)} />
+          <Checkbox fullWidth={false} checked={isRowSelected} />
         </TableCell>
         <TableCell>
           <Text.H5 noWrap color={textColor}>
@@ -175,4 +175,4 @@ export function SpanRow({
       )}
     </Fragment>
   )
-}
+})

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/useTraceSelection.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/useTraceSelection.ts
@@ -1,9 +1,9 @@
 import { use, useMemo } from 'react'
-import { TraceSpanSelectionContext } from './TraceSpanSelectionContext'
+import { TraceSpanSelectionStateContext } from './TraceSpanSelectionContext'
 import { ActiveRun } from '@latitude-data/constants'
 
 export function useTraceSelection(activeRuns: ActiveRun[] = []) {
-  const { selection } = use(TraceSpanSelectionContext)
+  const { selection } = use(TraceSpanSelectionStateContext)
 
   return useMemo(() => {
     const anySelection =

--- a/apps/web/src/app/providers/CommitProvider.tsx
+++ b/apps/web/src/app/providers/CommitProvider.tsx
@@ -29,8 +29,10 @@ const CommitProvider = ({
     return commits?.find((c) => c.uuid === serverCommit.uuid) ?? serverCommit
   }, [commits, serverCommit])
 
+  const contextValue = useMemo(() => ({ commit, isHead }), [commit, isHead])
+
   return (
-    <CommitContext.Provider value={{ commit, isHead }}>
+    <CommitContext.Provider value={contextValue}>
       {children}
     </CommitContext.Provider>
   )

--- a/apps/web/src/app/providers/DocumentProvider.tsx
+++ b/apps/web/src/app/providers/DocumentProvider.tsx
@@ -33,13 +33,16 @@ const DocumentVersionProvider = ({
     [documents, fallbackDocument],
   )
 
+  const contextValue = useMemo(
+    () => ({
+      mutateDocumentUpdated,
+      document: document ?? fallbackDocument,
+    }),
+    [mutateDocumentUpdated, document, fallbackDocument],
+  )
+
   return (
-    <DocumentContext.Provider
-      value={{
-        mutateDocumentUpdated,
-        document: document ?? fallbackDocument,
-      }}
-    >
+    <DocumentContext.Provider value={contextValue}>
       {children}
     </DocumentContext.Provider>
   )

--- a/apps/web/src/app/providers/ProjectProvider.tsx
+++ b/apps/web/src/app/providers/ProjectProvider.tsx
@@ -24,8 +24,10 @@ const ProjectProvider = ({
     return projects?.find((p) => p.id === serverProject.id) ?? serverProject
   }, [projects, serverProject])
 
+  const contextValue = useMemo(() => ({ project }), [project])
+
   return (
-    <ProjectContext.Provider value={{ project }}>
+    <ProjectContext.Provider value={contextValue}>
       {children}
     </ProjectContext.Provider>
   )

--- a/apps/web/src/hooks/useCurrentUrl.ts
+++ b/apps/web/src/hooks/useCurrentUrl.ts
@@ -3,6 +3,13 @@
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useMemo } from 'react'
 
+/**
+ * Be aware that this is a client-side only hook.
+ * It react to url changes and can provoke re-renders.
+ *
+ * If you have performance issues, consider using a static url instead.
+ * window.location.href or similar.
+ */
 export function useCurrentUrl({ full }: { full?: boolean } = {}) {
   const pathname = usePathname()
   const searchParams = useSearchParams()

--- a/apps/web/src/hooks/useFetcher.ts
+++ b/apps/web/src/hooks/useFetcher.ts
@@ -1,7 +1,6 @@
 import { ROUTES } from '$/services/routes'
 import { useToast } from '@latitude-data/web-ui/atoms/Toast'
 import { useCallback } from 'react'
-import { useCurrentUrl } from './useCurrentUrl'
 import { useNavigate } from './useNavigate'
 
 type ISearchParams =
@@ -177,10 +176,11 @@ export default function useFetcher<
 ) {
   const { toast } = useToast()
   const navigate = useNavigate()
-  const currentUrl = useCurrentUrl()
 
   return useCallback(async () => {
     if (!route) return fallback as R
+
+    const currentUrl = window.location.href
 
     const response = await executeFetch<R, I, Raw>({
       route,
@@ -201,7 +201,6 @@ export default function useFetcher<
     onFail,
     onSuccess,
     navigate,
-    currentUrl,
     fallback,
   ])
 }

--- a/apps/web/src/stores/commitsStore.ts
+++ b/apps/web/src/stores/commitsStore.ts
@@ -13,7 +13,7 @@ import { CommitStatus } from '@latitude-data/core/constants'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
 import { setCommitMainDocumentAction } from '$/actions/commits/setCommitMainDocumentAction'
 import { useEvents } from '$/lib/events'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 type CommitOptions = SWRConfiguration & {
   onSuccessCreate?: (commit: Commit) => void
@@ -59,7 +59,9 @@ export function useCommitsFromProject(
   const {
     data = [],
     mutate,
-    ...rest
+    error,
+    isLoading,
+    isValidating,
   } = useSWR<Commit[]>(['commits', projectId, commitStatus], fetcher, opts)
 
   const { execute: createDraft, isPending: isCreating } = useLatitudeAction(
@@ -161,17 +163,36 @@ export function useCommitsFromProject(
     },
   })
 
-  return {
-    data: data ?? [],
-    mutate,
-    ...rest,
-    createDraft,
-    isCreating,
-    destroyDraft,
-    isDestroying,
-    publishDraft,
-    isPublishing,
-    setCommitMainDocument,
-    isSettingMainDocument,
-  }
+  return useMemo(
+    () => ({
+      data: data ?? [],
+      mutate,
+      error,
+      isLoading,
+      isValidating,
+      createDraft,
+      isCreating,
+      destroyDraft,
+      isDestroying,
+      publishDraft,
+      isPublishing,
+      setCommitMainDocument,
+      isSettingMainDocument,
+    }),
+    [
+      data,
+      mutate,
+      error,
+      isLoading,
+      isValidating,
+      createDraft,
+      isCreating,
+      destroyDraft,
+      isDestroying,
+      publishDraft,
+      isPublishing,
+      setCommitMainDocument,
+      isSettingMainDocument,
+    ],
+  )
 }

--- a/apps/web/src/stores/evaluationResultsV2/byTraces.ts
+++ b/apps/web/src/stores/evaluationResultsV2/byTraces.ts
@@ -41,7 +41,13 @@ export default function useEvaluationResultsV2ByTraces(
   }, [traceIds, project.id, commit.uuid, document?.documentUuid])
 
   const fetcher = useFetcher<EvaluationResultV2[]>(`${route}?${query}`)
-  const { data = [], ...rest } = useSWR<EvaluationResultV2[]>(
+  const {
+    data = [],
+    mutate,
+    error,
+    isLoading,
+    isValidating,
+  } = useSWR<EvaluationResultV2[]>(
     disabled
       ? null
       : compact(['evaluationResultsV2ByTraces', ...traceIds, query]),
@@ -55,9 +61,15 @@ export default function useEvaluationResultsV2ByTraces(
     [data],
   )
 
-  return {
-    data,
-    dataByTraceId,
-    ...rest,
-  }
+  return useMemo(
+    () => ({
+      data,
+      dataByTraceId,
+      mutate,
+      error,
+      isLoading,
+      isValidating,
+    }),
+    [data, dataByTraceId, mutate, error, isLoading, isValidating],
+  )
 }


### PR DESCRIPTION
Try to find places where we could improve performance of traces table. Sometimes clicking on rows freeze the page. Looking at the task manager on Chrome dev tools I can see over time memory continully increase also when an active run is running cpu spikes which makes sense but maybe are things to improve. Overall i think we have some kind of memory leak but was not able to find some clear culprit

# Re-renders
The main culprit of the re-renders was [useFetcher](https://github.com/latitude-dev/latitude-llm/blob/main/apps/web/src/hooks/useFetcher.ts#L180) using [useCurrentUrl](https://github.com/latitude-dev/latitude-llm/blob/main/apps/web/src/hooks/useCurrentUrl.ts#L8) that was making the fetcher function change all the time. Use fetcher is used in `useCommits` which is used in [spanRow.tsx](https://github.com/latitude-dev/latitude-llm/blob/main/apps/web/src/app/(private)/projects/%5BprojectId%5D/versions/%5BcommitUuid%5D/documents/%5BdocumentUuid%5D/(withTabs)/traces/_components/SpanRow.tsx) so all the rows changed all the time. 

### Before 

https://github.com/user-attachments/assets/47642a21-58b7-43de-a53d-f36e621471c9



### After 

https://github.com/user-attachments/assets/24d45bc7-a2cd-4864-b6af-75c9114fd6a0


# Other changes
1. I split traces context in 2. Actions and State. The reason is to avoid re-rendering the rows because only use the actions in the context.
2. Replaced `useSearchParams` reactive nextjs hook and `useRouter` by simply intializing the traces with the URL state once. From there the updates are state -> URL. URL is changed in a way now that do not provoke a re-render. We just want to change the URL and push this new URL into the browser history. 
3. Wrap with `memo` main trace row component

# Memory leak
Not sure these changes are fixing the memory leak. But at least are improving the way the table is re-rendered when clicking on the rows
