### PR TITLE
Fix: redirect to outdated commit when entering a project

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/page.tsx
@@ -22,6 +22,19 @@ export type ProjectPageParams = {
   params: Promise<{ projectId: string }>
 }
 
+async function getLastSeenDataFromCookie(projectId: string) {
+  const cookieStore = await cookies()
+  const data = cookieStore.get(lastSeenCommitCookieName(Number(projectId)))
+  if (!data?.value) return {}
+
+  try {
+    const { commitUuid, documentUuid } = JSON.parse(data.value)
+    return { commitUuid, documentUuid }
+  } catch (_) {
+    return { commitUuid: data.value as string }
+  }
+}
+
 export default async function ProjectPage({ params }: ProjectPageParams) {
   const { projectId } = await params
   const { commitUuid: lastSeenCommitUuid, documentUuid: lastSeenDocumentUuid } =
@@ -40,6 +53,7 @@ export default async function ProjectPage({ params }: ProjectPageParams) {
     const commits = await findCommitsByProjectCached({
       projectId: project.id,
     })
+
     url = getRedirectUrl({
       commits,
       projectId: project.id,
@@ -56,17 +70,4 @@ export default async function ProjectPage({ params }: ProjectPageParams) {
   }
 
   return redirect(url)
-}
-
-async function getLastSeenDataFromCookie(projectId: string) {
-  const cookieStore = await cookies()
-  const data = cookieStore.get(lastSeenCommitCookieName(Number(projectId)))
-  if (!data?.value) return {}
-
-  try {
-    const { commitUuid, documentUuid } = JSON.parse(data.value)
-    return { commitUuid, documentUuid }
-  } catch (_) {
-    return { commitUuid: data.value as string }
-  }
 }


### PR DESCRIPTION
By default, when entering a project we always redirect to the last commit the user has visited.
If that commit has been merged, then you would still get redirected to it, meaning that you will see an outdated version.

Fix: This change will now redirect to Live if whatever last version you visited has been merged since.