### PR TITLE
fix: link evaluation to issue when discovered from result

### DIFF
--- a/packages/core/src/jobs/job-definitions/issues/discoverResultIssueJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/issues/discoverResultIssueJob.test.ts
@@ -16,6 +16,7 @@ import * as factories from '../../../tests/factories'
 import * as discoverIssueModule from '../../../services/issues/discover'
 import * as generateIssueModule from '../../../services/issues/generate'
 import * as assignModule from '../../../services/evaluationsV2/results/assign'
+import * as updateEvaluationModule from '../../../services/evaluationsV2/update'
 import { publisher } from '../../../events/publisher'
 import {
   discoverResultIssueJob,
@@ -46,6 +47,10 @@ const generateIssueSpy = vi.spyOn(generateIssueModule, 'generateIssue')
 const assignResultSpy = vi.spyOn(
   assignModule,
   'assignEvaluationResultV2ToIssue',
+)
+const updateEvaluationSpy = vi.spyOn(
+  updateEvaluationModule,
+  'updateEvaluationV2',
 )
 
 describe('discoverResultIssueJob', () => {
@@ -233,6 +238,16 @@ describe('discoverResultIssueJob', () => {
           create: undefined,
         }),
       )
+      expect(updateEvaluationSpy).toHaveBeenCalledTimes(1)
+      expect(updateEvaluationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          evaluation: expect.objectContaining({
+            uuid: evaluation.uuid,
+          }),
+          issueId: existingIssue.id,
+          force: true,
+        }),
+      )
       expect(publisher.publishLater).not.toHaveBeenCalled()
     })
 
@@ -323,6 +338,16 @@ describe('discoverResultIssueJob', () => {
             title: newIssueData.title,
             description: newIssueData.description,
           }),
+        }),
+      )
+      expect(updateEvaluationSpy).toHaveBeenCalledTimes(1)
+      expect(updateEvaluationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          evaluation: expect.objectContaining({
+            uuid: evaluation.uuid,
+          }),
+          issueId: createdIssue.id,
+          force: true,
         }),
       )
       expect(publisher.publishLater).toHaveBeenCalledWith({

--- a/packages/core/src/jobs/job-definitions/issues/discoverResultIssueJob.ts
+++ b/packages/core/src/jobs/job-definitions/issues/discoverResultIssueJob.ts
@@ -14,6 +14,7 @@ import {
   SpansRepository,
 } from '../../../repositories'
 import { assignEvaluationResultV2ToIssue } from '../../../services/evaluationsV2/results/assign'
+import { updateEvaluationV2 } from '../../../services/evaluationsV2/update'
 import { discoverIssue } from '../../../services/issues/discover'
 import { generateIssue } from '../../../services/issues/generate'
 import { captureException } from '../../../utils/datadogCapture'
@@ -142,6 +143,20 @@ export const discoverResultIssueJob = async (
       : undefined,
     workspace: workspace,
   }).then((r) => r.unwrap())
+
+  if (!evaluation.issueId && updatedIssue) {
+    const updating = await updateEvaluationV2({
+      evaluation,
+      commit,
+      workspace,
+      issueId: updatedIssue.id,
+      force: true,
+    })
+
+    if (updating.error) {
+      captureException(updating.error)
+    }
+  }
 
   if (newIssue) {
     await publisher.publishLater({


### PR DESCRIPTION
When a new issue is discovered or generated from an evaluation result, the evaluation itself was not being linked to the issue. This meant that while the result was associated with the issue, the configuration (EvaluationV2) remained unlinked.

This fix ensures that `updateEvaluationV2` is called to set the `issueId` on the evaluation when it is first associated with an issue.

- Update `discoverResultIssueJob` to call `updateEvaluationV2`
- Add tests to verify `updateEvaluationV2` is called