### PR TITLE
fix: traces page crash when searching by conversation ID

### DIFF
--- a/apps/web/src/app/api/spans/limited/route.ts
+++ b/apps/web/src/app/api/spans/limited/route.ts
@@ -62,13 +62,15 @@ export const GET = errorHandler(
       const spansRepository = new SpansRepository(workspace.id)
 
       if (filters.documentLogUuid) {
-        const spansRepository = new SpansRepository(workspace.id)
         const spans = await spansRepository.listByDocumentLogUuid(
           filters.documentLogUuid,
         )
+        const filteredItems = spans.filter(
+          (span) => span.type === SpanType.Prompt,
+        )
         spansResult = {
-          items: spans.filter((span) => span.type === SpanType.Prompt),
-          count: spans.length,
+          items: filteredItems,
+          count: filteredItems.length,
           next: null,
         }
       } else {

--- a/apps/web/src/stores/spansKeysetPagination/usePaginationMode.ts
+++ b/apps/web/src/stores/spansKeysetPagination/usePaginationMode.ts
@@ -92,6 +92,10 @@ export function usePaginationMode(
     if (!params.realtime) reset()
   }, [params.realtime, reset])
 
+  useEffect(() => {
+    reset()
+  }, [filtersKey, reset])
+
   return useMemo(
     () => ({
       data,


### PR DESCRIPTION
- Fix count mismatch bug where count showed total spans but items only had filtered Prompt spans, causing UI inconsistencies
- Reset pagination cursor when filters change to prevent using stale cursor from previous filter state
- Remove unnecessary variable shadowing of spansRepository