### PR TITLE
feat: add backup polling for experiments when realtime updates are unreliable

### DIFF
--- a/apps/web/src/helpers/experimentPolling.ts
+++ b/apps/web/src/helpers/experimentPolling.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+
+export const POLLING_INTERVAL_MS = 5000
+
+type ExperimentLike = {
+  startedAt?: Date | string | null
+  finishedAt?: Date | string | null
+}
+
+/**
+ * Checks if any experiments in the list are currently running
+ */
+export function hasRunningExperiments<T extends ExperimentLike>(
+  experiments: (T | undefined)[],
+): boolean {
+  return experiments.some((exp) => exp && exp.startedAt && !exp.finishedAt)
+}
+
+/**
+ * React hook that returns a refresh interval function for SWR polling
+ * Polls every POLLING_INTERVAL_MS when experiments are running, otherwise pauses
+ */
+export function useExperimentPolling<T extends ExperimentLike>() {
+  return useCallback((latestData: T[] | undefined) => {
+    if (!latestData) return 0
+    return hasRunningExperiments(latestData) ? POLLING_INTERVAL_MS : 0
+  }, [])
+}

--- a/apps/web/src/stores/experimentComparison.ts
+++ b/apps/web/src/stores/experimentComparison.ts
@@ -2,26 +2,19 @@ import { ROUTES } from '$/services/routes'
 import useFetcher from '$/hooks/useFetcher'
 import useSWR, { SWRConfiguration } from 'swr'
 import { useEvaluationsV2 } from './evaluationsV2'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   EventArgs,
   useSockets,
 } from '$/components/Providers/WebsocketsProvider/useSockets'
 import { ExperimentWithScores } from '@latitude-data/core/schema/models/types/Experiment'
 import { EvaluationV2 } from '@latitude-data/core/constants'
+import { useExperimentPolling } from '$/helpers/experimentPolling'
 
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
 import { Project } from '@latitude-data/core/schema/models/types/Project'
 const EMPTY_ARRAY: [] = []
-
-const POLLING_INTERVAL_MS = 5000
-
-function hasRunningExperiments(
-  experiments: (ExperimentWithScores | undefined)[],
-): boolean {
-  return experiments.some((exp) => exp && exp.startedAt && !exp.finishedAt)
-}
 
 export type BestLogsMetadata = {
   cost: string[]
@@ -150,13 +143,7 @@ export function useExperimentComparison(
       : undefined,
   )
 
-  const refreshIntervalFn = useCallback(
-    (latestData: ExperimentWithScores[] | undefined) => {
-      if (!latestData) return 0
-      return hasRunningExperiments(latestData) ? POLLING_INTERVAL_MS : 0
-    },
-    [],
-  )
+  const refreshIntervalFn = useExperimentPolling<ExperimentWithScores>()
 
   const { data = undefined, isLoading } = useSWR<ExperimentWithScores[]>(
     [

--- a/apps/web/src/stores/experiments.ts
+++ b/apps/web/src/stores/experiments.ts
@@ -3,18 +3,13 @@ import useFetcher from '$/hooks/useFetcher'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 import { ROUTES } from '$/services/routes'
 import { toast } from '@latitude-data/web-ui/atoms/Toast'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import useSWR, { SWRConfiguration } from 'swr'
 import { ExperimentDto } from '@latitude-data/core/schema/models/types/Experiment'
+import { useExperimentPolling } from '$/helpers/experimentPolling'
 
 import { Experiment } from '@latitude-data/core/schema/models/types/Experiment'
 const EMPTY_ARRAY: [] = []
-
-const POLLING_INTERVAL_MS = 5000
-
-function hasRunningExperiments(experiments: ExperimentDto[]): boolean {
-  return experiments.some((exp) => exp.startedAt && !exp.finishedAt)
-}
 
 export function useExperiments(
   {
@@ -45,13 +40,7 @@ export function useExperiments(
       .experiments.count,
   )
 
-  const refreshIntervalFn = useCallback(
-    (latestData: ExperimentDto[] | undefined) => {
-      if (!latestData) return 0
-      return hasRunningExperiments(latestData) ? POLLING_INTERVAL_MS : 0
-    },
-    [],
-  )
+  const refreshIntervalFn = useExperimentPolling<ExperimentDto>()
 
   const {
     data = EMPTY_ARRAY,


### PR DESCRIPTION
WebSocket notifications can be unreliable - messages might be lost or connections might drop temporarily. This caused issues where experiment progress showed stale data (e.g., 0/5 for 1:20 minutes when the experiment had actually finished in 50s).

This change adds automatic backup polling via SWR's refreshInterval when there are running experiments. The polling:
- Activates only when experiments are in a running state (startedAt && !finishedAt)
- Polls every 5 seconds to fetch fresh data from the server
- Automatically stops when all experiments finish
- Works alongside WebSocket updates for redundancy

The polling ensures the frontend state eventually becomes consistent with the backend state, even if WebSocket events are missed.

https://claude.ai/code/session_01VdDnNasCZCufvUadv48h7S