### PR TITLE
Fix root spans to aggregate tokens and cost from all completion children

### DIFF
--- a/packages/core/src/services/tracing/traces/assemble.test.ts
+++ b/packages/core/src/services/tracing/traces/assemble.test.ts
@@ -3,12 +3,12 @@ import {
   SpanType,
   SpanStatus,
   CompletionSpanMetadata,
+  AssembledSpan,
 } from '../../../constants'
 import * as factories from '../../../tests/factories'
 import { Workspace } from '../../../schema/models/types/Workspace'
 import { assembleTraceStructure, assembleTraceWithMessages } from './assemble'
 import { SpanMetadatasRepository } from '../../../repositories'
-import { Result } from '../../../lib/Result'
 
 let workspace: Workspace
 
@@ -276,8 +276,8 @@ describe('assembleTraceWithMessages', () => {
       configuration: {},
     } as unknown as CompletionSpanMetadata
 
-    vi.spyOn(SpanMetadatasRepository.prototype, 'get').mockResolvedValue(
-      Result.ok(mockMetadata),
+    vi.spyOn(SpanMetadatasRepository.prototype, 'getBatch').mockResolvedValue(
+      new Map([['trace-with-metadata:completion-span-id', mockMetadata]]),
     )
 
     const startTime = new Date()
@@ -289,7 +289,7 @@ describe('assembleTraceWithMessages', () => {
       startedAt: startTime,
     })
 
-    await factories.createSpan({
+    const completionSpan = await factories.createSpan({
       workspaceId: workspace.id,
       traceId: 'trace-with-metadata',
       parentId: promptSpan.id,
@@ -297,6 +297,10 @@ describe('assembleTraceWithMessages', () => {
       name: 'completion',
       startedAt: new Date(startTime.getTime() + 100),
     })
+
+    vi.spyOn(SpanMetadatasRepository.prototype, 'getBatch').mockResolvedValue(
+      new Map([[`trace-with-metadata:${completionSpan.id}`, mockMetadata]]),
+    )
 
     const result = await assembleTraceWithMessages({
       traceId: 'trace-with-metadata',
@@ -312,6 +316,272 @@ describe('assembleTraceWithMessages', () => {
     expect(result.value?.completionSpan?.metadata?.output).toEqual([
       { role: 'assistant', content: [{ type: 'text', text: 'Hi there!' }] },
     ])
+  })
+
+  it('attaches metadata to ALL completion spans for proper aggregation', async () => {
+    const startTime = new Date()
+    const promptSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-multi-completion',
+      type: SpanType.Prompt,
+      name: 'prompt',
+      startedAt: startTime,
+      duration: 3000,
+    })
+
+    const completion1 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-multi-completion',
+      parentId: promptSpan.id,
+      type: SpanType.Completion,
+      name: 'completion-1',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 500,
+    })
+
+    const completion2 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-multi-completion',
+      parentId: promptSpan.id,
+      type: SpanType.Completion,
+      name: 'completion-2',
+      startedAt: new Date(startTime.getTime() + 700),
+      duration: 500,
+    })
+
+    const completion3 = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-multi-completion',
+      parentId: promptSpan.id,
+      type: SpanType.Completion,
+      name: 'completion-3',
+      startedAt: new Date(startTime.getTime() + 1300),
+      duration: 500,
+    })
+
+    const mockMetadata1: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+      tokens: { prompt: 100, completion: 50, cached: 0, reasoning: 0 },
+      cost: 0.001,
+    } as unknown as CompletionSpanMetadata
+
+    const mockMetadata2: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+      tokens: { prompt: 200, completion: 100, cached: 10, reasoning: 0 },
+      cost: 0.002,
+    } as unknown as CompletionSpanMetadata
+
+    const mockMetadata3: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+      tokens: { prompt: 150, completion: 75, cached: 5, reasoning: 25 },
+      cost: 0.0015,
+    } as unknown as CompletionSpanMetadata
+
+    vi.spyOn(SpanMetadatasRepository.prototype, 'getBatch').mockResolvedValue(
+      new Map([
+        [`trace-multi-completion:${completion1.id}`, mockMetadata1],
+        [`trace-multi-completion:${completion2.id}`, mockMetadata2],
+        [`trace-multi-completion:${completion3.id}`, mockMetadata3],
+      ]),
+    )
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-multi-completion',
+      workspace,
+      spanId: promptSpan.id,
+    })
+
+    expect(result.ok).toBe(true)
+    const trace = result.value?.trace
+    expect(trace).toBeDefined()
+
+    const rootSpan = trace!.children[0]
+    expect(rootSpan?.children).toHaveLength(3)
+
+    const allCompletionSpans = rootSpan!.children
+    expect(allCompletionSpans[0]?.metadata).toBeDefined()
+    expect(allCompletionSpans[1]?.metadata).toBeDefined()
+    expect(allCompletionSpans[2]?.metadata).toBeDefined()
+
+    const meta0 = allCompletionSpans[0]?.metadata as CompletionSpanMetadata
+    const meta1 = allCompletionSpans[1]?.metadata as CompletionSpanMetadata
+    const meta2 = allCompletionSpans[2]?.metadata as CompletionSpanMetadata
+
+    expect(meta0.tokens?.prompt).toBe(100)
+    expect(meta1.tokens?.prompt).toBe(200)
+    expect(meta2.tokens?.prompt).toBe(150)
+
+    const totalPromptTokens =
+      (meta0.tokens?.prompt ?? 0) +
+      (meta1.tokens?.prompt ?? 0) +
+      (meta2.tokens?.prompt ?? 0)
+    const totalCompletionTokens =
+      (meta0.tokens?.completion ?? 0) +
+      (meta1.tokens?.completion ?? 0) +
+      (meta2.tokens?.completion ?? 0)
+    const totalCost =
+      (meta0.cost ?? 0) + (meta1.cost ?? 0) + (meta2.cost ?? 0)
+
+    expect(totalPromptTokens).toBe(450)
+    expect(totalCompletionTokens).toBe(225)
+    expect(totalCost).toBeCloseTo(0.0045)
+  })
+
+  it('attaches metadata to nested completion spans across subagents', async () => {
+    const startTime = new Date()
+
+    const mainPrompt = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      type: SpanType.Prompt,
+      name: 'main-prompt',
+      startedAt: startTime,
+      duration: 5000,
+    })
+
+    const mainCompletion = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      parentId: mainPrompt.id,
+      type: SpanType.Completion,
+      name: 'main-completion',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 1000,
+    })
+
+    const toolSpan = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      parentId: mainPrompt.id,
+      type: SpanType.Tool,
+      name: 'tool-call',
+      startedAt: new Date(startTime.getTime() + 1200),
+      duration: 2000,
+    })
+
+    const subagentPrompt = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      parentId: toolSpan.id,
+      type: SpanType.Prompt,
+      name: 'subagent-prompt',
+      startedAt: new Date(startTime.getTime() + 1300),
+      duration: 1500,
+    })
+
+    const subagentCompletion = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      parentId: subagentPrompt.id,
+      type: SpanType.Completion,
+      name: 'subagent-completion',
+      startedAt: new Date(startTime.getTime() + 1400),
+      duration: 800,
+    })
+
+    const finalCompletion = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-nested',
+      parentId: mainPrompt.id,
+      type: SpanType.Completion,
+      name: 'final-completion',
+      startedAt: new Date(startTime.getTime() + 3500),
+      duration: 500,
+    })
+
+    const mainMeta: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+      tokens: { prompt: 500, completion: 200, cached: 0, reasoning: 0 },
+      cost: 0.01,
+    } as unknown as CompletionSpanMetadata
+
+    const subagentMeta: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'anthropic',
+      model: 'claude-3',
+      configuration: {},
+      tokens: { prompt: 300, completion: 150, cached: 50, reasoning: 100 },
+      cost: 0.008,
+    } as unknown as CompletionSpanMetadata
+
+    const finalMeta: CompletionSpanMetadata = {
+      input: [],
+      output: [],
+      provider: 'openai',
+      model: 'gpt-4',
+      configuration: {},
+      tokens: { prompt: 600, completion: 250, cached: 0, reasoning: 0 },
+      cost: 0.012,
+    } as unknown as CompletionSpanMetadata
+
+    vi.spyOn(SpanMetadatasRepository.prototype, 'getBatch').mockResolvedValue(
+      new Map([
+        [`trace-nested:${mainCompletion.id}`, mainMeta],
+        [`trace-nested:${subagentCompletion.id}`, subagentMeta],
+        [`trace-nested:${finalCompletion.id}`, finalMeta],
+      ]),
+    )
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-nested',
+      workspace,
+      spanId: mainPrompt.id,
+    })
+
+    expect(result.ok).toBe(true)
+
+    function findAllCompletions(spans: AssembledSpan[]): AssembledSpan[] {
+      const completions: AssembledSpan[] = []
+      for (const span of spans) {
+        if (span.type === SpanType.Completion) {
+          completions.push(span)
+        }
+        if (span.children?.length) {
+          completions.push(...findAllCompletions(span.children))
+        }
+      }
+      return completions
+    }
+
+    const allCompletions = findAllCompletions(result.value!.trace.children)
+    expect(allCompletions).toHaveLength(3)
+
+    for (const span of allCompletions) {
+      expect(span.metadata).toBeDefined()
+      expect((span.metadata as CompletionSpanMetadata).tokens).toBeDefined()
+      expect((span.metadata as CompletionSpanMetadata).cost).toBeDefined()
+    }
+
+    const totalCost = allCompletions.reduce(
+      (sum, span) => sum + ((span.metadata as CompletionSpanMetadata).cost ?? 0),
+      0,
+    )
+    expect(totalCost).toBeCloseTo(0.03)
+
+    const totalPromptTokens = allCompletions.reduce(
+      (sum, span) =>
+        sum +
+        ((span.metadata as CompletionSpanMetadata).tokens?.prompt ?? 0),
+      0,
+    )
+    expect(totalPromptTokens).toBe(1400)
   })
 })
 


### PR DESCRIPTION
## Summary
Root spans were displaying incorrect token counts and costs in the UI. Instead of showing the aggregate of all completion child spans, they only showed values from the last completion span.

The trace assembly logic now fetches metadata for all completion spans in parallel and attaches it to each span in the trace tree. This enables frontend components to properly aggregate tokens and costs across all completions, including nested subagent scenarios.