### PR TITLE
Filter out inactive issues from vector DB search results before reranking

### DIFF
--- a/packages/constants/src/issues/constants.ts
+++ b/packages/constants/src/issues/constants.ts
@@ -102,7 +102,8 @@ export const ISSUE_DISCOVERY_SEARCH_RATIO = 0.75 // 75% vector search, 25% keywo
 export const ISSUE_DISCOVERY_MIN_SIMILARITY = 0.8 // 80% similarity (broader score)
 export const ISSUE_DISCOVERY_MIN_KEYWORDS = 1 // At least 1 keyword match
 export const ISSUE_DISCOVERY_MIN_RELEVANCE = 0.3 // 30% relevance (narrower score)
-export const ISSUE_DISCOVERY_MAX_CANDIDATES = 20
+export const ISSUE_DISCOVERY_MAX_CANDIDATES = 1000 // Large pool to allow filtering merged issues
+export const ISSUE_DISCOVERY_RERANK_LIMIT = 20 // Max candidates to send to reranker after filtering
 
 export const ISSUE_GENERATION_RECENCY_RATIO = 0.8 // 80% more recent, 20% long-tail
 export const ISSUE_GENERATION_RECENCY_DAYS = 7

--- a/packages/core/src/services/issues/discover.test.ts
+++ b/packages/core/src/services/issues/discover.test.ts
@@ -1,9 +1,13 @@
 import { env } from '@latitude-data/env'
+import { eq } from 'drizzle-orm'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { database } from '../../client'
 import { SpanType } from '../../constants'
+import { issues } from '../../schema/models/issues'
 import { createEvaluationResultV2 } from '../../tests/factories/evaluationResultsV2'
 import { createEvaluationV2 } from '../../tests/factories/evaluationsV2'
+import { createIssue } from '../../tests/factories/issues'
 import { createProject } from '../../tests/factories/projects'
 import { createSpan } from '../../tests/factories/spans'
 import { createWorkspace } from '../../tests/factories/workspaces'
@@ -382,6 +386,278 @@ describe('discoverIssue', () => {
       const { embedding, issue } = discovering.unwrap()
       expect(embedding).toBeDefined()
       expect(issue).toBeUndefined()
+    })
+  })
+
+  describe('Merged issue filtering', () => {
+    it('filters out merged issues from candidates', async () => {
+      const { workspace } = await createWorkspace({ features: ['issues'] })
+      const projectResult = await createProject({
+        workspace,
+        documents: {
+          'test-prompt': 'This is a test prompt',
+        },
+      })
+      const { project, commit, documents } = projectResult
+      const document = documents[0]!
+
+      const activeIssue = await createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      const mergedIssue = await createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await database
+        .update(issues)
+        .set({ mergedAt: new Date(), mergedToIssueId: activeIssue.issue.id })
+        .where(eq(issues.id, mergedIssue.issue.id))
+
+      const evaluation = await createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await createSpan({
+        workspaceId: workspace.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await createEvaluationResultV2({
+        evaluation,
+        span,
+        commit,
+        workspace,
+        hasPassed: false,
+      })
+
+      const mockEmbedding = Array(2048).fill(0.1)
+      vi.spyOn(sharedModule, 'embedReason').mockResolvedValue({
+        ok: true,
+        value: mockEmbedding,
+        unwrap: () => mockEmbedding,
+      } as any)
+
+      const mockHybrid = vi.fn().mockResolvedValue({
+        objects: [
+          {
+            uuid: mergedIssue.issue.uuid,
+            properties: {
+              title: 'Merged Issue',
+              description: 'This issue is merged',
+            },
+            metadata: { score: 0.99 },
+          },
+          {
+            uuid: activeIssue.issue.uuid,
+            properties: {
+              title: 'Active Issue',
+              description: 'This issue is active',
+            },
+            metadata: { score: 0.95 },
+          },
+        ],
+      })
+
+      const mockCollection = {
+        query: {
+          hybrid: mockHybrid,
+        },
+      }
+
+      vi.spyOn(weaviate, 'getIssuesCollection').mockResolvedValue(
+        mockCollection as any,
+      )
+
+      const discovering = await discoverIssue({
+        result: { result, evaluation },
+        document,
+        project,
+      })
+
+      expect(discovering.error).toBeFalsy()
+      const { issue } = discovering.unwrap()
+      expect(issue).toBeDefined()
+      expect(issue!.uuid).toBe(activeIssue.issue.uuid)
+    })
+
+    it('still matches ignored issues (ignore does not prevent matching)', async () => {
+      const { workspace } = await createWorkspace({ features: ['issues'] })
+      const projectResult = await createProject({
+        workspace,
+        documents: {
+          'test-prompt': 'This is a test prompt',
+        },
+      })
+      const { project, commit, documents } = projectResult
+      const document = documents[0]!
+
+      const ignoredIssue = await createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await database
+        .update(issues)
+        .set({ ignoredAt: new Date() })
+        .where(eq(issues.id, ignoredIssue.issue.id))
+
+      const evaluation = await createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await createSpan({
+        workspaceId: workspace.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await createEvaluationResultV2({
+        evaluation,
+        span,
+        commit,
+        workspace,
+        hasPassed: false,
+      })
+
+      const mockEmbedding = Array(2048).fill(0.1)
+      vi.spyOn(sharedModule, 'embedReason').mockResolvedValue({
+        ok: true,
+        value: mockEmbedding,
+        unwrap: () => mockEmbedding,
+      } as any)
+
+      const mockHybrid = vi.fn().mockResolvedValue({
+        objects: [
+          {
+            uuid: ignoredIssue.issue.uuid,
+            properties: {
+              title: 'Ignored Issue',
+              description: 'This issue is ignored but should still match',
+            },
+            metadata: { score: 0.95 },
+          },
+        ],
+      })
+
+      const mockCollection = {
+        query: {
+          hybrid: mockHybrid,
+        },
+      }
+
+      vi.spyOn(weaviate, 'getIssuesCollection').mockResolvedValue(
+        mockCollection as any,
+      )
+
+      const discovering = await discoverIssue({
+        result: { result, evaluation },
+        document,
+        project,
+      })
+
+      expect(discovering.error).toBeFalsy()
+      const { issue } = discovering.unwrap()
+      expect(issue).toBeDefined()
+      expect(issue!.uuid).toBe(ignoredIssue.issue.uuid)
+    })
+
+    it('still matches resolved issues (for regression detection)', async () => {
+      const { workspace } = await createWorkspace({ features: ['issues'] })
+      const projectResult = await createProject({
+        workspace,
+        documents: {
+          'test-prompt': 'This is a test prompt',
+        },
+      })
+      const { project, commit, documents } = projectResult
+      const document = documents[0]!
+
+      const resolvedIssue = await createIssue({
+        workspace,
+        project,
+        document,
+      })
+
+      await database
+        .update(issues)
+        .set({ resolvedAt: new Date() })
+        .where(eq(issues.id, resolvedIssue.issue.id))
+
+      const evaluation = await createEvaluationV2({
+        document,
+        commit,
+        workspace,
+      })
+
+      const span = await createSpan({
+        workspaceId: workspace.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+      })
+
+      const result = await createEvaluationResultV2({
+        evaluation,
+        span,
+        commit,
+        workspace,
+        hasPassed: false,
+      })
+
+      const mockEmbedding = Array(2048).fill(0.1)
+      vi.spyOn(sharedModule, 'embedReason').mockResolvedValue({
+        ok: true,
+        value: mockEmbedding,
+        unwrap: () => mockEmbedding,
+      } as any)
+
+      const mockHybrid = vi.fn().mockResolvedValue({
+        objects: [
+          {
+            uuid: resolvedIssue.issue.uuid,
+            properties: {
+              title: 'Resolved Issue',
+              description:
+                'This issue is resolved but should still match for regression',
+            },
+            metadata: { score: 0.95 },
+          },
+        ],
+      })
+
+      const mockCollection = {
+        query: {
+          hybrid: mockHybrid,
+        },
+      }
+
+      vi.spyOn(weaviate, 'getIssuesCollection').mockResolvedValue(
+        mockCollection as any,
+      )
+
+      const discovering = await discoverIssue({
+        result: { result, evaluation },
+        document,
+        project,
+      })
+
+      expect(discovering.error).toBeFalsy()
+      const { issue } = discovering.unwrap()
+      expect(issue).toBeDefined()
+      expect(issue!.uuid).toBe(resolvedIssue.issue.uuid)
     })
   })
 })


### PR DESCRIPTION


## Summary
Issue discovery was limited to 20 candidates from the vector database, but inactive issues (ignored, merged, resolved) were consuming slots in those results. This could cause valid active issues to be excluded from discovery when many inactive issues existed.

The vector search limit is now increased to 1000 to fetch a larger candidate pool, and candidates are filtered against PostgreSQL to exclude inactive issues before limiting to 20 for reranking. This ensures that only active issues compete for the limited reranking slots.