### PR TITLE
Add new running status to tool messages in message list

### DIFF
--- a/apps/web/src/components/ChatWrapper/Message/AssistantMessage.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/AssistantMessage.tsx
@@ -11,6 +11,7 @@ export function AssistantMessage({
   parameters,
   toolContentMap,
   isGeneratingToolCall,
+  isStreaming = false,
 }: Omit<MessageProps, 'debugMode' | 'role'>) {
   return (
     <div
@@ -30,6 +31,7 @@ export function AssistantMessage({
         parameters={parameters}
         debugMode={false}
         markdownSize='md'
+        isStreaming={isStreaming}
       />
       {isGeneratingToolCall && <ToolCardSkeleton />}
     </div>

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall.tsx
@@ -12,6 +12,7 @@ import { AgentToolCard } from './ToolCall/Agent'
 import { ProviderToolCard } from './ToolCall/Provider'
 import { LatitudeToolCard } from './ToolCall/LatitudeTool'
 import { ClientToolCard } from './ToolCall/Client'
+import { ToolCallStatus } from './ToolCall/_components/ToolCard'
 
 export function ToolCallMessageContent({
   toolRequest,
@@ -19,23 +20,25 @@ export function ToolCallMessageContent({
   debugMode,
   messageIndex,
   contentBlockIndex,
+  isStreaming = false,
 }: {
   toolRequest: ToolRequestContent
   toolContentMap?: Record<string, ToolContent>
   debugMode?: boolean
   messageIndex?: number
   contentBlockIndex?: number
+  isStreaming?: boolean
 }) {
   const toolResponse = useMemo(
     () => toolContentMap?.[toolRequest.toolCallId],
     [toolContentMap, toolRequest.toolCallId],
   )
   const sourceData = useMemo(() => toolRequest._sourceData, [toolRequest])
-  const status = useMemo(() => {
-    if (!toolResponse) return 'pending'
+  const status: ToolCallStatus = useMemo(() => {
+    if (!toolResponse) return isStreaming ? 'running' : 'waiting'
     if (toolResponse.isError) return 'error'
     return 'success'
-  }, [toolResponse])
+  }, [toolResponse, isStreaming])
 
   if (sourceData?.source === ToolSource.Latitude) {
     return (

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Agent.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Agent.tsx
@@ -6,7 +6,12 @@ import {
   ToolSource,
   ToolSourceData,
 } from '@latitude-data/constants/toolSources'
-import { ToolCard, ToolCardIcon, ToolCardText } from './_components/ToolCard'
+import {
+  ToolCard,
+  ToolCardIcon,
+  ToolCardText,
+  ToolCallStatus,
+} from './_components/ToolCard'
 
 export function AgentToolCard({
   toolRequest,
@@ -18,7 +23,7 @@ export function AgentToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   sourceData: ToolSourceData<ToolSource.Agent>
   messageIndex?: number
   contentBlockIndex?: number
@@ -31,6 +36,7 @@ export function AgentToolCard({
       headerLabel={<ToolCardText>{sourceData.agentPath}</ToolCardText>}
       messageIndex={messageIndex}
       contentBlockIndex={contentBlockIndex}
+      status={status}
     />
   )
 }

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Client.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Client.tsx
@@ -6,6 +6,7 @@ import {
   ToolCardIcon,
   ToolCardText,
   ToolCardWrapper,
+  ToolCallStatus,
 } from './_components/ToolCard'
 import {
   KeyboardEventHandler,
@@ -127,14 +128,15 @@ export function ClientToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   messageIndex?: number
   contentBlockIndex?: number
 }) {
   const [_isOpen, setIsOpen] = useState(false)
+  const isPendingStatus = status === 'running' || status === 'waiting'
   const isOpen = useMemo(
-    () => status === 'pending' || _isOpen,
-    [_isOpen, status],
+    () => isPendingStatus || _isOpen,
+    [_isOpen, isPendingStatus],
   )
 
   return (
@@ -148,7 +150,7 @@ export function ClientToolCard({
         status={status}
         isOpen={isOpen}
         simulated={toolRequest._sourceData?.simulated}
-        onToggle={status === 'pending' ? undefined : () => setIsOpen(!isOpen)}
+        onToggle={isPendingStatus ? undefined : () => setIsOpen(!isOpen)}
       />
 
       {isOpen && (
@@ -159,7 +161,7 @@ export function ClientToolCard({
         </ToolCardContentWrapper>
       )}
       {isOpen &&
-        (status === 'pending' || !toolResponse ? (
+        (isPendingStatus || !toolResponse ? (
           <UnansweredClientToolContent
             toolCallId={toolRequest.toolCallId}
             simulated={toolRequest._sourceData?.simulated}

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Generic.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Generic.tsx
@@ -2,7 +2,12 @@ import {
   ToolRequestContent,
   ToolContent,
 } from '@latitude-data/constants/legacyCompiler'
-import { ToolCard, ToolCardIcon, ToolCardText } from './_components/ToolCard'
+import {
+  ToolCard,
+  ToolCardIcon,
+  ToolCardText,
+  ToolCallStatus,
+} from './_components/ToolCard'
 
 export function GenericToolCard({
   toolRequest,
@@ -13,7 +18,7 @@ export function GenericToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   messageIndex?: number
   contentBlockIndex?: number
 }) {
@@ -25,6 +30,7 @@ export function GenericToolCard({
       headerLabel={<ToolCardText>{toolRequest.toolName}</ToolCardText>}
       messageIndex={messageIndex}
       contentBlockIndex={contentBlockIndex}
+      status={status}
     />
   )
 }

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Integration.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Integration.tsx
@@ -7,7 +7,12 @@ import {
   ToolSource,
   ToolSourceData,
 } from '@latitude-data/constants/toolSources'
-import { ToolCard, ToolCardIcon, ToolCardText } from './_components/ToolCard'
+import {
+  ToolCard,
+  ToolCardIcon,
+  ToolCardText,
+  ToolCallStatus,
+} from './_components/ToolCard'
 import useIntegrations from '$/stores/integrations'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
 import { Badge } from '@latitude-data/web-ui/atoms/Badge'
@@ -24,7 +29,7 @@ export function IntegrationToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   sourceData: ToolSourceData<ToolSource.Integration>
   messageIndex?: number
   contentBlockIndex?: number
@@ -74,6 +79,7 @@ export function IntegrationToolCard({
       }
       messageIndex={messageIndex}
       contentBlockIndex={contentBlockIndex}
+      status={status}
     />
   )
 }

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTool.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTool.tsx
@@ -6,7 +6,12 @@ import {
   ToolSource,
   ToolSourceData,
 } from '@latitude-data/constants/toolSources'
-import { ToolCard, ToolCardIcon, ToolCardText } from './_components/ToolCard'
+import {
+  ToolCard,
+  ToolCardIcon,
+  ToolCardText,
+  ToolCallStatus,
+} from './_components/ToolCard'
 import { LatitudeTool } from '@latitude-data/constants'
 import { WebSearchLatitudeToolCard } from './LatitudeTools/Search'
 import { WebExtractLatitudeToolCard } from './LatitudeTools/Extract'
@@ -26,14 +31,13 @@ export function LatitudeToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   sourceData: ToolSourceData<ToolSource.Latitude>
   debugMode?: boolean
   messageIndex?: number
   contentBlockIndex?: number
 }) {
   if (debugMode) {
-    // No custom UI
     return (
       <ToolCard
         toolRequest={toolRequest}
@@ -47,6 +51,7 @@ export function LatitudeToolCard({
         headerLabel={<ToolCardText>{toolRequest.toolName}</ToolCardText>}
         messageIndex={messageIndex}
         contentBlockIndex={contentBlockIndex}
+        status={status}
       />
     )
   }
@@ -116,6 +121,7 @@ export function LatitudeToolCard({
       headerLabel={<ToolCardText>{toolRequest.toolName}</ToolCardText>}
       messageIndex={messageIndex}
       contentBlockIndex={contentBlockIndex}
+      status={status}
     />
   )
 }

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Code.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Code.tsx
@@ -9,14 +9,14 @@ import {
   ToolCardIcon,
   ToolCardText,
   ToolCardWrapper,
+  ToolCallStatus,
 } from '../_components/ToolCard'
 import { ToolCardHeader } from '../_components/ToolCard/Header'
 import {
   ToolCardContentWrapper,
   ToolCardOutput,
+  ToolCardPendingState,
 } from '../_components/ToolCard/Content'
-import { Icon } from '@latitude-data/web-ui/atoms/Icons'
-import { Text } from '@latitude-data/web-ui/atoms/Text'
 
 const isExpectedOutput = (toolResponse: ToolContent | undefined) => {
   // Returns false if the tool response does not contain the expected output
@@ -30,9 +30,11 @@ const isExpectedOutput = (toolResponse: ToolContent | undefined) => {
 function RunCodeOutput({
   toolResponse,
   simulated,
+  status,
 }: {
   toolResponse: ToolContent | undefined
   simulated?: boolean
+  status: ToolCallStatus
 }) {
   const isExpectedResponse = useMemo(
     () => isExpectedOutput(toolResponse),
@@ -40,18 +42,17 @@ function RunCodeOutput({
   )
 
   if (!toolResponse) {
-    return (
-      <ToolCardContentWrapper>
-        <div className='flex flex-row gap-2 items-center justify-center pb-3'>
-          <Icon name='loader' color='foregroundMuted' spin />
-          <Text.H5 color='foregroundMuted'>Running code...</Text.H5>
-        </div>
-      </ToolCardContentWrapper>
-    )
+    return <ToolCardPendingState status={status} loadingText='Running code...' />
   }
 
   if (!isExpectedResponse) {
-    return <ToolCardOutput toolResponse={toolResponse} simulated={simulated} />
+    return (
+      <ToolCardOutput
+        toolResponse={toolResponse}
+        simulated={simulated}
+        status={status}
+      />
+    )
   }
 
   return (
@@ -82,7 +83,7 @@ export function RunCodeLatitudeToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   messageIndex?: number
   contentBlockIndex?: number
 }) {
@@ -111,6 +112,7 @@ export function RunCodeLatitudeToolCard({
           <RunCodeOutput
             toolResponse={toolResponse}
             simulated={toolRequest._sourceData?.simulated}
+            status={status}
           />
         </>
       )}

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Extract.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Extract.tsx
@@ -14,13 +14,14 @@ import {
   ToolCardIcon,
   ToolCardText,
   ToolCardWrapper,
+  ToolCallStatus,
 } from '../_components/ToolCard'
 import { ToolCardHeader } from '../_components/ToolCard/Header'
 import {
   ToolCardContentWrapper,
   ToolCardOutput,
+  ToolCardPendingState,
 } from '../_components/ToolCard/Content'
-import { Icon } from '@latitude-data/web-ui/atoms/Icons'
 
 const isExpectedOutput = (toolResponse: ToolContent | undefined) => {
   // Returns false if the tool response does not contain the expected output
@@ -41,9 +42,11 @@ const isExpectedOutput = (toolResponse: ToolContent | undefined) => {
 function WebExtractOutput({
   toolResponse,
   simulated,
+  status,
 }: {
   toolResponse: ToolContent | undefined
   simulated?: boolean
+  status: ToolCallStatus
 }) {
   const isExpectedResponse = useMemo(
     () => isExpectedOutput(toolResponse),
@@ -56,18 +59,17 @@ function WebExtractOutput({
   }, [toolResponse, isExpectedResponse])
 
   if (!toolResponse) {
-    return (
-      <ToolCardContentWrapper>
-        <div className='flex flex-row gap-2 items-center justify-center pb-3'>
-          <Icon name='loader' color='foregroundMuted' spin />
-          <Text.H5 color='foregroundMuted'>Loading page...</Text.H5>
-        </div>
-      </ToolCardContentWrapper>
-    )
+    return <ToolCardPendingState status={status} loadingText='Loading page...' />
   }
 
   if (!isExpectedResponse) {
-    return <ToolCardOutput toolResponse={toolResponse} simulated={simulated} />
+    return (
+      <ToolCardOutput
+        toolResponse={toolResponse}
+        simulated={simulated}
+        status={status}
+      />
+    )
   }
 
   return (
@@ -92,7 +94,7 @@ export function WebExtractLatitudeToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   messageIndex?: number
   contentBlockIndex?: number
 }) {
@@ -116,6 +118,7 @@ export function WebExtractLatitudeToolCard({
         <WebExtractOutput
           toolResponse={toolResponse}
           simulated={toolRequest._sourceData?.simulated}
+          status={status}
         />
       )}
     </ToolCardWrapper>

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Search.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/LatitudeTools/Search.tsx
@@ -14,11 +14,13 @@ import {
   ToolCardIcon,
   ToolCardText,
   ToolCardWrapper,
+  ToolCallStatus,
 } from '../_components/ToolCard'
 import { ToolCardHeader } from '../_components/ToolCard/Header'
 import {
   ToolCardContentWrapper,
   ToolCardOutput,
+  ToolCardPendingState,
 } from '../_components/ToolCard/Content'
 
 function topicText({
@@ -132,9 +134,11 @@ const isExpectedOutput = (toolResponse: ToolContent | undefined) => {
 function WebSearchOutput({
   toolResponse,
   simulated,
+  status,
 }: {
   toolResponse: ToolContent | undefined
   simulated?: boolean
+  status: ToolCallStatus
 }) {
   const isExpectedResponse = useMemo(
     () => isExpectedOutput(toolResponse),
@@ -147,18 +151,17 @@ function WebSearchOutput({
   }, [toolResponse, isExpectedResponse])
 
   if (!toolResponse) {
-    return (
-      <ToolCardContentWrapper>
-        <div className='flex flex-row gap-2 items-center justify-center pb-3'>
-          <Icon name='loader' color='foregroundMuted' spin />
-          <Text.H5 color='foregroundMuted'>Searching...</Text.H5>
-        </div>
-      </ToolCardContentWrapper>
-    )
+    return <ToolCardPendingState status={status} loadingText='Searching...' />
   }
 
   if (!isExpectedResponse) {
-    return <ToolCardOutput toolResponse={toolResponse} simulated={simulated} />
+    return (
+      <ToolCardOutput
+        toolResponse={toolResponse}
+        simulated={simulated}
+        status={status}
+      />
+    )
   }
 
   return (
@@ -185,7 +188,7 @@ export function WebSearchLatitudeToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   messageIndex?: number
   contentBlockIndex?: number
 }) {
@@ -214,6 +217,7 @@ export function WebSearchLatitudeToolCard({
         <WebSearchOutput
           toolResponse={toolResponse}
           simulated={toolRequest._sourceData?.simulated}
+          status={status}
         />
       )}
     </ToolCardWrapper>

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Provider.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/Provider.tsx
@@ -6,7 +6,12 @@ import {
   ToolSource,
   ToolSourceData,
 } from '@latitude-data/constants/toolSources'
-import { ToolCard, ToolCardIcon, ToolCardText } from './_components/ToolCard'
+import {
+  ToolCard,
+  ToolCardIcon,
+  ToolCardText,
+  ToolCallStatus,
+} from './_components/ToolCard'
 import { ICON_BY_LLM_PROVIDER } from '$/lib/providerIcons'
 
 export function ProviderToolCard({
@@ -19,7 +24,7 @@ export function ProviderToolCard({
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
-  status: 'pending' | 'success' | 'error'
+  status: ToolCallStatus
   sourceData: ToolSourceData<ToolSource.ProviderTool>
   messageIndex?: number
   contentBlockIndex?: number
@@ -37,6 +42,7 @@ export function ProviderToolCard({
       headerLabel={<ToolCardText>{toolRequest.toolName}</ToolCardText>}
       messageIndex={messageIndex}
       contentBlockIndex={contentBlockIndex}
+      status={status}
     />
   )
 }

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/Content.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/Content.tsx
@@ -12,6 +12,7 @@ import { stringifyUnknown } from '@latitude-data/web-ui/textUtils'
 import { cn } from '@latitude-data/web-ui/utils'
 import { ReactNode } from 'react'
 import { SimulationTag } from './SimulationTag'
+import { ToolCallStatus } from './Header'
 
 export function ToolCardContentWrapper({
   badge,
@@ -42,6 +43,32 @@ export function ToolCardContentWrapper({
   )
 }
 
+export function ToolCardPendingState({
+  status,
+  loadingText,
+}: {
+  status: ToolCallStatus
+  loadingText: string
+}) {
+  return (
+    <ToolCardContentWrapper>
+      <div className='flex flex-row gap-2 items-center justify-center pb-3'>
+        {status === 'running' ? (
+          <>
+            <Icon name='loader' color='foregroundMuted' spin />
+            <Text.H5 color='foregroundMuted'>{loadingText}</Text.H5>
+          </>
+        ) : (
+          <>
+            <Icon name='clock' color='foregroundMuted' />
+            <Text.H5 color='foregroundMuted'>Tool not executed yet</Text.H5>
+          </>
+        )}
+      </div>
+    </ToolCardContentWrapper>
+  )
+}
+
 export function ToolCardInput({
   toolRequest,
 }: {
@@ -59,9 +86,11 @@ export function ToolCardInput({
 export function ToolCardOutput({
   toolResponse,
   simulated,
+  status,
 }: {
   toolResponse: ToolContent | undefined
   simulated?: boolean
+  status?: ToolCallStatus
 }) {
   return (
     <ToolCardContentWrapper badge='Output' simulated={simulated}>
@@ -79,10 +108,15 @@ export function ToolCardOutput({
             {stringifyUnknown(toolResponse.result)}
           </CodeBlock>
         )
-      ) : (
+      ) : status === 'running' ? (
         <div className='flex flex-row gap-2 items-center justify-center pb-3'>
           <Icon name='loader' color='foregroundMuted' spin />
           <Text.H6 color='foregroundMuted'>Running...</Text.H6>
+        </div>
+      ) : (
+        <div className='flex flex-row gap-2 items-center justify-center pb-3'>
+          <Icon name='clock' color='foregroundMuted' />
+          <Text.H6 color='foregroundMuted'>Tool not executed yet</Text.H6>
         </div>
       )}
     </ToolCardContentWrapper>

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/Header.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/Header.tsx
@@ -4,12 +4,14 @@ import { cn } from '@latitude-data/web-ui/utils'
 import { ReactNode } from 'react'
 import { SimulationTag } from './SimulationTag'
 
-const statusIconColor = (
-  status: 'pending' | 'success' | 'error',
-): TextColor => {
+export type ToolCallStatus = 'running' | 'waiting' | 'success' | 'error'
+
+const statusIconColor = (status: ToolCallStatus): TextColor => {
   switch (status) {
-    case 'pending':
+    case 'running':
       return 'primaryForeground'
+    case 'waiting':
+      return 'foregroundMuted'
     case 'success':
       return 'successForeground'
     case 'error':
@@ -19,10 +21,12 @@ const statusIconColor = (
   }
 }
 
-const statusIcon = (status: 'pending' | 'success' | 'error'): IconName => {
+const statusIcon = (status: ToolCallStatus): IconName => {
   switch (status) {
-    case 'pending':
+    case 'running':
       return 'loader'
+    case 'waiting':
+      return 'clock'
     case 'success':
       return 'checkClean'
     case 'error':
@@ -40,7 +44,7 @@ export function ToolCardHeader({
 }: {
   icon: ReactNode
   label: ReactNode
-  status?: 'pending' | 'success' | 'error' | undefined
+  status?: ToolCallStatus
   isOpen: boolean
   onToggle?: () => void
   simulated?: boolean
@@ -57,7 +61,8 @@ export function ToolCardHeader({
             className={cn(
               'absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 p-0.5 rounded-full',
               {
-                'bg-primary': status === 'pending',
+                'bg-primary': status === 'running',
+                'bg-background': status === 'waiting',
                 'bg-success': status === 'success',
                 'bg-destructive': status === 'error',
               },
@@ -66,7 +71,7 @@ export function ToolCardHeader({
             <Icon
               name={statusIcon(status)}
               color={statusIconColor(status)}
-              spin={status === 'pending'}
+              spin={status === 'running'}
               size='small'
               strokeWidth={3}
             />

--- a/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/index.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/ToolCall/_components/ToolCard/index.tsx
@@ -4,6 +4,7 @@ import {
 } from '@latitude-data/constants/legacyCompiler'
 import { ReactNode, useMemo, useState } from 'react'
 import { ToolCardHeader } from './Header'
+import type { ToolCallStatus } from './Header'
 import { ToolCardInput, ToolCardOutput } from './Content'
 import { Icon, IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { TextColor } from '@latitude-data/web-ui/tokens'
@@ -20,12 +21,14 @@ import {
   SpanWithDetails,
 } from '@latitude-data/constants'
 
-const statusColor = (
-  status: 'pending' | 'success' | 'error' | undefined,
-): TextColor => {
+export type { ToolCallStatus }
+
+const statusColor = (status: ToolCallStatus | undefined): TextColor => {
   switch (status) {
-    case 'pending':
+    case 'running':
       return 'primary'
+    case 'waiting':
+      return 'foregroundMuted'
     case 'success':
       return 'success'
     case 'error':
@@ -40,7 +43,7 @@ export function ToolCardIcon({
   status,
 }: {
   name: IconName
-  status?: 'pending' | 'success' | 'error'
+  status?: ToolCallStatus
 }) {
   return <Icon name={name} color={statusColor(status)} />
 }
@@ -139,6 +142,7 @@ export function ToolCard({
   headerLabel,
   messageIndex,
   contentBlockIndex,
+  status,
 }: {
   toolRequest: ToolRequestContent
   toolResponse: ToolContent | undefined
@@ -146,14 +150,9 @@ export function ToolCard({
   headerLabel: ReactNode
   messageIndex?: number
   contentBlockIndex?: number
+  status: ToolCallStatus
 }) {
   const [isOpen, setIsOpen] = useState(false)
-
-  const status = useMemo(() => {
-    if (!toolResponse) return 'pending'
-    if (toolResponse.isError) return 'error'
-    return 'success'
-  }, [toolResponse])
 
   return (
     <ToolCardWrapper
@@ -173,6 +172,7 @@ export function ToolCard({
         <ToolCardOutput
           toolResponse={toolResponse}
           simulated={toolRequest._sourceData?.simulated}
+          status={status}
         />
       )}
     </ToolCardWrapper>

--- a/apps/web/src/components/ChatWrapper/Message/Content/index.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/Content/index.tsx
@@ -18,6 +18,7 @@ export function Content<M extends MarkdownSize | 'none'>({
   debugMode,
   limitVerticalPadding = false,
   messageIndex,
+  isStreaming = false,
   ...rest
 }: {
   index?: number
@@ -30,6 +31,7 @@ export function Content<M extends MarkdownSize | 'none'>({
   markdownSize: M
   limitVerticalPadding?: boolean
   messageIndex?: number
+  isStreaming?: boolean
 }) {
   const contentArr = useMemo<MessageContent[]>(() => {
     if (content === undefined || content === null) {
@@ -80,6 +82,7 @@ export function Content<M extends MarkdownSize | 'none'>({
           value={c}
           messageIndex={messageIndex}
           contentBlockIndex={idx}
+          isStreaming={isStreaming}
           {...rest}
         />
       </div>
@@ -98,6 +101,7 @@ function ContentItem<M extends MarkdownSize | 'none'>({
   markdownSize,
   messageIndex,
   contentBlockIndex,
+  isStreaming = false,
 }: {
   index?: number
   color: M extends 'none' ? TextColor : Extract<TextColor, ProseColor>
@@ -109,6 +113,7 @@ function ContentItem<M extends MarkdownSize | 'none'>({
   markdownSize: M
   messageIndex?: number
   contentBlockIndex?: number
+  isStreaming?: boolean
 }) {
   if (value.type === 'text') {
     return (
@@ -174,6 +179,7 @@ function ContentItem<M extends MarkdownSize | 'none'>({
         debugMode={debugMode}
         messageIndex={messageIndex}
         contentBlockIndex={contentBlockIndex}
+        isStreaming={isStreaming}
       />
     )
   }

--- a/apps/web/src/components/ChatWrapper/Message/DebugMessage/index.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/DebugMessage/index.tsx
@@ -37,6 +37,7 @@ export const DebugMessage = memo(
     toolContentMap,
     isGeneratingToolCall = false,
     messageIndex,
+    isStreaming = false,
   }: Omit<MessageProps, 'debugMode'>) => {
     const [collapsedMessage, setCollapseMessage] = useState(false)
 
@@ -74,6 +75,7 @@ export const DebugMessage = memo(
                 toolContentMap={toolContentMap}
                 markdownSize='sm'
                 messageIndex={messageIndex}
+                isStreaming={isStreaming}
               />
             )}
             {isGeneratingToolCall && <ToolCardSkeleton />}

--- a/apps/web/src/components/ChatWrapper/Message/index.tsx
+++ b/apps/web/src/components/ChatWrapper/Message/index.tsx
@@ -9,28 +9,27 @@ import { DebugMessage } from './DebugMessage'
 import { UserMessage } from './UserMessage'
 import { SystemMessage } from './SystemMessage'
 
-export const Message = memo(({ role, debugMode, ...rest }: MessageProps) => {
-  if (debugMode) {
-    // Debug Mode
-    return <DebugMessage role={role} {...rest} />
-  }
+export const Message = memo(
+  ({ role, debugMode, isStreaming = false, ...rest }: MessageProps) => {
+    if (debugMode) {
+      return <DebugMessage role={role} isStreaming={isStreaming} {...rest} />
+    }
 
-  // Readable Mode
-  if (role === MessageRole.assistant) {
-    return <AssistantMessage {...rest} />
-  }
+    if (role === MessageRole.assistant) {
+      return <AssistantMessage isStreaming={isStreaming} {...rest} />
+    }
 
-  if (role === MessageRole.user) {
-    return <UserMessage {...rest} />
-  }
+    if (role === MessageRole.user) {
+      return <UserMessage {...rest} />
+    }
 
-  if (role === MessageRole.system) {
-    return <SystemMessage {...rest} />
-  }
+    if (role === MessageRole.system) {
+      return <SystemMessage {...rest} />
+    }
 
-  // Fallback to Debug Mode
-  return <DebugMessage role={role} {...rest} />
-})
+    return <DebugMessage role={role} isStreaming={isStreaming} {...rest} />
+  },
+)
 
 export function MessageSkeleton({ role }: { role: string }) {
   return (

--- a/apps/web/src/components/ChatWrapper/Message/types.ts
+++ b/apps/web/src/components/ChatWrapper/Message/types.ts
@@ -15,4 +15,5 @@ export type MessageProps = {
   isGeneratingToolCall?: boolean
   additionalAssistantMessage?: boolean
   messageIndex?: number
+  isStreaming?: boolean
 }

--- a/apps/web/src/components/ChatWrapper/MessageList/index.tsx
+++ b/apps/web/src/components/ChatWrapper/MessageList/index.tsx
@@ -34,11 +34,13 @@ export const MessageList = memo(
     parameters,
     debugMode,
     toolContentMap: _toolContentMap,
+    isStreaming = false,
   }: {
     messages: ConversationMessage[]
     parameters?: string[]
     debugMode?: boolean
     toolContentMap?: Record<string, ToolContent>
+    isStreaming?: boolean
   }) => {
     const toolContentMap = useToolContentMap(messages, _toolContentMap)
     const displayableMessages = useMemo(
@@ -102,13 +104,13 @@ export const MessageList = memo(
                   message._isGeneratingToolCall
                 }
                 additionalAssistantMessage={
-                  // If this is an additional assistant message, added to a previous assistant message
                   displayIndex > 0 &&
                   message.role === MessageRole.assistant &&
                   displayableMessages[displayIndex - 1].role ===
                     MessageRole.assistant
                 }
                 messageIndex={originalIndex}
+                isStreaming={isStreaming}
               />
             </div>
           )

--- a/apps/web/src/components/PlaygroundCommon/Chat/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/Chat/index.tsx
@@ -125,6 +125,7 @@ function Messages({
         parameters={parameterKeys}
         debugMode={debugMode}
         toolContentMap={toolContentMap}
+        isStreaming={playground.isLoading}
       />
 
       {playground.error && <ErrorMessage error={playground.error} />}

--- a/apps/web/src/components/PlaygroundCommon/PromptPlaygroundChat/index.tsx
+++ b/apps/web/src/components/PlaygroundCommon/PromptPlaygroundChat/index.tsx
@@ -34,6 +34,7 @@ export default function PromptPlaygroundChat({
         parameterKeys={parameterKeys}
         debugMode={debugMode ?? false}
         toolContentMap={toolContentMap}
+        isStreaming={playground.isLoading}
       />
     </div>
   )
@@ -54,12 +55,14 @@ const Messages = memo(function Messages({
   parameterKeys,
   debugMode,
   toolContentMap,
+  isStreaming,
 }: {
   messages: ReturnType<typeof usePlaygroundChat>['messages']
   error: ReturnType<typeof usePlaygroundChat>['error']
   parameterKeys: string[]
   debugMode: boolean
   toolContentMap: ReturnType<typeof useToolContentMap>
+  isStreaming: boolean
 }) {
   return (
     <div className='flex flex-col gap-3 flex-grow flex-shrink min-h-0'>
@@ -68,6 +71,7 @@ const Messages = memo(function Messages({
         parameters={parameterKeys}
         debugMode={debugMode}
         toolContentMap={toolContentMap}
+        isStreaming={isStreaming}
       />
 
       {error && <ErrorMessage error={error} />}


### PR DESCRIPTION
Now we're showing tools without a response always as pending. This is not right. In an agentic trace a tool can be pending (`waiting` from now on) and have a response on the next response. So what we'll do now is introduce `running` that will be only true on the playgrounds when stream is happening

## Pending tool ⚠️ 
This tool is finish in the sense that is not happening now but the UI is showing a loading indicator. Now we'll show a `waiting` (clock) icon instead in this case
<img width="493" height="142" alt="image" src="https://github.com/user-attachments/assets/278e73bf-4278-4aea-b6c4-fa7ce8ed97af" />
