### PR TITLE
Add random delay to issue discovery for experiment results

### DIFF
--- a/packages/constants/src/issues/constants.ts
+++ b/packages/constants/src/issues/constants.ts
@@ -114,4 +114,5 @@ export const ISSUE_JOBS_MAX_ATTEMPTS = 3
 export const ISSUE_JOBS_GENERATE_DETAILS_THROTTLE = 6 * 60 * 60 * 1000 // 6 hours
 export const ISSUE_JOBS_MERGE_COMMON_THROTTLE = 24 * 60 * 60 * 1000 // 1 day
 export const ISSUE_JOBS_DISCOVER_RESULT_DELAY = 60 * 1000 // 1 minute
+export const ISSUE_JOBS_EXPERIMENT_RANDOM_DELAY_MAX = 30 * 1000 // 30 seconds max random delay for experiment results
 export const WHAT_ARE_ANNOTATIONS_VIDEO_ID = 'trOwCWaIAZk'


### PR DESCRIPTION
## Summary
Experiment evaluation results that do not have an issue linked to their evaluation now receive a random delay (0-30 seconds) before their discovery job runs. This reduces data races when multiple experiment results are processed in parallel, where each job would independently try to discover or create issues simultaneously—potentially leading to duplicate issues or inconsistent state.

By staggering the discovery jobs, the first job completes and creates/discovers an issue before subsequent jobs run, allowing them to find and use the existing issue instead of creating duplicates.