### PR TITLE
Add configurable target for auto-curating dataset examples

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/CurationTargetSelector.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/CurationTargetSelector.tsx
@@ -1,0 +1,190 @@
+import { FormFieldGroup } from '@latitude-data/web-ui/atoms/FormFieldGroup'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { Slider } from '@latitude-data/web-ui/atoms/Slider'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { cn } from '@latitude-data/web-ui/utils'
+import { useCallback, useState } from 'react'
+
+const DEFAULT_TARGET_ROWS = 250
+const MIN_TARGET_ROWS = 50
+const MAX_TARGET_ROWS = 500
+const TARGET_ROWS_STEP = 50
+
+const TARGET_ROWS_PRESETS = {
+  small: {
+    value: 100,
+    label: 'Small',
+    description: 'Quick runs with minimal data. Best for initial testing.',
+  },
+  standard: {
+    value: 250,
+    label: 'Standard',
+    description: 'Balanced dataset size. Recommended for most use cases.',
+  },
+  large: {
+    value: 500,
+    label: 'Large',
+    description: 'More examples for better coverage and accuracy.',
+  },
+} as const
+
+type PresetKey = keyof typeof TARGET_ROWS_PRESETS
+
+function PresetCard({
+  label,
+  description,
+  valueLabel,
+  selected,
+  onSelect,
+  disabled,
+}: {
+  label: string
+  description: string
+  valueLabel?: string
+  selected: boolean
+  onSelect: () => void
+  disabled?: boolean
+}) {
+  return (
+    <div
+      onClick={disabled ? undefined : onSelect}
+      className={cn(
+        'flex flex-col gap-2 p-3 rounded-lg border transition-all text-left flex-1',
+        {
+          'border-primary bg-accent': selected,
+          'border-border bg-background hover:bg-muted': !selected && !disabled,
+          'opacity-50 cursor-not-allowed': disabled,
+          'cursor-pointer': !disabled,
+        },
+      )}
+    >
+      <div className='flex items-center justify-between'>
+        <Text.H6M
+          color={selected ? 'primary' : 'foreground'}
+          userSelect={false}
+        >
+          {label}
+        </Text.H6M>
+        {selected && (
+          <Icon
+            name='check'
+            color='primary'
+            size='small'
+            className='shrink-0'
+          />
+        )}
+      </div>
+      <Text.H6 color='foregroundMuted' userSelect={false}>
+        {description}
+      </Text.H6>
+      {valueLabel && (
+        <Text.H6 color='foregroundMuted' userSelect={false}>
+          {valueLabel}
+        </Text.H6>
+      )}
+    </div>
+  )
+}
+
+export function CurationTargetSelector({
+  value,
+  onChange,
+  disabled,
+}: {
+  value?: number
+  onChange: (value: number) => void
+  disabled?: boolean
+}) {
+  const currentValue = value ?? DEFAULT_TARGET_ROWS
+  const [isCustomMode, setIsCustomMode] = useState(() => {
+    const presetValues = Object.values(TARGET_ROWS_PRESETS).map(
+      (p) => p.value,
+    ) as number[]
+    return !presetValues.includes(currentValue)
+  })
+
+  const selectedPreset = (): PresetKey | null => {
+    if (isCustomMode) return null
+    const presetKeys = Object.keys(TARGET_ROWS_PRESETS) as PresetKey[]
+    for (const key of presetKeys) {
+      if (TARGET_ROWS_PRESETS[key].value === currentValue) {
+        return key
+      }
+    }
+    return null
+  }
+
+  const handlePresetSelect = useCallback(
+    (presetKey: PresetKey) => {
+      setIsCustomMode(false)
+      onChange(TARGET_ROWS_PRESETS[presetKey].value)
+    },
+    [onChange],
+  )
+
+  const handleCustomSelect = useCallback(() => {
+    setIsCustomMode(true)
+  }, [])
+
+  const handleSliderChange = useCallback(
+    (values: number[]) => {
+      const newValue = values[0]
+      if (newValue !== undefined) {
+        onChange(newValue)
+      }
+    },
+    [onChange],
+  )
+
+  const presetKeys = Object.keys(TARGET_ROWS_PRESETS) as PresetKey[]
+  const currentPreset = selectedPreset()
+
+  return (
+    <FormFieldGroup
+      label='Curation target'
+      description='Number of examples to curate from your recent traces'
+      layout='vertical'
+    >
+      <div className='flex flex-col gap-4'>
+        <div className='flex gap-2'>
+          {presetKeys.map((key) => (
+            <PresetCard
+              key={key}
+              label={TARGET_ROWS_PRESETS[key].label}
+              description={TARGET_ROWS_PRESETS[key].description}
+              valueLabel={`${TARGET_ROWS_PRESETS[key].value} examples`}
+              selected={currentPreset === key}
+              onSelect={() => handlePresetSelect(key)}
+              disabled={disabled}
+            />
+          ))}
+          <PresetCard
+            label='Custom'
+            description='Fine-tune the exact number of examples to curate.'
+            valueLabel={isCustomMode ? `${currentValue} examples` : undefined}
+            selected={isCustomMode}
+            onSelect={handleCustomSelect}
+            disabled={disabled}
+          />
+        </div>
+        {isCustomMode && (
+          <div className='flex flex-col gap-2'>
+            <div className='flex items-center justify-between'>
+              <Text.H6 color='foregroundMuted'>{MIN_TARGET_ROWS}</Text.H6>
+              <Text.H5M color='primary'>{currentValue} examples</Text.H5M>
+              <Text.H6 color='foregroundMuted'>{MAX_TARGET_ROWS}</Text.H6>
+            </div>
+            <Slider
+              value={[currentValue]}
+              min={MIN_TARGET_ROWS}
+              max={MAX_TARGET_ROWS}
+              step={TARGET_ROWS_STEP}
+              onValueChange={handleSliderChange}
+              disabled={disabled}
+            />
+          </div>
+        )}
+      </div>
+    </FormFieldGroup>
+  )
+}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/DatasetSelector.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/DatasetSelector.tsx
@@ -1,20 +1,22 @@
 import useDatasets from '$/stores/datasets'
-import {
-  OPTIMIZATION_MAX_ROWS,
-  OPTIMIZATION_TARGET_ROWS,
-} from '@latitude-data/constants'
+import { OPTIMIZATION_MAX_ROWS } from '@latitude-data/constants'
 import { FormFieldGroup } from '@latitude-data/web-ui/atoms/FormFieldGroup'
 import { Select } from '@latitude-data/web-ui/atoms/Select'
 import { useMemo } from 'react'
+import { CurationTargetSelector } from './CurationTargetSelector'
 
 export function DatasetSelector({
   value,
   onChange,
+  targetRows,
+  onTargetRowsChange,
   errors,
   disabled,
 }: {
   value?: number
   onChange: (value?: number) => void
+  targetRows?: number
+  onTargetRowsChange: (value: number) => void
   errors?: Record<string, string[]>
   disabled?: boolean
 }) {
@@ -32,25 +34,40 @@ export function DatasetSelector({
     )
   }, [datasets])
 
+  const isAutoCurate = !value
+
   return (
-    <FormFieldGroup
-      label='Dataset'
-      tooltip={`We will try to curate up to ${OPTIMIZATION_TARGET_ROWS} high-quality traces. If you provide a dataset, the first ${OPTIMIZATION_MAX_ROWS} rows will be used`}
-    >
-      <Select
-        value={value ? String(value) : undefined}
-        name='datasetId'
-        description='The dataset used to train and test the optimization on. If not provided, one will be automatically curated from your recent traces'
-        placeholder='Auto-curate dataset'
-        placeholderIcon='sparkles'
-        options={options}
-        onChange={(val) => onChange(val ? Number(val) : undefined)}
-        errors={errors?.['datasetId']}
-        loading={isLoading}
-        disabled={disabled || isLoading}
-        searchable
-        removable
-      />
-    </FormFieldGroup>
+    <div className='flex flex-col gap-4'>
+      <FormFieldGroup
+        label='Dataset'
+        tooltip={
+          isAutoCurate
+            ? 'We will curate high-quality traces from your recent runs. Use the slider below to configure the target number of examples'
+            : `If you provide a dataset, the first ${OPTIMIZATION_MAX_ROWS} rows will be used`
+        }
+      >
+        <Select
+          value={value ? String(value) : undefined}
+          name='datasetId'
+          description='The dataset used to train and test the optimization on. If not provided, one will be automatically curated from your recent traces'
+          placeholder='Auto-curate dataset'
+          placeholderIcon='sparkles'
+          options={options}
+          onChange={(val) => onChange(val ? Number(val) : undefined)}
+          errors={errors?.['datasetId']}
+          loading={isLoading}
+          disabled={disabled || isLoading}
+          searchable
+          removable
+        />
+      </FormFieldGroup>
+      {isAutoCurate && (
+        <CurationTargetSelector
+          value={targetRows}
+          onChange={onTargetRowsChange}
+          disabled={disabled}
+        />
+      )}
+    </div>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationForm/index.tsx
@@ -151,6 +151,10 @@ export function OptimizationForm({
               <DatasetSelector
                 value={datasetId}
                 onChange={setDatasetId}
+                targetRows={configuration.targetRows}
+                onTargetRowsChange={(value) =>
+                  setConfiguration({ ...configuration, targetRows: value })
+                }
                 errors={errors}
                 disabled={disabled}
               />

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationsActions.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/optimizations/_components/OptimizationsActions.tsx
@@ -123,7 +123,7 @@ function StartOptimization({
       </TableWithHeader.Button>
       <ConfirmModal
         dismissible
-        size='medium'
+        size='large'
         open={openStartModal}
         title='Start a new optimization'
         description='Optimizations help you improve the quality of your prompts'

--- a/packages/constants/src/optimizations.ts
+++ b/packages/constants/src/optimizations.ts
@@ -6,6 +6,32 @@ export enum OptimizationEngine {
   Gepa = 'gepa',
 }
 
+export const OPTIMIZATION_SCORE_SCALE = 1 // Note: most algorithms use floats with a scale of [0,1]
+
+export const OPTIMIZATION_MAX_TIME = 2 * 60 * 60 // 2 hours
+export const OPTIMIZATION_MAX_TOKENS = 100_000_000 // 100M tokens
+
+export const OPTIMIZATION_CANCEL_TIMEOUT = 10 * 1000 // 10 seconds
+
+export const OPTIMIZATION_DEFAULT_ERROR = 'Optimization cancelled'
+export const OPTIMIZATION_CANCELLED_ERROR = 'Optimization cancelled by user'
+
+export const OPTIMIZATION_MIN_ROWS = 4
+export const OPTIMIZATION_TARGET_ROWS = 250 // Note: algorithms need a sufficient amount of data to generalize and converge to avoid noise and bias
+export const OPTIMIZATION_MAX_ROWS = 1000
+
+export const OPTIMIZATION_MIN_TARGET_ROWS = 50
+export const OPTIMIZATION_MAX_TARGET_ROWS = 500
+export const OPTIMIZATION_TARGET_ROWS_STEP = 50
+export const OPTIMIZATION_TARGET_ROWS_PRESETS = {
+  small: { value: 100, label: 'Small', description: 'Faster curation, fewer examples' },
+  standard: { value: 250, label: 'Standard', description: 'Balanced quality and speed' },
+  large: { value: 500, label: 'Large', description: 'More examples, better coverage' },
+} as const
+
+export const OPTIMIZATION_TESTSET_SPLIT = 0.7 // 70% trainset, 30% testset
+export const OPTIMIZATION_VALSET_SPLIT = 0.5 // 50% testset, 50% valset
+
 export const OptimizationBudgetSchema = z.object({
   time: z.number().min(0).optional(),
   tokens: z.number().min(0).optional(),
@@ -30,24 +56,12 @@ export const OptimizationConfigurationSchema = z.object({
     })
     .optional(),
   budget: OptimizationBudgetSchema.optional(),
+  targetRows: z
+    .number()
+    .min(OPTIMIZATION_MIN_TARGET_ROWS)
+    .max(OPTIMIZATION_MAX_TARGET_ROWS)
+    .optional(),
 })
 export type OptimizationConfiguration = z.infer<
   typeof OptimizationConfigurationSchema
 >
-
-export const OPTIMIZATION_SCORE_SCALE = 1 // Note: most algorithms use floats with a scale of [0,1]
-
-export const OPTIMIZATION_MAX_TIME = 2 * 60 * 60 // 2 hours
-export const OPTIMIZATION_MAX_TOKENS = 100_000_000 // 100M tokens
-
-export const OPTIMIZATION_CANCEL_TIMEOUT = 10 * 1000 // 10 seconds
-
-export const OPTIMIZATION_DEFAULT_ERROR = 'Optimization cancelled'
-export const OPTIMIZATION_CANCELLED_ERROR = 'Optimization cancelled by user'
-
-export const OPTIMIZATION_MIN_ROWS = 4
-export const OPTIMIZATION_TARGET_ROWS = 250 // Note: algorithms need a sufficient amount of data to generalize and converge to avoid noise and bias
-export const OPTIMIZATION_MAX_ROWS = 1000
-
-export const OPTIMIZATION_TESTSET_SPLIT = 0.7 // 70% trainset, 30% testset
-export const OPTIMIZATION_VALSET_SPLIT = 0.5 // 50% testset, 50% valset


### PR DESCRIPTION
## Summary
When starting an optimization with auto-curated datasets, users can now configure how many examples to curate from their traces. Previously, this was hardcoded to 250 examples.

The configuration offers preset options (Small: 100, Standard: 250, Large: 500) with descriptions explaining each choice, plus a Custom option with a slider for fine-grained control between 50-500 examples.

The selection appears in the Advanced Configuration section only when "Auto-curate dataset" is selected (no user-provided dataset). The backend respects the configured target when collecting positive and negative examples during the optimization preparation phase.

<img width="961" height="628" alt="image" src="https://github.com/user-attachments/assets/5d20a4dc-033a-4de4-9a82-c5ee50e1b928" />
