### PR TITLE
feat: add name length validation to API key services

### DIFF
--- a/packages/core/src/services/apiKeys/create.test.ts
+++ b/packages/core/src/services/apiKeys/create.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { BadRequestError } from '../../lib/errors'
+import * as factories from '../../tests/factories'
+import { createApiKey, MAX_API_KEY_NAME_LENGTH } from './create'
+
+describe('createApiKey', () => {
+  it('creates an api key without a name', async () => {
+    const { workspace } = await factories.createWorkspace()
+
+    const result = await createApiKey({ workspace })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.workspaceId).toBe(workspace.id)
+    expect(result.value?.name).toBeNull()
+  })
+
+  it('creates an api key with a valid name', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const name = 'My API Key'
+
+    const result = await createApiKey({ name, workspace })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.name).toBe(name)
+  })
+
+  it('creates an api key with name at max length', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const name = 'a'.repeat(MAX_API_KEY_NAME_LENGTH)
+
+    const result = await createApiKey({ name, workspace })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.name).toBe(name)
+  })
+
+  it('returns an error when name exceeds max length', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const name = 'a'.repeat(MAX_API_KEY_NAME_LENGTH + 1)
+
+    const result = await createApiKey({ name, workspace })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(BadRequestError)
+    expect(result.error?.message).toBe(
+      `API key name must be ${MAX_API_KEY_NAME_LENGTH} characters or less`,
+    )
+  })
+})

--- a/packages/core/src/services/apiKeys/create.ts
+++ b/packages/core/src/services/apiKeys/create.ts
@@ -1,13 +1,24 @@
 import type { Workspace } from '../../schema/models/types/Workspace'
+import { BadRequestError } from '../../lib/errors'
 import { generateUUIDIdentifier } from '../../lib/generateUUID'
 import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
 import { apiKeys } from '../../schema/models/apiKeys'
 
-export function createApiKey(
+export const MAX_API_KEY_NAME_LENGTH = 256
+
+export async function createApiKey(
   { name, workspace }: { name?: string; workspace: Workspace },
   transaction = new Transaction(),
 ) {
+  if (name && name.length > MAX_API_KEY_NAME_LENGTH) {
+    return Result.error(
+      new BadRequestError(
+        `API key name must be ${MAX_API_KEY_NAME_LENGTH} characters or less`,
+      ),
+    )
+  }
+
   return transaction.call(async (tx) => {
     const token = generateUUIDIdentifier()
     const result = await tx

--- a/packages/core/src/services/apiKeys/update.test.ts
+++ b/packages/core/src/services/apiKeys/update.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { BadRequestError } from '../../lib/errors'
+import * as factories from '../../tests/factories'
+import { MAX_API_KEY_NAME_LENGTH } from './create'
+import { updateApiKey } from './update'
+
+describe('updateApiKey', () => {
+  it('updates an api key with a valid name', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const { apiKey } = await factories.createApiKey({ workspace })
+    const newName = 'Updated API Key'
+
+    const result = await updateApiKey(apiKey, { name: newName })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.name).toBe(newName)
+  })
+
+  it('updates an api key with name at max length', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const { apiKey } = await factories.createApiKey({ workspace })
+    const newName = 'b'.repeat(MAX_API_KEY_NAME_LENGTH)
+
+    const result = await updateApiKey(apiKey, { name: newName })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.name).toBe(newName)
+  })
+
+  it('returns an error when name exceeds max length', async () => {
+    const { workspace } = await factories.createWorkspace()
+    const { apiKey } = await factories.createApiKey({ workspace })
+    const newName = 'b'.repeat(MAX_API_KEY_NAME_LENGTH + 1)
+
+    const result = await updateApiKey(apiKey, { name: newName })
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBeInstanceOf(BadRequestError)
+    expect(result.error?.message).toBe(
+      `API key name must be ${MAX_API_KEY_NAME_LENGTH} characters or less`,
+    )
+  })
+})

--- a/packages/core/src/services/apiKeys/update.ts
+++ b/packages/core/src/services/apiKeys/update.ts
@@ -1,15 +1,25 @@
 import { eq } from 'drizzle-orm'
 
 import { type ApiKey } from '../../schema/models/types/ApiKey'
+import { BadRequestError } from '../../lib/errors'
 import { Result } from '../../lib/Result'
 import Transaction from '../../lib/Transaction'
 import { apiKeys } from '../../schema/models/apiKeys'
+import { MAX_API_KEY_NAME_LENGTH } from './create'
 
 export async function updateApiKey(
   apiKey: ApiKey,
   { name }: { name: string },
   transaction = new Transaction(),
 ) {
+  if (name.length > MAX_API_KEY_NAME_LENGTH) {
+    return Result.error(
+      new BadRequestError(
+        `API key name must be ${MAX_API_KEY_NAME_LENGTH} characters or less`,
+      ),
+    )
+  }
+
   return transaction.call(async (trx) => {
     const result = await trx
       .update(apiKeys)


### PR DESCRIPTION
## Summary
- Add validation to `createApiKey` and `updateApiKey` services to ensure API key names don't exceed the database column limit of 256 characters
- Return a user-friendly `BadRequestError` when validation fails
- Add unit tests for the new validation logic

## Test plan
- [x] Unit tests pass for `createApiKey` (4 tests)
- [x] Unit tests pass for `updateApiKey` (3 tests)
- [x] Manual testing: attempt to create/update an API key with a name longer than 256 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)