### PR TITLE
Add BullMQ Flow system for sequential and dynamic job workflows

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,9 @@
     "./queues/types": {
       "import": "./src/jobs/queues/types.ts"
     },
+    "./flows": {
+      "import": "./src/jobs/flows/index.ts"
+    },
     "./redis": {
       "import": "./src/redis/index.ts"
     },

--- a/packages/core/src/jobs/flows/dynamicChildren.test.ts
+++ b/packages/core/src/jobs/flows/dynamicChildren.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Job, WaitingChildrenError } from 'bullmq'
+import { DynamicChildrenContext } from './dynamicChildren'
+import { Queues } from '../queues/types'
+
+vi.mock('../queues', () => {
+  const mockAdd = vi.fn()
+  const mockQueue = { add: mockAdd }
+  return {
+    queues: vi.fn().mockResolvedValue({
+      defaultQueue: mockQueue,
+      documentsQueue: mockQueue,
+      evaluationsQueue: mockQueue,
+      eventHandlersQueue: mockQueue,
+      eventsQueue: mockQueue,
+      maintenanceQueue: mockQueue,
+      notificationsQueue: mockQueue,
+      tracingQueue: mockQueue,
+      webhooksQueue: mockQueue,
+      latteQueue: mockQueue,
+      runsQueue: mockQueue,
+      issuesQueue: mockQueue,
+      generateEvaluationsQueue: mockQueue,
+      optimizationsQueue: mockQueue,
+    }),
+    __mockAdd: mockAdd,
+  }
+})
+
+describe('DynamicChildrenContext', () => {
+  let mockJob: Partial<Job>
+  let mockQueueAdd: ReturnType<typeof vi.fn>
+  const TEST_TOKEN = 'test-token'
+  const TEST_JOB_ID = 'test-job-id'
+  const TEST_QUEUE_NAME = 'bull:test-queue'
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const queuesMod = await import('../queues')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockQueueAdd = (queuesMod as any).__mockAdd
+
+    mockJob = {
+      id: TEST_JOB_ID,
+      queueQualifiedName: TEST_QUEUE_NAME,
+      data: { someData: 'value' },
+      getChildrenValues: vi.fn().mockResolvedValue({
+        'queue:child-1': { result: 'child1' },
+        'queue:child-2': { result: 'child2' },
+      }),
+      updateData: vi.fn().mockResolvedValue(undefined),
+      moveToWaitingChildren: vi.fn().mockResolvedValue(true),
+    }
+
+    mockQueueAdd.mockResolvedValue({ id: 'new-job-id' })
+  })
+
+  describe('create', () => {
+    it('returns DynamicChildrenContext when token is provided', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)
+      expect(ctx).toBeInstanceOf(DynamicChildrenContext)
+    })
+
+    it('returns undefined when token is not provided', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, undefined)
+      expect(ctx).toBeUndefined()
+    })
+
+    it('returns undefined when token is empty string', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, '')
+      expect(ctx).toBeUndefined()
+    })
+  })
+
+  describe('isResume', () => {
+    it('returns false for initial invocation', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+      expect(ctx.isResume()).toBe(false)
+    })
+
+    it('returns true when resume flag is set', () => {
+      mockJob.data = { __dynamicChildren_resumed: true }
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+      expect(ctx.isResume()).toBe(true)
+    })
+  })
+
+  describe('getChildrenResults', () => {
+    it('returns children values from job', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+      const results = await ctx.getChildrenResults()
+
+      expect(mockJob.getChildrenValues).toHaveBeenCalled()
+      expect(results).toEqual({
+        'queue:child-1': { result: 'child1' },
+        'queue:child-2': { result: 'child2' },
+      })
+    })
+  })
+
+  describe('addFlowStep', () => {
+    it('adds a job with parent reference', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.addFlowStep({
+        name: 'childJob',
+        queue: Queues.defaultQueue,
+        data: { childData: 'test' },
+      })
+
+      expect(mockQueueAdd).toHaveBeenCalledWith(
+        'childJob',
+        { childData: 'test' },
+        {
+          parent: {
+            id: TEST_JOB_ID,
+            queue: TEST_QUEUE_NAME,
+          },
+        },
+      )
+    })
+
+    it('includes custom opts with parent reference', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.addFlowStep({
+        name: 'childJob',
+        queue: Queues.defaultQueue,
+        data: { childData: 'test' },
+        opts: {
+          jobId: 'custom-id',
+          attempts: 3,
+        },
+      })
+
+      expect(mockQueueAdd).toHaveBeenCalledWith(
+        'childJob',
+        { childData: 'test' },
+        {
+          jobId: 'custom-id',
+          attempts: 3,
+          parent: {
+            id: TEST_JOB_ID,
+            queue: TEST_QUEUE_NAME,
+          },
+        },
+      )
+    })
+
+    it('sets hasAddedSteps to true', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      expect(ctx.hasAddedSteps()).toBe(false)
+      await ctx.addFlowStep({
+        name: 'childJob',
+        queue: Queues.defaultQueue,
+        data: {},
+      })
+      expect(ctx.hasAddedSteps()).toBe(true)
+    })
+  })
+
+  describe('addFlowSteps', () => {
+    it('adds multiple jobs', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.addFlowSteps([
+        { name: 'child1', queue: Queues.defaultQueue, data: { idx: 1 } },
+        { name: 'child2', queue: Queues.defaultQueue, data: { idx: 2 } },
+        { name: 'child3', queue: Queues.defaultQueue, data: { idx: 3 } },
+      ])
+
+      expect(mockQueueAdd).toHaveBeenCalledTimes(3)
+      expect(mockQueueAdd).toHaveBeenNthCalledWith(
+        1,
+        'child1',
+        { idx: 1 },
+        expect.objectContaining({
+          parent: { id: TEST_JOB_ID, queue: TEST_QUEUE_NAME },
+        }),
+      )
+      expect(mockQueueAdd).toHaveBeenNthCalledWith(
+        2,
+        'child2',
+        { idx: 2 },
+        expect.objectContaining({
+          parent: { id: TEST_JOB_ID, queue: TEST_QUEUE_NAME },
+        }),
+      )
+      expect(mockQueueAdd).toHaveBeenNthCalledWith(
+        3,
+        'child3',
+        { idx: 3 },
+        expect.objectContaining({
+          parent: { id: TEST_JOB_ID, queue: TEST_QUEUE_NAME },
+        }),
+      )
+    })
+  })
+
+  describe('waitForChildren', () => {
+    it('does nothing when no steps were added', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.waitForChildren()
+
+      expect(mockJob.updateData).not.toHaveBeenCalled()
+      expect(mockJob.moveToWaitingChildren).not.toHaveBeenCalled()
+    })
+
+    it('updates job data and throws WaitingChildrenError when steps were added', async () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.addFlowStep({
+        name: 'childJob',
+        queue: Queues.defaultQueue,
+        data: {},
+      })
+
+      await expect(ctx.waitForChildren()).rejects.toThrow(WaitingChildrenError)
+
+      expect(mockJob.updateData).toHaveBeenCalledWith({
+        someData: 'value',
+        __dynamicChildren_resumed: true,
+      })
+      expect(mockJob.moveToWaitingChildren).toHaveBeenCalledWith(TEST_TOKEN)
+    })
+
+    it('does not throw when moveToWaitingChildren returns false', async () => {
+      ;(
+        mockJob.moveToWaitingChildren as ReturnType<typeof vi.fn>
+      ).mockResolvedValue(false)
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+
+      await ctx.addFlowStep({
+        name: 'childJob',
+        queue: Queues.defaultQueue,
+        data: {},
+      })
+
+      await expect(ctx.waitForChildren()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('jobId and jobData', () => {
+    it('returns job id', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+      expect(ctx.jobId).toBe(TEST_JOB_ID)
+    })
+
+    it('returns job data', () => {
+      const ctx = DynamicChildrenContext.create(mockJob as Job, TEST_TOKEN)!
+      expect(ctx.jobData).toEqual({ someData: 'value' })
+    })
+  })
+})

--- a/packages/core/src/jobs/flows/dynamicChildren.ts
+++ b/packages/core/src/jobs/flows/dynamicChildren.ts
@@ -1,0 +1,176 @@
+import { Job, Queue, WaitingChildrenError } from 'bullmq'
+import { queues } from '../queues'
+import { Queues } from '../queues/types'
+import { FlowStep } from './types'
+
+type QueuesMap = Awaited<ReturnType<typeof queues>>
+
+const QUEUE_KEY_MAP: Record<Queues, keyof QueuesMap> = {
+  [Queues.defaultQueue]: 'defaultQueue',
+  [Queues.evaluationsQueue]: 'evaluationsQueue',
+  [Queues.eventHandlersQueue]: 'eventHandlersQueue',
+  [Queues.eventsQueue]: 'eventsQueue',
+  [Queues.maintenanceQueue]: 'maintenanceQueue',
+  [Queues.notificationsQueue]: 'notificationsQueue',
+  [Queues.webhooksQueue]: 'webhooksQueue',
+  [Queues.documentsQueue]: 'documentsQueue',
+  [Queues.tracingQueue]: 'tracingQueue',
+  [Queues.latteQueue]: 'latteQueue',
+  [Queues.runsQueue]: 'runsQueue',
+  [Queues.issuesQueue]: 'issuesQueue',
+  [Queues.generateEvaluationsQueue]: 'generateEvaluationsQueue',
+  [Queues.optimizationsQueue]: 'optimizationsQueue',
+}
+
+function getQueue(allQueues: QueuesMap, queueType: Queues): Queue {
+  const key = QUEUE_KEY_MAP[queueType]
+  return allQueues[key]
+}
+
+const RESUME_FLAG = '__dynamicChildren_resumed'
+
+/**
+ * Context for jobs that can dynamically add child steps within a flow.
+ *
+ * This enables the pattern where a job can add additional steps that must
+ * complete before the flow continues. The added steps become children of
+ * the current job, and the job waits for them to complete.
+ *
+ * @example
+ * ```typescript
+ * export const iterativeJob = async (job: Job, token?: string) => {
+ *   const ctx = DynamicChildrenContext.create(job, token)
+ *   if (!ctx) throw new Error('Token required')
+ *
+ *   // Check if resuming after children completed
+ *   if (ctx.isResume()) {
+ *     const childResults = await ctx.getChildrenResults()
+ *     return { phase: 'completed', childResults }
+ *   }
+ *
+ *   // Do work and decide if more steps needed
+ *   const result = await doWork()
+ *
+ *   if (needsMoreWork(result)) {
+ *     await ctx.addFlowStep({
+ *       name: 'iterativeJob',
+ *       queue: Queues.defaultQueue,
+ *       data: { previousResult: result },
+ *     })
+ *   }
+ *
+ *   // Throws WaitingChildrenError if steps were added
+ *   await ctx.waitForChildren()
+ *
+ *   return { result }
+ * }
+ * ```
+ */
+export class DynamicChildrenContext {
+  private job: Job
+  private token: string
+  private stepsAdded = false
+
+  private constructor(job: Job, token: string) {
+    this.job = job
+    this.token = token
+  }
+
+  /**
+   * Create a context for the current job.
+   * Returns undefined if token is not provided (required for waiting).
+   */
+  static create(job: Job, token?: string): DynamicChildrenContext | undefined {
+    if (!token) return undefined
+    return new DynamicChildrenContext(job, token)
+  }
+
+  /**
+   * Check if this invocation is a resume after children completed.
+   * Use this to differentiate between initial execution and post-children resume.
+   */
+  isResume(): boolean {
+    return this.job.data?.[RESUME_FLAG] === true
+  }
+
+  /**
+   * Get results from child jobs (only valid after resume).
+   * Returns a record keyed by `queueName:jobId`.
+   */
+  async getChildrenResults(): Promise<Record<string, unknown>> {
+    return this.job.getChildrenValues()
+  }
+
+  /**
+   * Add a step that will run before this job completes.
+   * The current job will wait for this step to finish.
+   *
+   * Multiple steps can be added - they will run in parallel.
+   * If you need sequential execution, have each step add the next one.
+   */
+  async addFlowStep(step: FlowStep): Promise<void> {
+    const allQueues = await queues()
+    const queue = getQueue(allQueues, step.queue)
+
+    await queue.add(step.name, step.data, {
+      ...step.opts,
+      parent: {
+        id: this.job.id!,
+        queue: this.job.queueQualifiedName,
+      },
+    })
+
+    this.stepsAdded = true
+  }
+
+  /**
+   * Add multiple steps (they will run in parallel).
+   */
+  async addFlowSteps(steps: FlowStep[]): Promise<void> {
+    for (const step of steps) {
+      await this.addFlowStep(step)
+    }
+  }
+
+  /**
+   * Wait for all dynamically added children to complete.
+   *
+   * IMPORTANT: Call this at the END of your job handler.
+   * If steps were added, this throws WaitingChildrenError.
+   * The job handler will be called again when children complete.
+   */
+  async waitForChildren(): Promise<void> {
+    if (!this.stepsAdded) return
+
+    await this.job.updateData({
+      ...this.job.data,
+      [RESUME_FLAG]: true,
+    })
+
+    const shouldWait = await this.job.moveToWaitingChildren(this.token)
+    if (shouldWait) {
+      throw new WaitingChildrenError()
+    }
+  }
+
+  /**
+   * Check if any steps have been added in this invocation.
+   */
+  hasAddedSteps(): boolean {
+    return this.stepsAdded
+  }
+
+  /**
+   * Get the current job's ID.
+   */
+  get jobId(): string | undefined {
+    return this.job.id
+  }
+
+  /**
+   * Get the current job's data.
+   */
+  get jobData(): Record<string, unknown> {
+    return this.job.data
+  }
+}

--- a/packages/core/src/jobs/flows/enqueue.ts
+++ b/packages/core/src/jobs/flows/enqueue.ts
@@ -1,0 +1,56 @@
+import { FlowJob } from 'bullmq'
+import { Result, TypedResult } from '../../lib/Result'
+import { UnprocessableEntityError } from '../../lib/errors'
+import { flowProducer } from './index'
+import { EnqueuedFlow } from './types'
+
+/**
+ * Enqueues a flow and returns a Result.
+ * The flow is added atomically - either all jobs are added or none.
+ */
+export async function enqueueFlow(
+  flow: FlowJob,
+): Promise<TypedResult<EnqueuedFlow, Error>> {
+  const producer = await flowProducer()
+
+  const { job } = await producer.add(flow)
+
+  if (!job.id) {
+    return Result.error(
+      new UnprocessableEntityError('Failed to enqueue flow: job ID is empty'),
+    )
+  }
+
+  return Result.ok({
+    flowJobId: flow.opts?.jobId ?? job.id,
+    rootJobId: job.id,
+  })
+}
+
+/**
+ * Enqueues multiple flows in bulk.
+ * Each flow is added atomically.
+ */
+export async function enqueueFlows(
+  flows: FlowJob[],
+): Promise<TypedResult<EnqueuedFlow[], Error>> {
+  const producer = await flowProducer()
+
+  const results = await producer.addBulk(flows)
+
+  const enqueuedFlows: EnqueuedFlow[] = []
+  for (let i = 0; i < results.length; i++) {
+    const { job } = results[i]!
+    if (!job.id) {
+      return Result.error(
+        new UnprocessableEntityError(`Failed to enqueue flow at index ${i}`),
+      )
+    }
+    enqueuedFlows.push({
+      flowJobId: flows[i]!.opts?.jobId ?? job.id,
+      rootJobId: job.id,
+    })
+  }
+
+  return Result.ok(enqueuedFlows)
+}

--- a/packages/core/src/jobs/flows/index.ts
+++ b/packages/core/src/jobs/flows/index.ts
@@ -1,0 +1,29 @@
+import { env } from '@latitude-data/env'
+import { FlowProducer } from 'bullmq'
+import { buildRedisConnection, REDIS_KEY_PREFIX } from '../../redis'
+
+export * from './types'
+export * from './sequential'
+export * from './enqueue'
+export * from './dynamicChildren'
+
+let _flowProducer: FlowProducer | undefined
+
+/**
+ * Returns a singleton FlowProducer instance for creating job flows.
+ * Uses the same Redis connection configuration as the queues.
+ */
+export async function flowProducer(): Promise<FlowProducer> {
+  if (_flowProducer) return _flowProducer
+
+  _flowProducer = new FlowProducer({
+    prefix: REDIS_KEY_PREFIX,
+    connection: await buildRedisConnection({
+      host: env.QUEUE_HOST,
+      port: env.QUEUE_PORT,
+      password: env.QUEUE_PASSWORD,
+    }),
+  })
+
+  return _flowProducer
+}

--- a/packages/core/src/jobs/flows/sequential.ts
+++ b/packages/core/src/jobs/flows/sequential.ts
@@ -1,0 +1,157 @@
+import { FlowJob, JobsOptions } from 'bullmq'
+import {
+  FlowStep,
+  FlowStepOrParallel,
+  SequentialFlowOptions,
+  BuildState,
+} from './types'
+
+/**
+ * Creates a BullMQ FlowJob structure for sequential execution with optional parallel steps.
+ *
+ * Steps execute in array order. Use nested arrays for parallel execution:
+ * - Single step: runs after previous step completes
+ * - Array of steps: all run in parallel, next step waits for ALL to complete
+ *
+ * @example
+ * // Execution: A → B → (C1 || C2 || C3) → D
+ * createSequentialFlow({
+ *   flowId: 'my-flow',
+ *   steps: [
+ *     { name: 'A', queue: Queues.defaultQueue, data: {} },
+ *     { name: 'B', queue: Queues.defaultQueue, data: {} },
+ *     [
+ *       { name: 'C1', queue: Queues.defaultQueue, data: {} },
+ *       { name: 'C2', queue: Queues.defaultQueue, data: {} },
+ *       { name: 'C3', queue: Queues.defaultQueue, data: {} },
+ *     ],
+ *     { name: 'D', queue: Queues.defaultQueue, data: {} },
+ *   ],
+ * })
+ */
+export function createSequentialFlow<TData = unknown>(
+  options: SequentialFlowOptions<TData>,
+): FlowJob {
+  const {
+    flowId,
+    steps,
+    defaultOpts = {},
+    continueOnChildFailure = false,
+  } = options
+
+  if (steps.length === 0) {
+    throw new Error('Flow must have at least one step')
+  }
+
+  const lastStep = steps[steps.length - 1]!
+  if (Array.isArray(lastStep)) {
+    throw new Error(
+      'Last step cannot be a parallel array - there must be a final step to wait for parallel jobs',
+    )
+  }
+
+  return buildFlowTree(steps, flowId, defaultOpts, continueOnChildFailure)
+}
+
+function buildFlowTree(
+  steps: FlowStepOrParallel[],
+  flowId: string,
+  defaultOpts: Omit<JobsOptions, 'parent'>,
+  continueOnChildFailure: boolean,
+): FlowJob {
+  const lastStep = steps[steps.length - 1] as FlowStep
+  const rootJob = stepToFlowJob(
+    lastStep,
+    flowId,
+    steps.length - 1,
+    0,
+    defaultOpts,
+    continueOnChildFailure,
+  )
+
+  let state: BuildState = {
+    root: rootJob,
+    leaves: [rootJob],
+  }
+
+  for (let i = steps.length - 2; i >= 0; i--) {
+    const step = steps[i]!
+    state = processStep(
+      state,
+      step,
+      flowId,
+      i,
+      defaultOpts,
+      continueOnChildFailure,
+    )
+  }
+
+  return state.root
+}
+
+function processStep(
+  state: BuildState,
+  step: FlowStepOrParallel,
+  flowId: string,
+  stepIndex: number,
+  defaultOpts: Omit<JobsOptions, 'parent'>,
+  continueOnChildFailure: boolean,
+): BuildState {
+  const newLeaves: FlowJob[] = []
+
+  if (Array.isArray(step)) {
+    for (const leaf of state.leaves) {
+      const parallelJobs = step.map((s, parallelIdx) =>
+        stepToFlowJob(
+          s,
+          flowId,
+          stepIndex,
+          parallelIdx,
+          defaultOpts,
+          continueOnChildFailure,
+        ),
+      )
+      leaf.children = [...(leaf.children ?? []), ...parallelJobs]
+      newLeaves.push(...parallelJobs)
+    }
+  } else {
+    for (const leaf of state.leaves) {
+      const job = stepToFlowJob(
+        step,
+        flowId,
+        stepIndex,
+        0,
+        defaultOpts,
+        continueOnChildFailure,
+      )
+      leaf.children = [...(leaf.children ?? []), job]
+      newLeaves.push(job)
+    }
+  }
+
+  return { root: state.root, leaves: newLeaves }
+}
+
+function stepToFlowJob(
+  step: FlowStep,
+  flowId: string,
+  stepIndex: number,
+  parallelIdx: number,
+  defaultOpts: Omit<JobsOptions, 'parent'>,
+  continueOnChildFailure: boolean,
+): FlowJob {
+  const jobId =
+    step.opts?.jobId ?? `${flowId}-${stepIndex}-${step.name}-${parallelIdx}`
+
+  return {
+    name: step.name,
+    queueName: step.queue,
+    data: step.data,
+    opts: {
+      ...defaultOpts,
+      ...step.opts,
+      jobId,
+      ...(continueOnChildFailure && { continueParentOnFailure: true }),
+    },
+  }
+}

--- a/packages/core/src/jobs/flows/types.ts
+++ b/packages/core/src/jobs/flows/types.ts
@@ -1,0 +1,45 @@
+import { JobsOptions, FlowJob } from 'bullmq'
+import { Queues } from '../queues/types'
+
+/**
+ * A single step in a flow with type-safe data
+ */
+export type FlowStep<TData = unknown> = {
+  name: string
+  queue: Queues
+  data: TData
+  opts?: Omit<JobsOptions, 'parent'>
+}
+
+/**
+ * A step can be either a single step or an array of parallel steps
+ */
+export type FlowStepOrParallel<TData = unknown> =
+  | FlowStep<TData>
+  | FlowStep<TData>[]
+
+/**
+ * Options for creating a sequential flow
+ */
+export type SequentialFlowOptions<TData = unknown> = {
+  flowId: string
+  steps: FlowStepOrParallel<TData>[]
+  defaultOpts?: Omit<JobsOptions, 'parent'>
+  continueOnChildFailure?: boolean
+}
+
+/**
+ * Result of enqueueing a flow
+ */
+export type EnqueuedFlow = {
+  flowJobId: string
+  rootJobId: string
+}
+
+/**
+ * Internal state for building the flow tree
+ */
+export type BuildState = {
+  root: FlowJob
+  leaves: FlowJob[]
+}

--- a/packages/core/src/services/evaluationsV2/generateFromIssue/createValidationFlow.ts
+++ b/packages/core/src/services/evaluationsV2/generateFromIssue/createValidationFlow.ts
@@ -1,23 +1,26 @@
-import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
-import { Commit } from '@latitude-data/core/schema/models/types/Commit'
-import { FlowProducer } from 'bullmq'
-import { REDIS_KEY_PREFIX } from '@latitude-data/core/redis'
-import { buildRedisConnection } from '@latitude-data/core/redis'
-import { env } from '@latitude-data/env'
-import { Queues } from '../../../jobs/queues/types'
-import { Result } from '@latitude-data/core/lib/Result'
 import { EvaluationV2 } from '@latitude-data/constants'
-import { Issue } from '../../../schema/models/types/Issue'
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { Result } from '@latitude-data/core/lib/Result'
 import { database } from '../../../client'
+import {
+  createSequentialFlow,
+  enqueueFlow,
+  FlowStep,
+} from '../../../jobs/flows'
+import { Queues } from '../../../jobs/queues/types'
+import { Issue } from '../../../schema/models/types/Issue'
 import { getEqualAmountsOfPositiveAndNegativeExamples } from './getEqualAmountsOfPositiveAndNegativeExamples'
 
-/*
-  This function validates an existing evaluation by calculating its MCC (Matthews Correlation Coefficient),
-    and updating the evaluation with the new alignment metric
-
-  To do this, it finds a set of positive and negative evaluation results from the issue and other issues/positive annotations of the same document,
-   and runs it against the created evalaluation. 
-*/
+/**
+ * Creates a validation flow for an existing evaluation by calculating its MCC
+ * (Matthews Correlation Coefficient) and updating the evaluation with the new
+ * alignment metric.
+ *
+ * The flow finds a set of positive and negative evaluation results from the issue
+ * and other issues/positive annotations of the same document, and runs it against
+ * the created evaluation.
+ */
 export async function createValidationFlow(
   {
     workspace,
@@ -74,71 +77,66 @@ export async function createValidationFlow(
     ...examplesThatShouldPassTheEvaluationSliced,
   ]
 
-  const flowProducer = new FlowProducer({
-    prefix: REDIS_KEY_PREFIX,
-    connection: await buildRedisConnection({
-      host: env.QUEUE_HOST,
-      port: env.QUEUE_PORT,
-      password: env.QUEUE_PASSWORD,
-    }),
-  })
+  const flowId = `validateGeneratedEvaluationJob-wf=${workflowUuid}-generationAttempt=${generationAttempt}`
 
-  const { job: validationFlowJob } = await flowProducer.add({
-    name: `validateGeneratedEvaluationJob`,
-    queueName: Queues.generateEvaluationsQueue,
+  const parallelEvaluationSteps: FlowStep[] = allSpans.map((span, index) => ({
+    name: 'runEvaluationV2Job',
+    queue: Queues.evaluationsQueue,
     data: {
       workspaceId: workspace.id,
       commitId: commit.id,
-      workflowUuid,
-      generationAttempt,
-      providerName,
-      model,
-      issueId: issue.id,
       evaluationUuid: evaluationToEvaluate.uuid,
-      documentUuid: issue.documentUuid,
-      spanAndTraceIdPairsOfExamplesThatShouldPassTheEvaluation,
-      spanAndTraceIdPairsOfExamplesThatShouldFailTheEvaluation,
+      spanId: span.id,
+      traceId: span.traceId,
+      dry: true,
     },
     opts: {
-      // Idempotency key
-      jobId: `validateGeneratedEvaluationJob-wf=${workflowUuid}-generationAttempt=${generationAttempt}`,
-      // FlowProducer does not inherit
-      attempts: 3,
+      jobId: `runEvaluationV2Job-wf=${workflowUuid}-gen=${generationAttempt}-idx=${index}`,
+      attempts: 2,
       backoff: {
-        type: 'exponential',
-        delay: 2000, // Need at least 2s for cases when runEval fails and we wait for the unprocessed children to finish
+        type: 'fixed' as const,
+        delay: 1000,
       },
+      continueParentOnFailure: true,
     },
-    children: allSpans.map((span, index) => ({
-      name: `runEvaluationV2Job`,
-      queueName: Queues.evaluationsQueue,
-      data: {
-        workspaceId: workspace.id,
-        commitId: commit.id,
-        evaluationUuid: evaluationToEvaluate.uuid,
-        spanId: span.id,
-        traceId: span.traceId,
-        dry: true,
-      },
-      opts: {
-        // Idempotency key
-        jobId: `runEvaluationV2Job-wf=${workflowUuid}-gen=${generationAttempt}-idx=${index}`,
-        // Overriding eval queue options for faster retry policy to avoid user waiting too long for the evaluation to be generated
-        attempts: 2,
-        backoff: {
-          type: 'fixed',
-          delay: 1000,
+  }))
+
+  const flow = createSequentialFlow({
+    flowId,
+    steps: [
+      parallelEvaluationSteps,
+      {
+        name: 'validateGeneratedEvaluationJob',
+        queue: Queues.generateEvaluationsQueue,
+        data: {
+          workspaceId: workspace.id,
+          commitId: commit.id,
+          workflowUuid,
+          generationAttempt,
+          providerName,
+          model,
+          issueId: issue.id,
+          evaluationUuid: evaluationToEvaluate.uuid,
+          documentUuid: issue.documentUuid,
+          spanAndTraceIdPairsOfExamplesThatShouldPassTheEvaluation,
+          spanAndTraceIdPairsOfExamplesThatShouldFailTheEvaluation,
         },
-        continueParentOnFailure: true, // If an evaluation run fails, continue the flow to calculate the alignment metric
+        opts: {
+          jobId: flowId,
+          attempts: 3,
+          backoff: {
+            type: 'exponential' as const,
+            delay: 2000,
+          },
+        },
       },
-    })),
+    ],
   })
 
-  if (!validationFlowJob.id) {
-    return Result.error(
-      new Error('Failed to create evaluation validation flow'),
-    )
+  const result = await enqueueFlow(flow)
+  if (!Result.isOk(result)) {
+    return result
   }
 
-  return Result.ok(validationFlowJob)
+  return Result.ok({ id: result.value.rootJobId })
 }


### PR DESCRIPTION
## Summary

Introduces a comprehensive Flow system built on top of BullMQ's FlowProducer, enabling declarative sequential job workflows with support for parallel steps and dynamic runtime step insertion.

This addresses the need to orchestrate multi-step background jobs where steps must execute in order, with the ability to fan-out for parallel work and dynamically extend the workflow based on job results.

## Why

I wanted to add more complexity and steps to the `backgroundRunJob`. Instead of having jobs enqueue other jobs in parallel and having them check if the other jobs finished through a common counter in redis, a waaayy better way to approach this is using BullMQ's Flow system.

In addition to this, the new conversation simulation feature will benefit from flows, but it also needs to add middle steps to that flow dinamically!

I have built this PR to build an abstraction to this complex job flow management system to both define, enqueue, and dynamically append jobs on runtime!

## How It Works

### Flow Execution Model

BullMQ flows use a **child-completes-before-parent** model. To achieve sequential execution (A → B → C), we structure it as:

```
┌─────────────────────────────────────────────────┐
│                  BullMQ Flow Tree               │
├─────────────────────────────────────────────────┤
│                                                 │
│                    ┌───┐                        │
│                    │ C │  ← Root (runs last)    │
│                    └─┬─┘                        │
│                      │                          │
│                    ┌─┴─┐                        │
│                    │ B │  ← Child of C          │
│                    └─┬─┘                        │
│                      │                          │
│                    ┌─┴─┐                        │
│                    │ A │  ← Leaf (runs first)   │
│                    └───┘                        │
│                                                 │
│  Execution order: A → B → C                     │
└─────────────────────────────────────────────────┘
```

### Parallel Steps

When steps should run in parallel, wrap them in an array:

```
┌─────────────────────────────────────────────────┐
│           Parallel Step Execution               │
├─────────────────────────────────────────────────┤
│                                                 │
│                   ┌───┐                         │
│                   │ D │  ← Runs after B1,B2,B3  │
│                   └─┬─┘                         │
│           ┌─────────┼─────────┐                 │
│         ┌─┴─┐     ┌─┴─┐     ┌─┴─┐               │
│         │B1 │     │B2 │     │B3 │  ← Parallel   │
│         └─┬─┘     └─┬─┘     └─┬─┘               │
│           └─────────┼─────────┘                 │
│                   ┌─┴─┐                         │
│                   │ A │  ← Runs first           │
│                   └───┘                         │
│                                                 │
│  Execution: A → (B1, B2, B3 in parallel) → D    │
└─────────────────────────────────────────────────┘
```

### Dynamic Flow Extension

Jobs can dynamically add sibling steps at runtime using `DynamicChildrenContext`:

```
┌─────────────────────────────────────────────────┐
│           Dynamic Step Insertion                │
├─────────────────────────────────────────────────┤
│                                                 │
│  Static flow: [A, B, C]                         │
│                                                 │
│  At runtime, B decides to add B2:               │
│                                                 │
│       ┌───┐                                     │
│       │ C │  ← Waits for B                      │
│       └─┬─┘                                     │
│         │                                       │
│       ┌─┴─┐                                     │
│       │ B │  ← Adds B2 as child, waits          │
│       └─┬─┘                                     │
│    ┌────┴────┐                                  │
│  ┌─┴─┐     ┌─┴─┐                                │
│  │ A │     │B2 │  ← B2 added dynamically        │
│  └───┘     └───┘                                │
│                                                 │
│  Execution: A → B(starts) → B2 → B(resumes) → C │
└─────────────────────────────────────────────────┘
```

## Usage

### Static Sequential Flow

```typescript
import { createSequentialFlow, enqueueFlow } from '@latitude-data/core/flows'
import { Queues } from '@latitude-data/core/jobs/queues/types'

const flow = createSequentialFlow({
  flowId: 'my-pipeline',
  steps: [
    { name: 'fetchData', queue: Queues.defaultQueue, data: { url: '...' } },
    { name: 'transform', queue: Queues.defaultQueue, data: { format: 'json' } },
    { name: 'save', queue: Queues.defaultQueue, data: { destination: 'db' } },
  ],
})

const result = await enqueueFlow(flow)
```

### With Parallel Steps

```typescript
const flow = createSequentialFlow({
  flowId: 'fan-out-pipeline',
  steps: [
    { name: 'prepare', queue: Queues.defaultQueue, data: {} },
    [
      { name: 'processA', queue: Queues.defaultQueue, data: { type: 'A' } },
      { name: 'processB', queue: Queues.defaultQueue, data: { type: 'B' } },
      { name: 'processC', queue: Queues.defaultQueue, data: { type: 'C' } },
    ],
    { name: 'aggregate', queue: Queues.defaultQueue, data: {} },
  ],
})
```

### Dynamic Step Insertion

```typescript
import { DynamicChildrenContext } from '@latitude-data/core/flows'

export const iterativeJob = async (job: Job, token?: string) => {
  const ctx = DynamicChildrenContext.create(job, token)
  if (!ctx) throw new Error('Token required for dynamic flows')

  // Check if resuming after children completed
  if (ctx.isResume()) {
    const childResults = await ctx.getChildrenResults()
    return { phase: 'completed', childResults }
  }

  // Do work
  const result = await processData(job.data)

  // Conditionally add more steps
  if (result.needsMoreProcessing) {
    await ctx.addFlowStep({
      name: 'iterativeJob',
      queue: Queues.defaultQueue,
      data: { iteration: job.data.iteration + 1 },
    })
  }

  // This throws WaitingChildrenError if steps were added
  await ctx.waitForChildren()

  return result
}
```

## API Reference

### `createSequentialFlow(options)`
Creates a BullMQ FlowJob structure from an array of steps.

### `enqueueFlow(flow)` / `enqueueFlows(flows)`
Enqueues flow(s) and returns a Result with `{ flowJobId, rootJobId }`.

### `DynamicChildrenContext`
- `.create(job, token)` - Create context for dynamic step insertion
- `.isResume()` - Check if job is resuming after children completed
- `.addFlowStep(step)` - Add a child step dynamically
- `.addFlowSteps(steps)` - Add multiple child steps (parallel)
- `.waitForChildren()` - Wait for children (throws if steps were added)
- `.getChildrenResults()` - Get results from completed children