### PR TITLE
Update PromptL Syntax Highlighting

### DIFF
--- a/packages/core/src/services/documents/getDocumentType.test.ts
+++ b/packages/core/src/services/documents/getDocumentType.test.ts
@@ -177,17 +177,5 @@ This is some content without frontmatter.
       })
       expect(result).toBe(DocumentType.Prompt)
     })
-
-    it('returns Agent even when frontmatter is not at the start', async () => {
-      // scan() can still extract config from YAML even if not at the very start
-      const result = await getDocumentType({
-        content: `This is plain text
----
-provider: openai
----
-More text`,
-      })
-      expect(result).toBe(DocumentType.Agent)
-    })
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 8.16.0
       version: 8.16.0
     promptl-ai:
-      specifier: 0.9.5
-      version: 0.9.5
+      specifier: 0.10.0
+      version: 0.10.0
     react:
       specifier: 19.2.4
       version: 19.2.4
@@ -199,7 +199,7 @@ importers:
         version: 4.17.21
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       rate-limiter-flexible:
         specifier: 5.0.3
         version: 5.0.3
@@ -398,7 +398,7 @@ importers:
         version: 1.298.0
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       rate-limiter-flexible:
         specifier: 5.0.3
         version: 5.0.3
@@ -718,7 +718,7 @@ importers:
         version: 0.4.0
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       zod:
         specifier: 'catalog:'
         version: 4.1.8
@@ -941,7 +941,7 @@ importers:
         version: 5.14.0
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       rate-limiter-flexible:
         specifier: 5.0.3
         version: 5.0.3
@@ -1148,7 +1148,7 @@ importers:
         version: 2.0.1
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       typescript:
         specifier: ^5.5.4
         version: 5.9.3
@@ -1303,7 +1303,7 @@ importers:
         version: 6.17.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.1.8)
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       rollup:
         specifier: ^4.53.3
         version: 4.53.3
@@ -1529,7 +1529,7 @@ importers:
         version: 16.1.1(postcss@8.5.6)
       promptl-ai:
         specifier: 'catalog:'
-        version: 0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       recast:
         specifier: ^0.23.4
         version: 0.23.11
@@ -11821,11 +11821,11 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  promptl-ai@0.10.0:
+    resolution: {integrity: sha512-ZuD0CJ4NjHWqvs3POvcoER8ifAZH3ivRBO5YGGPci/qNVRh5+u2kgkzSIQcbzMH1bSvnY2LuENxTX0uHC6lE/A==}
+
   promptl-ai@0.7.5:
     resolution: {integrity: sha512-qDJggAR34qqxc5/X6xqagMCVNVQK8U3ycohtKJNG1/1Ap5VJ/UzF4ERphWAmLrspl4KYcT2ITKQhq28TAcw3Qg==}
-
-  promptl-ai@0.9.5:
-    resolution: {integrity: sha512-Ad4yvnI2u6idmdA4Iynrkr5oDpXnDnZtqkb7Xs1OY0fREUIjp+JMy+TVvz2fyRYdtnx6iPFBdtGsb4GL9KOFww==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -27401,6 +27401,19 @@ snapshots:
 
   progress@2.0.3: {}
 
+  promptl-ai@0.10.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
+    dependencies:
+      acorn: 8.15.0
+      code-red: 1.0.4
+      fast-sha256: 1.3.0
+      locate-character: 3.0.0
+      openai: 4.104.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.1.8)
+      yaml: 2.4.5
+      zod: 4.1.8
+    transitivePeerDependencies:
+      - encoding
+      - ws
+
   promptl-ai@0.7.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
     dependencies:
       acorn: 8.15.0
@@ -27410,19 +27423,6 @@ snapshots:
       openai: 4.104.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
       yaml: 2.8.1
       zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
-  promptl-ai@0.9.5(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
-    dependencies:
-      acorn: 8.15.0
-      code-red: 1.0.4
-      fast-sha256: 1.3.0
-      locate-character: 3.0.0
-      openai: 4.104.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@4.1.8)
-      yaml: 2.4.5
-      zod: 4.1.8
     transitivePeerDependencies:
       - encoding
       - ws

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   drizzle-orm: 0.44.2
   drizzle-kit: 0.31.1
   dd-trace: 5.69.0
-  promptl-ai: 0.9.5
+  promptl-ai: 0.10.0
   rosetta-ai: 1.3.1
   zod: 4.1.8
   react: 19.2.4


### PR DESCRIPTION
Update PromptL Syntax Highlighting to match latest logic changes: `---` no longer requires to be escaped when it is added after the configuration section, or when there is no configuration section at all. In these cases, `---` is treated as regular text and now highlighted as such.