### PR TITLE
minor: show error in experiment when simulation fails

### DIFF
--- a/packages/core/src/jobs/job-definitions/runs/backgroundRunJob.ts
+++ b/packages/core/src/jobs/job-definitions/runs/backgroundRunJob.ts
@@ -179,7 +179,7 @@ export const backgroundRunJob = async (
         commitUuid,
         runUuid,
         initialMessages: await result.conversation.messages,
-      })
+      }).then((r) => r.unwrap())
     }
 
     if (experiment) {

--- a/packages/core/src/jobs/utils/progressTracker.test.ts
+++ b/packages/core/src/jobs/utils/progressTracker.test.ts
@@ -106,13 +106,23 @@ describe('ProgressTracker', () => {
       expect(progress.completed).toBe(1)
     })
 
-    it('marks evaluations as errors when document run fails', async () => {
+    it('marks run and evaluations as errors when document run fails', async () => {
       await tracker.initializeProgress(['uuid-1'], 2)
 
       await tracker.documentRunFinished('uuid-1', false)
 
       const progress = await tracker.getProgress()
-      expect(progress.errors).toBe(2)
+      expect(progress.errors).toBe(3)
+      expect(progress.completed).toBe(1)
+    })
+
+    it('marks run as error when document run fails with no evaluations', async () => {
+      await tracker.initializeProgress(['uuid-1'], 0)
+
+      await tracker.documentRunFinished('uuid-1', false)
+
+      const progress = await tracker.getProgress()
+      expect(progress.errors).toBe(1)
       expect(progress.completed).toBe(1)
     })
   })

--- a/packages/core/src/jobs/utils/progressTracker.ts
+++ b/packages/core/src/jobs/utils/progressTracker.ts
@@ -83,9 +83,9 @@ export class ProgressTracker {
     const evaluationsPerRow = await this.getEvaluationsPerRow(redis)
     const incrementCount = success ? 1 : 1 + evaluationsPerRow // If failed, evaluations will be marked as done too since they will not run
 
-    if (!success && evaluationsPerRow > 0) {
-      // Mark this row's evaluations as errors
-      await redis.incrby(this.getKey('errors'), evaluationsPerRow)
+    if (!success) {
+      // Mark this row as an error (1 for the failed document run + evaluations that won't run)
+      await redis.incrby(this.getKey('errors'), 1 + evaluationsPerRow)
     }
 
     return this.incrementRow(redis, uuid, incrementCount)


### PR DESCRIPTION
~Note: Although we persist the error in `runErrors`, it is not being displayed anywhere yet when reloading the page.~
(Not persisting anymore)