### PR TITLE
feat(mailer): add configurable host and port for mailpit adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,9 @@ WEBSOCKET_SECRET_TOKEN_KEY=websocket-secret-token
 MAIL_TRANSPORT= mailpit # smtp, mailgun, mailpit - default transport is mailpit
 # This is the email address that will be used as the sender of emails
 FROM_MAILER_EMAIL=hello@latitude.localhost # e.g hello@mayapp.com
+# Mailpit Configuration (if MAIL_TRANSPORT is set to mailpit)
+MAILPIT_HOST=localhost         # e.g. mailpit or 192.168.1.100 for container environments
+MAILPIT_PORT=1025              # default mailpit SMTP port
 # Only used if MAIL_TRANSPORT is set to mailgun
 MAILGUN_EMAIL_DOMAIN=latitude.localhost # e.g email.myapp.com
 MAILGUN_MAILER_API_KEY=                 # (optional)

--- a/packages/core/src/mailer/adapters/mailpit.ts
+++ b/packages/core/src/mailer/adapters/mailpit.ts
@@ -1,3 +1,4 @@
+import { env } from '@latitude-data/env'
 import nodemailer from 'nodemailer'
 
 import { MailerOptions } from '.'
@@ -7,7 +8,8 @@ export default function createMailtrapTransport({
 }: MailerOptions) {
   return nodemailer.createTransport(
     {
-      port: 1025,
+      host: env.MAILPIT_HOST,
+      port: env.MAILPIT_PORT,
       auth: {
         user: 'readfort',
         pass: 'secret',

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -231,6 +231,8 @@ export const env = createEnv({
     SMTP_SECURE: z.string().optional().default('true'),
     SMTP_USER: z.string().optional(),
     SMTP_PASS: z.string().optional(),
+    MAILPIT_HOST: z.string().optional().default('localhost'),
+    MAILPIT_PORT: z.coerce.number().optional().default(1025),
     MAIL_TRANSPORT: z
       .enum(['mailpit', 'mailgun', 'smtp'])
       .optional()


### PR DESCRIPTION
Adds MAILPIT_HOST and MAILPIT_PORT environment variables to make the mailpit adapter configurable for containerized environments.

Previously, the mailpit adapter used hardcoded values (localhost:1025), which doesn't work when mailpit runs in a separate container.

Defaults maintain backward compatibility:
- MAILPIT_HOST: localhost
- MAILPIT_PORT: 1025

Closes #1480