### PR TITLE
Add user goal setting for conversation simulation experiments

### DIFF
--- a/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/SimulationSettings.tsx
+++ b/apps/web/src/components/RunExperimentModal/ExperimentForm/_components/SimulationSettings.tsx
@@ -1,9 +1,17 @@
 import { SimulationSettingsPanel } from '$/components/SimulationSettings'
 import { SimulationSettings } from '@latitude-data/constants/simulation'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { ExperimentFormPayload } from '../useExperimentFormPayload'
+import { useLabels } from './useLabels'
 
 export function ExperimentSimulationSettings(payload: ExperimentFormPayload) {
+  const { labels, buildLabels } = useLabels()
+
+  useEffect(() => {
+    if (!payload.selectedDataset) return
+    buildLabels(payload.selectedDataset)
+  }, [payload.selectedDataset, buildLabels])
+
   const handleChange = useCallback(
     (settings: SimulationSettings) => {
       payload.setSimulationSettings(settings)
@@ -11,11 +19,15 @@ export function ExperimentSimulationSettings(payload: ExperimentFormPayload) {
     [payload],
   )
 
+  const isDatasetSource = payload.selectedParametersSource === 'dataset'
+
   return (
     <div className='flex flex-col gap-4 w-2/3'>
       <SimulationSettingsPanel
         value={payload.simulationSettings}
         onChange={handleChange}
+        isDatasetSource={isDatasetSource}
+        datasetColumns={isDatasetSource ? labels : undefined}
       />
     </div>
   )

--- a/apps/web/src/components/SimulationSettings/index.tsx
+++ b/apps/web/src/components/SimulationSettings/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SimulationSettings } from '@latitude-data/constants/simulation'
+import { SelectOption } from '@latitude-data/web-ui/atoms/Select'
 import { ToolSimulationSettings } from './ToolSimulation'
 import { ConversationSimulationSettings } from './ConversationSimulation'
 
@@ -8,12 +9,16 @@ export type SimulationSettingsProps = {
   value?: SimulationSettings
   onChange: (settings: SimulationSettings) => void
   disabled?: boolean
+  isDatasetSource?: boolean
+  datasetColumns?: SelectOption<number>[]
 }
 
 export function SimulationSettingsPanel({
   value = {},
   onChange,
   disabled,
+  isDatasetSource,
+  datasetColumns,
 }: SimulationSettingsProps) {
   return (
     <div className='flex flex-col gap-4'>
@@ -21,6 +26,8 @@ export function SimulationSettingsPanel({
         value={value}
         onChange={onChange}
         disabled={disabled}
+        isDatasetSource={isDatasetSource}
+        datasetColumns={datasetColumns}
       />
       <ToolSimulationSettings
         value={value}

--- a/packages/constants/src/simulation.ts
+++ b/packages/constants/src/simulation.ts
@@ -2,11 +2,32 @@ import { z } from 'zod'
 
 export const MAX_SIMULATION_TURNS = 10
 
+export const globalGoalSourceSchema = z.object({
+  type: z.literal('global'),
+  value: z.string(),
+})
+
+export const columnGoalSourceSchema = z.object({
+  type: z.literal('column'),
+  columnIndex: z.number(),
+})
+
+export const simulatedUserGoalSourceSchema = z.discriminatedUnion('type', [
+  globalGoalSourceSchema,
+  columnGoalSourceSchema,
+])
+
+export type SimulatedUserGoalSource = z.infer<
+  typeof simulatedUserGoalSourceSchema
+>
+
 export const SimulationSettingsSchema = z.object({
   simulateToolResponses: z.boolean().optional(),
   simulatedTools: z.array(z.string()).optional(), // Empty array means all tools are simulated (if simulateToolResponses is true).
   toolSimulationInstructions: z.string().optional(), // A prompt used to guide and generate the simulation result
   maxTurns: z.number().min(1).max(MAX_SIMULATION_TURNS).optional(), // The maximum number of turns to simulate. Default is 1, and any greater value will add a new user message to the simulated conversation.
+  simulatedUserGoal: z.string().optional(), // Deprecated: Use simulatedUserGoalSource instead. Kept for backward compatibility.
+  simulatedUserGoalSource: simulatedUserGoalSourceSchema.optional(), // The source for the simulated user goal (global text or dataset column).
 })
 
 export type SimulationSettings = z.infer<typeof SimulationSettingsSchema>

--- a/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.ts
+++ b/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.ts
@@ -37,6 +37,7 @@ type ExecuteSingleTurnArgs = RunIdentifiers & {
   messages: Message[]
   currentTurn: number
   maxTurns: number
+  simulationInstructions?: string
   workspace: WorkspaceDto
   documentLogUuid: string
   tools: Record<string, ToolHandler>
@@ -58,9 +59,10 @@ type TurnResult = {
  * - "respond": Continue with the generated message, then get the assistant's reply
  */
 async function executeSingleTurn({
-  messages,
+  simulationInstructions,
   currentTurn,
   maxTurns,
+  messages,
   workspace,
   documentLogUuid,
   tools,
@@ -75,7 +77,7 @@ async function executeSingleTurn({
 }: ExecuteSingleTurnArgs): PromisedResult<TurnResult, Error> {
   const userActionResult = await generateSimulatedUserAction({
     messages,
-    simulationInstructions: undefined,
+    simulationInstructions,
     currentTurn,
     maxTurns,
     abortSignal,
@@ -182,9 +184,10 @@ export async function simulateUserResponses({
     if (abortSignal?.aborted) break
 
     const turnResult = await executeSingleTurn({
-      messages,
+      simulationInstructions: simulationSettings.simulatedUserGoal,
       currentTurn,
       maxTurns,
+      messages,
       workspace,
       documentLogUuid,
       tools,

--- a/packages/core/src/services/experiments/start/getExperimentJobPayload.test.ts
+++ b/packages/core/src/services/experiments/start/getExperimentJobPayload.test.ts
@@ -1,4 +1,5 @@
 import { Providers } from '@latitude-data/constants'
+import { SimulatedUserGoalSource } from '@latitude-data/constants/simulation'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { EvaluationV2 } from '../../../constants'
 import { type Commit } from '../../../schema/models/types/Commit'
@@ -7,13 +8,17 @@ import { type DocumentVersion } from '../../../schema/models/types/DocumentVersi
 import { type Workspace } from '../../../schema/models/types/Workspace'
 import * as factories from '../../../tests/factories'
 import { createExperiment } from '../create'
-import { getExperimentJobPayload } from './getExperimentJobPayload'
+import {
+  getExperimentJobPayload,
+  resolveGoalFromSource,
+} from './getExperimentJobPayload'
 
 describe('getExperimentJobPayload', () => {
   let workspace: Workspace
   let document: DocumentVersion
   let commit: Commit
   let dataset: Dataset
+  let author: Awaited<ReturnType<typeof factories.createProject>>['user']
   const parametersMap = {
     a: 0,
     b: 1,
@@ -40,6 +45,7 @@ describe('getExperimentJobPayload', () => {
     workspace = createdWorkspace
     document = documents[0]!
     commit = createdCommit
+    author = user
 
     const { dataset: createdDataset } = await factories.createDataset({
       workspace,
@@ -170,5 +176,203 @@ describe('getExperimentJobPayload', () => {
     if (experiment.metadata.parametersSource.source === 'manual') {
       expect(experiment.metadata.parametersSource.count).toBe(1)
     }
+  })
+
+  it('Resolves simulatedUserGoal from global source', async () => {
+    const experiment = await createExperiment({
+      name: 'experiment-global-goal',
+      workspace,
+      document,
+      commit,
+      parametersPopulation: {
+        source: 'dataset',
+        dataset,
+        parametersMap,
+        datasetLabels,
+        fromRow: 1,
+        toRow: 3,
+      },
+      evaluations,
+      simulationSettings: {
+        simulateToolResponses: true,
+        maxTurns: 3,
+        simulatedUserGoalSource: {
+          type: 'global',
+          value: 'Complete the purchase flow',
+        },
+      },
+    }).then((r) => r.unwrap())
+
+    const { rows } = await getExperimentJobPayload({
+      experiment,
+      workspace,
+    }).then((r) => r.unwrap())
+
+    expect(rows).toHaveLength(3)
+    rows.forEach((row) => {
+      expect(row.simulatedUserGoal).toBe('Complete the purchase flow')
+    })
+  })
+
+  it('Resolves simulatedUserGoal from dataset column', async () => {
+    const { dataset: goalDataset } = await factories.createDataset({
+      workspace,
+      author,
+      fileContent: factories.generateCsvContent({
+        headers: ['a', 'b', 'goal'],
+        rows: [
+          ['a1', 'b1', 'Goal for row 1'],
+          ['a2', 'b2', 'Goal for row 2'],
+          ['a3', 'b3', 'Goal for row 3'],
+        ],
+      }),
+    })
+
+    const experiment = await createExperiment({
+      name: 'experiment-column-goal',
+      workspace,
+      document,
+      commit,
+      parametersPopulation: {
+        source: 'dataset',
+        dataset: goalDataset,
+        parametersMap: { a: 0, b: 1 },
+        datasetLabels,
+        fromRow: 1,
+        toRow: 3,
+      },
+      evaluations,
+      simulationSettings: {
+        simulateToolResponses: true,
+        maxTurns: 3,
+        simulatedUserGoalSource: {
+          type: 'column',
+          columnIndex: 2,
+        },
+      },
+    }).then((r) => r.unwrap())
+
+    const { rows } = await getExperimentJobPayload({
+      experiment,
+      workspace,
+    }).then((r) => r.unwrap())
+
+    expect(rows).toHaveLength(3)
+    const goals = rows.map((row) => row.simulatedUserGoal).sort()
+    expect(goals).toEqual([
+      'Goal for row 1',
+      'Goal for row 2',
+      'Goal for row 3',
+    ])
+  })
+
+  it('Returns undefined simulatedUserGoal when no goalSource is provided', async () => {
+    const experiment = await createExperiment({
+      name: 'experiment-no-goal',
+      workspace,
+      document,
+      commit,
+      parametersPopulation: {
+        source: 'dataset',
+        dataset,
+        parametersMap,
+        datasetLabels,
+        fromRow: 1,
+        toRow: 2,
+      },
+      evaluations,
+      simulationSettings: {
+        simulateToolResponses: true,
+      },
+    }).then((r) => r.unwrap())
+
+    const { rows } = await getExperimentJobPayload({
+      experiment,
+      workspace,
+    }).then((r) => r.unwrap())
+
+    expect(rows).toHaveLength(2)
+    rows.forEach((row) => {
+      expect(row.simulatedUserGoal).toBeUndefined()
+    })
+  })
+})
+
+describe('resolveGoalFromSource', () => {
+  const mockDataset: Dataset = {
+    id: 1,
+    name: 'test-dataset',
+    columns: [
+      { identifier: 'col_a', name: 'a', role: 'parameter' },
+      { identifier: 'col_b', name: 'b', role: 'parameter' },
+      { identifier: 'col_goal', name: 'goal', role: 'parameter' },
+    ],
+    workspaceId: 1,
+    authorId: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    tags: [],
+  }
+
+  const mockRowValues: Record<string, unknown> = {
+    col_a: 'value_a',
+    col_b: 'value_b',
+    col_goal: 'This is the goal from column',
+  }
+
+  it('returns undefined when goalSource is undefined', () => {
+    const result = resolveGoalFromSource(undefined, mockDataset, mockRowValues)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns global value when goalSource type is global', () => {
+    const goalSource: SimulatedUserGoalSource = {
+      type: 'global',
+      value: 'Global goal value',
+    }
+    const result = resolveGoalFromSource(goalSource, mockDataset, mockRowValues)
+    expect(result).toBe('Global goal value')
+  })
+
+  it('returns undefined when global value is empty string', () => {
+    const goalSource: SimulatedUserGoalSource = {
+      type: 'global',
+      value: '',
+    }
+    const result = resolveGoalFromSource(goalSource, mockDataset, mockRowValues)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns column value when goalSource type is column', () => {
+    const goalSource: SimulatedUserGoalSource = {
+      type: 'column',
+      columnIndex: 2,
+    }
+    const result = resolveGoalFromSource(goalSource, mockDataset, mockRowValues)
+    expect(result).toBe('This is the goal from column')
+  })
+
+  it('returns undefined when column index is out of bounds', () => {
+    const goalSource: SimulatedUserGoalSource = {
+      type: 'column',
+      columnIndex: 999,
+    }
+    const result = resolveGoalFromSource(goalSource, mockDataset, mockRowValues)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns undefined when column value is not in row', () => {
+    const goalSource: SimulatedUserGoalSource = {
+      type: 'column',
+      columnIndex: 0,
+    }
+    const emptyRowValues: Record<string, unknown> = {}
+    const result = resolveGoalFromSource(
+      goalSource,
+      mockDataset,
+      emptyRowValues,
+    )
+    expect(result).toBeUndefined()
   })
 })

--- a/packages/web-ui/src/ds/atoms/Select/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Select/index.tsx
@@ -24,6 +24,7 @@ export type SelectOption<V extends unknown = unknown> = {
   value: V
   icon?: ReactNode | IconName
   hoverDescription?: string
+  disabled?: boolean
 }
 
 export type SelectOptionGroup<V extends unknown = unknown> = {
@@ -32,7 +33,12 @@ export type SelectOptionGroup<V extends unknown = unknown> = {
 }
 export function Options({ options }: { options: SelectOption[] }) {
   return options.map((option, key) => (
-    <SelectItem key={key} value={String(option.value)} icon={option.icon}>
+    <SelectItem
+      key={key}
+      value={String(option.value)}
+      icon={option.icon}
+      disabled={option.disabled}
+    >
       {option.label}
     </SelectItem>
   ))


### PR DESCRIPTION
## Summary

Adds support for configuring a user goal in multi-turn conversation simulations. The goal describes the simulated user's intended behavior and helps guide the simulation to decide when to stop the conversation.

The goal can be configured in two ways:
- **Global**: A single goal text that applies to all rows in an experiment
- **From dataset column**: A column from the selected dataset, allowing per-row goals for more targeted simulations

When a dataset is selected in the experiment modal, users can toggle between these two modes. Without a dataset, only the global text input is shown.

The goal value is resolved per-row at experiment start time and passed to each background job, where it's used by the simulated user response generation.


https://github.com/user-attachments/assets/e0721ce8-b263-45a7-aa97-67aa87cfba86

