### PR TITLE
feat: add bearer token auth option for MCP servers

### DIFF
--- a/packages/core/src/services/integrations/McpClient/oauthRegistration.ts
+++ b/packages/core/src/services/integrations/McpClient/oauthRegistration.ts
@@ -99,8 +99,17 @@ async function registerClientWithPathSupport(
   })
 
   if (!response.ok) {
+    let errorDetails = ''
+    try {
+      const errorBody = await response.json()
+      errorDetails = errorBody.error
+        ? ` - ${errorBody.error}: ${errorBody.errorDescription || errorBody.error_description || ''}`
+        : ` - ${JSON.stringify(errorBody)}`
+    } catch {
+      // Response body is not JSON, ignore
+    }
     throw new Error(
-      `Dynamic client registration failed: HTTP ${response.status}`,
+      `Dynamic client registration failed: HTTP ${response.status}${errorDetails}`,
     )
   }
 


### PR DESCRIPTION
## Summary
- When an MCP server requires authentication, users can now choose between OAuth flow or Bearer token authentication
- Added a segmented control (TabSelect) to switch between the two auth methods
- Improved OAuth error messages to include the actual server error details (e.g., "invalid_redirect_uri")

## Context
Some MCP servers (like Databox) require authentication but their OAuth servers don't support dynamic client registration with arbitrary redirect URIs. This change allows users to:
1. Use the OAuth flow when it works (server accepts our redirect URI)
2. Use a Bearer token obtained from the provider's dashboard when OAuth registration fails

## Test plan
- [x] Enter an MCP URL that requires authentication
- [x] Verify the auth method selector appears with OAuth and Bearer token options
- [x] Test OAuth flow works when selected
- [x] Test Bearer token flow stores the token in headers and tests connection