### PR TITLE
fix(spans): bound first-page pagination to last 8 weeks

### DIFF
--- a/apps/web/src/app/api/spans/limited/route.test.ts
+++ b/apps/web/src/app/api/spans/limited/route.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { subWeeks } from 'date-fns'
+import { createProject, createSpan } from '@latitude-data/core/factories'
+import { SpanType } from '@latitude-data/constants'
+import { User } from '@latitude-data/core/schema/models/types/User'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { Project } from '@latitude-data/core/schema/models/types/Project'
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+
+import { GET } from './route'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+    captureException: vi.fn(),
+  }
+})
+
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+vi.mock('$/helpers/captureException', () => ({
+  captureException: mocks.captureException,
+}))
+
+describe('GET handler for spans/limited', () => {
+  let user: User
+  let workspace: Workspace
+  let project: Project
+  let commit: Commit
+  let document: DocumentVersion
+
+  beforeEach(async () => {
+    const setup = await createProject({
+      documents: {
+        'test-doc': 'Test content',
+      },
+    })
+    user = setup.user
+    workspace = setup.workspace
+    project = setup.project
+    commit = setup.commit
+    document = setup.documents[0]!
+  })
+
+  function buildRequest(params: Record<string, string>) {
+    const searchParams = new URLSearchParams(params)
+    return new NextRequest(
+      `http://localhost:3000/api/spans/limited?${searchParams.toString()}`,
+    )
+  }
+
+  describe('unauthorized', () => {
+    it('returns 401 if user is not authenticated', async () => {
+      mocks.getSession.mockResolvedValue(null)
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        types: SpanType.Prompt,
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({
+        message: 'Unauthorized',
+      })
+    })
+  })
+
+  describe('authorized', () => {
+    beforeEach(() => {
+      mocks.getSession.mockResolvedValue({
+        user,
+        session: { userId: user.id, currentWorkspaceId: workspace.id },
+      })
+    })
+
+    it('falls back to all-time on first page when default window returns no spans (document-level)', async () => {
+      const oldTraceId = 'old-trace'
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        type: SpanType.Prompt,
+        traceId: oldTraceId,
+        startedAt: subWeeks(new Date(), 9),
+      })
+
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        types: SpanType.Prompt,
+        limit: '50',
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.items).toHaveLength(1)
+      expect(data.items[0].traceId).toBe(oldTraceId)
+    })
+
+    it('does not include older spans when default window returns some spans (document-level)', async () => {
+      const oldTraceId = 'old-trace-2'
+      const recentTraceId = 'recent-trace-2'
+
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        type: SpanType.Prompt,
+        traceId: oldTraceId,
+        startedAt: subWeeks(new Date(), 9),
+      })
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        type: SpanType.Prompt,
+        traceId: recentTraceId,
+        startedAt: subWeeks(new Date(), 1),
+      })
+
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        types: SpanType.Prompt,
+        limit: '50',
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.items).toHaveLength(1)
+      expect(data.items[0].traceId).toBe(recentTraceId)
+      expect(data.items.some((s: any) => s.traceId === oldTraceId)).toBe(false)
+    })
+
+    it('does not fall back to all-time when createdAt is explicitly provided', async () => {
+      const oldTraceId = 'old-trace-3'
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        type: SpanType.Prompt,
+        traceId: oldTraceId,
+        startedAt: subWeeks(new Date(), 9),
+      })
+
+      const filters = JSON.stringify({
+        createdAt: {
+          from: subWeeks(new Date(), 8).toISOString(),
+        },
+      })
+
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        types: SpanType.Prompt,
+        limit: '50',
+        filters,
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.items).toHaveLength(0)
+    })
+
+    it('treats empty createdAt filter as not provided and can fall back to all-time', async () => {
+      const oldTraceId = 'old-trace-4'
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        type: SpanType.Prompt,
+        traceId: oldTraceId,
+        startedAt: subWeeks(new Date(), 9),
+      })
+
+      const filters = JSON.stringify({
+        createdAt: {},
+      })
+
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        types: SpanType.Prompt,
+        limit: '50',
+        filters,
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.items).toHaveLength(1)
+      expect(data.items[0].traceId).toBe(oldTraceId)
+    })
+
+    it('falls back to all-time on first page when default window returns no spans (project-level)', async () => {
+      const oldTraceId = 'old-trace-project'
+      await createSpan({
+        workspaceId: workspace.id,
+        commitUuid: commit.uuid,
+        documentUuid: document.documentUuid,
+        projectId: project.id,
+        type: SpanType.Prompt,
+        traceId: oldTraceId,
+        startedAt: subWeeks(new Date(), 9),
+      })
+
+      const request = buildRequest({
+        projectId: project.id.toString(),
+        types: SpanType.Prompt,
+        limit: '50',
+      })
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.items).toHaveLength(1)
+      expect(data.items[0].traceId).toBe(oldTraceId)
+    })
+  })
+})
+

--- a/apps/web/src/app/api/spans/limited/route.ts
+++ b/apps/web/src/app/api/spans/limited/route.ts
@@ -83,6 +83,11 @@ export const GET = errorHandler(
           const currentCommit = await commitsRepo
             .getCommitByUuid({ uuid: commitUuid, projectId: Number(projectId) })
             .then((r) => r.unwrap())
+          const commitUuids = await buildCommitFilter({
+            filters,
+            currentCommit,
+            commitsRepo,
+          })
           result = await spansRepository
             .findByDocumentAndCommitLimited({
               documentUuid,
@@ -91,11 +96,7 @@ export const GET = errorHandler(
                 ? { startedAt: fromCursor.value, id: fromCursor.id }
                 : undefined,
               limit: parsedParams.limit,
-              commitUuids: await buildCommitFilter({
-                filters,
-                currentCommit,
-                commitsRepo,
-              }),
+              commitUuids,
               experimentUuids: filters.experimentUuids,
               createdAt: filters.createdAt,
             })

--- a/apps/web/src/services/user/setupService.test.ts
+++ b/apps/web/src/services/user/setupService.test.ts
@@ -7,7 +7,6 @@ import { providerApiKeys } from '@latitude-data/core/schema/models/providerApiKe
 import { users } from '@latitude-data/core/schema/models/users'
 import { workspaceOnboarding } from '@latitude-data/core/schema/models/workspaceOnboarding'
 import { workspaces } from '@latitude-data/core/schema/models/workspaces'
-import setupServiceGlobal from './setupService'
 
 const mocks = vi.hoisted(() => ({
   claimReward: vi.fn(),
@@ -22,18 +21,21 @@ describe('setupService', () => {
   beforeAll(async () => {
     vi.stubEnv('NEXT_PUBLIC_DEFAULT_PROVIDER_NAME', 'Latitude')
     vi.stubEnv('DEFAULT_PROVIDER_API_KEY', 'default-provider-api-key')
-    vi.resetModules()
   })
 
   afterAll(() => {
     vi.unstubAllEnvs()
   })
 
-  it('should create all necessary entities when calling setup service', async () => {
-    const mod = await import('./setupService')
-    const setupService = mod.default
-    const result = await setupService({
-      email: 'test@example.com',
+  it(
+    'should create all necessary entities when calling setup service',
+    async () => {
+      const email = `test+${Date.now()}@example.com`
+
+      const mod = await import('./setupService')
+      const setupService = mod.default
+      const result = await setupService({
+        email,
       name: 'Test User',
       companyName: 'Test Company',
     })
@@ -52,7 +54,7 @@ describe('setupService', () => {
       .where(utils.eq(users.id, user.id))
       .then((rows) => rows[0])
     expect(createdUser).toBeDefined()
-    expect(createdUser?.email).toBe('test@example.com')
+    expect(createdUser?.email).toBe(email)
     expect(createdUser?.name).toBe('Test User')
 
     // Check workspace creation
@@ -98,11 +100,19 @@ describe('setupService', () => {
       .then((r) => r[0])
     expect(createdOnboarding).toBeDefined()
     expect(createdOnboarding?.completedAt).toBeNull()
-  })
+    },
+    15000,
+  )
 
-  it('publishes userCreated event', async () => {
-    const result = await setupServiceGlobal({
-      email: 'test@example.com',
+  it(
+    'publishes userCreated event',
+    async () => {
+      const email = `test+${Date.now()}@example.com`
+
+    const mod = await import('./setupService')
+    const setupService = mod.default
+    const result = await setupService({
+        email,
       name: 'Test User',
       companyName: 'Test Company',
     })
@@ -121,5 +131,7 @@ describe('setupService', () => {
     } else {
       throw new Error('User was not created')
     }
-  })
+    },
+    15000,
+  )
 })

--- a/packages/core/src/services/spans/defaultCreatedAtWindow.ts
+++ b/packages/core/src/services/spans/defaultCreatedAtWindow.ts
@@ -1,0 +1,30 @@
+import { subWeeks } from 'date-fns'
+
+const DEFAULT_SPANS_WINDOW_WEEKS = 8
+
+export type CreatedAtRange = { from?: Date; to?: Date }
+
+/**
+ * Returns the default createdAt range applied to spans queries when no explicit
+ * filters are provided (e.g. first page of pagination).
+ */
+export function getDefaultSpansCreatedAtRange(): CreatedAtRange {
+  return { from: subWeeks(new Date(), DEFAULT_SPANS_WINDOW_WEEKS) }
+}
+
+/**
+ * Applies the default createdAt range only for first-page queries (no cursor)
+ * when the caller didn't provide a createdAt filter.
+ */
+export function applyDefaultSpansCreatedAtRange({
+  createdAt,
+  hasCursor,
+}: {
+  createdAt?: CreatedAtRange
+  hasCursor: boolean
+}): CreatedAtRange | undefined {
+  if (hasCursor) return createdAt
+  if (createdAt) return createdAt
+  return getDefaultSpansCreatedAtRange()
+}
+

--- a/packages/core/src/services/users/setupService.ts
+++ b/packages/core/src/services/users/setupService.ts
@@ -76,9 +76,13 @@ export default async function setupService(
       r.unwrap(),
     )
 
-    await createDatasetOnboarding({ workspace, user }, transaction).then((r) =>
-      r.unwrap(),
+    const datasetOnboardingResult = await createDatasetOnboarding(
+      { workspace, user },
+      transaction,
     )
+    if (datasetOnboardingResult.error) {
+      captureException?.(datasetOnboardingResult.error)
+    }
 
     publisher.publishLater({
       type: 'userCreated',


### PR DESCRIPTION
First-page spans/traces pagination can time out for large workspaces because the keyset query is commonly executed without any started_at bounds. Even with a small LIMIT, an unbounded time range can force Postgres to scan large index ranges and discard most rows before it finds enough matches to return the first page.

SpansRepository now applies a default createdAt window of the last eight weeks when there is no cursor and the caller did not provide an explicit createdAt filter. This keeps the common first-page request bounded and dramatically reduces the amount of work required to satisfy the sort + limit. To avoid older documents appearing empty, the repository automatically falls back to an all-time query when the default window returns zero rows. The method returns didFallbackToAllTime so callers can avoid presenting an eight-week filter when results actually came from all-time.

The defaulting and fallback behavior is centralized in the repository so route handlers and pages do not have to duplicate two-pass pagination logic and will stay consistent as more spans listings are added. Tests cover the default window, the all-time fallback, and the requirement that explicit createdAt filters never fall back. While touching this flow, setupService was also hardened so dataset onboarding failures are captured instead of failing the overall setup, and its web test was made deterministic.