### PR TITLE
Add trigger settings to control which conversation interactions get evaluated

### DIFF
--- a/packages/constants/src/evaluations/shared.ts
+++ b/packages/constants/src/evaluations/shared.ts
@@ -22,10 +22,30 @@ export type ExpectedOutputConfiguration = z.infer<
 
 export const ACCESSIBLE_OUTPUT_FORMATS = ['json']
 
+export const EVALUATION_TRIGGER_TARGETS = ['first', 'every', 'last'] as const
+export type EvaluationTriggerTarget =
+  (typeof EVALUATION_TRIGGER_TARGETS)[number]
+
+export const DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS = 120
+export const LAST_INTERACTION_DEBOUNCE_MIN_SECONDS = 30
+export const LAST_INTERACTION_DEBOUNCE_MAX_SECONDS = 60 * 60 * 24 // 1 day
+
+const triggerConfiguration = z.object({
+  target: z.enum(EVALUATION_TRIGGER_TARGETS),
+  lastInteractionDebounce: z
+    .number()
+    .min(LAST_INTERACTION_DEBOUNCE_MIN_SECONDS)
+    .max(LAST_INTERACTION_DEBOUNCE_MAX_SECONDS)
+    .optional()
+    .default(DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS),
+})
+export type TriggerConfiguration = z.infer<typeof triggerConfiguration>
+
 export const baseEvaluationConfiguration = z.object({
   reverseScale: z.boolean(), // If true, lower is better, otherwise, higher is better
   actualOutput: actualOutputConfiguration,
   expectedOutput: expectedOutputConfiguration.optional(),
+  trigger: triggerConfiguration.optional(),
 })
 export const baseEvaluationResultMetadata = z.object({
   // configuration: Configuration snapshot is defined in every metric specification

--- a/packages/core/drizzle/0267_evaluation_trigger_options.sql
+++ b/packages/core/drizzle/0267_evaluation_trigger_options.sql
@@ -1,0 +1,3 @@
+UPDATE "latitude"."evaluation_versions"
+SET configuration = jsonb_set("configuration", '{trigger}', '{"target": "every"}'::jsonb)
+WHERE configuration IS NOT NULL AND configuration->>'trigger' IS NULL;

--- a/packages/core/drizzle/meta/0267_snapshot.json
+++ b/packages/core/drizzle/meta/0267_snapshot.json
@@ -1,0 +1,9401 @@
+{
+  "id": "5556770a-b3bd-4995-9cc8-21e24da1de43",
+  "prevId": "66764f0c-04f5-437f-8590-26a3501365d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "latitude.api_keys": {
+      "name": "api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_id_idx": {
+          "name": "workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "api_keys_workspace_id_workspaces_id_fk": {
+          "name": "api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "api_keys",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_token_unique": {
+          "name": "api_keys_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.claimed_promocodes": {
+      "name": "claimed_promocodes",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claimed_promocodes_workspace_id_idx": {
+          "name": "claimed_promocodes_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claimed_promocodes_code_idx": {
+          "name": "claimed_promocodes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claimed_promocodes_workspace_id_workspaces_id_fk": {
+          "name": "claimed_promocodes_workspace_id_workspaces_id_fk",
+          "tableFrom": "claimed_promocodes",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "claimed_promocodes_code_promocodes_code_fk": {
+          "name": "claimed_promocodes_code_promocodes_code_fk",
+          "tableFrom": "claimed_promocodes",
+          "columnsFrom": [
+            "code"
+          ],
+          "tableTo": "promocodes",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "code"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.claimed_rewards": {
+      "name": "claimed_rewards",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "reward_types",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "claimed_rewards_workspace_id_idx": {
+          "name": "claimed_rewards_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "claimed_rewards_workspace_id_workspaces_id_fk": {
+          "name": "claimed_rewards_workspace_id_workspaces_id_fk",
+          "tableFrom": "claimed_rewards",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "claimed_rewards_creator_id_users_id_fk": {
+          "name": "claimed_rewards_creator_id_users_id_fk",
+          "tableFrom": "claimed_rewards",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.commits": {
+      "name": "commits",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_document_uuid": {
+          "name": "main_document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_commit_order_idx": {
+          "name": "project_commit_order_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "unique_commit_version": {
+          "name": "unique_commit_version",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_idx": {
+          "name": "user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "merged_at_idx": {
+          "name": "merged_at_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "project_id_idx": {
+          "name": "project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "commits_deleted_at_indx": {
+          "name": "commits_deleted_at_indx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "commits_project_deleted_at_idx": {
+          "name": "commits_project_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "commits_main_document_uuid_idx": {
+          "name": "commits_main_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "main_document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "commits_project_id_projects_id_fk": {
+          "name": "commits_project_id_projects_id_fk",
+          "tableFrom": "commits",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "commits_user_id_users_id_fk": {
+          "name": "commits_user_id_users_id_fk",
+          "tableFrom": "commits",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commits_uuid_unique": {
+          "name": "commits_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.dataset_rows": {
+      "name": "dataset_rows",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_data": {
+          "name": "row_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dataset_row_workspace_idx": {
+          "name": "dataset_row_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "dataset_rows_workspace_id_workspaces_id_fk": {
+          "name": "dataset_rows_workspace_id_workspaces_id_fk",
+          "tableFrom": "dataset_rows",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "dataset_rows_dataset_id_datasets_v2_id_fk": {
+          "name": "dataset_rows_dataset_id_datasets_v2_id_fk",
+          "tableFrom": "dataset_rows",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.datasets_v2": {
+      "name": "datasets_v2",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(255)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::varchar[]"
+        },
+        "columns": {
+          "name": "columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_table_workspace_idx": {
+          "name": "datasets_table_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "datasets_table_author_idx": {
+          "name": "datasets_table_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "datasets_v2_workspace_id_workspaces_id_fk": {
+          "name": "datasets_v2_workspace_id_workspaces_id_fk",
+          "tableFrom": "datasets_v2",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "datasets_v2_author_id_users_id_fk": {
+          "name": "datasets_v2_author_id_users_id_fk",
+          "tableFrom": "datasets_v2",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "datasets_v2_workspace_id_name_deleted_at_unique": {
+          "name": "datasets_v2_workspace_id_name_deleted_at_unique",
+          "columns": [
+            "workspace_id",
+            "name",
+            "deleted_at"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.deployment_tests": {
+      "name": "deployment_tests",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenger_commit_id": {
+          "name": "challenger_commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "traffic_percentage": {
+          "name": "traffic_percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_deployment_tests_workspace": {
+          "name": "idx_deployment_tests_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_deployment_tests_project": {
+          "name": "idx_deployment_tests_project",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_deployment_tests_status": {
+          "name": "idx_deployment_tests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_deployment_tests_project_type_status": {
+          "name": "idx_deployment_tests_project_type_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "test_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "deployment_tests_workspace_id_workspaces_id_fk": {
+          "name": "deployment_tests_workspace_id_workspaces_id_fk",
+          "tableFrom": "deployment_tests",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "deployment_tests_project_id_projects_id_fk": {
+          "name": "deployment_tests_project_id_projects_id_fk",
+          "tableFrom": "deployment_tests",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "deployment_tests_challenger_commit_id_commits_id_fk": {
+          "name": "deployment_tests_challenger_commit_id_commits_id_fk",
+          "tableFrom": "deployment_tests",
+          "columnsFrom": [
+            "challenger_commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "deployment_tests_created_by_user_id_users_id_fk": {
+          "name": "deployment_tests_created_by_user_id_users_id_fk",
+          "tableFrom": "deployment_tests",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "deployment_tests_uuid_unique": {
+          "name": "deployment_tests_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.document_integration_references": {
+      "name": "document_integration_references",
+      "schema": "latitude",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "document_integration_references_workspace_id_workspaces_id_fk": {
+          "name": "document_integration_references_workspace_id_workspaces_id_fk",
+          "tableFrom": "document_integration_references",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_integration_references_project_id_projects_id_fk": {
+          "name": "document_integration_references_project_id_projects_id_fk",
+          "tableFrom": "document_integration_references",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_integration_references_integration_id_integrations_id_fk": {
+          "name": "document_integration_references_integration_id_integrations_id_fk",
+          "tableFrom": "document_integration_references",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "tableTo": "integrations",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_integration_references_fk": {
+          "name": "document_integration_references_fk",
+          "tableFrom": "document_integration_references",
+          "columnsFrom": [
+            "document_uuid",
+            "commit_id"
+          ],
+          "tableTo": "document_versions",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "document_uuid",
+            "commit_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_integration_references_document_uuid_commit_id_integration_id_pk": {
+          "name": "document_integration_references_document_uuid_commit_id_integration_id_pk",
+          "columns": [
+            "document_uuid",
+            "commit_id",
+            "integration_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.document_logs": {
+      "name": "document_logs",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_content": {
+          "name": "resolved_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_identifier": {
+          "name": "custom_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "log_source",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_log_uuid_idx": {
+          "name": "document_log_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_log_document_uuid_idx": {
+          "name": "document_log_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_workspace_idx": {
+          "name": "document_logs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_commit_id_idx": {
+          "name": "document_logs_commit_id_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_content_hash_idx": {
+          "name": "document_logs_content_hash_idx",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_created_at_idx": {
+          "name": "document_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_custom_identifier_trgm_idx": {
+          "name": "document_logs_custom_identifier_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"custom_identifier\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": true
+        },
+        "document_logs_commit_created_at_idx": {
+          "name": "document_logs_commit_created_at_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_source_created_at_idx": {
+          "name": "document_logs_source_created_at_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": true
+        },
+        "document_logs_experiment_id_idx": {
+          "name": "document_logs_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_logs_created_at_brin_idx": {
+          "name": "document_logs_created_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": true
+        }
+      },
+      "foreignKeys": {
+        "document_logs_workspace_id_workspaces_id_fk": {
+          "name": "document_logs_workspace_id_workspaces_id_fk",
+          "tableFrom": "document_logs",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_logs_commit_id_commits_id_fk": {
+          "name": "document_logs_commit_id_commits_id_fk",
+          "tableFrom": "document_logs",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "document_logs_experiment_id_experiments_id_fk": {
+          "name": "document_logs_experiment_id_experiments_id_fk",
+          "tableFrom": "document_logs",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "tableTo": "experiments",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "document_logs_uuid_unique": {
+          "name": "document_logs_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.document_trigger_events": {
+      "name": "document_trigger_events",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_uuid": {
+          "name": "trigger_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "document_trigger_types",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_hash": {
+          "name": "trigger_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_log_uuid": {
+          "name": "document_log_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_trigger_events_workspace_idx": {
+          "name": "document_trigger_events_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_trigger_events_trigger_uuid_idx": {
+          "name": "document_trigger_events_trigger_uuid_idx",
+          "columns": [
+            {
+              "expression": "trigger_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_trigger_events_document_log_uuid_idx": {
+          "name": "document_trigger_events_document_log_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_log_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_trigger_events_trigger_hash_idx": {
+          "name": "document_trigger_events_trigger_hash_idx",
+          "columns": [
+            {
+              "expression": "trigger_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "document_trigger_events_workspace_id_workspaces_id_fk": {
+          "name": "document_trigger_events_workspace_id_workspaces_id_fk",
+          "tableFrom": "document_trigger_events",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_trigger_events_document_log_uuid_document_logs_uuid_fk": {
+          "name": "document_trigger_events_document_log_uuid_document_logs_uuid_fk",
+          "tableFrom": "document_trigger_events",
+          "columnsFrom": [
+            "document_log_uuid"
+          ],
+          "tableTo": "document_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.document_triggers": {
+      "name": "document_triggers",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_status": {
+          "name": "trigger_status",
+          "type": "document_trigger_status",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "document_trigger_types",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_hash": {
+          "name": "trigger_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_settings": {
+          "name": "deployment_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_trigger_doc_workspace_idx": {
+          "name": "document_trigger_doc_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_triggers_uuid_commit_unique": {
+          "name": "document_triggers_uuid_commit_unique",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "scheduled_trigger_next_run_time_idx": {
+          "name": "scheduled_trigger_next_run_time_idx",
+          "columns": [
+            {
+              "expression": "(deployment_settings->>'nextRunTime')",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_trigger_type_idx": {
+          "name": "document_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "trigger_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_trigger_hash_idx": {
+          "name": "document_trigger_hash_idx",
+          "columns": [
+            {
+              "expression": "trigger_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "document_triggers_workspace_id_workspaces_id_fk": {
+          "name": "document_triggers_workspace_id_workspaces_id_fk",
+          "tableFrom": "document_triggers",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_triggers_project_id_projects_id_fk": {
+          "name": "document_triggers_project_id_projects_id_fk",
+          "tableFrom": "document_triggers",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_triggers_commit_id_commits_id_fk": {
+          "name": "document_triggers_commit_id_commits_id_fk",
+          "tableFrom": "document_triggers",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.document_versions": {
+      "name": "document_versions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "resolved_content": {
+          "name": "resolved_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptl_version": {
+          "name": "promptl_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "document_type_enum",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'agent'"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_v2_id": {
+          "name": "dataset_v2_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_dataset_by_dataset_id": {
+          "name": "linked_dataset_by_dataset_id",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "linked_dataset_by_dataset_id_and_row_id": {
+          "name": "linked_dataset_by_dataset_id_and_row_id",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::json"
+        },
+        "main_evaluation_uuid": {
+          "name": "main_evaluation_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_versions_unique_document_uuid_commit_id": {
+          "name": "document_versions_unique_document_uuid_commit_id",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_versions_unique_path_commit_id_deleted_at": {
+          "name": "document_versions_unique_path_commit_id_deleted_at",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_versions_commit_id_idx": {
+          "name": "document_versions_commit_id_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_versions_deleted_at_idx": {
+          "name": "document_versions_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_versions_path_idx": {
+          "name": "document_versions_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "document_versions_commit_id_commits_id_fk": {
+          "name": "document_versions_commit_id_commits_id_fk",
+          "tableFrom": "document_versions",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "document_versions_dataset_id_datasets_id_fk": {
+          "name": "document_versions_dataset_id_datasets_id_fk",
+          "tableFrom": "document_versions",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "tableTo": "datasets",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "document_versions_dataset_v2_id_datasets_v2_id_fk": {
+          "name": "document_versions_dataset_v2_id_datasets_v2_id_fk",
+          "tableFrom": "document_versions",
+          "columnsFrom": [
+            "dataset_v2_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.evaluation_results_v2": {
+      "name": "evaluation_results_v2",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_uuid": {
+          "name": "evaluation_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_row_id": {
+          "name": "evaluated_row_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_log_id": {
+          "name": "evaluated_log_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_span_id": {
+          "name": "evaluated_span_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_trace_id": {
+          "name": "evaluated_trace_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_score": {
+          "name": "normalized_score",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_passed": {
+          "name": "has_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evaluation_results_v2_workspace_id_idx": {
+          "name": "evaluation_results_v2_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_commit_id_idx": {
+          "name": "evaluation_results_v2_commit_id_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_evaluation_uuid_idx": {
+          "name": "evaluation_results_v2_evaluation_uuid_idx",
+          "columns": [
+            {
+              "expression": "evaluation_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_experiment_id_idx": {
+          "name": "evaluation_results_v2_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_dataset_id_idx": {
+          "name": "evaluation_results_v2_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_evaluated_row_id_idx": {
+          "name": "evaluation_results_v2_evaluated_row_id_idx",
+          "columns": [
+            {
+              "expression": "evaluated_row_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_evaluated_log_id_idx": {
+          "name": "evaluation_results_v2_evaluated_log_id_idx",
+          "columns": [
+            {
+              "expression": "evaluated_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_created_at_idx": {
+          "name": "evaluation_results_v2_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_commit_evaluation_idx": {
+          "name": "evaluation_results_v2_commit_evaluation_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluation_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_created_at_brin_idx": {
+          "name": "evaluation_results_v2_created_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": true
+        },
+        "evaluation_results_v2_evaluated_span_id_idx": {
+          "name": "evaluation_results_v2_evaluated_span_id_idx",
+          "columns": [
+            {
+              "expression": "evaluated_span_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluated_trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_v2_type_workspace_idx": {
+          "name": "evaluation_results_v2_type_workspace_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_v2_workspace_id_workspaces_id_fk": {
+          "name": "evaluation_results_v2_workspace_id_workspaces_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "evaluation_results_v2_commit_id_commits_id_fk": {
+          "name": "evaluation_results_v2_commit_id_commits_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "evaluation_results_v2_experiment_id_experiments_id_fk": {
+          "name": "evaluation_results_v2_experiment_id_experiments_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "tableTo": "experiments",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "evaluation_results_v2_dataset_id_datasets_v2_id_fk": {
+          "name": "evaluation_results_v2_dataset_id_datasets_v2_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "evaluation_results_v2_evaluated_row_id_dataset_rows_id_fk": {
+          "name": "evaluation_results_v2_evaluated_row_id_dataset_rows_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "evaluated_row_id"
+          ],
+          "tableTo": "dataset_rows",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "evaluation_results_v2_evaluated_log_id_provider_logs_id_fk": {
+          "name": "evaluation_results_v2_evaluated_log_id_provider_logs_id_fk",
+          "tableFrom": "evaluation_results_v2",
+          "columnsFrom": [
+            "evaluated_log_id"
+          ],
+          "tableTo": "provider_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluation_results_v2_uuid_unique": {
+          "name": "evaluation_results_v2_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.evaluation_versions": {
+      "name": "evaluation_versions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_uuid": {
+          "name": "evaluation_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alignment_metric_metadata": {
+          "name": "alignment_metric_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluate_live_logs": {
+          "name": "evaluate_live_logs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "evaluation_versions_workspace_id_idx": {
+          "name": "evaluation_versions_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_versions_unique_commit_id_evaluation_uuid": {
+          "name": "evaluation_versions_unique_commit_id_evaluation_uuid",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluation_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_versions_unique_name_commit_id_document_uuid_deleted_at": {
+          "name": "evaluation_versions_unique_name_commit_id_document_uuid_deleted_at",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_versions_commit_id_idx": {
+          "name": "evaluation_versions_commit_id_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_versions_evaluation_uuid_idx": {
+          "name": "evaluation_versions_evaluation_uuid_idx",
+          "columns": [
+            {
+              "expression": "evaluation_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_versions_document_uuid_idx": {
+          "name": "evaluation_versions_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_v2_issue_id_idx": {
+          "name": "evaluation_v2_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_versions_workspace_id_workspaces_id_fk": {
+          "name": "evaluation_versions_workspace_id_workspaces_id_fk",
+          "tableFrom": "evaluation_versions",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "evaluation_versions_commit_id_commits_id_fk": {
+          "name": "evaluation_versions_commit_id_commits_id_fk",
+          "tableFrom": "evaluation_versions",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "evaluation_versions_issue_id_issues_id_fk": {
+          "name": "evaluation_versions_issue_id_issues_id_fk",
+          "tableFrom": "evaluation_versions",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "issues",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.events": {
+      "name": "events",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_workspace_idx": {
+          "name": "event_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_type_idx": {
+          "name": "event_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "events_workspace_id_workspaces_id_fk": {
+          "name": "events_workspace_id_workspaces_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.experiments": {
+      "name": "experiments",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_uuids": {
+          "name": "evaluation_uuids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "experiments_workspace_id_idx": {
+          "name": "experiments_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "experiments_document_uuid_idx": {
+          "name": "experiments_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "experiments_document_commit_idx": {
+          "name": "experiments_document_commit_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "experiments_dataset_id_idx": {
+          "name": "experiments_dataset_id_idx",
+          "columns": [
+            {
+              "expression": "dataset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "experiments_workspace_id_workspaces_id_fk": {
+          "name": "experiments_workspace_id_workspaces_id_fk",
+          "tableFrom": "experiments",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "experiments_commit_id_commits_id_fk": {
+          "name": "experiments_commit_id_commits_id_fk",
+          "tableFrom": "experiments",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "experiments_dataset_id_datasets_v2_id_fk": {
+          "name": "experiments_dataset_id_datasets_v2_id_fk",
+          "tableFrom": "experiments",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_uuid_unique": {
+          "name": "experiments_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.exports": {
+      "name": "exports",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exports_user_id_users_id_fk": {
+          "name": "exports_user_id_users_id_fk",
+          "tableFrom": "exports",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "exports_workspace_id_workspaces_id_fk": {
+          "name": "exports_workspace_id_workspaces_id_fk",
+          "tableFrom": "exports",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.features": {
+      "name": "features",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "features_name_unique": {
+          "name": "features_name_unique",
+          "columns": [
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.grants": {
+      "name": "grants",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "grants_workspace_id_idx": {
+          "name": "grants_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "grants_reference_id_idx": {
+          "name": "grants_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "grants_expires_at_idx": {
+          "name": "grants_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "grants_created_at_idx": {
+          "name": "grants_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "grants_workspace_id_workspaces_id_fk": {
+          "name": "grants_workspace_id_workspaces_id_fk",
+          "tableFrom": "grants",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grants_uuid_unique": {
+          "name": "grants_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.integration_header_presets": {
+      "name": "integration_header_presets",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_header_presets_integration_id_idx": {
+          "name": "integration_header_presets_integration_id_idx",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "integration_header_presets_workspace_id_idx": {
+          "name": "integration_header_presets_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "integration_header_presets_integration_id_integrations_id_fk": {
+          "name": "integration_header_presets_integration_id_integrations_id_fk",
+          "tableFrom": "integration_header_presets",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "tableTo": "integrations",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "integration_header_presets_workspace_id_workspaces_id_fk": {
+          "name": "integration_header_presets_workspace_id_workspaces_id_fk",
+          "tableFrom": "integration_header_presets",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "integration_header_presets_author_id_users_id_fk": {
+          "name": "integration_header_presets_author_id_users_id_fk",
+          "tableFrom": "integration_header_presets",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_header_presets_integration_id_name_unique": {
+          "name": "integration_header_presets_integration_id_name_unique",
+          "columns": [
+            "integration_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.integrations": {
+      "name": "integrations",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_type": {
+          "name": "integration_type",
+          "type": "integration_types",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "has_tools": {
+          "name": "has_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_triggers": {
+          "name": "has_triggers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integrations_workspace_id_idx": {
+          "name": "integrations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "integrations_name_workspace_id_deleted_at_index": {
+          "name": "integrations_name_workspace_id_deleted_at_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "integrations_user_id_idx": {
+          "name": "integrations_user_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "integrations_workspace_id_workspaces_id_fk": {
+          "name": "integrations_workspace_id_workspaces_id_fk",
+          "tableFrom": "integrations",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "integrations_author_id_users_id_fk": {
+          "name": "integrations_author_id_users_id_fk",
+          "tableFrom": "integrations",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "integrations_mcp_server_id_mcp_servers_id_fk": {
+          "name": "integrations_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "integrations",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "tableTo": "mcp_servers",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integrations_name_workspace_id_deleted_at_unique": {
+          "name": "integrations_name_workspace_id_deleted_at_unique",
+          "columns": [
+            "name",
+            "workspace_id",
+            "deleted_at"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.issue_evaluation_results": {
+      "name": "issue_evaluation_results",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_result_id": {
+          "name": "evaluation_result_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_evaluation_results_workspace_id_idx": {
+          "name": "issue_evaluation_results_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_evaluation_results_issue_id_idx": {
+          "name": "issue_evaluation_results_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_evaluation_results_evaluation_result_id_idx": {
+          "name": "issue_evaluation_results_evaluation_result_id_idx",
+          "columns": [
+            {
+              "expression": "evaluation_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_evaluation_results_unique_issue_eval_idx": {
+          "name": "issue_evaluation_results_unique_issue_eval_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evaluation_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_evaluation_results_workspace_id_workspaces_id_fk": {
+          "name": "issue_evaluation_results_workspace_id_workspaces_id_fk",
+          "tableFrom": "issue_evaluation_results",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_evaluation_results_issue_id_issues_id_fk": {
+          "name": "issue_evaluation_results_issue_id_issues_id_fk",
+          "tableFrom": "issue_evaluation_results",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "issues",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.issue_histograms": {
+      "name": "issue_histograms",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_histograms_workspace_id_idx": {
+          "name": "issue_histograms_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_issue_id_idx": {
+          "name": "issue_histograms_issue_id_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_commit_id_idx": {
+          "name": "issue_histograms_commit_id_idx",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_date_idx": {
+          "name": "issue_histograms_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_project_id_idx": {
+          "name": "issue_histograms_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_document_uuid_idx": {
+          "name": "issue_histograms_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issue_histograms_occurred_at_brin_idx": {
+          "name": "issue_histograms_occurred_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"occurred_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": false
+        },
+        "issue_histograms_date_brin_idx": {
+          "name": "issue_histograms_date_brin_idx",
+          "columns": [
+            {
+              "expression": "\"date\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issue_histograms_workspace_id_workspaces_id_fk": {
+          "name": "issue_histograms_workspace_id_workspaces_id_fk",
+          "tableFrom": "issue_histograms",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_histograms_project_id_projects_id_fk": {
+          "name": "issue_histograms_project_id_projects_id_fk",
+          "tableFrom": "issue_histograms",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_histograms_issue_id_issues_id_fk": {
+          "name": "issue_histograms_issue_id_issues_id_fk",
+          "tableFrom": "issue_histograms",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "tableTo": "issues",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issue_histograms_commit_id_commits_id_fk": {
+          "name": "issue_histograms_commit_id_commits_id_fk",
+          "tableFrom": "issue_histograms",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issue_histograms_unique_issue_commit_date": {
+          "name": "issue_histograms_unique_issue_commit_date",
+          "columns": [
+            "issue_id",
+            "commit_id",
+            "date"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.issues": {
+      "name": "issues",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "centroid": {
+          "name": "centroid",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored_at": {
+          "name": "ignored_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_to_issue_id": {
+          "name": "merged_to_issue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escalating_at": {
+          "name": "escalating_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issues_workspace_id_idx": {
+          "name": "issues_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_project_id_idx": {
+          "name": "issues_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_document_uuid_idx": {
+          "name": "issues_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_title_trgm_idx": {
+          "name": "issues_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"title\" gin_trgm_ops",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "issues_resolved_at_idx": {
+          "name": "issues_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_ignored_at_idx": {
+          "name": "issues_ignored_at_idx",
+          "columns": [
+            {
+              "expression": "ignored_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_merged_at_idx": {
+          "name": "issues_merged_at_idx",
+          "columns": [
+            {
+              "expression": "merged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "issues_escalating_at_idx": {
+          "name": "issues_escalating_at_idx",
+          "columns": [
+            {
+              "expression": "escalating_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "issues_workspace_id_workspaces_id_fk": {
+          "name": "issues_workspace_id_workspaces_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issues_project_id_projects_id_fk": {
+          "name": "issues_project_id_projects_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "issues_merged_to_issue_id_issues_id_fk": {
+          "name": "issues_merged_to_issue_id_issues_id_fk",
+          "tableFrom": "issues",
+          "columnsFrom": [
+            "merged_to_issue_id"
+          ],
+          "tableTo": "issues",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "issues_uuid_unique": {
+          "name": "issues_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.latte_requests": {
+      "name": "latte_requests",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_uuid": {
+          "name": "thread_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "latte_requests_workspace_id_idx": {
+          "name": "latte_requests_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_requests_user_id_idx": {
+          "name": "latte_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_requests_thread_uuid_idx": {
+          "name": "latte_requests_thread_uuid_idx",
+          "columns": [
+            {
+              "expression": "thread_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_requests_credits_idx": {
+          "name": "latte_requests_credits_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\") INCLUDE (\"credits\", \"billable\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_requests_created_at_idx": {
+          "name": "latte_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_requests_created_at_brin_idx": {
+          "name": "latte_requests_created_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "latte_requests_workspace_id_workspaces_id_fk": {
+          "name": "latte_requests_workspace_id_workspaces_id_fk",
+          "tableFrom": "latte_requests",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "latte_requests_user_id_users_id_fk": {
+          "name": "latte_requests_user_id_users_id_fk",
+          "tableFrom": "latte_requests",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "latte_requests_thread_uuid_latte_threads_uuid_fk": {
+          "name": "latte_requests_thread_uuid_latte_threads_uuid_fk",
+          "tableFrom": "latte_requests",
+          "columnsFrom": [
+            "thread_uuid"
+          ],
+          "tableTo": "latte_threads",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "latte_requests_uuid_unique": {
+          "name": "latte_requests_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.latte_thread_checkpoints": {
+      "name": "latte_thread_checkpoints",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thread_uuid": {
+          "name": "thread_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_id": {
+          "name": "commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "latte_thread_checkpoints_commit_id_index": {
+          "name": "latte_thread_checkpoints_commit_id_index",
+          "columns": [
+            {
+              "expression": "commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_thread_checkpoints_thread_uuid_index": {
+          "name": "latte_thread_checkpoints_thread_uuid_index",
+          "columns": [
+            {
+              "expression": "thread_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "latte_thread_checkpoints_thread_uuid_latte_threads_uuid_fk": {
+          "name": "latte_thread_checkpoints_thread_uuid_latte_threads_uuid_fk",
+          "tableFrom": "latte_thread_checkpoints",
+          "columnsFrom": [
+            "thread_uuid"
+          ],
+          "tableTo": "latte_threads",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "latte_thread_checkpoints_commit_id_commits_id_fk": {
+          "name": "latte_thread_checkpoints_commit_id_commits_id_fk",
+          "tableFrom": "latte_thread_checkpoints",
+          "columnsFrom": [
+            "commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.latte_threads": {
+      "name": "latte_threads",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "latte_threads_user_workspace_index": {
+          "name": "latte_threads_user_workspace_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "latte_threads_project_index": {
+          "name": "latte_threads_project_index",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "latte_threads_user_id_users_id_fk": {
+          "name": "latte_threads_user_id_users_id_fk",
+          "tableFrom": "latte_threads",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "latte_threads_workspace_id_workspaces_id_fk": {
+          "name": "latte_threads_workspace_id_workspaces_id_fk",
+          "tableFrom": "latte_threads",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "latte_threads_uuid_unique": {
+          "name": "latte_threads_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "magic_link_tokens_user_id_users_id_fk": {
+          "name": "magic_link_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_link_tokens",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_link_tokens_token_unique": {
+          "name": "magic_link_tokens_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.mcp_oauth_credentials": {
+      "name": "mcp_oauth_credentials",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_oauth_credentials_workspace_id_idx": {
+          "name": "mcp_oauth_credentials_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_oauth_credentials_integration_id_idx": {
+          "name": "mcp_oauth_credentials_integration_id_idx",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_oauth_credentials_author_id_idx": {
+          "name": "mcp_oauth_credentials_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_credentials_workspace_id_workspaces_id_fk": {
+          "name": "mcp_oauth_credentials_workspace_id_workspaces_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_credentials_integration_id_integrations_id_fk": {
+          "name": "mcp_oauth_credentials_integration_id_integrations_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "tableTo": "integrations",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_oauth_credentials_author_id_users_id_fk": {
+          "name": "mcp_oauth_credentials_author_id_users_id_fk",
+          "tableFrom": "mcp_oauth_credentials",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_credentials_integration_id_unique": {
+          "name": "mcp_oauth_credentials_integration_id_unique",
+          "columns": [
+            "integration_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_name": {
+          "name": "unique_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_variables": {
+          "name": "environment_variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "k8s_app_status",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replicas": {
+          "name": "replicas",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "k8s_manifest": {
+          "name": "k8s_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_servers_workspace_id_idx": {
+          "name": "mcp_servers_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_servers_author_id_idx": {
+          "name": "mcp_servers_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_servers_status_idx": {
+          "name": "mcp_servers_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_servers_unique_name_idx": {
+          "name": "mcp_servers_unique_name_idx",
+          "columns": [
+            {
+              "expression": "unique_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "mcp_servers_last_used_at_idx": {
+          "name": "mcp_servers_last_used_at_idx",
+          "columns": [
+            {
+              "expression": "last_used_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_servers_workspace_id_workspaces_id_fk": {
+          "name": "mcp_servers_workspace_id_workspaces_id_fk",
+          "tableFrom": "mcp_servers",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_servers_author_id_users_id_fk": {
+          "name": "mcp_servers_author_id_users_id_fk",
+          "tableFrom": "mcp_servers",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.memberships": {
+      "name": "memberships",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitation_token": {
+          "name": "invitation_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "want_to_receive_weekly_email": {
+          "name": "want_to_receive_weekly_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "want_to_receive_escalating_issues_email": {
+          "name": "want_to_receive_escalating_issues_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memberships_workspace_id_user_id_index": {
+          "name": "memberships_workspace_id_user_id_index",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "memberships_invitation_token_index": {
+          "name": "memberships_invitation_token_index",
+          "columns": [
+            {
+              "expression": "invitation_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "want_to_receive_weekly_email_idx": {
+          "name": "want_to_receive_weekly_email_idx",
+          "columns": [
+            {
+              "expression": "want_to_receive_weekly_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "want_to_receive_escalating_issues_email_idx": {
+          "name": "want_to_receive_escalating_issues_email_idx",
+          "columns": [
+            {
+              "expression": "want_to_receive_escalating_issues_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "memberships_workspace_id_workspaces_id_fk": {
+          "name": "memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "memberships",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "memberships_user_id_users_id_fk": {
+          "name": "memberships_user_id_users_id_fk",
+          "tableFrom": "memberships",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "memberships_invitation_token_unique": {
+          "name": "memberships_invitation_token_unique",
+          "columns": [
+            "invitation_token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "latitude",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "oauth_providers",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_accounts_user_id_idx": {
+          "name": "oauth_accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oauth_accounts_provider_id_provider_user_id_pk": {
+          "name": "oauth_accounts_provider_id_provider_user_id_pk",
+          "columns": [
+            "provider_id",
+            "provider_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.optimizations": {
+      "name": "optimizations",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_commit_id": {
+          "name": "baseline_commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseline_prompt": {
+          "name": "baseline_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_uuid": {
+          "name": "evaluation_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trainset_id": {
+          "name": "trainset_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "testset_id": {
+          "name": "testset_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized_commit_id": {
+          "name": "optimized_commit_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized_prompt": {
+          "name": "optimized_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseline_experiment_id": {
+          "name": "baseline_experiment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized_experiment_id": {
+          "name": "optimized_experiment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "prepared_at": {
+          "name": "prepared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "optimizations_workspace_id_idx": {
+          "name": "optimizations_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_project_id_idx": {
+          "name": "optimizations_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_document_uuid_idx": {
+          "name": "optimizations_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_baseline_commit_id_idx": {
+          "name": "optimizations_baseline_commit_id_idx",
+          "columns": [
+            {
+              "expression": "baseline_commit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_evaluation_uuid_idx": {
+          "name": "optimizations_evaluation_uuid_idx",
+          "columns": [
+            {
+              "expression": "evaluation_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_engine_idx": {
+          "name": "optimizations_engine_idx",
+          "columns": [
+            {
+              "expression": "engine",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_trainset_id_idx": {
+          "name": "optimizations_trainset_id_idx",
+          "columns": [
+            {
+              "expression": "trainset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_testset_id_idx": {
+          "name": "optimizations_testset_id_idx",
+          "columns": [
+            {
+              "expression": "testset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_created_at_idx": {
+          "name": "optimizations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_prepared_at_idx": {
+          "name": "optimizations_prepared_at_idx",
+          "columns": [
+            {
+              "expression": "prepared_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_executed_at_idx": {
+          "name": "optimizations_executed_at_idx",
+          "columns": [
+            {
+              "expression": "executed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_validated_at_idx": {
+          "name": "optimizations_validated_at_idx",
+          "columns": [
+            {
+              "expression": "validated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "optimizations_finished_at_idx": {
+          "name": "optimizations_finished_at_idx",
+          "columns": [
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "optimizations_workspace_id_workspaces_id_fk": {
+          "name": "optimizations_workspace_id_workspaces_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "optimizations_project_id_projects_id_fk": {
+          "name": "optimizations_project_id_projects_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "optimizations_baseline_commit_id_commits_id_fk": {
+          "name": "optimizations_baseline_commit_id_commits_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "baseline_commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "optimizations_trainset_id_datasets_v2_id_fk": {
+          "name": "optimizations_trainset_id_datasets_v2_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "trainset_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "optimizations_testset_id_datasets_v2_id_fk": {
+          "name": "optimizations_testset_id_datasets_v2_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "testset_id"
+          ],
+          "tableTo": "datasets_v2",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "optimizations_optimized_commit_id_commits_id_fk": {
+          "name": "optimizations_optimized_commit_id_commits_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "optimized_commit_id"
+          ],
+          "tableTo": "commits",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "optimizations_baseline_experiment_id_experiments_id_fk": {
+          "name": "optimizations_baseline_experiment_id_experiments_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "baseline_experiment_id"
+          ],
+          "tableTo": "experiments",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "optimizations_optimized_experiment_id_experiments_id_fk": {
+          "name": "optimizations_optimized_experiment_id_experiments_id_fk",
+          "tableFrom": "optimizations",
+          "columnsFrom": [
+            "optimized_experiment_id"
+          ],
+          "tableTo": "experiments",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "optimizations_uuid_unique": {
+          "name": "optimizations_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        },
+        "optimizations_optimized_commit_id_unique": {
+          "name": "optimizations_optimized_commit_id_unique",
+          "columns": [
+            "optimized_commit_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "optimizations_baseline_experiment_id_unique": {
+          "name": "optimizations_baseline_experiment_id_unique",
+          "columns": [
+            "baseline_experiment_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "optimizations_optimized_experiment_id_unique": {
+          "name": "optimizations_optimized_experiment_id_unique",
+          "columns": [
+            "optimized_experiment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.projects": {
+      "name": "projects",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_at": {
+          "name": "last_edited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_idx": {
+          "name": "workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "projects_deleted_at_idx": {
+          "name": "projects_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "projects_workspace_id_workspaces_id_fk": {
+          "name": "projects_workspace_id_workspaces_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.promocodes": {
+      "name": "promocodes",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quota_type": {
+          "name": "quota_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promocodes_code_unique": {
+          "name": "promocodes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.provider_api_keys": {
+      "name": "provider_api_keys",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_apikeys_workspace_id_idx": {
+          "name": "provider_apikeys_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_api_keys_name_workspace_id_deleted_at_index": {
+          "name": "provider_api_keys_name_workspace_id_deleted_at_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_apikeys_user_id_idx": {
+          "name": "provider_apikeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_api_keys_token_provider_workspace_id_deleted_at_index": {
+          "name": "provider_api_keys_token_provider_workspace_id_deleted_at_index",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provider_api_keys_author_id_users_id_fk": {
+          "name": "provider_api_keys_author_id_users_id_fk",
+          "tableFrom": "provider_api_keys",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "provider_api_keys_workspace_id_workspaces_id_fk": {
+          "name": "provider_api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_api_keys",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_api_keys_name_workspace_id_deleted_at_unique": {
+          "name": "provider_api_keys_name_workspace_id_deleted_at_unique",
+          "columns": [
+            "name",
+            "workspace_id",
+            "deleted_at"
+          ],
+          "nullsNotDistinct": true
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.provider_logs": {
+      "name": "provider_logs",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_log_uuid": {
+          "name": "document_log_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stop'"
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_object": {
+          "name": "response_object",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_reasoning": {
+          "name": "response_reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_in_millicents": {
+          "name": "cost_in_millicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "log_source",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiKeyId": {
+          "name": "apiKeyId",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_idx": {
+          "name": "provider_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_logs_created_at_idx": {
+          "name": "provider_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_logs_workspace_id_index": {
+          "name": "provider_logs_workspace_id_index",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_uuid_idx": {
+          "name": "document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_log_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_logs_document_log_model_idx": {
+          "name": "provider_logs_document_log_model_idx",
+          "columns": [
+            {
+              "expression": "document_log_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_logs_created_at_brin_idx": {
+          "name": "provider_logs_created_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": true
+        }
+      },
+      "foreignKeys": {
+        "provider_logs_workspace_id_workspaces_id_fk": {
+          "name": "provider_logs_workspace_id_workspaces_id_fk",
+          "tableFrom": "provider_logs",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "provider_logs_provider_id_provider_api_keys_id_fk": {
+          "name": "provider_logs_provider_id_provider_api_keys_id_fk",
+          "tableFrom": "provider_logs",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "tableTo": "provider_api_keys",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "provider_logs_apiKeyId_api_keys_id_fk": {
+          "name": "provider_logs_apiKeyId_api_keys_id_fk",
+          "tableFrom": "provider_logs",
+          "columnsFrom": [
+            "apiKeyId"
+          ],
+          "tableTo": "api_keys",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_logs_uuid_unique": {
+          "name": "provider_logs_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.published_documents": {
+      "name": "published_documents",
+      "schema": "latitude",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "can_follow_conversation": {
+          "name": "can_follow_conversation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_prompt_only": {
+          "name": "display_prompt_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "published_doc_workspace_idx": {
+          "name": "published_doc_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "unique_project_document_uuid_idx": {
+          "name": "unique_project_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "published_documents_workspace_id_workspaces_id_fk": {
+          "name": "published_documents_workspace_id_workspaces_id_fk",
+          "tableFrom": "published_documents",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "published_documents_project_id_projects_id_fk": {
+          "name": "published_documents_project_id_projects_id_fk",
+          "tableFrom": "published_documents",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_documents_uuid_unique": {
+          "name": "published_documents_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.run_errors": {
+      "name": "run_errors",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "run_error_code_enum",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorable_type": {
+          "name": "errorable_type",
+          "type": "run_error_entity_enum",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorable_uuid": {
+          "name": "errorable_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "run_errors_errorable_entity_uuid_idx": {
+          "name": "run_errors_errorable_entity_uuid_idx",
+          "columns": [
+            {
+              "expression": "errorable_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "errorable_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.sessions": {
+      "name": "sessions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_workspace_id": {
+          "name": "current_workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sessions_current_workspace_id_workspaces_id_fk": {
+          "name": "sessions_current_workspace_id_workspaces_id_fk",
+          "tableFrom": "sessions",
+          "columnsFrom": [
+            "current_workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.spans": {
+      "name": "spans",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_log_uuid": {
+          "name": "document_log_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_trace_id": {
+          "name": "previous_trace_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_uuid": {
+          "name": "document_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_uuid": {
+          "name": "commit_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_uuid": {
+          "name": "experiment_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_deployment_id": {
+          "name": "test_deployment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_prompt": {
+          "name": "tokens_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_reasoning": {
+          "name": "tokens_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_completion": {
+          "name": "tokens_completion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "spans_id_idx": {
+          "name": "spans_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_document_log_uuid_idx": {
+          "name": "spans_document_log_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_log_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_parent_id_idx": {
+          "name": "spans_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_workspace_id_idx": {
+          "name": "spans_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_api_key_id_idx": {
+          "name": "spans_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_type_started_at_idx": {
+          "name": "spans_type_started_at_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_status_started_at_idx": {
+          "name": "spans_status_started_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_started_at_idx": {
+          "name": "spans_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_started_at_brin_idx": {
+          "name": "spans_started_at_brin_idx",
+          "columns": [
+            {
+              "expression": "\"started_at\"",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {
+            "pages_per_range": 32,
+            "autosummarize": true
+          },
+          "method": "brin",
+          "concurrently": false
+        },
+        "spans_document_uuid_idx": {
+          "name": "spans_document_uuid_idx",
+          "columns": [
+            {
+              "expression": "document_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_commit_uuid_idx": {
+          "name": "spans_commit_uuid_idx",
+          "columns": [
+            {
+              "expression": "commit_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_experiment_uuid_idx": {
+          "name": "spans_experiment_uuid_idx",
+          "columns": [
+            {
+              "expression": "experiment_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_test_deployment_id_idx": {
+          "name": "spans_test_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "test_deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_workspace_commit_started_at_id_idx": {
+          "name": "spans_workspace_commit_started_at_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_previous_trace_id_idx": {
+          "name": "spans_previous_trace_id_idx",
+          "columns": [
+            {
+              "expression": "previous_trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_workspace_type_source_idx": {
+          "name": "spans_workspace_type_source_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "spans_workspace_started_at_idx": {
+          "name": "spans_workspace_started_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "spans_workspace_id_workspaces_id_fk": {
+          "name": "spans_workspace_id_workspaces_id_fk",
+          "tableFrom": "spans",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "spans_api_key_id_api_keys_id_fk": {
+          "name": "spans_api_key_id_api_keys_id_fk",
+          "tableFrom": "spans",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "tableTo": "api_keys",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {
+        "spans_trace_id_id_pk": {
+          "name": "spans_trace_id_id_pk",
+          "columns": [
+            "trace_id",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.subscriptions": {
+      "name": "subscriptions",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "subscription_plans",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_workspace_id_index": {
+          "name": "subscriptions_workspace_id_index",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subscriptions_plan_index": {
+          "name": "subscriptions_plan_index",
+          "columns": [
+            {
+              "expression": "plan",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "subscriptions_cancelled_at_index": {
+          "name": "subscriptions_cancelled_at_index",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.users": {
+      "name": "users",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_suggestion_notified_at": {
+          "name": "last_suggestion_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_mode": {
+          "name": "dev_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_usage_stage": {
+          "name": "ai_usage_stage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude_goal": {
+          "name": "latitude_goal",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude_goal_other": {
+          "name": "latitude_goal_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_title_idx": {
+          "name": "users_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_status": {
+          "name": "response_status",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_webhook_id_idx": {
+          "name": "webhook_deliveries_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "webhook_deliveries_next_retry_at_idx": {
+          "name": "webhook_deliveries_next_retry_at_idx",
+          "columns": [
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "tableTo": "webhooks",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.webhooks": {
+      "name": "webhooks",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_ids": {
+          "name": "project_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhooks_workspace_id_idx": {
+          "name": "webhooks_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "webhooks_project_ids_idx": {
+          "name": "webhooks_project_ids_idx",
+          "columns": [
+            {
+              "expression": "project_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_workspace_id_workspaces_id_fk": {
+          "name": "webhooks_workspace_id_workspaces_id_fk",
+          "tableFrom": "webhooks",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.workspace_features": {
+      "name": "workspace_features",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_feature_unique": {
+          "name": "workspace_feature_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_features_workspace_id_workspaces_id_fk": {
+          "name": "workspace_features_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_features",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workspace_features_feature_id_features_id_fk": {
+          "name": "workspace_features_feature_id_features_id_fk",
+          "tableFrom": "workspace_features",
+          "columnsFrom": [
+            "feature_id"
+          ],
+          "tableTo": "features",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.workspace_onboarding": {
+      "name": "workspace_onboarding",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_onboarding_workspace_id_workspaces_id_fk": {
+          "name": "workspace_onboarding_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_onboarding",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_onboarding_workspace_id_unique": {
+          "name": "workspace_onboarding_workspace_id_unique",
+          "columns": [
+            "workspace_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.workspaces": {
+      "name": "workspaces",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_subscription_id": {
+          "name": "current_subscription_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_big_account": {
+          "name": "is_big_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_current_subscription_id_subscriptions_id_fk": {
+          "name": "workspaces_current_subscription_id_subscriptions_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "current_subscription_id"
+          ],
+          "tableTo": "subscriptions",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "workspaces_creator_id_users_id_fk": {
+          "name": "workspaces_creator_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "workspaces_default_provider_id_provider_api_keys_id_fk": {
+          "name": "workspaces_default_provider_id_provider_api_keys_id_fk",
+          "tableFrom": "workspaces",
+          "columnsFrom": [
+            "default_provider_id"
+          ],
+          "tableTo": "provider_api_keys",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.datasets": {
+      "name": "datasets",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "csv_delimiter": {
+          "name": "csv_delimiter",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "datasets_workspace_idx": {
+          "name": "datasets_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "datasets_author_idx": {
+          "name": "datasets_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "datasets_workspace_id_name_index": {
+          "name": "datasets_workspace_id_name_index",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "datasets_workspace_id_workspaces_id_fk": {
+          "name": "datasets_workspace_id_workspaces_id_fk",
+          "tableFrom": "datasets",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "datasets_author_id_users_id_fk": {
+          "name": "datasets_author_id_users_id_fk",
+          "tableFrom": "datasets",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.evaluation_results": {
+      "name": "evaluation_results",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_log_id": {
+          "name": "document_log_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_log_id": {
+          "name": "provider_log_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluated_provider_log_id": {
+          "name": "evaluated_provider_log_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_provider_log_id": {
+          "name": "evaluation_provider_log_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resultable_type": {
+          "name": "resultable_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resultable_id": {
+          "name": "resultable_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "log_source",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evaluation_idx": {
+          "name": "evaluation_idx",
+          "columns": [
+            {
+              "expression": "evaluation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_provider_log_idx": {
+          "name": "evaluation_provider_log_idx",
+          "columns": [
+            {
+              "expression": "evaluation_provider_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluated_provider_log_idx": {
+          "name": "evaluated_provider_log_idx",
+          "columns": [
+            {
+              "expression": "evaluated_provider_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "document_log_idx": {
+          "name": "document_log_idx",
+          "columns": [
+            {
+              "expression": "document_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "provider_log_idx": {
+          "name": "provider_log_idx",
+          "columns": [
+            {
+              "expression": "provider_log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "resultable_idx": {
+          "name": "resultable_idx",
+          "columns": [
+            {
+              "expression": "resultable_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resultable_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_results_created_at_idx": {
+          "name": "evaluation_results_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "evaluation_results_evaluation_id_evaluations_id_fk": {
+          "name": "evaluation_results_evaluation_id_evaluations_id_fk",
+          "tableFrom": "evaluation_results",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "tableTo": "evaluations",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "evaluation_results_document_log_id_document_logs_id_fk": {
+          "name": "evaluation_results_document_log_id_document_logs_id_fk",
+          "tableFrom": "evaluation_results",
+          "columnsFrom": [
+            "document_log_id"
+          ],
+          "tableTo": "document_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "evaluation_results_provider_log_id_provider_logs_id_fk": {
+          "name": "evaluation_results_provider_log_id_provider_logs_id_fk",
+          "tableFrom": "evaluation_results",
+          "columnsFrom": [
+            "provider_log_id"
+          ],
+          "tableTo": "provider_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "evaluation_results_evaluated_provider_log_id_provider_logs_id_fk": {
+          "name": "evaluation_results_evaluated_provider_log_id_provider_logs_id_fk",
+          "tableFrom": "evaluation_results",
+          "columnsFrom": [
+            "evaluated_provider_log_id"
+          ],
+          "tableTo": "provider_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "evaluation_results_evaluation_provider_log_id_provider_logs_id_fk": {
+          "name": "evaluation_results_evaluation_provider_log_id_provider_logs_id_fk",
+          "tableFrom": "evaluation_results",
+          "columnsFrom": [
+            "evaluation_provider_log_id"
+          ],
+          "tableTo": "provider_logs",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluation_results_uuid_unique": {
+          "name": "evaluation_results_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "latitude.evaluations": {
+      "name": "evaluations",
+      "schema": "latitude",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_type": {
+          "name": "metadata_type",
+          "type": "metadata_type",
+          "typeSchema": "latitude",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata_id": {
+          "name": "metadata_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_type": {
+          "name": "result_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_configuration_id": {
+          "name": "result_configuration_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evaluation_workspace_idx": {
+          "name": "evaluation_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluation_metadata_idx": {
+          "name": "evaluation_metadata_idx",
+          "columns": [
+            {
+              "expression": "metadata_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metadata_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "evaluations_deleted_at_idx": {
+          "name": "evaluations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "evaluations_workspace_id_workspaces_id_fk": {
+          "name": "evaluations_workspace_id_workspaces_id_fk",
+          "tableFrom": "evaluations",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspaces",
+          "schemaTo": "latitude",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "evaluations_uuid_unique": {
+          "name": "evaluations_uuid_unique",
+          "columns": [
+            "uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "latitude.reward_types": {
+      "name": "reward_types",
+      "schema": "latitude",
+      "values": [
+        "x_follow",
+        "linkedin_follow",
+        "github_star",
+        "x_post",
+        "linkedin_post",
+        "agent_share",
+        "producthunt_upvote",
+        "referral"
+      ]
+    },
+    "latitude.document_trigger_status": {
+      "name": "document_trigger_status",
+      "schema": "latitude",
+      "values": [
+        "pending",
+        "deployed",
+        "deprecated"
+      ]
+    },
+    "latitude.document_trigger_types": {
+      "name": "document_trigger_types",
+      "schema": "latitude",
+      "values": [
+        "email",
+        "scheduled",
+        "integration"
+      ]
+    },
+    "latitude.document_type_enum": {
+      "name": "document_type_enum",
+      "schema": "latitude",
+      "values": [
+        "prompt",
+        "agent"
+      ]
+    },
+    "latitude.integration_types": {
+      "name": "integration_types",
+      "schema": "latitude",
+      "values": [
+        "custom_mcp",
+        "mcp_server",
+        "pipedream"
+      ]
+    },
+    "latitude.k8s_app_status": {
+      "name": "k8s_app_status",
+      "schema": "latitude",
+      "values": [
+        "pending",
+        "deploying",
+        "deployed",
+        "failed",
+        "deleting",
+        "deleted"
+      ]
+    },
+    "latitude.oauth_providers": {
+      "name": "oauth_providers",
+      "schema": "latitude",
+      "values": [
+        "google",
+        "github"
+      ]
+    },
+    "latitude.provider": {
+      "name": "provider",
+      "schema": "latitude",
+      "values": [
+        "openai",
+        "anthropic",
+        "groq",
+        "mistral",
+        "azure",
+        "google",
+        "google_vertex",
+        "anthropic_vertex",
+        "xai",
+        "deepseek",
+        "perplexity",
+        "custom",
+        "amazon_bedrock"
+      ]
+    },
+    "latitude.log_source": {
+      "name": "log_source",
+      "schema": "latitude",
+      "values": [
+        "api",
+        "agent_as_tool",
+        "copilot",
+        "email_trigger",
+        "evaluation",
+        "experiment",
+        "integration_trigger",
+        "playground",
+        "scheduled_trigger",
+        "shared_prompt",
+        "shadow_test",
+        "ab_test_challenger",
+        "user",
+        "optimization"
+      ]
+    },
+    "latitude.run_error_code_enum": {
+      "name": "run_error_code_enum",
+      "schema": "latitude",
+      "values": [
+        "unknown_error",
+        "default_provider_exceeded_quota_error",
+        "document_config_error",
+        "missing_provider_error",
+        "chain_compile_error",
+        "ai_run_error",
+        "rate_limit_error",
+        "unsupported_provider_response_type_error",
+        "ai_provider_config_error",
+        "ev_run_missing_provider_log_error",
+        "ev_run_missing_workspace_error",
+        "ev_run_unsupported_result_type_error",
+        "ev_run_response_json_format_error",
+        "default_provider_invalid_model_error",
+        "max_step_count_exceeded_error",
+        "failed_to_wake_up_integration_error",
+        "invalid_response_format_error",
+        "error_generating_mock_tool_result",
+        "payment_required_error",
+        "abort_error"
+      ]
+    },
+    "latitude.run_error_entity_enum": {
+      "name": "run_error_entity_enum",
+      "schema": "latitude",
+      "values": [
+        "document_log",
+        "evaluation_result"
+      ]
+    },
+    "latitude.subscription_plans": {
+      "name": "subscription_plans",
+      "schema": "latitude",
+      "values": [
+        "hobby_v1",
+        "hobby_v2",
+        "team_v1",
+        "enterprise_v1",
+        "pro_v2",
+        "team_v2",
+        "team_v3",
+        "hobby_v3",
+        "team_v4",
+        "scale_v1"
+      ]
+    },
+    "latitude.metadata_type": {
+      "name": "metadata_type",
+      "schema": "latitude",
+      "values": [
+        "llm_as_judge",
+        "llm_as_judge_simple",
+        "manual"
+      ]
+    }
+  },
+  "schemas": {
+    "latitude": "latitude"
+  },
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -1863,6 +1863,13 @@
       "when": 1770308262917,
       "tag": "0266_lovely_talon",
       "breakpoints": true
+    },
+    {
+      "idx": 267,
+      "version": "7",
+      "when": 1770377812992,
+      "tag": "0267_evaluation_trigger_options",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/events/handlers/evaluateLiveLog.test.ts
+++ b/packages/core/src/events/handlers/evaluateLiveLog.test.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+  EvaluationType,
+  EvaluationV2,
+  LogSources,
+  PromptSpanMetadata,
+  RuleEvaluationMetric,
+  Span,
+  SpanType,
+} from '../../constants'
+import { evaluateLiveLogJob } from './evaluateLiveLog'
+import { SpanCreatedEvent } from '../events'
+
+vi.mock('../../data-access/workspaces', () => ({
+  unsafelyFindWorkspace: vi.fn(),
+}))
+
+vi.mock('../../jobs/queues', () => ({
+  queues: vi.fn(),
+}))
+
+vi.mock('../../repositories', () => ({
+  CommitsRepository: vi.fn(),
+  EvaluationsV2Repository: vi.fn(),
+  SpanMetadatasRepository: vi.fn(),
+  SpansRepository: vi.fn(),
+}))
+
+vi.mock('../../services/evaluationsV2/specifications', () => ({
+  getEvaluationMetricSpecification: vi.fn(),
+}))
+
+vi.mock('../../services/workspaceFeatures/isFeatureEnabledByName', () => ({
+  isFeatureEnabledByName: vi.fn(),
+}))
+
+vi.mock('../../utils/datadogCapture', () => ({
+  captureException: vi.fn(),
+}))
+
+import { unsafelyFindWorkspace } from '../../data-access/workspaces'
+import { queues } from '../../jobs/queues'
+import {
+  CommitsRepository,
+  EvaluationsV2Repository,
+  SpanMetadatasRepository,
+  SpansRepository,
+} from '../../repositories'
+import { getEvaluationMetricSpecification } from '../../services/evaluationsV2/specifications'
+import { isFeatureEnabledByName } from '../../services/workspaceFeatures/isFeatureEnabledByName'
+import { Result } from '../../lib/Result'
+
+describe('evaluateLiveLogJob', () => {
+  const mockWorkspace = { id: 1, name: 'Test Workspace' }
+  const mockCommit = { id: 1, uuid: 'commit-uuid' }
+  const mockSpan: Span = {
+    id: 'span-1',
+    traceId: 'trace-1',
+    workspaceId: 1,
+    type: SpanType.Prompt,
+    source: LogSources.API,
+    commitUuid: 'commit-uuid',
+    documentUuid: 'doc-uuid',
+    documentLogUuid: 'log-uuid',
+    apiKeyId: 1,
+    name: 'test-span',
+    startedAt: new Date(),
+    endedAt: new Date(),
+    duration: 100,
+    status: 'ok',
+    kind: 'client',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as Span
+  const mockSpanMetadata: PromptSpanMetadata = {
+    messages: [],
+    parameters: {},
+    template: '',
+  } as unknown as PromptSpanMetadata
+
+  const mockEvaluationsQueue = {
+    add: vi.fn(),
+    getJob: vi.fn(),
+  }
+
+  const mockSpansRepositoryGet = vi.fn()
+  const mockSpansRepositoryIsFirstMainSpanInConversation = vi.fn()
+  const mockSpanMetadatasRepositoryGet = vi.fn()
+  const mockCommitsRepositoryGetCommitByUuid = vi.fn()
+  const mockEvaluationsV2RepositoryListAtCommitByDocument = vi.fn()
+
+  function createEvaluation(
+    overrides: Partial<EvaluationV2> = {},
+  ): EvaluationV2<EvaluationType.Rule, RuleEvaluationMetric.ExactMatch> {
+    return {
+      uuid: 'eval-uuid',
+      versionId: 1,
+      workspaceId: 1,
+      commitId: 1,
+      documentUuid: 'doc-uuid',
+      name: 'Test Evaluation',
+      description: 'Test description',
+      type: EvaluationType.Rule,
+      metric: RuleEvaluationMetric.ExactMatch,
+      evaluateLiveLogs: true,
+      configuration: {
+        reverseScale: false,
+        actualOutput: {
+          messageSelection: 'last',
+          parsingFormat: 'string',
+        },
+        caseInsensitive: false,
+      },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    } as EvaluationV2<EvaluationType.Rule, RuleEvaluationMetric.ExactMatch>
+  }
+
+  function createEvent(overrides: Partial<SpanCreatedEvent['data']> = {}): {
+    data: SpanCreatedEvent
+  } {
+    return {
+      data: {
+        type: 'spanCreated',
+        data: {
+          spanId: 'span-1',
+          traceId: 'trace-1',
+          workspaceId: 1,
+          apiKeyId: 1,
+          documentUuid: 'doc-uuid',
+          ...overrides,
+        },
+      } as SpanCreatedEvent,
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(unsafelyFindWorkspace).mockResolvedValue(mockWorkspace as any)
+    vi.mocked(queues).mockResolvedValue({
+      evaluationsQueue: mockEvaluationsQueue,
+    } as any)
+
+    vi.mocked(SpansRepository).mockImplementation(
+      () =>
+        ({
+          get: mockSpansRepositoryGet,
+          isFirstMainSpanInConversation:
+            mockSpansRepositoryIsFirstMainSpanInConversation,
+        }) as unknown as SpansRepository,
+    )
+    vi.mocked(SpanMetadatasRepository).mockImplementation(
+      () =>
+        ({
+          get: mockSpanMetadatasRepositoryGet,
+        }) as unknown as SpanMetadatasRepository,
+    )
+    vi.mocked(CommitsRepository).mockImplementation(
+      () =>
+        ({
+          getCommitByUuid: mockCommitsRepositoryGetCommitByUuid,
+        }) as unknown as CommitsRepository,
+    )
+    vi.mocked(EvaluationsV2Repository).mockImplementation(
+      () =>
+        ({
+          listAtCommitByDocument:
+            mockEvaluationsV2RepositoryListAtCommitByDocument,
+        }) as unknown as EvaluationsV2Repository,
+    )
+
+    mockSpansRepositoryGet.mockResolvedValue(Result.ok(mockSpan))
+    mockSpanMetadatasRepositoryGet.mockResolvedValue(
+      Result.ok(mockSpanMetadata),
+    )
+    mockCommitsRepositoryGetCommitByUuid.mockResolvedValue(
+      Result.ok(mockCommit),
+    )
+    vi.mocked(getEvaluationMetricSpecification).mockReturnValue({
+      supportsLiveEvaluation: true,
+    } as any)
+    vi.mocked(isFeatureEnabledByName).mockResolvedValue(Result.ok(false))
+  })
+
+  describe('trigger target: every (default)', () => {
+    it('should enqueue evaluation job for span without trigger config', async () => {
+      const evaluation = createEvaluation()
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          workspaceId: 1,
+          commitId: 1,
+          evaluationUuid: 'eval-uuid',
+          spanId: 'span-1',
+          traceId: 'trace-1',
+        }),
+        expect.objectContaining({
+          deduplication: expect.any(Object),
+        }),
+      )
+    })
+
+    it('should enqueue evaluation job with trigger target "every"', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'every',
+            lastInteractionDebounce:
+              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          evaluationUuid: 'eval-uuid',
+        }),
+        expect.objectContaining({
+          deduplication: expect.any(Object),
+        }),
+      )
+      expect(mockEvaluationsQueue.add).not.toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.anything(),
+        expect.objectContaining({ delay: expect.any(Number) }),
+      )
+    })
+  })
+
+  describe('trigger target: first', () => {
+    it('should enqueue evaluation job only for first span in conversation', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'first',
+            lastInteractionDebounce:
+              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+      mockSpansRepositoryIsFirstMainSpanInConversation.mockResolvedValue(true)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(
+        mockSpansRepositoryIsFirstMainSpanInConversation,
+      ).toHaveBeenCalledWith('log-uuid', 'span-1', 'trace-1')
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          evaluationUuid: 'eval-uuid',
+        }),
+        expect.any(Object),
+      )
+    })
+
+    it('should skip evaluation job for non-first span in conversation', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'first',
+            lastInteractionDebounce:
+              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+      mockSpansRepositoryIsFirstMainSpanInConversation.mockResolvedValue(false)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(
+        mockSpansRepositoryIsFirstMainSpanInConversation,
+      ).toHaveBeenCalledWith('log-uuid', 'span-1', 'trace-1')
+      expect(mockEvaluationsQueue.add).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('trigger target: last', () => {
+    it('should schedule delayed job for last trigger', async () => {
+      const debounceSeconds = 60
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'last',
+            lastInteractionDebounce: debounceSeconds,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+      mockEvaluationsQueue.getJob.mockResolvedValue(null)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          evaluationUuid: 'eval-uuid',
+        }),
+        expect.objectContaining({
+          jobId: 'debouncedEvaluation-log-uuid-eval-uuid',
+          delay: debounceSeconds * 1000,
+          deduplication: expect.any(Object),
+        }),
+      )
+    })
+
+    it('should remove existing delayed job before scheduling new one', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'last',
+            lastInteractionDebounce: 120,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+      const mockExistingJob = { remove: vi.fn() }
+      mockEvaluationsQueue.getJob.mockResolvedValue(mockExistingJob)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.getJob).toHaveBeenCalledWith(
+        'debouncedEvaluation-log-uuid-eval-uuid',
+      )
+      expect(mockExistingJob.remove).toHaveBeenCalled()
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.anything(),
+        expect.objectContaining({
+          jobId: 'debouncedEvaluation-log-uuid-eval-uuid',
+          delay: 120 * 1000,
+        }),
+      )
+    })
+
+    it('should use default debounce when not specified', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: {
+            target: 'last',
+            lastInteractionDebounce:
+              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+          },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+      mockEvaluationsQueue.getJob.mockResolvedValue(null)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.anything(),
+        expect.objectContaining({
+          delay: DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS * 1000,
+        }),
+      )
+    })
+  })
+
+  describe('multiple evaluations with different triggers', () => {
+    it('should handle multiple evaluations with different trigger types', async () => {
+      const everyEvaluation = createEvaluation({
+        uuid: 'eval-every',
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: { target: 'every', lastInteractionDebounce: 120 },
+        },
+      })
+      const firstEvaluation = createEvaluation({
+        uuid: 'eval-first',
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: { target: 'first', lastInteractionDebounce: 120 },
+        },
+      })
+      const lastEvaluation = createEvaluation({
+        uuid: 'eval-last',
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: { target: 'last', lastInteractionDebounce: 60 },
+        },
+      })
+
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([everyEvaluation, firstEvaluation, lastEvaluation]),
+      )
+      mockSpansRepositoryIsFirstMainSpanInConversation.mockResolvedValue(true)
+      mockEvaluationsQueue.getJob.mockResolvedValue(null)
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(3)
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ evaluationUuid: 'eval-every' }),
+        expect.not.objectContaining({ delay: expect.any(Number) }),
+      )
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ evaluationUuid: 'eval-first' }),
+        expect.not.objectContaining({ delay: expect.any(Number) }),
+      )
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ evaluationUuid: 'eval-last' }),
+        expect.objectContaining({ delay: 60 * 1000 }),
+      )
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return early if span has no documentLogUuid', async () => {
+      const spanWithoutDocLogUuid = { ...mockSpan, documentLogUuid: null }
+      mockSpansRepositoryGet.mockResolvedValue(Result.ok(spanWithoutDocLogUuid))
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(
+        mockEvaluationsV2RepositoryListAtCommitByDocument,
+      ).not.toHaveBeenCalled()
+      expect(mockEvaluationsQueue.add).not.toHaveBeenCalled()
+    })
+
+    it('should not call isFirstMainSpanInConversation for every trigger', async () => {
+      const evaluation = createEvaluation({
+        configuration: {
+          reverseScale: false,
+          actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+          caseInsensitive: false,
+          trigger: { target: 'every', lastInteractionDebounce: 120 },
+        },
+      })
+      mockEvaluationsV2RepositoryListAtCommitByDocument.mockResolvedValue(
+        Result.ok([evaluation]),
+      )
+
+      await evaluateLiveLogJob(createEvent())
+
+      expect(
+        mockSpansRepositoryIsFirstMainSpanInConversation,
+      ).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.test.ts
@@ -1,0 +1,393 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Job } from 'bullmq'
+import {
+  EvaluationType,
+  EvaluationV2,
+  RuleEvaluationMetric,
+  Span,
+  SpanType,
+} from '../../../constants'
+import {
+  runEvaluationForExperimentJob,
+  RunEvaluationForExperimentJobData,
+} from './runEvaluationForExperimentJob'
+import { Result } from '../../../lib/Result'
+
+vi.mock('../../queues', () => ({
+  queues: vi.fn(),
+}))
+
+vi.mock('../../../repositories', () => ({
+  CommitsRepository: vi.fn(),
+  EvaluationsV2Repository: vi.fn(),
+  ExperimentsRepository: vi.fn(),
+}))
+
+vi.mock('../../../repositories/spansRepository', () => ({
+  SpansRepository: vi.fn(),
+}))
+
+vi.mock('../../../services/experiments/updateStatus', () => ({
+  updateExperimentStatus: vi.fn(),
+}))
+
+vi.mock('../../../utils/datadogCapture', () => ({
+  captureException: vi.fn(),
+}))
+
+import { queues } from '../../queues'
+import {
+  CommitsRepository,
+  EvaluationsV2Repository,
+  ExperimentsRepository,
+} from '../../../repositories'
+import { SpansRepository } from '../../../repositories/spansRepository'
+
+describe('runEvaluationForExperimentJob', () => {
+  const mockEvaluationsQueue = {
+    add: vi.fn(),
+  }
+
+  const mockExperimentsRepositoryFindByUuid = vi.fn()
+  const mockCommitsRepositoryGetCommitById = vi.fn()
+  const mockEvaluationsV2RepositoryGetAtCommitByDocument = vi.fn()
+  const mockSpansRepositoryListByDocumentLogUuid = vi.fn()
+  const mockSpansRepositoryGetLastTraceByLogUuid = vi.fn()
+
+  const mockExperiment = {
+    uuid: 'exp-uuid',
+    documentUuid: 'doc-uuid',
+    finishedAt: null,
+  }
+
+  const mockCommit = { id: 1, uuid: 'commit-uuid' }
+
+  function createSpan(
+    id: string,
+    type: SpanType = SpanType.Prompt,
+    startedAt: Date = new Date(),
+  ): Span {
+    return {
+      id,
+      traceId: `trace-${id}`,
+      type,
+      startedAt,
+      workspaceId: 1,
+    } as unknown as Span
+  }
+
+  function createEvaluation(
+    triggerTarget?: 'first' | 'every' | 'last',
+  ): EvaluationV2<EvaluationType.Rule, RuleEvaluationMetric.ExactMatch> {
+    const config: any = {
+      reverseScale: false,
+      actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+      caseInsensitive: false,
+    }
+    if (triggerTarget) {
+      config.trigger = { target: triggerTarget, lastInteractionDebounce: 120 }
+    }
+    return {
+      uuid: 'eval-uuid',
+      versionId: 1,
+      workspaceId: 1,
+      commitId: 1,
+      documentUuid: 'doc-uuid',
+      name: 'Test Evaluation',
+      description: 'Test description',
+      type: EvaluationType.Rule,
+      metric: RuleEvaluationMetric.ExactMatch,
+      configuration: config,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as EvaluationV2<EvaluationType.Rule, RuleEvaluationMetric.ExactMatch>
+  }
+
+  function createJobData(
+    overrides: Partial<RunEvaluationForExperimentJobData> = {},
+  ): RunEvaluationForExperimentJobData {
+    return {
+      workspaceId: 1,
+      conversationUuid: 'conversation-uuid',
+      experimentUuid: 'exp-uuid',
+      evaluationUuid: 'eval-uuid',
+      commitId: 1,
+      ...overrides,
+    }
+  }
+
+  function createMockJob(
+    data: RunEvaluationForExperimentJobData,
+  ): Job<RunEvaluationForExperimentJobData> {
+    return {
+      id: 'test-job-id',
+      data,
+      attemptsStarted: 0,
+      moveToDelayed: vi.fn(),
+    } as unknown as Job<RunEvaluationForExperimentJobData>
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(queues).mockResolvedValue({
+      evaluationsQueue: mockEvaluationsQueue,
+    } as any)
+
+    vi.mocked(ExperimentsRepository).mockImplementation(
+      () =>
+        ({
+          findByUuid: mockExperimentsRepositoryFindByUuid,
+        }) as unknown as ExperimentsRepository,
+    )
+    vi.mocked(CommitsRepository).mockImplementation(
+      () =>
+        ({
+          getCommitById: mockCommitsRepositoryGetCommitById,
+        }) as unknown as CommitsRepository,
+    )
+    vi.mocked(EvaluationsV2Repository).mockImplementation(
+      () =>
+        ({
+          getAtCommitByDocument:
+            mockEvaluationsV2RepositoryGetAtCommitByDocument,
+        }) as unknown as EvaluationsV2Repository,
+    )
+    vi.mocked(SpansRepository).mockImplementation(
+      () =>
+        ({
+          listByDocumentLogUuid: mockSpansRepositoryListByDocumentLogUuid,
+          getLastTraceByLogUuid: mockSpansRepositoryGetLastTraceByLogUuid,
+        }) as unknown as SpansRepository,
+    )
+
+    mockExperimentsRepositoryFindByUuid.mockResolvedValue(
+      Result.ok(mockExperiment),
+    )
+    mockCommitsRepositoryGetCommitById.mockResolvedValue(Result.ok(mockCommit))
+  })
+
+  describe('trigger target: first (default without trigger config)', () => {
+    it('should evaluate only the first prompt span when no trigger config', async () => {
+      const evaluation = createEvaluation()
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+
+      const spans = [
+        createSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue(spans)
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(3)
+    })
+
+    it('should evaluate only the first prompt span with trigger target "first"', async () => {
+      const evaluation = createEvaluation('first')
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+
+      const spans = [
+        createSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue(spans)
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(1)
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          spanId: 'span-1',
+          traceId: 'trace-span-1',
+        }),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('trigger target: every', () => {
+    it('should evaluate all prompt spans with trigger target "every"', async () => {
+      const evaluation = createEvaluation('every')
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+
+      const spans = [
+        createSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createSpan(
+          'span-tool',
+          SpanType.Tool,
+          new Date('2024-01-01T00:00:30Z'),
+        ),
+        createSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue(spans)
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(3)
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ spanId: 'span-1' }),
+        expect.any(Object),
+      )
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ spanId: 'span-2' }),
+        expect.any(Object),
+      )
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ spanId: 'span-3' }),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('trigger target: last', () => {
+    it('should evaluate only the last prompt span with trigger target "last"', async () => {
+      const evaluation = createEvaluation('last')
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+
+      const spans = [
+        createSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue(spans)
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(1)
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({
+          spanId: 'span-3',
+          traceId: 'trace-span-3',
+        }),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('filtering non-prompt spans', () => {
+    it('should only consider Prompt type spans for evaluation', async () => {
+      const evaluation = createEvaluation('every')
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+
+      const spans = [
+        createSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createSpan(
+          'span-tool',
+          SpanType.Tool,
+          new Date('2024-01-01T00:00:30Z'),
+        ),
+        createSpan(
+          'span-completion',
+          SpanType.Completion,
+          new Date('2024-01-01T00:00:45Z'),
+        ),
+        createSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue(spans)
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(2)
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ spanId: 'span-1' }),
+        expect.any(Object),
+      )
+      expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+        'runEvaluationV2Job',
+        expect.objectContaining({ spanId: 'span-2' }),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return early if experiment is finished', async () => {
+      mockExperimentsRepositoryFindByUuid.mockResolvedValue(
+        Result.ok({ ...mockExperiment, finishedAt: new Date() }),
+      )
+
+      const job = createMockJob(createJobData())
+      await runEvaluationForExperimentJob(job)
+
+      expect(mockEvaluationsV2RepositoryGetAtCommitByDocument).not.toHaveBeenCalled()
+      expect(mockEvaluationsQueue.add).not.toHaveBeenCalled()
+    })
+
+    it('should retry when no spans found yet', async () => {
+      const evaluation = createEvaluation('every')
+      mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+        Result.ok(evaluation),
+      )
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue([])
+      mockSpansRepositoryGetLastTraceByLogUuid.mockResolvedValue(null)
+
+      const job = createMockJob(createJobData())
+
+      await expect(runEvaluationForExperimentJob(job)).rejects.toThrow(
+        'Waiting for trace to show up',
+      )
+      expect(job.moveToDelayed).toHaveBeenCalled()
+      expect(mockEvaluationsQueue.add).not.toHaveBeenCalled()
+    })
+
+    it('should handle single span correctly for all trigger types', async () => {
+      const singleSpan = createSpan(
+        'only-span',
+        SpanType.Prompt,
+        new Date('2024-01-01T00:00:00Z'),
+      )
+      mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue([singleSpan])
+
+      for (const target of ['first', 'every', 'last'] as const) {
+        vi.clearAllMocks()
+        mockExperimentsRepositoryFindByUuid.mockResolvedValue(
+          Result.ok(mockExperiment),
+        )
+        mockCommitsRepositoryGetCommitById.mockResolvedValue(
+          Result.ok(mockCommit),
+        )
+        mockSpansRepositoryListByDocumentLogUuid.mockResolvedValue([singleSpan])
+
+        const evaluation = createEvaluation(target)
+        mockEvaluationsV2RepositoryGetAtCommitByDocument.mockResolvedValue(
+          Result.ok(evaluation),
+        )
+
+        const job = createMockJob(createJobData())
+        await runEvaluationForExperimentJob(job)
+
+        expect(mockEvaluationsQueue.add).toHaveBeenCalledTimes(1)
+        expect(mockEvaluationsQueue.add).toHaveBeenCalledWith(
+          'runEvaluationV2Job',
+          expect.objectContaining({ spanId: 'only-span' }),
+          expect.any(Object),
+        )
+      }
+    })
+  })
+})

--- a/packages/core/src/repositories/spansRepository.test.ts
+++ b/packages/core/src/repositories/spansRepository.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SpansRepository } from './spansRepository'
+import { Providers, SpanType } from '@latitude-data/constants'
+import * as factories from '../tests/factories'
+import { Commit } from '../schema/models/types/Commit'
+import { DocumentVersion } from '../schema/models/types/DocumentVersion'
+import { WorkspaceDto } from '../schema/models/types/Workspace'
+import { ApiKey } from '../schema/models/types/ApiKey'
+import { faker } from '@faker-js/faker'
+
+describe('SpansRepository', () => {
+  let workspace: WorkspaceDto
+  let commit: Commit
+  let document: DocumentVersion
+  let apiKey: ApiKey
+
+  beforeEach(async () => {
+    const projectData = await factories.createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      documents: {
+        prompt: factories.helpers.createPrompt({
+          provider: 'openai',
+          content: 'Test prompt content',
+        }),
+      },
+    })
+    workspace = projectData.workspace as WorkspaceDto
+    commit = projectData.commit
+    document = projectData.documents[0]!
+
+    const apiKeyData = await factories.createApiKey({
+      workspace,
+      name: 'test-api-key',
+    })
+    apiKey = apiKeyData.apiKey
+  })
+
+  describe('findFirstMainSpanByDocumentLogUuid', () => {
+    it('should return the first main span by startedAt', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'span-2',
+        traceId: 'trace-2',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:01:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'span-1',
+        traceId: 'trace-1',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'span-3',
+        traceId: 'trace-3',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:02:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const firstSpan =
+        await repo.findFirstMainSpanByDocumentLogUuid(documentLogUuid)
+
+      expect(firstSpan).toBeDefined()
+      expect(firstSpan?.id).toBe('span-1')
+      expect(firstSpan?.traceId).toBe('trace-1')
+    })
+
+    it('should only consider main span types (Prompt, Chat, External)', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'span-tool',
+        traceId: 'trace-tool',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Tool,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'span-prompt',
+        traceId: 'trace-prompt',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:01:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const firstSpan =
+        await repo.findFirstMainSpanByDocumentLogUuid(documentLogUuid)
+
+      expect(firstSpan).toBeDefined()
+      expect(firstSpan?.id).toBe('span-prompt')
+    })
+
+    it('should return undefined for non-existent documentLogUuid', async () => {
+      const repo = new SpansRepository(workspace.id)
+      const firstSpan = await repo.findFirstMainSpanByDocumentLogUuid(
+        faker.string.uuid(),
+      )
+
+      expect(firstSpan).toBeUndefined()
+    })
+  })
+
+  describe('isFirstMainSpanInConversation', () => {
+    it('should return true for the first main span', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'first-span',
+        traceId: 'first-trace',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'second-span',
+        traceId: 'second-trace',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:01:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const isFirst = await repo.isFirstMainSpanInConversation(
+        documentLogUuid,
+        'first-span',
+        'first-trace',
+      )
+
+      expect(isFirst).toBe(true)
+    })
+
+    it('should return false for non-first spans', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'first-span',
+        traceId: 'first-trace',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'second-span',
+        traceId: 'second-trace',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:01:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const isFirst = await repo.isFirstMainSpanInConversation(
+        documentLogUuid,
+        'second-span',
+        'second-trace',
+      )
+
+      expect(isFirst).toBe(false)
+    })
+
+    it('should return false for non-existent span', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'existing-span',
+        traceId: 'existing-trace',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const isFirst = await repo.isFirstMainSpanInConversation(
+        documentLogUuid,
+        'non-existent-span',
+        'non-existent-trace',
+      )
+
+      expect(isFirst).toBe(false)
+    })
+
+    it('should return false when documentLogUuid has no spans', async () => {
+      const repo = new SpansRepository(workspace.id)
+      const isFirst = await repo.isFirstMainSpanInConversation(
+        faker.string.uuid(),
+        'any-span',
+        'any-trace',
+      )
+
+      expect(isFirst).toBe(false)
+    })
+  })
+
+  describe('findLastMainSpanByDocumentLogUuid', () => {
+    it('should return the last main span by startedAt', async () => {
+      const documentLogUuid = faker.string.uuid()
+
+      await factories.createSpan({
+        id: 'span-1',
+        traceId: 'trace-1',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:00:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'span-3',
+        traceId: 'trace-3',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:02:00Z'),
+      })
+
+      await factories.createSpan({
+        id: 'span-2',
+        traceId: 'trace-2',
+        workspaceId: workspace.id,
+        apiKeyId: apiKey.id,
+        documentLogUuid,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        type: SpanType.Prompt,
+        startedAt: new Date('2024-01-01T00:01:00Z'),
+      })
+
+      const repo = new SpansRepository(workspace.id)
+      const lastSpan =
+        await repo.findLastMainSpanByDocumentLogUuid(documentLogUuid)
+
+      expect(lastSpan).toBeDefined()
+      expect(lastSpan?.id).toBe('span-3')
+      expect(lastSpan?.traceId).toBe('trace-3')
+    })
+  })
+})

--- a/packages/core/src/services/evaluationsV2/validate.ts
+++ b/packages/core/src/services/evaluationsV2/validate.ts
@@ -9,6 +9,8 @@ import {
   EvaluationType,
   EvaluationV2,
   ExpectedOutputConfiguration,
+  LAST_INTERACTION_DEBOUNCE_MAX_SECONDS,
+  LAST_INTERACTION_DEBOUNCE_MIN_SECONDS,
 } from '../../constants'
 import { BadRequestError } from '../../lib/errors'
 import { Result } from '../../lib/Result'
@@ -128,6 +130,7 @@ export async function validateEvaluationV2<
     reverseScale: settings.configuration.reverseScale,
     actualOutput: settings.configuration.actualOutput,
     expectedOutput: settings.configuration.expectedOutput,
+    trigger: settings.configuration.trigger,
   }
 
   if (evaluations.find((e) => e.name === settings.name)) {
@@ -147,6 +150,24 @@ export async function validateEvaluationV2<
     return Result.error(
       new BadRequestError('This metric does not support live evaluation'),
     )
+  }
+
+  const debounce = settings.configuration.trigger?.lastInteractionDebounce
+  if (debounce !== undefined) {
+    if (debounce < LAST_INTERACTION_DEBOUNCE_MIN_SECONDS) {
+      return Result.error(
+        new BadRequestError(
+          `lastInteractionDebounce must be at least ${LAST_INTERACTION_DEBOUNCE_MIN_SECONDS} seconds`,
+        ),
+      )
+    }
+    if (debounce > LAST_INTERACTION_DEBOUNCE_MAX_SECONDS) {
+      return Result.error(
+        new BadRequestError(
+          `lastInteractionDebounce must be at most ${LAST_INTERACTION_DEBOUNCE_MAX_SECONDS} seconds`,
+        ),
+      )
+    }
   }
 
   // ISSUE VALIDATIONS

--- a/packages/web-ui/src/ds/atoms/Icons/index.tsx
+++ b/packages/web-ui/src/ds/atoms/Icons/index.tsx
@@ -173,6 +173,7 @@ import {
   CreditCardIcon,
   KeyRound,
   MessageCircle,
+  MessageSquareDashedIcon,
   MessagesSquareIcon,
 } from 'lucide-react'
 import { MouseEvent } from 'react'
@@ -270,6 +271,7 @@ const Icons = {
   chat: MessageCircleIcon,
   messageSquareText: MessageSquareTextIcon,
   messagesSquare: MessagesSquareIcon,
+  messageSquareDashed: MessageSquareDashedIcon,
   check: CheckCircle2,
   checkCheck: CheckCheck,
   checkClean: CheckIcon,


### PR DESCRIPTION
## Summary
Introduces trigger configuration for evaluations to control which interaction within a conversation gets evaluated. Previously, all interactions were evaluated. Now users can choose to evaluate only the first interaction, every interaction (default), or the last interaction in a conversation.

For live evaluations with "last interaction" selected, a debounce mechanism ensures the evaluation only runs after a configurable period of inactivity (default 120 seconds), preventing premature evaluation while the conversation is still active.

Includes a migration to backfill existing evaluations with the default trigger setting (`target: 'every'`).