### PR TITLE
Fix evaluation result messages tab

### DIFF
--- a/packages/core/src/lib/streamManager/chainStreamManager.ts
+++ b/packages/core/src/lib/streamManager/chainStreamManager.ts
@@ -92,7 +92,6 @@ export class ChainStreamManager extends StreamManager implements StreamManager {
         source: this.source,
         workspace: this.workspace,
         resolvedTools: toolsBySource,
-        telemetryOptions: this.telemetryOptions,
       })
 
       this.updateStateFromResponse({

--- a/packages/core/src/lib/streamManager/defaultStreamManager.ts
+++ b/packages/core/src/lib/streamManager/defaultStreamManager.ts
@@ -89,7 +89,6 @@ export class DefaultStreamManager
           source: this.source,
           workspace: this.workspace,
           resolvedTools: toolsBySource,
-          telemetryOptions: this.telemetryOptions,
         })
 
       this.updateStateFromResponse({

--- a/packages/core/src/lib/streamManager/index.ts
+++ b/packages/core/src/lib/streamManager/index.ts
@@ -28,7 +28,6 @@ import { generateUUIDIdentifier } from '../generateUUID'
 import { ToolHandler } from '../../services/documents/tools/clientTools/handlers'
 import { ResolvedToolsDict } from '@latitude-data/constants/tools'
 import { createPromiseWithResolver } from './utils/createPromiseResolver'
-import { CompletionTelemetryOptions } from '../../services/ai'
 import { ProviderApiKey } from '../../schema/models/types/ProviderApiKey'
 
 const addTokens = ({
@@ -91,7 +90,6 @@ export abstract class StreamManager {
   public mcpClientManager: McpClientManager
   public mcpHeaders?: Record<string, Record<string, string>>
   public promptSource: PromptSource
-  public telemetryOptions?: CompletionTelemetryOptions
   public source: LogSources
   public stream: ReadableStream<ChainEvent>
   public tools: Record<string, ToolHandler>
@@ -151,14 +149,6 @@ export abstract class StreamManager {
         this.controller = controller
       },
     })
-
-    this.telemetryOptions =
-      promptSource && 'document' in promptSource
-        ? {
-            promptUuid: promptSource.document.documentUuid,
-            versionUuid: promptSource.commit.uuid,
-          }
-        : undefined
 
     this.handleAbortSignal(abortSignal)
   }

--- a/packages/core/src/lib/streamManager/step/streamAIResponse.ts
+++ b/packages/core/src/lib/streamManager/step/streamAIResponse.ts
@@ -9,7 +9,7 @@ import { JSONSchema7 } from 'json-schema'
 import { LogSources } from '../../../constants'
 import { type ProviderApiKey } from '../../../schema/models/types/ProviderApiKey'
 import { WorkspaceDto } from '../../../schema/models/types/Workspace'
-import { ai, AIReturn, CompletionTelemetryOptions } from '../../../services/ai'
+import { ai, AIReturn } from '../../../services/ai'
 import { processResponse } from '../../../services/chains/ProviderProcessor'
 import { writeConversationCache } from '../../../services/conversations/cache'
 import { assertUsageWithinPlanLimits } from '../../../services/workspaces/usage'
@@ -37,7 +37,6 @@ export async function streamAIResponse({
   output,
   abortSignal,
   resolvedTools,
-  telemetryOptions,
 }: {
   context: TelemetryContext
   controller: ReadableStreamDefaultController
@@ -52,7 +51,6 @@ export async function streamAIResponse({
   output?: Output
   abortSignal?: AbortSignal
   resolvedTools?: ResolvedToolsDict
-  telemetryOptions?: CompletionTelemetryOptions
 }): Promise<{
   response: ChainStepResponse<StreamType>
   messages: Message[]
@@ -71,7 +69,6 @@ export async function streamAIResponse({
     output,
     abortSignal,
     onError: handleAIError,
-    telemetryOptions,
   }).then((r) => r.unwrap())
 
   const checkResult = checkValidStream({ type: aiResult.type })

--- a/packages/core/src/services/ai/getLanguageModel.ts
+++ b/packages/core/src/services/ai/getLanguageModel.ts
@@ -8,7 +8,6 @@ import { LlmProvider } from './helpers'
 import { VercelConfigWithProviderRules } from './providers/rules'
 import { createTelemetryMiddleware } from './telemetryMiddleware'
 import { TelemetryContext } from '@latitude-data/telemetry'
-import { CompletionTelemetryOptions } from '.'
 
 // FIXME: Is this doing anything? There are no options available here.
 function buildGenericLanguageModel({
@@ -36,7 +35,6 @@ export function getLanguageModel({
   llmProvider,
   customLanguageModel,
   context,
-  telemetryOptions,
 }: {
   model: string
   config: VercelConfigWithProviderRules
@@ -44,7 +42,6 @@ export function getLanguageModel({
   llmProvider: LlmProvider
   customLanguageModel?: LanguageModel
   context: TelemetryContext
-  telemetryOptions?: CompletionTelemetryOptions
 }): LanguageModel {
   if (customLanguageModel) {
     return wrapCompletionTelemetry({
@@ -52,7 +49,6 @@ export function getLanguageModel({
       provider,
       model,
       context,
-      telemetryOptions,
     })
   }
 
@@ -63,7 +59,6 @@ export function getLanguageModel({
       provider,
       model,
       context,
-      telemetryOptions,
     })
   }
 
@@ -87,7 +82,6 @@ export function getLanguageModel({
     provider,
     model,
     context,
-    telemetryOptions,
   })
 }
 
@@ -96,16 +90,12 @@ function wrapCompletionTelemetry({
   provider,
   model,
   context,
-  telemetryOptions,
 }: {
   languageModel: LanguageModel
   provider: ProviderApiKey
   model: string
   context: TelemetryContext
-  telemetryOptions?: CompletionTelemetryOptions
 }): LanguageModel {
-  if (!telemetryOptions) return languageModel
-
   // wrapLanguageModel expects a LanguageModelV2 object, not a string model identifier.
   // Since buildGenericLanguageModel always returns a LanguageModelV2 object, we can safely cast.
   if (typeof languageModel === 'string') {
@@ -119,7 +109,6 @@ function wrapCompletionTelemetry({
       context,
       providerName: provider.provider,
       model,
-      ...telemetryOptions,
     }),
   })
 }

--- a/packages/core/src/services/ai/index.ts
+++ b/packages/core/src/services/ai/index.ts
@@ -73,12 +73,6 @@ function getStopWhen({ maxSteps }: { maxSteps?: number | undefined }) {
 
 export type OnErrorParameters = Parameters<StreamTextOnErrorCallback>[0]
 
-export type CompletionTelemetryOptions = {
-  promptUuid?: string
-  versionUuid?: string
-  experimentUuid?: string
-}
-
 export async function ai({
   context,
   provider,
@@ -89,7 +83,6 @@ export async function ai({
   output,
   aiSdkProvider,
   abortSignal,
-  telemetryOptions,
 }: {
   context: TelemetryContext
   provider: ProviderApiKey
@@ -100,7 +93,6 @@ export async function ai({
   output?: ObjectOutput
   aiSdkProvider?: Partial<AISDKProvider>
   abortSignal?: AbortSignal
-  telemetryOptions?: CompletionTelemetryOptions
 }): Promise<
   TypedResult<
     AIReturn<StreamType>,
@@ -153,7 +145,6 @@ export async function ai({
       config,
       model,
       context,
-      telemetryOptions,
     })
 
     const toolsResult = buildTools(tools)

--- a/packages/core/src/services/ai/telemetryMiddleware.ts
+++ b/packages/core/src/services/ai/telemetryMiddleware.ts
@@ -70,16 +70,10 @@ export function createTelemetryMiddleware({
   context,
   providerName,
   model,
-  promptUuid,
-  versionUuid,
-  experimentUuid,
 }: {
   context: TelemetryContext
   providerName: string
   model: string
-  promptUuid?: string
-  versionUuid?: string
-  experimentUuid?: string
 }): LanguageModelMiddleware {
   return {
     wrapGenerate: async ({ doGenerate, params }) => {
@@ -94,9 +88,6 @@ export function createTelemetryMiddleware({
             model,
             ...((params as Record<string, unknown>) ?? {}),
           },
-          promptUuid,
-          versionUuid,
-          experimentUuid,
         },
         context,
       )
@@ -135,9 +126,6 @@ export function createTelemetryMiddleware({
             model,
             ...((params as Record<string, unknown>) ?? {}),
           },
-          promptUuid,
-          versionUuid,
-          experimentUuid,
         },
         context,
       )


### PR DESCRIPTION
# What?
This UI was missing from the provider logs migration

## TODO
- [x] 🐛 Messages panel was using providers
- [x] 🐛 Completion spans were not created for evaluations