### PR TITLE
Fix updateLoopsContact payload length limits

### DIFF
--- a/packages/core/src/events/handlers/updateLoopsContact.test.ts
+++ b/packages/core/src/events/handlers/updateLoopsContact.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AIUsageStage,
+  LatitudeGoal,
+  UserTitle,
+} from '@latitude-data/constants/users'
+
+import { updateLoopsContact } from './updateLoopsContact'
+import { type UserOnboardingInfoUpdatedEvent } from '../events'
+
+const updateContactMock = vi.fn()
+
+vi.mock('@latitude-data/env', () => ({
+  env: {
+    LOOPS_API_KEY: 'test-api-key',
+  },
+}))
+
+vi.mock('loops', () => ({
+  LoopsClient: vi.fn().mockImplementation(() => ({
+    updateContact: updateContactMock,
+  })),
+}))
+
+describe('updateLoopsContact', () => {
+  beforeEach(() => {
+    updateContactMock.mockResolvedValue({ success: true })
+    updateContactMock.mockClear()
+  })
+
+  it('truncates oversized fields before updating contact', async () => {
+    const longValue = 'a'.repeat(300)
+    const event = {
+      type: 'userOnboardingInfoUpdated',
+      data: {
+        id: 'user-id',
+        name: 'Test User',
+        email: 'user@example.com',
+        confirmedAt: null,
+        admin: false,
+        lastSuggestionNotifiedAt: null,
+        devMode: null,
+        title: UserTitle.Engineer,
+        aiUsageStage: AIUsageStage.LiveWithCustomers,
+        latitudeGoal: LatitudeGoal.Other,
+        latitudeGoalOther: longValue,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        userEmail: 'user@example.com',
+      },
+    } as UserOnboardingInfoUpdatedEvent
+
+    await updateLoopsContact({ data: event })
+
+    const expectedValue = longValue.slice(0, 255)
+
+    expect(updateContactMock).toHaveBeenCalledWith('user@example.com', {
+      jobTitle: UserTitle.Engineer,
+      aiUsageStage: AIUsageStage.LiveWithCustomers,
+      latitudeGoal: expectedValue,
+    })
+  })
+})

--- a/packages/sdks/typescript/src/tests/acceptance.test.ts
+++ b/packages/sdks/typescript/src/tests/acceptance.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
-import { Latitude } from '../../dist/index.js'
+import { Latitude } from '../index'
 
 const shouldRunAcceptance = process.env.RUN_ACCEPTANCE_TESTS === '1'
 // const describeAcceptance = shouldRunAcceptance ? describe : describe.skip


### PR DESCRIPTION
## Datadog
https://app.datadoghq.eu/error-tracking/unified?query=service%3A%2A&issueId=6dbe8848-0335-11f1-901a-da7ad0900005&from_ts=1770280000000&to_ts=1770366400000&live=false&monitor_id=90296800&monitor_sub_type=.new%28%29&link_source=monitor_notif

## Error Message
For email: mohammedjamal1208@gmail.com: Some body key or value is longer than allowable.

## Stack Snippet
```
Error: For email: mohammedjamal1208@gmail.com: Some body key or value is longer than allowable.
    at updateLoopsContact (file:///app/apps/workers/dist/server.js:10271:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## What Changed
- Trim and cap Loops contact fields before update to avoid oversized payloads.
- Added a unit test to cover truncation behavior.
- Switched SDK acceptance test to import from source so typecheck works without dist.

## Validation
- pnpm lint
- pnpm --filter @latitude-data/sdk build
- pnpm --filter @latitude-data/telemetry build
- pnpm tc