### PR TITLE
Fix experiments run from logs

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/ActionButtons.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/ActionButtons.tsx
@@ -114,7 +114,7 @@ export function ActionButtons({
             placement: 'right',
           }}
         >
-          See {experiment.logsMetadata.count} Logs
+          See {experiment.runMetadata.count} Logs
         </Button>
       </Link>
     </div>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/LogsMetadata.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/LogsMetadata.tsx
@@ -1,11 +1,11 @@
 import { formatCostInMillicents, formatDuration } from '$/app/_lib/formatUtils'
-import { BestLogsMetadata } from '$/stores/experimentComparison'
+import { BestRunMetadata } from '$/stores/experimentComparison'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { cn } from '@latitude-data/web-ui/utils'
 import { ExperimentWithScores } from '@latitude-data/core/schema/models/types/Experiment'
 
-function ExperimentLogMetadataItem({
+function ExperimentRunMetadataItem({
   label,
   value,
   isBest = false,
@@ -31,59 +31,58 @@ function ExperimentLogMetadataItem({
   )
 }
 
-export function ExperimentLogsMetadata({
+export function ExperimentRunMetadata({
   experiment,
-  bestLogsMetadata,
+  bestRunMetadata,
 }: {
   experiment: ExperimentWithScores
-  bestLogsMetadata: BestLogsMetadata
+  bestRunMetadata: BestRunMetadata
 }) {
   return (
     <div className='flex flex-row items-center gap-4'>
-      <ExperimentLogMetadataItem
+      <ExperimentRunMetadataItem
         label='Duration'
         value={
-          experiment.logsMetadata.count > 0
+          experiment.runMetadata.count > 0
             ? formatDuration(
-                experiment.logsMetadata.totalDuration /
-                  experiment.logsMetadata.count,
+                experiment.runMetadata.totalDuration /
+                  experiment.runMetadata.count,
               )
             : '—'
         }
-        isBest={bestLogsMetadata.duration.includes(experiment.uuid)}
-        onlyOneBest={bestLogsMetadata.duration.length === 1}
+        isBest={bestRunMetadata.duration.includes(experiment.uuid)}
+        onlyOneBest={bestRunMetadata.duration.length === 1}
       />
-      <ExperimentLogMetadataItem
+      <ExperimentRunMetadataItem
         label='Tokens'
         value={
-          experiment.logsMetadata.count > 0
+          experiment.runMetadata.count > 0
             ? Math.floor(
-                experiment.logsMetadata.totalTokens /
-                  experiment.logsMetadata.count,
+                experiment.runMetadata.totalTokens /
+                  experiment.runMetadata.count,
               ).toString()
             : '—'
         }
-        isBest={bestLogsMetadata.tokens.includes(experiment.uuid)}
-        onlyOneBest={bestLogsMetadata.tokens.length === 1}
+        isBest={bestRunMetadata.tokens.includes(experiment.uuid)}
+        onlyOneBest={bestRunMetadata.tokens.length === 1}
       />
-      <ExperimentLogMetadataItem
+      <ExperimentRunMetadataItem
         label='Cost'
         value={
-          experiment.logsMetadata.count > 0
+          experiment.runMetadata.count > 0
             ? formatCostInMillicents(
-                experiment.logsMetadata.totalCost /
-                  experiment.logsMetadata.count,
+                experiment.runMetadata.totalCost / experiment.runMetadata.count,
               )
             : '—'
         }
-        isBest={bestLogsMetadata.cost.includes(experiment.uuid)}
-        onlyOneBest={bestLogsMetadata.cost.length === 1}
+        isBest={bestRunMetadata.cost.includes(experiment.uuid)}
+        onlyOneBest={bestRunMetadata.cost.length === 1}
       />
     </div>
   )
 }
 
-export function ExperimentLogsMetadataPlaceholder() {
+export function ExperimentRunMetadataPlaceholder() {
   return (
     <div className='flex flex-row items-center gap-4'>
       <div className='flex flex-col w-full gap-2 items-center p-4 rounded-md bg-muted animate-pulse'>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/ExperimentItem/index.tsx
@@ -4,7 +4,7 @@ import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import { useCurrentProject } from '$/app/providers/ProjectProvider'
 import useLatitudeAction from '$/hooks/useLatitudeAction'
 import {
-  BestLogsMetadata,
+  BestRunMetadata,
   EvaluationWithBestExperiment,
 } from '$/stores/experimentComparison'
 import { DocumentVersion } from '@latitude-data/constants'
@@ -22,8 +22,8 @@ import {
   ExperimentEvaluationScoresPlaceholder,
 } from './EvaluationScores'
 import {
-  ExperimentLogsMetadata,
-  ExperimentLogsMetadataPlaceholder,
+  ExperimentRunMetadata,
+  ExperimentRunMetadataPlaceholder,
 } from './LogsMetadata'
 import { ExperimentPrompt } from './Prompt'
 
@@ -45,7 +45,7 @@ export function ExperimentItemPlaceholder({
     >
       <Skeleton height='h4' className='w-[85%]' />
       <ExperimentPrompt experiment={undefined} />
-      <ExperimentLogsMetadataPlaceholder />
+      <ExperimentRunMetadataPlaceholder />
       <ExperimentEvaluationScoresPlaceholder
         evaluationCount={evaluationCount}
       />
@@ -56,7 +56,7 @@ export function ExperimentItemPlaceholder({
 export function ExperimentItem({
   experiment,
   evaluations,
-  bestLogsMetadata,
+  bestRunMetadata,
   isFirst,
   isLast,
   isSamePrompt,
@@ -65,7 +65,7 @@ export function ExperimentItem({
 }: {
   experiment?: ExperimentWithScores
   evaluations?: EvaluationWithBestExperiment[]
-  bestLogsMetadata: BestLogsMetadata
+  bestRunMetadata: BestRunMetadata
   isFirst: boolean
   isLast: boolean
   isSamePrompt: boolean
@@ -141,9 +141,9 @@ export function ExperimentItem({
         onCompare={isFirst ? undefined : onCompare}
         isSamePrompt={isSamePrompt}
       />
-      <ExperimentLogsMetadata
+      <ExperimentRunMetadata
         experiment={experiment}
-        bestLogsMetadata={bestLogsMetadata}
+        bestRunMetadata={bestRunMetadata}
       />
       <ExperimentEvaluationScores
         experiment={experiment}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/_components/ExperimentsComparison/index.tsx
@@ -24,13 +24,14 @@ export function ExperimentComparison({
   const { commit } = useCurrentCommit()
   const { document } = useCurrentDocument()
 
-  const { experiments, evaluations, bestLogsMetadata } =
-    useExperimentComparison({
+  const { experiments, evaluations, bestRunMetadata } = useExperimentComparison(
+    {
       project: project as Project,
       commit: commit as Commit,
       document,
       experimentUuids: selectedExperimentUuids,
-    })
+    },
+  )
 
   const [isComparing, setIsComparing] = useState(false)
   const baseline = useMemo(() => experiments?.[0], [experiments])
@@ -66,7 +67,7 @@ export function ExperimentComparison({
                   }
                 : undefined
             }
-            bestLogsMetadata={bestLogsMetadata}
+            bestRunMetadata={bestRunMetadata}
           />
         )
       })}

--- a/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/experiments/comparison/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/experiments/comparison/route.test.ts
@@ -1,0 +1,556 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import {
+  createProject,
+  createExperiment,
+  createEvaluationV2,
+  createSpan,
+  createWorkspace,
+  helpers,
+} from '@latitude-data/core/factories'
+import { LogSources, Providers, SpanType } from '@latitude-data/constants'
+import { User } from '@latitude-data/core/schema/models/types/User'
+import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
+import { Project } from '@latitude-data/core/schema/models/types/Project'
+import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
+import { Experiment } from '@latitude-data/core/schema/models/types/Experiment'
+import { EvaluationV2 } from '@latitude-data/core/constants'
+
+import { GET } from './route'
+
+const mocks = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+    captureException: vi.fn(),
+  }
+})
+vi.mock('$/services/auth/getSession', () => ({
+  getSession: mocks.getSession,
+}))
+vi.mock('$/helpers/captureException', () => ({
+  captureException: mocks.captureException,
+}))
+
+describe('GET /api/projects/[projectId]/documents/[documentUuid]/experiments/comparison', () => {
+  let user: User
+  let workspace: Workspace
+  let project: Project
+  let commit: Commit
+  let document: DocumentVersion
+  let evaluations: EvaluationV2[]
+
+  beforeEach(async () => {
+    const setup = await createProject({
+      providers: [{ type: Providers.OpenAI, name: 'openai' }],
+      documents: {
+        'test-doc': helpers.createPrompt({
+          provider: 'openai',
+          content: 'Test content',
+        }),
+      },
+    })
+    user = setup.user
+    workspace = setup.workspace
+    project = setup.project
+    commit = setup.commit
+    document = setup.documents[0]!
+
+    evaluations = await Promise.all([
+      createEvaluationV2({
+        workspace,
+        commit,
+        document,
+        name: 'evaluation-1',
+      }),
+      createEvaluationV2({
+        workspace,
+        commit,
+        document,
+        name: 'evaluation-2',
+      }),
+    ])
+  })
+
+  function buildRequest(uuids: string[]) {
+    const searchParams = new URLSearchParams()
+    if (uuids.length > 0) {
+      searchParams.set('uuids', uuids.join(','))
+    }
+    return new NextRequest(
+      `http://localhost:3000/api/projects/${project.id}/documents/${document.documentUuid}/experiments/comparison?${searchParams.toString()}`,
+    )
+  }
+
+  async function createTestExperiment(name: string): Promise<Experiment> {
+    const { experiment } = await createExperiment({
+      name,
+      document,
+      commit,
+      evaluations,
+      user,
+      workspace,
+    })
+    return experiment
+  }
+
+  describe('unauthorized', () => {
+    it('returns 401 if user is not authenticated', async () => {
+      mocks.getSession.mockResolvedValue(null)
+      const request = buildRequest([])
+
+      const response = await GET(request, { workspace } as any)
+
+      expect(response.status).toBe(401)
+      expect(await response.json()).toEqual({
+        message: 'Unauthorized',
+      })
+    })
+  })
+
+  describe('authorized', () => {
+    beforeEach(() => {
+      mocks.getSession.mockResolvedValue({
+        user,
+        session: { userId: user.id, currentWorkspaceId: workspace.id },
+      })
+    })
+
+    describe('basic functionality', () => {
+      it('returns empty array when no uuids provided', async () => {
+        const request = buildRequest([])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data).toEqual([])
+      })
+
+      it('returns experiment with scores and run metadata', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const traceId = 'trace-1'
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId,
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId,
+          cost: 100,
+          tokensPrompt: 50,
+          tokensCompletion: 25,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data).toHaveLength(1)
+        expect(data[0]).toMatchObject({
+          uuid: experiment.uuid,
+          name: experiment.name,
+        })
+        expect(data[0].scores).toBeDefined()
+        expect(data[0].runMetadata).toBeDefined()
+      })
+
+      it('returns multiple experiments when multiple uuids provided', async () => {
+        const experiment1 = await createTestExperiment('experiment-1')
+        const experiment2 = await createTestExperiment('experiment-2')
+
+        const request = buildRequest([experiment1.uuid, experiment2.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data).toHaveLength(2)
+
+        const uuids = data.map((e: any) => e.uuid)
+        expect(uuids).toContain(experiment1.uuid)
+        expect(uuids).toContain(experiment2.uuid)
+      })
+    })
+
+    describe('getRunMetadata query logic', () => {
+      it('counts Prompt spans and sums their duration', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: 'trace-1',
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: 'trace-2',
+          duration: 2000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: 'trace-3',
+          duration: 3000,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(3)
+        expect(data[0].runMetadata.totalDuration).toBe(6000)
+      })
+
+      it('gets cost and tokens from Completion spans matching Prompt traceIds', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const traceId1 = 'trace-1'
+        const traceId2 = 'trace-2'
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: traceId1,
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: traceId2,
+          duration: 2000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId: traceId1,
+          cost: 100,
+          tokensPrompt: 50,
+          tokensCompletion: 25,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId: traceId2,
+          cost: 200,
+          tokensPrompt: 100,
+          tokensCompletion: 50,
+          tokensCached: 10,
+          tokensReasoning: 5,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(2)
+        expect(data[0].runMetadata.totalDuration).toBe(3000)
+        expect(data[0].runMetadata.totalCost).toBe(300)
+        expect(data[0].runMetadata.totalTokens).toBe(
+          50 + 25 + 100 + 50 + 10 + 5,
+        )
+      })
+
+      it('ignores spans that do not belong to the experiment', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const traceId = 'trace-1'
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId,
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId,
+          cost: 100,
+          tokensPrompt: 50,
+          tokensCompletion: 25,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId: 'orphan-trace',
+          cost: 9999,
+          tokensPrompt: 9999,
+          tokensCompletion: 9999,
+          source: LogSources.API,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.totalCost).toBe(100)
+        expect(data[0].runMetadata.totalTokens).toBe(75)
+      })
+
+      it('handles multiple Completion spans per trace', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const traceId = 'trace-1'
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId,
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId,
+          cost: 100,
+          tokensPrompt: 50,
+          tokensCompletion: 25,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId,
+          cost: 200,
+          tokensPrompt: 100,
+          tokensCompletion: 50,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(1)
+        expect(data[0].runMetadata.totalCost).toBe(300)
+        expect(data[0].runMetadata.totalTokens).toBe(225)
+      })
+
+      it('returns zeros when no spans exist', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(0)
+        expect(data[0].runMetadata.totalDuration).toBe(0)
+        expect(data[0].runMetadata.totalCost).toBe(0)
+        expect(data[0].runMetadata.totalTokens).toBe(0)
+      })
+
+      it('returns zeros for cost/tokens when only Prompt spans exist (no Completions)', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: 'trace-1',
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(1)
+        expect(data[0].runMetadata.totalDuration).toBe(1000)
+        expect(data[0].runMetadata.totalCost).toBe(0)
+        expect(data[0].runMetadata.totalTokens).toBe(0)
+      })
+    })
+
+    describe('tenancy', () => {
+      it('does not return experiments from another workspace', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const { workspace: otherWorkspace, userData: otherUser } =
+          await createWorkspace()
+
+        mocks.getSession.mockResolvedValue({
+          user: otherUser,
+          session: {
+            userId: otherUser.id,
+            currentWorkspaceId: otherWorkspace.id,
+          },
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, {
+          workspace: otherWorkspace,
+        } as any)
+
+        expect(response.status).toBe(404)
+      })
+
+      it('does not include spans from another workspace in run metadata', async () => {
+        const experiment = await createTestExperiment('test-experiment')
+
+        const { workspace: otherWorkspace } = await createWorkspace()
+
+        const traceId = 'trace-1'
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId,
+          duration: 1000,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: workspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId,
+          cost: 100,
+          tokensPrompt: 50,
+          tokensCompletion: 25,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: otherWorkspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Prompt,
+          traceId: 'other-trace',
+          duration: 9999,
+          source: LogSources.Experiment,
+        })
+
+        await createSpan({
+          workspaceId: otherWorkspace.id,
+          experimentUuid: experiment.uuid,
+          documentUuid: document.documentUuid,
+          commitUuid: commit.uuid,
+          type: SpanType.Completion,
+          traceId: 'other-trace',
+          cost: 9999,
+          tokensPrompt: 9999,
+          tokensCompletion: 9999,
+          source: LogSources.Experiment,
+        })
+
+        const request = buildRequest([experiment.uuid])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data[0].runMetadata.count).toBe(1)
+        expect(data[0].runMetadata.totalDuration).toBe(1000)
+        expect(data[0].runMetadata.totalCost).toBe(100)
+        expect(data[0].runMetadata.totalTokens).toBe(75)
+      })
+    })
+
+    describe('error handling', () => {
+      it('returns 404 when experiment does not exist', async () => {
+        const request = buildRequest(['00000000-0000-0000-0000-000000000000'])
+
+        const response = await GET(request, { workspace } as any)
+
+        expect(response.status).toBe(404)
+      })
+    })
+  })
+})

--- a/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/experiments/comparison/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/documents/[documentUuid]/experiments/comparison/route.ts
@@ -29,14 +29,14 @@ export const GET = errorHandler(
           await Promise.all([experimentResult, scoresResult])
           const experiment = await experimentResult.then((r) => r.unwrap())
           const scores = await scoresResult.then((r) => r.unwrap())
-          const logsMetadata = await scope
-            .getLogsMetadata(uuid)
+          const runMetadata = await scope
+            .getRunMetadata(uuid)
             .then((r) => r.unwrap())
 
           return {
             ...experiment,
             scores,
-            logsMetadata,
+            runMetadata,
           } as ExperimentWithScores
         }),
       )

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -643,6 +643,20 @@ export type StripeCustomerIdUnassignedEvent = LatitudeEventGeneric<
   }
 >
 
+type DocumentRunMetrics = {
+  runUsage: {
+    inputTokens: number
+    outputTokens: number
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+    reasoningTokens: number
+    cachedInputTokens: number
+  }
+  runCost: number
+  duration: number
+}
+
 type DocumentRunStatusEventData = {
   workspaceId: number
   projectId: number
@@ -655,6 +669,8 @@ type DocumentRunStatusEventData = {
   customIdentifier?: string | null
   tools?: string[]
   userMessage?: string
+  metrics?: DocumentRunMetrics
+  experimentId?: number
 }
 
 export type DocumentRunQueuedEvent = LatitudeEventGeneric<

--- a/packages/core/src/events/handlers/evaluateLiveLog.test.ts
+++ b/packages/core/src/events/handlers/evaluateLiveLog.test.ts
@@ -217,8 +217,7 @@ describe('evaluateLiveLogJob', () => {
           caseInsensitive: false,
           trigger: {
             target: 'every',
-            lastInteractionDebounce:
-              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+            lastInteractionDebounce: DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
           },
         },
       })
@@ -254,8 +253,7 @@ describe('evaluateLiveLogJob', () => {
           caseInsensitive: false,
           trigger: {
             target: 'first',
-            lastInteractionDebounce:
-              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+            lastInteractionDebounce: DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
           },
         },
       })
@@ -286,8 +284,7 @@ describe('evaluateLiveLogJob', () => {
           caseInsensitive: false,
           trigger: {
             target: 'first',
-            lastInteractionDebounce:
-              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+            lastInteractionDebounce: DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
           },
         },
       })
@@ -381,8 +378,7 @@ describe('evaluateLiveLogJob', () => {
           caseInsensitive: false,
           trigger: {
             target: 'last',
-            lastInteractionDebounce:
-              DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
+            lastInteractionDebounce: DEFAULT_LAST_INTERACTION_DEBOUNCE_SECONDS,
           },
         },
       })

--- a/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.test.ts
+++ b/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.test.ts
@@ -58,12 +58,13 @@ describe('notifyClientOfRunStatusByDocument', () => {
         workspaceId: baseEventData.workspaceId,
         data: {
           event: 'documentRunQueued',
-          eventContext: 'background',
           workspaceId: baseEventData.workspaceId,
           projectId: baseEventData.projectId,
           documentUuid: baseEventData.documentUuid,
           commitUuid: baseEventData.commitUuid,
           run: baseEventData.run,
+          metrics: undefined,
+          experimentId: undefined,
         },
       },
     )
@@ -90,12 +91,13 @@ describe('notifyClientOfRunStatusByDocument', () => {
         workspaceId: eventData.workspaceId,
         data: {
           event: 'documentRunStarted',
-          eventContext: 'background',
           workspaceId: eventData.workspaceId,
           projectId: eventData.projectId,
           documentUuid: eventData.documentUuid,
           commitUuid: eventData.commitUuid,
           run: eventData.run,
+          metrics: undefined,
+          experimentId: undefined,
         },
       },
     )
@@ -123,12 +125,13 @@ describe('notifyClientOfRunStatusByDocument', () => {
         workspaceId: eventData.workspaceId,
         data: {
           event: 'documentRunProgress',
-          eventContext: 'background',
           workspaceId: eventData.workspaceId,
           projectId: eventData.projectId,
           documentUuid: eventData.documentUuid,
           commitUuid: eventData.commitUuid,
           run: eventData.run,
+          metrics: undefined,
+          experimentId: undefined,
         },
       },
     )
@@ -156,12 +159,13 @@ describe('notifyClientOfRunStatusByDocument', () => {
         workspaceId: eventData.workspaceId,
         data: {
           event: 'documentRunEnded',
-          eventContext: 'background',
           workspaceId: eventData.workspaceId,
           projectId: eventData.projectId,
           documentUuid: eventData.documentUuid,
           commitUuid: eventData.commitUuid,
           run: eventData.run,
+          metrics: undefined,
+          experimentId: undefined,
         },
       },
     )
@@ -188,12 +192,130 @@ describe('notifyClientOfRunStatusByDocument', () => {
         workspaceId: eventData.workspaceId,
         data: {
           event: 'documentRunQueued',
-          eventContext: 'background',
           workspaceId: eventData.workspaceId,
           projectId: eventData.projectId,
           documentUuid: eventData.documentUuid,
           commitUuid: eventData.commitUuid,
           run: eventData.run,
+          metrics: undefined,
+          experimentId: undefined,
+        },
+      },
+    )
+  })
+
+  it('should include metrics when provided', async () => {
+    const metrics = {
+      runUsage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        reasoningTokens: 10,
+        cachedInputTokens: 5,
+      },
+      runCost: 0.01,
+      duration: 1500,
+    }
+    const eventData = {
+      ...baseEventData,
+      metrics,
+    }
+    const event = {
+      type: 'documentRunEnded',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunEnded',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+          metrics,
+          experimentId: undefined,
+        },
+      },
+    )
+  })
+
+  it('should include experimentId when provided', async () => {
+    const eventData = {
+      ...baseEventData,
+      experimentId: 42,
+    }
+    const event = {
+      type: 'documentRunEnded',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunEnded',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+          metrics: undefined,
+          experimentId: 42,
+        },
+      },
+    )
+  })
+
+  it('should include both metrics and experimentId when provided', async () => {
+    const metrics = {
+      runUsage: {
+        inputTokens: 200,
+        outputTokens: 100,
+        promptTokens: 200,
+        completionTokens: 100,
+        totalTokens: 300,
+        reasoningTokens: 20,
+        cachedInputTokens: 10,
+      },
+      runCost: 0.025,
+      duration: 2500,
+    }
+    const eventData = {
+      ...baseEventData,
+      metrics,
+      experimentId: 123,
+    }
+    const event = {
+      type: 'documentRunEnded',
+      data: eventData,
+    } as DocumentRunStatusEvent
+
+    await notifyClientOfRunStatusByDocument({ data: event })
+
+    expect(WebsocketClient.sendEvent).toHaveBeenCalledWith(
+      'documentRunStatus',
+      {
+        workspaceId: eventData.workspaceId,
+        data: {
+          event: 'documentRunEnded',
+          workspaceId: eventData.workspaceId,
+          projectId: eventData.projectId,
+          documentUuid: eventData.documentUuid,
+          commitUuid: eventData.commitUuid,
+          run: eventData.run,
+          metrics,
+          experimentId: 123,
         },
       },
     )

--- a/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.ts
+++ b/packages/core/src/events/handlers/notifyClientOfRunStatusByDocument.ts
@@ -17,6 +17,8 @@ export const notifyClientOfRunStatusByDocument = async ({
     commitUuid,
     run,
     eventContext,
+    metrics,
+    experimentId,
   } = event.data
 
   if (eventContext === 'foreground') return
@@ -30,7 +32,8 @@ export const notifyClientOfRunStatusByDocument = async ({
       documentUuid,
       commitUuid,
       run,
-      eventContext,
+      metrics,
+      experimentId,
     },
   })
 }

--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.test.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.test.ts
@@ -334,7 +334,9 @@ describe('runEvaluationForExperimentJob', () => {
       const job = createMockJob(createJobData())
       await runEvaluationForExperimentJob(job)
 
-      expect(mockEvaluationsV2RepositoryGetAtCommitByDocument).not.toHaveBeenCalled()
+      expect(
+        mockEvaluationsV2RepositoryGetAtCommitByDocument,
+      ).not.toHaveBeenCalled()
       expect(mockEvaluationsQueue.add).not.toHaveBeenCalled()
     })
 

--- a/packages/core/src/jobs/job-definitions/runs/helpers/types.ts
+++ b/packages/core/src/jobs/job-definitions/runs/helpers/types.ts
@@ -1,8 +1,18 @@
 import { LogSources } from '@latitude-data/constants'
+import { LegacyVercelSDKVersion4Usage as LanguageModelUsage } from '@latitude-data/constants/ai'
 import { SimulationSettings } from '@latitude-data/constants/simulation'
+import { LanguageModelUsage as LanguageModelUsageType } from '../../../../constants'
 import { OkType } from '../../../../lib/Result'
-import { runDocumentAtCommit } from '../../../../services/commits/runDocumentAtCommit'
 import { DeploymentTest } from '../../../../schema/models/types/DeploymentTest'
+import { runDocumentAtCommit } from '../../../../services/commits/runDocumentAtCommit'
+
+export type RunMetrics = {
+  runUsage: LanguageModelUsage
+  runCost: number
+  duration: number
+}
+
+export type { LanguageModelUsageType }
 
 /**
  * Input data for the background run job

--- a/packages/core/src/lib/streamManager/index.test.ts
+++ b/packages/core/src/lib/streamManager/index.test.ts
@@ -1,0 +1,412 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Providers } from '@latitude-data/constants'
+import { LegacyVercelSDKVersion4Usage as LanguageModelUsage } from '@latitude-data/constants/ai'
+import { LogSources } from '../../constants'
+import { incrementTokens, StreamManager, StreamManagerProps } from './index'
+import * as estimateCostModule from '../../services/ai/estimateCost'
+
+vi.spyOn(estimateCostModule, 'estimateCost')
+
+class TestStreamManager extends StreamManager {
+  async step() {}
+
+  public get $provider() {
+    return this.provider
+  }
+  public get $model() {
+    return this.model
+  }
+  public $startProviderStep = this.startProviderStep.bind(this)
+  public $incrementLogUsage = this.incrementLogUsage.bind(this)
+  public $incrementLogCost = this.incrementLogCost.bind(this)
+  public $incrementRunCostFromUsage = this.incrementRunCostFromUsage.bind(this)
+  public $updateStateFromResponse = this.updateStateFromResponse.bind(this)
+  public $startStream = this.startStream.bind(this)
+  public $endStream = this.endStream.bind(this)
+}
+
+const createUsage = (multiplier: number = 1): LanguageModelUsage => ({
+  inputTokens: 100 * multiplier,
+  outputTokens: 50 * multiplier,
+  promptTokens: 100 * multiplier,
+  completionTokens: 50 * multiplier,
+  totalTokens: 150 * multiplier,
+  reasoningTokens: 10 * multiplier,
+  cachedInputTokens: 5 * multiplier,
+})
+
+describe('incrementTokens', () => {
+  it('adds tokens when prev is undefined', () => {
+    const next = createUsage()
+    const result = incrementTokens({ prev: undefined, next })
+
+    expect(result).toEqual(next)
+  })
+
+  it('adds tokens when prev has values', () => {
+    const prev = createUsage(1)
+    const next = createUsage(2)
+    const result = incrementTokens({ prev, next })
+
+    expect(result).toEqual({
+      inputTokens: 300,
+      outputTokens: 150,
+      promptTokens: 300,
+      completionTokens: 150,
+      totalTokens: 450,
+      reasoningTokens: 30,
+      cachedInputTokens: 15,
+    })
+  })
+
+  it('handles zero values correctly', () => {
+    const prev: LanguageModelUsage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+      reasoningTokens: 0,
+      cachedInputTokens: 0,
+    }
+    const next = createUsage()
+    const result = incrementTokens({ prev, next })
+
+    expect(result).toEqual(next)
+  })
+})
+
+describe('StreamManager', () => {
+  let streamManager: TestStreamManager
+  let defaultProps: StreamManagerProps
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    defaultProps = {
+      workspace: { id: 1, name: 'test' } as any,
+      promptSource: {
+        commit: { uuid: 'commit-uuid' },
+        document: { documentUuid: 'doc-uuid' },
+      } as any,
+      source: LogSources.API,
+      context: {} as any,
+    }
+
+    streamManager = new TestStreamManager(defaultProps)
+  })
+
+  describe('startProviderStep', () => {
+    it('stores provider and model', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      await streamManager.$startProviderStep({ config, provider })
+
+      expect(streamManager.$provider).toBe(provider)
+      expect(streamManager.$model).toBe('gpt-4')
+    })
+  })
+
+  describe('incrementLogUsage', () => {
+    it('increments log usage', async () => {
+      const { logUsage } = streamManager.prepare()
+
+      streamManager.$startStream()
+      streamManager.$incrementLogUsage(createUsage(1))
+      streamManager.$incrementLogUsage(createUsage(2))
+      streamManager.$endStream()
+
+      await expect(logUsage).resolves.toEqual({
+        inputTokens: 300,
+        outputTokens: 150,
+        promptTokens: 300,
+        completionTokens: 150,
+        totalTokens: 450,
+        reasoningTokens: 30,
+        cachedInputTokens: 15,
+      })
+    })
+  })
+
+  describe('incrementRunUsage', () => {
+    it('increments run usage', async () => {
+      const { runUsage } = streamManager.prepare()
+
+      streamManager.$startStream()
+      streamManager.incrementRunUsage(createUsage(1))
+      streamManager.incrementRunUsage(createUsage(3))
+      streamManager.$endStream()
+
+      await expect(runUsage).resolves.toEqual({
+        inputTokens: 400,
+        outputTokens: 200,
+        promptTokens: 400,
+        completionTokens: 200,
+        totalTokens: 600,
+        reasoningTokens: 40,
+        cachedInputTokens: 20,
+      })
+    })
+  })
+
+  describe('cost tracking', () => {
+    beforeEach(() => {
+      vi.mocked(estimateCostModule.estimateCost).mockReturnValue(0.01)
+    })
+
+    it('incrementLogCost calculates cost using estimateCost', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+      const usage = createUsage()
+
+      const { logCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+      streamManager.$incrementLogCost(usage)
+      streamManager.$endStream()
+
+      expect(estimateCostModule.estimateCost).toHaveBeenCalledWith({
+        provider: Providers.OpenAI,
+        model: 'gpt-4',
+        usage,
+      })
+      await expect(logCost).resolves.toBeCloseTo(0.01)
+    })
+
+    it('incrementLogCost does nothing without provider/model', async () => {
+      const usage = createUsage()
+
+      const { logCost } = streamManager.prepare()
+      streamManager.$startStream()
+      streamManager.$incrementLogCost(usage)
+      streamManager.$endStream()
+
+      expect(estimateCostModule.estimateCost).not.toHaveBeenCalled()
+      await expect(logCost).resolves.toBe(0)
+    })
+
+    it('incrementRunCostFromUsage calculates cost using estimateCost', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+      const usage = createUsage()
+
+      const { runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+      streamManager.$incrementRunCostFromUsage(usage)
+      streamManager.$endStream()
+
+      expect(estimateCostModule.estimateCost).toHaveBeenCalledWith({
+        provider: Providers.OpenAI,
+        model: 'gpt-4',
+        usage,
+      })
+      await expect(runCost).resolves.toBeCloseTo(0.01)
+    })
+
+    it('incrementRunCost adds pre-computed cost directly', async () => {
+      const { runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      streamManager.incrementRunCost(0.05)
+      streamManager.incrementRunCost(0.03)
+      streamManager.$endStream()
+
+      await expect(runCost).resolves.toBeCloseTo(0.08)
+    })
+
+    it('accumulates costs from multiple calls', async () => {
+      vi.mocked(estimateCostModule.estimateCost).mockReturnValue(0.01)
+
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      const { logCost, runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      streamManager.$incrementLogCost(createUsage())
+      streamManager.$incrementLogCost(createUsage())
+
+      streamManager.$incrementRunCostFromUsage(createUsage())
+      streamManager.incrementRunCost(0.05)
+
+      streamManager.$endStream()
+
+      await expect(logCost).resolves.toBeCloseTo(0.02)
+      await expect(runCost).resolves.toBeCloseTo(0.06)
+    })
+  })
+
+  describe('updateStateFromResponse', () => {
+    beforeEach(() => {
+      vi.mocked(estimateCostModule.estimateCost).mockReturnValue(0.01)
+    })
+
+    it('updates all state including usage and cost', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+      const usage = createUsage()
+
+      const { logUsage, runUsage, logCost, runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'Hello' } as any,
+        messages: [{ role: 'assistant', content: 'Hello' }] as any,
+        tokenUsage: usage,
+        finishReason: 'stop',
+      })
+
+      streamManager.$endStream()
+
+      await expect(logUsage).resolves.toEqual(usage)
+      await expect(runUsage).resolves.toEqual(usage)
+      await expect(logCost).resolves.toBeCloseTo(0.01)
+      await expect(runCost).resolves.toBeCloseTo(0.01)
+    })
+
+    it('accumulates across multiple updateStateFromResponse calls', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      const { logUsage, runUsage, logCost, runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'Hello' } as any,
+        messages: [{ role: 'assistant', content: 'Hello' }] as any,
+        tokenUsage: createUsage(1),
+        finishReason: 'stop',
+      })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'World' } as any,
+        messages: [{ role: 'assistant', content: 'World' }] as any,
+        tokenUsage: createUsage(2),
+        finishReason: 'stop',
+      })
+
+      streamManager.$endStream()
+
+      const expectedUsage = {
+        inputTokens: 300,
+        outputTokens: 150,
+        promptTokens: 300,
+        completionTokens: 150,
+        totalTokens: 450,
+        reasoningTokens: 30,
+        cachedInputTokens: 15,
+      }
+
+      await expect(logUsage).resolves.toEqual(expectedUsage)
+      await expect(runUsage).resolves.toEqual(expectedUsage)
+      await expect(logCost).resolves.toBeCloseTo(0.02)
+      await expect(runCost).resolves.toBeCloseTo(0.02)
+    })
+  })
+
+  describe('sub-agent aggregation', () => {
+    beforeEach(() => {
+      vi.mocked(estimateCostModule.estimateCost).mockReturnValue(0.01)
+    })
+
+    it('runCost includes both own cost and sub-agent costs', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      const { logCost, runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'Hello' } as any,
+        messages: [{ role: 'assistant', content: 'Hello' }] as any,
+        tokenUsage: createUsage(),
+        finishReason: 'stop',
+      })
+
+      streamManager.incrementRunCost(0.05)
+      streamManager.incrementRunCost(0.03)
+
+      streamManager.$endStream()
+
+      await expect(logCost).resolves.toBeCloseTo(0.01)
+      await expect(runCost).resolves.toBeCloseTo(0.09)
+    })
+
+    it('runUsage includes both own usage and sub-agent usage', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      const { logUsage, runUsage } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'Hello' } as any,
+        messages: [{ role: 'assistant', content: 'Hello' }] as any,
+        tokenUsage: createUsage(1),
+        finishReason: 'stop',
+      })
+
+      streamManager.incrementRunUsage(createUsage(2))
+      streamManager.incrementRunUsage(createUsage(3))
+
+      streamManager.$endStream()
+
+      await expect(logUsage).resolves.toEqual(createUsage(1))
+      await expect(runUsage).resolves.toEqual({
+        inputTokens: 600,
+        outputTokens: 300,
+        promptTokens: 600,
+        completionTokens: 300,
+        totalTokens: 900,
+        reasoningTokens: 60,
+        cachedInputTokens: 30,
+      })
+    })
+
+    it('aggregates both tokens and costs from multiple sub-agents', async () => {
+      const provider = { provider: Providers.OpenAI } as any
+      const config = { model: 'gpt-4' } as any
+
+      const { logUsage, runUsage, logCost, runCost } = streamManager.prepare()
+      streamManager.$startStream()
+      await streamManager.$startProviderStep({ config, provider })
+
+      await streamManager.$updateStateFromResponse({
+        response: { text: 'Main agent response' } as any,
+        messages: [
+          { role: 'assistant', content: 'Main agent response' },
+        ] as any,
+        tokenUsage: createUsage(1),
+        finishReason: 'stop',
+      })
+
+      streamManager.incrementRunUsage(createUsage(2))
+      streamManager.incrementRunCost(0.02)
+
+      streamManager.incrementRunUsage(createUsage(1))
+      streamManager.incrementRunCost(0.01)
+
+      streamManager.$endStream()
+
+      await expect(logUsage).resolves.toEqual(createUsage(1))
+      await expect(logCost).resolves.toBeCloseTo(0.01)
+
+      await expect(runUsage).resolves.toEqual({
+        inputTokens: 400,
+        outputTokens: 200,
+        promptTokens: 400,
+        completionTokens: 200,
+        totalTokens: 600,
+        reasoningTokens: 40,
+        cachedInputTokens: 20,
+      })
+      await expect(runCost).resolves.toBeCloseTo(0.04)
+    })
+  })
+})

--- a/packages/core/src/repositories/spansRepository.ts
+++ b/packages/core/src/repositories/spansRepository.ts
@@ -324,7 +324,8 @@ export class SpansRepository extends Repository<Span> {
     spanId: string,
     traceId: string,
   ): Promise<boolean> {
-    const firstSpan = await this.findFirstMainSpanByDocumentLogUuid(documentLogUuid)
+    const firstSpan =
+      await this.findFirstMainSpanByDocumentLogUuid(documentLogUuid)
     return firstSpan?.id === spanId && firstSpan?.traceId === traceId
   }
 
@@ -585,6 +586,10 @@ export class SpanMetadatasRepository {
     this.disk = disk
   }
 
+  static buildKey(span: { traceId: string; id: string }) {
+    return `${span.traceId}:${span.id}`
+  }
+
   async get<T extends SpanType = SpanType>({
     spanId,
     traceId,
@@ -638,7 +643,7 @@ export class SpanMetadatasRepository {
       spanIdentifiers.map(async ({ traceId, spanId }) => {
         const result = await this.get<T>({ traceId, spanId })
         return {
-          key: `${traceId}:${spanId}`,
+          key: SpanMetadatasRepository.buildKey({ traceId, id: spanId }),
           metadata: result.ok ? result.value : undefined,
         }
       }),

--- a/packages/core/src/schema/models/types/Experiment.ts
+++ b/packages/core/src/schema/models/types/Experiment.ts
@@ -16,7 +16,7 @@ export type ExperimentDto = Experiment & {
   results: TrackedProgress
 }
 
-export type ExperimentLogsMetadata = {
+export type ExperimentRunMetadata = {
   totalCost: number
   totalTokens: number
   totalDuration: number
@@ -24,5 +24,5 @@ export type ExperimentLogsMetadata = {
 }
 export type ExperimentWithScores = ExperimentDto & {
   scores: ExperimentScores
-  logsMetadata: ExperimentLogsMetadata
+  runMetadata: ExperimentRunMetadata
 }

--- a/packages/core/src/services/documents/tools/resolve/agentsAsTools.ts
+++ b/packages/core/src/services/documents/tools/resolve/agentsAsTools.ts
@@ -84,7 +84,7 @@ export async function resolveAgentAsToolDefinition({
 
       try {
         // prettier-ignore
-        const { response, stream, error, runUsage } = await runDocumentAtCommit({
+        const { response, stream, error, runUsage, runCost } = await runDocumentAtCommit({
         context: $tool.context,
         workspace,
         commit,
@@ -111,7 +111,9 @@ export async function resolveAgentAsToolDefinition({
         })
 
         const usage = await runUsage
+        const cost = await runCost
         streamManager.incrementRunUsage(usage)
+        streamManager.incrementRunCost(cost)
 
         const res = await response
         if (!res) {

--- a/packages/core/src/services/evaluationsV2/llm/buildStreamEvaluationRun.test.ts
+++ b/packages/core/src/services/evaluationsV2/llm/buildStreamEvaluationRun.test.ts
@@ -107,6 +107,8 @@ Evaluate the response: {{ actualOutput }}`,
         duration: Promise.resolve(1000),
         logUsage: Promise.resolve(mockUsage),
         runUsage: Promise.resolve(mockUsage),
+        logCost: Promise.resolve(0),
+        runCost: Promise.resolve(0),
         stream: new ReadableStream<ChainEvent>({
           start(controller) {
             controller.close()

--- a/packages/core/src/services/runs/end.test.ts
+++ b/packages/core/src/services/runs/end.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ActiveRun } from '@latitude-data/constants'
+import { Result } from '../../lib/Result'
+import { NotFoundError } from '../../lib/errors'
+import { endRun, RunMetrics } from './end'
+import { publisher } from '../../events/publisher'
+import * as deleteModule from './active/byDocument/delete'
+
+vi.mock('../../events/publisher', () => ({
+  publisher: {
+    publishLater: vi.fn(),
+  },
+}))
+
+vi.spyOn(deleteModule, 'deleteActiveRunByDocument')
+
+describe('endRun', () => {
+  const mockActiveRun: ActiveRun = {
+    uuid: 'run-uuid-123',
+    queuedAt: new Date('2024-01-01T10:00:00Z'),
+    startedAt: new Date('2024-01-01T10:00:01Z'),
+    documentUuid: 'doc-uuid-456',
+    commitUuid: 'commit-uuid-789',
+  }
+
+  const baseParams = {
+    workspaceId: 1,
+    projectId: 2,
+    documentUuid: 'doc-uuid-456',
+    commitUuid: 'commit-uuid-789',
+    runUuid: 'run-uuid-123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(publisher.publishLater).mockResolvedValue(undefined)
+  })
+
+  describe('deleteActiveRunByDocument integration', () => {
+    it('calls deleteActiveRunByDocument with correct parameters', async () => {
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.ok(mockActiveRun),
+      )
+
+      await endRun(baseParams)
+
+      expect(deleteModule.deleteActiveRunByDocument).toHaveBeenCalledWith({
+        workspaceId: baseParams.workspaceId,
+        projectId: baseParams.projectId,
+        documentUuid: baseParams.documentUuid,
+        runUuid: baseParams.runUuid,
+      })
+    })
+
+    it('returns error if deleteActiveRunByDocument fails', async () => {
+      const error = new NotFoundError('Run not found')
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.error(error),
+      )
+
+      const result = await endRun(baseParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe(error)
+      expect(publisher.publishLater).not.toHaveBeenCalled()
+    })
+
+    it('returns the deleted run on success', async () => {
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.ok(mockActiveRun),
+      )
+
+      const result = await endRun(baseParams)
+
+      expect(result.ok).toBe(true)
+      expect(result.value).toBe(mockActiveRun)
+    })
+  })
+
+  describe('event publishing', () => {
+    beforeEach(() => {
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.ok(mockActiveRun),
+      )
+    })
+
+    it('publishes documentRunEnded event with correct base data', async () => {
+      await endRun(baseParams)
+
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: {
+          projectId: baseParams.projectId,
+          workspaceId: baseParams.workspaceId,
+          documentUuid: baseParams.documentUuid,
+          commitUuid: baseParams.commitUuid,
+          run: mockActiveRun,
+          eventContext: 'background',
+          metrics: undefined,
+          experimentId: undefined,
+        },
+      })
+    })
+
+    it('includes metrics in event when provided', async () => {
+      const metrics: RunMetrics = {
+        runUsage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          promptTokens: 100,
+          completionTokens: 50,
+          totalTokens: 150,
+          reasoningTokens: 10,
+          cachedInputTokens: 5,
+        },
+        runCost: 0.0025,
+        duration: 1500,
+      }
+
+      await endRun({ ...baseParams, metrics })
+
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: expect.objectContaining({
+          metrics,
+        }),
+      })
+    })
+
+    it('includes experimentId in event when provided', async () => {
+      const experimentId = 42
+
+      await endRun({ ...baseParams, experimentId })
+
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: expect.objectContaining({
+          experimentId,
+        }),
+      })
+    })
+
+    it('includes both metrics and experimentId when provided', async () => {
+      const metrics: RunMetrics = {
+        runUsage: {
+          inputTokens: 200,
+          outputTokens: 100,
+          promptTokens: 200,
+          completionTokens: 100,
+          totalTokens: 300,
+          reasoningTokens: 20,
+          cachedInputTokens: 10,
+        },
+        runCost: 0.005,
+        duration: 2000,
+      }
+      const experimentId = 99
+
+      await endRun({ ...baseParams, metrics, experimentId })
+
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: {
+          projectId: baseParams.projectId,
+          workspaceId: baseParams.workspaceId,
+          documentUuid: baseParams.documentUuid,
+          commitUuid: baseParams.commitUuid,
+          run: mockActiveRun,
+          eventContext: 'background',
+          metrics,
+          experimentId,
+        },
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles run with no startedAt', async () => {
+      const runWithoutStart: ActiveRun = {
+        uuid: 'run-uuid-no-start',
+        queuedAt: new Date('2024-01-01T10:00:00Z'),
+        startedAt: undefined,
+        documentUuid: 'doc-uuid-456',
+        commitUuid: 'commit-uuid-789',
+      }
+
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.ok(runWithoutStart),
+      )
+
+      const result = await endRun(baseParams)
+
+      expect(result.ok).toBe(true)
+      expect(result.value).toBe(runWithoutStart)
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: expect.objectContaining({
+          run: runWithoutStart,
+        }),
+      })
+    })
+
+    it('handles metrics with zero values', async () => {
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.ok(mockActiveRun),
+      )
+
+      const metrics: RunMetrics = {
+        runUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          reasoningTokens: 0,
+          cachedInputTokens: 0,
+        },
+        runCost: 0,
+        duration: 0,
+      }
+
+      await endRun({ ...baseParams, metrics })
+
+      expect(publisher.publishLater).toHaveBeenCalledWith({
+        type: 'documentRunEnded',
+        data: expect.objectContaining({
+          metrics,
+        }),
+      })
+    })
+
+    it('handles generic error from deleteActiveRunByDocument', async () => {
+      const error = new Error('Redis connection failed')
+      vi.mocked(deleteModule.deleteActiveRunByDocument).mockResolvedValue(
+        Result.error(error),
+      )
+
+      const result = await endRun(baseParams)
+
+      expect(result.ok).toBe(false)
+      expect(result.error).toBe(error)
+    })
+  })
+})

--- a/packages/core/src/services/runs/end.ts
+++ b/packages/core/src/services/runs/end.ts
@@ -1,6 +1,9 @@
 import { publisher } from '../../events/publisher'
+import { RunMetrics } from '../../jobs/job-definitions/runs/helpers/types'
 import { Result } from '../../lib/Result'
 import { deleteActiveRunByDocument } from './active/byDocument/delete'
+
+export type { RunMetrics }
 
 export async function endRun({
   workspaceId,
@@ -8,12 +11,16 @@ export async function endRun({
   documentUuid,
   commitUuid,
   runUuid,
+  metrics,
+  experimentId,
 }: {
   workspaceId: number
   projectId: number
   documentUuid: string
   commitUuid: string
   runUuid: string
+  metrics?: RunMetrics
+  experimentId?: number
 }) {
   const deleteResult = await deleteActiveRunByDocument({
     workspaceId,
@@ -21,6 +28,7 @@ export async function endRun({
     documentUuid,
     runUuid,
   })
+
   if (!Result.isOk(deleteResult)) return deleteResult
 
   const run = deleteResult.unwrap()
@@ -34,6 +42,8 @@ export async function endRun({
       commitUuid,
       run,
       eventContext: 'background',
+      metrics,
+      experimentId,
     },
   })
 

--- a/packages/core/src/websockets/constants.ts
+++ b/packages/core/src/websockets/constants.ts
@@ -160,6 +160,20 @@ export type LatteProjectChangesArgs = {
   changes: LatteChange[]
 }
 
+export type DocumentRunMetrics = {
+  runUsage: {
+    inputTokens: number
+    outputTokens: number
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+    reasoningTokens: number
+    cachedInputTokens: number
+  }
+  runCost: number
+  duration: number
+}
+
 type DocumentRunStatusArgs = {
   event: DocumentRunStatusEvent['type']
   workspaceId: number
@@ -167,6 +181,8 @@ type DocumentRunStatusArgs = {
   documentUuid: string
   commitUuid: string
   run: ActiveRun
+  metrics?: DocumentRunMetrics
+  experimentId?: number
 }
 
 type SpanCreatedArgs = {


### PR DESCRIPTION
# What?
When picking logs to run an experiment, we were using documentLogs. Now is using spans. 

Also, when generating experiments metadata, we also were using document logs

## TODO
- [x] QA it works
- [x] Add test fixes