### PR TITLE
fix(web): guard socket payload in documentTriggerEvents onMessage

### DIFF
--- a/apps/web/src/stores/documentTriggerEvents.ts
+++ b/apps/web/src/stores/documentTriggerEvents.ts
@@ -54,8 +54,15 @@ export default function useDocumentTriggerEvents(
 
   useSockets({
     event: 'triggerEventCreated',
-    onMessage: ({ triggerEvent }) => {
-      if (triggerEvent.triggerUuid !== triggerUuid) return
+    onMessage: (payload) => {
+      // Datadog: "Right side of assignment cannot be destructured"
+      // Socket payload can be undefined/null (or missing triggerEvent).
+      const triggerEvent = payload?.triggerEvent
+      if (!triggerEvent) return
+
+      // If this hook is scoped to a specific trigger, only accept events for it.
+      if (triggerUuid && triggerEvent.triggerUuid !== triggerUuid) return
+
       onRealtimeTriggerEventCreated?.(triggerEvent)
       mutate((prev) => [triggerEvent, ...(prev ?? [])], {
         revalidate: false,


### PR DESCRIPTION
Datadog: https://app.datadoghq.eu/error-tracking/unified?query=service%3A%2A&issueId=784db7c0-0344-11f1-afb1-da7ad0900005&from_ts=1770286600000&to_ts=1770373000000&live=false&monitor_id=90296800&monitor_sub_type=.new%28%29&link_source=monitor_notif

Error:
TypeError: Right side of assignment cannot be destructured

Stack/file:
apps/web/src/stores/documentTriggerEvents.ts (onMessage)

Change:
- Stop destructuring socket payload directly; guard when payload/triggerEvent is missing.
- Only filter by triggerUuid when the hook is scoped to one (allows updates when triggerUuid is undefined).

Validation:
- pnpm lint
- pnpm tc (after building @latitude-data/sdk and @latitude-data/telemetry dist artifacts)
