### PR TITLE
Add BullMQ queue monitoring and management to backoffice

### DIFF
--- a/apps/web/src/actions/admin/workers/drainQueue.ts
+++ b/apps/web/src/actions/admin/workers/drainQueue.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { z } from 'zod'
+
+import { withAdmin } from '../../procedures'
+import { drainQueue } from '@latitude-data/core/services/workers/manage'
+
+export const drainQueueAction = withAdmin
+  .inputSchema(
+    z.object({
+      queueName: z.string(),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const result = await drainQueue({
+      queueName: parsedInput.queueName,
+    })
+    return result.unwrap()
+  })

--- a/apps/web/src/actions/admin/workers/removeWorkspaceJobs.ts
+++ b/apps/web/src/actions/admin/workers/removeWorkspaceJobs.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { z } from 'zod'
+
+import { withAdmin } from '../../procedures'
+import { removeWorkspaceJobs } from '@latitude-data/core/services/workers/manage'
+
+export const removeWorkspaceJobsAction = withAdmin
+  .inputSchema(
+    z.object({
+      workspaceId: z.number(),
+      queueName: z.string().optional(),
+    }),
+  )
+  .action(async ({ parsedInput }) => {
+    const result = await removeWorkspaceJobs({
+      workspaceId: parsedInput.workspaceId,
+      queueName: parsedInput.queueName,
+    })
+    return result.unwrap()
+  })

--- a/apps/web/src/app/(admin)/backoffice/_components/BackofficeTabs/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/_components/BackofficeTabs/index.tsx
@@ -52,6 +52,11 @@ export function BackofficeTabs({ children }: { children: ReactNode }) {
               route: ROUTES.backoffice.triggers.root,
             },
             {
+              label: 'Workers',
+              value: BackofficeRoutes.workers,
+              route: ROUTES.backoffice.workers.root,
+            },
+            {
               label: 'Error tests',
               value: BackofficeRoutes.errorTests,
               route: ROUTES.backoffice.errorTests.root,

--- a/apps/web/src/app/(admin)/backoffice/search/workspace/[id]/_components/WorkspaceDashboard/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/search/workspace/[id]/_components/WorkspaceDashboard/index.tsx
@@ -25,6 +25,7 @@ import { BigAccountBanner } from '../BigAccountBanner'
 import { DeleteWorkspaceButton } from '../DeleteWorkspaceButton'
 import { IssueGrantModal } from '../IssueGrantModal'
 import { WeeklyEmailModal } from '../WeeklyEmailModal'
+import { WorkspaceWorkersUsage } from '../WorkspaceWorkersUsage'
 import { SubscriptionRow } from '$/components/Subscriptions/SubscriptionRow'
 import { useRecentSearches } from '$/app/(admin)/backoffice/search/_hooks/useRecentSearches'
 
@@ -600,7 +601,10 @@ export function WorkspaceDashboard({ workspace }: Props) {
           </div>
         </Card>
 
-        {/* Section 5: Admin Tools */}
+        {/* Section 5: Workers Usage */}
+        <WorkspaceWorkersUsage workspaceId={workspace.id} />
+
+        {/* Section 6: Admin Tools */}
         <Card className='p-6'>
           <div className='flex flex-col gap-4'>
             <button

--- a/apps/web/src/app/(admin)/backoffice/search/workspace/[id]/_components/WorkspaceWorkersUsage/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/search/workspace/[id]/_components/WorkspaceWorkersUsage/index.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Badge } from '@latitude-data/web-ui/atoms/Badge'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Card } from '@latitude-data/web-ui/atoms/Card'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { ConfirmModal } from '@latitude-data/web-ui/atoms/Modal'
+import { TableCell, TableRow } from '@latitude-data/web-ui/atoms/Table'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import {
+  useWorkspaceWorkerUsage,
+  useWorkerActions,
+} from '$/stores/admin/workers'
+import { DataTable } from '$/app/(admin)/backoffice/search/_components/DataTable'
+
+export function WorkspaceWorkersUsage({
+  workspaceId,
+}: {
+  workspaceId: number
+}) {
+  const { data: usage, mutate } = useWorkspaceWorkerUsage(workspaceId)
+  const { removeWorkspaceJobs, isRemovingWorkspaceJobs } = useWorkerActions()
+  const [confirmKillAll, setConfirmKillAll] = useState(false)
+  const [confirmKillQueue, setConfirmKillQueue] = useState<string | null>(null)
+
+  const totalJobs = usage.reduce((sum, q) => sum + q.total, 0)
+
+  const handleKillAll = async () => {
+    await removeWorkspaceJobs({ workspaceId })
+    setConfirmKillAll(false)
+    mutate()
+  }
+
+  const handleKillQueue = async () => {
+    if (!confirmKillQueue) return
+    await removeWorkspaceJobs({ workspaceId, queueName: confirmKillQueue })
+    setConfirmKillQueue(null)
+    mutate()
+  }
+
+  return (
+    <Card className='p-6'>
+      <div className='flex flex-col gap-6'>
+        <div className='flex flex-row items-center justify-between'>
+          <div className='flex flex-row items-center gap-3'>
+            <div className='p-2 bg-accent rounded-lg'>
+              <Icon name='cpu' size='normal' color='primary' />
+            </div>
+            <div>
+              <Text.H3>Workers Usage</Text.H3>
+              <Text.H6 color='foregroundMuted'>
+                Active and queued jobs for this workspace
+              </Text.H6>
+            </div>
+          </div>
+          <div className='flex flex-row items-center gap-2'>
+            <Button
+              variant='outline'
+              size='small'
+              onClick={() => mutate()}
+              iconProps={{ name: 'refresh' }}
+            >
+              Refresh
+            </Button>
+            {totalJobs > 0 && (
+              <Button
+                variant='destructive'
+                size='small'
+                onClick={() => setConfirmKillAll(true)}
+              >
+                Kill All Jobs ({totalJobs})
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {totalJobs === 0 ? (
+          <div className='py-6 text-center'>
+            <Text.H5 color='foregroundMuted'>
+              No active or queued jobs for this workspace
+            </Text.H5>
+          </div>
+        ) : (
+          <DataTable
+            title=''
+            count={usage.length}
+            columns={[
+              { header: 'Queue' },
+              { header: 'Total' },
+              { header: 'Job Types' },
+              { header: 'Actions' },
+            ]}
+            emptyMessage='No active jobs'
+            noCard
+          >
+            {usage.map((q) => (
+              <TableRow key={q.queueName}>
+                <TableCell className='p-2'>
+                  <div className='flex flex-row items-center gap-2'>
+                    <div className='w-2 h-2 rounded-full bg-green-500 animate-pulse' />
+                    <Text.H5>{q.displayName}</Text.H5>
+                    <Text.H6 color='foregroundMuted' monospace>
+                      ({q.queueName})
+                    </Text.H6>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Badge variant='accent' size='small'>
+                    {q.total}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <div className='flex flex-row flex-wrap gap-1'>
+                    {Object.entries(q.jobCounts)
+                      .sort(([, a], [, b]) => b - a)
+                      .map(([jobName, count]) => (
+                        <Badge key={jobName} variant='muted' size='small'>
+                          {jobName}: {count}
+                        </Badge>
+                      ))}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant='destructive'
+                    size='small'
+                    onClick={() => setConfirmKillQueue(q.queueName)}
+                  >
+                    Kill
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </DataTable>
+        )}
+      </div>
+
+      {confirmKillAll && (
+        <ConfirmModal
+          dismissible
+          open={confirmKillAll}
+          title={`Kill all jobs for Workspace #${workspaceId}`}
+          type='destructive'
+          onOpenChange={setConfirmKillAll}
+          onConfirm={handleKillAll}
+          onCancel={() => setConfirmKillAll(false)}
+          confirm={{
+            label: isRemovingWorkspaceJobs ? 'Removing...' : 'Kill All Jobs',
+            description: `This will remove all waiting and delayed jobs for this workspace across all queues. Active jobs cannot be removed.`,
+            disabled: isRemovingWorkspaceJobs,
+            isConfirming: isRemovingWorkspaceJobs,
+          }}
+        />
+      )}
+
+      {confirmKillQueue && (
+        <ConfirmModal
+          dismissible
+          open={!!confirmKillQueue}
+          title={`Kill jobs from ${confirmKillQueue}`}
+          type='destructive'
+          onOpenChange={(open) => {
+            if (!open) setConfirmKillQueue(null)
+          }}
+          onConfirm={handleKillQueue}
+          onCancel={() => setConfirmKillQueue(null)}
+          confirm={{
+            label: isRemovingWorkspaceJobs ? 'Removing...' : 'Kill Queue Jobs',
+            description: `This will remove all waiting and delayed jobs for this workspace from the ${confirmKillQueue} queue.`,
+            disabled: isRemovingWorkspaceJobs,
+            isConfirming: isRemovingWorkspaceJobs,
+          }}
+        />
+      )}
+    </Card>
+  )
+}

--- a/apps/web/src/app/(admin)/backoffice/workers/_components/QueueDetailPanel.tsx
+++ b/apps/web/src/app/(admin)/backoffice/workers/_components/QueueDetailPanel.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Badge } from '@latitude-data/web-ui/atoms/Badge'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Card } from '@latitude-data/web-ui/atoms/Card'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { ConfirmModal } from '@latitude-data/web-ui/atoms/Modal'
+import { TableCell, TableRow } from '@latitude-data/web-ui/atoms/Table'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { useQueueDetail, useWorkerActions } from '$/stores/admin/workers'
+import { DataTable } from '$/app/(admin)/backoffice/search/_components/DataTable'
+import { ROUTES, BackofficeRoutes } from '$/services/routes'
+import Link from 'next/link'
+
+type ConfirmState =
+  | { type: 'drain' }
+  | { type: 'workspace'; workspaceId: number }
+
+export function QueueDetailPanel({
+  queueName,
+  onClose,
+  onMutateStats,
+}: {
+  queueName: string
+  onClose: () => void
+  onMutateStats: () => void
+}) {
+  const { data, mutate } = useQueueDetail(queueName)
+  const {
+    drainQueue,
+    isDrainingQueue,
+    removeWorkspaceJobs,
+    isRemovingWorkspaceJobs,
+  } = useWorkerActions()
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null)
+
+  if (!data) {
+    return (
+      <Card className='p-6'>
+        <div className='flex items-center gap-2'>
+          <Icon name='loader' className='animate-spin' />
+          <Text.H5 color='foregroundMuted'>Loading queue details...</Text.H5>
+        </div>
+      </Card>
+    )
+  }
+
+  const isProcessing = isDrainingQueue || isRemovingWorkspaceJobs
+
+  const handleConfirm = async () => {
+    if (!confirm) return
+
+    if (confirm.type === 'drain') {
+      await drainQueue({ queueName })
+    } else {
+      await removeWorkspaceJobs({
+        workspaceId: confirm.workspaceId,
+        queueName,
+      })
+    }
+
+    setConfirm(null)
+    mutate()
+    onMutateStats()
+  }
+
+  const allWorkspaces = new Map<number, number>()
+  for (const job of data.jobBreakdown) {
+    for (const [wsId, count] of Object.entries(job.workspaces)) {
+      const id = Number(wsId)
+      allWorkspaces.set(id, (allWorkspaces.get(id) ?? 0) + count)
+    }
+  }
+  const sortedWorkspaces = Array.from(allWorkspaces.entries()).sort(
+    (a, b) => b[1] - a[1],
+  )
+
+  const hasBacklog = data.stats.waiting > 0 || data.stats.delayed > 0
+
+  return (
+    <Card className='p-6'>
+      <div className='flex flex-col gap-6'>
+        <div className='flex flex-row items-center justify-between'>
+          <div className='flex flex-row items-center gap-3'>
+            <div className='p-2 bg-accent rounded-lg'>
+              <Icon name='cpu' size='normal' color='primary' />
+            </div>
+            <div>
+              <Text.H3>{data.stats.displayName}</Text.H3>
+              <Text.H6 color='foregroundMuted' monospace>
+                {data.stats.name}
+              </Text.H6>
+            </div>
+          </div>
+          <div className='flex flex-row items-center gap-2'>
+            {hasBacklog && (
+              <Button
+                variant='destructive'
+                size='small'
+                onClick={() => setConfirm({ type: 'drain' })}
+              >
+                Drain Entire Queue
+              </Button>
+            )}
+            <Button variant='ghost' size='small' onClick={onClose}>
+              <Icon name='close' />
+            </Button>
+          </div>
+        </div>
+
+        <div className='grid grid-cols-3 gap-3'>
+          <MiniStat label='Active' value={data.stats.active} variant='accent' />
+          <MiniStat
+            label='Waiting'
+            value={data.stats.waiting}
+            variant='default'
+          />
+          <MiniStat
+            label='Delayed'
+            value={data.stats.delayed}
+            variant='warningMuted'
+          />
+        </div>
+
+        <DataTable
+          title={`Job Breakdown (${data.jobBreakdown.length} types)`}
+          count={data.jobBreakdown.length}
+          columns={[
+            { header: 'Job Name' },
+            { header: 'Count' },
+            { header: 'Workspaces' },
+          ]}
+          emptyMessage='No jobs in this queue'
+          noCard
+        >
+          {data.jobBreakdown.map((job) => (
+            <TableRow key={job.jobName}>
+              <TableCell className='p-2'>
+                <Text.H5 monospace>{job.jobName}</Text.H5>
+              </TableCell>
+              <TableCell>
+                <Badge variant='default' size='small'>
+                  {job.count}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <div className='flex flex-row flex-wrap gap-1'>
+                  {Object.entries(job.workspaces)
+                    .sort(([, a], [, b]) => b - a)
+                    .slice(0, 5)
+                    .map(([wsId, count]) => (
+                      <Link
+                        key={wsId}
+                        href={ROUTES.backoffice[
+                          BackofficeRoutes.search
+                        ].workspace(Number(wsId))}
+                      >
+                        <Badge variant='muted' size='small'>
+                          WS#{wsId}: {count}
+                        </Badge>
+                      </Link>
+                    ))}
+                  {Object.keys(job.workspaces).length > 5 && (
+                    <Badge variant='muted' size='small'>
+                      +{Object.keys(job.workspaces).length - 5} more
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </DataTable>
+
+        {sortedWorkspaces.length > 0 && (
+          <DataTable
+            title={`Workspace Usage (${sortedWorkspaces.length} workspaces)`}
+            count={sortedWorkspaces.length}
+            columns={[
+              { header: 'Workspace' },
+              { header: 'Jobs' },
+              { header: 'Actions' },
+            ]}
+            emptyMessage='No workspace data'
+            noCard
+          >
+            {sortedWorkspaces.map(([wsId, count]) => (
+              <TableRow key={wsId}>
+                <TableCell className='p-2'>
+                  <Link
+                    href={ROUTES.backoffice[BackofficeRoutes.search].workspace(
+                      wsId,
+                    )}
+                  >
+                    <Text.H5 color='primary'>Workspace #{wsId}</Text.H5>
+                  </Link>
+                </TableCell>
+                <TableCell>
+                  <Badge variant='default' size='small'>
+                    {count}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant='destructive'
+                    size='small'
+                    onClick={() =>
+                      setConfirm({ type: 'workspace', workspaceId: wsId })
+                    }
+                  >
+                    Kill Jobs
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </DataTable>
+        )}
+      </div>
+
+      {confirm && (
+        <ConfirmModal
+          dismissible
+          open={!!confirm}
+          title={
+            confirm.type === 'drain'
+              ? `Drain entire queue: ${data.stats.displayName}`
+              : `Kill jobs for Workspace #${confirm.workspaceId}`
+          }
+          type='destructive'
+          onOpenChange={(open) => {
+            if (!open) setConfirm(null)
+          }}
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirm(null)}
+          confirm={{
+            label: isProcessing
+              ? 'Processing...'
+              : confirm.type === 'drain'
+                ? 'Drain Entire Queue'
+                : 'Kill Workspace Jobs',
+            description:
+              confirm.type === 'drain'
+                ? `This will remove all ${data.stats.waiting + data.stats.delayed} waiting and delayed jobs from the ${data.stats.displayName} queue. Jobs already being processed by workers will not be affected. This cannot be undone.`
+                : `This will remove all waiting and delayed jobs for workspace #${confirm.workspaceId} from the ${data.stats.displayName} queue. Jobs already being processed cannot be removed. This cannot be undone.`,
+            disabled: isProcessing,
+            isConfirming: isProcessing,
+          }}
+        />
+      )}
+    </Card>
+  )
+}
+
+const MINI_STAT_STYLES = {
+  accent: 'border-l-4 border-l-primary',
+  default: 'border-l-4 border-l-foreground/30',
+  warningMuted: 'border-l-4 border-l-yellow-500',
+} as const
+
+function MiniStat({
+  label,
+  value,
+  variant,
+}: {
+  label: string
+  value: number
+  variant: 'accent' | 'default' | 'warningMuted'
+}) {
+  return (
+    <div className={`flex flex-col gap-1 p-3 bg-muted/30 rounded-lg ${MINI_STAT_STYLES[variant]}`}>
+      <Text.H6 color='foregroundMuted'>{label}</Text.H6>
+      <Text.H4>{value.toLocaleString()}</Text.H4>
+    </div>
+  )
+}

--- a/apps/web/src/app/(admin)/backoffice/workers/_components/WorkersOverview.tsx
+++ b/apps/web/src/app/(admin)/backoffice/workers/_components/WorkersOverview.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Badge } from '@latitude-data/web-ui/atoms/Badge'
+import { Button } from '@latitude-data/web-ui/atoms/Button'
+import { Card } from '@latitude-data/web-ui/atoms/Card'
+import { Icon } from '@latitude-data/web-ui/atoms/Icons'
+import { ConfirmModal } from '@latitude-data/web-ui/atoms/Modal'
+import { TableCell, TableRow } from '@latitude-data/web-ui/atoms/Table'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { useQueueStats, useWorkerActions } from '$/stores/admin/workers'
+import { DataTable } from '$/app/(admin)/backoffice/search/_components/DataTable'
+import type { QueueStats } from '@latitude-data/core/services/workers/inspect'
+
+import { QueueDetailPanel } from './QueueDetailPanel'
+
+export function WorkersOverview() {
+  const { data: stats, mutate } = useQueueStats()
+  const { drainQueue, isDrainingQueue } = useWorkerActions()
+  const [selectedQueue, setSelectedQueue] = useState<string | null>(null)
+  const [drainTarget, setDrainTarget] = useState<string | null>(null)
+
+  const totalActive = stats.reduce((sum, q) => sum + q.active, 0)
+  const totalWaiting = stats.reduce((sum, q) => sum + q.waiting, 0)
+  const totalDelayed = stats.reduce((sum, q) => sum + q.delayed, 0)
+
+  const handleDrainConfirm = async () => {
+    if (!drainTarget) return
+    await drainQueue({ queueName: drainTarget })
+    setDrainTarget(null)
+    mutate()
+  }
+
+  return (
+    <div className='container mx-auto p-6 max-w-7xl'>
+      <div className='flex flex-col gap-8'>
+        <div className='flex flex-col gap-2'>
+          <div className='flex flex-row items-center justify-between'>
+            <div className='flex flex-row items-center gap-3'>
+              <div className='p-2 bg-accent rounded-lg'>
+                <Icon name='cpu' size='normal' color='primary' />
+              </div>
+              <div>
+                <Text.H1>Workers</Text.H1>
+                <Text.H4 color='foregroundMuted'>
+                  Live queue status and management
+                </Text.H4>
+              </div>
+            </div>
+            <Button
+              variant='outline'
+              size='small'
+              onClick={() => mutate()}
+              iconProps={{ name: 'refresh' }}
+            >
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        <div className='grid grid-cols-3 gap-4'>
+          <StatCard label='Active' value={totalActive} variant='accent' />
+          <StatCard label='Waiting' value={totalWaiting} variant='default' />
+          <StatCard
+            label='Delayed'
+            value={totalDelayed}
+            variant='warningMuted'
+          />
+        </div>
+
+        <DataTable
+          title='Queues'
+          count={stats.length}
+          columns={[
+            { header: 'Queue' },
+            { header: 'Active' },
+            { header: 'Waiting' },
+            { header: 'Delayed' },
+            { header: 'Actions' },
+          ]}
+          emptyMessage='No queues found'
+          icon='cpu'
+        >
+          {stats.map((queue) => (
+            <QueueRow
+              key={queue.name}
+              queue={queue}
+              isSelected={selectedQueue === queue.name}
+              onSelect={() =>
+                setSelectedQueue(
+                  selectedQueue === queue.name ? null : queue.name,
+                )
+              }
+              onDrain={() => setDrainTarget(queue.name)}
+            />
+          ))}
+        </DataTable>
+
+        {selectedQueue && (
+          <QueueDetailPanel
+            queueName={selectedQueue}
+            onClose={() => setSelectedQueue(null)}
+            onMutateStats={mutate}
+          />
+        )}
+
+        {drainTarget && (
+          <ConfirmModal
+            dismissible
+            open={!!drainTarget}
+            title={`Drain queue: ${drainTarget}`}
+            type='destructive'
+            onOpenChange={(open) => {
+              if (!open) setDrainTarget(null)
+            }}
+            onConfirm={handleDrainConfirm}
+            onCancel={() => setDrainTarget(null)}
+            confirm={{
+              label: isDrainingQueue ? 'Draining...' : 'Drain Queue',
+              description:
+                'This will remove all waiting and delayed jobs from this queue. Jobs already being processed will not be affected. Use this when a queue is overwhelmed and needs to be cleared.',
+              disabled: isDrainingQueue,
+              isConfirming: isDrainingQueue,
+            }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+const STAT_VARIANT_STYLES = {
+  accent: 'border-l-4 border-l-primary',
+  default: 'border-l-4 border-l-foreground/30',
+  warningMuted: 'border-l-4 border-l-yellow-500',
+} as const
+
+function StatCard({
+  label,
+  value,
+  variant,
+}: {
+  label: string
+  value: number
+  variant: 'accent' | 'default' | 'warningMuted'
+}) {
+  return (
+    <Card className={`p-4 ${STAT_VARIANT_STYLES[variant]}`}>
+      <div className='flex flex-col gap-1'>
+        <Text.H6 color='foregroundMuted'>{label}</Text.H6>
+        <Text.H2>{value.toLocaleString()}</Text.H2>
+      </div>
+    </Card>
+  )
+}
+
+function QueueRow({
+  queue,
+  isSelected,
+  onSelect,
+  onDrain,
+}: {
+  queue: QueueStats
+  isSelected: boolean
+  onSelect: () => void
+  onDrain: () => void
+}) {
+  const hasActivity = queue.active > 0 || queue.waiting > 0 || queue.delayed > 0
+  const hasBacklog = queue.waiting > 0 || queue.delayed > 0
+
+  return (
+    <TableRow
+      className={`cursor-pointer transition-colors ${isSelected ? 'bg-accent/50' : ''}`}
+      onClick={onSelect}
+    >
+      <TableCell className='p-2'>
+        <div className='flex flex-row items-center gap-2'>
+          {hasActivity && (
+            <div className='w-2 h-2 rounded-full bg-green-500 animate-pulse' />
+          )}
+          <Text.H5>{queue.displayName}</Text.H5>
+          <Text.H6 color='foregroundMuted' monospace>
+            ({queue.name})
+          </Text.H6>
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant={queue.active > 0 ? 'accent' : 'muted'} size='small'>
+          {queue.active}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant={queue.waiting > 0 ? 'default' : 'muted'} size='small'>
+          {queue.waiting}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Badge
+          variant={queue.delayed > 0 ? 'warningMuted' : 'muted'}
+          size='small'
+        >
+          {queue.delayed}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <div
+          className='flex flex-row items-center gap-1'
+          onClick={(e) => e.stopPropagation()}
+        >
+          {hasBacklog && (
+            <Button variant='outline' size='small' onClick={onDrain}>
+              Drain
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}

--- a/apps/web/src/app/(admin)/backoffice/workers/page.tsx
+++ b/apps/web/src/app/(admin)/backoffice/workers/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { WorkersOverview } from './_components/WorkersOverview'
+
+export default function WorkersPage() {
+  return <WorkersOverview />
+}

--- a/apps/web/src/app/api/admin/workers/[queueName]/route.ts
+++ b/apps/web/src/app/api/admin/workers/[queueName]/route.ts
@@ -1,0 +1,17 @@
+import { getQueueDetail } from '@latitude-data/core/services/workers/inspect'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { adminHandler } from '$/middlewares/adminHandler'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const GET = errorHandler(
+  adminHandler(
+    async (
+      _: NextRequest,
+      { params }: { params: { queueName: string } },
+    ) => {
+      const result = await getQueueDetail({ queueName: params.queueName })
+      const detail = result.unwrap()
+      return NextResponse.json(detail, { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/app/api/admin/workers/route.ts
+++ b/apps/web/src/app/api/admin/workers/route.ts
@@ -1,0 +1,12 @@
+import { getAllQueueStats } from '@latitude-data/core/services/workers/inspect'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { adminHandler } from '$/middlewares/adminHandler'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const GET = errorHandler(
+  adminHandler(async (_: NextRequest) => {
+    const result = await getAllQueueStats()
+    const stats = result.unwrap()
+    return NextResponse.json(stats, { status: 200 })
+  }),
+)

--- a/apps/web/src/app/api/admin/workers/workspace/[workspaceId]/route.ts
+++ b/apps/web/src/app/api/admin/workers/workspace/[workspaceId]/route.ts
@@ -1,0 +1,48 @@
+import { getWorkspaceQueueUsage } from '@latitude-data/core/services/workers/inspect'
+import { removeWorkspaceJobs } from '@latitude-data/core/services/workers/manage'
+import { errorHandler } from '$/middlewares/errorHandler'
+import { adminHandler } from '$/middlewares/adminHandler'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const GET = errorHandler(
+  adminHandler(
+    async (
+      _: NextRequest,
+      { params }: { params: { workspaceId: string } },
+    ) => {
+      const workspaceId = parseInt(params.workspaceId)
+      if (isNaN(workspaceId)) {
+        return NextResponse.json(
+          { message: 'Invalid workspaceId' },
+          { status: 400 },
+        )
+      }
+
+      const result = await getWorkspaceQueueUsage({ workspaceId })
+      return NextResponse.json(result.unwrap(), { status: 200 })
+    },
+  ),
+)
+
+export const DELETE = errorHandler(
+  adminHandler(
+    async (
+      req: NextRequest,
+      { params }: { params: { workspaceId: string } },
+    ) => {
+      const workspaceId = parseInt(params.workspaceId)
+      if (isNaN(workspaceId)) {
+        return NextResponse.json(
+          { message: 'Invalid workspaceId' },
+          { status: 400 },
+        )
+      }
+
+      const body = await req.json().catch(() => ({}))
+      const { queueName } = body as { queueName?: string }
+
+      const result = await removeWorkspaceJobs({ workspaceId, queueName })
+      return NextResponse.json(result.unwrap(), { status: 200 })
+    },
+  ),
+)

--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -26,6 +26,7 @@ export enum BackofficeRoutes {
   billing = 'billing',
   integrations = 'integrations',
   triggers = 'triggers',
+  workers = 'workers',
   errorTests = 'errorTests',
 }
 
@@ -73,6 +74,9 @@ export const ROUTES = {
     },
     [BackofficeRoutes.triggers]: {
       root: `${BACKOFFICE_ROOT}/triggers`,
+    },
+    [BackofficeRoutes.workers]: {
+      root: `${BACKOFFICE_ROOT}/workers`,
     },
     [BackofficeRoutes.errorTests]: {
       root: `${BACKOFFICE_ROOT}/error-tests`,

--- a/apps/web/src/services/routes/api.ts
+++ b/apps/web/src/services/routes/api.ts
@@ -346,6 +346,15 @@ export const API_ROUTES = {
         root: '/api/admin/rewards/pending',
       },
     },
+    workers: {
+      root: '/api/admin/workers',
+      detail: (queueName: string) => ({
+        root: `/api/admin/workers/${queueName}`,
+      }),
+      workspace: (workspaceId: number) => ({
+        root: `/api/admin/workers/workspace/${workspaceId}`,
+      }),
+    },
   },
   conversations: {
     root: '/api/conversations',

--- a/apps/web/src/stores/admin/workers.ts
+++ b/apps/web/src/stores/admin/workers.ts
@@ -1,0 +1,131 @@
+'use client'
+
+import useFetcher from '$/hooks/useFetcher'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { ROUTES } from '$/services/routes'
+import { useCallback, useMemo } from 'react'
+import useSWR, { SWRConfiguration } from 'swr'
+import { useToast } from '@latitude-data/web-ui/atoms/Toast'
+import { drainQueueAction } from '$/actions/admin/workers/drainQueue'
+import { removeWorkspaceJobsAction } from '$/actions/admin/workers/removeWorkspaceJobs'
+import type {
+  QueueStats,
+  QueueDetail,
+  WorkspaceQueueUsage,
+} from '@latitude-data/core/services/workers/inspect'
+
+export function useQueueStats(opts?: SWRConfiguration) {
+  const route = ROUTES.api.admin.workers.root
+  const fetcher = useFetcher<QueueStats[]>(route)
+
+  const { data = [], mutate, ...rest } = useSWR<QueueStats[]>(route, fetcher, {
+    refreshInterval: 5000,
+    ...opts,
+  })
+
+  return useMemo(
+    () => ({ data, mutate, ...rest }),
+    [data, mutate, rest],
+  )
+}
+
+export function useQueueDetail(
+  queueName: string | null,
+  opts?: SWRConfiguration,
+) {
+  const route = queueName
+    ? ROUTES.api.admin.workers.detail(queueName).root
+    : null
+  const fetcher = useFetcher<QueueDetail>(route ?? undefined)
+
+  const { data, mutate, ...rest } = useSWR<QueueDetail>(
+    route,
+    fetcher,
+    {
+      refreshInterval: 5000,
+      ...opts,
+    },
+  )
+
+  return useMemo(
+    () => ({ data, mutate, ...rest }),
+    [data, mutate, rest],
+  )
+}
+
+export function useWorkspaceWorkerUsage(
+  workspaceId: number,
+  opts?: SWRConfiguration,
+) {
+  const route = ROUTES.api.admin.workers.workspace(workspaceId).root
+  const fetcher = useFetcher<WorkspaceQueueUsage[]>(route)
+
+  const { data = [], mutate, ...rest } = useSWR<WorkspaceQueueUsage[]>(
+    route,
+    fetcher,
+    {
+      refreshInterval: 10000,
+      ...opts,
+    },
+  )
+
+  return useMemo(
+    () => ({ data, mutate, ...rest }),
+    [data, mutate, rest],
+  )
+}
+
+export function useWorkerActions() {
+  const { toast } = useToast()
+
+  const { execute: executeDrainQueue, isPending: isDrainingQueue } =
+    useLatitudeAction(drainQueueAction, {
+      onSuccess: async () => {
+        toast({
+          title: 'Queue drained',
+          description: 'All waiting jobs removed',
+        })
+      },
+    })
+
+  const {
+    execute: executeRemoveWorkspaceJobs,
+    isPending: isRemovingWorkspaceJobs,
+  } = useLatitudeAction(removeWorkspaceJobsAction, {
+    onSuccess: async ({ data: result }) => {
+      toast({
+        title: 'Workspace jobs removed',
+        description: `Removed ${result.removed} jobs`,
+      })
+    },
+  })
+
+  const drainQueue = useCallback(
+    async (params: { queueName: string }) => {
+      return executeDrainQueue(params)
+    },
+    [executeDrainQueue],
+  )
+
+  const removeWorkspaceJobs = useCallback(
+    async (params: { workspaceId: number; queueName?: string }) => {
+      return executeRemoveWorkspaceJobs(params)
+    },
+    [executeRemoveWorkspaceJobs],
+  )
+
+  return useMemo(
+    () => ({
+      drainQueue,
+      isDrainingQueue,
+      removeWorkspaceJobs,
+      isRemovingWorkspaceJobs,
+    }),
+    [
+      drainQueue,
+      isDrainingQueue,
+      removeWorkspaceJobs,
+      isRemovingWorkspaceJobs,
+    ],
+  )
+}

--- a/packages/core/src/services/workers/inspect.ts
+++ b/packages/core/src/services/workers/inspect.ts
@@ -1,0 +1,252 @@
+import { Queue, Job } from 'bullmq'
+
+import { queues } from '../../jobs/queues'
+import { Queues } from '../../jobs/queues/types'
+import { Result } from '../../lib/Result'
+
+export type QueueStats = {
+  name: string
+  displayName: string
+  active: number
+  waiting: number
+  delayed: number
+  completed: number
+  failed: number
+  paused: number
+  prioritized: number
+}
+
+export type QueueJobSummary = {
+  jobName: string
+  count: number
+  workspaces: Record<number, number>
+}
+
+export type QueueDetail = {
+  stats: QueueStats
+  jobBreakdown: QueueJobSummary[]
+}
+
+export type JobInfo = {
+  id: string
+  name: string
+  state: string
+  data: Record<string, unknown>
+  workspaceId: number | null
+  progress: unknown
+  attemptsMade: number
+  failedReason?: string
+  processedOn?: number
+  finishedOn?: number
+  timestamp: number
+  delay: number
+}
+
+export type WorkspaceQueueUsage = {
+  queueName: string
+  displayName: string
+  jobCounts: Record<string, number>
+  total: number
+}
+
+const QUEUE_DISPLAY_NAMES: Record<string, string> = {
+  [Queues.defaultQueue]: 'Default',
+  [Queues.evaluationsQueue]: 'Evaluations',
+  [Queues.eventHandlersQueue]: 'Event Handlers',
+  [Queues.eventsQueue]: 'Events',
+  [Queues.maintenanceQueue]: 'Maintenance',
+  [Queues.notificationsQueue]: 'Notifications',
+  [Queues.webhooksQueue]: 'Webhooks',
+  [Queues.documentsQueue]: 'Documents',
+  [Queues.tracingQueue]: 'Tracing',
+  [Queues.latteQueue]: 'Latte (Copilot)',
+  [Queues.runsQueue]: 'Runs',
+  [Queues.issuesQueue]: 'Issues',
+  [Queues.generateEvaluationsQueue]: 'Generate Evaluations',
+  [Queues.optimizationsQueue]: 'Optimizations',
+}
+
+export async function getAllQueueStats() {
+  const qs = await queues()
+  const queueEntries = Object.entries(qs) as [string, Queue][]
+
+  const stats: QueueStats[] = await Promise.all(
+    queueEntries.map(async ([_, queue]) => {
+      const counts = await queue.getJobCounts()
+      return {
+        name: queue.name,
+        displayName: QUEUE_DISPLAY_NAMES[queue.name] ?? queue.name,
+        active: counts.active ?? 0,
+        waiting: counts.waiting ?? 0,
+        delayed: counts.delayed ?? 0,
+        completed: counts.completed ?? 0,
+        failed: counts.failed ?? 0,
+        paused: counts.paused ?? 0,
+        prioritized: counts.prioritized ?? 0,
+      }
+    }),
+  )
+
+  return Result.ok(stats)
+}
+
+export async function getQueueDetail({
+  queueName,
+  states = ['active', 'waiting', 'delayed', 'failed'],
+}: {
+  queueName: string
+  states?: ('active' | 'waiting' | 'delayed' | 'completed' | 'failed')[]
+}) {
+  const queue = await findQueue(queueName)
+  if (!queue) return Result.ok(null)
+
+  const counts = await queue.getJobCounts()
+  const stats: QueueStats = {
+    name: queue.name,
+    displayName: QUEUE_DISPLAY_NAMES[queue.name] ?? queue.name,
+    active: counts.active ?? 0,
+    waiting: counts.waiting ?? 0,
+    delayed: counts.delayed ?? 0,
+    completed: counts.completed ?? 0,
+    failed: counts.failed ?? 0,
+    paused: counts.paused ?? 0,
+    prioritized: counts.prioritized ?? 0,
+  }
+
+  const jobs = await queue.getJobs(states, 0, 500)
+  const jobBreakdown = buildJobBreakdown(jobs, queueName)
+
+  return Result.ok({ stats, jobBreakdown } satisfies QueueDetail)
+}
+
+export async function getQueueJobs({
+  queueName,
+  state = 'active',
+  start = 0,
+  end = 50,
+}: {
+  queueName: string
+  state?: 'active' | 'waiting' | 'delayed' | 'completed' | 'failed'
+  start?: number
+  end?: number
+}) {
+  const queue = await findQueue(queueName)
+  if (!queue) return Result.ok([])
+
+  const jobs = await queue.getJobs([state], start, end)
+
+  const jobInfos: JobInfo[] = await Promise.all(
+    jobs.map(async (job) => {
+      const jobState = await job.getState()
+      return {
+        id: job.id!,
+        name: job.name,
+        state: jobState,
+        data: job.data as Record<string, unknown>,
+        workspaceId: extractWorkspaceId(job, queueName),
+        progress: job.progress,
+        attemptsMade: job.attemptsMade,
+        failedReason: job.failedReason,
+        processedOn: job.processedOn,
+        finishedOn: job.finishedOn,
+        timestamp: job.timestamp,
+        delay: job.delay,
+      }
+    }),
+  )
+
+  return Result.ok(jobInfos)
+}
+
+export async function getWorkspaceQueueUsage({
+  workspaceId,
+}: {
+  workspaceId: number
+}) {
+  const qs = await queues()
+  const queueEntries = Object.entries(qs) as [string, Queue][]
+
+  const usage: WorkspaceQueueUsage[] = []
+
+  await Promise.all(
+    queueEntries.map(async ([_, queue]) => {
+      const jobs = await queue.getJobs(
+        ['active', 'waiting', 'delayed'],
+        0,
+        1000,
+      )
+
+      const jobCounts: Record<string, number> = {}
+      let total = 0
+
+      for (const job of jobs) {
+        const jobWorkspaceId = extractWorkspaceId(job, queue.name)
+        if (jobWorkspaceId === workspaceId) {
+          jobCounts[job.name] = (jobCounts[job.name] ?? 0) + 1
+          total++
+        }
+      }
+
+      if (total > 0) {
+        usage.push({
+          queueName: queue.name,
+          displayName: QUEUE_DISPLAY_NAMES[queue.name] ?? queue.name,
+          jobCounts,
+          total,
+        })
+      }
+    }),
+  )
+
+  return Result.ok(usage)
+}
+
+function extractWorkspaceId(job: Job, queueName: string): number | null {
+  const data = job.data as Record<string, unknown>
+
+  if (queueName === Queues.eventHandlersQueue || queueName === Queues.eventsQueue) {
+    const eventData = data.data as Record<string, unknown> | undefined
+    if (eventData && typeof eventData.workspaceId === 'number') {
+      return eventData.workspaceId
+    }
+  }
+
+  if (typeof data.workspaceId === 'number') {
+    return data.workspaceId
+  }
+
+  return null
+}
+
+function buildJobBreakdown(
+  jobs: Job[],
+  queueName: string,
+): QueueJobSummary[] {
+  const map = new Map<string, { count: number; workspaces: Record<number, number> }>()
+
+  for (const job of jobs) {
+    const entry = map.get(job.name) ?? { count: 0, workspaces: {} }
+    entry.count++
+
+    const wsId = extractWorkspaceId(job, queueName)
+    if (wsId !== null) {
+      entry.workspaces[wsId] = (entry.workspaces[wsId] ?? 0) + 1
+    }
+
+    map.set(job.name, entry)
+  }
+
+  return Array.from(map.entries())
+    .map(([jobName, data]) => ({
+      jobName,
+      count: data.count,
+      workspaces: data.workspaces,
+    }))
+    .sort((a, b) => b.count - a.count)
+}
+
+async function findQueue(queueName: string): Promise<Queue | null> {
+  const qs = await queues()
+  const allQueues = Object.values(qs) as Queue[]
+  return allQueues.find((q) => q.name === queueName) ?? null
+}

--- a/packages/core/src/services/workers/manage.ts
+++ b/packages/core/src/services/workers/manage.ts
@@ -1,0 +1,70 @@
+import { Queue, Job } from 'bullmq'
+
+import { queues } from '../../jobs/queues'
+import { Queues } from '../../jobs/queues/types'
+import { Result } from '../../lib/Result'
+
+export async function drainQueue({ queueName }: { queueName: string }) {
+  const queue = await findQueue(queueName)
+  if (!queue) return Result.ok({ drained: false })
+
+  await queue.drain()
+  return Result.ok({ drained: true })
+}
+
+export async function removeWorkspaceJobs({
+  workspaceId,
+  queueName,
+}: {
+  workspaceId: number
+  queueName?: string
+}) {
+  const qs = await queues()
+  const queueList = queueName
+    ? [await findQueue(queueName)].filter(Boolean) as Queue[]
+    : (Object.values(qs) as Queue[])
+
+  let totalRemoved = 0
+
+  for (const queue of queueList) {
+    const jobs = await queue.getJobs(['waiting', 'delayed'], 0, 5000)
+    const removable = jobs.filter((job) => {
+      const wsId = extractWorkspaceId(job, queue.name)
+      return wsId === workspaceId
+    })
+
+    for (const job of removable) {
+      try {
+        await job.remove()
+        totalRemoved++
+      } catch {
+        // Job may have been picked up by a worker already
+      }
+    }
+  }
+
+  return Result.ok({ removed: totalRemoved })
+}
+
+function extractWorkspaceId(job: Job, queueName: string): number | null {
+  const data = job.data as Record<string, unknown>
+
+  if (queueName === Queues.eventHandlersQueue || queueName === Queues.eventsQueue) {
+    const eventData = data.data as Record<string, unknown> | undefined
+    if (eventData && typeof eventData.workspaceId === 'number') {
+      return eventData.workspaceId
+    }
+  }
+
+  if (typeof data.workspaceId === 'number') {
+    return data.workspaceId
+  }
+
+  return null
+}
+
+async function findQueue(queueName: string): Promise<Queue | null> {
+  const qs = await queues()
+  const allQueues = Object.values(qs) as Queue[]
+  return allQueues.find((q) => q.name === queueName) ?? null
+}


### PR DESCRIPTION
## Summary
Adds a Workers section to the backoffice that provides live visibility into BullMQ queue states and the ability to intervene when queues are overwhelmed or a specific workspace is monopolizing resources. The overview shows real-time active, waiting, and delayed job counts across all 14 queues (auto-refreshing every 5s). Clicking a queue reveals a breakdown of job types with per-workspace attribution, making it easy to identify which workspaces are driving load. Two targeted operational actions are available, both behind confirmation modals:
- **Drain a queue** — clears all waiting/delayed jobs as an emergency release valve for backlog situations
- **Kill workspace jobs** — removes only a specific workspace's waiting/delayed jobs from a queue (or across all queues from the workspace page) The workspace detail page in the backoffice also gains a Workers Usage section showing that workspace's active jobs across all queues, with per-queue kill capability.