### PR TITLE
fix(web): guard unknown integration types when resolving icons

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/toolsHelpers/utils.ts
@@ -51,7 +51,14 @@ export function getIntegrationData({
     }
   }
 
-  const { icon } = INTEGRATION_TYPE_VALUES[integration.type]
+  const icon =
+    // Some integration types are not part of ActiveIntegrationType (or may be added before web is updated).
+    // Avoid crashing the editor UI and fall back to a generic icon.
+    INTEGRATION_TYPE_VALUES[
+      integration.type as keyof typeof INTEGRATION_TYPE_VALUES
+    ]?.icon ??
+    ({ type: 'icon', name: 'unplug' as IconName } as const)
+
   return {
     ...commonData,
     icon,

--- a/apps/web/src/components/Integrations/IntegrationIcon.tsx
+++ b/apps/web/src/components/Integrations/IntegrationIcon.tsx
@@ -57,7 +57,11 @@ export function IntegrationIcon({
   }
 
   // Standard integration types: use INTEGRATION_TYPE_VALUES
-  const { icon } = INTEGRATION_TYPE_VALUES[integration.type]
+  const icon =
+    INTEGRATION_TYPE_VALUES[
+      integration.type as keyof typeof INTEGRATION_TYPE_VALUES
+    ]?.icon ??
+    ({ type: 'icon', name: 'unplug' } as const)
 
   if (icon.type === 'image') {
     return (

--- a/apps/web/src/lib/integrationTypeOptions.tsx
+++ b/apps/web/src/lib/integrationTypeOptions.tsx
@@ -58,5 +58,12 @@ export function integrationOptions(
     }
   }
 
-  return INTEGRATION_TYPE_VALUES[integration.type]
+  return (
+    INTEGRATION_TYPE_VALUES[
+      integration.type as keyof typeof INTEGRATION_TYPE_VALUES
+    ] ?? {
+      label: integration.name,
+      icon: { type: 'icon' as const, name: 'unplug' },
+    }
+  )
 }


### PR DESCRIPTION
Datadog: https://app.datadoghq.eu/error-tracking/unified?query=service%3A%2A&issueId=a642f8cc-0423-11f1-b39e-da7ad0900005

Error:
TypeError: Cannot destructure property `icon` of `INTEGRATION_TYPE_VALUES[a.type]` as it is undefined.

What changed:
- Avoid crashing when integration.type is not present in INTEGRATION_TYPE_VALUES.
- Fall back to a generic `unplug` icon.

Validation:
- pnpm lint
- pnpm tc
