### PR TITLE
Include changed files in commitPublished event

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.ts
@@ -12,7 +12,7 @@ import {
 } from '@latitude-data/core/constants'
 import { cache as redis } from '@latitude-data/core/cache'
 import { diskFactory } from '@latitude-data/core/lib/disk'
-import { publisher } from '@latitude-data/core/events/publisher'
+import { publishSpanCreated } from '@latitude-data/core/services/tracing/publishSpanCreated'
 import { AppRouteHandler } from '$/openApi/types'
 import { CreateLogRoute } from './create.route'
 import { getData } from '$/common/documents/getData'
@@ -246,15 +246,14 @@ async function createSpansFromLogData({
     .then((r) => r.unwrap())
   await cache.del(completionMetadataKey)
 
-  await publisher.publishLater({
-    type: 'spanCreated',
-    data: {
-      spanId: promptSpanId,
-      traceId,
-      apiKeyId: apiKey.id,
-      workspaceId: workspace.id,
-      documentUuid: document.documentUuid,
-    },
+  await publishSpanCreated({
+    spanId: promptSpanId,
+    traceId,
+    apiKeyId: apiKey.id,
+    workspaceId: workspace.id,
+    documentUuid: document.documentUuid,
+    spanType: SpanType.Prompt,
+    parentId: null,
   })
 
   return {

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.handler.test.ts
@@ -638,8 +638,6 @@ describe('POST /run', () => {
       )
     })
 
-
-
     it('returns 499 when request is aborted and no final response is produced', async () => {
       const stream = new ReadableStream({
         start(controller) {

--- a/apps/web/src/actions/commits/publishDraftCommitAction.ts
+++ b/apps/web/src/actions/commits/publishDraftCommitAction.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { publisher } from '@latitude-data/core/events/publisher'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { updateAndMergeCommit } from '@latitude-data/core/services/commits/updateAndMerge'
 import { z } from 'zod'
@@ -24,7 +23,7 @@ export const publishDraftCommitAction = withProject
       .getCommitById(commitId)
       .then((r) => r.unwrap())
 
-    const merged = await updateAndMergeCommit({
+    return updateAndMergeCommit({
       commit,
       workspace,
       data: {
@@ -32,15 +31,4 @@ export const publishDraftCommitAction = withProject
         description,
       },
     }).then((r) => r.unwrap())
-
-    publisher.publishLater({
-      type: 'commitPublished',
-      data: {
-        commit: merged,
-        userEmail: ctx.user.email,
-        workspaceId: ctx.workspace.id,
-      },
-    })
-
-    return merged
   })

--- a/packages/core/src/events/events.d.ts
+++ b/packages/core/src/events/events.d.ts
@@ -3,6 +3,8 @@ import {
   AlignmentMetricMetadata,
 } from '@latitude-data/constants/evaluations'
 import { ExperimentVariant } from '@latitude-data/constants/experiments'
+import { ModifiedDocumentType } from '@latitude-data/constants/history'
+import { SpanType } from '@latitude-data/constants/tracing'
 import { type Commit } from '../schema/models/types/Commit'
 import { type Dataset } from '../schema/models/types/Dataset'
 import { type DatasetRow } from '../schema/models/types/DatasetRow'
@@ -278,12 +280,18 @@ export type UserInvitedEvent = LatitudeEventGeneric<
   }
 >
 
+export type CommitPublishedDocumentChange = {
+  path: string
+  changeType: ModifiedDocumentType
+}
+
 export type CommitPublishedEvent = LatitudeEventGeneric<
   'commitPublished',
   {
     commit: Commit
     userEmail: string
     workspaceId: number
+    changedDocuments: CommitPublishedDocumentChange[]
   }
 >
 
@@ -518,6 +526,8 @@ export type SpanCreatedEvent = LatitudeEventGeneric<
     spanId: string
     traceId: string
     documentUuid: string | undefined
+    spanType: SpanType
+    isConversationRoot: boolean
   }
 >
 

--- a/packages/core/src/jobs/job-definitions/webhooks/utils/processSpanCreated.test.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/utils/processSpanCreated.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LogSources, Providers } from '@latitude-data/constants'
+import * as factories from '../../../../tests/factories'
+import { processSpanCreated } from './processSpanCreated'
+
+type DocumentLogPayload = {
+  prompt?: { documentUuid: string }
+  uuid?: string
+  parameters?: Record<string, unknown>
+  customIdentifier?: string
+  duration?: number
+  source?: string
+  commitUuid?: string
+  messages?: unknown[]
+  toolCalls?: unknown[]
+  response?: string
+}
+
+describe('processSpanCreated', () => {
+  let workspaceId: number
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const { workspace } = await factories.createWorkspace()
+    workspaceId = workspace.id
+  })
+
+  describe('basic span processing', () => {
+    it('returns error when span is not found', async () => {
+      const result = await processSpanCreated({
+        spanId: 'non-existent',
+        traceId: 'non-existent',
+        workspaceId,
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.error?.message).toBe('Span not found')
+    })
+
+    it('returns payload with span data', async () => {
+      const { span } = await factories.createPromptSpan({
+        workspaceId,
+        source: LogSources.API,
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value).toMatchObject({
+        eventType: 'documentLogCreated',
+        payload: expect.objectContaining({
+          uuid: span.documentLogUuid,
+          source: LogSources.API,
+        }),
+      })
+    })
+
+    it('returns eventType as documentLogCreated for backward compatibility', async () => {
+      const { span } = await factories.createPromptSpan({
+        workspaceId,
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value?.eventType).toBe('documentLogCreated')
+    })
+  })
+
+  describe('document fetching', () => {
+    it('includes prompt when documentUuid and commitUuid are present', async () => {
+      const { workspace, project, commit, documents } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            test: factories.helpers.createPrompt({
+              provider: 'openai',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const { span } = await factories.createPromptSpan({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId: workspace.id,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.prompt).toBeDefined()
+      expect(payload.prompt?.documentUuid).toBe(document.documentUuid)
+    })
+
+    it('returns undefined prompt when documentUuid is missing', async () => {
+      const { span } = await factories.createPromptSpan({
+        workspaceId,
+        documentUuid: undefined,
+        commitUuid: undefined,
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.prompt).toBeUndefined()
+    })
+  })
+
+  describe('metadata extraction', () => {
+    it('includes parameters from metadata', async () => {
+      const { workspace, project, commit, documents } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            test: factories.helpers.createPrompt({
+              provider: 'openai',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const { span } = await factories.createPromptSpan({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        parameters: { foo: 'bar', count: 42 },
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId: workspace.id,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.parameters).toEqual({ foo: 'bar', count: 42 })
+    })
+  })
+
+  describe('completion span messages', () => {
+    it('extracts messages and response from completion span', async () => {
+      const { workspace, project, commit, documents } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            test: factories.helpers.createPrompt({
+              provider: 'openai',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const { input, output } = factories.createTestMessages({
+        userText: 'Hello',
+        assistantText: 'Hi there!',
+      })
+
+      const { promptSpan } = await factories.createPromptWithCompletion({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        input,
+        output,
+      })
+
+      const result = await processSpanCreated({
+        spanId: promptSpan.id,
+        traceId: promptSpan.traceId,
+        workspaceId: workspace.id,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.messages).toEqual(input)
+      expect(payload.response).toBe('Hi there!')
+    })
+
+    it('extracts tool calls from output messages', async () => {
+      const { workspace, project, commit, documents } =
+        await factories.createProject({
+          providers: [{ type: Providers.OpenAI, name: 'openai' }],
+          documents: {
+            test: factories.helpers.createPrompt({
+              provider: 'openai',
+            }),
+          },
+        })
+
+      const document = documents[0]!
+      const output = [
+        {
+          role: 'assistant' as const,
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 'call-123',
+              toolName: 'get_weather',
+              args: { location: 'NYC' },
+            },
+          ],
+          toolCalls: [],
+        },
+      ]
+
+      const { promptSpan } = await factories.createPromptWithCompletion({
+        workspaceId: workspace.id,
+        projectId: project.id,
+        documentUuid: document.documentUuid,
+        commitUuid: commit.uuid,
+        output,
+      })
+
+      const result = await processSpanCreated({
+        spanId: promptSpan.id,
+        traceId: promptSpan.traceId,
+        workspaceId: workspace.id,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.toolCalls).toEqual([
+        {
+          id: 'call-123',
+          name: 'get_weather',
+          arguments: { location: 'NYC' },
+        },
+      ])
+    })
+
+    it('returns undefined messages when no completion span exists', async () => {
+      const { span } = await factories.createPromptSpan({
+        workspaceId,
+      })
+
+      const result = await processSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        workspaceId,
+      })
+
+      expect(result.ok).toBe(true)
+      const payload = result.value?.payload as DocumentLogPayload
+      expect(payload.messages).toBeUndefined()
+      expect(payload.response).toBeUndefined()
+      expect(payload.toolCalls).toBeUndefined()
+    })
+  })
+})

--- a/packages/core/src/jobs/job-definitions/webhooks/utils/processSpanCreated.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/utils/processSpanCreated.ts
@@ -1,0 +1,134 @@
+import {
+  CompletionSpanMetadata,
+  Message,
+  PromptSpanMetadata,
+  SpanType,
+  ToolCall,
+} from '../../../../constants'
+import { Result, TypedResult } from '../../../../lib/Result'
+import {
+  DocumentVersionsRepository,
+  SpanMetadatasRepository,
+  SpansRepository,
+} from '../../../../repositories'
+import { assembleTraceWithMessages } from '../../../../services/tracing/traces/assemble'
+import { WebhookPayload } from '../../../../services/webhooks/types'
+
+export async function processSpanCreated({
+  spanId,
+  traceId,
+  workspaceId,
+}: {
+  spanId: string
+  traceId: string
+  workspaceId: number
+}): Promise<TypedResult<WebhookPayload, Error>> {
+  const spansRepo = new SpansRepository(workspaceId)
+  const spanResult = await spansRepo.get({ spanId, traceId })
+  if (!spanResult.ok || !spanResult.value) {
+    return Result.error(new Error('Span not found'))
+  }
+  const span = spanResult.value
+
+  const metadataRepo = new SpanMetadatasRepository(workspaceId)
+  const metadataResult = await metadataRepo.get<SpanType.Prompt>({
+    spanId,
+    traceId,
+  })
+  const metadata = metadataResult.ok
+    ? (metadataResult.value as PromptSpanMetadata)
+    : undefined
+
+  let prompt = undefined
+  if (span.documentUuid && span.commitUuid) {
+    const docsRepo = new DocumentVersionsRepository(workspaceId)
+    const docResult = await docsRepo.getDocumentByUuid({
+      commitUuid: span.commitUuid,
+      documentUuid: span.documentUuid,
+    })
+    if (docResult.ok && docResult.value) {
+      prompt = docResult.value
+    }
+  }
+
+  let messages: Message[] | undefined
+  let toolCalls: ToolCall[] | undefined
+  let response: string | undefined
+
+  const traceResult = await assembleTraceWithMessages({
+    traceId,
+    workspace: { id: workspaceId },
+    spanId,
+  })
+
+  if (traceResult.ok && traceResult.value) {
+    const { completionSpan } = traceResult.value
+    if (completionSpan?.metadata) {
+      const completionMetadata =
+        completionSpan.metadata as CompletionSpanMetadata
+      messages = completionMetadata.input
+      const outputMessages = completionMetadata.output
+
+      if (outputMessages && outputMessages.length > 0) {
+        response = extractResponseText(outputMessages)
+        toolCalls = extractToolCalls(outputMessages)
+      }
+    }
+  }
+
+  // Return eventType as 'documentLogCreated' for backward compatibility
+  return Result.ok({
+    eventType: 'documentLogCreated',
+    payload: {
+      prompt,
+      uuid: span.documentLogUuid,
+      parameters: metadata?.parameters,
+      customIdentifier: metadata?.externalId,
+      duration: span.duration,
+      source: span.source,
+      commitUuid: span.commitUuid,
+      messages,
+      toolCalls,
+      response,
+    },
+  })
+}
+
+function extractResponseText(messages: Message[]): string | undefined {
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue
+
+    for (const content of message.content) {
+      if (content.type === 'text' && content.text) {
+        return content.text
+      }
+    }
+  }
+  return undefined
+}
+
+function extractToolCalls(messages: Message[]): ToolCall[] | undefined {
+  const toolCalls: ToolCall[] = []
+
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue
+
+    // Check deprecated toolCalls field first
+    if (message.toolCalls && message.toolCalls.length > 0) {
+      toolCalls.push(...message.toolCalls)
+    }
+
+    // Check content for tool-call items
+    for (const content of message.content) {
+      if (content.type === 'tool-call') {
+        toolCalls.push({
+          id: content.toolCallId,
+          name: content.toolName,
+          arguments: content.args,
+        })
+      }
+    }
+  }
+
+  return toolCalls.length > 0 ? toolCalls : undefined
+}

--- a/packages/core/src/jobs/job-definitions/webhooks/utils/processWebhookPayload.ts
+++ b/packages/core/src/jobs/job-definitions/webhooks/utils/processWebhookPayload.ts
@@ -1,41 +1,16 @@
 import { LatitudeEvent } from '../../../../events/events'
 import { WebhookPayload } from '../../../../services/webhooks/types'
-import { findDocumentFromLog } from '../../../../data-access/documentLogs'
 import { Result, TypedResult } from '../../../../lib/Result'
-import { findLastProviderLogFromDocumentLogUuid } from '../../../../data-access/providerLogs'
-import { buildProviderLogResponse } from '../../../../services/providerLogs/buildResponse'
-import { DocumentLogsRepository } from '../../../../repositories'
+import { processSpanCreated } from './processSpanCreated'
 
 export async function processWebhookPayload(
   event: LatitudeEvent,
 ): Promise<TypedResult<WebhookPayload, Error>> {
   try {
     switch (event.type) {
-      case 'documentLogCreated': {
-        const { id, workspaceId } = event.data
-        const repo = new DocumentLogsRepository(workspaceId)
-        const log = await repo.find(id).then((r) => r.unwrap())
-        const providerLog = await findLastProviderLogFromDocumentLogUuid(
-          log.uuid,
-        )
-
-        return Result.ok({
-          eventType: event.type,
-          payload: {
-            prompt: await findDocumentFromLog(log),
-            uuid: log.uuid,
-            parameters: log.parameters,
-            customIdentifier: log.customIdentifier,
-            duration: log.duration,
-            source: log.source,
-            commitId: log.commitId,
-            messages: providerLog?.messages,
-            toolCalls: providerLog?.toolCalls,
-            response: providerLog
-              ? buildProviderLogResponse(providerLog)
-              : undefined,
-          },
-        })
+      case 'spanCreated': {
+        const { spanId, traceId, workspaceId } = event.data
+        return processSpanCreated({ spanId, traceId, workspaceId })
       }
       default:
         return Result.ok({

--- a/packages/core/src/lib/Transaction.ts
+++ b/packages/core/src/lib/Transaction.ts
@@ -86,7 +86,9 @@ export default class Transaction {
         if (isDeadlock && attempt < maxAttempts) {
           // small exponential backoff with a bit of jitter
           const base = 50
-          const backoffMs = Math.round(base * 2 ** (attempt - 1) + Math.random() * 50)
+          const backoffMs = Math.round(
+            base * 2 ** (attempt - 1) + Math.random() * 50,
+          )
           await new Promise((r) => setTimeout(r, backoffMs))
           continue
         }

--- a/packages/core/src/services/documentTriggers/triggerEvents/runFromEvent.ts
+++ b/packages/core/src/services/documentTriggers/triggerEvents/runFromEvent.ts
@@ -145,9 +145,7 @@ async function resolveEffectiveCommit({
   const liveCommit = await commitsRepo.getHeadCommit(commit.projectId)
   if (!liveCommit) {
     return Result.error(
-      new NotFoundError(
-        `Live commit not found in project ${commit.projectId}`,
-      ),
+      new NotFoundError(`Live commit not found in project ${commit.projectId}`),
     )
   }
 

--- a/packages/core/src/services/tracing/publishSpanCreated.ts
+++ b/packages/core/src/services/tracing/publishSpanCreated.ts
@@ -1,0 +1,35 @@
+import { SpanType } from '../../constants'
+import { publisher } from '../../events/publisher'
+
+export type PublishSpanCreatedParams = {
+  spanId: string
+  traceId: string
+  apiKeyId: number
+  workspaceId: number
+  documentUuid: string | undefined
+  spanType: SpanType
+  parentId?: string | null
+}
+
+export function publishSpanCreated({
+  spanId,
+  traceId,
+  apiKeyId,
+  workspaceId,
+  documentUuid,
+  spanType,
+  parentId,
+}: PublishSpanCreatedParams) {
+  return publisher.publishLater({
+    type: 'spanCreated',
+    data: {
+      spanId,
+      traceId,
+      apiKeyId,
+      workspaceId,
+      documentUuid,
+      spanType,
+      isConversationRoot: spanType === SpanType.Prompt && !parentId,
+    },
+  })
+}

--- a/packages/core/src/services/tracing/spans/ingestion/processBulk.ts
+++ b/packages/core/src/services/tracing/spans/ingestion/processBulk.ts
@@ -16,7 +16,7 @@ import {
   SpanStatus,
   SpanType,
 } from '../../../../constants'
-import { publisher } from '../../../../events/publisher'
+import { publishSpanCreated } from '../../publishSpanCreated'
 import { diskFactory, DiskWrapper } from '../../../../lib/disk'
 import { LatitudeError, UnprocessableEntityError } from '../../../../lib/errors'
 import { Result, TypedResult } from '../../../../lib/Result'
@@ -369,17 +369,15 @@ export async function processSpansBulk(
       disk,
     )
 
-    // Publish events for all spans
     const eventPromises = insertedSpans.map((span) =>
-      publisher.publishLater({
-        type: 'spanCreated',
-        data: {
-          spanId: span.id,
-          traceId: span.traceId,
-          apiKeyId: apiKey.id,
-          workspaceId: workspace.id,
-          documentUuid: span.documentUuid,
-        },
+      publishSpanCreated({
+        spanId: span.id,
+        traceId: span.traceId,
+        apiKeyId: apiKey.id,
+        workspaceId: workspace.id,
+        documentUuid: span.documentUuid,
+        spanType: span.type,
+        parentId: span.parentId,
       }),
     )
     await Promise.all(eventPromises)

--- a/packages/core/src/services/tracing/traces/assemble.ts
+++ b/packages/core/src/services/tracing/traces/assemble.ts
@@ -10,11 +10,13 @@ import { UnprocessableEntityError } from '../../../lib/errors'
 import { Result } from '../../../lib/Result'
 import { PromisedResult } from '../../../lib/Transaction'
 import { SpanMetadatasRepository, SpansRepository } from '../../../repositories'
-import { type Workspace } from '../../../schema/models/types/Workspace'
 import { findAllSpansOfType } from '../spans/fetching/findAllSpansOfType'
 import { findCompletionSpanFromTrace } from '../spans/fetching/findCompletionSpanFromTrace'
 import { findCompletionSpanForSpan } from '../spans/fetching/findCompletionSpanForSpan'
 import { findSpanById } from '../spans/fetching/findSpanById'
+import { Workspace } from '../../../schema/models/types/Workspace'
+
+type WorkspaceRef = Pick<Workspace, 'id'>
 
 /**
  * Assembles a trace structure without fetching span metadata.
@@ -26,7 +28,7 @@ export async function assembleTraceStructure(
     workspace,
   }: {
     traceId: string
-    workspace: Workspace
+    workspace: WorkspaceRef
   },
   db = database,
 ) {
@@ -84,7 +86,7 @@ export async function assembleTraceStructure(
  *
  * @param params - Trace lookup parameters.
  * @param params.traceId - Trace identifier to assemble.
- * @param params.workspace - Workspace owning the trace.
+ * @param params.workspace - Workspace owning the trace (only id is required).
  * @param params.spanId - Span used to scope the main completion selection.
  * @param db - Database connection override.
  * @returns Result with the assembled trace and optional main completion span.
@@ -96,7 +98,7 @@ export async function assembleTraceWithMessages(
     spanId,
   }: {
     traceId: string
-    workspace: Workspace
+    workspace: WorkspaceRef
     spanId?: string
   },
   db = database,


### PR DESCRIPTION
# What?
We want to let users know what files were changed when a commit is published

## TODO
- [x] Add the file paths that were added/changed/removed when a commit is published. 
- [x] Fix the way we do `documentLogCreated` webhook to listen to `spanCreated`. 