### PR TITLE
Split CI test workflow into parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           NODE_ENV: test
           DATABASE_URL: postgres://latitude:secret@localhost:5432/latitude_test
-        run: cd packages/core && vitest run --pool=threads --shard=${{ matrix.shard }}/4
+        run: cd packages/core && pnpm vitest run --pool=threads --shard=${{ matrix.shard }}/4
 
   test-web:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Run tests for packages/core, apps/web, apps/gateway, and the rest (cli, sdk, web-ui, telemetry, python) in separate parallel jobs to reduce overall CI time.

https://claude.ai/code/session_01GU1ev9uhgyWSukG9CRb4qR