### PR TITLE
Add multi-turn conversation simulation to optimization pipeline

### DIFF
--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationForExperimentJob.ts
@@ -1,16 +1,15 @@
 import { DelayedError, Job } from 'bullmq'
-import {
-  EvaluationTriggerTarget,
-  isMainSpan,
-  Span,
-  TriggerConfiguration,
-} from '../../../constants'
+import { isMainSpan } from '../../../constants'
 import { SpansRepository } from '../../../repositories/spansRepository'
 import {
   CommitsRepository,
   EvaluationsV2Repository,
   ExperimentsRepository,
 } from '../../../repositories'
+import {
+  getTriggerTarget,
+  selectSpansForTrigger,
+} from '../../../services/evaluationsV2/triggers'
 import { updateExperimentStatus } from '../../../services/experiments/updateStatus'
 import { captureException } from '../../../utils/datadogCapture'
 import { queues } from '../../queues'
@@ -33,29 +32,6 @@ export type RunEvaluationForExperimentJobData = {
 
 const INITIAL_DELAY_MS = 1000
 const MAX_ATTEMPTS = 120
-
-function getTriggerTarget(
-  trigger?: TriggerConfiguration,
-): EvaluationTriggerTarget {
-  return trigger?.target ?? 'every'
-}
-
-function selectSpansForTrigger(
-  spans: Span[],
-  triggerTarget: EvaluationTriggerTarget,
-): Span[] {
-  if (spans.length === 0) return []
-
-  switch (triggerTarget) {
-    case 'first':
-      return [spans[0]!]
-    case 'last':
-      return [spans[spans.length - 1]!]
-    case 'every':
-    default:
-      return spans
-  }
-}
 
 export async function runEvaluationForExperimentJob(
   job: Job<RunEvaluationForExperimentJobData>,

--- a/packages/core/src/services/evaluationsV2/triggers.test.ts
+++ b/packages/core/src/services/evaluationsV2/triggers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { Span, SpanType, TriggerConfiguration } from '../../constants'
+import { getTriggerTarget, selectSpansForTrigger } from './triggers'
+
+function createSpan(id: string, startedAt = new Date()): Span {
+  return {
+    id,
+    traceId: `trace-${id}`,
+    type: SpanType.Prompt,
+    startedAt,
+    workspaceId: 1,
+  } as unknown as Span
+}
+
+describe('getTriggerTarget', () => {
+  it('defaults to every when trigger is undefined', () => {
+    expect(getTriggerTarget(undefined)).toBe('every')
+  })
+
+  it('defaults to every when trigger has no target', () => {
+    expect(getTriggerTarget({} as TriggerConfiguration)).toBe('every')
+  })
+
+  it('returns first when configured', () => {
+    expect(
+      getTriggerTarget({ target: 'first', lastInteractionDebounce: 60 }),
+    ).toBe('first')
+  })
+
+  it('returns last when configured', () => {
+    expect(
+      getTriggerTarget({ target: 'last', lastInteractionDebounce: 60 }),
+    ).toBe('last')
+  })
+
+  it('returns every when configured', () => {
+    expect(
+      getTriggerTarget({ target: 'every', lastInteractionDebounce: 60 }),
+    ).toBe('every')
+  })
+})
+
+describe('selectSpansForTrigger', () => {
+  const spans = [
+    createSpan('span-1', new Date('2024-01-01T00:00:00Z')),
+    createSpan('span-2', new Date('2024-01-01T00:01:00Z')),
+    createSpan('span-3', new Date('2024-01-01T00:02:00Z')),
+  ]
+
+  it('returns empty array when given no spans', () => {
+    expect(selectSpansForTrigger([], 'first')).toEqual([])
+    expect(selectSpansForTrigger([], 'last')).toEqual([])
+    expect(selectSpansForTrigger([], 'every')).toEqual([])
+  })
+
+  describe('first', () => {
+    it('selects only the first span', () => {
+      const result = selectSpansForTrigger(spans, 'first')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('span-1')
+    })
+
+    it('works with a single span', () => {
+      const result = selectSpansForTrigger([spans[0]!], 'first')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('span-1')
+    })
+  })
+
+  describe('last', () => {
+    it('selects only the last span', () => {
+      const result = selectSpansForTrigger(spans, 'last')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('span-3')
+    })
+
+    it('works with a single span', () => {
+      const result = selectSpansForTrigger([spans[0]!], 'last')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('span-1')
+    })
+  })
+
+  describe('every', () => {
+    it('selects all spans', () => {
+      const result = selectSpansForTrigger(spans, 'every')
+      expect(result).toHaveLength(3)
+      expect(result.map((s) => s.id)).toEqual(['span-1', 'span-2', 'span-3'])
+    })
+
+    it('works with a single span', () => {
+      const result = selectSpansForTrigger([spans[0]!], 'every')
+      expect(result).toHaveLength(1)
+      expect(result[0]!.id).toBe('span-1')
+    })
+  })
+})

--- a/packages/core/src/services/evaluationsV2/triggers.ts
+++ b/packages/core/src/services/evaluationsV2/triggers.ts
@@ -1,0 +1,28 @@
+import {
+  EvaluationTriggerTarget,
+  Span,
+  TriggerConfiguration,
+} from '../../constants'
+
+export function getTriggerTarget(
+  trigger?: TriggerConfiguration,
+): EvaluationTriggerTarget {
+  return trigger?.target ?? 'every'
+}
+
+export function selectSpansForTrigger(
+  spans: Span[],
+  triggerTarget: EvaluationTriggerTarget,
+): Span[] {
+  if (spans.length === 0) return []
+
+  switch (triggerTarget) {
+    case 'first':
+      return [spans[0]!]
+    case 'last':
+      return [spans[spans.length - 1]!]
+    case 'every':
+    default:
+      return spans
+  }
+}

--- a/packages/core/src/services/optimizations/optimizers/evaluate.test.ts
+++ b/packages/core/src/services/optimizations/optimizers/evaluate.test.ts
@@ -1,0 +1,781 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SpanType } from '../../../constants'
+import { Result } from '../../../lib/Result'
+import { evaluateFactory } from './evaluate'
+
+const mocks = vi.hoisted(() => ({
+  scanDocumentContent: vi.fn(),
+  runDocumentAtCommit: vi.fn(),
+  runEvaluationV2: vi.fn(),
+  getEvaluationMetricSpecification: vi.fn(),
+  generateSimulatedUserAction: vi.fn(),
+  addMessages: vi.fn(),
+  listByDocumentLogUuid: vi.fn(),
+  metadataGet: vi.fn(),
+}))
+
+vi.mock('../../documents', () => ({
+  scanDocumentContent: mocks.scanDocumentContent,
+}))
+
+vi.mock('../../commits/runDocumentAtCommit', () => ({
+  runDocumentAtCommit: mocks.runDocumentAtCommit,
+}))
+
+vi.mock('../../evaluationsV2/run', () => ({
+  runEvaluationV2: mocks.runEvaluationV2,
+}))
+
+vi.mock('../../evaluationsV2/specifications', () => ({
+  getEvaluationMetricSpecification: mocks.getEvaluationMetricSpecification,
+}))
+
+vi.mock('../../simulation/simulateUserResponse', () => ({
+  generateSimulatedUserAction: mocks.generateSimulatedUserAction,
+}))
+
+vi.mock('../../documentLogs/addMessages', () => ({
+  addMessages: mocks.addMessages,
+}))
+
+vi.mock('../../../repositories/spansRepository', () => ({
+  SpansRepository: vi.fn().mockImplementation(() => ({
+    listByDocumentLogUuid: mocks.listByDocumentLogUuid,
+  })),
+  SpanMetadatasRepository: vi.fn().mockImplementation(() => ({
+    get: mocks.metadataGet,
+  })),
+}))
+
+vi.mock('../../../telemetry', () => ({
+  BACKGROUND: vi.fn().mockReturnValue({}),
+}))
+
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: vi.fn() },
+}))
+
+function createMockSpan(
+  id: string,
+  type: SpanType = SpanType.Prompt,
+  startedAt = new Date(),
+) {
+  return {
+    id,
+    traceId: `trace-${id}`,
+    type,
+    startedAt,
+    workspaceId: 1,
+    documentLogUuid: 'test-log-uuid',
+  }
+}
+
+function createMockMetadata(spanType: SpanType = SpanType.Prompt) {
+  return { spanType, actualOutput: 'test output' }
+}
+
+function mockScanDocumentContent() {
+  mocks.scanDocumentContent.mockResolvedValue(
+    Result.ok({
+      parameters: new Set<string>(),
+      config: { provider: 'openai', model: 'gpt-4o' },
+      instructions: 'test instructions',
+      errors: [],
+    }),
+  )
+}
+
+function mockRunDocumentAtCommit(uuid = 'test-log-uuid') {
+  mocks.runDocumentAtCommit.mockResolvedValue(
+    Result.ok({
+      uuid,
+      error: Promise.resolve(null),
+      messages: Promise.resolve([
+        { role: 'assistant', content: [{ type: 'text', text: 'response' }] },
+      ]),
+      duration: Promise.resolve(100),
+      runUsage: Promise.resolve({
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+      }),
+    }),
+  )
+}
+
+function mockEvaluation(
+  score: number,
+  passed: boolean,
+  reason = 'test reason',
+) {
+  mocks.runEvaluationV2.mockResolvedValue(
+    Result.ok({
+      result: {
+        normalizedScore: score,
+        hasPassed: passed,
+        metadata: { actualOutput: 'test output' },
+        error: null,
+      },
+    }),
+  )
+  mocks.getEvaluationMetricSpecification.mockReturnValue({
+    resultReason: () => reason,
+  })
+}
+
+function mockEvaluationSequence(
+  evaluations: { score: number; passed: boolean; reason?: string }[],
+) {
+  for (const e of evaluations) {
+    mocks.runEvaluationV2.mockResolvedValueOnce(
+      Result.ok({
+        result: {
+          normalizedScore: e.score,
+          hasPassed: e.passed,
+          metadata: { actualOutput: 'test output' },
+          error: null,
+        },
+      }),
+    )
+  }
+  mocks.getEvaluationMetricSpecification.mockReturnValue({
+    resultReason: () => 'test reason',
+  })
+}
+
+function mockSpansAndMetadata(
+  spans: ReturnType<typeof createMockSpan>[],
+) {
+  mocks.listByDocumentLogUuid.mockResolvedValue(spans)
+  mocks.metadataGet.mockImplementation(
+    async ({ spanId }: { spanId: string }) => {
+      const span = spans.find((s) => s.id === spanId)
+      if (!span) return Result.ok(null)
+      return Result.ok(createMockMetadata(span.type))
+    },
+  )
+}
+
+const baseDocument = {
+  id: 1,
+  documentUuid: 'doc-uuid',
+  path: 'test-prompt',
+  content: '---\nprovider: openai\nmodel: gpt-4o\n---\nHello',
+  commitId: 1,
+  workspaceId: 1,
+} as any
+
+const baseCommit = { id: 1, uuid: 'commit-uuid' } as any
+const baseWorkspace = { id: 1 } as any
+
+const baseOptimization = {
+  id: 1,
+  uuid: 'opt-uuid',
+  baselinePrompt: '---\nprovider: openai\nmodel: gpt-4o\n---\nHello',
+  configuration: {},
+} as any
+
+const baseExample = {
+  id: 1,
+  datasetId: 1,
+  workspaceId: 1,
+  rowData: {},
+} as any
+
+function createEvaluation(triggerTarget?: 'first' | 'every' | 'last') {
+  const config: any = {
+    reverseScale: false,
+    actualOutput: { messageSelection: 'last', parsingFormat: 'string' },
+  }
+  if (triggerTarget) {
+    config.trigger = { target: triggerTarget }
+  }
+  return {
+    uuid: 'eval-uuid',
+    versionId: 1,
+    workspaceId: 1,
+    type: 'rule',
+    metric: 'exact_match',
+    configuration: config,
+  } as any
+}
+
+describe('evaluateFactory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockScanDocumentContent()
+  })
+
+  describe('trigger target selection', () => {
+    it('evaluates only the first span when trigger target is first', async () => {
+      const evaluation = createEvaluation('first')
+      mockRunDocumentAtCommit()
+      mockEvaluation(80, true)
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createMockSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(1)
+      expect(mocks.metadataGet).toHaveBeenCalledWith(
+        expect.objectContaining({ spanId: 'span-1' }),
+      )
+    })
+
+    it('evaluates only the last span when trigger target is last', async () => {
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+      mockEvaluation(90, true)
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createMockSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(1)
+      expect(mocks.metadataGet).toHaveBeenCalledWith(
+        expect.objectContaining({ spanId: 'span-3' }),
+      )
+    })
+
+    it('evaluates all spans when trigger target is every', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 70, passed: true },
+        { score: 80, passed: true },
+        { score: 90, passed: true },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createMockSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(3)
+    })
+
+    it('defaults to every when no trigger is configured', async () => {
+      const evaluation = createEvaluation()
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 60, passed: false },
+        { score: 80, passed: true },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(2)
+    })
+
+    it('filters out non-main spans before applying trigger', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 75, passed: true },
+        { score: 85, passed: true },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('tool-span', SpanType.Tool, new Date('2024-01-01T00:00:30Z')),
+        createMockSpan('completion-span', SpanType.Completion, new Date('2024-01-01T00:00:45Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('aggregation of evaluation results', () => {
+    it('averages scores across all spans for every trigger', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 60, passed: true },
+        { score: 80, passed: true },
+        { score: 100, passed: true },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+        createMockSpan('span-3', SpanType.Prompt, new Date('2024-01-01T00:02:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      const trajectory = result.value!
+      expect(trajectory.score).toBeCloseTo(80 / 100, 2)
+    })
+
+    it('fails passed if any span evaluation fails', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 90, passed: true },
+        { score: 30, passed: false },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value!.passed).toBe(false)
+    })
+
+    it('includes turn labels in feedback for multi-span evaluation', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 70, passed: true },
+        { score: 90, passed: true },
+      ])
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value!.feedback).toContain('[Turn 1]')
+      expect(result.value!.feedback).toContain('[Turn 2]')
+    })
+
+    it('returns single result directly for first trigger', async () => {
+      const evaluation = createEvaluation('first')
+      mockRunDocumentAtCommit()
+      mockEvaluation(85, true)
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value!.feedback).not.toContain('[Turn')
+    })
+  })
+
+  describe('multi-turn simulation', () => {
+    const simulationOptimization = {
+      ...baseOptimization,
+      configuration: {
+        simulation: {
+          simulateToolResponses: true,
+          simulatedTools: [],
+          toolSimulationInstructions: '',
+          maxTurns: 3,
+          simulatedUserGoal: 'Test the agent',
+        },
+      },
+    }
+
+    it('runs simulation when maxTurns > 1', async () => {
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+      mockEvaluation(80, true)
+
+      mocks.generateSimulatedUserAction
+        .mockResolvedValueOnce(
+          Result.ok({ action: 'continue', message: 'Turn 2 message' }),
+        )
+        .mockResolvedValueOnce(Result.ok({ action: 'end', message: '' }))
+
+      const addMessagesResult = {
+        error: Promise.resolve(null),
+        messages: Promise.resolve([
+          { role: 'user', content: [{ type: 'text', text: 'Turn 2 message' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Response 2' }] },
+        ]),
+      }
+      mocks.addMessages.mockResolvedValue(Result.ok(addMessagesResult))
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: simulationOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.generateSimulatedUserAction).toHaveBeenCalledTimes(2)
+      expect(mocks.addMessages).toHaveBeenCalledTimes(1)
+    })
+
+    it('waits for correct number of main spans based on turnsExecuted', async () => {
+      const evaluation = createEvaluation('every')
+      mockRunDocumentAtCommit()
+      mockEvaluationSequence([
+        { score: 70, passed: true },
+        { score: 90, passed: true },
+      ])
+
+      mocks.generateSimulatedUserAction
+        .mockResolvedValueOnce(
+          Result.ok({ action: 'continue', message: 'Turn 2 message' }),
+        )
+        .mockResolvedValueOnce(Result.ok({ action: 'end', message: '' }))
+
+      const addMessagesResult = {
+        error: Promise.resolve(null),
+        messages: Promise.resolve([
+          { role: 'assistant', content: [{ type: 'text', text: 'Response 1' }] },
+          { role: 'user', content: [{ type: 'text', text: 'Turn 2 message' }] },
+          { role: 'assistant', content: [{ type: 'text', text: 'Response 2' }] },
+        ]),
+      }
+      mocks.addMessages.mockResolvedValue(Result.ok(addMessagesResult))
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        createMockSpan('span-2', SpanType.Prompt, new Date('2024-01-01T00:01:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: simulationOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not simulate when maxTurns is 1', async () => {
+      const noSimulationOpt = {
+        ...baseOptimization,
+        configuration: {
+          simulation: {
+            simulateToolResponses: true,
+            simulatedTools: [],
+            toolSimulationInstructions: '',
+            maxTurns: 1,
+          },
+        },
+      }
+
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+      mockEvaluation(80, true)
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: noSimulationOpt,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.generateSimulatedUserAction).not.toHaveBeenCalled()
+      expect(mocks.addMessages).not.toHaveBeenCalled()
+    })
+
+    it('does not simulate when no simulation config exists', async () => {
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+      mockEvaluation(80, true)
+
+      const spans = [
+        createMockSpan('span-1', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+      ]
+      mockSpansAndMetadata(spans)
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(mocks.generateSimulatedUserAction).not.toHaveBeenCalled()
+    })
+
+    it('returns learnable trajectory on simulation error', async () => {
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+
+      mocks.generateSimulatedUserAction.mockResolvedValue(
+        Result.error(new Error('Simulation failed')),
+      )
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: simulationOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const result = await evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      expect(result.ok).toBe(true)
+      expect(result.value!.feedback).toContain('multi-turn simulation')
+      expect(result.value!.feedback).toContain('Simulation failed')
+    })
+  })
+
+  describe('span waiting', () => {
+    it('times out when expected spans do not appear', async () => {
+      vi.useFakeTimers()
+
+      const evaluation = createEvaluation('last')
+      mockRunDocumentAtCommit()
+
+      mocks.listByDocumentLogUuid.mockResolvedValue([])
+
+      const evaluate = await evaluateFactory({
+        columns: [],
+        evaluation,
+        optimization: baseOptimization,
+        document: baseDocument,
+        commit: baseCommit,
+        workspace: baseWorkspace,
+      })
+
+      const resultPromise = evaluate({
+        prompt: baseDocument.content,
+        example: baseExample,
+      })
+
+      for (let i = 0; i < 15; i++) {
+        await vi.advanceTimersByTimeAsync(3000)
+      }
+
+      const result = await resultPromise
+
+      vi.useRealTimers()
+
+      expect(result.ok).toBe(false)
+      expect(result.error!.message).toContain(
+        'Expected main spans did not appear',
+      )
+    })
+
+    it('handles single span correctly for all trigger targets', async () => {
+      for (const target of ['first', 'every', 'last'] as const) {
+        vi.clearAllMocks()
+        mockScanDocumentContent()
+        mockRunDocumentAtCommit()
+        mockEvaluation(75, true)
+
+        const spans = [
+          createMockSpan('only-span', SpanType.Prompt, new Date('2024-01-01T00:00:00Z')),
+        ]
+        mockSpansAndMetadata(spans)
+
+        const evaluation = createEvaluation(target)
+        const evaluate = await evaluateFactory({
+          columns: [],
+          evaluation,
+          optimization: baseOptimization,
+          document: baseDocument,
+          commit: baseCommit,
+          workspace: baseWorkspace,
+        })
+
+        const result = await evaluate({
+          prompt: baseDocument.content,
+          example: baseExample,
+        })
+
+        expect(result.ok).toBe(true)
+        expect(mocks.runEvaluationV2).toHaveBeenCalledTimes(1)
+      }
+    })
+  })
+})

--- a/packages/core/src/services/optimizations/validate/start.ts
+++ b/packages/core/src/services/optimizations/validate/start.ts
@@ -139,12 +139,10 @@ export async function startValidateOptimization(
     toRow: testrows, // Note: 1-based index
   }
 
-  const simulation = {
-    simulateToolResponses:
-      optimization.configuration.simulation?.simulateToolResponses ?? true,
-    simulatedTools: optimization.configuration.simulation?.simulatedTools ?? [], // Note: empty array means all tools are simulated
-    toolSimulationInstructions:
-      optimization.configuration.simulation?.toolSimulationInstructions ?? '',
+  const simulation = optimization.configuration.simulation ?? {
+    simulateToolResponses: true,
+    simulatedTools: [], // Note: empty array means all tools are simulated
+    toolSimulationInstructions: '',
   }
 
   const creatingex = await transaction.call(async (tx) => {


### PR DESCRIPTION
## Summary

The optimization pipeline's simulation settings already supported multi-turn conversation configuration (`maxTurns`, `simulatedUserGoal`), but the actual simulation logic was never executed during optimization runs. Only tool simulation was being applied.

This adds multi-turn user simulation to the two places where documents are executed in the optimization pipeline:

- **Execute phase**: After `runDocumentAtCommit` in the GEPA evaluation loop, simulated user turns are now generated and sent via `addMessages`, mirroring the pattern used in background run jobs. The span lookup was also updated to find the last main span in the conversation (Prompt or Chat) rather than only the first Prompt span, so evaluations run against the final state of a multi-turn conversation.

- **Validate phase**: The experiment creation now forwards the full simulation settings from the optimization configuration, rather than only the tool-related subset. The downstream experiment pipeline already handled multi-turn simulation, so this was a data-passing fix. In addition to the simulation, the evaluation now runs with the configured target of each evaluation.