### PR TITLE
Fix tool simulation not applied in multi-turn conversation turns

### DIFF
--- a/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.test.ts
+++ b/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.test.ts
@@ -373,6 +373,7 @@ describe('multiTurnSimulation', () => {
         tools: {},
         mcpHeaders,
         abortSignal: undefined,
+        simulationSettings: { maxTurns: 3 },
       })
     })
 

--- a/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.ts
+++ b/packages/core/src/jobs/job-definitions/runs/helpers/multiTurnSimulation.ts
@@ -5,9 +5,9 @@ import {
   SimulationSettings,
 } from '@latitude-data/constants/simulation'
 import { RedisStream } from '../../../../lib/redisStream'
+import { PromisedResult } from '../../../../lib/Transaction'
 import { Result } from '../../../../lib/Result'
 import { incrementTokens } from '../../../../lib/streamManager'
-import { PromisedResult } from '../../../../lib/Transaction'
 import { WorkspaceDto } from '../../../../schema/models/types/Workspace'
 import { addMessages } from '../../../../services/documentLogs/addMessages'
 import { ToolHandler } from '../../../../services/documents/tools/clientTools/handlers'
@@ -39,6 +39,7 @@ type ExecuteSingleTurnArgs = RunIdentifiers & {
   currentTurn: number
   maxTurns: number
   simulationInstructions?: string
+  simulationSettings?: SimulationSettings
   workspace: WorkspaceDto
   documentLogUuid: string
   tools: Record<string, ToolHandler>
@@ -62,6 +63,7 @@ type TurnResult = {
  */
 async function executeSingleTurn({
   simulationInstructions,
+  simulationSettings,
   currentTurn,
   maxTurns,
   messages,
@@ -123,6 +125,7 @@ async function executeSingleTurn({
     tools,
     mcpHeaders,
     abortSignal,
+    simulationSettings,
   })
 
   if (!Result.isOk(addMessagesResult)) {
@@ -224,6 +227,7 @@ export async function simulateUserResponses({
 
     const turnResult = await executeSingleTurn({
       simulationInstructions: simulationSettings.simulatedUserGoal,
+      simulationSettings,
       currentTurn,
       maxTurns,
       messages,

--- a/packages/core/src/services/documentLogs/addMessages/index.ts
+++ b/packages/core/src/services/documentLogs/addMessages/index.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from '@latitude-data/constants/errors'
 import { LatitudePromptConfig } from '@latitude-data/constants/latitudePromptSchema'
 import { type Message } from '@latitude-data/constants/messages'
+import { SimulationSettings } from '@latitude-data/constants/simulation'
 import { LogSources } from '../../../constants'
 import { isRetryableError } from '../../../lib/isRetryableError'
 import { Result } from '../../../lib/Result'
@@ -36,6 +37,7 @@ type AddMessagesArgs = {
   abortSignal?: AbortSignal
   context?: TelemetryContext
   testDeploymentId?: number
+  simulationSettings?: SimulationSettings
 }
 
 export async function addMessages(
@@ -48,6 +50,7 @@ export async function addMessages(
     tools = {},
     mcpHeaders,
     context = BACKGROUND({ workspaceId: workspace.id }),
+    simulationSettings,
   }: AddMessagesArgs,
   telemetry: LatitudeTelemetry = realTelemetry,
 ) {
@@ -103,6 +106,7 @@ export async function addMessages(
     tools,
     mcpHeaders,
     abortSignal,
+    simulationSettings,
   })
 
   const { start, ...streamResult } = streamManager.prepare()

--- a/packages/core/src/services/optimizations/optimizers/evaluate.ts
+++ b/packages/core/src/services/optimizations/optimizers/evaluate.ts
@@ -635,6 +635,7 @@ async function simulateConversation({
       ],
       source: LogSources.Optimization,
       abortSignal,
+      simulationSettings,
     })
     if (addResult.error) {
       return Result.error(addResult.error)


### PR DESCRIPTION
## Summary
Multi-turn simulated conversations (used in background runs and optimizations) failed when the prompt used tools. The first turn correctly applied simulation settings to resolve tools as simulated, but all subsequent turns via `addMessages` did not forward `simulationSettings` to the stream manager. This caused tools to be unresolvable (no client handler, no simulation fallback), breaking the conversation after the first turn.

`simulationSettings` is now propagated through the full multi-turn loop so that tool simulation remains active for every turn of the conversation.