### PR TITLE
test(core): update simulation error expectation

### DIFF
--- a/packages/core/src/services/optimizations/optimizers/evaluate.test.ts
+++ b/packages/core/src/services/optimizations/optimizers/evaluate.test.ts
@@ -681,7 +681,7 @@ describe('evaluateFactory', () => {
       expect(mocks.generateSimulatedUserAction).not.toHaveBeenCalled()
     })
 
-    it('returns learnable trajectory on simulation error', async () => {
+    it('returns error on simulation error', async () => {
       const evaluation = createEvaluation('last')
       mockRunDocumentAtCommit()
 
@@ -703,9 +703,8 @@ describe('evaluateFactory', () => {
         example: baseExample,
       })
 
-      expect(result.ok).toBe(true)
-      expect(result.value!.feedback).toContain('multi-turn simulation')
-      expect(result.value!.feedback).toContain('Simulation failed')
+      expect(result.ok).toBe(false)
+      expect(result.error!.message).toContain('Simulation failed')
     })
   })
 


### PR DESCRIPTION
CI is failing on main because evaluate.test.ts still expects simulation errors to be learnable (result.ok=true), but simulateConversation now returns Result.error for post-first-turn simulation errors (commit 0ecb7d2).

This updates the test to assert result.ok=false and to match the propagated error message.