### PR TITLE
Fix moving a trace between issues leaving source issue behind

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/getAll/getAll.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/getAll/getAll.handler.ts
@@ -1,11 +1,11 @@
 import { Context } from 'hono'
-import { ProjectsRepository } from '@latitude-data/core/repositories'
+import { projectsScope } from '@latitude-data/core/queries/projects/scope'
+import { findAllActiveProjects } from '@latitude-data/core/queries/projects/findAllActive'
 
 export const getAllHandler = async (c: Context) => {
   const workspace = c.get('workspace')
-  const projectsRepository = new ProjectsRepository(workspace.id)
-  const projectsResult = await projectsRepository.findAllActive()
-  const projects = projectsResult.unwrap()
+  const projects = projectsScope(workspace.id)
+  const result = await findAllActiveProjects(projects)
 
-  return c.json(projects, 200)
+  return c.json(result.unwrap(), 200)
 }

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,4 +1,5 @@
-import { ProjectsRepository } from '@latitude-data/core/repositories'
+import { projectsScope } from '@latitude-data/core/queries/projects/scope'
+import { findAllActiveProjects } from '@latitude-data/core/queries/projects/findAllActive'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
@@ -14,10 +15,10 @@ export const GET = errorHandler(
         workspace: Workspace
       },
     ) => {
-      const scope = new ProjectsRepository(workspace.id)
-      const projects = await scope.findAllActive().then((r) => r.unwrap())
+      const projects = projectsScope(workspace.id)
+      const result = await findAllActiveProjects(projects)
 
-      return NextResponse.json(projects, { status: 200 })
+      return NextResponse.json(result.unwrap(), { status: 200 })
     },
   ),
 )

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,6 +100,12 @@
     "./utils/*": {
       "import": "./src/utils/*.ts"
     },
+    "./queries": {
+      "import": "./src/queries/index.ts"
+    },
+    "./queries/*": {
+      "import": "./src/queries/*.ts"
+    },
     "./telemetry": {
       "import": "./src/telemetry/index.ts"
     }

--- a/packages/core/src/queries/index.ts
+++ b/packages/core/src/queries/index.ts
@@ -1,0 +1,27 @@
+export {
+  scope,
+  unsafeScope,
+  findAll,
+  findById,
+  findMany,
+  findFirst,
+} from './scope'
+export type { Scope, UnsafeScope, QueryOptions } from './scope'
+
+export { projectsScope } from './projects/scope'
+export type { ProjectsScope } from './projects/scope'
+export { findProjectById } from './projects/findById'
+export { findProjectByName } from './projects/findByName'
+export { findProjectByDocumentUuid } from './projects/findByDocumentUuid'
+export { findFirstProject } from './projects/findFirst'
+export { findAllActiveProjects } from './projects/findAllActive'
+
+export { workspaceUsersScope, usersScope } from './users/scope'
+export type { WorkspaceUsersScope, UsersScope } from './users/scope'
+export { unsafelyFindUserById } from './users/findById'
+export {
+  unsafelyFindUserByEmail,
+  unsafelyFindUserIdByEmail,
+} from './users/findByEmail'
+export { findFirstUserInWorkspace } from './users/findFirstInWorkspace'
+export { lockUser } from './users/lock'

--- a/packages/core/src/queries/projects/findAllActive.ts
+++ b/packages/core/src/queries/projects/findAllActive.ts
@@ -1,0 +1,16 @@
+import { desc, isNull } from 'drizzle-orm'
+
+import { type Project } from '../../schema/models/types/Project'
+import { Result, TypedResult } from '../../lib/Result'
+import { projects } from '../../schema/models/projects'
+import { type ProjectsScope } from './scope'
+
+export async function findAllActiveProjects(
+  scope: ProjectsScope,
+): Promise<TypedResult<Project[]>> {
+  const result = await scope
+    .where(isNull(projects.deletedAt))
+    .orderBy(desc(projects.lastEditedAt), desc(projects.id))
+
+  return Result.ok(result as Project[])
+}

--- a/packages/core/src/queries/projects/findByDocumentUuid.ts
+++ b/packages/core/src/queries/projects/findByDocumentUuid.ts
@@ -1,0 +1,31 @@
+import { and, eq, getTableColumns } from 'drizzle-orm'
+
+import { type Project } from '../../schema/models/types/Project'
+import { NotFoundError } from '../../lib/errors'
+import { Result, TypedResult } from '../../lib/Result'
+import { commits } from '../../schema/models/commits'
+import { documentVersions } from '../../schema/models/documentVersions'
+import { projects } from '../../schema/models/projects'
+import { type ProjectsScope } from './scope'
+
+const NOT_FOUND_MSG = 'Project not found'
+
+export async function findProjectByDocumentUuid(
+  scope: ProjectsScope,
+  documentUuid: string,
+): Promise<TypedResult<Project>> {
+  const tt = getTableColumns(projects)
+  const results = await scope.db
+    .select(tt)
+    .from(projects)
+    .innerJoin(commits, eq(commits.projectId, projects.id))
+    .innerJoin(documentVersions, eq(documentVersions.commitId, commits.id))
+    .where(and(scope.filter, eq(documentVersions.documentUuid, documentUuid)))
+    .limit(1)
+
+  if (results.length === 0) {
+    return Result.error(new NotFoundError(NOT_FOUND_MSG))
+  }
+
+  return Result.ok(results[0]!)
+}

--- a/packages/core/src/queries/projects/findById.ts
+++ b/packages/core/src/queries/projects/findById.ts
@@ -1,0 +1,19 @@
+import { eq } from 'drizzle-orm'
+
+import { type Project } from '../../schema/models/types/Project'
+import { NotFoundError } from '../../lib/errors'
+import { Result, TypedResult } from '../../lib/Result'
+import { projects } from '../../schema/models/projects'
+import { type ProjectsScope } from './scope'
+
+const NOT_FOUND_MSG = 'Project not found'
+
+export async function findProjectById(
+  scope: ProjectsScope,
+  id: number,
+): Promise<TypedResult<Project>> {
+  const result = await scope.where(eq(projects.id, id)).limit(1)
+  const project = result[0] as Project | undefined
+  if (!project) return Result.error(new NotFoundError(NOT_FOUND_MSG))
+  return Result.ok(project)
+}

--- a/packages/core/src/queries/projects/findByName.ts
+++ b/packages/core/src/queries/projects/findByName.ts
@@ -1,0 +1,19 @@
+import { eq } from 'drizzle-orm'
+
+import { type Project } from '../../schema/models/types/Project'
+import { NotFoundError } from '../../lib/errors'
+import { Result, TypedResult } from '../../lib/Result'
+import { projects } from '../../schema/models/projects'
+import { type ProjectsScope } from './scope'
+
+const NOT_FOUND_MSG = 'Project not found'
+
+export async function findProjectByName(
+  scope: ProjectsScope,
+  name: string,
+): Promise<TypedResult<Project>> {
+  const result = await scope.where(eq(projects.name, name)).limit(1)
+  const project = result[0] as Project | undefined
+  if (!project) return Result.error(new NotFoundError(NOT_FOUND_MSG))
+  return Result.ok(project)
+}

--- a/packages/core/src/queries/projects/findFirst.ts
+++ b/packages/core/src/queries/projects/findFirst.ts
@@ -1,0 +1,15 @@
+import { type Project } from '../../schema/models/types/Project'
+import { NotFoundError } from '../../lib/errors'
+import { Result, TypedResult } from '../../lib/Result'
+import { type ProjectsScope } from './scope'
+
+const NOT_FOUND_MSG = 'Project not found'
+
+export async function findFirstProject(
+  scope: ProjectsScope,
+): Promise<TypedResult<Project>> {
+  const result = await scope.base().limit(1)
+  const project = result[0] as Project | undefined
+  if (!project) return Result.error(new NotFoundError(NOT_FOUND_MSG))
+  return Result.ok(project)
+}

--- a/packages/core/src/queries/projects/scope.ts
+++ b/packages/core/src/queries/projects/scope.ts
@@ -1,0 +1,14 @@
+import { eq, getTableColumns } from 'drizzle-orm'
+
+import { type Project } from '../../schema/models/types/Project'
+import { projects } from '../../schema/models/projects'
+import { scope } from '../scope'
+
+const tt = getTableColumns(projects)
+
+export const projectsScope = scope<Project>({
+  from: (db) => db.select(tt).from(projects).$dynamic(),
+  tenancyFilter: (workspaceId) => eq(projects.workspaceId, workspaceId),
+})
+
+export type ProjectsScope = ReturnType<typeof projectsScope>

--- a/packages/core/src/queries/scope.ts
+++ b/packages/core/src/queries/scope.ts
@@ -1,0 +1,113 @@
+import { and, eq, inArray, SQL } from 'drizzle-orm'
+import { PgColumn, PgSelect } from 'drizzle-orm/pg-core'
+
+import { Database, database } from '../client'
+import { NotFoundError } from '../lib/errors'
+import { Result, TypedResult } from '../lib/Result'
+
+export type QueryOptions = {
+  limit?: number
+  offset?: number
+}
+
+export type Scope<TResult extends Record<string, unknown>> = {
+  workspaceId: number
+  db: Database
+  filter: SQL<unknown> | undefined
+  base(): PgSelect
+  where(...conditions: (SQL<unknown> | undefined)[]): PgSelect
+}
+
+export type UnsafeScope<TResult extends Record<string, unknown>> = {
+  db: Database
+  base(): PgSelect
+  where(...conditions: (SQL<unknown> | undefined)[]): PgSelect
+}
+
+/**
+ * Creates a workspace-scoped query factory.
+ * The `from` callback must return a dynamic query (call `.$dynamic()` at the end).
+ */
+export function scope<TResult extends Record<string, unknown>>(config: {
+  from: (db: Database) => PgSelect
+  tenancyFilter: (workspaceId: number) => SQL<unknown> | undefined
+}) {
+  return function createScope(
+    workspaceId: number,
+    db: Database = database,
+  ): Scope<TResult> {
+    const filter = config.tenancyFilter(workspaceId)
+
+    return {
+      workspaceId,
+      db,
+      filter,
+      base() {
+        return config.from(db).where(filter)
+      },
+      where(...conditions: (SQL<unknown> | undefined)[]) {
+        return config.from(db).where(and(filter, ...conditions))
+      },
+    }
+  }
+}
+
+/**
+ * Creates a non-tenanted query factory (no workspace scoping).
+ * The `from` callback must return a dynamic query (call `.$dynamic()` at the end).
+ */
+export function unsafeScope<TResult extends Record<string, unknown>>(config: {
+  from: (db: Database) => PgSelect
+}) {
+  return function createUnsafeScope(
+    db: Database = database,
+  ): UnsafeScope<TResult> {
+    return {
+      db,
+      base() {
+        return config.from(db)
+      },
+      where(...conditions: (SQL<unknown> | undefined)[]) {
+        return config.from(db).where(and(...conditions))
+      },
+    }
+  }
+}
+
+export async function findAll<TResult extends Record<string, unknown>>(
+  s: Scope<TResult> | UnsafeScope<TResult>,
+  opts: QueryOptions = {},
+): Promise<TypedResult<TResult[]>> {
+  let query = s.base()
+  if (opts.limit !== undefined) query = query.limit(opts.limit)
+  if (opts.offset !== undefined) query = query.offset(opts.offset)
+  return Result.ok((await query) as TResult[])
+}
+
+export async function findById<TResult extends Record<string, unknown>>(
+  s: Scope<TResult> | UnsafeScope<TResult>,
+  idColumn: PgColumn,
+  id: string | number | null | undefined,
+): Promise<TypedResult<TResult>> {
+  const rows = await s.where(eq(idColumn, id!)).limit(1)
+  const row = rows[0]
+  if (!row)
+    return Result.error(new NotFoundError(`Record with id ${id} not found`))
+  return Result.ok(row as TResult)
+}
+
+export async function findMany<TResult extends Record<string, unknown>>(
+  s: Scope<TResult> | UnsafeScope<TResult>,
+  idColumn: PgColumn,
+  ids: (string | number)[],
+): Promise<TypedResult<TResult[]>> {
+  const rows = await s.where(inArray(idColumn, ids)).limit(ids.length)
+  return Result.ok(rows as TResult[])
+}
+
+export async function findFirst<TResult extends Record<string, unknown>>(
+  s: Scope<TResult> | UnsafeScope<TResult>,
+): Promise<TypedResult<TResult | undefined>> {
+  const rows = await s.base().limit(1)
+  return Result.ok(rows[0] as TResult | undefined)
+}

--- a/packages/core/src/queries/users/findByEmail.ts
+++ b/packages/core/src/queries/users/findByEmail.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm'
+
+import { type User } from '../../schema/models/types/User'
+import { users } from '../../schema/models/users'
+import { type UsersScope } from './scope'
+
+export async function unsafelyFindUserByEmail(
+  scope: UsersScope,
+  email: string,
+): Promise<User | null> {
+  const rows = await scope.where(eq(users.email, email)).limit(1)
+  return (rows[0] as User) ?? null
+}
+
+export async function unsafelyFindUserIdByEmail(
+  scope: UsersScope,
+  email: string,
+): Promise<{ id: string; email: string } | undefined> {
+  const rows = await scope.db
+    .select({ id: users.id, email: users.email })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1)
+  return rows[0]
+}

--- a/packages/core/src/queries/users/findById.ts
+++ b/packages/core/src/queries/users/findById.ts
@@ -1,0 +1,13 @@
+import { eq } from 'drizzle-orm'
+
+import { type User } from '../../schema/models/types/User'
+import { users } from '../../schema/models/users'
+import { type UsersScope } from './scope'
+
+export async function unsafelyFindUserById(
+  scope: UsersScope,
+  id: string,
+): Promise<User | null> {
+  const rows = await scope.where(eq(users.id, id)).limit(1)
+  return (rows[0] as User) ?? null
+}

--- a/packages/core/src/queries/users/findFirstInWorkspace.ts
+++ b/packages/core/src/queries/users/findFirstInWorkspace.ts
@@ -1,0 +1,10 @@
+import { asc } from 'drizzle-orm'
+
+import { type User } from '../../schema/models/types/User'
+import { users } from '../../schema/models/users'
+import { type WorkspaceUsersScope } from './scope'
+
+export async function findFirstUserInWorkspace(scope: WorkspaceUsersScope) {
+  const results = await scope.base().orderBy(asc(users.createdAt)).limit(1)
+  return results[0] as User
+}

--- a/packages/core/src/queries/users/lock.ts
+++ b/packages/core/src/queries/users/lock.ts
@@ -1,0 +1,35 @@
+import { sql } from 'drizzle-orm'
+
+import { databaseErrorCodes, UnprocessableEntityError } from '../../lib/errors'
+import { Result, TypedResult } from '../../lib/Result'
+import { memberships } from '../../schema/models/memberships'
+import { users } from '../../schema/models/users'
+import { type WorkspaceUsersScope } from './scope'
+
+export async function lockUser(
+  scope: WorkspaceUsersScope,
+  { id, wait }: { id: string; wait?: boolean },
+): Promise<TypedResult<undefined>> {
+  const shouldWait = wait !== false
+
+  try {
+    await scope.db.execute(sql<boolean>`
+      SELECT TRUE
+      FROM ${users}
+      INNER JOIN ${memberships} ON ${memberships.userId} = ${users.id}
+      WHERE (
+        ${memberships.workspaceId} = ${scope.workspaceId} AND
+        ${users.id} = ${id}
+      ) LIMIT 1 FOR NO KEY UPDATE ${sql.raw(!shouldWait ? 'NOWAIT' : '')};
+        `)
+  } catch (error: any) {
+    if (error?.code === databaseErrorCodes.lockNotAvailable) {
+      return Result.error(
+        new UnprocessableEntityError('Cannot obtain lock on user'),
+      )
+    }
+    return Result.error(error as Error)
+  }
+
+  return Result.nil()
+}

--- a/packages/core/src/queries/users/scope.ts
+++ b/packages/core/src/queries/users/scope.ts
@@ -1,0 +1,31 @@
+import { eq, getTableColumns } from 'drizzle-orm'
+
+import { type User } from '../../schema/models/types/User'
+import { memberships } from '../../schema/models/memberships'
+import { users } from '../../schema/models/users'
+import { scope, unsafeScope } from '../scope'
+
+const tt = {
+  ...getTableColumns(users),
+  confirmedAt: memberships.confirmedAt,
+}
+
+export const workspaceUsersScope = scope<User>({
+  from: (db) =>
+    db
+      .select(tt)
+      .from(users)
+      .innerJoin(memberships, eq(memberships.userId, users.id))
+      .$dynamic(),
+  tenancyFilter: (workspaceId) => eq(memberships.workspaceId, workspaceId),
+})
+
+export type WorkspaceUsersScope = ReturnType<typeof workspaceUsersScope>
+
+const unsafeTt = getTableColumns(users)
+
+export const usersScope = unsafeScope<User>({
+  from: (db) => db.select(unsafeTt).from(users).$dynamic(),
+})
+
+export type UsersScope = ReturnType<typeof usersScope>

--- a/packages/core/src/services/billing/utils.ts
+++ b/packages/core/src/services/billing/utils.ts
@@ -2,7 +2,8 @@ import Stripe from 'stripe'
 import { BillingError } from '@latitude-data/constants/errors'
 import { STRIPE_PLANS, SubscriptionPlans } from '../../plans'
 import { Workspace } from '../../schema/models/types/Workspace'
-import { findFirstUserInWorkspace } from '../../data-access/users'
+import { workspaceUsersScope } from '../../queries/users/scope'
+import { findFirstUserInWorkspace } from '../../queries/users/findFirstInWorkspace'
 import { Result } from '../../lib/Result'
 
 /**
@@ -58,7 +59,8 @@ export function findTargetPlan(stripeSubscription: Stripe.Subscription) {
 }
 
 export async function getFirstUserAsBillingActor(workspace: Workspace) {
-  const user = await findFirstUserInWorkspace(workspace)
+  const usersInWorkspace = workspaceUsersScope(workspace.id)
+  const user = await findFirstUserInWorkspace(usersInWorkspace)
 
   if (!user) {
     return Result.error(

--- a/packages/core/src/services/copilot/getCopilotData.ts
+++ b/packages/core/src/services/copilot/getCopilotData.ts
@@ -9,7 +9,10 @@ import {
   unsafelyGetFirstApiKeyByWorkspaceId,
 } from '../../data-access/apiKeys'
 import { Result, TypedResult } from '../../lib/Result'
-import { CommitsRepository, ProjectsRepository } from '../../repositories'
+import { CommitsRepository } from '../../repositories'
+import { projectsScope } from '../../queries/projects/scope'
+import { findProjectById } from '../../queries/projects/findById'
+import { findProjectByName } from '../../queries/projects/findByName'
 import { type Project } from '../../schema/models/types/Project'
 import { type WorkspaceDto } from '../../schema/models/types/Workspace'
 import { Commit } from '../../schema/models/types/Commit'
@@ -48,8 +51,8 @@ export async function getCopilotData(
       return Result.error(new Error('Copilot workspace not found'))
     }
 
-    const projectsRepository = new ProjectsRepository(workspace.id, db)
-    const projectResult = await projectsRepository.getProjectByName(projectName)
+    const projects = projectsScope(workspace.id, db)
+    const projectResult = await findProjectByName(projects, projectName)
     if (projectResult.error) {
       return Result.error(new Error('Copilot project not found'))
     }
@@ -108,8 +111,8 @@ export async function getCopilotData(
     return Result.error(new Error('Copilot workspace not found'))
   }
 
-  const projectsRepository = new ProjectsRepository(workspace.id, db)
-  const projectResult = await projectsRepository.getProjectById(projectId)
+  const projects = projectsScope(workspace.id, db)
+  const projectResult = await findProjectById(projects, projectId)
   if (projectResult.error) {
     return Result.error(new Error('Copilot project not found'))
   }


### PR DESCRIPTION
### Problem\nWhen a trace appears as a single entry in an issue, moving it to another issue from the trace UI can still leave the same trace in the source issue. This happens because issues are linked to *evaluation_results_v2*; the issue trace list is deduped by (evaluatedSpanId,evaluatedTraceId), so multiple evaluation results for the same trace can keep the trace visible even after reassigning the latest result.\n\n### Fix\nIn , when removing from the current issue, remove *all* issue↔evaluation-result associations for the same evaluatedSpanId/evaluatedTraceId within the current evaluation, rather than only the single evaluation result. This allows the source issue to truly become empty and be deleted when appropriate.\n\n### Tests\nAdded a unit test ensuring all evaluation results for the same trace are removed from the current issue.