### PR TITLE
Fix annotation failing for traces without a document UUID

### DIFF
--- a/apps/web/src/components/evaluations/Annotation/Form/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/index.tsx
@@ -123,7 +123,7 @@ export function AnnotationForm<
       commit={commit}
       span={span}
       evaluation={evaluation}
-      documentUuid={span.documentUuid ?? ''}
+      documentUuid={evaluation.documentUuid}
       result={result}
       onSubmit={wrappedOnSubmit}
       isSubmitting={isSubmitting}

--- a/apps/web/src/components/evaluations/Annotation/useAnnotationForm.ts
+++ b/apps/web/src/components/evaluations/Annotation/useAnnotationForm.ts
@@ -43,7 +43,7 @@ export function useAnnotationForm<
     commit,
     document: {
       commitId: commit.id,
-      documentUuid: span.documentUuid!,
+      documentUuid: evaluation.documentUuid,
     },
   })
   const { mutate } = useEvaluationResultsV2BySpans({
@@ -51,7 +51,7 @@ export function useAnnotationForm<
     commit,
     document: {
       commitId: commit.id,
-      documentUuid: span.documentUuid!,
+      documentUuid: evaluation.documentUuid,
     },
     spanId: span.id,
     documentLogUuid: span.documentLogUuid,
@@ -62,7 +62,7 @@ export function useAnnotationForm<
 
       startTransition(async () => {
         const [updatedResult, errors] = await annotateEvaluation({
-          documentUuid: span.documentUuid!,
+          documentUuid: evaluation.documentUuid,
           evaluationUuid: evaluation.uuid,
           spanId: span.id,
           traceId: span.traceId,


### PR DESCRIPTION
## Summary
Annotating a trace would fail with `Invalid data: {"documentUuid": ["Invalid input: expected string, received null"]}` when the span being annotated had no `documentUuid` (e.g., traces sent via the SDK/API without a document context).

The annotation flow was sourcing `documentUuid` from the span, which is optional and can be null. It now sources it from the evaluation, which is always scoped to a document and always has a valid `documentUuid`.