### PR TITLE
Allow removing passed results from issues

### DIFF
--- a/packages/core/src/services/issues/results/remove.ts
+++ b/packages/core/src/services/issues/results/remove.ts
@@ -53,6 +53,7 @@ export async function removeResultFromIssue<
     result: { result, evaluation },
     issue: issue,
     skipBelongsCheck: true,
+    skipPassedCheck: true,
   })
   if (validating.error) {
     return Result.error(validating.error)
@@ -104,6 +105,7 @@ export async function removeResultFromIssue<
           result: { result, evaluation },
           issue: issue,
           skipBelongsCheck: true,
+          skipPassedCheck: true,
         },
         tx,
       )

--- a/packages/core/src/services/issues/results/validate.ts
+++ b/packages/core/src/services/issues/results/validate.ts
@@ -20,11 +20,13 @@ export async function validateResultForIssue<
     issue,
     skipBelongsCheck = false,
     skipReasonCheck = false,
+    skipPassedCheck = false,
   }: {
     result: ResultWithEvaluationV2<T, M>
     issue?: Issue
     skipBelongsCheck?: boolean
     skipReasonCheck?: boolean
+    skipPassedCheck?: boolean
   },
   db = database,
 ) {
@@ -36,7 +38,7 @@ export async function validateResultForIssue<
     )
   }
 
-  if (result.hasPassed) {
+  if (result.hasPassed && !skipPassedCheck) {
     return Result.error(
       new UnprocessableEntityError('Cannot use a result that has passed'),
     )


### PR DESCRIPTION
## Summary
This change allows the result removal operation to bypass the validation check that prevents using results that have already passed, enabling cleanup of passed results from issues.

## Key Changes
- Added `skipPassedCheck` parameter to `validateResultForIssue()` function to optionally skip the validation that rejects passed results
- Updated `removeResultFromIssue()` to set `skipPassedCheck: true` when validating results before removal, allowing both initial validation and transaction-based removal to proceed even if the result has passed

## Implementation Details
The `skipPassedCheck` parameter defaults to `false`, maintaining backward compatibility and preserving the existing validation behavior for other callers. Only the removal operation explicitly opts into skipping this check, which is appropriate since removing a passed result is a valid cleanup operation.

https://claude.ai/code/session_01TnAdfFYFsErysRawZE31oj