### PR TITLE
Support Chat and External spans in annotations

### DIFF
--- a/apps/web/src/actions/evaluationsV2/annotate.ts
+++ b/apps/web/src/actions/evaluationsV2/annotate.ts
@@ -35,7 +35,9 @@ export const annotateEvaluationV2Action = withEvaluation
       .then((r) => r.value)
     if (!span) throw new NotFoundError('Span not found')
     if (!MAIN_SPAN_TYPES.has(span.type)) {
-      throw new BadRequestError('Span is not of type prompt')
+      throw new BadRequestError(
+        `Span type '${span.type}' is not annotatable. Only prompt, chat, and external spans can be annotated`,
+      )
     }
 
     const metadata = await spansMetadataRepo

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
@@ -44,6 +44,7 @@ export function AnnotationsPanel({
     () =>
       findFirstSpanOfType(trace?.children ?? [], [
         SpanType.Prompt,
+        SpanType.Chat,
         SpanType.External,
       ]),
     [trace?.children],

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationsPage.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationsPage.tsx
@@ -10,9 +10,9 @@ import {
   EvaluationType,
   EvaluationV2,
   MAIN_SPAN_TYPES,
+  MainSpanType,
   RunSourceGroup,
   Span,
-  SpanType,
   SpanWithDetails,
 } from '@latitude-data/constants'
 import { SplitPane } from '@latitude-data/web-ui/atoms/SplitPane'
@@ -161,7 +161,7 @@ export function AnnotationsPage({
           selectedSpan ? (
             <AnnotationsPanel
               key={selectedSpan.id}
-              span={selectedSpan as SpanWithDetails<SpanType.Prompt>}
+              span={selectedSpan as SpanWithDetails<MainSpanType>}
               onAnnotate={onAnnotate}
             />
           ) : (

--- a/apps/web/src/components/ChatWrapper/AnnotationFormWithoutContext.tsx
+++ b/apps/web/src/components/ChatWrapper/AnnotationFormWithoutContext.tsx
@@ -5,7 +5,7 @@ import {
   EvaluationType,
   EvaluationV2,
   HumanEvaluationMetric,
-  SpanType,
+  MainSpanType,
   SpanWithDetails,
 } from '@latitude-data/constants'
 import { useAnnotations } from './AnnotationsContext'
@@ -58,7 +58,7 @@ export function AnnotationFormWithoutContext() {
           key={item.result?.uuid ?? `new-${index}`}
           evaluation={item.evaluation}
           result={item.result}
-          span={span as SpanWithDetails<SpanType.Prompt>}
+          span={span as SpanWithDetails<MainSpanType>}
           onAnnotate={handleAnnotate}
         />
       ))}

--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -10,6 +10,7 @@ import {
   AssembledSpan,
   AssembledTrace,
   isMainSpan,
+  MainSpanType,
   SpanType,
   SpanWithDetails,
 } from '@latitude-data/constants'
@@ -90,9 +91,9 @@ function TraceMetadata({
 
   return (
     <div className='flex flex-col gap-4'>
-      {span.type === SpanType.Prompt ? (
+      {isMainSpan(span) ? (
         <AnnotationsProvider
-          span={span as SpanWithDetails<SpanType.Prompt>}
+          span={span as SpanWithDetails<MainSpanType>}
           commit={commit}
           project={project}
         >
@@ -140,11 +141,16 @@ function TraceMessages({ span }: { span?: SpanWithDetails }) {
     )
   }
 
+  const annotationSpan =
+    span && isMainSpan(span)
+      ? (span as SpanWithDetails<MainSpanType>)
+      : undefined
+
   return (
     <AnnotationsProvider
       project={project}
       commit={commit}
-      span={span}
+      span={annotationSpan}
       messages={messages}
     >
       <div className='flex flex-col gap-4'>


### PR DESCRIPTION
## Summary
This PR extends annotation support to include Chat and External span types, not just Prompt spans. The changes update type checking and casting logic throughout the codebase to use the `MainSpanType` union type and the `isMainSpan()` helper function instead of checking for `SpanType.Prompt` specifically.

## Key Changes
- **Type system updates**: Replaced `SpanType.Prompt` type casts with `MainSpanType` to support Prompt, Chat, and External spans
- **Helper function adoption**: Updated span type checks to use `isMainSpan()` instead of direct `SpanType.Prompt` comparisons
- **Error message improvement**: Enhanced the annotation validation error message to clarify which span types are annotatable
- **Span discovery**: Added `SpanType.Chat` to the list of span types searched when finding the first main span in a trace

## Notable Implementation Details
- The `AnnotationsProvider` component now accepts spans of type `MainSpanType` instead of just `SpanType.Prompt`
- The annotation validation in `annotateEvaluationV2Action` now checks against `MAIN_SPAN_TYPES` set and provides a more descriptive error message
- The `TraceMetadata` and `TraceMessages` components use `isMainSpan()` for type-safe span filtering before passing to `AnnotationsProvider`

https://claude.ai/code/session_01Pzs7E6ArrazTg3aFgvmw9t