### PR TITLE
LAT-392: Scope evaluation results to current draft

### DIFF
--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/pagination/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/pagination/route.ts
@@ -2,7 +2,10 @@ import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
 import { ROUTES } from '$/services/routes'
 import { buildPagination } from '@latitude-data/core/lib/pagination/buildPagination'
-import { EvaluationResultsV2Repository } from '@latitude-data/core/repositories'
+import {
+  CommitsRepository,
+  EvaluationResultsV2Repository,
+} from '@latitude-data/core/repositories'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -32,6 +35,18 @@ export const GET = errorHandler(
       const search = evaluationResultsV2SearchFromQueryParams(
         Object.fromEntries(request.nextUrl.searchParams.entries()),
       )
+
+      if (search.filters?.commitIds === undefined) {
+        const commitsRepository = new CommitsRepository(workspace.id)
+        const commit = await commitsRepository
+          .getCommitByUuid({ projectId, uuid: commitUuid })
+          .then((r) => r.unwrap())
+
+        search.filters = {
+          ...search.filters,
+          commitIds: [commit.id],
+        }
+      }
 
       const repository = new EvaluationResultsV2Repository(workspace.id)
       const count = await repository

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/route.test.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('$/middlewares/authHandler', () => ({
+  authHandler: (fn: unknown) => fn,
+}))
+
+vi.mock('$/middlewares/errorHandler', () => ({
+  errorHandler: (fn: unknown) => fn,
+}))
+
+const listByEvaluationMock = vi.fn()
+const getCommitByUuidMock = vi.fn()
+
+vi.mock('@latitude-data/core/repositories', () => {
+  return {
+    CommitsRepository: class {
+      constructor(_: number) {}
+      getCommitByUuid = getCommitByUuidMock
+    },
+    EvaluationResultsV2Repository: class {
+      constructor(_: number) {}
+      listByEvaluation = listByEvaluationMock
+    },
+  }
+})
+
+vi.mock('@latitude-data/core/helpers', () => ({
+  evaluationResultsV2SearchFromQueryParams: () => ({
+    filters: {},
+    orders: {},
+    pagination: { page: 1, pageSize: 25 },
+  }),
+}))
+
+describe('evaluation results route', () => {
+  it('defaults commitIds filter to current commit when absent', async () => {
+    getCommitByUuidMock.mockResolvedValue({
+      unwrap: () => ({ id: 123 }),
+    })
+
+    listByEvaluationMock.mockResolvedValue({
+      unwrap: () => [],
+    })
+
+    const { GET } = await import('./route')
+
+    await GET(
+      {
+        nextUrl: { searchParams: new URLSearchParams() },
+      } as any,
+      {
+        params: {
+          projectId: 1,
+          commitUuid: 'commit-uuid',
+          documentUuid: 'doc-uuid',
+          evaluationUuid: 'eval-uuid',
+        },
+        workspace: { id: 999 },
+      } as any,
+    )
+
+    expect(getCommitByUuidMock).toHaveBeenCalledWith({
+      projectId: 1,
+      uuid: 'commit-uuid',
+    })
+
+    expect(listByEvaluationMock).toHaveBeenCalledWith({
+      evaluationUuid: 'eval-uuid',
+      params: expect.objectContaining({
+        filters: expect.objectContaining({ commitIds: [123] }),
+      }),
+    })
+  })
+})

--- a/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/route.ts
+++ b/apps/web/src/app/api/projects/[projectId]/commits/[commitUuid]/documents/[documentUuid]/evaluations/[evaluationUuid]/results/route.ts
@@ -1,6 +1,9 @@
 import { authHandler } from '$/middlewares/authHandler'
 import { errorHandler } from '$/middlewares/errorHandler'
-import { EvaluationResultsV2Repository } from '@latitude-data/core/repositories'
+import {
+  CommitsRepository,
+  EvaluationResultsV2Repository,
+} from '@latitude-data/core/repositories'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { evaluationResultsV2SearchFromQueryParams } from '@latitude-data/core/helpers'
@@ -23,10 +26,22 @@ export const GET = errorHandler(
         workspace: Workspace
       },
     ) => {
-      const { evaluationUuid } = params
+      const { projectId, commitUuid, evaluationUuid } = params
       const search = evaluationResultsV2SearchFromQueryParams(
         Object.fromEntries(request.nextUrl.searchParams.entries()),
       )
+
+      if (search.filters?.commitIds === undefined) {
+        const commitsRepository = new CommitsRepository(workspace.id)
+        const commit = await commitsRepository
+          .getCommitByUuid({ projectId, uuid: commitUuid })
+          .then((r) => r.unwrap())
+
+        search.filters = {
+          ...search.filters,
+          commitIds: [commit.id],
+        }
+      }
 
       const repository = new EvaluationResultsV2Repository(workspace.id)
       const results = await repository


### PR DESCRIPTION
Fixes evaluation results mixing across drafts by scoping evaluation results queries to the current commit when no commit filter is provided.\n\nLinear: https://linear.app/latitude/issue/LAT-392/evaluation-results-from-other-drafts-seen-in-current-draft