### PR TITLE
fix: set hobby v3 plan seats to unlimited

### DIFF
--- a/packages/core/src/plans.ts
+++ b/packages/core/src/plans.ts
@@ -51,7 +51,7 @@ export const SubscriptionPlans = {
   [SubscriptionPlan.HobbyV3]: {
     name: 'Hobby',
     credits: 10_000, // runs
-    users: 2,
+    users: 'unlimited' as const,
     retention_period: 30, // days
     rate_limit: 10, // per second
     latte_credits: 30,


### PR DESCRIPTION
## Summary\n\nChanges the default seats limit of HobbyV3 plan from 2 users to unlimited.\n\n## Changes\n\n- HobbyV3: users changed from `2` to `'unlimited'`\n\n## Test plan\n\n- [x] `pnpm lint` passes\n- [x] `pnpm tc` passes