### PR TITLE
fix: guard against undefined document in TriggerCard Header

### DIFF
--- a/apps/web/src/components/TriggersManagement/TriggerCard/Header.tsx
+++ b/apps/web/src/components/TriggersManagement/TriggerCard/Header.tsx
@@ -157,12 +157,12 @@ export function TriggerHeader({
 
   const isLoading = isLoadingIntegrations || isLoadingDocuments
 
-  if (isLoading) return <LoadingTriggerHeader />
+  if (isLoading || !document) return <LoadingTriggerHeader />
   return (
     <LoadedTriggerHeader
       trigger={trigger}
       commit={commit}
-      document={document!}
+      document={document}
       integrations={integrations!}
     />
   )


### PR DESCRIPTION
Root Cause Analysis:
When a trigger references a documentUuid that no longer exists (e.g., document was
deleted), the useMemo in TriggerHeader returns undefined. The code was passing
document! (with non-null assertion) to LoadedTriggerHeader, which then tried to
access document.documentUuid without checking if it was defined, causing the
TypeError.

The fix adds a guard check: if document is undefined after loading completes,
we show the LoadingTriggerHeader instead of crashing.

Datadog: https://app.datadoghq.eu/error-tracking?issueId=97a405d4-08ad-11f1-b14a-da7ad0900005
Lint: Passed (only pre-existing warnings unrelated to this change)
TC: Failed due to pre-existing telemetry module issues, not related to this change
