### PR TITLE
fix: prevent duplicate commit version on concurrent publish

### DIFF
--- a/packages/core/src/services/commits/merge.ts
+++ b/packages/core/src/services/commits/merge.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm'
+import { and, desc, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 
 import { type Commit } from '../../schema/models/types/Commit'
 import { type DocumentVersion } from '../../schema/models/types/DocumentVersion'
@@ -147,6 +147,10 @@ export async function mergeCommit(
   // Phase 3: finalize merge in a new short transaction
   return transaction.call<Commit>(
     async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(${sql.raw(String(commit.projectId))})`,
+      )
+
       const lastMergedCommit = await tx
         .select()
         .from(commits)


### PR DESCRIPTION
## Summary

- Fixes `duplicate key value violates unique constraint "unique_commit_version"` error that occurs when two commits are published concurrently for the same project
- Adds `pg_advisory_xact_lock` in Phase 3 of the merge process to serialize version assignment per project

## Root cause

The version assignment in `mergeCommit` Phase 3 is a read-then-write: it reads `MAX(version)`, increments it, then updates. When two publishes run concurrently for the same project, both can read the same max version and both try to write `version + 1`, violating the `unique_commit_version` constraint on `(version, projectId)`.

## How the fix works

`pg_advisory_xact_lock(projectId)` acquires a transaction-scoped advisory lock keyed on the project ID. This ensures only one transaction at a time can compute and assign the next version for a given project. The lock is automatically released when the transaction commits or rolls back.

## Test plan

- [x] Existing merge tests pass (13/13)
- [ ] Verify in staging with concurrent publish requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)