### PR TITLE
fix: remove annotation UI from trace Metadata tab

### DIFF
--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -83,30 +83,10 @@ function TraceMetadata({
   isLoading: boolean
   documentLogUuid: string
 }) {
-  const { commit } = useCurrentCommit()
-  const { project } = useCurrentProject()
-
   if (isLoading) return <LoadingText alignX='center' />
   if (!span) return null
 
-  return (
-    <div className='flex flex-col gap-4'>
-      {isMainSpan(span) ? (
-        <AnnotationsProvider
-          span={span as SpanWithDetails<MainSpanType>}
-          commit={commit}
-          project={project}
-        >
-          <div className='flex flex-col gap-4'>
-            <DetailsPanel span={span} documentLogUuid={documentLogUuid} />
-            <AnnotationFormWithoutContext />
-          </div>
-        </AnnotationsProvider>
-      ) : (
-        <DetailsPanel span={span} documentLogUuid={documentLogUuid} />
-      )}
-    </div>
-  )
+  return <DetailsPanel span={span} documentLogUuid={documentLogUuid} />
 }
 
 function TraceMessages({ span }: { span?: SpanWithDetails }) {


### PR DESCRIPTION
The thumbs up/down annotation UI appearing below the metadata in the trace detail view was confusing users - they thought they were giving feedback to the metadata itself rather than the overall trace output.

Removed the annotation form from the Metadata tab since:
- Annotations are about the actual conversation/output, not metadata
- The annotation form is already available in the Messages tab
- This eliminates the confusion entirely

Users can still annotate traces by using the Messages tab where the annotation UI appears in the proper context alongside the messages.

https://claude.ai/code/session_01J98WUbCwUjxVXpghN6MjJd