### PR TITLE
Fix last result in traces panel showing always last result for trace even for sub-agents

### DIFF
--- a/apps/web/src/components/tracing/spans/External.tsx
+++ b/apps/web/src/components/tracing/spans/External.tsx
@@ -1,17 +1,10 @@
 import { MetadataItem } from '$/components/MetadataItem'
-import {
-  CompletionSpanMetadata,
-  SPAN_SPECIFICATIONS,
-  SpanType,
-} from '@latitude-data/constants'
+import { SPAN_SPECIFICATIONS, SpanType } from '@latitude-data/constants'
 import { IconName } from '@latitude-data/web-ui/atoms/Icons'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { ClickToCopy } from '@latitude-data/web-ui/molecules/ClickToCopy'
 import { DetailsPanelProps, SPAN_COLORS } from './shared'
-import { useTrace } from '$/stores/traces'
-import { findAllSpansOfType } from '@latitude-data/core/services/tracing/spans/fetching/findAllSpansOfType'
-import { findLastSpanOfType } from '@latitude-data/core/services/tracing/spans/fetching/findLastSpanOfType'
-import { useMemo } from 'react'
+import { useSpanCompletionData } from './useSpanCompletionData'
 import { formatCostInMillicents } from '$/app/_lib/formatUtils'
 import { MessageList } from '$/components/ChatWrapper'
 
@@ -24,60 +17,10 @@ export default {
 }
 
 function DetailsPanel({ span }: DetailsPanelProps<SpanType.External>) {
-  const { data: trace } = useTrace({ traceId: span.traceId })
-  const completionSpan = useMemo(() => {
-    if (!trace) return undefined
-
-    return findLastSpanOfType({
-      children: trace.children,
-      spanType: SpanType.Completion,
-    })
-  }, [trace])
-  const completionSpans = useMemo(
-    () => findAllSpansOfType(trace?.children ?? [], SpanType.Completion),
-    [trace],
-  )
-  const aggregatedMetadata = useMemo(() => {
-    if (!completionSpans.length) return undefined
-
-    type AggregatedData = {
-      finishReason?: CompletionSpanMetadata['finishReason']
-      cost: number
-      tokens: {
-        prompt: number
-        cached: number
-        reasoning: number
-        completion: number
-      }
-    }
-
-    return completionSpans.reduce<AggregatedData>(
-      (acc, span) => {
-        const metadata = span.metadata as CompletionSpanMetadata | undefined
-        if (!metadata) return acc
-
-        return {
-          finishReason: metadata.finishReason,
-          cost: acc.cost + (metadata.cost || 0),
-          tokens: {
-            prompt: acc.tokens.prompt + (metadata.tokens?.prompt || 0),
-            cached: acc.tokens.cached + (metadata.tokens?.cached || 0),
-            reasoning: acc.tokens.reasoning + (metadata.tokens?.reasoning || 0),
-            completion:
-              acc.tokens.completion + (metadata.tokens?.completion || 0),
-          },
-        }
-      },
-      {
-        finishReason: undefined,
-        cost: 0,
-        tokens: { prompt: 0, cached: 0, reasoning: 0, completion: 0 },
-      },
-    )
-  }, [completionSpans])
-  const completionSpanMetadata = completionSpan?.metadata as
-    | CompletionSpanMetadata
-    | undefined
+  const { aggregatedMetadata, completionSpanMetadata } = useSpanCompletionData({
+    traceId: span.traceId,
+    spanId: span.id,
+  })
 
   return (
     <>

--- a/apps/web/src/components/tracing/spans/useSpanCompletionData.ts
+++ b/apps/web/src/components/tracing/spans/useSpanCompletionData.ts
@@ -1,0 +1,90 @@
+import { useMemo } from 'react'
+import { useTrace } from '$/stores/traces'
+import {
+  CompletionSpanMetadata,
+  SpanType,
+} from '@latitude-data/constants'
+import { findAllSpansOfType } from '@latitude-data/core/services/tracing/spans/fetching/findAllSpansOfType'
+import { findLastSpanOfType } from '@latitude-data/core/services/tracing/spans/fetching/findLastSpanOfType'
+import { findSpanById } from '@latitude-data/core/services/tracing/spans/fetching/findSpanById'
+
+type AggregatedCompletionData = {
+  finishReason?: CompletionSpanMetadata['finishReason']
+  cost: number
+  tokens: {
+    prompt: number
+    cached: number
+    reasoning: number
+    completion: number
+  }
+}
+
+export function useSpanCompletionData({
+  traceId,
+  spanId,
+}: {
+  traceId: string
+  spanId: string
+}) {
+  const { data: trace } = useTrace({ traceId })
+
+  const assembledSpan = useMemo(() => {
+    if (!trace) return undefined
+    return findSpanById(trace.children, spanId)
+  }, [trace, spanId])
+
+  const completionSpan = useMemo(() => {
+    if (!assembledSpan) return undefined
+
+    return findLastSpanOfType({
+      children: assembledSpan.children,
+      spanType: SpanType.Completion,
+      searchNestedAgents: false,
+    })
+  }, [assembledSpan])
+
+  const completionSpans = useMemo(
+    () => findAllSpansOfType(assembledSpan?.children ?? [], SpanType.Completion),
+    [assembledSpan],
+  )
+
+  const aggregatedMetadata = useMemo(() => {
+    if (!completionSpans.length) return undefined
+
+    return completionSpans.reduce<AggregatedCompletionData>(
+      (acc, span) => {
+        const metadata = span.metadata as CompletionSpanMetadata | undefined
+        if (!metadata) return acc
+
+        return {
+          finishReason: metadata.finishReason,
+          cost: acc.cost + (metadata.cost || 0),
+          tokens: {
+            prompt: acc.tokens.prompt + (metadata.tokens?.prompt || 0),
+            cached: acc.tokens.cached + (metadata.tokens?.cached || 0),
+            reasoning: acc.tokens.reasoning + (metadata.tokens?.reasoning || 0),
+            completion:
+              acc.tokens.completion + (metadata.tokens?.completion || 0),
+          },
+        }
+      },
+      {
+        finishReason: undefined,
+        cost: 0,
+        tokens: { prompt: 0, cached: 0, reasoning: 0, completion: 0 },
+      },
+    )
+  }, [completionSpans])
+
+  const completionSpanMetadata = completionSpan?.metadata as
+    | CompletionSpanMetadata
+    | undefined
+
+  return {
+    assembledSpan,
+    completionSpan,
+    completionSpans,
+    aggregatedMetadata,
+    completionSpanMetadata,
+  }
+}


### PR DESCRIPTION
# What?

When a trace has multiple calls to sub-agents if you click on the sub-agent, the field for the last result still shows the last result for the full traces. This was happening for all types. Prompt, Chat, and External. We centralized this logic into a hook that extracts the information from the children passed to the panel, which can be the top span or any sub-span, like a sub-agent.