### PR TITLE
Fix copy runs to traces

### DIFF
--- a/apps/web/src/app/(admin)/backoffice/usage-overview/_components/TrendCell/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/usage-overview/_components/TrendCell/index.tsx
@@ -20,11 +20,11 @@ export function TrendCell({ trend }: { trend: UsageTrend }) {
           </div>
         }
       >
-        {trend.twoMonthsAgoRuns <= 0 && trend.last30daysRuns <= 0
-          ? 'No runs'
-          : `${trend.twoMonthsAgoRuns} runs 2 months ago  / ${trend.last30daysRuns} runs last 30 days`}
+        {trend.twoMonthsAgoTraces <= 0 && trend.last30daysTraces <= 0
+          ? 'No traces'
+          : `${trend.twoMonthsAgoTraces} traces 2 months ago  / ${trend.last30daysTraces} traces last 30 days`}
       </Tooltip>
-      <Text.H6>{trend.last30daysRuns}</Text.H6>
+      <Text.H6>{trend.last30daysTraces}</Text.H6>
     </div>
   )
 }

--- a/apps/web/src/app/(admin)/backoffice/usage-overview/_components/UsageCell/index.tsx
+++ b/apps/web/src/app/(admin)/backoffice/usage-overview/_components/UsageCell/index.tsx
@@ -6,12 +6,12 @@ export function UsageCell({
 }: {
   usageOverview: GetUsageOverviewRow
 }) {
-  const lastMonth = usageOverview.lastMonthRuns ?? 0
-  const prevMonth = usageOverview.lastTwoMonthsRuns ?? 0
+  const lastMonth = usageOverview.lastMonthTraces ?? 0
+  const prevMonth = usageOverview.lastTwoMonthsTraces ?? 0
 
   return (
     <div className='flex flex-col gap-1'>
-      <Text.H5>{lastMonth.toLocaleString()} runs</Text.H5>
+      <Text.H5>{lastMonth.toLocaleString()} traces</Text.H5>
       <Text.H6 color='foregroundMuted'>
         {prevMonth.toLocaleString()} prev month
       </Text.H6>

--- a/apps/web/src/app/(admin)/backoffice/usage-overview/buildUsageInformation.ts
+++ b/apps/web/src/app/(admin)/backoffice/usage-overview/buildUsageInformation.ts
@@ -6,25 +6,25 @@ import { SubscriptionPlanData } from '@latitude-data/core/plans'
 const TOLERANCE_PERCENT = 0.05
 export type UsageTrend = {
   icon: IconName
-  last30daysRuns: number
-  twoMonthsAgoRuns: number
+  last30daysTraces: number
+  twoMonthsAgoTraces: number
 }
 
 function getTrendIndicator({
-  runsTwoMonthsAgo,
-  runsLast30Days,
+  tracesTwoMonthsAgo,
+  tracesLast30Days,
 }: {
-  runsTwoMonthsAgo: number
-  runsLast30Days: number
+  tracesTwoMonthsAgo: number
+  tracesLast30Days: number
   plan: SubscriptionPlanData
 }): UsageTrend {
-  const smallerValue = Math.min(runsTwoMonthsAgo, runsLast30Days)
+  const smallerValue = Math.min(tracesTwoMonthsAgo, tracesLast30Days)
   const tolerance = smallerValue * TOLERANCE_PERCENT
-  const diff = runsLast30Days - runsTwoMonthsAgo
+  const diff = tracesLast30Days - tracesTwoMonthsAgo
 
   const commonProps = {
-    last30daysRuns: runsLast30Days,
-    twoMonthsAgoRuns: runsTwoMonthsAgo,
+    last30daysTraces: tracesLast30Days,
+    twoMonthsAgoTraces: tracesTwoMonthsAgo,
   }
 
   if (Math.abs(diff) < tolerance || diff === 0) {
@@ -54,8 +54,8 @@ function getEmailsList(emails: string | null) {
 export function buildUsageInformation(usage: GetUsageOverviewRow) {
   const plan = getPlanFromSubscriptionSlug(usage.subscriptionPlan)
   const trend = getTrendIndicator({
-    runsTwoMonthsAgo: usage.lastTwoMonthsRuns,
-    runsLast30Days: usage.lastMonthRuns,
+    tracesTwoMonthsAgo: usage.lastTwoMonthsTraces,
+    tracesLast30Days: usage.lastMonthTraces,
     plan,
   })
 

--- a/apps/web/src/app/(admin)/backoffice/usage-overview/page.tsx
+++ b/apps/web/src/app/(admin)/backoffice/usage-overview/page.tsx
@@ -54,11 +54,11 @@ export default async function AdminPage({
     <div className='w-full max-w-[1250px] m-auto px-4 py-8 pt-0 flex flex-col gap-8'>
       <TableWithHeader
         title='Usage overview by workspace'
-        description='List of workspaces by usage ordered by the most usage in the current month. The workspaces with more runs in their current period are listed first.'
+        description='List of workspaces by usage ordered by the most usage in the current month. The workspaces with more traces in their current period are listed first.'
         table={
           <>
             {workspacesUsage.length <= 0 ? (
-              <TableBlankSlate description='There are no more Workspaces with runs to show' />
+              <TableBlankSlate description='There are no more Workspaces with traces to show' />
             ) : (
               <Table
                 externalFooter={
@@ -68,7 +68,7 @@ export default async function AdminPage({
                 <TableHeader>
                   <TableRow>
                     <TableHead>Trend</TableHead>
-                    <TableHead>Last run</TableHead>
+                    <TableHead>Last trace</TableHead>
                     <TableHead>Workspace</TableHead>
                     <TableHead>Subscription</TableHead>
                     <TableHead>Usage</TableHead>
@@ -88,8 +88,8 @@ export default async function AdminPage({
                         </ServerSideTableCell>
                         <ServerSideTableCell className='w-40'>
                           <Text.H6 color='foregroundMuted'>
-                            {usage.latestRunAt
-                              ? formatDistanceToNow(usage.latestRunAt, {
+                            {usage.latestTraceAt
+                              ? formatDistanceToNow(usage.latestTraceAt, {
                                   addSuffix: true,
                                 })
                               : '-'}

--- a/apps/web/src/app/(private)/choose-plan/_lib/buildPlanOptions.ts
+++ b/apps/web/src/app/(private)/choose-plan/_lib/buildPlanOptions.ts
@@ -60,7 +60,7 @@ function formatOptimizations(value: number | 'unlimited'): string {
 function buildTeamPlanFeatures(plan: PlanConfig): PlanFeature[] {
   return [
     {
-      text: `${formatNumber(plan.credits)} runs/month`,
+      text: `${formatNumber(plan.credits)} traces/month`,
       icon: 'checkClean',
       iconColor: 'primary',
     },
@@ -217,7 +217,7 @@ export function buildPlanOptions({
           iconColor: 'accentForeground',
         },
         {
-          text: `${formatNumber(SCALE_V1.credits)} runs/month`,
+          text: `${formatNumber(SCALE_V1.credits)} traces/month`,
           icon: 'checkClean',
           iconColor: 'primary',
         },

--- a/apps/web/src/components/UsageIndicatorPopover/index.tsx
+++ b/apps/web/src/components/UsageIndicatorPopover/index.tsx
@@ -31,19 +31,19 @@ export function SubscriptionBadge({
   )
 }
 
-function runsDescription({ ratio, max }: { ratio: number; max: Quota }) {
+function tracesDescription({ ratio, max }: { ratio: number; max: Quota }) {
   if (max === 'unlimited') {
-    return 'Your plan includes unlimited runs. Enjoy!'
+    return 'Your plan includes unlimited traces. Enjoy!'
   }
 
   if (ratio <= 0) {
-    return "You've reached the maximum number of runs. Your app will continue working, the Latitude limit reached means you'll no longer be able to run tests, view new logs or evaluation results."
+    return "You've reached the maximum number of traces. Your app will continue working, the Latitude limit reached means you'll no longer be able to run tests, view new logs or evaluation results."
   }
   if (ratio < 0.25) {
-    return "You're running low on runs in your current plan. Your app will continue working, the Latitude limit reached means you'll no longer be able to run tests, view new logs or evaluation results."
+    return "You're running low on traces in your current plan. Your app will continue working, the Latitude limit reached means you'll no longer be able to run tests, view new logs or evaluation results."
   }
 
-  return `Your plan includes ${max} runs. You can upgrade your plan to get more runs.`
+  return `Your plan includes ${max} traces. You can upgrade your plan to get more traces.`
 }
 
 function membersDescription({
@@ -162,8 +162,8 @@ export function UsageIndicatorPopover({
         : undefined,
     [workspaceUsage],
   )
-  const runsText = useMemo(
-    () => (workspaceUsage ? runsDescription({ ratio, max }) : undefined),
+  const tracesText = useMemo(
+    () => (workspaceUsage ? tracesDescription({ ratio, max }) : undefined),
     [workspaceUsage, ratio, max],
   )
   const isFree = FREE_PLANS.includes(subscription.plan)
@@ -233,7 +233,7 @@ export function UsageIndicatorPopover({
                       {workspaceUsage?.max === 'unlimited'
                         ? 'unlimited'
                         : workspaceUsage?.max}{' '}
-                      runs
+                      traces
                     </Text.H4>
                     <div className='w-full flex items-center justify-end'>
                       <SubscriptionBadge subscription={subscription} />
@@ -241,8 +241,8 @@ export function UsageIndicatorPopover({
                   </div>
                 </LoadingText>
               </div>
-              {runsText ? (
-                <Text.H6 display='block'>{runsText}</Text.H6>
+              {tracesText ? (
+                <Text.H6 display='block'>{tracesText}</Text.H6>
               ) : (
                 <div className='w-full flex flex-col gap-1'>
                   <Skeleton className='w-full h-3 animate-pulse' />

--- a/packages/core/src/services/workspaces/usageOverview/index.test.ts
+++ b/packages/core/src/services/workspaces/usageOverview/index.test.ts
@@ -23,7 +23,7 @@ describe('getUsageOverview', () => {
     vi.unstubAllEnvs()
   })
 
-  it('returns all workspaces ordered by usage of runs', async () => {
+  it('returns all workspaces ordered by usage of traces', async () => {
     const result = await getUsageOverview({
       page: 1,
       pageSize: 10,
@@ -34,16 +34,16 @@ describe('getUsageOverview', () => {
       {
         ...data.workspaces.workspaceA.expectedData,
         emails: expect.any(String), // TODO: fix troll tests
-        lastMonthRuns: '4',
-        lastTwoMonthsRuns: '1',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '4',
+        lastTwoMonthsTraces: '1',
+        latestTraceAt: expect.any(String),
       },
       {
         ...data.workspaces.workspaceB.expectedData,
         emails: expect.any(String),
-        lastMonthRuns: '3',
-        lastTwoMonthsRuns: '2',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '3',
+        lastTwoMonthsTraces: '2',
+        latestTraceAt: expect.any(String),
       },
     ])
   })
@@ -65,17 +65,17 @@ describe('getUsageOverview', () => {
       {
         ...data.workspaces.workspaceA.expectedData,
         emails: expect.any(String),
-        lastMonthRuns: '4',
-        lastTwoMonthsRuns: '1',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '4',
+        lastTwoMonthsTraces: '1',
+        latestTraceAt: expect.any(String),
       },
       {
         ...data.workspaces.workspaceB.expectedData,
         emails: expect.any(String),
         name: data.workspaces.workspaceB.expectedData.name,
-        lastMonthRuns: '3',
-        lastTwoMonthsRuns: '2',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '3',
+        lastTwoMonthsTraces: '2',
+        latestTraceAt: expect.any(String),
       },
     ])
   })
@@ -107,17 +107,17 @@ describe('getUsageOverview', () => {
       {
         ...data.workspaces.workspaceA.expectedData,
         emails: expect.any(String),
-        lastMonthRuns: '4',
-        lastTwoMonthsRuns: '1',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '4',
+        lastTwoMonthsTraces: '1',
+        latestTraceAt: expect.any(String),
       },
       {
         ...data.workspaces.workspaceB.expectedData,
         emails: expect.any(String),
         subscriptionCreatedAt: '2024-07-19 00:00:00',
-        lastMonthRuns: '2',
-        lastTwoMonthsRuns: '1',
-        latestRunAt: expect.any(String),
+        lastMonthTraces: '2',
+        lastTwoMonthsTraces: '1',
+        latestTraceAt: expect.any(String),
       },
     ])
   })


### PR DESCRIPTION
Change copy of "runs" to "traces" in:
- Usage overview page in backoffice
- Choose your plan page
- Usage counter 