### PR TITLE
Add gzip compression for span metadata storage

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.ts
@@ -12,6 +12,7 @@ import {
 } from '@latitude-data/core/constants'
 import { cache as redis } from '@latitude-data/core/cache'
 import { diskFactory } from '@latitude-data/core/lib/disk'
+import { compressString } from '@latitude-data/core/lib/disk/compression'
 import { publishSpanCreated } from '@latitude-data/core/services/tracing/publishSpanCreated'
 import { AppRouteHandler } from '$/openApi/types'
 import { CreateLogRoute } from './create.route'
@@ -232,8 +233,11 @@ async function createSpansFromLogData({
     traceId,
     promptSpanId,
   )
+  const compressedPromptMetadata = await compressString(
+    JSON.stringify(promptMetadata),
+  )
   await disk
-    .put(promptMetadataKey, JSON.stringify(promptMetadata))
+    .putBuffer(promptMetadataKey, compressedPromptMetadata)
     .then((r) => r.unwrap())
   await cache.del(promptMetadataKey)
 
@@ -242,8 +246,11 @@ async function createSpansFromLogData({
     traceId,
     completionSpanId,
   )
+  const compressedCompletionMetadata = await compressString(
+    JSON.stringify(completionMetadata),
+  )
   await disk
-    .put(completionMetadataKey, JSON.stringify(completionMetadata))
+    .putBuffer(completionMetadataKey, compressedCompletionMetadata)
     .then((r) => r.unwrap())
   await cache.del(completionMetadataKey)
 

--- a/apps/web/src/app/api/evaluatedSpans/route.test.ts
+++ b/apps/web/src/app/api/evaluatedSpans/route.test.ts
@@ -11,6 +11,7 @@ import {
   SpanType,
 } from '@latitude-data/constants'
 import { diskFactory } from '@latitude-data/core/lib/disk'
+import { compressString } from '@latitude-data/core/lib/disk/compression'
 import { cache as redis } from '@latitude-data/core/cache'
 import { User } from '@latitude-data/core/schema/models/types/User'
 import { Workspace } from '@latitude-data/core/schema/models/types/Workspace'
@@ -142,7 +143,8 @@ describe('GET handler for evaluatedSpans', () => {
       completionSpan.traceId,
       completionSpan.id,
     )
-    await disk.put(metadataKey, JSON.stringify(completionMetadata))
+    const compressed = await compressString(JSON.stringify(completionMetadata))
+    await disk.putBuffer(metadataKey, compressed)
 
     const cache = await redis()
     await cache.del(metadataKey)

--- a/packages/core/src/lib/disk/compression.ts
+++ b/packages/core/src/lib/disk/compression.ts
@@ -1,0 +1,27 @@
+import { gzip, gunzip } from 'zlib'
+import { promisify } from 'util'
+
+const gzipAsync = promisify(gzip)
+const gunzipAsync = promisify(gunzip)
+
+const GZIP_MAGIC_BYTE_1 = 0x1f
+const GZIP_MAGIC_BYTE_2 = 0x8b
+
+export function isGzipped(data: Buffer): boolean {
+  return (
+    data.length >= 2 &&
+    data[0] === GZIP_MAGIC_BYTE_1 &&
+    data[1] === GZIP_MAGIC_BYTE_2
+  )
+}
+
+export async function compressString(input: string): Promise<Buffer> {
+  return gzipAsync(Buffer.from(input, 'utf-8'))
+}
+
+export async function decompressToString(data: Buffer): Promise<string> {
+  if (!isGzipped(data)) return data.toString('utf-8')
+
+  const decompressed = await gunzipAsync(data)
+  return decompressed.toString('utf-8')
+}

--- a/packages/core/src/repositories/spansRepository.ts
+++ b/packages/core/src/repositories/spansRepository.ts
@@ -26,6 +26,7 @@ import {
   SpanType,
 } from '../constants'
 import { diskFactory, DiskWrapper } from '../lib/disk'
+import { decompressToString } from '../lib/disk/compression'
 import { Result } from '../lib/Result'
 import {
   applyDefaultSpansCreatedAtRange,
@@ -795,7 +796,10 @@ export class SpanMetadatasRepository {
 
     try {
       let payload = fresh ? undefined : await cache.get(key)
-      if (!payload) payload = await this.disk.get(key)
+      if (!payload) {
+        const raw = await this.disk.getBuffer(key)
+        payload = await decompressToString(raw)
+      }
 
       const metadata = JSON.parse(payload)
 

--- a/packages/core/src/services/issues/results/getOrSetEnrichedReason.test.ts
+++ b/packages/core/src/services/issues/results/getOrSetEnrichedReason.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { cache as redis } from '../../../cache'
 import { database } from '../../../client'
 import { diskFactory } from '../../../lib/disk'
+import { compressString } from '../../../lib/disk/compression'
 import { Result } from '../../../lib/Result'
 import { evaluationResultsV2 } from '../../../schema/models/evaluationResultsV2'
 import { type Commit } from '../../../schema/models/types/Commit'
@@ -115,7 +116,8 @@ describe('getOrSetEnrichedReason', () => {
       completionSpan.traceId,
       completionSpan.id,
     )
-    await disk.put(metadataKey, JSON.stringify(completionMetadata))
+    const compressed = await compressString(JSON.stringify(completionMetadata))
+    await disk.putBuffer(metadataKey, compressed)
 
     // Clear cache to ensure we read from disk
     const cache = await redis()

--- a/packages/core/src/services/tracing/spans/ingestion/processBulk.ts
+++ b/packages/core/src/services/tracing/spans/ingestion/processBulk.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../constants'
 import { publishSpanCreated } from '../../publishSpanCreated'
 import { diskFactory, DiskWrapper } from '../../../../lib/disk'
+import { compressString } from '../../../../lib/disk/compression'
 import { LatitudeError, UnprocessableEntityError } from '../../../../lib/errors'
 import { Result, TypedResult } from '../../../../lib/Result'
 import Transaction from '../../../../lib/Transaction'
@@ -553,7 +554,8 @@ async function saveMetadataBatch(
     const promise = (async () => {
       try {
         const payload = JSON.stringify(metadata)
-        await disk.put(key, payload).then((r) => r.unwrap())
+        const compressed = await compressString(payload)
+        await disk.putBuffer(key, compressed).then((r) => r.unwrap())
         await cache.del(key)
       } catch (error) {
         captureException(new LatitudeError(`Error saving metadata:, ${error}`))

--- a/packages/core/src/tests/factories/spansWithMetadata.ts
+++ b/packages/core/src/tests/factories/spansWithMetadata.ts
@@ -11,6 +11,7 @@ import {
 import { Message } from '@latitude-data/constants/messages'
 import { cache as redis } from '../../cache'
 import { diskFactory } from '../../lib/disk'
+import { compressString } from '../../lib/disk/compression'
 import { generateUUIDIdentifier } from '../../lib/generateUUID'
 import { createSpan } from './spans'
 
@@ -73,7 +74,8 @@ async function storeMetadata({
 }) {
   const disk = diskFactory('private')
   const key = SPAN_METADATA_STORAGE_KEY(workspaceId, traceId, spanId)
-  await disk.put(key, JSON.stringify(metadata))
+  const compressed = await compressString(JSON.stringify(metadata))
+  await disk.putBuffer(key, compressed)
 
   const cache = await redis()
   await cache.del(key)


### PR DESCRIPTION
## Summary
This PR adds gzip compression for span metadata stored on disk to reduce storage costs and improve performance. Metadata is now automatically compressed when written and decompressed when read.

## Key Changes
- **New compression module** (`packages/core/src/lib/disk/compression.ts`):
  - Added `compressString()` to compress strings to gzip format
  - Added `decompressToString()` to decompress gzip data with fallback for uncompressed data
  - Added `isGzipped()` helper to detect gzip magic bytes

- **Enhanced DiskWrapper** (`packages/core/src/lib/disk.ts`):
  - Added `getBuffer()` method to read raw binary data from disk
  - Added `putBuffer()` method to write binary data to disk

- **Updated metadata storage**:
  - Modified span metadata writes to use compression in:
    - `createSpansFromLogData` handler
    - `processBulk` service
    - Test factories and test files
  - Modified span metadata reads to use decompression in `SpanMetadatasRepository`

## Implementation Details
- Compression is transparent to callers - `decompressToString()` automatically detects and handles both compressed and uncompressed data
- Uses Node.js built-in `zlib` module with promisified async wrappers
- Maintains backward compatibility by supporting uncompressed data during reads
- All metadata storage operations now go through the compression layer

https://claude.ai/code/session_01VC6xgLtYYKVkhXenuyYAGT