### PR TITLE
fix: add asChild to Tooltip components wrapping Button triggers

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationTree.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/traces/_components/ConversationTree.tsx
@@ -35,6 +35,7 @@ const CollapseButton = memo(
 
     return (
       <Tooltip
+        asChild
         trigger={
           <Button
             variant='ghost'

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/CustomMcpHeaders/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/SidebarArea/Tools/ActiveIntegration/CustomMcpHeaders/index.tsx
@@ -351,6 +351,7 @@ export function CustomMcpHeadersButton({
   return (
     <>
       <Tooltip
+        asChild
         trigger={
           <Button
             variant={hasHeaders ? 'primaryMuted' : 'ghost'}

--- a/apps/web/src/components/TablePaginationFooter/SimpleKeysetTablePaginationFooter.tsx
+++ b/apps/web/src/components/TablePaginationFooter/SimpleKeysetTablePaginationFooter.tsx
@@ -33,6 +33,7 @@ export function SimpleKeysetTablePaginationFooter({
         {isLoading && <Icon name='loader' spin size='small' className='mr-2' />}
         {disabledTooltip ? (
           <Tooltip
+            asChild
             trigger={
               <div className='flex items-center'>
                 <Button


### PR DESCRIPTION
TooltipTrigger renders its own <button> element by default. When a Button component is passed as the trigger, this creates nested <button> elements which is invalid HTML and causes hydration errors.

Adding asChild makes the TooltipTrigger merge its props into the child element instead of wrapping it in an additional button.

https://claude.ai/code/session_01EsKrmtqHDcdzBA5wifn2d7