### PR TITLE
fix: handle deleted project gracefully in span ingestion worker

### DIFF
--- a/packages/core/src/services/tracing/spans/specifications/unresolvedExternal.ts
+++ b/packages/core/src/services/tracing/spans/specifications/unresolvedExternal.ts
@@ -146,6 +146,8 @@ async function process(
     includeInitialDraft: true,
   })
 
+  if (!Result.isOk(commitResult)) return commitResult
+
   const result = await getResolvedData({
     path: promptPath,
     commit: commitResult.unwrap(),


### PR DESCRIPTION
## Problem
The error `NotFoundError: Project not found` occurs in `CommitsRepository.getCommitByUuid` during the `ingestSpansJob` BullMQ job. This happens when span telemetry references a project that has been deleted, but the ingestion job still tries to process it.

## Solution
Added a check after calling `commitsRepo.getCommitByUuid()` to verify if the result is OK before proceeding. If the result is an error (project not found), the function now returns early gracefully instead of throwing a `NotFoundError`.

## Changes
- In `process` function: Added `if (!Result.isOk(commitResult)) return commitResult` check before calling `.unwrap()`

This follows the pattern used elsewhere in the codebase (e.g., `getResolvedData` function).