### PR TITLE
Hide prompt management features when disabled

### DIFF
--- a/apps/web/src/actions/workspaces/setDefaultProvider.ts
+++ b/apps/web/src/actions/workspaces/setDefaultProvider.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { WorkspacesRepository } from '@latitude-data/core/repositories'
 import { updateWorkspace } from '@latitude-data/core/services/workspaces/update'
 import { z } from 'zod'
 
@@ -9,18 +8,11 @@ import { authProcedure } from '../procedures'
 export const setDefaultProviderAction = authProcedure
   .inputSchema(
     z.object({
-      workspaceId: z.number(),
       defaultProviderId: z.number().nullable(),
     }),
   )
   .action(async ({ parsedInput, ctx }) => {
-    const userId = ctx.session.userId
-    const workspacesScope = new WorkspacesRepository(userId)
-    const workspace = await workspacesScope
-      .find(parsedInput.workspaceId)
-      .then((r) => r.unwrap())
-
-    const updatedWorkspace = await updateWorkspace(workspace, {
+    const updatedWorkspace = await updateWorkspace(ctx.workspace, {
       defaultProviderId: parsedInput.defaultProviderId,
     }).then((r) => r.unwrap())
 

--- a/apps/web/src/actions/workspaces/update.ts
+++ b/apps/web/src/actions/workspaces/update.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { WorkspacesRepository } from '@latitude-data/core/repositories'
 import { updateWorkspace } from '@latitude-data/core/services/workspaces/update'
 import { z } from 'zod'
 
@@ -9,18 +8,11 @@ import { authProcedure } from '../procedures'
 export const updateWorkspaceAction = authProcedure
   .inputSchema(
     z.object({
-      workspaceId: z.number(),
       name: z.string(),
     }),
   )
   .action(async ({ parsedInput, ctx }) => {
-    const userId = ctx.session.userId
-    const workspacesScope = new WorkspacesRepository(userId)
-    const workspace = await workspacesScope
-      .find(parsedInput.workspaceId)
-      .then((r) => r.unwrap())
-
-    const updatedWorkspace = await updateWorkspace(workspace, {
+    const updatedWorkspace = await updateWorkspace(ctx.workspace, {
       name: parsedInput.name,
     }).then((r) => r.unwrap())
 

--- a/apps/web/src/actions/workspaces/updateProductAccess.ts
+++ b/apps/web/src/actions/workspaces/updateProductAccess.ts
@@ -1,0 +1,21 @@
+'use server'
+
+import { updateProductAccess } from '@latitude-data/core/services/workspaces/updateProductAccess'
+import { z } from 'zod'
+
+import { authProcedure } from '../procedures'
+
+export const updateProductAccessAction = authProcedure
+  .inputSchema(
+    z.object({
+      promptManagerEnabled: z.boolean().optional(),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const updatedWorkspace = await updateProductAccess({
+      workspace: ctx.workspace,
+      promptManagerEnabled: parsedInput.promptManagerEnabled,
+    }).then((r) => r.unwrap())
+
+    return updatedWorkspace
+  })

--- a/apps/web/src/app/(private)/projects/[projectId]/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/page.tsx
@@ -1,7 +1,6 @@
 import {
   findCommitsByProjectCached,
   findProjectCached,
-  getDocumentsAtCommitCached,
 } from '$/app/(private)/_data-access'
 import { lastSeenCommitCookieName } from '$/helpers/cookies/lastSeenCommit'
 import {
@@ -56,11 +55,6 @@ export default async function ProjectPage({ params }: ProjectPageParams) {
       projectId: project.id,
     })
 
-    const headCommit = commits.find((c) => c.mergedAt) ?? commits[0]
-    const documents = headCommit
-      ? await getDocumentsAtCommitCached({ commit: headCommit })
-      : []
-
     url = getRedirectUrl({
       commits,
       projectId: project.id,
@@ -68,7 +62,7 @@ export default async function ProjectPage({ params }: ProjectPageParams) {
       lastSeenDocumentUuid,
       PROJECT_ROUTE,
       agentBuilder: productAccess.agentBuilder,
-      documents,
+      promptManagement: productAccess.promptManagement,
     })
   } catch (error) {
     if (error instanceof NotFoundError) {

--- a/apps/web/src/app/(private)/projects/[projectId]/utils.test.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { HEAD_COMMIT } from '@latitude-data/core/constants'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
-import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
 
 import { ROUTES } from '../../../../services/routes'
 import { getRedirectUrl } from './utils'
@@ -15,12 +14,7 @@ describe('getRedirectUrl', () => {
     { uuid: '3', mergedAt: null },
   ] as Commit[]
 
-  const mockDocuments = [
-    { documentUuid: 'doc-1' },
-    { documentUuid: 'doc-2' },
-  ] as DocumentVersion[]
-
-  describe('when agentBuilder is enabled', () => {
+  describe('when full product (agentBuilder and promptManagement both enabled)', () => {
     it('returns latest commit home URL when lastSeenCommitUuid is HEAD_COMMIT', () => {
       const result = getRedirectUrl({
         commits: mockCommits,
@@ -28,7 +22,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: HEAD_COMMIT,
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/live/home')
     })
@@ -40,7 +34,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: 'non-existent',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/live/home')
     })
@@ -52,7 +46,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: '2',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/2/home')
     })
@@ -64,7 +58,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: '1',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/live/home')
     })
@@ -76,7 +70,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: undefined,
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/live/home')
     })
@@ -89,7 +83,7 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: undefined,
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/1/home')
     })
@@ -102,7 +96,7 @@ describe('getRedirectUrl', () => {
         lastSeenDocumentUuid: 'fake-document-uuid',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/2/documents/fake-document-uuid')
     })
@@ -115,7 +109,7 @@ describe('getRedirectUrl', () => {
         lastSeenDocumentUuid: 'fake-document-uuid',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe(
         '/projects/1/versions/live/documents/fake-document-uuid',
@@ -130,7 +124,7 @@ describe('getRedirectUrl', () => {
         lastSeenDocumentUuid: 'fake-document-uuid',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe(
         '/projects/1/versions/live/documents/fake-document-uuid',
@@ -145,7 +139,7 @@ describe('getRedirectUrl', () => {
         lastSeenDocumentUuid: 'fake-document-uuid',
         PROJECT_ROUTE,
         agentBuilder: true,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe(
         '/projects/1/versions/live/documents/fake-document-uuid',
@@ -153,42 +147,30 @@ describe('getRedirectUrl', () => {
     })
   })
 
-  describe('when agentBuilder is disabled', () => {
-    it('returns first document URL when documents exist', () => {
+  describe('when simplified product (agentBuilder disabled)', () => {
+    it('returns issues URL', () => {
       const result = getRedirectUrl({
         commits: mockCommits,
         projectId: 1,
         lastSeenCommitUuid: HEAD_COMMIT,
         PROJECT_ROUTE,
         agentBuilder: false,
-        documents: mockDocuments,
-      })
-      expect(result).toBe('/projects/1/versions/live/documents/doc-1')
-    })
-
-    it('returns issues URL when no documents exist', () => {
-      const result = getRedirectUrl({
-        commits: mockCommits,
-        projectId: 1,
-        lastSeenCommitUuid: HEAD_COMMIT,
-        PROJECT_ROUTE,
-        agentBuilder: false,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/live/issues')
     })
 
-    it('ignores lastSeenDocumentUuid and returns first document URL', () => {
+    it('ignores lastSeenDocumentUuid and returns issues URL', () => {
       const result = getRedirectUrl({
         commits: mockCommits,
         projectId: 1,
         lastSeenCommitUuid: '2',
-        lastSeenDocumentUuid: 'some-other-document',
+        lastSeenDocumentUuid: 'some-document',
         PROJECT_ROUTE,
         agentBuilder: false,
-        documents: mockDocuments,
+        promptManagement: true,
       })
-      expect(result).toBe('/projects/1/versions/2/documents/doc-1')
+      expect(result).toBe('/projects/1/versions/2/issues')
     })
 
     it('uses correct commit when lastSeenCommitUuid is not merged', () => {
@@ -198,9 +180,9 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: '2',
         PROJECT_ROUTE,
         agentBuilder: false,
-        documents: mockDocuments,
+        promptManagement: true,
       })
-      expect(result).toBe('/projects/1/versions/2/documents/doc-1')
+      expect(result).toBe('/projects/1/versions/2/issues')
     })
 
     it('uses head commit when lastSeenCommitUuid is merged', () => {
@@ -210,12 +192,12 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: '1',
         PROJECT_ROUTE,
         agentBuilder: false,
-        documents: mockDocuments,
+        promptManagement: true,
       })
-      expect(result).toBe('/projects/1/versions/live/documents/doc-1')
+      expect(result).toBe('/projects/1/versions/live/issues')
     })
 
-    it('returns issues URL on first commit when no head commit and no documents', () => {
+    it('returns issues URL on first commit when no head commit', () => {
       const noHeadCommits = [{ uuid: '1', mergedAt: null }] as Commit[]
       const result = getRedirectUrl({
         commits: noHeadCommits,
@@ -223,9 +205,99 @@ describe('getRedirectUrl', () => {
         lastSeenCommitUuid: undefined,
         PROJECT_ROUTE,
         agentBuilder: false,
-        documents: [],
+        promptManagement: true,
       })
       expect(result).toBe('/projects/1/versions/1/issues')
+    })
+  })
+
+  describe('when simplified product (promptManagement disabled)', () => {
+    it('returns issues URL', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: HEAD_COMMIT,
+        PROJECT_ROUTE,
+        agentBuilder: true,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/live/issues')
+    })
+
+    it('ignores lastSeenDocumentUuid and returns issues URL', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: '2',
+        lastSeenDocumentUuid: 'some-document',
+        PROJECT_ROUTE,
+        agentBuilder: true,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/2/issues')
+    })
+
+    it('uses correct commit when lastSeenCommitUuid is not merged', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: '2',
+        PROJECT_ROUTE,
+        agentBuilder: true,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/2/issues')
+    })
+
+    it('uses head commit when lastSeenCommitUuid is merged', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: '1',
+        PROJECT_ROUTE,
+        agentBuilder: true,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/live/issues')
+    })
+
+    it('returns issues URL on first commit when no head commit', () => {
+      const noHeadCommits = [{ uuid: '1', mergedAt: null }] as Commit[]
+      const result = getRedirectUrl({
+        commits: noHeadCommits,
+        projectId: 1,
+        lastSeenCommitUuid: undefined,
+        PROJECT_ROUTE,
+        agentBuilder: true,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/1/issues')
+    })
+  })
+
+  describe('when simplified product (both disabled)', () => {
+    it('returns issues URL', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: HEAD_COMMIT,
+        PROJECT_ROUTE,
+        agentBuilder: false,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/live/issues')
+    })
+
+    it('returns issues URL on specific commit', () => {
+      const result = getRedirectUrl({
+        commits: mockCommits,
+        projectId: 1,
+        lastSeenCommitUuid: '2',
+        PROJECT_ROUTE,
+        agentBuilder: false,
+        promptManagement: false,
+      })
+      expect(result).toBe('/projects/1/versions/2/issues')
     })
   })
 })

--- a/apps/web/src/app/(private)/projects/[projectId]/utils.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/utils.ts
@@ -1,7 +1,6 @@
 import { ROUTES } from '$/services/routes'
 import { HEAD_COMMIT } from '@latitude-data/core/constants'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
-import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
 
 type GetCommitUrlParams = {
   commits: Commit[]
@@ -10,7 +9,7 @@ type GetCommitUrlParams = {
   lastSeenDocumentUuid?: string | undefined
   PROJECT_ROUTE: typeof ROUTES.projects.detail
   agentBuilder: boolean
-  documents: DocumentVersion[]
+  promptManagement: boolean
 }
 
 export function getRedirectUrl({
@@ -20,7 +19,7 @@ export function getRedirectUrl({
   lastSeenDocumentUuid,
   PROJECT_ROUTE,
   agentBuilder,
-  documents,
+  promptManagement,
 }: GetCommitUrlParams): string {
   const url = getCommitUrl({
     commits,
@@ -29,20 +28,17 @@ export function getRedirectUrl({
     PROJECT_ROUTE,
   })
 
-  if (agentBuilder) {
-    if (!lastSeenDocumentUuid) {
-      return url.home.root
-    }
-    return url.documents.detail({ uuid: lastSeenDocumentUuid }).root
+  const simplifiedProduct = !agentBuilder || !promptManagement
+
+  if (simplifiedProduct) {
+    return url.issues.root
   }
 
-  const firstDocument = documents[0]
-  if (firstDocument) {
-    return url.documents.detail({ uuid: firstDocument.documentUuid }).root
+  if (!lastSeenDocumentUuid) {
+    return url.home.root
   }
 
-  // TODO: Replace with /traces project level when ready
-  return url.issues.root
+  return url.documents.detail({ uuid: lastSeenDocumentUuid }).root
 }
 
 function getCommitUrl({
@@ -52,7 +48,7 @@ function getCommitUrl({
   PROJECT_ROUTE,
 }: Omit<
   GetCommitUrlParams,
-  'lastSeenDocumentUuid' | 'agentBuilder' | 'documents'
+  'lastSeenDocumentUuid' | 'agentBuilder' | 'promptManagement'
 >) {
   const headCommit = commits.find((c) => c.mergedAt)
   const firstCommit = commits[0]

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ClientFilesTree/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ClientFilesTree/index.tsx
@@ -17,10 +17,12 @@ import { useCommits } from '$/stores/commitsStore'
 import { useRunningDocuments } from '$/stores/runs/runningDocuments'
 
 export default function ClientFilesTree({
+  promptManagement,
   documents: serverDocuments,
   liveDocuments: serverLiveDocuments,
   currentDocument,
 }: {
+  promptManagement: boolean
   documents: SidebarDocument[]
   liveDocuments?: SidebarDocument[]
   currentDocument: SidebarDocument | undefined
@@ -117,6 +119,7 @@ export default function ClientFilesTree({
   return (
     <>
       <FilesTree
+        promptManagement={promptManagement}
         sidebarLinkContext={sidebarLinkContext}
         isLoading={isLoading}
         isMerged={isMerged}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CommitItem/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/CommitSelector/CommitItem/index.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { MouseEvent, useMemo, useState } from 'react'
 import { ROUTES } from '$/services/routes'
 import { Badge } from '@latitude-data/web-ui/atoms/Badge'
@@ -121,7 +119,7 @@ export function CommitItem({
     if (!selectedSegment) return documentRoute.editor.root
 
     return (
-      documentRoute[selectedSegment as 'editor' | 'logs']?.root ??
+      documentRoute[selectedSegment as 'editor' | 'traces']?.root ??
       documentRoute.editor.root
     )
   }, [project.id, commit, isHead, currentDocument, selectedSegment])

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ProjectSection/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/ProjectSection/index.tsx
@@ -86,7 +86,7 @@ export default function ProjectSection({
   project: Project
   commit: Commit
 }) {
-  const { agentBuilder } = useProductAccess()
+  const { agentBuilder, promptManagement } = useProductAccess()
   const { value: lastRunTab } = useLocalStorage<RunSourceGroup>({
     key: AppLocalStorage.lastRunTab,
     defaultValue: RunSourceGroup.Playground,
@@ -117,7 +117,7 @@ export default function ProjectSection({
             .detail({ id: project.id })
             .commits.detail({ uuid: commit.uuid }).issues.root,
         },
-        {
+        promptManagement && {
           label: 'History',
           route: ROUTES.projects
             .detail({ id: project.id })
@@ -125,7 +125,7 @@ export default function ProjectSection({
           iconName: 'history',
         },
       ].filter(Boolean) as ProjectRoute[],
-    [project, commit, lastRunTab, agentBuilder],
+    [project, commit, lastRunTab, agentBuilder, promptManagement],
   )
 
   return (

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/_components/Sidebar/index.tsx
@@ -15,6 +15,7 @@ import {
   CommitsRepository,
   DeploymentTestsRepository,
 } from '@latitude-data/core/repositories/index'
+import { computeProductAccess } from '@latitude-data/core/services/productAccess/computeProductAccess'
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
 import { DocumentVersion } from '@latitude-data/core/schema/models/types/DocumentVersion'
 import { Project } from '@latitude-data/core/schema/models/types/Project'
@@ -33,6 +34,7 @@ export default async function Sidebar({
   currentDocument?: DocumentVersion
 }) {
   const { workspace } = await getCurrentUserOrRedirect()
+  const productAccess = computeProductAccess(workspace)
   const documents = await getDocumentsAtCommitCached({ commit })
   const commitsScope = new CommitsRepository(workspace.id)
   const headCommit = await getHeadCommitCached({
@@ -79,19 +81,22 @@ export default async function Sidebar({
     <DocumentSidebar
       banner={<ProductionBanner project={project} />}
       header={
-        <CommitSelector
-          headCommit={headCommit}
-          currentCommit={commit}
-          currentDocument={currentDocument}
-          draftCommits={rows}
-          commitsInActiveTests={commitsInActiveTests}
-          activeTests={activeTests}
-        />
+        productAccess.promptManagement ? (
+          <CommitSelector
+            headCommit={headCommit}
+            currentCommit={commit}
+            currentDocument={currentDocument}
+            draftCommits={rows}
+            commitsInActiveTests={commitsInActiveTests}
+            activeTests={activeTests}
+          />
+        ) : null
       }
       tree={
         <div className='flex flex-col gap-4'>
           <ProjectSection project={project} commit={commit} />
           <ClientFilesTree
+            promptManagement={productAccess.promptManagement}
             currentDocument={currentDocument}
             documents={documents}
             liveDocuments={liveDocuments}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/_components/EvaluationsTable/BlankSlate.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/evaluations/_components/EvaluationsTable/BlankSlate.tsx
@@ -1,3 +1,4 @@
+import { useProductAccess } from '$/components/Providers/SessionProvider'
 import { useEvaluationsV2 } from '$/stores/evaluationsV2'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import {
@@ -20,6 +21,7 @@ export function EvaluationsTableBlankSlate({
   isCreatingEvaluation: boolean
   isGeneratingEvaluation: boolean
 }) {
+  const { promptManagement } = useProductAccess()
   const [openGenerateModal, setOpenGenerateModal] = useState(false)
 
   return (
@@ -40,17 +42,18 @@ export function EvaluationsTableBlankSlate({
           title='How to evaluate your prompts using LLMs and Latitude.so'
         />
       </BlankSlateStep>
-      <BlankSlateStep
-        number={2}
-        title='Generate an evaluation'
-        description='Our AI can craft an evaluation just for this specific prompt, try it out!'
-        className='animate-in fade-in duration-300 max-h-[360px] over overflow-y-auto'
-      >
-        <div className='relative bg-secondary px-4 py-2 rounded-lg border max-h-[272px] overflow-hidden'>
-          <div className='max-h-[272px] overflow-hidden'>
-            <span className='whitespace-pre-wrap text-sm leading-1 text-muted-foreground'>
-              {generatorEnabled
-                ? `
+      {promptManagement && (
+        <BlankSlateStep
+          number={2}
+          title='Generate an evaluation'
+          description='Our AI can craft an evaluation just for this specific prompt, try it out!'
+          className='animate-in fade-in duration-300 max-h-[360px] over overflow-y-auto'
+        >
+          <div className='relative bg-secondary px-4 py-2 rounded-lg border max-h-[272px] overflow-hidden'>
+            <div className='max-h-[272px] overflow-hidden'>
+              <span className='whitespace-pre-wrap text-sm leading-1 text-muted-foreground'>
+                {generatorEnabled
+                  ? `
 ---
   provider: OpenAI
   model: gpt-5.2
@@ -59,7 +62,7 @@ This is just a placeholder for the evaluation prompt because generating it takes
 
 Don't rawdog your prompts!
             `.trim()
-                : `
+                  : `
 ---
   provider: OpenAI
   model: gpt-5.2
@@ -68,29 +71,30 @@ This is just a placeholder for the evaluation prompt because the evaluation gene
 
 Don't rawdog your prompts!
             `.trim()}
-            </span>
+              </span>
+            </div>
+            <div className='absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-secondary to-transparent pointer-events-none'></div>
+            <div className='flex justify-center absolute right-0 bottom-4 w-full'>
+              <Button
+                fancy
+                onClick={() => setOpenGenerateModal(true)}
+                disabled={!generatorEnabled}
+              >
+                Generate the evaluation
+              </Button>
+              <EvaluationsGenerator
+                open={openGenerateModal}
+                setOpen={setOpenGenerateModal}
+                createEvaluation={createEvaluation}
+                generateEvaluation={generateEvaluation}
+                generatorEnabled={generatorEnabled}
+                isCreatingEvaluation={isCreatingEvaluation}
+                isGeneratingEvaluation={isGeneratingEvaluation}
+              />
+            </div>
           </div>
-          <div className='absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-secondary to-transparent pointer-events-none'></div>
-          <div className='flex justify-center absolute right-0 bottom-4 w-full'>
-            <Button
-              fancy
-              onClick={() => setOpenGenerateModal(true)}
-              disabled={!generatorEnabled}
-            >
-              Generate the evaluation
-            </Button>
-            <EvaluationsGenerator
-              open={openGenerateModal}
-              setOpen={setOpenGenerateModal}
-              createEvaluation={createEvaluation}
-              generateEvaluation={generateEvaluation}
-              generatorEnabled={generatorEnabled}
-              isCreatingEvaluation={isCreatingEvaluation}
-              isGeneratingEvaluation={isGeneratingEvaluation}
-            />
-          </div>
-        </div>
-      </BlankSlateStep>
+        </BlankSlateStep>
+      )}
     </BlankSlateWithSteps>
   )
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/layout.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/layout.tsx
@@ -1,24 +1,15 @@
-import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
-import { ExperimentsRepository } from '@latitude-data/core/repositories'
-import { ExperimentsPageContent } from './_components/ExperimentsPage'
+import { ReactNode } from 'react'
 import buildMetatags from '$/app/_lib/buildMetatags'
+import { Metadata } from 'next'
 
-export const metadata = buildMetatags({
+export const metadata: Promise<Metadata> = buildMetatags({
   locationDescription: 'Prompt Experiments Page',
 })
 
-export default async function ExperimentsLayout({
-  params,
+export default function ExperimentsLayout({
+  children,
 }: {
-  params: Promise<{
-    documentUuid: string
-  }>
+  children: ReactNode
 }) {
-  const { workspace } = await getCurrentUserOrRedirect()
-  const { documentUuid } = await params
-
-  const experimentsScope = new ExperimentsRepository(workspace.id)
-  const count = await experimentsScope.countByDocumentUuid(documentUuid)
-
-  return <ExperimentsPageContent initialCount={count} />
+  return children
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/(withTabs)/experiments/page.tsx
@@ -1,3 +1,34 @@
-export default function ExperimentsPage() {
-  return null // --> layout.tsx
+import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
+import { ROUTES } from '$/services/routes'
+import { computeProductAccess } from '@latitude-data/core/services/productAccess/computeProductAccess'
+import { ExperimentsRepository } from '@latitude-data/core/repositories'
+import { ExperimentsPageContent } from './_components/ExperimentsPage'
+import { redirect } from 'next/navigation'
+
+export default async function ExperimentsPage({
+  params,
+}: {
+  params: Promise<{
+    projectId: string
+    commitUuid: string
+    documentUuid: string
+  }>
+}) {
+  const { workspace } = await getCurrentUserOrRedirect()
+  const { projectId, commitUuid, documentUuid } = await params
+
+  const productAccess = computeProductAccess(workspace)
+  if (!productAccess.promptManagement) {
+    redirect(
+      ROUTES.projects
+        .detail({ id: Number(projectId) })
+        .commits.detail({ uuid: commitUuid })
+        .documents.detail({ uuid: documentUuid }).traces.root,
+    )
+  }
+
+  const experimentsScope = new ExperimentsRepository(workspace.id)
+  const count = await experimentsScope.countByDocumentUuid(documentUuid)
+
+  return <ExperimentsPageContent initialCount={count} />
 }

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/index.tsx
@@ -13,6 +13,7 @@ import { useCurrentDocument } from '$/app/providers/DocumentProvider'
 import { useToggleStates } from './ContentArea/hooks/usePlaygroundLogic'
 import { DocumentEditorSidebarArea } from './SidebarArea'
 import { DocumentParametersProvider } from './V2Playground/DocumentParams/DocumentParametersContext'
+import { useProductAccess } from '$/components/Providers/SessionProvider'
 
 export default function DocumentEditor(props: {
   freeRunsCount?: number
@@ -21,6 +22,7 @@ export default function DocumentEditor(props: {
   const { commit } = useCurrentCommit()
   const { project } = useCurrentProject()
   const { document } = useCurrentDocument()
+  const { promptManagement } = useProductAccess()
   const [selectedTab, setSelectedTab] = useState<TabValue>(
     props.showPreview ? 'preview' : DocumentRoutes.editor,
   )
@@ -52,17 +54,19 @@ export default function DocumentEditor(props: {
           documentUuid={document.documentUuid}
           onPreviewToggle={onPreviewToggle}
         />
-        <Button
-          variant='ghost'
-          onClick={toggleDocumentation}
-          iconProps={{ name: 'code2', placement: 'right' }}
-          className='truncate font-normal hover:text-primary transition-colors'
-          userSelect={false}
-        >
-          <Text.H5 ellipsis noWrap>
-            Deploy this prompt
-          </Text.H5>
-        </Button>
+        {promptManagement && (
+          <Button
+            variant='ghost'
+            onClick={toggleDocumentation}
+            iconProps={{ name: 'code2', placement: 'right' }}
+            className='truncate font-normal hover:text-primary transition-colors'
+            userSelect={false}
+          >
+            <Text.H5 ellipsis noWrap>
+              Deploy this prompt
+            </Text.H5>
+          </Button>
+        )}
       </div>
       <div className='flex flex-1 gap-x-8 min-h-0'>
         <div className='flex flex-1 h-full'>

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/index.tsx
@@ -6,6 +6,7 @@ import { ReactNode } from 'react'
 import { Button } from '@latitude-data/web-ui/atoms/Button'
 import { useDeployPrompt } from '../DocumentationModal'
 import { DocumentTabSelector } from './tabs'
+import { useProductAccess } from '$/components/Providers/SessionProvider'
 
 export default function DocumentTabs({
   params,
@@ -15,6 +16,7 @@ export default function DocumentTabs({
   document: DocumentVersion
   children: ReactNode
 }) {
+  const { promptManagement } = useProductAccess()
   const { toggleDocumentation } = useDeployPrompt()
 
   return (
@@ -25,15 +27,17 @@ export default function DocumentTabs({
           commitUuid={params.commitUuid}
           documentUuid={params.documentUuid}
         />
-        <div className='flex flex-row items-center gap-x-4'>
-          <Button
-            variant='ghost'
-            onClick={toggleDocumentation}
-            iconProps={{ name: 'code2', placement: 'right' }}
-          >
-            Deploy this prompt
-          </Button>
-        </div>
+        {promptManagement && (
+          <div className='flex flex-row items-center gap-x-4'>
+            <Button
+              variant='ghost'
+              onClick={toggleDocumentation}
+              iconProps={{ name: 'code2', placement: 'right' }}
+            >
+              Deploy this prompt
+            </Button>
+          </div>
+        )}
       </div>
       <div className='flex-grow min-h-0 flex flex-col w-full relative'>
         {children}

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/tabs.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentTabs/tabs.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useProductAccess } from '$/components/Providers/SessionProvider'
 import { TabSelector } from '$/components/TabSelector'
 import { DocumentRoutes, ROUTES } from '$/services/routes'
 import useFeature from '$/stores/useFeature'
@@ -67,6 +68,7 @@ export const DocumentTabSelector = memo(
     }, [projectId, commitUuid, documentUuid])
 
     const { isEnabled: optimizationsEnabled } = useFeature('optimizations')
+    const { promptManagement } = useProductAccess()
 
     // --- Tabs definition ---
     const data = useMemo(() => {
@@ -91,11 +93,6 @@ export const DocumentTabSelector = memo(
           value: DocumentRoutes.experiments,
           route: baseRoute.experiments.root,
         },
-        [DocumentRoutes.logs]: {
-          label: 'Logs',
-          value: DocumentRoutes.logs,
-          route: baseRoute.logs.root,
-        },
         [DocumentRoutes.traces]: {
           label: 'Traces',
           value: DocumentRoutes.traces,
@@ -108,6 +105,16 @@ export const DocumentTabSelector = memo(
         },
       } satisfies Record<TabValue, TabSelectorOption<TabValue>>
 
+      if (!promptManagement) {
+        return {
+          tabs,
+          options: [
+            tabs[DocumentRoutes.traces],
+            tabs[DocumentRoutes.evaluations],
+          ],
+        }
+      }
+
       return {
         tabs,
         options: [
@@ -118,7 +125,7 @@ export const DocumentTabSelector = memo(
           ...(optimizationsEnabled ? [tabs[DocumentRoutes.optimizations]] : []),
         ],
       }
-    }, [baseRoute, optimizationsEnabled])
+    }, [baseRoute, optimizationsEnabled, promptManagement])
 
     const setPreviewState = useCallback(
       (showPreview: boolean) => {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/page.tsx
@@ -6,6 +6,7 @@ import {
 import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
 import { ROUTES } from '$/services/routes'
 import { NotFoundError } from '@latitude-data/core/lib/errors'
+import { computeProductAccess } from '@latitude-data/core/services/productAccess/computeProductAccess'
 import { getFreeRuns } from '@latitude-data/core/services/freeRunsManager/index'
 import { redirect } from 'next/navigation'
 import { MetadataProvider } from '$/components/MetadataProvider'
@@ -53,6 +54,16 @@ export default async function DocumentPage({
   const { projectId: pjid, commitUuid, documentUuid } = await params
   const projectId = Number(pjid)
   const { workspace } = await getCurrentUserOrRedirect()
+
+  const productAccess = computeProductAccess(workspace)
+  if (!productAccess.promptManagement) {
+    redirect(
+      ROUTES.projects
+        .detail({ id: projectId })
+        .commits.detail({ uuid: commitUuid })
+        .documents.detail({ uuid: documentUuid }).traces.root,
+    )
+  }
 
   let commit
   try {

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/page.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/history/page.tsx
@@ -1,4 +1,8 @@
 import { findCommitsByProjectCached } from '$/app/(private)/_data-access'
+import { getCurrentUserOrRedirect } from '$/services/auth/getCurrentUser'
+import { ROUTES } from '$/services/routes'
+import { computeProductAccess } from '@latitude-data/core/services/productAccess/computeProductAccess'
+import { redirect } from 'next/navigation'
 import ProjectLayout from '../_components/ProjectLayout'
 import { ProjectChanges } from './_components/ProjectChanges'
 import buildMetatags from '$/app/_lib/buildMetatags'
@@ -14,6 +18,13 @@ export default async function HistoryPage({
   params: Promise<{ projectId: string; commitUuid: string }>
 }) {
   const { projectId, commitUuid } = await params
+  const { workspace } = await getCurrentUserOrRedirect()
+
+  const productAccess = computeProductAccess(workspace)
+  if (!productAccess.promptManagement) {
+    redirect(ROUTES.projects.detail({ id: Number(projectId) }).root)
+  }
+
   const allCommits = await findCommitsByProjectCached({
     projectId: Number(projectId),
   })

--- a/apps/web/src/app/(private)/settings/_components/ProductFeatures/index.tsx
+++ b/apps/web/src/app/(private)/settings/_components/ProductFeatures/index.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { updateProductAccessAction } from '$/actions/workspaces/updateProductAccess'
+import useLatitudeAction from '$/hooks/useLatitudeAction'
+import { useSession } from '$/components/Providers/SessionProvider'
+import { SwitchToggle } from '@latitude-data/web-ui/atoms/Switch'
+import { Text } from '@latitude-data/web-ui/atoms/Text'
+import { useToast } from '@latitude-data/web-ui/atoms/Toast'
+import { Tooltip } from '@latitude-data/web-ui/atoms/Tooltip'
+import { useCallback, useState } from 'react'
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@latitude-data/web-ui/atoms/Card'
+
+export default function ProductFeatures() {
+  const { toast } = useToast()
+  const { productAccess } = useSession()
+  const [promptManagerEnabled, setPromptManagerEnabled] = useState(
+    productAccess.promptManagement,
+  )
+  const { execute: updateProductAccess, isPending } = useLatitudeAction(
+    updateProductAccessAction,
+  )
+
+  const handlePromptManagerToggle = useCallback(
+    async (enabled: boolean) => {
+      setPromptManagerEnabled(enabled)
+
+      const [, error] = await updateProductAccess({
+        promptManagerEnabled: enabled,
+      })
+
+      if (error) {
+        setPromptManagerEnabled(!enabled)
+        toast({
+          title: 'Failed to update product features',
+          description: error.message,
+          variant: 'destructive',
+        })
+        return
+      }
+
+      toast({
+        title: enabled ? 'Prompt Manager enabled' : 'Prompt Manager disabled',
+        description: enabled
+          ? 'You can now create and manage prompts'
+          : 'Prompt management features are now hidden',
+      })
+
+      window.location.reload()
+    },
+    [updateProductAccess, toast],
+  )
+
+  return (
+    <Card shadow='sm' background='light'>
+      <CardHeader>
+        <CardTitle>Product features</CardTitle>
+        <CardDescription>
+          Enable or disable features for your workspace. Changes will take
+          effect immediately for all members.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className='flex flex-row gap-x-4'>
+        <div className='flex flex-col gap-6 py-4'>
+          <div className='flex flex-row items-start justify-between gap-4'>
+            <div className='flex flex-col gap-1'>
+              <Text.H5M>Monitoring</Text.H5M>
+              <Text.H6 color='foregroundMuted'>
+                Monitor your AI applications with traces and evaluations. This
+                feature is always enabled.
+              </Text.H6>
+            </div>
+            <Tooltip trigger={<SwitchToggle checked disabled />}>
+              Monitoring is enabled by default and cannot be disabled
+            </Tooltip>
+          </div>
+
+          <div className='flex flex-row items-start justify-between gap-4'>
+            <div className='flex flex-col gap-1'>
+              <Text.H5M>Prompt Manager</Text.H5M>
+              <Text.H6 color='foregroundMuted'>
+                Create, edit, and version your prompts. Enable this to access
+                the full prompt editor, experiments, and optimization features.
+              </Text.H6>
+            </div>
+            <SwitchToggle
+              checked={promptManagerEnabled}
+              onCheckedChange={handlePromptManagerToggle}
+              disabled={isPending}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/app/(private)/settings/layout.tsx
+++ b/apps/web/src/app/(private)/settings/layout.tsx
@@ -14,6 +14,7 @@ import WorkspaceName from './_components/WorkspaceName'
 import Integrations from './_components/Integrations'
 import Webhooks from './_components/Webhooks'
 import Promocodes from './_components/Promocodes'
+import ProductFeatures from './_components/ProductFeatures'
 import { CustomerPortalButton } from './_components/CustomerPortalButton'
 
 export const metadata: Promise<Metadata> = buildMetatags({
@@ -34,6 +35,9 @@ export default async function SettingsLayout({
       {children}
       <TitleWithActions title='Workspace' actions={<CustomerPortalButton />} />
       <WorkspaceName />
+      <div id='product-features'>
+        <ProductFeatures />
+      </div>
       <Memberships />
       <WorkspaceApiKeys />
       <ProviderApiKeys />

--- a/apps/web/src/components/Sidebar/Files/FilesProvider/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/FilesProvider/index.tsx
@@ -22,6 +22,7 @@ import { type SidebarLinkContext } from '../index'
 import { ClientOnly } from '@latitude-data/web-ui/atoms/ClientOnly'
 
 type IFilesContext = {
+  promptManagement: boolean
   isLoading: boolean
   isMerged: boolean
   mainDocumentUuid: string | undefined
@@ -40,6 +41,7 @@ type IFilesContext = {
 const FileTreeContext = createContext({} as IFilesContext)
 
 const FileTreeProvider = ({
+  promptManagement,
   isLoading,
   isMerged,
   onMergeCommitClick,
@@ -69,7 +71,7 @@ const FileTreeProvider = ({
     openPaths: state.openPaths,
     togglePath: state.togglePath,
   }))
-  const { onDragEnd } = useDragEndFile({ renamePaths })
+  const { onDragEnd } = useDragEndFile({ promptManagement, renamePaths })
   const onDragOver = useCallback(
     (event: DragOverEvent) => {
       const { over } = event
@@ -97,6 +99,7 @@ const FileTreeProvider = ({
     >
       <FileTreeContext.Provider
         value={{
+          promptManagement,
           isLoading,
           isMerged,
           onMergeCommitClick,

--- a/apps/web/src/components/Sidebar/Files/FilesProvider/useDragEndFile/index.test.ts
+++ b/apps/web/src/components/Sidebar/Files/FilesProvider/useDragEndFile/index.test.ts
@@ -51,9 +51,37 @@ describe('useDragEndFile', () => {
     vi.clearAllMocks()
   })
 
+  it('does nothing if promptManagement is disabled', async () => {
+    const { result } = renderHook(() =>
+      useDragEndFile({ promptManagement: false, renamePaths: renamePathsMock }),
+    )
+    const dragNode: DraggableAndDroppableData = {
+      nodeId: 'drag-1',
+      name: 'file.txt',
+      path: '/path/to/file',
+      isFile: true,
+      isRoot: false,
+    }
+    const destinationFolder: DraggableAndDroppableData = {
+      nodeId: 'dest-1',
+      name: 'Documents',
+      path: '/destination',
+      isFile: false,
+      isRoot: false,
+    }
+    const event = createDragEndEvent(dragNode, destinationFolder)
+
+    await act(async () => {
+      await result.current.onDragEnd(event as DragEndEvent)
+    })
+
+    expect(renamePathsMock).not.toHaveBeenCalled()
+    expect(deleteTmpFolderMock).not.toHaveBeenCalled()
+  })
+
   it('does nothing if active drag data is missing', async () => {
     const { result } = renderHook(() =>
-      useDragEndFile({ renamePaths: renamePathsMock }),
+      useDragEndFile({ promptManagement: true, renamePaths: renamePathsMock }),
     )
     const event = createDragEndEvent(undefined, {
       nodeId: 'dest-1',
@@ -73,7 +101,7 @@ describe('useDragEndFile', () => {
 
   it('does nothing if destination folder data is missing', async () => {
     const { result } = renderHook(() =>
-      useDragEndFile({ renamePaths: renamePathsMock }),
+      useDragEndFile({ promptManagement: true, renamePaths: renamePathsMock }),
     )
     const event = createDragEndEvent(
       {
@@ -96,7 +124,7 @@ describe('useDragEndFile', () => {
 
   it('does nothing if the computed paths are equal (for folders)', async () => {
     const { result } = renderHook(() =>
-      useDragEndFile({ renamePaths: renamePathsMock }),
+      useDragEndFile({ promptManagement: true, renamePaths: renamePathsMock }),
     )
 
     const dragNode: DraggableAndDroppableData = {
@@ -126,7 +154,7 @@ describe('useDragEndFile', () => {
 
   it('calls renamePaths and deleteTmpFolder for a valid file move', async () => {
     const { result } = renderHook(() =>
-      useDragEndFile({ renamePaths: renamePathsMock }),
+      useDragEndFile({ promptManagement: true, renamePaths: renamePathsMock }),
     )
     const dragNode: DraggableAndDroppableData = {
       nodeId: 'drag-1',
@@ -159,7 +187,7 @@ describe('useDragEndFile', () => {
 
   it('calls renamePaths and deleteTmpFolder for a valid folder move', async () => {
     const { result } = renderHook(() =>
-      useDragEndFile({ renamePaths: renamePathsMock }),
+      useDragEndFile({ promptManagement: true, renamePaths: renamePathsMock }),
     )
     const dragNode: DraggableAndDroppableData = {
       nodeId: 'drag-2',

--- a/apps/web/src/components/Sidebar/Files/FilesProvider/useDragEndFile/index.ts
+++ b/apps/web/src/components/Sidebar/Files/FilesProvider/useDragEndFile/index.ts
@@ -4,8 +4,10 @@ import { DragEndEvent } from '@latitude-data/web-ui/hooks/useDnD'
 import { DraggableAndDroppableData } from '../DragOverlayNode'
 
 export function useDragEndFile({
+  promptManagement,
   renamePaths,
 }: {
+  promptManagement: boolean
   renamePaths: (args: { oldPath: string; newPath: string }) => Promise<void>
 }) {
   const { deleteTmpFolder } = useTempNodes((state) => ({
@@ -13,6 +15,8 @@ export function useDragEndFile({
   }))
   const onDragEnd = useCallback(
     async (event: DragEndEvent) => {
+      if (!promptManagement) return
+
       const { active, over } = event
 
       // Skip if the drag is over itself
@@ -34,7 +38,7 @@ export function useDragEndFile({
       await renamePaths({ oldPath, newPath })
       deleteTmpFolder({ id: draggedFolderData.nodeId })
     },
-    [renamePaths, deleteTmpFolder],
+    [promptManagement, renamePaths, deleteTmpFolder],
   )
 
   return { onDragEnd }

--- a/apps/web/src/components/Sidebar/Files/FolderHeader/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/FolderHeader/index.tsx
@@ -30,6 +30,7 @@ export default function FolderHeader({
   runningCount?: number
 }) {
   const {
+    promptManagement,
     isLoading,
     isMerged,
     onMergeCommitClick,
@@ -87,6 +88,8 @@ export default function FolderHeader({
 
   const onSaveValue = useCallback(
     ({ path }: { path: string }) => {
+      if (!promptManagement) return
+
       if (isMerged) {
         onMergeCommitClick()
         return
@@ -100,7 +103,14 @@ export default function FolderHeader({
         updateFolder({ id: node.id, path })
       }
     },
-    [node, updateFolder, isMerged, onMergeCommitClick, onRenameFile],
+    [
+      promptManagement,
+      node,
+      updateFolder,
+      isMerged,
+      onMergeCommitClick,
+      onRenameFile,
+    ],
   )
 
   const fileUploadInputRef = useRef<HTMLInputElement>(null)
@@ -123,9 +133,12 @@ export default function FolderHeader({
     [node, deleteTmpFolder, onUploadFile],
   )
 
-  const [isEditing, setIsEditing] = useState(node.name === ' ')
-  const actions = useMemo<MenuOption[]>(
-    () => [
+  const [isEditingState, setIsEditing] = useState(node.name === ' ')
+  const isEditing = promptManagement && isEditingState
+  const actions = useMemo<MenuOption[]>(() => {
+    if (!promptManagement) return []
+
+    return [
       {
         label: 'Rename folder',
         lookDisabled: isMerged,
@@ -180,19 +193,19 @@ export default function FolderHeader({
           }
         },
       },
-    ],
-    [
-      node,
-      isLoading,
-      isMerged,
-      onMergeCommitClick,
-      onClickFileUploadInput,
-      onDeleteFolder,
-      deleteTmpFolder,
-      setIsEditing,
-      onAddNode,
-    ],
-  )
+    ]
+  }, [
+    promptManagement,
+    node,
+    isLoading,
+    isMerged,
+    onMergeCommitClick,
+    onClickFileUploadInput,
+    onDeleteFolder,
+    deleteTmpFolder,
+    setIsEditing,
+    onAddNode,
+  ])
 
   return (
     <>

--- a/apps/web/src/components/Sidebar/Files/NodeHeaderWrapper/MainPromptIcon.tsx
+++ b/apps/web/src/components/Sidebar/Files/NodeHeaderWrapper/MainPromptIcon.tsx
@@ -27,6 +27,7 @@ export function MainPromptIcon({
   )
 
   if (!isFile) return null
+  if (isMainDocument === undefined) return null
 
   return (
     <Tooltip

--- a/apps/web/src/components/Sidebar/Files/TreeToolbar/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/TreeToolbar/index.tsx
@@ -32,8 +32,13 @@ export function TreeToolbar() {
   const { addToRootFolder } = useTempNodes((s) => ({
     addToRootFolder: s.addToRootFolder,
   }))
-  const { isLoading, isMerged, onMergeCommitClick, onCreateAgent } =
-    useFileTreeContext()
+  const {
+    promptManagement,
+    isLoading,
+    isMerged,
+    onMergeCommitClick,
+    onCreateAgent,
+  } = useFileTreeContext()
   const { nodeInput, setNodeInput } = useNodeInput()
   const isFile = nodeInput ? FILE_TYPES.includes(nodeInput) : false
   const icons: IconName[] = nodeInput
@@ -58,39 +63,41 @@ export function TreeToolbar() {
   return (
     <>
       <div className='bg-background sticky top-0 flex flex-row items-center justify-between pl-4 pr-2 z-10'>
-        <Text.H5M>Files</Text.H5M>
-        <div className='flex flex-row space-x-2'>
-          <Tooltip
-            asChild
-            trigger={
-              <Button
-                variant='ghost'
-                size='icon'
-                lookDisabled={isMerged}
-                disabled={isLoading}
-                iconProps={{ name: 'folderPlus' }}
-                onClick={onClick(EntityType.Folder)}
-              />
-            }
-          >
-            New folder
-          </Tooltip>
-          <Tooltip
-            asChild
-            trigger={
-              <Button
-                variant='ghost'
-                size='icon'
-                lookDisabled={isMerged}
-                disabled={isLoading}
-                iconProps={{ name: 'filePlus' }}
-                onClick={onClick(EntityType.Prompt)}
-              />
-            }
-          >
-            New prompt
-          </Tooltip>
-        </div>
+        <Text.H5M>{promptManagement ? 'Files' : 'Traces paths'}</Text.H5M>
+        {promptManagement && (
+          <div className='flex flex-row space-x-2'>
+            <Tooltip
+              asChild
+              trigger={
+                <Button
+                  variant='ghost'
+                  size='icon'
+                  lookDisabled={isMerged}
+                  disabled={isLoading}
+                  iconProps={{ name: 'folderPlus' }}
+                  onClick={onClick(EntityType.Folder)}
+                />
+              }
+            >
+              New folder
+            </Tooltip>
+            <Tooltip
+              asChild
+              trigger={
+                <Button
+                  variant='ghost'
+                  size='icon'
+                  lookDisabled={isMerged}
+                  disabled={isLoading}
+                  iconProps={{ name: 'filePlus' }}
+                  onClick={onClick(EntityType.Prompt)}
+                />
+              }
+            >
+              New prompt
+            </Tooltip>
+          </div>
+        )}
       </div>
       {nodeInput ? (
         <NodeHeaderWrapper

--- a/apps/web/src/components/Sidebar/Files/index.tsx
+++ b/apps/web/src/components/Sidebar/Files/index.tsx
@@ -211,6 +211,7 @@ export type SidebarLinkContext = {
 }
 
 export function FilesTree({
+  promptManagement,
   sidebarLinkContext,
   isLoading,
   isMerged,
@@ -228,6 +229,7 @@ export function FilesTree({
   setMainDocumentUuid,
   isDestroying,
 }: {
+  promptManagement: boolean
   sidebarLinkContext: SidebarLinkContext
   isLoading: boolean
   isMerged: boolean
@@ -307,6 +309,7 @@ export function FilesTree({
   return (
     <ClientOnly>
       <FileTreeProvider
+        promptManagement={promptManagement}
         sidebarLinkContext={sidebarLinkContext}
         isLoading={isLoading}
         isMerged={isMerged}

--- a/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/Versions/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/Versions/index.tsx
@@ -8,10 +8,9 @@ import { Text } from '@latitude-data/web-ui/atoms/Text'
 import { BreadcrumbItemSkeleton } from '@latitude-data/web-ui/molecules/Breadcrumb'
 import { ClickToCopy } from '@latitude-data/web-ui/molecules/ClickToCopy'
 import { useCommitsFromProject } from '$/stores/commitsStore'
-
 import { HEAD_COMMIT } from '@latitude-data/core/constants'
-
 import { Commit } from '@latitude-data/core/schema/models/types/Commit'
+
 export function CommitBreadcrumbItems({
   segments,
   projectId,

--- a/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/index.tsx
+++ b/apps/web/src/components/layouts/AppLayout/Header/Breadcrumb/Projects/index.tsx
@@ -11,16 +11,19 @@ import useProjects from '$/stores/projects'
 
 import { BreadcrumbSelector, BreadcrumbSelectorOption } from '../Selector'
 import { CommitBreadcrumbItems } from './Versions'
+import { useProductAccess } from '$/components/Providers/SessionProvider'
 
 export function ProjectBreadcrumbItems({ segments }: { segments: string[] }) {
   const projectId = Number(segments[0])
-
+  const { promptManagement } = useProductAccess()
   const { data: projects, isLoading } = useProjects()
   const currentProject = useMemo(
     () => projects?.find((project) => project.id === projectId),
     [projects, projectId],
   )
 
+  const showVersions =
+    promptManagement && segments.length > 2 && segments[1] == 'versions'
   const options = useMemo<BreadcrumbSelectorOption[]>(() => {
     if (!projects) return []
     return projects.map((p) => ({
@@ -51,7 +54,7 @@ export function ProjectBreadcrumbItems({ segments }: { segments: string[] }) {
         )}
       </BreadcrumbItem>
 
-      {segments.length > 2 && segments[1] == 'versions' && (
+      {showVersions && (
         <CommitBreadcrumbItems
           segments={segments.slice(2)}
           projectId={projectId}

--- a/apps/web/src/services/routes.ts
+++ b/apps/web/src/services/routes.ts
@@ -7,7 +7,6 @@ export type IDatasetSettingsModal = 'new' | 'generate'
 
 export enum DocumentRoutes {
   editor = 'editor',
-  logs = 'logs',
   evaluations = 'evaluations',
   experiments = 'experiments',
   traces = 'traces',
@@ -220,21 +219,6 @@ export const ROUTES = {
                             root: `${root}/editor`,
                           },
                         }
-                      },
-                    },
-                    [DocumentRoutes.logs]: {
-                      root: `${root}/${DocumentRoutes.logs}`,
-                      upload: `${root}/${DocumentRoutes.logs}/upload`,
-                      withFilters: ({
-                        experimentId,
-                      }: {
-                        experimentId?: number
-                      }) => {
-                        const base = `${root}/${DocumentRoutes.logs}`
-                        if (experimentId) {
-                          return `${base}?experimentId=${experimentId}`
-                        }
-                        return base
                       },
                     },
                     [DocumentRoutes.traces]: {

--- a/apps/web/src/stores/currentWorkspace.ts
+++ b/apps/web/src/stores/currentWorkspace.ts
@@ -27,7 +27,6 @@ export default function useCurrentWorkspace(opts?: SWRConfiguration) {
       if (!data) return
 
       const [workspace, error] = await updateWorkspace({
-        workspaceId: data!.id,
         name: payload.name,
       })
       if (error) {
@@ -59,7 +58,6 @@ export default function useCurrentWorkspace(opts?: SWRConfiguration) {
       if (!data) return
 
       const [workspace, error] = await setDefaultProvider({
-        workspaceId: data!.id,
         defaultProviderId: payload.defaultProviderId,
       })
       if (error) {

--- a/packages/core/src/services/optimizations/prepare.test.ts
+++ b/packages/core/src/services/optimizations/prepare.test.ts
@@ -2134,7 +2134,9 @@ describe('prepareOptimization', () => {
         const datasetsRepository = new DatasetsRepository(
           workspaceWithParams.id,
         )
-        const listing = await datasetsRepository.findAll().then((r) => r.unwrap())
+        const listing = await datasetsRepository
+          .findAll()
+          .then((r) => r.unwrap())
         const optimizationDatasets = listing.filter(
           (d) =>
             d.name.includes('Trainset') &&


### PR DESCRIPTION
## Summary

Conditionally hide and redirect from prompt management features when `promptManagerEnabled` is false for a workspace. This allows users to use Latitude as an observability-only tool without the prompt management features.

### Navigation & Redirects

When prompt management is disabled:
- **Editor**, **Experiments**, and **Optimizations** pages redirect to the document's Traces page
- **History** page redirects to the project root
- **Document tabs** show only Traces and Evaluations (hide Editor, Experiments, Optimizations)
- **History link** is hidden from the project sidebar
- **Project landing page** redirects to Issues instead of Home/document pages

### Sidebar Changes

When prompt management is disabled:
- **Version selector** (CommitSelector) is hidden - users only see the "live" commit
- **File tree header** renamed from "Files" to "Prompts"
- **Create folder/file buttons** are hidden
- **Delete/rename actions** on files and folders are hidden
- **Main prompt icon** is not shown
- **Drag-and-drop file/folder moving** is disabled

### Document Editor

When prompt management is disabled:
- **"Deploy this prompt" button** is hidden in both the Editor and DocumentTabs components

### Evaluations

When prompt management is disabled:
- **"Generate evaluation" button and section** are hidden (requires prompt content)
- **Evaluation types requiring expected output** are blocked with a warning:
  - Shows warning variant Alert explaining that expected output is matched from dataset columns to prompt parameters
  - Includes link to settings to enable Prompt Manager
  - Create button is disabled for these evaluation types
- **Backend validation** added in `createEvaluationV2` service to reject evaluations requiring expected output when prompt manager is disabled

### Settings

Added new **Product Features** section at `/settings#product-features`:
- **Observability** toggle (always enabled, cannot be disabled) with tooltip explanation
- **Prompt Manager** toggle to enable/disable prompt management features
- Full page reload on setting change to ensure UI state consistency

### New Server Action

- `updateProductAccessAction` - Updates workspace product access settings (only exposes `promptManagerEnabled`, not `agentBuilderEnabled`)

### Type Updates

- `ConfirmModal` component now accepts `ReactNode` for `confirm.description` prop

## Test Plan

- [x] Verify redirects work correctly when prompt management is disabled
- [x] Verify sidebar elements are hidden appropriately
- [x] Verify drag-and-drop is disabled when prompt management is disabled
- [x] Verify evaluation creation is blocked for types requiring expected output
- [x] Verify settings toggle works and triggers page reload
- [x] Unit tests added for `createEvaluationV2` service validation
- [x] Unit tests updated for `useDragEndFile` hook