### PR TITLE
Add secondary indexes for ClickHouse evaluation_results

### DIFF
--- a/packages/core/clickhouse/migrations/clustered/0005_add_evaluation_results_secondary_indexes.down.sql
+++ b/packages/core/clickhouse/migrations/clustered/0005_add_evaluation_results_secondary_indexes.down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE evaluation_results ON CLUSTER default DROP INDEX IF EXISTS idx_evaluated_span_id;
+ALTER TABLE evaluation_results ON CLUSTER default DROP INDEX IF EXISTS idx_evaluated_trace_span;
 ALTER TABLE evaluation_results ON CLUSTER default DROP INDEX IF EXISTS idx_evaluated_trace_id;
 ALTER TABLE evaluation_results ON CLUSTER default DROP INDEX IF EXISTS idx_experiment_id;
 ALTER TABLE evaluation_results ON CLUSTER default DROP INDEX IF EXISTS idx_document_uuid;

--- a/packages/core/clickhouse/migrations/clustered/0005_add_evaluation_results_secondary_indexes.up.sql
+++ b/packages/core/clickhouse/migrations/clustered/0005_add_evaluation_results_secondary_indexes.up.sql
@@ -4,11 +4,11 @@ ALTER TABLE evaluation_results ON CLUSTER default
   ADD INDEX IF NOT EXISTS idx_document_uuid document_uuid TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_experiment_id experiment_id TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_evaluated_trace_id evaluated_trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_evaluated_span_id evaluated_span_id TYPE bloom_filter(0.01) GRANULARITY 1;
+  ADD INDEX IF NOT EXISTS idx_evaluated_trace_span tuple(evaluated_trace_id, evaluated_span_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_uuid;
 ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_commit_uuid;
 ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_document_uuid;
 ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_experiment_id;
 ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_evaluated_trace_id;
-ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_evaluated_span_id;
+ALTER TABLE evaluation_results ON CLUSTER default MATERIALIZE INDEX idx_evaluated_trace_span;

--- a/packages/core/clickhouse/migrations/unclustered/0005_add_evaluation_results_secondary_indexes.down.sql
+++ b/packages/core/clickhouse/migrations/unclustered/0005_add_evaluation_results_secondary_indexes.down.sql
@@ -1,4 +1,4 @@
-ALTER TABLE evaluation_results DROP INDEX IF EXISTS idx_evaluated_span_id;
+ALTER TABLE evaluation_results DROP INDEX IF EXISTS idx_evaluated_trace_span;
 ALTER TABLE evaluation_results DROP INDEX IF EXISTS idx_evaluated_trace_id;
 ALTER TABLE evaluation_results DROP INDEX IF EXISTS idx_experiment_id;
 ALTER TABLE evaluation_results DROP INDEX IF EXISTS idx_document_uuid;

--- a/packages/core/clickhouse/migrations/unclustered/0005_add_evaluation_results_secondary_indexes.up.sql
+++ b/packages/core/clickhouse/migrations/unclustered/0005_add_evaluation_results_secondary_indexes.up.sql
@@ -4,11 +4,11 @@ ALTER TABLE evaluation_results
   ADD INDEX IF NOT EXISTS idx_document_uuid document_uuid TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_experiment_id experiment_id TYPE bloom_filter(0.01) GRANULARITY 1,
   ADD INDEX IF NOT EXISTS idx_evaluated_trace_id evaluated_trace_id TYPE bloom_filter(0.01) GRANULARITY 1,
-  ADD INDEX IF NOT EXISTS idx_evaluated_span_id evaluated_span_id TYPE bloom_filter(0.01) GRANULARITY 1;
+  ADD INDEX IF NOT EXISTS idx_evaluated_trace_span tuple(evaluated_trace_id, evaluated_span_id) TYPE bloom_filter(0.01) GRANULARITY 1;
 
 ALTER TABLE evaluation_results MATERIALIZE INDEX idx_uuid;
 ALTER TABLE evaluation_results MATERIALIZE INDEX idx_commit_uuid;
 ALTER TABLE evaluation_results MATERIALIZE INDEX idx_document_uuid;
 ALTER TABLE evaluation_results MATERIALIZE INDEX idx_experiment_id;
 ALTER TABLE evaluation_results MATERIALIZE INDEX idx_evaluated_trace_id;
-ALTER TABLE evaluation_results MATERIALIZE INDEX idx_evaluated_span_id;
+ALTER TABLE evaluation_results MATERIALIZE INDEX idx_evaluated_trace_span;


### PR DESCRIPTION
## Summary
- add secondary bloom-filter indexes for `evaluation_results` on lookup-heavy columns used by the read migration: `uuid`, `commit_uuid`, `document_uuid`, `experiment_id`, `evaluated_trace_id`, and `evaluated_span_id`
- add both unclustered and clustered migration variants
- materialize each added index in the up migration so existing rows benefit immediately

## Rollback
- drops all newly added indexes in reverse order in matching down migrations