### PR TITLE
fix: experiments real-time updates not working

### DIFF
--- a/packages/core/src/events/handlers/notifyClientOfExperimentStatus.ts
+++ b/packages/core/src/events/handlers/notifyClientOfExperimentStatus.ts
@@ -1,0 +1,24 @@
+import { unsafelyFindWorkspace } from '../../data-access/workspaces'
+import { NotFoundError } from '../../lib/errors'
+import { ExperimentDto } from '../../schema/models/types/Experiment'
+import { WebsocketClient } from '../../websockets/workers'
+
+export type ExperimentStatusEventData = {
+  workspaceId: number
+  experiment: ExperimentDto
+}
+
+export const notifyClientOfExperimentStatus = async ({
+  workspaceId,
+  experiment,
+}: ExperimentStatusEventData) => {
+  const workspace = await unsafelyFindWorkspace(workspaceId)
+  if (!workspace) throw new NotFoundError(`Workspace not found ${workspaceId}`)
+
+  await WebsocketClient.sendEvent('experimentStatus', {
+    workspaceId: workspace.id,
+    data: {
+      experiment,
+    },
+  })
+}


### PR DESCRIPTION
## Problem

The issue was that WebSocket events for experiment status updates were sending raw experiment data with progress tracker results, but the frontend expects `ExperimentDto` data as transformed by the repository's `experimentDtoPresenter` function.

This caused a mismatch in the data structure, particularly in the `completed` field calculation. The repository calculates `completed` based on completed evaluation cycles divided by total evaluations, while the progress tracker returns raw counts from Redis.

## Solution

- Create `notifyClientOfExperimentStatus` handler to centralize experiment status notifications  
- Update `updateStatus.ts` to fetch `ExperimentDto` from repository before sending WebSocket events
- Update `stop.ts` to use the same pattern
- Update `stop.test.ts` to mock the repository and notification handler

This ensures that the WebSocket events send data in the same format as the API endpoints, providing consistent data to the frontend and fixing the real-time update issues.

## Related Issue

Fixes LAT-403

## Testing

- [x] pnpm lint passes
- [x] pnpm tc passes
- [ ] Tests updated to reflect new implementation