### PR TITLE
API v4 gateway endpoints

### DIFF
--- a/apps/gateway/src/api.routes.ts
+++ b/apps/gateway/src/api.routes.ts
@@ -1,61 +1,61 @@
-export const API_ROUTES = {
-  v3: {
-    tools: {
-      results: `/api/v3/tools/results`,
+const API_VERSIONED_ROUTES = (version: string) => ({
+  tools: {
+    results: `/api/${version}/tools/results`,
+  },
+  projects: {
+    getAll: `/api/${version}/projects`,
+    create: `/api/${version}/projects`,
+    push: `/api/${version}/projects/:projectId/versions/:versionUuid/push`,
+    versions: {
+      get: `/api/${version}/projects/:projectId/versions/:versionUuid`,
+      getAll: `/api/${version}/projects/:projectId/versions`,
+      create: `/api/${version}/projects/:projectId/versions`,
+      publish: `/api/${version}/projects/:projectId/versions/:versionUuid/publish`,
     },
-    projects: {
-      getAll: '/api/v3/projects',
-      create: '/api/v3/projects',
-      push: '/api/v3/projects/:projectId/versions/:versionUuid/push',
-      versions: {
-        get: '/api/v3/projects/:projectId/versions/:versionUuid',
-        getAll: '/api/v3/projects/:projectId/versions',
-        create: '/api/v3/projects/:projectId/versions',
-        publish: '/api/v3/projects/:projectId/versions/:versionUuid/publish',
-      },
-      documents: {
-        get: '/api/v3/projects/:projectId/versions/:versionUuid/documents/:documentPath{.+}',
-        getAll: '/api/v3/projects/:projectId/versions/:versionUuid/documents',
-        create: '/api/v3/projects/:projectId/versions/:versionUuid/documents',
-        createOrUpdate:
-          '/api/v3/projects/:projectId/versions/:versionUuid/documents/create-or-update',
-        getOrCreate:
-          '/api/v3/projects/:projectId/versions/:versionUuid/documents/get-or-create',
-        logs: '/api/v3/projects/:projectId/versions/:versionUuid/documents/logs',
-        run: '/api/v3/projects/:projectId/versions/:versionUuid/documents/run',
-      },
-    },
-    conversations: {
-      chat: '/api/v3/conversations/:conversationUuid/chat',
-      stop: '/api/v3/conversations/:conversationUuid/stop',
-      attach: '/api/v3/conversations/:conversationUuid/attach',
-      annotate:
-        '/api/v3/conversations/:conversationUuid/evaluations/:evaluationUuid/annotate',
-      get: '/api/v3/conversations/:conversationUuid',
-    },
-    traces: {
-      ingest: '/api/v3/traces',
-    },
-    datasets: {
-      getAll: '/api/v3/datasets',
-      get: '/api/v3/datasets/:datasetId',
-      create: '/api/v3/datasets',
-      update: '/api/v3/datasets/:datasetId',
-      destroy: '/api/v3/datasets/:datasetId',
-    },
-    datasetRows: {
-      getAll: '/api/v3/dataset-rows',
-      get: '/api/v3/dataset-rows/:rowId',
-      create: '/api/v3/dataset-rows',
-      update: '/api/v3/dataset-rows/:rowId',
-      destroy: '/api/v3/dataset-rows/:rowId',
-    },
-    providerApiKeys: {
-      getAll: '/api/v3/provider-api-keys',
-      get: '/api/v3/provider-api-keys/:providerApiKeyId',
-      create: '/api/v3/provider-api-keys',
-      update: '/api/v3/provider-api-keys/:providerApiKeyId',
-      destroy: '/api/v3/provider-api-keys/:providerApiKeyId',
+    documents: {
+      get: `/api/${version}/projects/:projectId/versions/:versionUuid/documents/:documentPath{.+}`,
+      getAll: `/api/${version}/projects/:projectId/versions/:versionUuid/documents`,
+      create: `/api/${version}/projects/:projectId/versions/:versionUuid/documents`,
+      createOrUpdate: `/api/${version}/projects/:projectId/versions/:versionUuid/documents/create-or-update`,
+      getOrCreate: `/api/${version}/projects/:projectId/versions/:versionUuid/documents/get-or-create`,
+      logs: `/api/${version}/projects/:projectId/versions/:versionUuid/documents/logs`,
+      run: `/api/${version}/projects/:projectId/versions/:versionUuid/documents/run`,
     },
   },
-}
+  conversations: {
+    chat: `/api/${version}/conversations/:conversationUuid/chat`,
+    stop: `/api/${version}/conversations/:conversationUuid/stop`,
+    attach: `/api/${version}/conversations/:conversationUuid/attach`,
+    annotate: `/api/${version}/conversations/:conversationUuid/evaluations/:evaluationUuid/annotate`,
+    get: `/api/${version}/conversations/:conversationUuid`,
+  },
+  traces: {
+    ingest: `/api/${version}/traces`,
+  },
+  datasets: {
+    getAll: `/api/${version}/datasets`,
+    get: `/api/${version}/datasets/:datasetId`,
+    create: `/api/${version}/datasets`,
+    update: `/api/${version}/datasets/:datasetId`,
+    destroy: `/api/${version}/datasets/:datasetId`,
+  },
+  datasetRows: {
+    getAll: `/api/${version}/dataset-rows`,
+    get: `/api/${version}/dataset-rows/:rowId`,
+    create: `/api/${version}/dataset-rows`,
+    update: `/api/${version}/dataset-rows/:rowId`,
+    destroy: `/api/${version}/dataset-rows/:rowId`,
+  },
+  providerApiKeys: {
+    getAll: `/api/${version}/provider-api-keys`,
+    get: `/api/${version}/provider-api-keys/:providerApiKeyId`,
+    create: `/api/${version}/provider-api-keys`,
+    update: `/api/${version}/provider-api-keys/:providerApiKeyId`,
+    destroy: `/api/${version}/provider-api-keys/:providerApiKeyId`,
+  },
+})
+
+export const API_ROUTES = {
+  v3: API_VERSIONED_ROUTES('v3'),
+  v4: API_VERSIONED_ROUTES('v4'),
+} as const

--- a/apps/gateway/src/routes/api/helpers.ts
+++ b/apps/gateway/src/routes/api/helpers.ts
@@ -1,0 +1,14 @@
+import { createRoute, type RouteConfig } from '@hono/zod-openapi'
+
+export function defineRouteConfig<T extends Omit<RouteConfig, 'path'>>(
+  route: T,
+): T & { path: string } {
+  return route as T & { path: string }
+}
+
+export function route<T extends Omit<RouteConfig, 'path'>>(r: T, path: string) {
+  return createRoute({
+    ...r,
+    path,
+  }) as T & { path: string }
+}

--- a/apps/gateway/src/routes/api/index.ts
+++ b/apps/gateway/src/routes/api/index.ts
@@ -1,19 +1,8 @@
-import { conversationsRouter } from '$/routes/api/v3/conversations'
-import { projectsRouter } from '$/routes/api/v3/projects'
-import { tracesRouter } from '$/routes/api/v3/traces'
-import { datasetsRouter } from '$/routes/api/v3/datasets'
-import { datasetRowsRouter } from '$/routes/api/v3/datasetRows'
-import { providerApiKeysRouter } from '$/routes/api/v3/providerApiKeys'
 import { OpenAPIHono } from '@hono/zod-openapi'
-import { toolResultsRouter } from './v3/tools/results'
+import { v3Router } from '$/routes/api/v3'
+import { v4Router } from '$/routes/api/v4'
 
 export function configureApiRoutes(app: OpenAPIHono) {
-  // V3
-  app.route('/', conversationsRouter)
-  app.route('/', projectsRouter)
-  app.route('/', tracesRouter)
-  app.route('/', toolResultsRouter)
-  app.route('/', datasetsRouter)
-  app.route('/', datasetRowsRouter)
-  app.route('/', providerApiKeysRouter)
+  app.route('/', v3Router)
+  app.route('/', v4Router)
 }

--- a/apps/gateway/src/routes/api/v3/conversations/annotate/annotate.route.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/annotate/annotate.route.ts
@@ -1,19 +1,18 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 
 export const annotateParamsSchema = z.object({
   conversationUuid: z.string().openapi({ description: 'Conversation UUID' }),
   evaluationUuid: z.string().openapi({ description: 'Evaluation UUID' }),
 })
 
-export const annotateRoute = createRoute({
+export const annotateRouteConfig = defineRouteConfig({
   operationId: 'annotate',
   tags: ['Evaluations'],
   description: 'Annotate a conversation with an existing evaluation',
   method: http.Methods.POST,
-  path: ROUTES.api.v3.conversations.annotate,
   request: {
     params: annotateParamsSchema,
     body: {
@@ -90,4 +89,4 @@ export const annotateRoute = createRoute({
   },
 })
 
-export type AnnotateRoute = typeof annotateRoute
+export type AnnotateRoute = typeof annotateRouteConfig

--- a/apps/gateway/src/routes/api/v3/conversations/attach/attach.route.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/attach/attach.route.ts
@@ -4,16 +4,15 @@ import {
   chainEventDtoSchema,
   runSyncAPIResponseSchema,
 } from '$/openApi/schemas'
-import { ROUTES } from '$/routes'
 import { conversationsParamsSchema } from '$/routes/api/v3/conversations/paramsSchema'
-import { createRoute, z } from '@hono/zod-openapi'
+import { z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const attachRoute = createRoute({
+export const attachRouteConfig = defineRouteConfig({
   operationId: 'attachConversation',
   tags: ['Conversations'],
   description: 'Attach to an active conversation',
   method: http.Methods.POST,
-  path: ROUTES.api.v3.conversations.attach,
   request: {
     params: conversationsParamsSchema,
     body: {
@@ -39,4 +38,4 @@ export const attachRoute = createRoute({
   },
 })
 
-export type AttachRoute = typeof attachRoute
+export type AttachRoute = typeof attachRouteConfig

--- a/apps/gateway/src/routes/api/v3/conversations/chat/chat.route.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/chat/chat.route.ts
@@ -6,16 +6,15 @@ import {
   runSyncAPIResponseSchema,
   messageSchema,
 } from '$/openApi/schemas'
-import { ROUTES } from '$/routes'
 import { conversationsParamsSchema } from '$/routes/api/v3/conversations/paramsSchema'
-import { createRoute, z } from '@hono/zod-openapi'
+import { z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const chatRoute = createRoute({
+export const chatRouteConfig = defineRouteConfig({
   operationId: 'createChat',
   tags: ['Conversations'],
   description: 'Chat with an existing conversation',
   method: http.Methods.POST,
-  path: ROUTES.api.v3.conversations.chat,
   request: {
     params: conversationsParamsSchema,
     body: {
@@ -54,4 +53,4 @@ export const chatRoute = createRoute({
   },
 })
 
-export type ChatRoute = typeof chatRoute
+export type ChatRoute = typeof chatRouteConfig

--- a/apps/gateway/src/routes/api/v3/conversations/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/get/get.route.ts
@@ -1,16 +1,14 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { conversationPresenterSchema } from '$/openApi/schemas/conversations'
-import { ROUTES } from '$/routes'
 import { conversationsParamsSchema } from '$/routes/api/v3/conversations/paramsSchema'
-import { createRoute } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getRoute = createRoute({
+export const getRouteConfig = defineRouteConfig({
   operationId: 'getConversation',
   tags: ['Conversations'],
   description: 'Get a conversation',
   method: http.Methods.GET,
-  path: ROUTES.api.v3.conversations.get,
   request: {
     params: conversationsParamsSchema,
   },
@@ -25,4 +23,4 @@ export const getRoute = createRoute({
   },
 })
 
-export type GetRoute = typeof getRoute
+export type GetRoute = typeof getRouteConfig

--- a/apps/gateway/src/routes/api/v3/conversations/index.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/index.ts
@@ -1,13 +1,40 @@
 import { createRouter } from '$/openApi/createApp'
-import { annotateHandler, annotateRoute } from './annotate'
-import { attachHandler, attachRoute } from './attach'
-import { chatHandler, chatRoute } from './chat'
-import { stopHandler, stopRoute } from './stop'
-import { getHandler, getRoute } from './get'
+import { route } from '$/routes/api/helpers'
+import { ROUTES } from '$/routes'
+
+import {
+  annotateHandler,
+  annotateRouteConfig,
+} from '$/routes/api/v3/conversations/annotate'
+import {
+  attachHandler,
+  attachRouteConfig,
+} from '$/routes/api/v3/conversations/attach'
+import {
+  chatHandler,
+  chatRouteConfig,
+} from '$/routes/api/v3/conversations/chat'
+import {
+  stopHandler,
+  stopRouteConfig,
+} from '$/routes/api/v3/conversations/stop'
+import { getHandler, getRouteConfig } from '$/routes/api/v3/conversations/get'
 
 export const conversationsRouter = createRouter()
-  .openapi(chatRoute, chatHandler)
-  .openapi(attachRoute, attachHandler)
-  .openapi(stopRoute, stopHandler)
-  .openapi(annotateRoute, annotateHandler)
-  .openapi(getRoute, getHandler)
+  .openapi(
+    route(chatRouteConfig, ROUTES.api.v3.conversations.chat),
+    chatHandler,
+  )
+  .openapi(
+    route(attachRouteConfig, ROUTES.api.v3.conversations.attach),
+    attachHandler,
+  )
+  .openapi(
+    route(stopRouteConfig, ROUTES.api.v3.conversations.stop),
+    stopHandler,
+  )
+  .openapi(
+    route(annotateRouteConfig, ROUTES.api.v3.conversations.annotate),
+    annotateHandler,
+  )
+  .openapi(route(getRouteConfig, ROUTES.api.v3.conversations.get), getHandler)

--- a/apps/gateway/src/routes/api/v3/conversations/stop/stop.route.ts
+++ b/apps/gateway/src/routes/api/v3/conversations/stop/stop.route.ts
@@ -1,15 +1,13 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
-import { ROUTES } from '$/routes'
+import { defineRouteConfig } from '$/routes/api/helpers'
 import { conversationsParamsSchema } from '$/routes/api/v3/conversations/paramsSchema'
-import { createRoute } from '@hono/zod-openapi'
 
-export const stopRoute = createRoute({
+export const stopRouteConfig = defineRouteConfig({
   operationId: 'stopConversation',
   tags: ['Conversations'],
   description: 'Stop an active conversation',
   method: http.Methods.POST,
-  path: ROUTES.api.v3.conversations.stop,
   request: {
     params: conversationsParamsSchema,
   },
@@ -21,4 +19,4 @@ export const stopRoute = createRoute({
   },
 })
 
-export type StopRoute = typeof stopRoute
+export type StopRoute = typeof stopRouteConfig

--- a/apps/gateway/src/routes/api/v3/datasetRows/create/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/create/create.handler.ts
@@ -2,10 +2,10 @@ import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { createDatasetRow } from '@latitude-data/core/services/datasetRows/create'
 import { type DatasetRowData } from '@latitude-data/core/schema/models/datasetRows'
 import { AppRouteHandler } from '$/openApi/types'
-import { createDatasetRowRoute } from './create.route'
+import { createDatasetRowRouteConfig } from './create.route'
 
 export const createDatasetRowHandler: AppRouteHandler<
-  typeof createDatasetRowRoute
+  typeof createDatasetRowRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/datasetRows/create/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/create/create.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetRowSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const createDatasetRowRoute = createOpenAPIRoute({
+export const createDatasetRowRouteConfig = defineRouteConfig({
   method: 'post',
-  path: API_ROUTES.v3.datasetRows.create,
   tags: ['Dataset Rows'],
   security: [{ bearerAuth: [] }],
   summary: 'Create a new dataset row',

--- a/apps/gateway/src/routes/api/v3/datasetRows/destroy/destroy.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/destroy/destroy.handler.ts
@@ -4,10 +4,10 @@ import {
 } from '@latitude-data/core/repositories'
 import { deleteManyRows } from '@latitude-data/core/services/datasetRows/deleteManyRows'
 import { AppRouteHandler } from '$/openApi/types'
-import { destroyDatasetRowRoute } from './destroy.route'
+import { destroyDatasetRowRouteConfig } from './destroy.route'
 
 export const destroyDatasetRowHandler: AppRouteHandler<
-  typeof destroyDatasetRowRoute
+  typeof destroyDatasetRowRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { rowId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/datasetRows/destroy/destroy.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/destroy/destroy.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetRowSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const destroyDatasetRowRoute = createOpenAPIRoute({
+export const destroyDatasetRowRouteConfig = defineRouteConfig({
   method: 'delete',
-  path: API_ROUTES.v3.datasetRows.destroy,
   tags: ['Dataset Rows'],
   security: [{ bearerAuth: [] }],
   summary: 'Delete a dataset row',

--- a/apps/gateway/src/routes/api/v3/datasetRows/get/get.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/get/get.handler.ts
@@ -1,9 +1,9 @@
 import { DatasetRowsRepository } from '@latitude-data/core/repositories'
 import { AppRouteHandler } from '$/openApi/types'
-import { getDatasetRowRoute } from './get.route'
+import { getDatasetRowRouteConfig } from './get.route'
 
 export const getDatasetRowHandler: AppRouteHandler<
-  typeof getDatasetRowRoute
+  typeof getDatasetRowRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { rowId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/datasetRows/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/get/get.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetRowSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getDatasetRowRoute = createOpenAPIRoute({
+export const getDatasetRowRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.datasetRows.get,
   tags: ['Dataset Rows'],
   security: [{ bearerAuth: [] }],
   summary: 'Get a dataset row by ID',

--- a/apps/gateway/src/routes/api/v3/datasetRows/getAll/getAll.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/getAll/getAll.handler.ts
@@ -4,10 +4,10 @@ import {
 } from '@latitude-data/core/repositories'
 import { DEFAULT_PAGINATION_SIZE } from '@latitude-data/core/constants'
 import { AppRouteHandler } from '$/openApi/types'
-import { getAllDatasetRowsRoute } from './getAll.route'
+import { getAllDatasetRowsRouteConfig } from './getAll.route'
 
 export const getAllDatasetRowsHandler: AppRouteHandler<
-  typeof getAllDatasetRowsRoute
+  typeof getAllDatasetRowsRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { datasetId, page, pageSize } = c.req.valid('query')

--- a/apps/gateway/src/routes/api/v3/datasetRows/getAll/getAll.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/getAll/getAll.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetRowSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getAllDatasetRowsRoute = createOpenAPIRoute({
+export const getAllDatasetRowsRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.datasetRows.getAll,
   tags: ['Dataset Rows'],
   security: [{ bearerAuth: [] }],
   summary: 'Get all rows for a dataset',

--- a/apps/gateway/src/routes/api/v3/datasetRows/index.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/index.ts
@@ -1,18 +1,36 @@
 import { createRouter } from '$/openApi/createApp'
-import { getAllDatasetRowsHandler } from './getAll/getAll.handler'
-import { getAllDatasetRowsRoute } from './getAll/getAll.route'
-import { getDatasetRowHandler } from './get/get.handler'
-import { getDatasetRowRoute } from './get/get.route'
-import { createDatasetRowHandler } from './create/create.handler'
-import { createDatasetRowRoute } from './create/create.route'
-import { updateDatasetRowHandler } from './update/update.handler'
-import { updateDatasetRowRoute } from './update/update.route'
-import { destroyDatasetRowHandler } from './destroy/destroy.handler'
-import { destroyDatasetRowRoute } from './destroy/destroy.route'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllDatasetRowsHandler } from '$/routes/api/v3/datasetRows/getAll/getAll.handler'
+import { getAllDatasetRowsRouteConfig } from '$/routes/api/v3/datasetRows/getAll/getAll.route'
+import { getDatasetRowHandler } from '$/routes/api/v3/datasetRows/get/get.handler'
+import { getDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/get/get.route'
+import { createDatasetRowHandler } from '$/routes/api/v3/datasetRows/create/create.handler'
+import { createDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/create/create.route'
+import { updateDatasetRowHandler } from '$/routes/api/v3/datasetRows/update/update.handler'
+import { updateDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/update/update.route'
+import { destroyDatasetRowHandler } from '$/routes/api/v3/datasetRows/destroy/destroy.handler'
+import { destroyDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/destroy/destroy.route'
 
 export const datasetRowsRouter = createRouter()
-  .openapi(getAllDatasetRowsRoute, getAllDatasetRowsHandler)
-  .openapi(getDatasetRowRoute, getDatasetRowHandler)
-  .openapi(createDatasetRowRoute, createDatasetRowHandler)
-  .openapi(updateDatasetRowRoute, updateDatasetRowHandler)
-  .openapi(destroyDatasetRowRoute, destroyDatasetRowHandler)
+  .openapi(
+    route(getAllDatasetRowsRouteConfig, API_ROUTES.v3.datasetRows.getAll),
+    getAllDatasetRowsHandler,
+  )
+  .openapi(
+    route(getDatasetRowRouteConfig, API_ROUTES.v3.datasetRows.get),
+    getDatasetRowHandler,
+  )
+  .openapi(
+    route(createDatasetRowRouteConfig, API_ROUTES.v3.datasetRows.create),
+    createDatasetRowHandler,
+  )
+  .openapi(
+    route(updateDatasetRowRouteConfig, API_ROUTES.v3.datasetRows.update),
+    updateDatasetRowHandler,
+  )
+  .openapi(
+    route(destroyDatasetRowRouteConfig, API_ROUTES.v3.datasetRows.destroy),
+    destroyDatasetRowHandler,
+  )

--- a/apps/gateway/src/routes/api/v3/datasetRows/update/update.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/update/update.handler.ts
@@ -5,10 +5,10 @@ import {
 import { updateDatasetRow } from '@latitude-data/core/services/datasetRows/update'
 import { type DatasetRowData } from '@latitude-data/core/schema/models/datasetRows'
 import { AppRouteHandler } from '$/openApi/types'
-import { updateDatasetRowRoute } from './update.route'
+import { updateDatasetRowRouteConfig } from './update.route'
 
 export const updateDatasetRowHandler: AppRouteHandler<
-  typeof updateDatasetRowRoute
+  typeof updateDatasetRowRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/datasetRows/update/update.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasetRows/update/update.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetRowSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const updateDatasetRowRoute = createOpenAPIRoute({
+export const updateDatasetRowRouteConfig = defineRouteConfig({
   method: 'put',
-  path: API_ROUTES.v3.datasetRows.update,
   tags: ['Dataset Rows'],
   security: [{ bearerAuth: [] }],
   summary: 'Update a dataset row',

--- a/apps/gateway/src/routes/api/v3/datasets/create/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/create/create.handler.ts
@@ -3,10 +3,10 @@ import { createDataset } from '@latitude-data/core/services/datasets/create'
 import { findFirstUserInWorkspace } from '@latitude-data/core/queries/users/findFirstInWorkspace'
 import { type Column } from '@latitude-data/core/schema/models/datasets'
 import { AppRouteHandler } from '$/openApi/types'
-import { createDatasetRoute } from './create.route'
+import { createDatasetRouteConfig } from './create.route'
 
 export const createDatasetHandler: AppRouteHandler<
-  typeof createDatasetRoute
+  typeof createDatasetRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/datasets/create/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/create/create.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetSchema, DatasetColumnSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const createDatasetRoute = createOpenAPIRoute({
+export const createDatasetRouteConfig = defineRouteConfig({
   method: 'post',
-  path: API_ROUTES.v3.datasets.create,
   tags: ['Datasets'],
   security: [{ bearerAuth: [] }],
   summary: 'Create a new dataset',

--- a/apps/gateway/src/routes/api/v3/datasets/destroy/destroy.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/destroy/destroy.handler.ts
@@ -1,10 +1,10 @@
 import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { destroyDataset } from '@latitude-data/core/services/datasets/destroy'
 import { AppRouteHandler } from '$/openApi/types'
-import { destroyDatasetRoute } from './destroy.route'
+import { destroyDatasetRouteConfig } from './destroy.route'
 
 export const destroyDatasetHandler: AppRouteHandler<
-  typeof destroyDatasetRoute
+  typeof destroyDatasetRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { datasetId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/datasets/destroy/destroy.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/destroy/destroy.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const destroyDatasetRoute = createOpenAPIRoute({
+export const destroyDatasetRouteConfig = defineRouteConfig({
   method: 'delete',
-  path: API_ROUTES.v3.datasets.destroy,
   tags: ['Datasets'],
   security: [{ bearerAuth: [] }],
   summary: 'Delete a dataset',

--- a/apps/gateway/src/routes/api/v3/datasets/get/get.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/get/get.handler.ts
@@ -1,9 +1,9 @@
 import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { AppRouteHandler } from '$/openApi/types'
-import { getDatasetRoute } from './get.route'
+import { getDatasetRouteConfig } from './get.route'
 
 export const getDatasetHandler: AppRouteHandler<
-  typeof getDatasetRoute
+  typeof getDatasetRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { datasetId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/datasets/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/get/get.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getDatasetRoute = createOpenAPIRoute({
+export const getDatasetRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.datasets.get,
   tags: ['Datasets'],
   security: [{ bearerAuth: [] }],
   summary: 'Get a dataset by ID',

--- a/apps/gateway/src/routes/api/v3/datasets/getAll/getAll.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/getAll/getAll.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getAllDatasetsRoute = createOpenAPIRoute({
+export const getAllDatasetsRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.datasets.getAll,
   tags: ['Datasets'],
   security: [{ bearerAuth: [] }],
   summary: 'Get all datasets for a workspace',

--- a/apps/gateway/src/routes/api/v3/datasets/index.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/index.ts
@@ -1,18 +1,36 @@
 import { createRouter } from '$/openApi/createApp'
-import { getAllDatasetsHandler } from './getAll/getAll.handler'
-import { getAllDatasetsRoute } from './getAll/getAll.route'
-import { getDatasetHandler } from './get/get.handler'
-import { getDatasetRoute } from './get/get.route'
-import { createDatasetHandler } from './create/create.handler'
-import { createDatasetRoute } from './create/create.route'
-import { updateDatasetHandler } from './update/update.handler'
-import { updateDatasetRoute } from './update/update.route'
-import { destroyDatasetHandler } from './destroy/destroy.handler'
-import { destroyDatasetRoute } from './destroy/destroy.route'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllDatasetsHandler } from '$/routes/api/v3/datasets/getAll/getAll.handler'
+import { getAllDatasetsRouteConfig } from '$/routes/api/v3/datasets/getAll/getAll.route'
+import { getDatasetHandler } from '$/routes/api/v3/datasets/get/get.handler'
+import { getDatasetRouteConfig } from '$/routes/api/v3/datasets/get/get.route'
+import { createDatasetHandler } from '$/routes/api/v3/datasets/create/create.handler'
+import { createDatasetRouteConfig } from '$/routes/api/v3/datasets/create/create.route'
+import { updateDatasetHandler } from '$/routes/api/v3/datasets/update/update.handler'
+import { updateDatasetRouteConfig } from '$/routes/api/v3/datasets/update/update.route'
+import { destroyDatasetHandler } from '$/routes/api/v3/datasets/destroy/destroy.handler'
+import { destroyDatasetRouteConfig } from '$/routes/api/v3/datasets/destroy/destroy.route'
 
 export const datasetsRouter = createRouter()
-  .openapi(getAllDatasetsRoute, getAllDatasetsHandler)
-  .openapi(getDatasetRoute, getDatasetHandler)
-  .openapi(createDatasetRoute, createDatasetHandler)
-  .openapi(updateDatasetRoute, updateDatasetHandler)
-  .openapi(destroyDatasetRoute, destroyDatasetHandler)
+  .openapi(
+    route(getAllDatasetsRouteConfig, API_ROUTES.v3.datasets.getAll),
+    getAllDatasetsHandler,
+  )
+  .openapi(
+    route(getDatasetRouteConfig, API_ROUTES.v3.datasets.get),
+    getDatasetHandler,
+  )
+  .openapi(
+    route(createDatasetRouteConfig, API_ROUTES.v3.datasets.create),
+    createDatasetHandler,
+  )
+  .openapi(
+    route(updateDatasetRouteConfig, API_ROUTES.v3.datasets.update),
+    updateDatasetHandler,
+  )
+  .openapi(
+    route(destroyDatasetRouteConfig, API_ROUTES.v3.datasets.destroy),
+    destroyDatasetHandler,
+  )

--- a/apps/gateway/src/routes/api/v3/datasets/update/update.handler.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/update/update.handler.ts
@@ -2,10 +2,10 @@ import { DatasetsRepository } from '@latitude-data/core/repositories'
 import { updateDataset } from '@latitude-data/core/services/datasets/update'
 import { type Column } from '@latitude-data/core/schema/models/datasets'
 import { AppRouteHandler } from '$/openApi/types'
-import { updateDatasetRoute } from './update.route'
+import { updateDatasetRouteConfig } from './update.route'
 
 export const updateDatasetHandler: AppRouteHandler<
-  typeof updateDatasetRoute
+  typeof updateDatasetRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/datasets/update/update.route.ts
+++ b/apps/gateway/src/routes/api/v3/datasets/update/update.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { DatasetSchema, DatasetColumnSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const updateDatasetRoute = createOpenAPIRoute({
+export const updateDatasetRouteConfig = defineRouteConfig({
   method: 'put',
-  path: API_ROUTES.v3.datasets.update,
   tags: ['Datasets'],
   security: [{ bearerAuth: [] }],
   summary: 'Update a dataset',

--- a/apps/gateway/src/routes/api/v3/index.ts
+++ b/apps/gateway/src/routes/api/v3/index.ts
@@ -1,0 +1,18 @@
+import { createRouter } from '$/openApi/createApp'
+
+import { conversationsRouter } from './conversations'
+import { projectsRouter } from './projects'
+import { tracesRouter } from './traces'
+import { datasetsRouter } from './datasets'
+import { datasetRowsRouter } from './datasetRows'
+import { providerApiKeysRouter } from './providerApiKeys'
+import { toolResultsRouter } from './tools/results'
+
+export const v3Router = createRouter()
+  .route('/', conversationsRouter)
+  .route('/', projectsRouter)
+  .route('/', tracesRouter)
+  .route('/', toolResultsRouter)
+  .route('/', datasetsRouter)
+  .route('/', datasetRowsRouter)
+  .route('/', providerApiKeysRouter)

--- a/apps/gateway/src/routes/api/v3/projects/create/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/create/create.handler.ts
@@ -2,10 +2,12 @@ import { createProject } from '@latitude-data/core/services/projects/create'
 import { findFirstUserInWorkspace } from '@latitude-data/core/queries/users/findFirstInWorkspace'
 import { NotFoundError } from '@latitude-data/constants/errors'
 import { AppRouteHandler } from '$/openApi/types'
-import { createRoute } from './create.route'
+import { createRouteConfig } from './create.route'
 
 // @ts-expect-error: broken types
-export const createHandler: AppRouteHandler<typeof createRoute> = async (c) => {
+export const createHandler: AppRouteHandler<typeof createRouteConfig> = async (
+  c,
+) => {
   const workspace = c.get('workspace')
 
   const { name } = c.req.valid('json')

--- a/apps/gateway/src/routes/api/v3/projects/create/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/create/create.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProjectSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const createRoute = createOpenAPIRoute({
+export const createRouteConfig = defineRouteConfig({
   method: 'post',
-  path: API_ROUTES.v3.projects.create,
   tags: ['Projects'],
   security: [{ bearerAuth: [] }],
   summary: 'Create a new project',

--- a/apps/gateway/src/routes/api/v3/projects/getAll/getAll.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/getAll/getAll.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProjectSchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getAllRoute = createOpenAPIRoute({
+export const getAllRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.projects.getAll,
   tags: ['Projects'],
   security: [{ bearerAuth: [] }],
   summary: 'Get all projects for a workspace',

--- a/apps/gateway/src/routes/api/v3/projects/index.ts
+++ b/apps/gateway/src/routes/api/v3/projects/index.ts
@@ -1,15 +1,28 @@
 import { createRouter } from '$/openApi/createApp'
-import { getAllHandler } from './getAll/getAll.handler'
-import { createHandler } from './create/create.handler'
-import { createRoute } from './create/create.route'
-import { pushRoute } from './push/push.route'
-import { pushHandler } from './push/push.handler'
-import { getAllRoute } from './getAll/getAll.route'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
 import { versionsRouter } from './versions'
+import { createRouteConfig } from '$/routes/api/v3/projects/create/create.route'
+import { createHandler } from '$/routes/api/v3/projects/create/create.handler'
+import { pushRouteConfig } from '$/routes/api/v3/projects/push/push.route'
+import { pushHandler } from '$/routes/api/v3/projects/push/push.handler'
+import { getAllRouteConfig } from '$/routes/api/v3/projects/getAll/getAll.route'
+import { getAllHandler } from '$/routes/api/v3/projects/getAll/getAll.handler'
 
 export const projectsRouter = createRouter()
-  .openapi(getAllRoute, getAllHandler)
-  .openapi(createRoute, createHandler)
-  .openapi(pushRoute, pushHandler)
+  .openapi(
+    route(getAllRouteConfig, API_ROUTES.v3.projects.getAll),
+    getAllHandler,
+  )
+  .openapi(
+    route(createRouteConfig, API_ROUTES.v3.projects.create),
+    createHandler,
+  )
+  .openapi(
+    route(pushRouteConfig, API_ROUTES.v3.projects.push),
+    pushHandler,
+    // prettier-ignore
+  )
 
 projectsRouter.route('/', versionsRouter)

--- a/apps/gateway/src/routes/api/v3/projects/push/push.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/push/push.handler.ts
@@ -4,10 +4,10 @@ import { AppRouteHandler } from '$/openApi/types'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { findProjectById } from '@latitude-data/core/queries/projects/findById'
 import { persistPushChanges } from '@latitude-data/core/services/commits/persistPushChanges'
-import { pushRoute } from './push.route'
+import { pushRouteConfig } from './push.route'
 
 // @ts-expect-error - TODO: Fix this
-export const pushHandler: AppRouteHandler<typeof pushRoute> = async (
+export const pushHandler: AppRouteHandler<typeof pushRouteConfig> = async (
   c: Context,
 ) => {
   const workspace = c.get('workspace')

--- a/apps/gateway/src/routes/api/v3/projects/push/push.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/push/push.route.ts
@@ -1,7 +1,6 @@
-import { createRoute, z } from '@hono/zod-openapi'
-
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
 const pushParamsSchema = z.object({
   projectId: z.string().openapi({
@@ -58,8 +57,7 @@ const pushResponseSchema = z.object({
   }),
 })
 
-export const pushRoute = createRoute({
-  path: API_ROUTES.v3.projects.push,
+export const pushRouteConfig = defineRouteConfig({
   method: 'post',
   tags: ['Projects'],
   summary: 'Push commit changes',

--- a/apps/gateway/src/routes/api/v3/projects/versions/create/createCommit.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/create/createCommit.route.ts
@@ -1,7 +1,7 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
 export const CommitSchema = z.object({
   id: z.number(),
@@ -17,9 +17,8 @@ export const CommitSchema = z.object({
   parentCommitUuid: z.string().nullable(),
 })
 
-export const createVersionRoute = createOpenAPIRoute({
+export const createVersionRouteConfig = defineRouteConfig({
   method: http.Methods.POST,
-  path: API_ROUTES.v3.projects.versions.create,
   tags: ['Versions'],
   security: [{ bearerAuth: [] }],
   summary: 'Create project version',
@@ -49,4 +48,4 @@ export const createVersionRoute = createOpenAPIRoute({
   },
 })
 
-export type CreateCommitRoute = typeof createVersionRoute
+export type CreateCommitRoute = typeof createVersionRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/create/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/create/create.route.ts
@@ -1,47 +1,39 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { documentPresenterSchema } from '$/presenters/documentPresenter'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 
-function createRouteFactory({ path, tags }: { path: string; tags: string[] }) {
-  return createRoute({
-    operationId: 'createDocument',
-    method: http.Methods.POST,
-    description: 'Create a prompt',
-    path,
-    tags,
-    request: {
-      params: z.object({
-        projectId: z.string(),
-        versionUuid: z.string().optional(),
-      }),
-      body: {
-        content: {
-          [http.MediaTypes.JSON]: {
-            schema: z.object({
-              path: z.string(),
-              prompt: z.string().optional(),
-            }),
-          },
-        },
-      },
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The document was created successfully',
-        content: {
-          [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
-        },
-      },
-    },
-  })
-}
-
-export const createDocumentRoute = createRouteFactory({
-  path: ROUTES.api.v3.projects.documents.create,
+export const createDocumentRouteConfig = defineRouteConfig({
+  operationId: 'createDocument',
+  method: http.Methods.POST,
+  description: 'Create a prompt',
   tags: ['Documents'],
+  request: {
+    params: z.object({
+      projectId: z.string(),
+      versionUuid: z.string().optional(),
+    }),
+    body: {
+      content: {
+        [http.MediaTypes.JSON]: {
+          schema: z.object({
+            path: z.string(),
+            prompt: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The document was created successfully',
+      content: {
+        [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
+      },
+    },
+  },
 })
 
-export type CreateDocumentRoute = typeof createDocumentRoute
+export type CreateDocumentRoute = typeof createDocumentRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/createOrUpdate/createOrUpdate.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/createOrUpdate/createOrUpdate.route.ts
@@ -1,49 +1,42 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { documentPresenterSchema } from '$/presenters/documentPresenter'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 
-function createRouteFactory({ path, tags }: { path: string; tags: string[] }) {
-  return createRoute({
-    operationId: 'createOrUpdateDocument',
-    method: http.Methods.POST,
-    description:
-      'Create or update a prompt. By default, this endpoint only works with draft commits. Use force=true to allow modifications to the live commit.',
-    path,
-    tags,
-    request: {
-      params: z.object({
-        projectId: z.string(),
-        versionUuid: z.string().optional(),
-      }),
-      body: {
-        content: {
-          [http.MediaTypes.JSON]: {
-            schema: z.object({
-              path: z.string(),
-              prompt: z.string(),
-              force: z.boolean().optional().default(false),
-            }),
-          },
-        },
-      },
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The document was created or updated successfully',
-        content: {
-          [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
-        },
-      },
-    },
-  })
-}
-
-export const createOrUpdateDocumentRoute = createRouteFactory({
-  path: ROUTES.api.v3.projects.documents.createOrUpdate,
+export const createOrUpdateDocumentRouteConfig = defineRouteConfig({
+  operationId: 'createOrUpdateDocument',
+  method: http.Methods.POST,
+  description:
+    'Create or update a prompt. By default, this endpoint only works with draft commits. Use force=true to allow modifications to the live commit.',
   tags: ['Documents'],
+  request: {
+    params: z.object({
+      projectId: z.string(),
+      versionUuid: z.string().optional(),
+    }),
+    body: {
+      content: {
+        [http.MediaTypes.JSON]: {
+          schema: z.object({
+            path: z.string(),
+            prompt: z.string(),
+            force: z.boolean().optional().default(false),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The document was created or updated successfully',
+      content: {
+        [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
+      },
+    },
+  },
 })
 
-export type CreateOrUpdateDocumentRoute = typeof createOrUpdateDocumentRoute
+export type CreateOrUpdateDocumentRoute =
+  typeof createOrUpdateDocumentRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/get/get.route.ts
@@ -1,39 +1,31 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { documentPresenterSchema } from '$/presenters/documentPresenter'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 import { documentParamsSchema } from '../paramsSchema'
 
-function getRouteFactory({ path, tags }: { path: string; tags: string[] }) {
-  return createRoute({
-    operationId: 'getDocument',
-    method: http.Methods.GET,
-    description: 'Get a prompt',
-    path,
-    tags,
-    request: {
-      params: documentParamsSchema.extend({
-        documentPath: z.string().openapi({
-          description: 'Prompt path',
-        }),
+export const getRouteConfig = defineRouteConfig({
+  operationId: 'getDocument',
+  method: http.Methods.GET,
+  description: 'Get a prompt',
+  tags: ['Documents'],
+  request: {
+    params: documentParamsSchema.extend({
+      documentPath: z.string().openapi({
+        description: 'Prompt path',
       }),
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The document was created or retrieved successfully',
-        content: {
-          [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
-        },
+    }),
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The document was created or retrieved successfully',
+      content: {
+        [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
       },
     },
-  })
-}
-
-export const getRouteV3 = getRouteFactory({
-  path: ROUTES.api.v3.projects.documents.get,
-  tags: ['Documents'],
+  },
 })
 
-export type GetRoute = typeof getRouteV3
+export type GetRoute = typeof getRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/getAll/getAll.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/getAll/getAll.route.ts
@@ -1,37 +1,29 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { documentPresenterSchema } from '$/presenters/documentPresenter'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { z } from '@hono/zod-openapi'
 import { documentParamsSchema } from '../paramsSchema'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-function getRouteFactory({ path, tags }: { path: string; tags: string[] }) {
-  return createRoute({
-    operationId: 'getDocument',
-    method: http.Methods.GET,
-    description: 'Get all prompts in a version',
-    path,
-    tags,
-    request: {
-      params: documentParamsSchema,
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The list of documents for a project at specific version',
-        content: {
-          [http.MediaTypes.JSON]: {
-            schema: z.array(documentPresenterSchema),
-          },
+export const getAllRouteConfig = defineRouteConfig({
+  operationId: 'getDocument',
+  method: http.Methods.GET,
+  description: 'Get all prompts in a version',
+  tags: ['Documents'],
+  request: {
+    params: documentParamsSchema,
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The list of documents for a project at specific version',
+      content: {
+        [http.MediaTypes.JSON]: {
+          schema: z.array(documentPresenterSchema),
         },
       },
     },
-  })
-}
-
-export const getAllRoute = getRouteFactory({
-  path: ROUTES.api.v3.projects.documents.getAll,
-  tags: ['Documents'],
+  },
 })
 
-export type GetRoute = typeof getAllRoute
+export type GetRoute = typeof getAllRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/getOrCreate/getOrCreate.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/getOrCreate/getOrCreate.route.ts
@@ -1,51 +1,37 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { documentPresenterSchema } from '$/presenters/documentPresenter'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { z } from '@hono/zod-openapi'
 import { documentParamsSchema } from '../paramsSchema'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-function getOrCreateRouteFactory({
-  path,
-  tags,
-}: {
-  path: string
-  tags: string[]
-}) {
-  return createRoute({
-    operationId: 'getOrCreateDocument',
-    method: http.Methods.POST,
-    description: 'Find or create a prompt',
-    path,
-    tags,
-    request: {
-      params: documentParamsSchema,
-      body: {
-        content: {
-          [http.MediaTypes.JSON]: {
-            schema: z.object({
-              path: z.string(),
-              prompt: z.string().optional(),
-            }),
-          },
-        },
-      },
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The document was created or retrieved successfully',
-        content: {
-          [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
-        },
-      },
-    },
-  })
-}
-
-export const getOrCreateRouteV3 = getOrCreateRouteFactory({
-  path: ROUTES.api.v3.projects.documents.getOrCreate,
+export const getOrCreateRouteConfig = defineRouteConfig({
+  operationId: 'getOrCreateDocument',
+  method: http.Methods.POST,
+  description: 'Find or create a prompt',
   tags: ['Documents'],
+  request: {
+    params: documentParamsSchema,
+    body: {
+      content: {
+        [http.MediaTypes.JSON]: {
+          schema: z.object({
+            path: z.string(),
+            prompt: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The document was created or retrieved successfully',
+      content: {
+        [http.MediaTypes.JSON]: { schema: documentPresenterSchema },
+      },
+    },
+  },
 })
 
-export type GetOrCreateRoute = typeof getOrCreateRouteV3
+export type GetOrCreateRoute = typeof getOrCreateRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/index.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/index.ts
@@ -1,22 +1,61 @@
 import { createRouter } from '$/openApi/createApp'
-import { createDocumentHandler } from './create/create.handler'
-import { createDocumentRoute } from './create/create.route'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { createDocumentHandler } from '$/routes/api/v3/projects/versions/documents/create/create.handler'
+import { createDocumentRouteConfig } from '$/routes/api/v3/projects/versions/documents/create/create.route'
 import {
   createOrUpdateDocumentHandler,
-  createOrUpdateDocumentRoute,
-} from './createOrUpdate'
-import { getHandler, getRouteV3 } from './get'
-import { getAllHandler, getAllRoute } from './getAll'
-import { getOrCreateHandler, getOrCreateRouteV3 } from './getOrCreate'
-import { createLogHandler } from './logs/create.handler'
-import { createLogRouteV3 } from './logs/create.route'
-import { runHandler, runRoute } from './run'
+  createOrUpdateDocumentRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/createOrUpdate'
+import {
+  getHandler,
+  getRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/get'
+import {
+  getAllHandler,
+  getAllRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/getAll'
+import {
+  getOrCreateHandler,
+  getOrCreateRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/getOrCreate'
+import { createLogHandler } from '$/routes/api/v3/projects/versions/documents/logs/create.handler'
+import { createLogRouteConfig } from '$/routes/api/v3/projects/versions/documents/logs/create.route'
+import {
+  runHandler,
+  runRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/run'
 
 export const documentsRouter = createRouter()
-  .openapi(getRouteV3, getHandler)
-  .openapi(getAllRoute, getAllHandler)
-  .openapi(createDocumentRoute, createDocumentHandler)
-  .openapi(createOrUpdateDocumentRoute, createOrUpdateDocumentHandler)
-  .openapi(getOrCreateRouteV3, getOrCreateHandler)
-  .openapi(runRoute, runHandler)
-  .openapi(createLogRouteV3, createLogHandler)
+  .openapi(
+    route(getRouteConfig, API_ROUTES.v3.projects.documents.get),
+    getHandler,
+  )
+  .openapi(
+    route(getAllRouteConfig, API_ROUTES.v3.projects.documents.getAll),
+    getAllHandler,
+  )
+  .openapi(
+    route(createDocumentRouteConfig, API_ROUTES.v3.projects.documents.create),
+    createDocumentHandler,
+  )
+  .openapi(
+    route(
+      createOrUpdateDocumentRouteConfig,
+      API_ROUTES.v3.projects.documents.createOrUpdate,
+    ),
+    createOrUpdateDocumentHandler,
+  )
+  .openapi(
+    route(getOrCreateRouteConfig, API_ROUTES.v3.projects.documents.getOrCreate),
+    getOrCreateHandler,
+  )
+  .openapi(
+    route(runRouteConfig, API_ROUTES.v3.projects.documents.run),
+    runHandler,
+  )
+  .openapi(
+    route(createLogRouteConfig, API_ROUTES.v3.projects.documents.logs),
+    createLogHandler,
+  )

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.route.ts
@@ -1,8 +1,8 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { messageSchema } from '$/openApi/schemas'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 import { LogSources } from '@latitude-data/core/constants'
 
 const spanLogSchema = z.object({
@@ -30,50 +30,35 @@ const documentParamsSchema = z.object({
     .openapi({ description: 'The version UUID or "live"' }),
 })
 
-function createLogRouteFactory({
-  path,
-  tags,
-}: {
-  path: string
-  tags: string[]
-}) {
-  return createRoute({
-    deprecated: true,
-    path,
-    operationId: 'createDocumentLog',
-    method: http.Methods.POST,
-    description:
-      'Create a prompt log. Deprecated: Use the traces ingest endpoint instead.',
-    tags,
-    request: {
-      params: documentParamsSchema,
-      body: {
-        content: {
-          [http.MediaTypes.JSON]: {
-            schema: z.object({
-              path: z.string(),
-              messages: z.array(messageSchema),
-              response: z.string().optional(),
-            }),
-          },
-        },
-      },
-    },
-    responses: {
-      ...GENERIC_ERROR_RESPONSES,
-      [http.Status.OK]: {
-        description: 'The document log was created successfully',
-        content: {
-          [http.MediaTypes.JSON]: { schema: spanLogSchema },
-        },
-      },
-    },
-  })
-}
-
-export const createLogRouteV3 = createLogRouteFactory({
-  path: ROUTES.api.v3.projects.documents.logs,
+export const createLogRouteConfig = defineRouteConfig({
+  operationId: 'createDocumentLog',
+  method: http.Methods.POST,
+  description:
+    'Create a prompt log. Deprecated: Use the traces ingest endpoint instead.',
   tags: ['Logs'],
+  request: {
+    params: documentParamsSchema,
+    body: {
+      content: {
+        [http.MediaTypes.JSON]: {
+          schema: z.object({
+            path: z.string(),
+            messages: z.array(messageSchema),
+            response: z.string().optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    ...GENERIC_ERROR_RESPONSES,
+    [http.Status.OK]: {
+      description: 'The document log was created successfully',
+      content: {
+        [http.MediaTypes.JSON]: { schema: spanLogSchema },
+      },
+    },
+  },
 })
 
-export type CreateLogRoute = typeof createLogRouteV3
+export type CreateLogRoute = typeof createLogRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/run/run.route.ts
@@ -7,13 +7,12 @@ import {
   runBackgroundAPIResponseSchema,
   runSyncAPIResponseSchema,
 } from '$/openApi/schemas'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 import { documentParamsSchema } from '../paramsSchema'
 
-export const runRoute = createRoute({
+export const runRouteConfig = defineRouteConfig({
   method: http.Methods.POST,
-  path: ROUTES.api.v3.projects.documents.run,
   tags: ['Documents'],
   description: 'Run a prompt',
   request: {
@@ -80,4 +79,4 @@ export const runRoute = createRoute({
   },
 })
 
-export type RunRoute = typeof runRoute
+export type RunRoute = typeof runRouteConfig

--- a/apps/gateway/src/routes/api/v3/projects/versions/get/getCommit.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/get/getCommit.handler.ts
@@ -2,11 +2,11 @@ import { Context } from 'hono'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { BadRequestError } from '@latitude-data/constants/errors'
 import { AppRouteHandler } from '$/openApi/types'
-import { getVersionRoute } from './getCommit.route'
+import { getVersionRouteConfig } from './getCommit.route'
 
 // @ts-expect-error: Types are not working as expected
 export const getVersionHandler: AppRouteHandler<
-  typeof getVersionRoute
+  typeof getVersionRouteConfig
 > = async (c: Context) => {
   const workspace = c.get('workspace')
   const { projectId, versionUuid } = c.req.param()

--- a/apps/gateway/src/routes/api/v3/projects/versions/get/getCommit.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/get/getCommit.route.ts
@@ -1,7 +1,7 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
 export const VersionSchema = z.object({
   id: z.number(),
@@ -17,9 +17,8 @@ export const VersionSchema = z.object({
   parentCommitUuid: z.string().nullable(),
 })
 
-export const getVersionRoute = createOpenAPIRoute({
+export const getVersionRouteConfig = defineRouteConfig({
   method: http.Methods.GET,
-  path: API_ROUTES.v3.projects.versions.get,
   tags: ['Versions'],
   security: [{ bearerAuth: [] }],
   summary: 'Get project version',

--- a/apps/gateway/src/routes/api/v3/projects/versions/getAll/getAllVersions.handler.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/getAll/getAllVersions.handler.ts
@@ -2,10 +2,10 @@ import { Context } from 'hono'
 import { CommitsRepository } from '@latitude-data/core/repositories'
 import { BadRequestError } from '@latitude-data/constants/errors'
 import { AppRouteHandler } from '$/openApi/types'
-import { getAllVersionsRoute } from './getAllVersions.route'
+import { getAllVersionsRouteConfig } from './getAllVersions.route'
 
 export const getAllVersionsHandler: AppRouteHandler<
-  typeof getAllVersionsRoute
+  typeof getAllVersionsRouteConfig
 > = async (c: Context) => {
   const workspace = c.get('workspace')
   const { projectId } = c.req.param()

--- a/apps/gateway/src/routes/api/v3/projects/versions/getAll/getAllVersions.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/getAll/getAllVersions.route.ts
@@ -1,7 +1,7 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
 export const VersionSchema = z.object({
   id: z.number(),
@@ -17,9 +17,8 @@ export const VersionSchema = z.object({
   deletedAt: z.string().nullable(),
 })
 
-export const getAllVersionsRoute = createOpenAPIRoute({
+export const getAllVersionsRouteConfig = defineRouteConfig({
   method: http.Methods.GET,
-  path: API_ROUTES.v3.projects.versions.getAll,
   tags: ['Versions'],
   security: [{ bearerAuth: [] }],
   summary: 'Get all project versions',

--- a/apps/gateway/src/routes/api/v3/projects/versions/index.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/index.ts
@@ -1,18 +1,33 @@
 import { createRouter } from '$/openApi/createApp'
-import { getVersionRoute } from './get/getCommit.route'
-import { getVersionHandler } from './get/getCommit.handler'
-import { createVersionRoute } from './create/createCommit.route'
-import { createCommitHandler } from './create/createCommit.handler'
-import { getAllVersionsRoute } from './getAll/getAllVersions.route'
-import { getAllVersionsHandler } from './getAll/getAllVersions.handler'
-import { publishCommitRoute } from './publish/publishCommit.route'
-import { publishCommitHandler } from './publish/publishCommit.handler'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
 import { documentsRouter } from './documents'
+import { getVersionRouteConfig } from '$/routes/api/v3/projects/versions/get/getCommit.route'
+import { getVersionHandler } from '$/routes/api/v3/projects/versions/get/getCommit.handler'
+import { createVersionRouteConfig } from '$/routes/api/v3/projects/versions/create/createCommit.route'
+import { createCommitHandler } from '$/routes/api/v3/projects/versions/create/createCommit.handler'
+import { getAllVersionsRouteConfig } from '$/routes/api/v3/projects/versions/getAll/getAllVersions.route'
+import { getAllVersionsHandler } from '$/routes/api/v3/projects/versions/getAll/getAllVersions.handler'
+import { publishCommitRouteConfig } from '$/routes/api/v3/projects/versions/publish/publishCommit.route'
+import { publishCommitHandler } from '$/routes/api/v3/projects/versions/publish/publishCommit.handler'
 
 export const versionsRouter = createRouter()
-  .openapi(getVersionRoute, getVersionHandler)
-  .openapi(getAllVersionsRoute, getAllVersionsHandler)
-  .openapi(createVersionRoute, createCommitHandler)
-  .openapi(publishCommitRoute, publishCommitHandler)
+  .openapi(
+    route(getVersionRouteConfig, API_ROUTES.v3.projects.versions.get),
+    getVersionHandler,
+  )
+  .openapi(
+    route(getAllVersionsRouteConfig, API_ROUTES.v3.projects.versions.getAll),
+    getAllVersionsHandler,
+  )
+  .openapi(
+    route(createVersionRouteConfig, API_ROUTES.v3.projects.versions.create),
+    createCommitHandler,
+  )
+  .openapi(
+    route(publishCommitRouteConfig, API_ROUTES.v3.projects.versions.publish),
+    publishCommitHandler,
+  )
 
 versionsRouter.route('/', documentsRouter)

--- a/apps/gateway/src/routes/api/v3/projects/versions/publish/publishCommit.route.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/publish/publishCommit.route.ts
@@ -1,12 +1,11 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
 import { CommitSchema } from '../create/createCommit.route'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const publishCommitRoute = createOpenAPIRoute({
+export const publishCommitRouteConfig = defineRouteConfig({
   method: http.Methods.POST,
-  path: API_ROUTES.v3.projects.versions.publish,
   tags: ['Versions'],
   security: [{ bearerAuth: [] }],
   summary: 'Publish project version',
@@ -40,4 +39,4 @@ export const publishCommitRoute = createOpenAPIRoute({
   },
 })
 
-export type PublishCommitRoute = typeof publishCommitRoute
+export type PublishCommitRoute = typeof publishCommitRouteConfig

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/create/create.handler.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/create/create.handler.ts
@@ -5,10 +5,10 @@ import { NotFoundError } from '@latitude-data/constants/errors'
 import { type ProviderConfiguration } from '@latitude-data/core/schema/models/providerApiKeys'
 import { AppRouteHandler } from '$/openApi/types'
 import { providerApiKeyPresenter } from '@latitude-data/core/services/providerApiKeys/helpers/presenter'
-import { createProviderApiKeyRoute } from './create.route'
+import { createProviderApiKeyRouteConfig } from './create.route'
 
 export const createProviderApiKeyHandler: AppRouteHandler<
-  typeof createProviderApiKeyRoute
+  typeof createProviderApiKeyRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/create/create.route.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/create/create.route.ts
@@ -1,12 +1,11 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
+import { z } from '@hono/zod-openapi'
 import { Providers } from '@latitude-data/constants'
-import { API_ROUTES } from '$/api.routes'
 import { ProviderApiKeySchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const createProviderApiKeyRoute = createOpenAPIRoute({
+export const createProviderApiKeyRouteConfig = defineRouteConfig({
   method: 'post',
-  path: API_ROUTES.v3.providerApiKeys.create,
   tags: ['Provider API Keys'],
   security: [{ bearerAuth: [] }],
   summary: 'Create a new provider API key',

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/destroy/destroy.handler.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/destroy/destroy.handler.ts
@@ -1,10 +1,10 @@
 import { findProviderApiKeyById } from '@latitude-data/core/queries/providerApiKeys/findById'
 import { destroyProviderApiKey } from '@latitude-data/core/services/providerApiKeys/destroy'
 import { AppRouteHandler } from '$/openApi/types'
-import { destroyProviderApiKeyRoute } from './destroy.route'
+import { destroyProviderApiKeyRouteConfig } from './destroy.route'
 
 export const destroyProviderApiKeyHandler: AppRouteHandler<
-  typeof destroyProviderApiKeyRoute
+  typeof destroyProviderApiKeyRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { providerApiKeyId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/destroy/destroy.route.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/destroy/destroy.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProviderApiKeySchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const destroyProviderApiKeyRoute = createOpenAPIRoute({
+export const destroyProviderApiKeyRouteConfig = defineRouteConfig({
   method: 'delete',
-  path: API_ROUTES.v3.providerApiKeys.destroy,
   tags: ['Provider API Keys'],
   security: [{ bearerAuth: [] }],
   summary: 'Delete a provider API key',

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/get/get.handler.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/get/get.handler.ts
@@ -1,10 +1,10 @@
 import { findProviderApiKeyById } from '@latitude-data/core/queries/providerApiKeys/findById'
 import { AppRouteHandler } from '$/openApi/types'
 import { providerApiKeyPresenter } from '@latitude-data/core/services/providerApiKeys/helpers/presenter'
-import { getProviderApiKeyRoute } from './get.route'
+import { getProviderApiKeyRouteConfig } from './get.route'
 
 export const getProviderApiKeyHandler: AppRouteHandler<
-  typeof getProviderApiKeyRoute
+  typeof getProviderApiKeyRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
   const { providerApiKeyId } = c.req.valid('param')

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/get/get.route.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/get/get.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProviderApiKeySchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getProviderApiKeyRoute = createOpenAPIRoute({
+export const getProviderApiKeyRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.providerApiKeys.get,
   tags: ['Provider API Keys'],
   security: [{ bearerAuth: [] }],
   summary: 'Get a provider API key by ID',

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/getAll/getAll.handler.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/getAll/getAll.handler.ts
@@ -1,10 +1,10 @@
 import { findAllProviderApiKeys } from '@latitude-data/core/queries/providerApiKeys/findAll'
 import { AppRouteHandler } from '$/openApi/types'
 import { providerApiKeyPresenter } from '@latitude-data/core/services/providerApiKeys/helpers/presenter'
-import { getAllProviderApiKeysRoute } from './getAll.route'
+import { getAllProviderApiKeysRouteConfig } from './getAll.route'
 
 export const getAllProviderApiKeysHandler: AppRouteHandler<
-  typeof getAllProviderApiKeysRoute
+  typeof getAllProviderApiKeysRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/getAll/getAll.route.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/getAll/getAll.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProviderApiKeySchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const getAllProviderApiKeysRoute = createOpenAPIRoute({
+export const getAllProviderApiKeysRouteConfig = defineRouteConfig({
   method: 'get',
-  path: API_ROUTES.v3.providerApiKeys.getAll,
   tags: ['Provider API Keys'],
   security: [{ bearerAuth: [] }],
   summary: 'Get all provider API keys for a workspace',

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/index.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/index.ts
@@ -1,18 +1,48 @@
 import { createRouter } from '$/openApi/createApp'
-import { getAllProviderApiKeysHandler } from './getAll/getAll.handler'
-import { getAllProviderApiKeysRoute } from './getAll/getAll.route'
-import { getProviderApiKeyHandler } from './get/get.handler'
-import { getProviderApiKeyRoute } from './get/get.route'
-import { createProviderApiKeyHandler } from './create/create.handler'
-import { createProviderApiKeyRoute } from './create/create.route'
-import { updateProviderApiKeyHandler } from './update/update.handler'
-import { updateProviderApiKeyRoute } from './update/update.route'
-import { destroyProviderApiKeyHandler } from './destroy/destroy.handler'
-import { destroyProviderApiKeyRoute } from './destroy/destroy.route'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllProviderApiKeysHandler } from '$/routes/api/v3/providerApiKeys/getAll/getAll.handler'
+import { getAllProviderApiKeysRouteConfig } from '$/routes/api/v3/providerApiKeys/getAll/getAll.route'
+import { getProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/get/get.handler'
+import { getProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/get/get.route'
+import { createProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/create/create.handler'
+import { createProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/create/create.route'
+import { updateProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/update/update.handler'
+import { updateProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/update/update.route'
+import { destroyProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/destroy/destroy.handler'
+import { destroyProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/destroy/destroy.route'
 
 export const providerApiKeysRouter = createRouter()
-  .openapi(getAllProviderApiKeysRoute, getAllProviderApiKeysHandler)
-  .openapi(getProviderApiKeyRoute, getProviderApiKeyHandler)
-  .openapi(createProviderApiKeyRoute, createProviderApiKeyHandler)
-  .openapi(updateProviderApiKeyRoute, updateProviderApiKeyHandler)
-  .openapi(destroyProviderApiKeyRoute, destroyProviderApiKeyHandler)
+  .openapi(
+    route(
+      getAllProviderApiKeysRouteConfig,
+      API_ROUTES.v3.providerApiKeys.getAll,
+    ),
+    getAllProviderApiKeysHandler,
+  )
+  .openapi(
+    route(getProviderApiKeyRouteConfig, API_ROUTES.v3.providerApiKeys.get),
+    getProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      createProviderApiKeyRouteConfig,
+      API_ROUTES.v3.providerApiKeys.create,
+    ),
+    createProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      updateProviderApiKeyRouteConfig,
+      API_ROUTES.v3.providerApiKeys.update,
+    ),
+    updateProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      destroyProviderApiKeyRouteConfig,
+      API_ROUTES.v3.providerApiKeys.destroy,
+    ),
+    destroyProviderApiKeyHandler,
+  )

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/update/update.handler.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/update/update.handler.ts
@@ -2,10 +2,10 @@ import { findProviderApiKeyById } from '@latitude-data/core/queries/providerApiK
 import { updateProviderApiKeyName } from '@latitude-data/core/services/providerApiKeys/updateName'
 import { AppRouteHandler } from '$/openApi/types'
 import { providerApiKeyPresenter } from '@latitude-data/core/services/providerApiKeys/helpers/presenter'
-import { updateProviderApiKeyRoute } from './update.route'
+import { updateProviderApiKeyRouteConfig } from './update.route'
 
 export const updateProviderApiKeyHandler: AppRouteHandler<
-  typeof updateProviderApiKeyRoute
+  typeof updateProviderApiKeyRouteConfig
 > = async (c) => {
   const workspace = c.get('workspace')
 

--- a/apps/gateway/src/routes/api/v3/providerApiKeys/update/update.route.ts
+++ b/apps/gateway/src/routes/api/v3/providerApiKeys/update/update.route.ts
@@ -1,11 +1,10 @@
-import { createRoute as createOpenAPIRoute, z } from '@hono/zod-openapi'
-import { API_ROUTES } from '$/api.routes'
+import { z } from '@hono/zod-openapi'
 import { ProviderApiKeySchema } from '$/openApi/schemas/ai'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
+import { defineRouteConfig } from '$/routes/api/helpers'
 
-export const updateProviderApiKeyRoute = createOpenAPIRoute({
+export const updateProviderApiKeyRouteConfig = defineRouteConfig({
   method: 'put',
-  path: API_ROUTES.v3.providerApiKeys.update,
   tags: ['Provider API Keys'],
   security: [{ bearerAuth: [] }],
   summary: 'Update a provider API key',

--- a/apps/gateway/src/routes/api/v3/tools/results/index.ts
+++ b/apps/gateway/src/routes/api/v3/tools/results/index.ts
@@ -1,8 +1,11 @@
 import { createRouter } from '$/openApi/createApp'
-import { clientToolResultRoute } from './route'
-import { clientToolResultHandler } from './handler'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { clientToolResultRouteConfig } from '$/routes/api/v3/tools/results/route'
+import { clientToolResultHandler } from '$/routes/api/v3/tools/results/handler'
 
 export const toolResultsRouter = createRouter().openapi(
-  clientToolResultRoute,
+  route(clientToolResultRouteConfig, API_ROUTES.v3.tools.results),
   clientToolResultHandler,
 )

--- a/apps/gateway/src/routes/api/v3/tools/results/route.ts
+++ b/apps/gateway/src/routes/api/v3/tools/results/route.ts
@@ -1,7 +1,6 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
-import { ROUTES } from '$/routes'
-import { createRoute } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
 import { z } from '@hono/zod-openapi'
 
 export const clientToolResultBodySchema = z.object({
@@ -14,9 +13,8 @@ export const clientToolResultBodySchema = z.object({
   isError: z.boolean().default(false),
 })
 
-export const clientToolResultRoute = createRoute({
+export const clientToolResultRouteConfig = defineRouteConfig({
   method: http.Methods.POST,
-  path: ROUTES.api.v3.tools.results,
   tags: ['Tools'],
   request: {
     body: {
@@ -30,4 +28,4 @@ export const clientToolResultRoute = createRoute({
   responses: GENERIC_ERROR_RESPONSES,
 })
 
-export type ClientToolResultRoute = typeof clientToolResultRoute
+export type ClientToolResultRoute = typeof clientToolResultRouteConfig

--- a/apps/gateway/src/routes/api/v3/traces/index.ts
+++ b/apps/gateway/src/routes/api/v3/traces/index.ts
@@ -1,5 +1,11 @@
 import { createRouter } from '$/openApi/createApp'
-import { ingestHandler } from './ingest/ingest.handler'
-import { ingestRoute } from './ingest/ingest.route'
+import { API_ROUTES } from '$/api.routes'
+import { route } from '$/routes/api/helpers'
 
-export const tracesRouter = createRouter().openapi(ingestRoute, ingestHandler)
+import { ingestHandler } from '$/routes/api/v3/traces/ingest/ingest.handler'
+import { ingestRouteConfig } from '$/routes/api/v3/traces/ingest/ingest.route'
+
+export const tracesRouter = createRouter().openapi(
+  route(ingestRouteConfig, API_ROUTES.v3.traces.ingest),
+  ingestHandler,
+)

--- a/apps/gateway/src/routes/api/v3/traces/ingest/ingest.route.ts
+++ b/apps/gateway/src/routes/api/v3/traces/ingest/ingest.route.ts
@@ -1,12 +1,11 @@
 import http from '$/common/http'
 import { GENERIC_ERROR_RESPONSES } from '$/openApi/responses/errorResponses'
-import { ROUTES } from '$/routes'
-import { createRoute, z } from '@hono/zod-openapi'
+import { defineRouteConfig } from '$/routes/api/helpers'
+import { z } from '@hono/zod-openapi'
 import { Otlp } from '@latitude-data/constants'
 
-export const ingestRoute = createRoute({
+export const ingestRouteConfig = defineRouteConfig({
   method: http.Methods.POST,
-  path: ROUTES.api.v3.traces.ingest,
   tags: ['Traces'],
   description: 'Ingest OTLP spans (JSON or Protobuf)',
   request: {
@@ -31,4 +30,4 @@ export const ingestRoute = createRoute({
   },
 })
 
-export type IngestRoute = typeof ingestRoute
+export type IngestRoute = typeof ingestRouteConfig

--- a/apps/gateway/src/routes/api/v4/conversations/index.ts
+++ b/apps/gateway/src/routes/api/v4/conversations/index.ts
@@ -1,0 +1,40 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { ROUTES } from '$/routes'
+
+import {
+  annotateHandler,
+  annotateRouteConfig,
+} from '$/routes/api/v3/conversations/annotate'
+import {
+  attachHandler,
+  attachRouteConfig,
+} from '$/routes/api/v3/conversations/attach'
+import {
+  chatHandler,
+  chatRouteConfig,
+} from '$/routes/api/v3/conversations/chat'
+import {
+  stopHandler,
+  stopRouteConfig,
+} from '$/routes/api/v3/conversations/stop'
+import { getHandler, getRouteConfig } from '$/routes/api/v3/conversations/get'
+
+export const conversationsRouter = createRouter()
+  .openapi(
+    route(chatRouteConfig, ROUTES.api.v4.conversations.chat),
+    chatHandler,
+  )
+  .openapi(
+    route(attachRouteConfig, ROUTES.api.v4.conversations.attach),
+    attachHandler,
+  )
+  .openapi(
+    route(stopRouteConfig, ROUTES.api.v4.conversations.stop),
+    stopHandler,
+  )
+  .openapi(
+    route(annotateRouteConfig, ROUTES.api.v4.conversations.annotate),
+    annotateHandler,
+  )
+  .openapi(route(getRouteConfig, ROUTES.api.v4.conversations.get), getHandler)

--- a/apps/gateway/src/routes/api/v4/datasetRows/index.ts
+++ b/apps/gateway/src/routes/api/v4/datasetRows/index.ts
@@ -1,0 +1,36 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllDatasetRowsHandler } from '$/routes/api/v3/datasetRows/getAll/getAll.handler'
+import { getAllDatasetRowsRouteConfig } from '$/routes/api/v3/datasetRows/getAll/getAll.route'
+import { getDatasetRowHandler } from '$/routes/api/v3/datasetRows/get/get.handler'
+import { getDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/get/get.route'
+import { createDatasetRowHandler } from '$/routes/api/v3/datasetRows/create/create.handler'
+import { createDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/create/create.route'
+import { updateDatasetRowHandler } from '$/routes/api/v3/datasetRows/update/update.handler'
+import { updateDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/update/update.route'
+import { destroyDatasetRowHandler } from '$/routes/api/v3/datasetRows/destroy/destroy.handler'
+import { destroyDatasetRowRouteConfig } from '$/routes/api/v3/datasetRows/destroy/destroy.route'
+
+export const datasetRowsRouter = createRouter()
+  .openapi(
+    route(getAllDatasetRowsRouteConfig, API_ROUTES.v4.datasetRows.getAll),
+    getAllDatasetRowsHandler,
+  )
+  .openapi(
+    route(getDatasetRowRouteConfig, API_ROUTES.v4.datasetRows.get),
+    getDatasetRowHandler,
+  )
+  .openapi(
+    route(createDatasetRowRouteConfig, API_ROUTES.v4.datasetRows.create),
+    createDatasetRowHandler,
+  )
+  .openapi(
+    route(updateDatasetRowRouteConfig, API_ROUTES.v4.datasetRows.update),
+    updateDatasetRowHandler,
+  )
+  .openapi(
+    route(destroyDatasetRowRouteConfig, API_ROUTES.v4.datasetRows.destroy),
+    destroyDatasetRowHandler,
+  )

--- a/apps/gateway/src/routes/api/v4/datasets/index.ts
+++ b/apps/gateway/src/routes/api/v4/datasets/index.ts
@@ -1,0 +1,36 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllDatasetsHandler } from '$/routes/api/v3/datasets/getAll/getAll.handler'
+import { getAllDatasetsRouteConfig } from '$/routes/api/v3/datasets/getAll/getAll.route'
+import { getDatasetHandler } from '$/routes/api/v3/datasets/get/get.handler'
+import { getDatasetRouteConfig } from '$/routes/api/v3/datasets/get/get.route'
+import { createDatasetHandler } from '$/routes/api/v3/datasets/create/create.handler'
+import { createDatasetRouteConfig } from '$/routes/api/v3/datasets/create/create.route'
+import { updateDatasetHandler } from '$/routes/api/v3/datasets/update/update.handler'
+import { updateDatasetRouteConfig } from '$/routes/api/v3/datasets/update/update.route'
+import { destroyDatasetHandler } from '$/routes/api/v3/datasets/destroy/destroy.handler'
+import { destroyDatasetRouteConfig } from '$/routes/api/v3/datasets/destroy/destroy.route'
+
+export const datasetsRouter = createRouter()
+  .openapi(
+    route(getAllDatasetsRouteConfig, API_ROUTES.v4.datasets.getAll),
+    getAllDatasetsHandler,
+  )
+  .openapi(
+    route(getDatasetRouteConfig, API_ROUTES.v4.datasets.get),
+    getDatasetHandler,
+  )
+  .openapi(
+    route(createDatasetRouteConfig, API_ROUTES.v4.datasets.create),
+    createDatasetHandler,
+  )
+  .openapi(
+    route(updateDatasetRouteConfig, API_ROUTES.v4.datasets.update),
+    updateDatasetHandler,
+  )
+  .openapi(
+    route(destroyDatasetRouteConfig, API_ROUTES.v4.datasets.destroy),
+    destroyDatasetHandler,
+  )

--- a/apps/gateway/src/routes/api/v4/index.ts
+++ b/apps/gateway/src/routes/api/v4/index.ts
@@ -1,0 +1,18 @@
+import { createRouter } from '$/openApi/createApp'
+
+import { conversationsRouter } from './conversations'
+import { projectsRouter } from './projects'
+import { tracesRouter } from './traces'
+import { datasetsRouter } from './datasets'
+import { datasetRowsRouter } from './datasetRows'
+import { providerApiKeysRouter } from './providerApiKeys'
+import { toolResultsRouter } from './tools/results'
+
+export const v4Router = createRouter()
+  .route('/', conversationsRouter)
+  .route('/', projectsRouter)
+  .route('/', tracesRouter)
+  .route('/', toolResultsRouter)
+  .route('/', datasetsRouter)
+  .route('/', datasetRowsRouter)
+  .route('/', providerApiKeysRouter)

--- a/apps/gateway/src/routes/api/v4/projects/index.ts
+++ b/apps/gateway/src/routes/api/v4/projects/index.ts
@@ -1,0 +1,28 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { versionsRouter } from './versions'
+import { createRouteConfig } from '$/routes/api/v3/projects/create/create.route'
+import { createHandler } from '$/routes/api/v3/projects/create/create.handler'
+import { pushRouteConfig } from '$/routes/api/v3/projects/push/push.route'
+import { pushHandler } from '$/routes/api/v3/projects/push/push.handler'
+import { getAllRouteConfig } from '$/routes/api/v3/projects/getAll/getAll.route'
+import { getAllHandler } from '$/routes/api/v3/projects/getAll/getAll.handler'
+
+export const projectsRouter = createRouter()
+  .openapi(
+    route(getAllRouteConfig, API_ROUTES.v4.projects.getAll),
+    getAllHandler,
+  )
+  .openapi(
+    route(createRouteConfig, API_ROUTES.v4.projects.create),
+    createHandler,
+  )
+  .openapi(
+    route(pushRouteConfig, API_ROUTES.v4.projects.push),
+    pushHandler,
+    // prettier-ignore
+  )
+
+projectsRouter.route('/', versionsRouter)

--- a/apps/gateway/src/routes/api/v4/projects/versions/documents/index.ts
+++ b/apps/gateway/src/routes/api/v4/projects/versions/documents/index.ts
@@ -1,0 +1,61 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { createDocumentHandler } from '$/routes/api/v3/projects/versions/documents/create/create.handler'
+import { createDocumentRouteConfig } from '$/routes/api/v3/projects/versions/documents/create/create.route'
+import {
+  createOrUpdateDocumentHandler,
+  createOrUpdateDocumentRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/createOrUpdate'
+import {
+  getHandler,
+  getRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/get'
+import {
+  getAllHandler,
+  getAllRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/getAll'
+import {
+  getOrCreateHandler,
+  getOrCreateRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/getOrCreate'
+import { createLogHandler } from '$/routes/api/v3/projects/versions/documents/logs/create.handler'
+import { createLogRouteConfig } from '$/routes/api/v3/projects/versions/documents/logs/create.route'
+import {
+  runHandler,
+  runRouteConfig,
+} from '$/routes/api/v3/projects/versions/documents/run'
+
+export const documentsRouter = createRouter()
+  .openapi(
+    route(getRouteConfig, API_ROUTES.v4.projects.documents.get),
+    getHandler,
+  )
+  .openapi(
+    route(getAllRouteConfig, API_ROUTES.v4.projects.documents.getAll),
+    getAllHandler,
+  )
+  .openapi(
+    route(createDocumentRouteConfig, API_ROUTES.v4.projects.documents.create),
+    createDocumentHandler,
+  )
+  .openapi(
+    route(
+      createOrUpdateDocumentRouteConfig,
+      API_ROUTES.v4.projects.documents.createOrUpdate,
+    ),
+    createOrUpdateDocumentHandler,
+  )
+  .openapi(
+    route(getOrCreateRouteConfig, API_ROUTES.v4.projects.documents.getOrCreate),
+    getOrCreateHandler,
+  )
+  .openapi(
+    route(runRouteConfig, API_ROUTES.v4.projects.documents.run),
+    runHandler,
+  )
+  .openapi(
+    route(createLogRouteConfig, API_ROUTES.v4.projects.documents.logs),
+    createLogHandler,
+  )

--- a/apps/gateway/src/routes/api/v4/projects/versions/index.ts
+++ b/apps/gateway/src/routes/api/v4/projects/versions/index.ts
@@ -1,0 +1,33 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { documentsRouter } from './documents'
+import { getVersionRouteConfig } from '$/routes/api/v3/projects/versions/get/getCommit.route'
+import { getVersionHandler } from '$/routes/api/v3/projects/versions/get/getCommit.handler'
+import { createVersionRouteConfig } from '$/routes/api/v3/projects/versions/create/createCommit.route'
+import { createCommitHandler } from '$/routes/api/v3/projects/versions/create/createCommit.handler'
+import { getAllVersionsRouteConfig } from '$/routes/api/v3/projects/versions/getAll/getAllVersions.route'
+import { getAllVersionsHandler } from '$/routes/api/v3/projects/versions/getAll/getAllVersions.handler'
+import { publishCommitRouteConfig } from '$/routes/api/v3/projects/versions/publish/publishCommit.route'
+import { publishCommitHandler } from '$/routes/api/v3/projects/versions/publish/publishCommit.handler'
+
+export const versionsRouter = createRouter()
+  .openapi(
+    route(getVersionRouteConfig, API_ROUTES.v4.projects.versions.get),
+    getVersionHandler,
+  )
+  .openapi(
+    route(getAllVersionsRouteConfig, API_ROUTES.v4.projects.versions.getAll),
+    getAllVersionsHandler,
+  )
+  .openapi(
+    route(createVersionRouteConfig, API_ROUTES.v4.projects.versions.create),
+    createCommitHandler,
+  )
+  .openapi(
+    route(publishCommitRouteConfig, API_ROUTES.v4.projects.versions.publish),
+    publishCommitHandler,
+  )
+
+versionsRouter.route('/', documentsRouter)

--- a/apps/gateway/src/routes/api/v4/providerApiKeys/index.ts
+++ b/apps/gateway/src/routes/api/v4/providerApiKeys/index.ts
@@ -1,0 +1,48 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { getAllProviderApiKeysHandler } from '$/routes/api/v3/providerApiKeys/getAll/getAll.handler'
+import { getAllProviderApiKeysRouteConfig } from '$/routes/api/v3/providerApiKeys/getAll/getAll.route'
+import { getProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/get/get.handler'
+import { getProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/get/get.route'
+import { createProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/create/create.handler'
+import { createProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/create/create.route'
+import { updateProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/update/update.handler'
+import { updateProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/update/update.route'
+import { destroyProviderApiKeyHandler } from '$/routes/api/v3/providerApiKeys/destroy/destroy.handler'
+import { destroyProviderApiKeyRouteConfig } from '$/routes/api/v3/providerApiKeys/destroy/destroy.route'
+
+export const providerApiKeysRouter = createRouter()
+  .openapi(
+    route(
+      getAllProviderApiKeysRouteConfig,
+      API_ROUTES.v4.providerApiKeys.getAll,
+    ),
+    getAllProviderApiKeysHandler,
+  )
+  .openapi(
+    route(getProviderApiKeyRouteConfig, API_ROUTES.v4.providerApiKeys.get),
+    getProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      createProviderApiKeyRouteConfig,
+      API_ROUTES.v4.providerApiKeys.create,
+    ),
+    createProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      updateProviderApiKeyRouteConfig,
+      API_ROUTES.v4.providerApiKeys.update,
+    ),
+    updateProviderApiKeyHandler,
+  )
+  .openapi(
+    route(
+      destroyProviderApiKeyRouteConfig,
+      API_ROUTES.v4.providerApiKeys.destroy,
+    ),
+    destroyProviderApiKeyHandler,
+  )

--- a/apps/gateway/src/routes/api/v4/tools/results/index.ts
+++ b/apps/gateway/src/routes/api/v4/tools/results/index.ts
@@ -1,0 +1,11 @@
+import { createRouter } from '$/openApi/createApp'
+import { route } from '$/routes/api/helpers'
+import { API_ROUTES } from '$/api.routes'
+
+import { clientToolResultRouteConfig } from '$/routes/api/v3/tools/results/route'
+import { clientToolResultHandler } from '$/routes/api/v3/tools/results/handler'
+
+export const toolResultsRouter = createRouter().openapi(
+  route(clientToolResultRouteConfig, API_ROUTES.v4.tools.results),
+  clientToolResultHandler,
+)

--- a/apps/gateway/src/routes/api/v4/traces/index.ts
+++ b/apps/gateway/src/routes/api/v4/traces/index.ts
@@ -1,0 +1,11 @@
+import { createRouter } from '$/openApi/createApp'
+import { API_ROUTES } from '$/api.routes'
+import { route } from '$/routes/api/helpers'
+
+import { ingestHandler } from '$/routes/api/v3/traces/ingest/ingest.handler'
+import { ingestRouteConfig } from '$/routes/api/v3/traces/ingest/ingest.route'
+
+export const tracesRouter = createRouter().openapi(
+  route(ingestRouteConfig, API_ROUTES.v4.traces.ingest),
+  ingestHandler,
+)


### PR DESCRIPTION
We are modifying the behavior of the Traces Ingestion API, which will break the current SDK client version. To avoid this, we need to add a new API version.
This PR introduces a new v4 route to all API routes while maintaining the same route configuration and handlers as v3.