### PR TITLE
Thumbs up annotations visibility

### DIFF
--- a/apps/web/src/components/evaluations/Annotation/Form/index.tsx
+++ b/apps/web/src/components/evaluations/Annotation/Form/index.tsx
@@ -102,7 +102,7 @@ export function AnnotationForm<
     result,
   })
 
-  const [isExpanded, setIsExpanded] = useState(initialExpanded ?? !!result)
+  const [isExpanded, setIsExpanded] = useState(!!result || (initialExpanded ?? false))
   const wrappedOnSubmit = useCallback(
     async ({ score, resultMetadata }: OnSubmitProps<T, M>) => {
       await onSubmit({

--- a/apps/web/src/components/evaluations/human/Binary.tsx
+++ b/apps/web/src/components/evaluations/human/Binary.tsx
@@ -166,13 +166,15 @@ function AnnotationForm({
 
   const onThumbsUpClick = useCallback(
     (newThumbsUp: boolean) => {
-      if (newThumbsUp === thumbsUp) return
+      if (newThumbsUp === thumbsUp) {
+        setIsExpanded((prev) => !prev)
+        return
+      }
 
       setThumbsUp(newThumbsUp)
       const newScore = newThumbsUp ? 1 : 0
       setLocalScore(newScore)
 
-      // Expand the form when user interacts
       if (!isExpanded) {
         setIsExpanded(true)
       }


### PR DESCRIPTION
Fixes a bug where annotation forms for thumbs-up/down were not expanding, preventing users from seeing their text.

The `isExpanded` state in `Annotation/Form/index.tsx` was incorrectly initialized, causing forms to remain collapsed even when an annotation result existed. Additionally, clicking an already-selected thumbs button in `human/Binary.tsx` did nothing, preventing users from toggling the form open to view their annotation text.

---
[Slack Thread](https://latitudedata.slack.com/archives/C0672DS68DD/p1771488262220669?thread_ts=1771488262.220669&cid=C0672DS68DD)

<p><a href="https://cursor.com/background-agent?bcId=bc-2c5cc6a2-0e64-5132-9843-0c03a2778207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c5cc6a2-0e64-5132-9843-0c03a2778207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

