### PR TITLE
Error trace annotation

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/annotations/_components/AnnotationPanel/index.tsx
@@ -103,13 +103,7 @@ export function AnnotationsPanel({
             <div className='flex flex-row items-center justify-between w-full pb-2'>
               <Text.H6M>Messages</Text.H6M>
             </div>
-            <AnnotationsProvider
-              project={project}
-              commit={commit}
-              span={span}
-              messages={conversation as unknown as Message[]}
-              onAnnotate={onAnnotate}
-            >
+            {span.status === 'error' ? (
               <MessageList
                 debugMode
                 messages={conversation as unknown as Message[]}
@@ -120,8 +114,27 @@ export function AnnotationsPanel({
                 }
                 toolContentMap={toolContentMap}
               />
-              <AnnotationFormWithoutContext />
-            </AnnotationsProvider>
+            ) : (
+              <AnnotationsProvider
+                project={project}
+                commit={commit}
+                span={span}
+                messages={conversation as unknown as Message[]}
+                onAnnotate={onAnnotate}
+              >
+                <MessageList
+                  debugMode
+                  messages={conversation as unknown as Message[]}
+                  parameters={
+                    spanMetadata && 'parameters' in spanMetadata
+                      ? Object.keys(spanMetadata.parameters)
+                      : []
+                  }
+                  toolContentMap={toolContentMap}
+                />
+                <AnnotationFormWithoutContext />
+              </AnnotationsProvider>
+            )}
           </div>
         ) : (
           <Text.H5 color='foregroundMuted'>

--- a/apps/web/src/components/TracesPanel/index.tsx
+++ b/apps/web/src/components/TracesPanel/index.tsx
@@ -121,8 +121,9 @@ function TraceMessages({ span }: { span?: SpanWithDetails }) {
     )
   }
 
+  const isError = span?.status === 'error'
   const annotationSpan =
-    span && isMainSpan(span)
+    span && isMainSpan(span) && !isError
       ? (span as SpanWithDetails<MainSpanType>)
       : undefined
 
@@ -139,7 +140,7 @@ function TraceMessages({ span }: { span?: SpanWithDetails }) {
           messages={messages}
           parameters={parameters ? Object.keys(parameters) : undefined}
         />
-        <AnnotationFormWithoutContext />
+        {!isError && <AnnotationFormWithoutContext />}
       </div>
     </AnnotationsProvider>
   )

--- a/packages/core/src/services/evaluationsV2/annotate.ts
+++ b/packages/core/src/services/evaluationsV2/annotate.ts
@@ -7,6 +7,7 @@ import {
   EvaluationType,
   EvaluationV2,
   MainSpanType,
+  SpanStatus,
   SpanWithDetails,
 } from '../../constants'
 import { publisher } from '../../events/publisher'
@@ -51,6 +52,12 @@ export async function annotateEvaluationV2<
   },
   transaction = new Transaction(),
 ) {
+  if (span.status === SpanStatus.Error) {
+    return Result.error(
+      new BadRequestError('Cannot annotate a trace that ended with an error'),
+    )
+  }
+
   const resultUuid = existingResultUuid ?? generateUUIDIdentifier()
   const isUpdate = !!existingResultUuid
   const typeSpecification = EVALUATION_SPECIFICATIONS[evaluation.type]


### PR DESCRIPTION
Disable annotation UI and server-side annotation for error traces.

This prevents users from annotating traces that have an error status, addressing a bug where the annotation UI was still visible and functional for such traces.

---
[Slack Thread](https://latitudedata.slack.com/archives/C0672DS68DD/p1771488093118089?thread_ts=1771488093.118089&cid=C0672DS68DD)

<p><a href="https://cursor.com/background-agent?bcId=bc-ed4450ef-e5e6-5134-a054-77abfb684e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed4450ef-e5e6-5134-a054-77abfb684e57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

