### PR TITLE
fix(web): add dd-trace to serverExternalPackages

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,7 @@ const nextConfig = {
     '@latitude-data/telemetry',
     '@napi-rs/canvas',
     'bullmq',
+    'dd-trace',
     'openid-client',
     'pdfjs-dist',
     'promptl-ai',


### PR DESCRIPTION
## Summary

- Adds `dd-trace` to `serverExternalPackages` in `next.config.mjs`

Since the Next.js 16 / Turbopack migration (#2210), `dd-trace` is no longer properly externalized during the production build. Turbopack mangles the module name to `dd-trace-7beb4d2325fcd252`, which fails to resolve at runtime since no such module exists in `node_modules`. This causes the instrumentation hook (`instrumentation.ts`) to fail silently, and on self-hosted deployments using the GHCR `web:latest` image, it contributes to the server hanging at "Starting..." and never reaching a ready state.

Adding `dd-trace` to `serverExternalPackages` tells Turbopack to keep it as a standard external require, matching the pattern already used for `bullmq`, `@napi-rs/canvas`, and other packages that rely on native modules or runtime monkey-patching.

## Test plan

- [x] Verified the mangled require (`dd-trace-7beb4d2325fcd252`) fails in the current `ghcr.io/latitude-dev/web:latest` container
- [ ] Rebuild with this fix and confirm `dd-trace` loads correctly via `require('dd-trace')`
- [ ] Verify instrumentation hook completes without error