### PR TITLE
feat: make span metadata cache TTL configurable via env var

### DIFF
--- a/packages/core/src/repositories/spansMetadataCache.test.ts
+++ b/packages/core/src/repositories/spansMetadataCache.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SPAN_METADATA_CACHE_TTL } from '../constants'
+
+const mockCache = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}
+
+vi.mock('../cache', () => ({
+  cache: vi.fn().mockResolvedValue(mockCache),
+}))
+
+vi.mock('../lib/disk', () => ({
+  diskFactory: vi.fn().mockReturnValue({
+    getBuffer: vi.fn(),
+    putBuffer: vi.fn(),
+  }),
+}))
+
+vi.mock('../lib/disk/compression', () => ({
+  decompressToString: vi.fn().mockResolvedValue('{"type":"prompt"}'),
+}))
+
+describe('SpanMetadataRepository TTL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses default TTL when env var is not set', async () => {
+    mockCache.get.mockResolvedValueOnce('{"type":"prompt"}')
+
+    const { SpanMetadataRepository } = await import('./spansRepository')
+    const repo = new SpanMetadataRepository(1)
+    await repo.get({ spanId: 'span-1', traceId: 'trace-1' })
+
+    expect(mockCache.set).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'EX',
+      SPAN_METADATA_CACHE_TTL,
+    )
+  })
+
+  it('uses env var TTL when SPAN_METADATA_CACHE_TTL_SECONDS is set', async () => {
+    vi.stubEnv('SPAN_METADATA_CACHE_TTL_SECONDS', '3600')
+    mockCache.get.mockResolvedValueOnce('{"type":"prompt"}')
+
+    vi.resetModules()
+
+    vi.doMock('../cache', () => ({
+      cache: vi.fn().mockResolvedValue(mockCache),
+    }))
+    vi.doMock('../lib/disk', () => ({
+      diskFactory: vi.fn().mockReturnValue({
+        getBuffer: vi.fn(),
+        putBuffer: vi.fn(),
+      }),
+    }))
+    vi.doMock('../lib/disk/compression', () => ({
+      decompressToString: vi.fn().mockResolvedValue('{"type":"prompt"}'),
+    }))
+
+    const { SpanMetadataRepository } = await import('./spansRepository')
+    const repo = new SpanMetadataRepository(1)
+    await repo.get({ spanId: 'span-1', traceId: 'trace-1' })
+
+    expect(mockCache.set).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'EX',
+      3600,
+    )
+  })
+})

--- a/packages/core/src/repositories/spansRepository.ts
+++ b/packages/core/src/repositories/spansRepository.ts
@@ -14,6 +14,7 @@ import {
   sql,
   SQL,
 } from 'drizzle-orm'
+import { env } from '@latitude-data/env'
 import { cache as redis } from '../cache'
 import {
   DEFAULT_PAGINATION_SIZE,
@@ -803,7 +804,8 @@ export class SpanMetadatasRepository {
 
       const metadata = JSON.parse(payload)
 
-      await cache.set(key, payload, 'EX', SPAN_METADATA_CACHE_TTL)
+      const ttl = env.SPAN_METADATA_CACHE_TTL_SECONDS ?? SPAN_METADATA_CACHE_TTL
+      await cache.set(key, payload, 'EX', ttl)
 
       return Result.ok<SpanMetadata<T>>(metadata)
     } catch {

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -83,6 +83,10 @@ export const env = createEnv({
     CACHE_HOST: z.string(),
     CACHE_PORT: z.coerce.number().optional().default(6379),
     CACHE_PASSWORD: z.string().optional(),
+    SPAN_METADATA_CACHE_TTL_SECONDS: z.coerce
+      .number()
+      .optional()
+      .default(86400),
 
     // Postgres
     DATABASE_URL: z.url(),


### PR DESCRIPTION
## Summary
Adds a `SPAN_METADATA_CACHE_TTL_SECONDS` environment variable to control the TTL of span metadata cache entries in Redis (default: 86400s / 24h, preserving current behavior).

## Problem
Under high trace volume, span metadata cache keys can accumulate in Redis faster than they expire. Each key stores compressed span metadata and can be significant in size. When the inflow rate exceeds the expiry rate, Redis memory usage grows unboundedly.

## Solution
Allow operators to tune the cache TTL via `SPAN_METADATA_CACHE_TTL_SECONDS` env var. Lowering the TTL reduces the steady-state number of cached keys, which reduces Redis memory pressure in high-throughput environments.

The existing `SPAN_METADATA_CACHE_TTL` constant remains as the default fallback.

## Changes
- `packages/env/src/index.ts`: Add `SPAN_METADATA_CACHE_TTL_SECONDS` (default 86400)
- `packages/core/src/repositories/spansRepository.ts`: Prefer env var over hardcoded constant