### PR TITLE
Fix missing commitUuid parameter in traces aggregation query

### DIFF
--- a/packages/core/src/queries/clickhouse/spans/computeDocumentTracesAggregations.ts
+++ b/packages/core/src/queries/clickhouse/spans/computeDocumentTracesAggregations.ts
@@ -31,6 +31,7 @@ export const computeDocumentTracesAggregations = scopedQuery(
 
     if (commitUuid) {
       conditions.push(`commit_uuid_key = {commitUuid: UUID}`)
+      params.commitUuid = commitUuid
     }
 
     // Query all metrics in a single pass


### PR DESCRIPTION
## Summary

Fixes "Substitution `commitUuid` is not set" error when querying document traces aggregations filtered by commit.

The query condition for `commitUuid` was being added to the WHERE clause, but the parameter value itself was not included in the `query_params` object passed to ClickHouse.

Made with [Cursor](https://cursor.com)