### PR TITLE
Fix confusion showing name variables with {{}}

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/index.tsx
@@ -250,7 +250,7 @@ export function DatasetParams({
                 >
                   <div className='flex flex-row items-center gap-x-2 min-h-8'>
                     <Badge variant={isMapped ? 'accent' : 'muted'}>
-                      &#123;&#123;{param}&#125;&#125;
+                      {param}
                     </Badge>
                   </div>
                   <div className='flex flex-grow min-w-0 items-start w-full'>


### PR DESCRIPTION
<img width="878" height="249" alt="image" src="https://github.com/user-attachments/assets/3e12d92b-f5a4-43b6-ad3a-2f0c928730bd" />


Showing the {{}} in the name of the variables in the playground was creating confusion for users when running a prompt with a dataset row.

They tried to put the same name of the column as the variable with the {{}} and the auto select wouldnt work (obvs as the name of the variable really doesnt include the {{}})

This fix removes the {{}} as its clear that those are the variables of the prompt