### PR TITLE
Fix infinite loop fetch position dataset in playground

### DIFF
--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/index.tsx
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/index.tsx
@@ -12,7 +12,7 @@ import { Select, SelectOption } from '@latitude-data/web-ui/atoms/Select'
 import { Skeleton } from '@latitude-data/web-ui/atoms/Skeleton'
 import { Text } from '@latitude-data/web-ui/atoms/Text'
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDocumentParameterValues } from '../DocumentParametersContext'
 import { NoInputsMessage } from '../NoInputsMessage'
 import { useDatasetRowPosition } from './useRowPosition'
@@ -40,6 +40,8 @@ export function DatasetParams({
   const { setParameterValues } = useDocumentParameterValues()
   const { getPosition, position, setPosition, isLoadingPosition } =
     useDatasetRowPosition()
+  const getPositionRef = useRef(getPosition)
+  getPositionRef.current = getPosition
 
   // Column mapping
   const [mappedValues, setMappedValues] = useState<Record<string, string>>({})
@@ -158,21 +160,15 @@ export function DatasetParams({
     }
   }
 
-  // Initialize position when document loads with a dataset
   useEffect(() => {
     if (selectedDataset && document.datasetV2Id === selectedDataset.id) {
-      getPosition({
+      getPositionRef.current({
         dataset: selectedDataset,
         datasetRowId:
           document.linkedDatasetAndRow?.[selectedDataset.id]?.datasetRowId,
       })
     }
-  }, [
-    document.datasetV2Id,
-    selectedDataset,
-    document.linkedDatasetAndRow,
-    getPosition,
-  ])
+  }, [document.datasetV2Id, selectedDataset, document.linkedDatasetAndRow])
 
   const selectedId = selectedDataset?.id
   const isLoading = isLoadingDatasets || isLoadingPosition

--- a/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/useRowPosition.ts
+++ b/apps/web/src/app/(private)/projects/[projectId]/versions/[commitUuid]/documents/[documentUuid]/_components/DocumentEditor/Editor/V2Playground/DocumentParams/DatasetParams/useRowPosition.ts
@@ -4,7 +4,7 @@ import { useNavigate } from '$/hooks/useNavigate'
 import { ROUTES } from '$/services/routes'
 import { compactObject } from '@latitude-data/core/lib/compactObject'
 import { useToast } from '@latitude-data/web-ui/atoms/Toast'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Dataset } from '@latitude-data/core/schema/models/types/Dataset'
 
 export type WithPositionData = {
@@ -49,7 +49,10 @@ export function useDatasetRowPosition() {
   const { toast } = useToast()
   const navigate = useNavigate()
   const currentUrl = useCurrentUrl()
-  const fetchPosition = buildFetcher({ toast, navigate, currentUrl })
+  const fetchPosition = useMemo(
+    () => buildFetcher({ toast, navigate, currentUrl }),
+    [toast, navigate, currentUrl],
+  )
   const [position, setPosition] = useState<number | undefined>(undefined)
   const [isLoadingPosition, setIsLoadingPosition] = useState(false)
   const getPosition = useCallback(


### PR DESCRIPTION
<img width="1335" height="472" alt="image" src="https://github.com/user-attachments/assets/268f4006-4b4f-4815-a5d4-db40e05579f1" />

We had an infinite loop when a dataset was auto selected for a document in the playground. This was due to a typical combo of useEffect and no memoization. This fix fixes that.