### PR TITLE
fix(web): preserve Turbopack symlinks in Docker standalone copy

### DIFF
--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -258,8 +258,11 @@ RUN mkdir -p apps/web/.next/cache
 RUN chown nextjs:nodejs apps/web/.next
 RUN chown nextjs:nodejs apps/web/.next/cache
 
-# Copy the standalone server and node_modules
-COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+# Copy the standalone server (dereference symlinks — Turbopack creates
+# relative symlinks in standalone/node_modules that break in multi-stage
+# Docker builds, see vercel/next.js#89851)
+RUN --mount=from=builder,source=/app/apps/web/.next/standalone,target=/mnt/standalone \
+  cp -a /mnt/standalone/. ./ && chown -R nextjs:nodejs ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/node_modules ./apps/web/node_modules
 # Set permissions for local storage


### PR DESCRIPTION
## Summary

- Turbopack 16.1.x creates relative symlinks in `.next/standalone/node_modules` for `serverExternalPackages` (e.g. `dd-trace`, `bullmq`, `pg`). Docker `COPY` in multi-stage builds does not preserve these symlinks, breaking module resolution at runtime and causing the web pod to crash loop.
- Replace `COPY --from=builder` with `RUN --mount` + `cp -a` (archive mode) which preserves symlinks. All 592 symlinks in standalone are relative and resolve within the tree, so they work in the final image.
- Verified locally: server starts in 170ms with all modules resolving correctly.

References: vercel/next.js#89851

## Test plan

- [x] Docker build succeeds locally
- [x] Server starts without hang or crash (`Ready in 170ms`)
- [x] `dd-trace` and mangled `dd-trace-7beb4d2325fcd252` both resolve correctly
- [x] `styled-jsx` resolves through Next.js require hooks (server starts)
- [ ] Deploy to staging and verify pod stability