### PR TITLE
Fix broken workers docker image

### DIFF
--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -128,7 +128,6 @@ WORKDIR /app
 
 COPY --from=builder --chown=latitude:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=latitude:nodejs /app/${PROJECT_PATH} ./${PROJECT_PATH}
-COPY --from=builder --chown=latitude:nodejs /app/packages/telemetry/typescript ./packages/telemetry/typescript
 COPY --from=builder --chown=latitude:nodejs /app/packages/core/src/assets/eu-central-1-bundle.pem ./packages/core/src/assets/eu-central-1-bundle.pem
 
 # Copy Python engine source and install dependencies

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -19,7 +19,6 @@
     "@bull-board/express": "6.15.0",
     "@latitude-data/core": "workspace:^",
     "@latitude-data/env": "workspace:^",
-    "@latitude-data/telemetry": "catalog:",
     "@t3-oss/env-core": "*",
     "bullmq": "catalog:",
     "dd-trace": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,9 +608,6 @@ importers:
       '@latitude-data/env':
         specifier: workspace:^
         version: link:../../packages/env
-      '@latitude-data/telemetry':
-        specifier: 'catalog:'
-        version: 3.0.0-beta.0(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(typescript@5.9.3)
       '@t3-oss/env-core':
         specifier: '*'
         version: 0.13.8(typescript@5.9.3)(zod@4.3.6)


### PR DESCRIPTION
After adding latitude telemetry to pnpm catalog the copy of the telemetry files is not necessary on the built of the workers image. Also the package is not directly used in workers but used in latitude core