### PR TITLE
feat: Datasets domain — data model, RFC, and Zod 4 migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,7 +68,7 @@ LAT_REDIS_PORT=6379
 
 # Object Storage
 LAT_STORAGE_DRIVER=fs
-LAT_STORAGE_FS_ROOT=./storage
+LAT_STORAGE_FS_ROOT="/Users/YOUR_USER/latitude/to/storage"
 # LAT_STORAGE_S3_BUCKET=latitude-spans
 # LAT_STORAGE_S3_REGION=us-east-1
 # LAT_STORAGE_S3_ACCESS_KEY_ID=your-access-key

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ dist
 # Vim crap
 *.ts-E
 *.tsx-E
+*.tsconfig.tsbuildinfo
 
 # macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,7 @@ Base config: `tsconfig.base.json`
 - Variables/functions/methods: `camelCase`
 - Constants: `UPPER_SNAKE_CASE` only for true constants; otherwise `camelCase` + `as const`
 - File names favor concise module roots (`src/index.ts`, `src/server.ts`, `src/main.tsx`)
+- React component files use **kebab-case**: `my-component.tsx` or `my-component/index.tsx` — never `PascalCase` file names (e.g. `MyComponent.tsx`). This matches the `@repo/ui` convention (`table-skeleton.tsx`, `form-field.tsx`, etc.)
 - Package names follow scoped workspace style (`@app/*`, `@domain/*`, etc.)
 
 ### Domain Design (DDD)
@@ -235,7 +236,7 @@ Base config: `tsconfig.base.json`
 ## Database Patterns
 
 - Postgres adapter stack uses Drizzle ORM in `packages/platform/db-postgres`
-- ClickHouse adapter stack remains SQL-oriented in `packages/platform/db-clickhouse`
+- ClickHouse adapter stack remains SQL-oriented in `packages/platform/db-clickhouse`. **All ClickHouse queries must use parameterized bindings** (`{name:Type}` syntax with `query_params`) — never interpolate user-supplied values directly into SQL strings. **All ClickHouse queries must use parameterized bindings** (`{name:Type}` syntax with `query_params`) — never interpolate user-supplied values directly into SQL strings
 - Weaviate adapter stack lives in `packages/platform/db-weaviate`
 - Domain models are independent from table/row shapes
 - Mapping from DB rows to domain objects belongs in platform adapters
@@ -252,7 +253,7 @@ docker compose exec postgres psql -U latitude -d latitude_development
 To reset only the Postgres volume and start fresh (without affecting other services):
 
 ```bash
-pnpm --filter @platform/db-postgres pg:reset_db
+pnpm --filter @platform/db-postgres pg:reset
 ```
 
 This runs `docker/reset-postgres.sh` which stops postgres, removes the `data-llm_postgres_data` volume, restarts postgres, waits for it to be ready, runs migrations, and seeds the database.
@@ -266,6 +267,7 @@ All Drizzle table definitions in `packages/platform/db-postgres/src/schema/` **m
 3. **Use `tzTimestamp(name)`** — never use raw `timestamp(name, { withTimezone: true })`. Import `tzTimestamp` from the helpers.
 4. **Use `...timestamps()`** — every table that has `createdAt`/`updatedAt` must spread the `timestamps()` helper (includes `$onUpdateFn` on `updatedAt`).
 5. **Use `organizationRLSPolicy(tableName)`** — every table with an `organization_id` column must include this helper in its third argument to enable row-level security.
+6. **No foreign keys** — do not use `.references()` or manually create `FOREIGN KEY` constraints. Referential integrity is enforced at the application/domain layer. FK constraints cause lock contention on high-write tables, complicate zero-downtime migrations, and conflict with soft-delete patterns. Use indexes on relationship columns instead (e.g. `index().on(t.datasetId)` rather than `.references(() => datasets.id)`).
 
 ```typescript
 // ✅ Good - follows all conventions
@@ -578,6 +580,24 @@ When working on `apps/web` or any frontend code:
 - **Always** use `Button` component from `@repo/ui` for all buttons
 - **Always** use `GoogleIcon` and `GitHubIcon` from `@repo/ui` for OAuth provider icons
 
+### Route-Level Component Organization
+
+Place React components close to the routes that use them, inside a `components/` subfolder within the route directory. This keeps route files (which TanStack Router auto-discovers) clearly separated from supporting components.
+
+```
+routes/_authenticated/projects/$projectId/datasets/
+├── index.tsx                       # route file
+├── $datasetId.tsx                  # route file
+└── components/                     # supporting components for these routes
+    ├── dataset-table.tsx
+    ├── row-detail-panel.tsx
+    └── version-badge.tsx
+```
+
+- Route files live directly in the route directory — TanStack Router discovers them
+- Components that support those routes live in an adjacent `components/` folder
+- `domains/` directories (`apps/web/src/domains/`) are for state management only: server functions (writes) and collections/queries (reads) — **not** UI components
+
 ### Design System Showcase
 
 - When adding a new implemented UI component in `packages/ui` (or replacing a placeholder export with a real implementation), update `apps/web/src/routes/design-system.tsx` to include a usage example for that component in both light and dark mode previews.
@@ -599,7 +619,7 @@ export const listProjects = createServerFn({ method: "GET" }).handler(async () =
 
 // Mutation (POST) with Zod validation
 export const createProject = createServerFn({ method: "POST" })
-  .inputValidator(zodValidator(createProjectSchema))
+  .inputValidator(z.object({ name: z.string().min(1) }))
   .handler(async ({ data }) => { ... })
 ```
 

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -15,6 +15,5 @@ export const OrgAndIdParamsSchema = z.object({
   id: z.string().openapi({ description: "Resource ID" }),
 })
 
-
 /** Security scheme applied to protected endpoints. */
 export const PROTECTED_SECURITY = [{ ApiKeyAuth: [] }]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@domain/api-keys": "workspace:*",
     "@domain/auth": "workspace:*",
+    "@domain/datasets": "workspace:*",
     "@domain/email": "workspace:*",
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
@@ -35,7 +36,6 @@
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.163.3",
     "@tanstack/react-start": "1.166.1",
-    "@tanstack/zod-adapter": "1.163.3",
     "better-auth": "catalog:",
     "effect": "catalog:",
     "lucide-react": "^0.481.0",

--- a/apps/web/src/domains/api-keys/api-keys.functions.ts
+++ b/apps/web/src/domains/api-keys/api-keys.functions.ts
@@ -3,7 +3,6 @@ import type { ApiKey } from "@domain/api-keys"
 import { ApiKeyId, OrganizationId } from "@domain/shared"
 import { createApiKeyPostgresRepository, runCommand } from "@platform/db-postgres"
 import { createServerFn } from "@tanstack/react-start"
-import { zodValidator } from "@tanstack/zod-adapter"
 import { Effect } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
@@ -53,7 +52,7 @@ export const listApiKeys = createServerFn({ method: "GET" })
 
 export const createApiKey = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ name: z.string().min(1).max(256) })))
+  .inputValidator(z.object({ name: z.string().min(1).max(256) }))
   .handler(async ({ data }): Promise<ApiKeyRecord> => {
     const { organizationId } = await requireSession()
     const { db } = getPostgresClient()
@@ -75,7 +74,7 @@ export const createApiKey = createServerFn({ method: "POST" })
 
 export const updateApiKey = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ id: z.string(), name: z.string().min(1).max(256) })))
+  .inputValidator(z.object({ id: z.string(), name: z.string().min(1).max(256) }))
   .handler(async ({ data }): Promise<ApiKeyRecord> => {
     const { organizationId } = await requireSession()
     const { db } = getPostgresClient()
@@ -97,7 +96,7 @@ export const updateApiKey = createServerFn({ method: "POST" })
 
 export const deleteApiKey = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ id: z.string() })))
+  .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data }): Promise<void> => {
     const { organizationId } = await requireSession()
     const { db } = getPostgresClient()

--- a/apps/web/src/domains/auth/auth.functions.ts
+++ b/apps/web/src/domains/auth/auth.functions.ts
@@ -17,7 +17,6 @@ import {
   runCommand,
 } from "@platform/db-postgres"
 import { createServerFn } from "@tanstack/react-start"
-import { zodValidator } from "@tanstack/zod-adapter"
 import { Effect } from "effect"
 import { z } from "zod"
 import { getAdminPostgresClient, getRedisClient } from "../../server/clients.ts"
@@ -44,7 +43,7 @@ const provideAuthServices = <A, E>(
 
 export const createLoginIntent = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(createLoginIntentInputSchema))
+  .inputValidator(createLoginIntentInputSchema)
   .handler(async ({ data }) => {
     const { db } = getAdminPostgresClient()
 
@@ -57,7 +56,7 @@ export const createLoginIntent = createServerFn({ method: "POST" })
 
 export const createSignupIntent = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(createSignupIntentInputSchema))
+  .inputValidator(createSignupIntentInputSchema)
   .handler(async ({ data }) => {
     const { db } = getAdminPostgresClient()
 
@@ -88,7 +87,7 @@ export interface AuthIntentInfo {
 
 export const getAuthIntentInfo = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(getAuthIntentInfoInputSchema))
+  .inputValidator(getAuthIntentInfoInputSchema)
   .handler(async ({ data }): Promise<AuthIntentInfo> => {
     const session = await ensureSession()
     const { db } = getAdminPostgresClient()
@@ -116,7 +115,7 @@ export const getAuthIntentInfo = createServerFn({ method: "POST" })
 
 export const completeAuthIntent = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(completeAuthIntentInputSchema))
+  .inputValidator(completeAuthIntentInputSchema)
   .handler(async ({ data }) => {
     const session = await ensureSession()
     const { db } = getAdminPostgresClient()
@@ -142,7 +141,7 @@ export const completeAuthIntent = createServerFn({ method: "POST" })
 
 export const exchangeCliSession = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ sessionToken: z.string() })))
+  .inputValidator(z.object({ sessionToken: z.string() }))
   .handler(async ({ data }) => {
     const session = await ensureSession()
     const redis = getRedisClient()

--- a/apps/web/src/domains/datasets/datasets.collection.ts
+++ b/apps/web/src/domains/datasets/datasets.collection.ts
@@ -1,0 +1,107 @@
+import { queryCollectionOptions } from "@tanstack/query-db-collection"
+import type { Context, QueryBuilder, SchemaFromSource } from "@tanstack/react-db"
+import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { getQueryClient } from "../../lib/data/query-client.tsx"
+import type { DatasetRecord, DatasetRowRecord } from "./datasets.functions.ts"
+import { listDatasetsQuery, listRowsQuery } from "./datasets.functions.ts"
+
+const queryClient = getQueryClient()
+
+const makeDatasetsCollection = (projectId: string) =>
+  createCollection(
+    queryCollectionOptions({
+      queryClient,
+      queryKey: ["datasets", projectId],
+      queryFn: async () => {
+        const result = await listDatasetsQuery({ data: { projectId } })
+        return result.datasets
+      },
+      getKey: (item: DatasetRecord) => item.id,
+    }),
+  )
+
+type DatasetsCollection = ReturnType<typeof makeDatasetsCollection>
+const datasetsCollectionsCache = new Map<string, DatasetsCollection>()
+
+const getDatasetsCollection = (projectId: string): DatasetsCollection => {
+  const cached = datasetsCollectionsCache.get(projectId)
+  if (cached) return cached
+  const collection = makeDatasetsCollection(projectId)
+  datasetsCollectionsCache.set(projectId, collection)
+  return collection
+}
+
+type DatasetsSource = { dataset: DatasetsCollection }
+type DatasetsContext = {
+  baseSchema: SchemaFromSource<DatasetsSource>
+  schema: SchemaFromSource<DatasetsSource>
+  fromSourceName: "dataset"
+  hasJoins: false
+}
+
+export const useDatasetsCollection = <TContext extends Context = DatasetsContext>(
+  projectId: string,
+  queryFn?: (datasets: QueryBuilder<DatasetsContext>) => QueryBuilder<TContext>,
+  deps?: Array<unknown>,
+) => {
+  const collection = getDatasetsCollection(projectId)
+  return useLiveQuery<TContext>(
+    (q) => {
+      const datasets = q.from({ dataset: collection })
+      if (queryFn) return queryFn(datasets)
+      return datasets as unknown as QueryBuilder<TContext>
+    },
+    [projectId, ...(deps ?? [])],
+  )
+}
+
+const makeDatasetRowsCollection = (datasetId: string, search?: string) =>
+  createCollection(
+    queryCollectionOptions({
+      queryClient,
+      queryKey: ["datasetRows", datasetId, search ?? ""],
+      queryFn: async () => {
+        const result = await listRowsQuery({
+          data: {
+            datasetId,
+            ...(search ? { search } : {}),
+            limit: 50,
+            offset: 0,
+          },
+        })
+        return result.rows as DatasetRowRecord[]
+      },
+      getKey: (item: DatasetRowRecord) => item.rowId,
+    }),
+  )
+
+type DatasetRowsCollection = ReturnType<typeof makeDatasetRowsCollection>
+const MAX_ROW_COLLECTIONS = 10
+const rowsCollectionsCache = new Map<string, DatasetRowsCollection>()
+
+const getDatasetRowsCollection = (datasetId: string, search?: string): DatasetRowsCollection => {
+  const cacheKey = `${datasetId}:${search ?? ""}`
+  const cached = rowsCollectionsCache.get(cacheKey)
+  if (cached) {
+    rowsCollectionsCache.delete(cacheKey)
+    rowsCollectionsCache.set(cacheKey, cached)
+    return cached
+  }
+
+  const collection = makeDatasetRowsCollection(datasetId, search)
+  rowsCollectionsCache.set(cacheKey, collection)
+
+  if (rowsCollectionsCache.size > MAX_ROW_COLLECTIONS) {
+    const oldest = rowsCollectionsCache.keys().next().value
+    if (oldest) {
+      rowsCollectionsCache.delete(oldest)
+    }
+  }
+
+  return collection
+}
+
+export const useDatasetRowsCollection = (datasetId: string, search?: string) => {
+  const collection = getDatasetRowsCollection(datasetId, search)
+  return useLiveQuery((q) => q.from({ row: collection }), [datasetId, search])
+}

--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -1,0 +1,116 @@
+import type { Dataset, DatasetRow } from "@domain/datasets"
+import { DatasetRepository, DatasetRowRepository, listDatasets, listRows } from "@domain/datasets"
+import { DatasetId, DatasetVersionId, OrganizationId, ProjectId } from "@domain/shared"
+import { createDatasetRowClickHouseRepository } from "@platform/db-clickhouse"
+import { createDatasetPostgresRepository, runCommand } from "@platform/db-postgres"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getClickhouseClient, getPostgresClient } from "../../server/clients.ts"
+import { errorHandler } from "../../server/middlewares.ts"
+
+export interface DatasetRecord {
+  readonly id: string
+  readonly organizationId: string
+  readonly projectId: string
+  readonly name: string
+  readonly description: string | null
+  readonly currentVersion: number
+  readonly latestVersionId: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }
+
+export interface DatasetRowRecord {
+  readonly rowId: string
+  readonly datasetId: string
+  readonly input: Record<string, JsonValue>
+  readonly output: Record<string, JsonValue>
+  readonly metadata: Record<string, JsonValue>
+  readonly createdAt: string
+  readonly version: number
+}
+
+const toDatasetRecord = (d: Dataset): DatasetRecord => ({
+  id: d.id,
+  organizationId: d.organizationId,
+  projectId: d.projectId,
+  name: d.name,
+  description: d.description,
+  currentVersion: d.currentVersion,
+  latestVersionId: d.latestVersionId,
+  createdAt: d.createdAt.toISOString(),
+  updatedAt: d.updatedAt.toISOString(),
+})
+
+const toRowRecord = (r: DatasetRow): DatasetRowRecord => ({
+  rowId: r.rowId,
+  datasetId: r.datasetId,
+  input: r.input as Record<string, JsonValue>,
+  output: r.output as Record<string, JsonValue>,
+  metadata: r.metadata as Record<string, JsonValue>,
+  createdAt: r.createdAt.toISOString(),
+  version: r.version,
+})
+
+export const listDatasetsQuery = createServerFn({ method: "GET" })
+  .middleware([errorHandler])
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }): Promise<{ datasets: DatasetRecord[]; total: number }> => {
+    const { organizationId } = await requireSession()
+    const { db } = getPostgresClient()
+
+    const result = await runCommand(
+      db,
+      organizationId,
+    )(async (txDb) =>
+      Effect.runPromise(
+        listDatasets({
+          organizationId: OrganizationId(organizationId),
+          projectId: ProjectId(data.projectId),
+        }).pipe(Effect.provideService(DatasetRepository, createDatasetPostgresRepository(txDb))),
+      ),
+    )
+
+    return { datasets: result.datasets.map(toDatasetRecord), total: result.total }
+  })
+
+export const listRowsQuery = createServerFn({ method: "GET" })
+  .middleware([errorHandler])
+  .inputValidator(
+    z.object({
+      datasetId: z.string(),
+      versionId: z.string().optional(),
+      search: z.string().optional(),
+      limit: z.number().int().min(1).max(500).default(50),
+      offset: z.number().default(0),
+    }),
+  )
+  .handler(async ({ data }): Promise<{ rows: DatasetRowRecord[]; total: number }> => {
+    const { organizationId } = await requireSession()
+    const { db } = getPostgresClient()
+
+    const result = await runCommand(
+      db,
+      organizationId,
+    )(async (txDb) =>
+      Effect.runPromise(
+        listRows({
+          organizationId: OrganizationId(organizationId),
+          datasetId: DatasetId(data.datasetId),
+          ...(data.versionId ? { versionId: DatasetVersionId(data.versionId) } : {}),
+          ...(data.search ? { search: data.search } : {}),
+          limit: data.limit,
+          offset: data.offset,
+        }).pipe(
+          Effect.provideService(DatasetRepository, createDatasetPostgresRepository(txDb)),
+          Effect.provideService(DatasetRowRepository, createDatasetRowClickHouseRepository(getClickhouseClient())),
+        ),
+      ),
+    )
+
+    return { rows: result.rows.map(toRowRecord), total: result.total }
+  })

--- a/apps/web/src/domains/members/members.functions.ts
+++ b/apps/web/src/domains/members/members.functions.ts
@@ -9,7 +9,6 @@ import {
   runCommand,
 } from "@platform/db-postgres"
 import { createServerFn } from "@tanstack/react-start"
-import { zodValidator } from "@tanstack/zod-adapter"
 import { Effect } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
@@ -80,7 +79,7 @@ export const listMembers = createServerFn({ method: "GET" })
 
 export const inviteMember = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ email: z.string().email() })))
+  .inputValidator(z.object({ email: z.string().email() }))
   .handler(async ({ data }): Promise<{ intentId: string }> => {
     const session = await ensureSession()
     const { organizationId } = await requireSession()
@@ -114,7 +113,7 @@ export const inviteMember = createServerFn({ method: "POST" })
 
 export const removeMember = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ membershipId: z.string() })))
+  .inputValidator(z.object({ membershipId: z.string() }))
   .handler(async ({ data }): Promise<void> => {
     const { userId, organizationId } = await requireSession()
     const { db } = getPostgresClient()

--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -3,7 +3,6 @@ import type { Project } from "@domain/projects"
 import { OrganizationId, ProjectId, UserId } from "@domain/shared"
 import { createProjectPostgresRepository, runCommand } from "@platform/db-postgres"
 import { createServerFn } from "@tanstack/react-start"
-import { zodValidator } from "@tanstack/zod-adapter"
 import { Effect } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
@@ -55,7 +54,7 @@ export const listProjects = createServerFn({ method: "GET" })
 
 export const createProject = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ name: z.string(), description: z.string().optional() })))
+  .inputValidator(z.object({ name: z.string(), description: z.string().optional() }))
   .handler(async ({ data }): Promise<ProjectRecord> => {
     const { userId, organizationId } = await requireSession()
     const { db } = getPostgresClient()
@@ -80,13 +79,11 @@ export const createProject = createServerFn({ method: "POST" })
 export const updateProject = createServerFn({ method: "POST" })
   .middleware([errorHandler])
   .inputValidator(
-    zodValidator(
-      z.object({
-        id: z.string(),
-        name: z.string().optional(),
-        description: z.string().nullable().optional(),
-      }),
-    ),
+    z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      description: z.string().nullable().optional(),
+    }),
   )
   .handler(async ({ data }): Promise<ProjectRecord> => {
     const { organizationId } = await requireSession()
@@ -111,7 +108,7 @@ export const updateProject = createServerFn({ method: "POST" })
 
 export const deleteProject = createServerFn({ method: "POST" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ id: z.string() })))
+  .inputValidator(z.object({ id: z.string() }))
   .handler(async ({ data }): Promise<void> => {
     const { organizationId } = await requireSession()
     const { db } = getPostgresClient()

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,15 +1,11 @@
 import { NotFoundError, OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
 import type { Span, SpanDetail, SpanRepository, Trace, TraceRepository } from "@domain/spans"
-import {
-  createClickhouseClient,
-  createSpanClickhouseRepository,
-  createTraceClickhouseRepository,
-} from "@platform/db-clickhouse"
+import { createSpanClickhouseRepository, createTraceClickhouseRepository } from "@platform/db-clickhouse"
 import { createServerFn } from "@tanstack/react-start"
-import { zodValidator } from "@tanstack/zod-adapter"
 import { Effect } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
+import { getClickhouseClient } from "../../server/clients.ts"
 import { errorHandler } from "../../server/middlewares.ts"
 
 export interface SpanRecord {
@@ -69,7 +65,7 @@ export interface SpanDetailRecord extends SpanRecord {
 let spanRepoInstance: SpanRepository | undefined
 const getSpanRepository = () => {
   if (!spanRepoInstance) {
-    spanRepoInstance = createSpanClickhouseRepository(createClickhouseClient())
+    spanRepoInstance = createSpanClickhouseRepository(getClickhouseClient())
   }
   return spanRepoInstance
 }
@@ -77,7 +73,7 @@ const getSpanRepository = () => {
 let traceRepoInstance: TraceRepository | undefined
 const getTraceRepository = () => {
   if (!traceRepoInstance) {
-    traceRepoInstance = createTraceClickhouseRepository(createClickhouseClient())
+    traceRepoInstance = createTraceClickhouseRepository(getClickhouseClient())
   }
   return traceRepoInstance
 }
@@ -139,7 +135,7 @@ const serializeSpanDetail = (span: SpanDetail): SpanDetailRecord => ({
 
 export const listSpansByTrace = createServerFn({ method: "GET" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ traceId: z.string() })))
+  .inputValidator(z.object({ traceId: z.string() }))
   .handler(async ({ data }): Promise<SpanRecord[]> => {
     const { organizationId } = await requireSession()
     const repo = getSpanRepository()
@@ -151,7 +147,7 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
 
 export const getSpanDetail = createServerFn({ method: "GET" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ traceId: z.string(), spanId: z.string() })))
+  .inputValidator(z.object({ traceId: z.string(), spanId: z.string() }))
   .handler(async ({ data }): Promise<SpanDetailRecord> => {
     const { organizationId } = await requireSession()
     const repo = getSpanRepository()
@@ -224,7 +220,7 @@ const serializeTrace = (trace: Trace): TraceRecord => ({
 
 export const listTracesByProject = createServerFn({ method: "GET" })
   .middleware([errorHandler])
-  .inputValidator(zodValidator(z.object({ projectId: z.string() })))
+  .inputValidator(z.object({ projectId: z.string() }))
   .handler(async ({ data }): Promise<TraceRecord[]> => {
     const { organizationId } = await requireSession()
     const repo = getTraceRepository()

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as AuthenticatedProjectsProjectIdRouteImport } from './routes/_au
 import { Route as AuthenticatedProjectsProjectIdIndexRouteImport } from './routes/_authenticated/projects/$projectId/index'
 import { Route as AuthenticatedProjectsProjectIdIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectId/issues/index'
 import { Route as AuthenticatedProjectsProjectIdDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectId/datasets/index'
+import { Route as AuthenticatedProjectsProjectIdDatasetsDatasetIdRouteImport } from './routes/_authenticated/projects/$projectId/datasets/$datasetId'
 import { Route as AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRouteImport } from './routes/_authenticated/projects/$projectId/traces/$traceId/spans/index'
 import { Route as AuthenticatedProjectsProjectIdTracesTraceIdSpansSpanIdIndexRouteImport } from './routes/_authenticated/projects/$projectId/traces/$traceId/spans/$spanId/index'
 
@@ -93,6 +94,12 @@ const AuthenticatedProjectsProjectIdDatasetsIndexRoute =
     path: '/datasets/',
     getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
   } as any)
+const AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute =
+  AuthenticatedProjectsProjectIdDatasetsDatasetIdRouteImport.update({
+    id: '/datasets/$datasetId',
+    path: '/datasets/$datasetId',
+    getParentRoute: () => AuthenticatedProjectsProjectIdRoute,
+  } as any)
 const AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute =
   AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRouteImport.update({
     id: '/traces/$traceId/spans/',
@@ -119,6 +126,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/projects/$projectId/': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/projects/$projectId/datasets/$datasetId': typeof AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute
   '/projects/$projectId/datasets/': typeof AuthenticatedProjectsProjectIdDatasetsIndexRoute
   '/projects/$projectId/issues/': typeof AuthenticatedProjectsProjectIdIssuesIndexRoute
   '/projects/$projectId/traces/$traceId/spans/': typeof AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute
@@ -134,6 +142,7 @@ export interface FileRoutesByTo {
   '/': typeof AuthenticatedIndexRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/projects/$projectId': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/projects/$projectId/datasets/$datasetId': typeof AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute
   '/projects/$projectId/datasets': typeof AuthenticatedProjectsProjectIdDatasetsIndexRoute
   '/projects/$projectId/issues': typeof AuthenticatedProjectsProjectIdIssuesIndexRoute
   '/projects/$projectId/traces/$traceId/spans': typeof AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute
@@ -152,6 +161,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectId': typeof AuthenticatedProjectsProjectIdRouteWithChildren
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/_authenticated/projects/$projectId/': typeof AuthenticatedProjectsProjectIdIndexRoute
+  '/_authenticated/projects/$projectId/datasets/$datasetId': typeof AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute
   '/_authenticated/projects/$projectId/datasets/': typeof AuthenticatedProjectsProjectIdDatasetsIndexRoute
   '/_authenticated/projects/$projectId/issues/': typeof AuthenticatedProjectsProjectIdIssuesIndexRoute
   '/_authenticated/projects/$projectId/traces/$traceId/spans/': typeof AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute
@@ -170,6 +180,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId'
     | '/api/auth/$'
     | '/projects/$projectId/'
+    | '/projects/$projectId/datasets/$datasetId'
     | '/projects/$projectId/datasets/'
     | '/projects/$projectId/issues/'
     | '/projects/$projectId/traces/$traceId/spans/'
@@ -185,6 +196,7 @@ export interface FileRouteTypes {
     | '/'
     | '/api/auth/$'
     | '/projects/$projectId'
+    | '/projects/$projectId/datasets/$datasetId'
     | '/projects/$projectId/datasets'
     | '/projects/$projectId/issues'
     | '/projects/$projectId/traces/$traceId/spans'
@@ -202,6 +214,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectId'
     | '/api/auth/$'
     | '/_authenticated/projects/$projectId/'
+    | '/_authenticated/projects/$projectId/datasets/$datasetId'
     | '/_authenticated/projects/$projectId/datasets/'
     | '/_authenticated/projects/$projectId/issues/'
     | '/_authenticated/projects/$projectId/traces/$traceId/spans/'
@@ -311,6 +324,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectIdDatasetsIndexRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectIdRoute
     }
+    '/_authenticated/projects/$projectId/datasets/$datasetId': {
+      id: '/_authenticated/projects/$projectId/datasets/$datasetId'
+      path: '/datasets/$datasetId'
+      fullPath: '/projects/$projectId/datasets/$datasetId'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectIdDatasetsDatasetIdRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectIdRoute
+    }
     '/_authenticated/projects/$projectId/traces/$traceId/spans/': {
       id: '/_authenticated/projects/$projectId/traces/$traceId/spans/'
       path: '/traces/$traceId/spans'
@@ -330,6 +350,7 @@ declare module '@tanstack/react-router' {
 
 interface AuthenticatedProjectsProjectIdRouteChildren {
   AuthenticatedProjectsProjectIdIndexRoute: typeof AuthenticatedProjectsProjectIdIndexRoute
+  AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute: typeof AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute
   AuthenticatedProjectsProjectIdDatasetsIndexRoute: typeof AuthenticatedProjectsProjectIdDatasetsIndexRoute
   AuthenticatedProjectsProjectIdIssuesIndexRoute: typeof AuthenticatedProjectsProjectIdIssuesIndexRoute
   AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute: typeof AuthenticatedProjectsProjectIdTracesTraceIdSpansIndexRoute
@@ -340,6 +361,8 @@ const AuthenticatedProjectsProjectIdRouteChildren: AuthenticatedProjectsProjectI
   {
     AuthenticatedProjectsProjectIdIndexRoute:
       AuthenticatedProjectsProjectIdIndexRoute,
+    AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute:
+      AuthenticatedProjectsProjectIdDatasetsDatasetIdRoute,
     AuthenticatedProjectsProjectIdDatasetsIndexRoute:
       AuthenticatedProjectsProjectIdDatasetsIndexRoute,
     AuthenticatedProjectsProjectIdIssuesIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/$datasetId.tsx
@@ -1,0 +1,67 @@
+import { Container, Input, TableSkeleton, Text } from "@repo/ui"
+import { createFileRoute } from "@tanstack/react-router"
+import { useDeferredValue, useState } from "react"
+import { useDatasetRowsCollection, useDatasetsCollection } from "../../../../../domains/datasets/datasets.collection.ts"
+import type { DatasetRowRecord } from "../../../../../domains/datasets/datasets.functions.ts"
+import { DatasetTable } from "./components/dataset-table.tsx"
+import { RowDetailPanel } from "./components/row-detail-panel.tsx"
+import { VersionBadge } from "./components/version-badge.tsx"
+
+export const Route = createFileRoute("/_authenticated/projects/$projectId/datasets/$datasetId")({
+  component: DatasetDetailPage,
+})
+
+function DatasetDetailPage() {
+  const { projectId, datasetId } = Route.useParams()
+  const [search, setSearch] = useState("")
+  const deferredSearch = useDeferredValue(search)
+  const [selectedRow, setSelectedRow] = useState<DatasetRowRecord | null>(null)
+  const rowsCollection = useDatasetRowsCollection(datasetId, deferredSearch)
+  const rows = rowsCollection.data
+  const isLoading = !rowsCollection.data
+
+  const datasetsCollection = useDatasetsCollection(projectId)
+  const dataset = datasetsCollection.data?.find((d) => d.id === datasetId)
+
+  return (
+    <Container>
+      <div className="flex flex-col gap-4 flex-1 min-h-0">
+        <div className="flex flex-row items-center justify-between">
+          <Text.H3 weight="bold">{dataset?.name ?? "Dataset"}</Text.H3>
+          {dataset?.latestVersionId && <VersionBadge versionId={dataset.latestVersionId} />}
+        </div>
+
+        <div className="flex flex-row flex-1 min-h-0 border rounded-lg overflow-hidden">
+          <div className={`flex flex-col ${selectedRow ? "w-1/2" : "w-full"} min-h-0`}>
+            <div className="flex flex-row items-center gap-2 px-4 py-3 border-b">
+              <Input
+                type="text"
+                placeholder="Search rows..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="flex-1"
+              />
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {isLoading ? (
+                <TableSkeleton cols={4} rows={8} />
+              ) : rows.length > 0 ? (
+                <DatasetTable rows={rows} selectedRowId={selectedRow?.rowId ?? null} onSelectRow={setSelectedRow} />
+              ) : (
+                <div className="flex items-center justify-center p-8">
+                  <Text.H5 color="foregroundMuted">No rows found</Text.H5>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {selectedRow && (
+            <div className="w-1/2 min-h-0">
+              <RowDetailPanel row={selectedRow} onClose={() => setSelectedRow(null)} />
+            </div>
+          )}
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/dataset-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/dataset-table.tsx
@@ -1,0 +1,56 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import type { DatasetRowRecord } from "../../../../../../domains/datasets/datasets.functions.ts"
+
+function truncateJson(data: Record<string, unknown>, maxLen = 30): string {
+  const values = Object.values(data)
+  if (values.length === 0) return "{}"
+  const first = String(values[0])
+  return first.length > maxLen ? `${first.slice(0, maxLen)}…` : first
+}
+
+export function DatasetTable({
+  rows,
+  selectedRowId,
+  onSelectRow,
+}: {
+  rows: DatasetRowRecord[]
+  selectedRowId: string | null
+  onSelectRow: (row: DatasetRowRecord) => void
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow verticalPadding>
+          <TableHead>#</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead>Input</TableHead>
+          <TableHead>Output</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow
+            key={row.rowId}
+            verticalPadding
+            className={`cursor-pointer ${selectedRowId === row.rowId ? "bg-accent" : ""}`}
+            onClick={() => onSelectRow(row)}
+          >
+            <TableCell>
+              <Text.H6 color="foregroundMuted">{index + 1}</Text.H6>
+            </TableCell>
+            <TableCell>
+              <Text.H6 color="foregroundMuted">{relativeTime(row.createdAt)}</Text.H6>
+            </TableCell>
+            <TableCell>
+              <Text.H6 className="font-mono truncate max-w-48">{truncateJson(row.input)}</Text.H6>
+            </TableCell>
+            <TableCell>
+              <Text.H6 className="font-mono truncate max-w-48">{truncateJson(row.output)}</Text.H6>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/row-detail-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/row-detail-panel.tsx
@@ -1,0 +1,70 @@
+import { Button, Text } from "@repo/ui"
+import { X } from "lucide-react"
+import { useState } from "react"
+import type { DatasetRowRecord } from "../../../../../../domains/datasets/datasets.functions.ts"
+
+function JsonView({ data }: { data: Record<string, unknown> }) {
+  const formatted = JSON.stringify(data, null, 2)
+  const lineCount = formatted.split("\n").length
+
+  return (
+    <div className="flex flex-row rounded-md border bg-muted/50 overflow-x-auto">
+      <div className="flex flex-col items-end px-2 py-3 border-r bg-muted/80 select-none">
+        {Array.from({ length: lineCount }, (_, i) => `line-${i + 1}`).map((key, i) => (
+          <Text.H6 key={key} color="foregroundMuted" className="leading-5 font-mono">
+            {i + 1}
+          </Text.H6>
+        ))}
+      </div>
+      <pre className="flex-1 px-3 py-3 text-sm font-mono leading-5 whitespace-pre overflow-x-auto">{formatted}</pre>
+    </div>
+  )
+}
+
+function CollapsibleSection({
+  title,
+  data,
+  defaultOpen = true,
+}: {
+  title: string
+  data: Record<string, unknown>
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button type="button" className="flex items-center gap-1.5 cursor-pointer" onClick={() => setOpen(!open)}>
+        <Text.H6 color="foregroundMuted">{open ? "▾" : "▸"}</Text.H6>
+        <Text.H5 weight="bold">{title}</Text.H5>
+      </button>
+      {open && <JsonView data={data} />}
+    </div>
+  )
+}
+
+export function RowDetailPanel({
+  row,
+  onClose,
+}: {
+  row: DatasetRowRecord
+  onClose: () => void
+}) {
+  return (
+    <div className="flex flex-col h-full border-l">
+      <div className="flex flex-row items-center justify-between px-4 py-3 border-b">
+        <Text.H5 color="foregroundMuted" className="font-mono truncate">
+          {row.rowId}
+        </Text.H5>
+        <Button flat variant="ghost" onClick={onClose}>
+          <X className="w-4 h-4" />
+        </Button>
+      </div>
+      <div className="flex flex-col gap-4 p-4 overflow-y-auto flex-1">
+        <CollapsibleSection title="Input" data={row.input} />
+        <CollapsibleSection title="Output" data={row.output} />
+        <CollapsibleSection title="Metadata" data={row.metadata} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/version-badge.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/components/version-badge.tsx
@@ -1,0 +1,11 @@
+import { Text } from "@repo/ui"
+
+export function VersionBadge({ versionId }: { versionId?: string }) {
+  return (
+    <div className="flex items-center rounded-md border px-2.5 py-1 bg-muted/50">
+      <Text.H6 color="foregroundMuted" className="font-mono uppercase tracking-wider">
+        v:{versionId}
+      </Text.H6>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/index.tsx
@@ -1,16 +1,91 @@
-import { Container, TableBlankSlate, TableWithHeader } from "@repo/ui"
-import { createFileRoute } from "@tanstack/react-router"
+import {
+  Container,
+  Table,
+  TableBlankSlate,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableSkeleton,
+  TableWithHeader,
+  Text,
+} from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { Link, createFileRoute } from "@tanstack/react-router"
+import { useDatasetsCollection } from "../../../../../domains/datasets/datasets.collection.ts"
+import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/datasets/")({
   component: DatasetsPage,
 })
 
+function DatasetsTable({ datasets, projectId }: { datasets: DatasetRecord[]; projectId: string }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow verticalPadding>
+          <TableHead>Name</TableHead>
+          <TableHead>Version</TableHead>
+          <TableHead>Created</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {datasets.map((dataset) => (
+          <TableRow key={dataset.id} verticalPadding className="cursor-pointer">
+            <TableCell>
+              <Link
+                to="/projects/$projectId/datasets/$datasetId"
+                params={{ projectId, datasetId: dataset.id }}
+                className="contents"
+              >
+                <Text.H5>{dataset.name}</Text.H5>
+              </Link>
+            </TableCell>
+            <TableCell>
+              <Link
+                to="/projects/$projectId/datasets/$datasetId"
+                params={{ projectId, datasetId: dataset.id }}
+                className="contents"
+              >
+                <Text.H5 color="foregroundMuted">{dataset.currentVersion}</Text.H5>
+              </Link>
+            </TableCell>
+            <TableCell>
+              <Link
+                to="/projects/$projectId/datasets/$datasetId"
+                params={{ projectId, datasetId: dataset.id }}
+                className="contents"
+              >
+                <Text.H5 color="foregroundMuted">{relativeTime(dataset.createdAt)}</Text.H5>
+              </Link>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+
 function DatasetsPage() {
+  const { projectId } = Route.useParams()
+  const datasetsCollection = useDatasetsCollection(projectId)
+  const datasets = datasetsCollection.data ?? []
+  const isLoading = !datasetsCollection.data
+
   return (
     <Container className="pt-14">
       <TableWithHeader
         title="Datasets"
-        table={<TableBlankSlate description="Datasets will appear here once you create them." />}
+        table={
+          isLoading ? (
+            <TableSkeleton cols={3} rows={3} />
+          ) : datasets.length > 0 ? (
+            <DatasetsTable datasets={datasets} projectId={projectId} />
+          ) : (
+            <TableBlankSlate description="There are no datasets yet." />
+          )
+        }
       />
     </Container>
   )

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -9,6 +9,7 @@ import {
 import { createBetterAuth } from "@platform/auth-better"
 import { createRedisClient, createRedisConnection } from "@platform/cache-redis"
 import type { RedisClient } from "@platform/cache-redis"
+import { type ClickHouseClient, createClickhouseClient } from "@platform/db-clickhouse"
 import {
   type PostgresClient,
   createAuthIntentPostgresRepository,
@@ -22,6 +23,7 @@ import { Effect } from "effect"
 let postgresClientInstance: PostgresClient | undefined
 let adminPostgresClientInstance: PostgresClient | undefined
 let redisClientInstance: RedisClient | undefined
+let clickhouseClientInstance: ClickHouseClient | undefined
 let betterAuthInstance: ReturnType<typeof createBetterAuth> | undefined
 
 interface AuthIntentEmailContext {
@@ -85,6 +87,13 @@ export const getRedisClient = (): RedisClient => {
     redisClientInstance = createRedisClient(connection)
   }
   return redisClientInstance
+}
+
+export const getClickhouseClient = (): ClickHouseClient => {
+  if (!clickhouseClientInstance) {
+    clickhouseClientInstance = createClickhouseClient()
+  }
+  return clickhouseClientInstance
 }
 
 export const getBetterAuth = () => {

--- a/packages/domain/datasets/package.json
+++ b/packages/domain/datasets/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@domain/datasets",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "check": "biome check src",
+    "format": "biome format --write src",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests",
+    "check:fix": "biome check --fix src"
+  },
+  "dependencies": {
+    "@domain/shared": "workspace:*",
+    "effect": "catalog:"
+  }
+}

--- a/packages/domain/datasets/src/entities/dataset-row.ts
+++ b/packages/domain/datasets/src/entities/dataset-row.ts
@@ -1,0 +1,21 @@
+import type { DatasetId, DatasetRowId } from "@domain/shared"
+import { Data } from "effect"
+
+export interface DatasetRow {
+  readonly rowId: DatasetRowId
+  readonly datasetId: DatasetId
+  readonly input: Record<string, unknown>
+  readonly output: Record<string, unknown>
+  readonly metadata: Record<string, unknown>
+  readonly createdAt: Date
+  readonly version: number
+}
+
+export class RowNotFoundError extends Data.TaggedError("RowNotFoundError")<{
+  readonly rowId: string
+}> {
+  readonly httpStatus = 404
+  get httpMessage() {
+    return `Row ${this.rowId} not found`
+  }
+}

--- a/packages/domain/datasets/src/entities/dataset.ts
+++ b/packages/domain/datasets/src/entities/dataset.ts
@@ -1,0 +1,35 @@
+import type { DatasetId, DatasetVersionId, OrganizationId, ProjectId } from "@domain/shared"
+import { Data } from "effect"
+
+export interface Dataset {
+  readonly id: DatasetId
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly name: string
+  readonly description: string | null
+  readonly currentVersion: number
+  readonly latestVersionId: DatasetVersionId | null
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}
+
+export interface DatasetVersion {
+  readonly id: DatasetVersionId
+  readonly datasetId: DatasetId
+  readonly version: number
+  readonly rowsInserted: number
+  readonly rowsUpdated: number
+  readonly rowsDeleted: number
+  readonly source: string
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}
+
+export class DatasetNotFoundError extends Data.TaggedError("DatasetNotFoundError")<{
+  readonly datasetId: string
+}> {
+  readonly httpStatus = 404
+  get httpMessage() {
+    return `Dataset ${this.datasetId} not found`
+  }
+}

--- a/packages/domain/datasets/src/index.ts
+++ b/packages/domain/datasets/src/index.ts
@@ -1,0 +1,13 @@
+export { type Dataset, type DatasetVersion, DatasetNotFoundError } from "./entities/dataset.ts"
+export { type DatasetRow, RowNotFoundError } from "./entities/dataset-row.ts"
+
+export { DatasetRepository } from "./ports/dataset-repository.ts"
+export { DatasetRowRepository, type DatasetRowRepositoryShape } from "./ports/dataset-row-repository.ts"
+
+export { buildValidRowId } from "./validate-row-id.ts"
+
+export { createDataset } from "./use-cases/create-dataset.ts"
+export { listDatasets } from "./use-cases/list-datasets.ts"
+export { insertRows } from "./use-cases/insert-rows.ts"
+export { listRows } from "./use-cases/list-rows.ts"
+export { getRowDetail } from "./use-cases/get-row-detail.ts"

--- a/packages/domain/datasets/src/ports/dataset-repository.ts
+++ b/packages/domain/datasets/src/ports/dataset-repository.ts
@@ -1,0 +1,38 @@
+import type { DatasetId, DatasetVersionId, OrganizationId, ProjectId, RepositoryError } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { Dataset, DatasetNotFoundError, DatasetVersion } from "../entities/dataset.ts"
+
+export class DatasetRepository extends ServiceMap.Service<
+  DatasetRepository,
+  {
+    create(args: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly name: string
+      readonly description?: string
+    }): Effect.Effect<Dataset, RepositoryError>
+
+    findById(id: DatasetId): Effect.Effect<Dataset, DatasetNotFoundError | RepositoryError>
+
+    listByProject(args: {
+      readonly organizationId: OrganizationId
+      readonly projectId: ProjectId
+      readonly limit?: number
+      readonly offset?: number
+    }): Effect.Effect<{ readonly datasets: readonly Dataset[]; readonly total: number }, RepositoryError>
+
+    softDelete(id: DatasetId): Effect.Effect<void, DatasetNotFoundError | RepositoryError>
+
+    incrementVersion(args: {
+      readonly organizationId: OrganizationId
+      readonly id: DatasetId
+      readonly rowsInserted: number
+      readonly source?: string
+    }): Effect.Effect<DatasetVersion, DatasetNotFoundError | RepositoryError>
+
+    resolveVersion(args: {
+      readonly datasetId: DatasetId
+      readonly versionId: DatasetVersionId
+    }): Effect.Effect<number, DatasetNotFoundError | RepositoryError>
+  }
+>()("@domain/datasets/DatasetRepository") {}

--- a/packages/domain/datasets/src/ports/dataset-row-repository.ts
+++ b/packages/domain/datasets/src/ports/dataset-row-repository.ts
@@ -1,0 +1,37 @@
+import type { DatasetId, DatasetRowId, OrganizationId, RepositoryError } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { DatasetRow, RowNotFoundError } from "../entities/dataset-row.ts"
+
+export interface DatasetRowRepositoryShape {
+  insertBatch(args: {
+    readonly organizationId: OrganizationId
+    readonly datasetId: DatasetId
+    readonly version: number
+    readonly rows: readonly {
+      readonly id: DatasetRowId
+      readonly input: Record<string, unknown>
+      readonly output?: Record<string, unknown>
+      readonly metadata?: Record<string, unknown>
+    }[]
+  }): Effect.Effect<readonly DatasetRowId[], RepositoryError>
+
+  list(args: {
+    readonly organizationId: OrganizationId
+    readonly datasetId: DatasetId
+    readonly version?: number
+    readonly search?: string
+    readonly limit?: number
+    readonly offset?: number
+  }): Effect.Effect<{ readonly rows: readonly DatasetRow[]; readonly total: number }, RepositoryError>
+
+  findById(args: {
+    readonly organizationId: OrganizationId
+    readonly datasetId: DatasetId
+    readonly rowId: DatasetRowId
+    readonly version?: number
+  }): Effect.Effect<DatasetRow, RowNotFoundError | RepositoryError>
+}
+
+export class DatasetRowRepository extends ServiceMap.Service<DatasetRowRepository, DatasetRowRepositoryShape>()(
+  "@domain/datasets/DatasetRowRepository",
+) {}

--- a/packages/domain/datasets/src/use-cases/create-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/create-dataset.ts
@@ -1,0 +1,15 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+
+export function createDataset(args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly name: string
+  readonly description?: string
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* DatasetRepository
+    return yield* repo.create(args)
+  })
+}

--- a/packages/domain/datasets/src/use-cases/get-row-detail.ts
+++ b/packages/domain/datasets/src/use-cases/get-row-detail.ts
@@ -1,0 +1,31 @@
+import type { DatasetId, DatasetRowId, DatasetVersionId, OrganizationId } from "@domain/shared"
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
+
+export function getRowDetail(args: {
+  readonly organizationId: OrganizationId
+  readonly datasetId: DatasetId
+  readonly rowId: DatasetRowId
+  readonly versionId?: DatasetVersionId
+}) {
+  return Effect.gen(function* () {
+    const rowRepo = yield* DatasetRowRepository
+
+    let version: number | undefined
+    if (args.versionId) {
+      const datasetRepo = yield* DatasetRepository
+      version = yield* datasetRepo.resolveVersion({
+        datasetId: args.datasetId,
+        versionId: args.versionId,
+      })
+    }
+
+    return yield* rowRepo.findById({
+      organizationId: args.organizationId,
+      datasetId: args.datasetId,
+      rowId: args.rowId,
+      ...(version !== undefined ? { version } : {}),
+    })
+  })
+}

--- a/packages/domain/datasets/src/use-cases/insert-rows.ts
+++ b/packages/domain/datasets/src/use-cases/insert-rows.ts
@@ -1,0 +1,42 @@
+import type { DatasetId, DatasetRowId, OrganizationId } from "@domain/shared"
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
+import { buildValidRowId } from "../validate-row-id.ts"
+
+export function insertRows(args: {
+  readonly organizationId: OrganizationId
+  readonly datasetId: DatasetId
+  readonly rows: readonly {
+    readonly id?: DatasetRowId
+    readonly input: Record<string, unknown>
+    readonly output?: Record<string, unknown>
+    readonly metadata?: Record<string, unknown>
+  }[]
+  readonly source?: string
+}) {
+  return Effect.gen(function* () {
+    const resolvedRows = yield* Effect.forEach(args.rows, (row) =>
+      buildValidRowId(row.id).pipe(Effect.map((id) => ({ ...row, id }))),
+    )
+
+    const datasetRepo = yield* DatasetRepository
+    const rowRepo = yield* DatasetRowRepository
+
+    const version = yield* datasetRepo.incrementVersion({
+      organizationId: args.organizationId,
+      id: args.datasetId,
+      rowsInserted: resolvedRows.length,
+      source: args.source ?? "api",
+    })
+
+    const rowIds = yield* rowRepo.insertBatch({
+      organizationId: args.organizationId,
+      datasetId: args.datasetId,
+      version: version.version,
+      rows: resolvedRows,
+    })
+
+    return { versionId: version.id, version: version.version, rowIds }
+  })
+}

--- a/packages/domain/datasets/src/use-cases/list-datasets.ts
+++ b/packages/domain/datasets/src/use-cases/list-datasets.ts
@@ -1,0 +1,15 @@
+import type { OrganizationId, ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+
+export function listDatasets(args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly limit?: number
+  readonly offset?: number
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* DatasetRepository
+    return yield* repo.listByProject(args)
+  })
+}

--- a/packages/domain/datasets/src/use-cases/list-rows.ts
+++ b/packages/domain/datasets/src/use-cases/list-rows.ts
@@ -1,0 +1,35 @@
+import type { DatasetId, DatasetVersionId, OrganizationId } from "@domain/shared"
+import { Effect } from "effect"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
+
+export function listRows(args: {
+  readonly organizationId: OrganizationId
+  readonly datasetId: DatasetId
+  readonly versionId?: DatasetVersionId
+  readonly search?: string
+  readonly limit?: number
+  readonly offset?: number
+}) {
+  return Effect.gen(function* () {
+    const rowRepo = yield* DatasetRowRepository
+
+    let version: number | undefined
+    if (args.versionId) {
+      const datasetRepo = yield* DatasetRepository
+      version = yield* datasetRepo.resolveVersion({
+        datasetId: args.datasetId,
+        versionId: args.versionId,
+      })
+    }
+
+    return yield* rowRepo.list({
+      organizationId: args.organizationId,
+      datasetId: args.datasetId,
+      ...(version !== undefined ? { version } : {}),
+      ...(args.search ? { search: args.search } : {}),
+      ...(args.limit !== undefined ? { limit: args.limit } : {}),
+      ...(args.offset !== undefined ? { offset: args.offset } : {}),
+    })
+  })
+}

--- a/packages/domain/datasets/src/validate-row-id.ts
+++ b/packages/domain/datasets/src/validate-row-id.ts
@@ -1,0 +1,42 @@
+import { type DatasetRowId, ValidationError, generateId, DatasetRowId as mkDatasetRowId } from "@domain/shared"
+import { Effect } from "effect"
+
+const MAX_ROW_ID_LENGTH = 128
+const ROW_ID_PATTERN = /^[\w.~-]+$/
+
+/**
+ * Resolves and validates a row ID.
+ *
+ * When `id` is provided it is validated and returned as-is. This lets
+ * callers supply their own stable identifiers (source DB primary keys,
+ * UUIDs, composite keys, etc.) so that re-ingesting the same data
+ * appends a new version instead of creating duplicate rows.
+ *
+ * When `id` is omitted a fresh CUID2 is generated automatically.
+ *
+ * Caller-provided ID constraints:
+ *  - At most 128 characters
+ *  - URL-safe: alphanumeric, hyphens, underscores, dots, tildes
+ */
+export function buildValidRowId(id?: DatasetRowId): Effect.Effect<DatasetRowId, ValidationError> {
+  if (id === undefined) {
+    return Effect.succeed(mkDatasetRowId(generateId()))
+  }
+
+  if (id.length > MAX_ROW_ID_LENGTH) {
+    return Effect.fail(
+      new ValidationError({ field: "rowId", message: `Row ID must be at most ${MAX_ROW_ID_LENGTH} characters` }),
+    )
+  }
+
+  if (!ROW_ID_PATTERN.test(id)) {
+    return Effect.fail(
+      new ValidationError({
+        field: "rowId",
+        message: "Row ID must contain only alphanumeric characters, hyphens, underscores, dots, or tildes",
+      }),
+    )
+  }
+
+  return Effect.succeed(id)
+}

--- a/packages/domain/datasets/tsconfig.json
+++ b/packages/domain/datasets/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/domain/shared/src/id.ts
+++ b/packages/domain/shared/src/id.ts
@@ -28,7 +28,12 @@ export type ApiKeyId = Branded<string, "ApiKeyId">
 export type SubscriptionId = Branded<string, "SubscriptionId">
 export type GrantId = Branded<string, "GrantId">
 
-// Telemetry-related IDs (ClickHouse — externally generated, not CUIDs)
+// Dataset-related IDs
+export type DatasetId = Branded<string, "DatasetId">
+export type DatasetRowId = Branded<string, "DatasetRowId">
+export type DatasetVersionId = Branded<string, "DatasetVersionId">
+
+// Telemetry-related IDs
 export type TraceId = Branded<string, "TraceId">
 export type SpanId = Branded<string, "SpanId">
 export type SessionId = Branded<string, "SessionId">
@@ -41,10 +46,13 @@ export const OrganizationId = (value: string): OrganizationId => value as Organi
 export const MembershipId = (value: string): MembershipId => value as MembershipId
 export const ProjectId = (value: string): ProjectId => value as ProjectId
 export const ApiKeyId = (value: string): ApiKeyId => value as ApiKeyId
-export const TraceId = (value: string): TraceId => value as TraceId
-export const SpanId = (value: string): SpanId => value as SpanId
 export const SubscriptionId = (value: string): SubscriptionId => value as SubscriptionId
 export const GrantId = (value: string): GrantId => value as GrantId
+export const TraceId = (value: string): TraceId => value as TraceId
+export const SpanId = (value: string): SpanId => value as SpanId
+export const DatasetId = (value: string): DatasetId => value as DatasetId
+export const DatasetRowId = (value: string): DatasetRowId => value as DatasetRowId
+export const DatasetVersionId = (value: string): DatasetVersionId => value as DatasetVersionId
 
 /**
  * Generate a unique ID using CUID2.

--- a/packages/domain/shared/src/index.ts
+++ b/packages/domain/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./id.ts"
 export * from "./errors.ts"
 export * from "./repository.ts"
+export * from "./seeds.ts"

--- a/packages/domain/shared/src/seeds.ts
+++ b/packages/domain/shared/src/seeds.ts
@@ -1,0 +1,33 @@
+import {
+  ApiKeyId,
+  DatasetId,
+  DatasetVersionId,
+  GrantId,
+  MembershipId,
+  OrganizationId,
+  ProjectId,
+  SubscriptionId,
+  UserId,
+} from "./id.ts"
+
+// Constants for seeding the database with initial data
+export const SEED_ORG_ID = OrganizationId("iapkf6osmlm7mbw9kulosua4")
+export const SEED_SUBSCRIPTION_ID = SubscriptionId("ry0fy0n6qwszk3kk04zlfsuy")
+export const SEED_GRANT_SEATS_ID = GrantId("nkbbtxd5o7rbrr8miamhrnif")
+export const SEED_GRANT_RUNS_ID = GrantId("drkvcpudmblnqxgk48irmt94")
+export const SEED_OWNER_USER_ID = UserId("ye9d77pxi50nh1gyqljkffnb")
+export const SEED_ADMIN_USER_ID = UserId("uzm4d8pb5k0bd2oug9ud2xjs")
+export const SEED_PROJECT_ID = ProjectId("yvl1e78evmwfs2mosyjb08rc")
+export const SEED_API_KEY_ID = ApiKeyId("v42lqe92hgq2hpvilg91brnt")
+export const SEED_DATASET_ID = DatasetId("m8k2p4r6t0v1w3x5y7z9a1b3")
+export const SEED_DATASET_VERSION_ID = DatasetVersionId("v1a2b3c4d5e6f7g8h9i0j1k2")
+export const SEED_OWNER_MEMBERSHIP_ID = MembershipId("bg5hvjzpeop0atmz2nqydas7")
+export const SEED_ADMIN_MEMBERSHIP_ID = MembershipId("h5q2nionpzqmzvkgp0sp7jnl")
+
+// Additional constants for seeding
+export const SEED_ORG_NAME = "Acme Inc."
+export const SEED_ORG_SLUG = "acme"
+export const SEED_OWNER_EMAIL = "owner@acme.com"
+export const SEED_ADMIN_EMAIL = "admin@acme.com"
+export const SEED_PROJECT_NAME = "Default Project"
+export const SEED_PROJECT_SLUG = "default-project"

--- a/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00003_create_dataset_rows.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/clustered/00003_create_dataset_rows.sql
@@ -1,0 +1,51 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE TABLE IF NOT EXISTS dataset_rows ON CLUSTER default
+(
+    -- ═══════════════════════════════════════════════════════
+    -- TENANCY & SCOPE
+    -- ═══════════════════════════════════════════════════════
+
+    organization_id          LowCardinality(String),
+    dataset_id               LowCardinality(String),
+
+    -- ═══════════════════════════════════════════════════════
+    -- ROW IDENTITY & VERSIONING
+    -- ═══════════════════════════════════════════════════════
+
+    row_id                   String,
+
+    -- Monotonic version number matching Postgres current_version.
+    -- Each mutation appends a new row with incremented xact_id;
+    -- latest state is resolved via argMax(col, xact_id).
+    xact_id                  UInt64,
+
+    created_at               DateTime64(3, 'UTC') DEFAULT now64(3),
+
+    -- Tombstone flag: true means this row was soft-deleted at this xact_id.
+    _object_delete           Bool DEFAULT false,
+
+    -- ═══════════════════════════════════════════════════════
+    -- PAYLOAD
+    --
+    -- Schemaless JSON. ZSTD(3) for maximum compression on
+    -- potentially large user-generated content.
+    -- ═══════════════════════════════════════════════════════
+
+    input                    String DEFAULT ''                        CODEC(ZSTD(3)),
+    output                   String DEFAULT ''                        CODEC(ZSTD(3)),
+    metadata                 String DEFAULT ''                        CODEC(ZSTD(3)),
+
+    -- ═══════════════════════════════════════════════════════
+    -- SKIP INDEXES
+    -- ═══════════════════════════════════════════════════════
+
+    INDEX idx_row_id         row_id       TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = ReplicatedMergeTree()
+PARTITION BY (organization_id, toYYYYMM(created_at))
+PRIMARY KEY (organization_id, dataset_id)
+ORDER BY (organization_id, dataset_id, row_id, xact_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS dataset_rows ON CLUSTER default;

--- a/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00003_create_dataset_rows.sql
+++ b/packages/platform/db-clickhouse/clickhouse/migrations/unclustered/00003_create_dataset_rows.sql
@@ -1,0 +1,51 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE TABLE IF NOT EXISTS dataset_rows
+(
+    -- ═══════════════════════════════════════════════════════
+    -- TENANCY & SCOPE
+    -- ═══════════════════════════════════════════════════════
+
+    organization_id          LowCardinality(String),
+    dataset_id               LowCardinality(String),
+
+    -- ═══════════════════════════════════════════════════════
+    -- ROW IDENTITY & VERSIONING
+    -- ═══════════════════════════════════════════════════════
+
+    row_id                   String,
+
+    -- Monotonic version number matching Postgres current_version.
+    -- Each mutation appends a new row with incremented xact_id;
+    -- latest state is resolved via argMax(col, xact_id).
+    xact_id                  UInt64,
+
+    created_at               DateTime64(3, 'UTC') DEFAULT now64(3),
+
+    -- Tombstone flag: true means this row was soft-deleted at this xact_id.
+    _object_delete           Bool DEFAULT false,
+
+    -- ═══════════════════════════════════════════════════════
+    -- PAYLOAD
+    --
+    -- Schemaless JSON. ZSTD(3) for maximum compression on
+    -- potentially large user-generated content.
+    -- ═══════════════════════════════════════════════════════
+
+    input                    String DEFAULT ''                        CODEC(ZSTD(3)),
+    output                   String DEFAULT ''                        CODEC(ZSTD(3)),
+    metadata                 String DEFAULT ''                        CODEC(ZSTD(3)),
+
+    -- ═══════════════════════════════════════════════════════
+    -- SKIP INDEXES
+    -- ═══════════════════════════════════════════════════════
+
+    INDEX idx_row_id         row_id       TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree()
+PARTITION BY (organization_id, toYYYYMM(created_at))
+PRIMARY KEY (organization_id, dataset_id)
+ORDER BY (organization_id, dataset_id, row_id, xact_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS dataset_rows;

--- a/packages/platform/db-clickhouse/package.json
+++ b/packages/platform/db-clickhouse/package.json
@@ -24,9 +24,11 @@
   },
   "dependencies": {
     "@clickhouse/client": "catalog:",
+    "@domain/datasets": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "@platform/env": "workspace:*",
+    "@repo/utils": "workspace:*",
     "effect": "catalog:",
     "rosetta-ai": "catalog:"
   },

--- a/packages/platform/db-clickhouse/src/index.ts
+++ b/packages/platform/db-clickhouse/src/index.ts
@@ -1,3 +1,4 @@
+export type { ClickHouseClient } from "@clickhouse/client"
 export type { ClickhouseConfig } from "./client.ts"
 export {
   closeClickhouse,
@@ -7,5 +8,6 @@ export {
 export { InvalidEnvValueError, MissingEnvValueError } from "@platform/env"
 export { healthcheckClickhouse } from "./health.ts"
 export { commandClickhouse, insertJsonEachRow, queryClickhouse } from "./sql.ts"
+export { createDatasetRowClickHouseRepository } from "./repositories/dataset-row-repository.ts"
 export { createSpanClickhouseRepository } from "./repositories/span-repository.ts"
 export { createTraceClickhouseRepository } from "./repositories/trace-repository.ts"

--- a/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/dataset-row-repository.ts
@@ -1,0 +1,191 @@
+import type { ClickHouseClient } from "@clickhouse/client"
+import type { DatasetRow } from "@domain/datasets"
+import { RowNotFoundError } from "@domain/datasets"
+import { DatasetId, DatasetRowId, toRepositoryError } from "@domain/shared"
+import { safeParseJson, safeStringifyJson } from "@repo/utils"
+import { Effect } from "effect"
+import { insertJsonEachRow, queryClickhouse } from "../sql.ts"
+
+type DatasetRowCH = {
+  row_id: string
+  input: string
+  output: string
+  metadata: string
+  created_at: string
+  latest_xact_id: string
+}
+
+const toDomainRow = (row: DatasetRowCH, datasetId: string): DatasetRow => ({
+  rowId: DatasetRowId(row.row_id),
+  datasetId: DatasetId(datasetId),
+  input: safeParseJson(row.input),
+  output: safeParseJson(row.output),
+  metadata: safeParseJson(row.metadata),
+  createdAt: new Date(row.created_at),
+  version: Number(row.latest_xact_id),
+})
+
+// Searches raw JSON strings — may match keys/syntax, not just values
+const buildSearchClause = (search: string | undefined) =>
+  search
+    ? "AND (positionCaseInsensitive(input, {search:String}) > 0 OR positionCaseInsensitive(output, {search:String}) > 0)"
+    : ""
+
+const buildVersionClause = (version: number | undefined) =>
+  version !== undefined ? "AND xact_id <= {version:UInt64}" : ""
+
+const INSERT_BATCH_SIZE = 500
+
+export const createDatasetRowClickHouseRepository = (client: ClickHouseClient) => ({
+  insertBatch: (args: {
+    organizationId: string
+    datasetId: string
+    version: number
+    rows: readonly {
+      readonly id: DatasetRowId
+      readonly input: Record<string, unknown>
+      readonly output?: Record<string, unknown>
+      readonly metadata?: Record<string, unknown>
+    }[]
+  }) =>
+    Effect.gen(function* () {
+      const values = args.rows.map((row) => ({
+        organization_id: args.organizationId,
+        dataset_id: args.datasetId,
+        row_id: row.id,
+        xact_id: args.version,
+        input: safeStringifyJson(row.input),
+        output: safeStringifyJson(row.output ?? {}),
+        metadata: safeStringifyJson(row.metadata ?? {}),
+      }))
+
+      for (let i = 0; i < values.length; i += INSERT_BATCH_SIZE) {
+        const batch = values.slice(i, i + INSERT_BATCH_SIZE)
+        yield* insertJsonEachRow(client, "dataset_rows", batch).pipe(
+          Effect.mapError((e) => toRepositoryError(e, "insertBatch")),
+        )
+      }
+
+      return args.rows.map((r) => r.id)
+    }),
+
+  list: (args: {
+    organizationId: string
+    datasetId: string
+    version?: number
+    search?: string
+    limit?: number
+    offset?: number
+  }) =>
+    Effect.gen(function* () {
+      const limit = args.limit ?? 50
+      const offset = args.offset ?? 0
+      const params: Record<string, unknown> = {
+        organizationId: args.organizationId,
+        datasetId: args.datasetId,
+        limit,
+        offset,
+      }
+
+      if (args.version !== undefined) params.version = args.version
+      if (args.search) params.search = args.search
+
+      const versionClause = buildVersionClause(args.version)
+      const searchClause = buildSearchClause(args.search)
+
+      const dataQuery = `
+        SELECT
+          row_id,
+          argMax(input, xact_id) AS input,
+          argMax(output, xact_id) AS output,
+          argMax(metadata, xact_id) AS metadata,
+          min(created_at) AS created_at,
+          max(xact_id) AS latest_xact_id
+        FROM dataset_rows
+        WHERE organization_id = {organizationId:String}
+          AND dataset_id = {datasetId:String}
+          ${versionClause}
+        GROUP BY row_id
+        HAVING argMax(_object_delete, xact_id) = false
+          ${searchClause}
+        ORDER BY created_at DESC
+        LIMIT {limit:UInt32} OFFSET {offset:UInt32}
+      `
+
+      const countQuery = `
+        SELECT count() AS total FROM (
+          SELECT
+            row_id,
+            argMax(input, xact_id) AS input,
+            argMax(output, xact_id) AS output
+          FROM dataset_rows
+          WHERE organization_id = {organizationId:String}
+            AND dataset_id = {datasetId:String}
+            ${versionClause}
+          GROUP BY row_id
+          HAVING argMax(_object_delete, xact_id) = false
+            ${searchClause}
+        )
+      `
+
+      const [rows, countResult] = yield* Effect.all([
+        queryClickhouse<DatasetRowCH>(client, dataQuery, params).pipe(
+          Effect.mapError((e) => toRepositoryError(e, "list")),
+        ),
+        queryClickhouse<{ total: string }>(client, countQuery, params).pipe(
+          Effect.mapError((e) => toRepositoryError(e, "list:count")),
+        ),
+      ])
+
+      return {
+        rows: rows.map((row) => toDomainRow(row, args.datasetId)),
+        total: Number(countResult[0]?.total ?? 0),
+      } as const
+    }),
+
+  findById: (args: {
+    organizationId: string
+    datasetId: string
+    rowId: string
+    version?: number
+  }) =>
+    Effect.gen(function* () {
+      const params: Record<string, unknown> = {
+        organizationId: args.organizationId,
+        datasetId: args.datasetId,
+        rowId: args.rowId,
+      }
+
+      if (args.version !== undefined) params.version = args.version
+
+      const versionClause = buildVersionClause(args.version)
+
+      const query = `
+        SELECT
+          row_id,
+          argMax(input, xact_id) AS input,
+          argMax(output, xact_id) AS output,
+          argMax(metadata, xact_id) AS metadata,
+          min(created_at) AS created_at,
+          max(xact_id) AS latest_xact_id
+        FROM dataset_rows
+        WHERE organization_id = {organizationId:String}
+          AND dataset_id = {datasetId:String}
+          AND row_id = {rowId:String}
+          ${versionClause}
+        GROUP BY row_id
+        HAVING argMax(_object_delete, xact_id) = false
+        LIMIT 1
+      `
+
+      const rows = yield* queryClickhouse<DatasetRowCH>(client, query, params).pipe(
+        Effect.mapError((e) => toRepositoryError(e, "findById")),
+      )
+
+      if (rows.length === 0) {
+        return yield* new RowNotFoundError({ rowId: args.rowId })
+      }
+
+      return toDomainRow(rows[0] ?? [], args.datasetId)
+    }),
+})

--- a/packages/platform/db-clickhouse/src/seeds/all.ts
+++ b/packages/platform/db-clickhouse/src/seeds/all.ts
@@ -1,3 +1,4 @@
+import { datasetRowSeeders } from "./datasets/index.ts"
 import { spanSeeders } from "./spans/index.ts"
 
-export const allSeeders = [...spanSeeders]
+export const allSeeders = [...spanSeeders, ...datasetRowSeeders]

--- a/packages/platform/db-clickhouse/src/seeds/datasets/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/datasets/index.ts
@@ -1,0 +1,70 @@
+import { SEED_DATASET_ID, SEED_ORG_ID } from "@domain/shared"
+import { insertJsonEachRow } from "../../sql.ts"
+import type { Seeder } from "../types.ts"
+
+const XACT_ID = 1
+
+const rows = [
+  { code: "grey37", firstName: "Laura", lastName: "Grey", identifier: 2070 },
+  { code: "blue12", firstName: "Craig", lastName: "Johnson", identifier: 2071 },
+  { code: "red88", firstName: "Sara", lastName: "Martinez", identifier: 2072 },
+  { code: "green45", firstName: "David", lastName: "Chen", identifier: 2073 },
+  { code: "grey21", firstName: "Emily", lastName: "Grey", identifier: 2074 },
+  {
+    code: "yellow09",
+    firstName: "Marcus",
+    lastName: "Williams",
+    identifier: 2075,
+  },
+  { code: "blue55", firstName: "Anna", lastName: "Kowalski", identifier: 2076 },
+  { code: "red03", firstName: "James", lastName: "Brown", identifier: 2077 },
+  { code: "grey99", firstName: "Sofia", lastName: "Grey", identifier: 2078 },
+  { code: "green11", firstName: "Omar", lastName: "Hassan", identifier: 2079 },
+  { code: "blue77", firstName: "Lucia", lastName: "Rossi", identifier: 2080 },
+  { code: "red41", firstName: "Thomas", lastName: "Müller", identifier: 2081 },
+  { code: "grey63", firstName: "Priya", lastName: "Sharma", identifier: 2082 },
+  {
+    code: "yellow33",
+    firstName: "Robert",
+    lastName: "Taylor",
+    identifier: 2083,
+  },
+  { code: "green78", firstName: "Yuki", lastName: "Tanaka", identifier: 2084 },
+  { code: "blue29", firstName: "Elena", lastName: "Popov", identifier: 2085 },
+  { code: "grey14", firstName: "Michael", lastName: "Grey", identifier: 2086 },
+  {
+    code: "red56",
+    firstName: "Fatima",
+    lastName: "Al-Rashid",
+    identifier: 2087,
+  },
+  {
+    code: "yellow72",
+    firstName: "Henrik",
+    lastName: "Larsson",
+    identifier: 2088,
+  },
+  {
+    code: "green02",
+    firstName: "Camille",
+    lastName: "Dubois",
+    identifier: 2089,
+  },
+]
+
+const datasetRows = rows.map((r, i) => ({
+  organization_id: SEED_ORG_ID,
+  dataset_id: SEED_DATASET_ID,
+  row_id: `seed-row-${String(i + 1).padStart(3, "0")}`,
+  xact_id: XACT_ID,
+  input: JSON.stringify({ code: r.code }),
+  output: JSON.stringify({ firstName: r.firstName, lastName: r.lastName }),
+  metadata: JSON.stringify({ identifier: r.identifier }),
+}))
+
+const seedDatasetRows: Seeder = {
+  name: "datasets/big-comma-delimiter-rows",
+  run: (ctx) => insertJsonEachRow(ctx.client, "dataset_rows", datasetRows),
+}
+
+export const datasetRowSeeders: Seeder[] = [seedDatasetRows]

--- a/packages/platform/db-clickhouse/src/seeds/spans/index.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/index.ts
@@ -1,3 +1,4 @@
+import { SEED_API_KEY_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared"
 import { Effect } from "effect"
 import { insertJsonEachRow } from "../../sql.ts"
 import type { Seeder } from "../types.ts"
@@ -5,10 +6,6 @@ import { type SpanRow, type TraceConfig, generateAllSpans } from "./generator.ts
 
 const TRACE_COUNT = 2000
 const BATCH_SIZE = 500
-
-const ORG_ID = "iapkf6osmlm7mbw9kulosua4"
-const PROJECT_ID = "yvl1e78evmwfs2mosyjb08rc"
-const API_KEY_ID = "v42lqe92hgq2hpvilg91brnt"
 
 const seedSpans: Seeder = {
   name: "spans",
@@ -20,9 +17,9 @@ const seedSpans: Seeder = {
       const config: TraceConfig = {
         traceCount: TRACE_COUNT,
         timeWindow: { from: thirtyDaysAgo, to: now },
-        organizationId: ORG_ID,
-        projectId: PROJECT_ID,
-        apiKeyId: API_KEY_ID,
+        organizationId: SEED_ORG_ID,
+        projectId: SEED_PROJECT_ID,
+        apiKeyId: SEED_API_KEY_ID,
       }
 
       const allSpans = generateAllSpans(config)

--- a/packages/platform/db-postgres/drizzle.config.ts
+++ b/packages/platform/db-postgres/drizzle.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
     "./src/schema/auth-intent.ts",
     "./src/schema/subscription.ts",
     // Domain tables
+    "./src/schema/datasets.ts",
+    "./src/schema/datasetVersions.ts",
     "./src/schema/projects.ts",
     "./src/schema/api-keys.ts",
     "./src/schema/grants.ts",

--- a/packages/platform/db-postgres/drizzle/20260311134756_dataset-tables/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260311134756_dataset-tables/migration.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "latitude"."datasets" (
+	"id" varchar(24) PRIMARY KEY,
+	"organization_id" varchar(24) NOT NULL,
+	"project_id" varchar(24) NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"description" text,
+	"file_key" text,
+	"current_version" bigint DEFAULT 0 NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "datasets_unique_name_per_project_idx" UNIQUE NULLS NOT DISTINCT("organization_id","project_id","name","deleted_at")
+);
+--> statement-breakpoint
+ALTER TABLE "latitude"."datasets" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE TABLE "latitude"."dataset_versions" (
+	"id" varchar(24) PRIMARY KEY,
+	"organization_id" varchar(24) NOT NULL,
+	"dataset_id" varchar(24) NOT NULL,
+	"version" bigint NOT NULL,
+	"rows_inserted" integer DEFAULT 0 NOT NULL,
+	"rows_updated" integer DEFAULT 0 NOT NULL,
+	"rows_deleted" integer DEFAULT 0 NOT NULL,
+	"source" varchar(64) DEFAULT 'api' NOT NULL,
+	"actor_id" varchar(24),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "latitude"."dataset_versions" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE INDEX "datasets_project_id_idx" ON "latitude"."datasets" ("organization_id","project_id","deleted_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "dataset_versions_dataset_id_version_idx" ON "latitude"."dataset_versions" ("dataset_id","version");--> statement-breakpoint
+CREATE POLICY "datasets_organization_policy" ON "latitude"."datasets" AS PERMISSIVE FOR ALL TO public USING (organization_id = get_current_organization_id()) WITH CHECK (organization_id = get_current_organization_id());--> statement-breakpoint
+CREATE POLICY "dataset_versions_organization_policy" ON "latitude"."dataset_versions" AS PERMISSIVE FOR ALL TO public USING (organization_id = get_current_organization_id()) WITH CHECK (organization_id = get_current_organization_id());

--- a/packages/platform/db-postgres/drizzle/20260311134756_dataset-tables/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260311134756_dataset-tables/snapshot.json
@@ -1,0 +1,2467 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "ebf66caf-8215-4cd7-ae4a-bcacac2db74a",
+  "prevIds": [
+    "164e387c-ea42-4e67-b875-693339a380b7"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "account",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "invitation",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "member",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organization",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "session",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verification",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "auth_intent",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "subscription",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "datasets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "dataset_versions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "projects",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "grants",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "creator_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "current_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "user"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verification"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'{}'",
+      "generated": null,
+      "identity": null,
+      "name": "data",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "existing_account_at_request",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "consumed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "auth_intent"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seats",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_interval",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_schedule_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "current_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_inserted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_deleted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'api'",
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "amount",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "balance",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "grants"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "published",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "occurred_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "dataset_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_dataset_id_version_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "account_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "account"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitation_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitation_inviter_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organization",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "member_organization_id_organization_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "member_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "creator_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "NO ACTION",
+      "name": "organization_creator_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "organization"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "user",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "session_user_id_user_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "account_pkey",
+      "schema": "latitude",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitation_pkey",
+      "schema": "latitude",
+      "table": "invitation",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "member_pkey",
+      "schema": "latitude",
+      "table": "member",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_pkey",
+      "schema": "latitude",
+      "table": "organization",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pkey",
+      "schema": "latitude",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_pkey",
+      "schema": "latitude",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verification_pkey",
+      "schema": "latitude",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "auth_intent_pkey",
+      "schema": "latitude",
+      "table": "auth_intent",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "subscription_pkey",
+      "schema": "latitude",
+      "table": "subscription",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "datasets_pkey",
+      "schema": "latitude",
+      "table": "datasets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dataset_versions_pkey",
+      "schema": "latitude",
+      "table": "dataset_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pkey",
+      "schema": "latitude",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "grants_pkey",
+      "schema": "latitude",
+      "table": "grants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_events_pkey",
+      "schema": "latitude",
+      "table": "outbox_events",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_slug_key",
+      "schema": "latitude",
+      "table": "organization",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "session_token_key",
+      "schema": "latitude",
+      "table": "session",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_email_key",
+      "schema": "latitude",
+      "table": "user",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_token_hash_key",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "uniques"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "invitation_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "invitation"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "member_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "member"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "reference_id = get_current_organization_id()",
+      "withCheck": "reference_id = get_current_organization_id()",
+      "name": "subscription_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "subscription"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "datasets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "dataset_versions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "projects_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "api_keys_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "grants_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "grants"
+    }
+  ],
+  "renames": []
+}

--- a/packages/platform/db-postgres/package.json
+++ b/packages/platform/db-postgres/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@domain/auth": "workspace:*",
     "@domain/api-keys": "workspace:^",
+    "@domain/datasets": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/subscriptions": "workspace:*",

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -13,6 +13,7 @@ export {
   createApiKeyPostgresRepository,
   createAuthIntentPostgresRepository,
   createAuthUserPostgresRepository,
+  createDatasetPostgresRepository,
   createGrantPostgresRepository,
   createMembershipPostgresRepository,
   createOrganizationPostgresRepository,

--- a/packages/platform/db-postgres/src/repositories/dataset-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/dataset-repository.ts
@@ -1,0 +1,184 @@
+import type { Dataset, DatasetVersion } from "@domain/datasets"
+import { DatasetNotFoundError } from "@domain/datasets"
+import { DatasetId, DatasetVersionId, OrganizationId, ProjectId, toRepositoryError } from "@domain/shared"
+import { and, count, eq, getTableColumns, isNull, sql } from "drizzle-orm"
+import { Effect } from "effect"
+import type { PostgresDb } from "../client.ts"
+import { datasetVersions, datasets } from "../schema/index.ts"
+
+const toDomainDataset = (row: typeof datasets.$inferSelect, latestVersionId?: string | null): Dataset => ({
+  id: DatasetId(row.id),
+  organizationId: OrganizationId(row.organizationId),
+  projectId: ProjectId(row.projectId),
+  name: row.name,
+  description: row.description ?? null,
+  currentVersion: Number(row.currentVersion),
+  latestVersionId: latestVersionId ? DatasetVersionId(latestVersionId) : null,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+})
+
+const toDomainVersion = (row: typeof datasetVersions.$inferSelect): DatasetVersion => ({
+  id: DatasetVersionId(row.id),
+  datasetId: DatasetId(row.datasetId),
+  version: Number(row.version),
+  rowsInserted: row.rowsInserted,
+  rowsUpdated: row.rowsUpdated,
+  rowsDeleted: row.rowsDeleted,
+  source: row.source,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+})
+
+export const createDatasetPostgresRepository = (db: PostgresDb) => ({
+  create: (args: { organizationId: string; projectId: string; name: string; description?: string }) =>
+    Effect.gen(function* () {
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .insert(datasets)
+            .values({
+              organizationId: args.organizationId,
+              projectId: args.projectId,
+              name: args.name,
+              description: args.description ?? null,
+            })
+            .returning(),
+        catch: (error) => toRepositoryError(error, "create"),
+      })
+      return toDomainDataset(rows[0] as typeof datasets.$inferSelect)
+    }),
+
+  findById: (id: string) =>
+    Effect.gen(function* () {
+      const datasetCols = getTableColumns(datasets)
+      const [row] = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ ...datasetCols, latestVersionId: datasetVersions.id })
+            .from(datasets)
+            .leftJoin(
+              datasetVersions,
+              and(eq(datasetVersions.datasetId, datasets.id), eq(datasetVersions.version, datasets.currentVersion)),
+            )
+            .where(and(eq(datasets.id, id), isNull(datasets.deletedAt)))
+            .limit(1),
+        catch: (error) => toRepositoryError(error, "findById"),
+      })
+
+      if (!row) {
+        return yield* new DatasetNotFoundError({ datasetId: id })
+      }
+
+      return toDomainDataset(row, row.latestVersionId)
+    }),
+
+  listByProject: (args: { organizationId: string; projectId: string; limit?: number; offset?: number }) =>
+    Effect.gen(function* () {
+      const limit = args.limit ?? 50
+      const offset = args.offset ?? 0
+      const datasetCols = getTableColumns(datasets)
+
+      const projectFilter = and(
+        eq(datasets.organizationId, args.organizationId),
+        eq(datasets.projectId, args.projectId),
+        isNull(datasets.deletedAt),
+      )
+
+      const [rows, totalResult] = yield* Effect.tryPromise({
+        try: () =>
+          Promise.all([
+            db
+              .select({ ...datasetCols, latestVersionId: datasetVersions.id })
+              .from(datasets)
+              .leftJoin(
+                datasetVersions,
+                and(eq(datasetVersions.datasetId, datasets.id), eq(datasetVersions.version, datasets.currentVersion)),
+              )
+              .where(projectFilter)
+              .orderBy(datasets.createdAt)
+              .limit(limit)
+              .offset(offset),
+            db.select({ total: count() }).from(datasets).where(projectFilter),
+          ]),
+        catch: (error) => toRepositoryError(error, "listByProject"),
+      })
+
+      return {
+        datasets: rows.map((r) => toDomainDataset(r, r.latestVersionId)),
+        total: totalResult[0]?.total ?? 0,
+      } as const
+    }),
+
+  softDelete: (id: string) =>
+    Effect.gen(function* () {
+      const [updated] = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .update(datasets)
+            .set({ deletedAt: new Date() })
+            .where(and(eq(datasets.id, id), isNull(datasets.deletedAt)))
+            .returning({ id: datasets.id }),
+        catch: (error) => toRepositoryError(error, "softDelete"),
+      })
+
+      if (!updated) {
+        return yield* new DatasetNotFoundError({ datasetId: id })
+      }
+    }),
+
+  incrementVersion: (args: { organizationId: string; id: string; rowsInserted: number; source?: string }) =>
+    Effect.gen(function* () {
+      const [updated] = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .update(datasets)
+            .set({ currentVersion: sql`${datasets.currentVersion} + 1` })
+            .where(and(eq(datasets.id, args.id), isNull(datasets.deletedAt)))
+            .returning({ currentVersion: datasets.currentVersion }),
+        catch: (error) => toRepositoryError(error, "incrementVersion"),
+      })
+
+      if (!updated) {
+        return yield* new DatasetNotFoundError({ datasetId: args.id })
+      }
+
+      const newVersion = Number(updated.currentVersion)
+
+      const [versionRow] = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .insert(datasetVersions)
+            .values({
+              organizationId: args.organizationId,
+              datasetId: args.id,
+              version: newVersion,
+              rowsInserted: args.rowsInserted,
+              source: args.source ?? "api",
+            })
+            .returning(),
+        catch: (error) => toRepositoryError(error, "incrementVersion:insertVersion"),
+      })
+
+      return toDomainVersion(versionRow as typeof datasetVersions.$inferSelect)
+    }),
+
+  resolveVersion: (args: { datasetId: string; versionId: string }) =>
+    Effect.gen(function* () {
+      const [row] = yield* Effect.tryPromise({
+        try: () =>
+          db
+            .select({ version: datasetVersions.version })
+            .from(datasetVersions)
+            .where(and(eq(datasetVersions.id, args.versionId), eq(datasetVersions.datasetId, args.datasetId)))
+            .limit(1),
+        catch: (error) => toRepositoryError(error, "resolveVersion"),
+      })
+
+      if (!row) {
+        return yield* new DatasetNotFoundError({ datasetId: args.datasetId })
+      }
+
+      return Number(row.version)
+    }),
+})

--- a/packages/platform/db-postgres/src/repositories/index.ts
+++ b/packages/platform/db-postgres/src/repositories/index.ts
@@ -1,4 +1,5 @@
 export { createApiKeyPostgresRepository } from "./api-key-repository.ts"
+export { createDatasetPostgresRepository } from "./dataset-repository.ts"
 export { createAuthIntentPostgresRepository } from "./auth-intent-repository.ts"
 export { createAuthUserPostgresRepository } from "./auth-user-repository.ts"
 export { createGrantPostgresRepository } from "./grant-repository.ts"

--- a/packages/platform/db-postgres/src/schema/datasetVersions.ts
+++ b/packages/platform/db-postgres/src/schema/datasetVersions.ts
@@ -1,0 +1,22 @@
+import { bigint, integer, uniqueIndex, varchar } from "drizzle-orm/pg-core"
+import { cuid, latitudeSchema, organizationRLSPolicy, timestamps } from "../schemaHelpers.ts"
+
+export const datasetVersions = latitudeSchema.table(
+  "dataset_versions",
+  {
+    id: cuid("id").primaryKey(),
+    organizationId: cuid("organization_id").notNull(),
+    datasetId: cuid("dataset_id").notNull(),
+    version: bigint("version", { mode: "number" }).notNull(),
+    rowsInserted: integer("rows_inserted").notNull().default(0),
+    rowsUpdated: integer("rows_updated").notNull().default(0),
+    rowsDeleted: integer("rows_deleted").notNull().default(0),
+    source: varchar("source", { length: 64 }).notNull().default("api"),
+    actorId: varchar("actor_id", { length: 24 }),
+    ...timestamps(),
+  },
+  (t) => [
+    organizationRLSPolicy("dataset_versions"),
+    uniqueIndex("dataset_versions_dataset_id_version_idx").on(t.datasetId, t.version),
+  ],
+)

--- a/packages/platform/db-postgres/src/schema/datasets.ts
+++ b/packages/platform/db-postgres/src/schema/datasets.ts
@@ -1,0 +1,24 @@
+import { bigint, index, text, unique, varchar } from "drizzle-orm/pg-core"
+import { cuid, latitudeSchema, organizationRLSPolicy, timestamps, tzTimestamp } from "../schemaHelpers.ts"
+
+export const datasets = latitudeSchema.table(
+  "datasets",
+  {
+    id: cuid("id").primaryKey(),
+    organizationId: cuid("organization_id").notNull(),
+    projectId: cuid("project_id").notNull(),
+    name: varchar("name", { length: 256 }).notNull(),
+    description: text("description"),
+    fileKey: text("file_key"),
+    currentVersion: bigint("current_version", { mode: "number" }).notNull().default(0),
+    deletedAt: tzTimestamp("deleted_at"),
+    ...timestamps(),
+  },
+  (t) => [
+    organizationRLSPolicy("datasets"),
+    index("datasets_project_id_idx").on(t.organizationId, t.projectId, t.deletedAt),
+    unique("datasets_unique_name_per_project_idx")
+      .on(t.organizationId, t.projectId, t.name, t.deletedAt)
+      .nullsNotDistinct(),
+  ],
+)

--- a/packages/platform/db-postgres/src/schema/index.ts
+++ b/packages/platform/db-postgres/src/schema/index.ts
@@ -5,6 +5,8 @@ export * from "./subscription.ts"
 
 // Domain tables
 export * from "./api-keys.ts"
+export * from "./datasets.ts"
+export * from "./datasetVersions.ts"
 export * from "./grants.ts"
 export * from "./outbox-events.ts"
 export * from "./projects.ts"

--- a/packages/platform/db-postgres/src/seeds/all.ts
+++ b/packages/platform/db-postgres/src/seeds/all.ts
@@ -1,4 +1,5 @@
 import { apiKeySeeders } from "./api-keys/index.ts"
+import { datasetSeeders } from "./datasets/index.ts"
 import { organizationSeeders } from "./organizations/index.ts"
 import { projectSeeders } from "./projects/index.ts"
 import { subscriptionSeeders } from "./subscriptions/index.ts"
@@ -9,4 +10,5 @@ export const allSeeders: readonly Seeder[] = [
   ...projectSeeders,
   ...apiKeySeeders,
   ...subscriptionSeeders,
+  ...datasetSeeders,
 ]

--- a/packages/platform/db-postgres/src/seeds/api-keys/index.ts
+++ b/packages/platform/db-postgres/src/seeds/api-keys/index.ts
@@ -1,11 +1,9 @@
 import { createApiKey } from "@domain/api-keys"
-import { ApiKeyId } from "@domain/shared"
+import { SEED_API_KEY_ID, SEED_ORG_ID } from "@domain/shared"
 import { hashToken } from "@repo/utils"
 import { Effect } from "effect"
-import { SEED_ORG_ID } from "../organizations/index.ts"
 import type { SeedContext, Seeder } from "../types.ts"
 
-const SEED_API_KEY_ID = ApiKeyId("v42lqe92hgq2hpvilg91brnt")
 const SEED_API_KEY_TOKEN = "lat_seed_default_api_key_token"
 const SEED_API_KEY_NAME = "Default API Key"
 

--- a/packages/platform/db-postgres/src/seeds/datasets/index.ts
+++ b/packages/platform/db-postgres/src/seeds/datasets/index.ts
@@ -1,0 +1,48 @@
+import { SEED_DATASET_ID, SEED_DATASET_VERSION_ID, SEED_ORG_ID, SEED_PROJECT_ID } from "@domain/shared"
+import { Effect } from "effect"
+import { postgresSchema } from "../../index.ts"
+import { type SeedContext, SeedError, type Seeder } from "../types.ts"
+
+const seedDatasets: Seeder = {
+  name: "datasets/big-comma-delimiter",
+  run: (ctx: SeedContext) =>
+    Effect.tryPromise({
+      try: async () => {
+        await ctx.db
+          .insert(postgresSchema.datasets)
+          .values({
+            id: SEED_DATASET_ID,
+            organizationId: SEED_ORG_ID,
+            projectId: SEED_PROJECT_ID,
+            name: "Big Comma Delimiter",
+            description: "People directory with color identifiers",
+            currentVersion: 1,
+          })
+          .onConflictDoUpdate({
+            target: postgresSchema.datasets.id,
+            set: {
+              name: "Big Comma Delimiter",
+              description: "People directory with color identifiers",
+              currentVersion: 1,
+            },
+          })
+
+        await ctx.db
+          .insert(postgresSchema.datasetVersions)
+          .values({
+            id: SEED_DATASET_VERSION_ID,
+            organizationId: SEED_ORG_ID,
+            datasetId: SEED_DATASET_ID,
+            version: 1,
+            rowsInserted: 20,
+            source: "seed",
+          })
+          .onConflictDoNothing()
+
+        console.log("  -> dataset: Big Comma Delimiter (version 1, 20 rows)")
+      },
+      catch: (error) => new SeedError({ reason: "Failed to seed datasets", cause: error }),
+    }).pipe(Effect.asVoid),
+}
+
+export const datasetSeeders: readonly Seeder[] = [seedDatasets]

--- a/packages/platform/db-postgres/src/seeds/index.ts
+++ b/packages/platform/db-postgres/src/seeds/index.ts
@@ -2,6 +2,7 @@ export type { SeedContext, Seeder } from "./types.ts"
 export { SeedError } from "./types.ts"
 export { runSeeders } from "./runner.ts"
 
+export { datasetSeeders } from "./datasets/index.ts"
 export { organizationSeeders } from "./organizations/index.ts"
 export { projectSeeders } from "./projects/index.ts"
 export { apiKeySeeders } from "./api-keys/index.ts"

--- a/packages/platform/db-postgres/src/seeds/organizations/index.ts
+++ b/packages/platform/db-postgres/src/seeds/organizations/index.ts
@@ -1,18 +1,18 @@
 import { createMembership, createOrganization } from "@domain/organizations"
-import { OrganizationId, UserId } from "@domain/shared"
+import {
+  SEED_ADMIN_EMAIL,
+  SEED_ADMIN_MEMBERSHIP_ID,
+  SEED_ADMIN_USER_ID,
+  SEED_ORG_ID,
+  SEED_ORG_NAME,
+  SEED_ORG_SLUG,
+  SEED_OWNER_EMAIL,
+  SEED_OWNER_MEMBERSHIP_ID,
+  SEED_OWNER_USER_ID,
+} from "@domain/shared"
 import { Effect } from "effect"
 import { postgresSchema } from "../../index.ts"
 import { type SeedContext, SeedError, type Seeder } from "../types.ts"
-
-export const SEED_OWNER_USER_ID = UserId("ye9d77pxi50nh1gyqljkffnb")
-const SEED_ADMIN_USER_ID = UserId("uzm4d8pb5k0bd2oug9ud2xjs")
-export const SEED_ORG_ID = OrganizationId("iapkf6osmlm7mbw9kulosua4")
-const SEED_OWNER_MEMBERSHIP_ID = "bg5hvjzpeop0atmz2nqydas7"
-const SEED_ADMIN_MEMBERSHIP_ID = "h5q2nionpzqmzvkgp0sp7jnl"
-const SEED_OWNER_EMAIL = "owner@acme.com"
-const SEED_ADMIN_EMAIL = "admin@acme.com"
-const SEED_ORG_NAME = "Acme Inc."
-const SEED_ORG_SLUG = "acme"
 
 const seedUsers: Seeder = {
   name: "organizations/users",

--- a/packages/platform/db-postgres/src/seeds/projects/index.ts
+++ b/packages/platform/db-postgres/src/seeds/projects/index.ts
@@ -1,12 +1,7 @@
 import { createProject } from "@domain/projects"
-import { ProjectId } from "@domain/shared"
+import { SEED_ORG_ID, SEED_OWNER_USER_ID, SEED_PROJECT_ID, SEED_PROJECT_NAME, SEED_PROJECT_SLUG } from "@domain/shared"
 import { Effect } from "effect"
-import { SEED_ORG_ID, SEED_OWNER_USER_ID } from "../organizations/index.ts"
 import type { SeedContext, Seeder } from "../types.ts"
-
-const SEED_PROJECT_ID = ProjectId("yvl1e78evmwfs2mosyjb08rc")
-const SEED_PROJECT_NAME = "Default Project"
-const SEED_PROJECT_SLUG = "default-project"
 
 const seedProjects: Seeder = {
   name: "projects/default-project",

--- a/packages/platform/db-postgres/src/seeds/subscriptions/index.ts
+++ b/packages/platform/db-postgres/src/seeds/subscriptions/index.ts
@@ -1,13 +1,9 @@
-import { GrantId, SubscriptionId } from "@domain/shared"
+import { SEED_GRANT_RUNS_ID, SEED_GRANT_SEATS_ID, SEED_ORG_ID, SEED_SUBSCRIPTION_ID } from "@domain/shared"
 import { createGrant } from "@domain/subscriptions"
 import { Effect } from "effect"
 import { postgresSchema } from "../../index.ts"
-import { SEED_ORG_ID } from "../organizations/index.ts"
 import { type SeedContext, SeedError, type Seeder } from "../types.ts"
 
-const SEED_SUBSCRIPTION_ID = SubscriptionId("ry0fy0n6qwszk3kk04zlfsuy")
-const SEED_GRANT_SEATS_ID = GrantId("nkbbtxd5o7rbrr8miamhrnif")
-const SEED_GRANT_RUNS_ID = GrantId("drkvcpudmblnqxgk48irmt94")
 const HOBBY_PLAN_SEATS = 5
 const HOBBY_PLAN_RUNS = 10_000
 

--- a/packages/ui/src/components/table/table.tsx
+++ b/packages/ui/src/components/table/table.tsx
@@ -20,7 +20,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       className={cn("flex flex-col relative w-full rounded-xl border overflow-hidden", wrapperClassName)}
     >
       <div
-        className={cn("relative w-full flex-grow", overflow, {
+        className={cn("relative w-full grow", overflow, {
           "custom-scrollbar min-w-full": overflow === "overflow-auto",
         })}
       >

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -41,3 +41,21 @@ export function formatDuration(ns: number): string {
   if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(1)}ms`
   return `${(ns / 1_000_000_000).toFixed(2)}s`
 }
+
+export function safeParseJson(value: string): Record<string, unknown> {
+  try {
+    return (JSON.parse(value || "{}") ?? {}) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function safeStringifyJson(value: unknown, fallback = ""): string {
+  if (value === undefined || value === null) return fallback
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value) ?? fallback
+  } catch {
+    return fallback
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,11 @@
 export { CryptoError, decrypt, encrypt, hashToken } from "./crypto.ts"
 export { extractLeadingEmoji } from "./extractLeadingEmoji.ts"
-export { formatCount, formatDuration, formatPrice } from "./format.ts"
+export {
+  formatCount,
+  formatDuration,
+  formatPrice,
+  safeParseJson,
+  safeStringifyJson,
+} from "./format.ts"
 export { relativeTime } from "./relativeTime.ts"
 export * from "./http-errors.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: 3.11.0
       version: 3.11.0
     zod:
-      specifier: 4.0.0
-      version: 4.0.0
+      specifier: 4.3.6
+      version: 4.3.6
 
 importers:
 
@@ -142,7 +142,7 @@ importers:
         version: 0.5.3(hono@4.9.12)
       '@hono/zod-openapi':
         specifier: ^1.0.0
-        version: 1.2.2(hono@4.9.12)(zod@4.0.0)
+        version: 1.2.2(hono@4.9.12)(zod@4.3.6)
       '@platform/auth-better':
         specifier: workspace:*
         version: link:../../packages/platform/auth-better
@@ -172,7 +172,7 @@ importers:
         version: 17.3.1
       drizzle-orm:
         specifier: 'catalog:'
-        version: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0)
+        version: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.3.6)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.0
@@ -187,7 +187,7 @@ importers:
         version: 4.21.0
       zod:
         specifier: 'catalog:'
-        version: 4.0.0
+        version: 4.3.6
     devDependencies:
       '@electric-sql/pglite':
         specifier: 0.3.15
@@ -240,6 +240,9 @@ importers:
       '@domain/auth':
         specifier: workspace:*
         version: link:../../packages/domain/auth
+      '@domain/datasets':
+        specifier: workspace:*
+        version: link:../../packages/domain/datasets
       '@domain/email':
         specifier: workspace:*
         version: link:../../packages/domain/email
@@ -300,12 +303,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.166.1
         version: 1.166.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@tanstack/zod-adapter':
-        specifier: 1.163.3
-        version: 1.163.3(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(zod@4.0.0)
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.0(7e161043eef4da6dee96e2ae9b076528)
+        version: 1.5.0(9a1c8e5a13e2f7a47ac96fa05c69e1a9)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.0
@@ -320,7 +320,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       zod:
         specifier: 'catalog:'
-        version: 4.0.0
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
@@ -424,6 +424,15 @@ importers:
       '@domain/organizations':
         specifier: workspace:*
         version: link:../organizations
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../shared
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.0
+
+  packages/domain/datasets:
+    dependencies:
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
@@ -594,6 +603,9 @@ importers:
       '@clickhouse/client':
         specifier: 'catalog:'
         version: 1.17.0
+      '@domain/datasets':
+        specifier: workspace:*
+        version: link:../../domain/datasets
       '@domain/shared':
         specifier: workspace:*
         version: link:../../domain/shared
@@ -603,6 +615,9 @@ importers:
       '@platform/env':
         specifier: workspace:*
         version: link:../env
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.0
@@ -625,6 +640,9 @@ importers:
       '@domain/auth':
         specifier: workspace:*
         version: link:../../domain/auth
+      '@domain/datasets':
+        specifier: workspace:*
+        version: link:../../domain/datasets
       '@domain/organizations':
         specifier: workspace:*
         version: link:../../domain/organizations
@@ -3385,13 +3403,6 @@ packages:
     resolution: {integrity: sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==}
     engines: {node: '>=20.19'}
 
-  '@tanstack/zod-adapter@1.163.3':
-    resolution: {integrity: sha512-qeSo04zpALsqbKz1ymSZUDlO2xqUh4frDYhtcVZS4/NGECgh6iExAin1yIYyahxwah+S3FGoKuMjt+zGys6r0g==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@tanstack/react-router': '>=1.43.2'
-      zod: ^3.23.8
-
   '@tediousjs/connection-string@0.5.0':
     resolution: {integrity: sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ==}
 
@@ -5741,9 +5752,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.0:
-    resolution: {integrity: sha512-9diLdTPc/L7w/5jI4C3gHYNiGHDV9IZYxo1e5LSD8cabi65WVTWWb+g2BGPEpUUCOxR4D+6O5B0AzyMdUAXwrw==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -5760,10 +5768,10 @@ snapshots:
       lru-cache: 10.4.3
     optional: true
 
-  '@asteasolutions/zod-to-openapi@8.4.3(zod@4.0.0)':
+  '@asteasolutions/zod-to-openapi@8.4.3(zod@4.3.6)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 4.0.0
+      zod: 4.3.6
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6502,17 +6510,11 @@ snapshots:
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@4.0.0)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.1.3
       kysely: 0.28.11
       nanostores: 1.1.1
       zod: 4.3.6
-
-  '@better-auth/drizzle-adapter@1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0))':
-    dependencies:
-      '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/utils': 0.3.1
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0)
 
   '@better-auth/drizzle-adapter@1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.3.6))':
     dependencies:
@@ -6958,18 +6960,18 @@ snapshots:
     dependencies:
       hono: 4.9.12
 
-  '@hono/zod-openapi@1.2.2(hono@4.9.12)(zod@4.0.0)':
+  '@hono/zod-openapi@1.2.2(hono@4.9.12)(zod@4.3.6)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 8.4.3(zod@4.0.0)
-      '@hono/zod-validator': 0.7.6(hono@4.9.12)(zod@4.0.0)
+      '@asteasolutions/zod-to-openapi': 8.4.3(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.9.12)(zod@4.3.6)
       hono: 4.9.12
       openapi3-ts: 4.5.0
-      zod: 4.0.0
+      zod: 4.3.6
 
-  '@hono/zod-validator@0.7.6(hono@4.9.12)(zod@4.0.0)':
+  '@hono/zod-validator@0.7.6(hono@4.9.12)(zod@4.3.6)':
     dependencies:
       hono: 4.9.12
-      zod: 4.0.0
+      zod: 4.3.6
 
   '@humanwhocodes/retry@0.4.3': {}
 
@@ -8530,11 +8532,6 @@ snapshots:
 
   '@tanstack/virtual-file-routes@1.161.4': {}
 
-  '@tanstack/zod-adapter@1.163.3(@tanstack/react-router@1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(zod@4.0.0)':
-    dependencies:
-      '@tanstack/react-router': 1.163.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      zod: 4.0.0
-
   '@tediousjs/connection-string@0.5.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -8762,40 +8759,6 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.5.0(7e161043eef4da6dee96e2ae9b076528):
-    dependencies:
-      '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/drizzle-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0))
-      '@better-auth/kysely-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))
-      '@better-auth/telemetry': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.0.0)
-      defu: 6.1.4
-      jose: 6.1.3
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
-    optionalDependencies:
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3)
-      '@tanstack/react-start': 1.166.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      drizzle-kit: 0.31.9
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0)
-      mongodb: 7.1.0
-      mysql2: 3.15.3
-      pg: 8.16.0
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.3)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-
   better-auth@1.5.0(9a1c8e5a13e2f7a47ac96fa05c69e1a9):
     dependencies:
       '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
@@ -8829,15 +8792,6 @@ snapshots:
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.3)(jiti@2.6.1)(jsdom@24.1.3(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.31.1)(msw@2.12.7(@types/node@24.10.3)(typescript@5.8.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
-
-  better-call@1.3.2(zod@4.0.0):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.0.1
-    optionalDependencies:
-      zod: 4.0.0
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -9160,22 +9114,6 @@ snapshots:
       '@js-temporal/polyfill': 0.5.1
       esbuild: 0.25.10
       jiti: 2.6.1
-
-  drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.0.0):
-    dependencies:
-      '@types/mssql': 9.1.9(@azure/core-client@1.10.1)
-      mssql: 11.0.1(@azure/core-client@1.10.1)
-    optionalDependencies:
-      '@electric-sql/pglite': 0.3.15
-      '@opentelemetry/api': 1.9.0
-      '@prisma/client': 7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3)
-      '@types/pg': 8.16.0
-      mysql2: 3.15.3
-      pg: 8.16.0
-      postgres: 3.4.7
-      prisma: 7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3)
-      valibot: 1.2.0(typescript@5.8.3)
-      zod: 4.0.0
 
   drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.3.6):
     dependencies:
@@ -11018,7 +10956,5 @@ snapshots:
       graphmatch: 1.1.1
 
   zod@3.25.76: {}
-
-  zod@4.0.0: {}
 
   zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,6 @@ catalog:
   drizzle-orm: 1.0.0-beta.15-859cf75
   effect: 4.0.0-beta.0
   hono: 4.9.12
-  zod: 4.0.0
   ioredis: 5.8.2
   pg: 8.16.0
   react: 19.2.4
@@ -30,6 +29,7 @@ catalog:
   typescript: 5.8.3
   vite: 7.3.1
   vitest: 3.2.4
+  zod: 4.3.6
   weaviate-client: 3.11.0
 
 ignoredBuiltDependencies:

--- a/rfcs/filters.md
+++ b/rfcs/filters.md
@@ -1,0 +1,652 @@
+# RFC: Filters
+
+**Status:** Draft
+**Authors:** Andrés, César
+**Date:** 2026-03-04
+
+## 1. Context and Motivation
+
+Filters are a shared primitive across multiple platform entities — datasets, annotation queues, and the traces UI all own and store filters. However, a filter always queries the same target: the spans table in ClickHouse. The filter abstraction is reused across entities, but the data it filters is always spans.
+
+This RFC defines the filter grammar, attribute type system, storage model, and the shared package that owns this logic.
+
+## 2. Filter Model
+
+A filter is a set of predicates evaluated against span attributes. Multiple predicates combine with AND semantics by default.
+
+### 2.1 Predicate Structure
+
+Each predicate has three parts:
+
+| Field | Type | Description |
+|---|---|---|
+| `attribute` | `AttributeKey` | The span field to filter on (e.g., `duration`, `provider`, `tags`) |
+| `operator` | `Operator` | The comparison operator |
+| `value` | `FilterValue` | A static value or another attribute key |
+
+**Static value example:** `duration > 500`
+**Attribute-to-attribute example:** `model != responseModel` (comparing two span fields at query time)
+
+### 2.2 Attribute Types
+
+Each attribute has a declared type. The type determines which operators are valid for that attribute. Types map directly to ClickHouse column types so that the query builder can generate correct SQL without runtime type coercion.
+
+| Type | ClickHouse equivalent | Valid operators |
+|---|---|---|
+| `string` | `String`, `LowCardinality(String)` | `=`, `!=`, `contains`, `notContains`, `startsWith`, `endsWith`, `matchesRegex`, `notMatchesRegex`, `in`, `notIn`, `isEmpty`, `isNotEmpty` |
+| `number` | `Int8/16/32/64`, `UInt8/16/32/64`, `Float32/64`, `Decimal` | `=`, `!=`, `>`, `<`, `>=`, `<=`, `between`, `in`, `notIn` |
+| `boolean` | `Bool` (`UInt8` alias) | `=`, `!=` |
+| `date` | `Date`, `Date32` | `=`, `!=`, `>`, `<`, `>=`, `<=`, `between` |
+| `datetime` | `DateTime`, `DateTime64` | `=`, `!=`, `>`, `<`, `>=`, `<=`, `between` |
+| `enum` | `Enum8`, `Enum16`, `LowCardinality(String)` | `=`, `!=`, `in`, `notIn` |
+| `string[]` | `Array(String)` | `contains`, `notContains`, `containsAny`, `containsAll`, `isEmpty`, `isNotEmpty` |
+| `number[]` | `Array(Int64)`, `Array(Float64)` | `contains`, `notContains`, `containsAny`, `containsAll`, `isEmpty`, `isNotEmpty` |
+| `map` | `Map(String, String)` | `hasKey`, `hasValue` |
+| `nullable<T>` | `Nullable(T)` | All operators valid for `T`, plus `isNull`, `isNotNull` |
+
+**Notes:**
+- `matchesRegex` translates to ClickHouse's `match(col, pattern)` function, which uses RE2 syntax (no lookaheads, no backreferences). In URLs, regex values are wrapped in `/…/` (e.g. `query=content:/[a-z]+/`).
+- `between` translates to `col >= low AND col <= high` and applies to `number`, `date`, and `datetime` types.
+- `in` / `notIn` accept an array of static values and apply to scalar types (`string`, `number`, `enum`).
+- For array-typed attributes: `contains` / `notContains` check for a single value (`has`); `containsAny` checks if the array contains at least one of the given values (`hasAny`); `containsAll` checks if the array contains all of the given values (`hasAll`).
+- Time range filtering (`start_time`) is not expressed as a predicate — it is a first-class field handled separately. See section 3.
+
+The canonical attribute list is defined in `packages/domain/filters` and is the source of truth for both the UI and the ClickHouse query builder. It will be finalized once the span schema is stable.
+
+### 2.3 Filter Grammar (JSON)
+
+A filter is represented as an array of predicate objects:
+
+```json
+[
+  { "attribute": "tags", "operator": "containsAny", "value": ["production", "staging"] },
+  { "attribute": "model", "operator": "!=", "value": { "attribute": "responseModel" } }
+]
+```
+
+## 3. Storage Model
+
+Filters use two tables: `filters` is a parent container row that owns the filter identity and enforces tenancy; `filter_predicates` holds one row per predicate, FK'd to the parent.
+
+```
+latitude.filters
+├── id              (cuid, PK)
+├── organization_id (text, for RLS)
+├── time_range      (varchar, nullable — relative preset: "1h" | "6h" | "12h" | "24h" | "7d" | "14d" | "30d" | "90d" | "6mo" | "1y")
+├── from_ts         (timestamptz, nullable — absolute range start, UTC)
+├── to_ts           (timestamptz, nullable — absolute range end, UTC)
+├── created_at      (timestamptz)
+└── updated_at      (timestamptz)
+
+latitude.filter_predicates
+├── id              (cuid, PK)
+├── filter_id       (FK → filters.id, ON DELETE CASCADE)
+├── organization_id (text, for RLS)
+├── position        (integer — ordering of predicates within the filter)
+├── attribute       (varchar — attribute key)
+├── operator        (varchar — operator name)
+├── value           (jsonb — static value or attribute reference object)
+├── created_at      (timestamptz)
+└── updated_at      (timestamptz)
+```
+
+Entities that own a filter (e.g. `datasets`) hold a non-nullable `filter_id` FK → `filters.id`. An empty filter (zero predicates, no time range) means "no filter applied" — the `filters` row is created eagerly alongside the owning entity in the same transaction. There is no null state.
+
+**Time range rules:**
+- `time_range` and `from_ts`/`to_ts` are mutually exclusive. Set one or the other, never both.
+- `time_range` is a relative preset resolved to absolute UTC timestamps at query execution time.
+- `from_ts`/`to_ts` are absolute UTC timestamps — used when the user picked a custom date range.
+- All three nullable means no time constraint (return all spans regardless of time).
+
+A filter defines *which* records match. Concerns like `limit`, `order_by`, and `order_direction` are query-time parameters supplied by the caller, not stored state.
+
+### Write Flow
+
+The UI manages predicates as local state. On apply, the full predicate array is sent and the server replaces atomically:
+
+1. `DELETE FROM filter_predicates WHERE filter_id = ?`
+2. `INSERT INTO filter_predicates (...)` for each predicate
+3. All in a single transaction
+
+No predicate IDs are needed on the client. No diff logic is needed on the server.
+
+## 4. Implementation
+
+All filter logic is centralized in a new domain package: `packages/domain/filters`.
+
+### 4.1 Package Responsibilities
+
+- **Schema definitions:** Zod schemas for the filter grammar, attribute keys, operators, and value types.
+- **Validation:** Parse and validate filter JSON from any source (API body, URL query string, DB row).
+- **URL serialization:** `filterToSearchParams` and `searchParamsToFilter` — used in `apps/web` with TanStack typed routes and in `apps/api` for query string parsing.
+- **DB serialization:** `rowsToFilter` and `filterToRows` — map between DB rows and the domain `Filter` type.
+
+ClickHouse translation is **not** a responsibility of this package. The spans domain receives a `Filter` and is responsible for translating it into ClickHouse SQL, since it owns the span schema and knows which columns map to which attributes.
+
+### 4.2 URL Serialization Format
+
+All predicates are expressed in a single `query` parameter, space-separated:
+
+```
+?query=<expression> <expression> ...
+```
+
+Spaces between predicates are percent-encoded as `%20` on the wire. `URLSearchParams` handles encoding and decoding transparently — code always works with the decoded form:
+
+```
+# decoded (readable)
+?query=environment:production temperature:>0.5
+
+# on the wire
+?query=environment%3Aproduction%20temperature%3A%3E0.5
+```
+
+`&` is not used between predicates — it separates distinct URL parameters. Using `&query=` a second time would create a second parameter, not a second predicate. All predicates belong to the single `query` value.
+
+Values are documented in their decoded form throughout this RFC.
+
+**Grammar:**
+
+| Syntax | Operator |
+|---|---|
+| `attr:value` | `=` (default) |
+| `-attr:value` | `!=` |
+| `attr:>value` | `>` |
+| `attr:<value` | `<` |
+| `attr:>=value` | `>=` |
+| `attr:<=value` | `<=` |
+| `attr:(A OR B)` | `in` / `containsAny` |
+| `-attr:(A OR B)` | `notIn` / `notContains` |
+| `attr:[A TO B]` | `between` |
+| `attr:value*` | `startsWith` |
+| `attr:*value` | `endsWith` |
+| `attr:*value*` | `contains` |
+| `attr:/pattern/` | `matchesRegex` |
+| `attr:*` | `isNotEmpty` |
+| `attr:""` | `isEmpty` |
+
+**Operator parsing rules:**
+- `>=` and `<=` are matched greedily before `>` and `<`.
+- `(A OR B)` and `[A TO B]` are distinguished by their opening bracket; `OR` and `TO` keywords are case-insensitive.
+- Negation (`-attr:...`) inverts the operator to its natural pair: `=` → `!=`, `in` → `notIn`, `containsAny` → `notContains`.
+- `attr:""` and `attr:*` translate to `empty(attr)` and `notEmpty(attr)` respectively. This correctly handles `LowCardinality(String)` columns that use `''` as the null sentinel — never `= ''` or `!= ''`.
+
+**Special value prefixes:**
+
+| Prefix | Meaning |
+|---|---|
+| `$` | Attribute reference — e.g. `model:!=$responseModel` |
+
+**Time range parameters** (separate from `query=` predicates):
+
+Time range is always expressed as dedicated URL parameters, never as `query=` predicates. All timestamps are UTC milliseconds (Unix epoch ms).
+
+| Parameter | Meaning |
+|---|---|
+| `from_ts=<ms>` | Absolute range start — produced by the date picker |
+| `to_ts=<ms>` | Absolute range end — produced by the date picker |
+| `time_range=<preset>` | Relative preset — e.g. `7d`, `30d`. Mutually exclusive with `from_ts`/`to_ts` |
+
+The date picker always materializes to `from_ts`/`to_ts` when the user picks a custom range. `time_range=` is written when the user selects a relative preset (last 7 days, last 30 days, etc.).
+
+**Full example:**
+
+```
+?query=tags:(production OR staging) -model:$responseModel&time_range=30d
+```
+
+**Escaping:**
+
+The following characters have special meaning in the expression grammar and must be escaped with `\` when they appear literally in a value:
+
+```
+: ( ) [ ] * ? " \
+```
+
+Examples:
+
+| Raw value | Escaped expression |
+|---|---|
+| `https://example.com` | `url:https\://example.com` |
+| `order (pending)` | `status:order\ \(pending\)` |
+| `v1.*` | `version:v1\.*` |
+
+In practice the UI always generates expressions programmatically, so escaping is handled transparently. Manual escaping is only relevant when constructing `query=` params by hand (e.g. API calls, CLI scripts).
+
+Alternatively, wrap the entire value in double quotes to avoid escaping individual characters — any value inside `"..."` is treated as a literal string:
+
+```
+url:"https://example.com"
+status:"order (pending)"
+```
+
+Double quotes themselves inside a quoted value are escaped with `\"`:
+
+```
+message:"he said \"hello\""
+```
+
+### 4.3 Filter UI Rendering
+
+Active predicates are rendered as **chips** — compact, read-only tag-like elements displayed in a row above the results table. Each chip shows the attribute name, operator, and value(s) in a human-readable form (e.g. `provider = openai`, `tags: production`). Chips have an × to remove the predicate and are clickable to open an inline edit popover.
+
+There is no freeform text omnibar. The UI is entirely structured: users pick an attribute from a dropdown, choose an operator from the valid set for that attribute, and enter a value in the appropriate input control (text field, multiselect, date picker, etc.). This avoids the need for a text parser and keeps the UI discoverable.
+
+On the client, a filter is a plain array of `Predicate` objects. The active chips reflect this array directly. Adding a predicate opens the add-filter panel; removing a chip splices from the array. The array is serialized to the URL when the user applies the filter.
+
+```typescript
+// Serialize to URL when the user applies the filter
+navigate({ search: filterToSearchParams(predicates) })
+```
+
+### 4.4 Serialization Contracts
+
+Apps pass the raw query string in and receive a validated `Predicate[]` out — no encoding knowledge required at the app layer.
+
+```typescript
+// URL round-trip
+function searchParamsToFilter(rawQuery: string): Predicate[]  // parses + validates, throws on invalid input
+function filterToSearchParams(predicates: Predicate[]): string // produces the compact query string
+
+// DB round-trip (used when reading/writing filter rows)
+function rowsToFilter(rows: FilterPredicateRow[]): Predicate[]
+function filterToRows(predicates: Predicate[], filterId: string): FilterPredicateRow[]
+```
+
+**Hono usage:**
+```typescript
+const predicates = searchParamsToFilter(new URL(c.req.url).search)
+```
+
+**TanStack usage:**
+```typescript
+// configure once at the router level
+const router = createRouter({
+  parseSearch: (search) => ({ filters: searchParamsToFilter(search) }),
+  stringifySearch: ({ filters }) => filterToSearchParams(filters),
+})
+```
+
+### 4.5 Filter State and UI (`apps/web`)
+
+Filter state and filter UI are separate concerns. The store is the source of truth; UI components are dumb readers and writers; URL sync is a side effect of the store.
+
+#### Filter store
+
+A Zustand store holds the complete filter state — predicates and time range together:
+
+```typescript
+// apps/web/src/stores/filter-store.ts
+type FilterState = {
+  predicates: Predicate[]
+  timeRange: TimeRange  // { preset: TimeRangePreset } | { fromTs: number; toTs: number } | null
+  setPredicates: (predicates: Predicate[]) => void
+  setTimeRange: (timeRange: TimeRange | null) => void
+  addPredicate: (predicate: Predicate) => void
+  removePredicate: (index: number) => void
+  reset: () => void
+}
+
+export const createFilterStore = (initial?: { predicates?: Predicate[]; timeRange?: TimeRange }) =>
+  create<FilterState>((set) => ({
+    predicates: initial?.predicates ?? [],
+    timeRange: initial?.timeRange ?? null,
+    setPredicates: (predicates) => set({ predicates }),
+    setTimeRange: (timeRange) => set({ timeRange }),
+    addPredicate: (predicate) => set((s) => ({ predicates: [...s.predicates, predicate] })),
+    removePredicate: (index) => set((s) => ({ predicates: s.predicates.filter((_, i) => i !== index) })),
+    reset: () => set({ predicates: initial?.predicates ?? [], timeRange: initial?.timeRange ?? null }),
+  }))
+```
+
+`FilterStoreProvider` creates the store and provides it via context. It takes optional initial state — used when loading stored predicates from a dynamic dataset or annotation queue:
+
+```typescript
+<FilterStoreProvider initialPredicates={dataset?.filterPredicates} initialTimeRange={dataset?.timeRange}>
+  <FilterSidebar />
+  <FilterChips />
+  <SpanTable />
+  <SaveFilterButton />
+</FilterStoreProvider>
+```
+
+#### URL sync
+
+URL sync is a single subscriber mounted at the provider level. It runs whenever predicates or time range change and calls `navigate` — no component needs to know about it:
+
+```typescript
+// inside FilterStoreProvider
+const { predicates, timeRange } = useFilterStore()
+
+useEffect(() => {
+  navigate({
+    search: (prev) => ({
+      ...prev,
+      ...filterToSearchParams({ predicates, timeRange }),
+    }),
+  })
+}, [predicates, timeRange])
+```
+
+On mount, the store is initialized from the URL (for ephemeral traces page) or from the passed initial state (for stored filters). These are mutually exclusive — pages either own a stored filter or read from the URL, not both.
+
+#### Attribute facets sidebar
+
+The sidebar renders one stacked panel per `facet: true` attribute. Each panel shows the attribute name and a checkbox list of its top N values with occurrence counts. Checking a value calls `addPredicate`; unchecking calls `removePredicate` — both write directly to the store.
+
+Which attributes appear is declared in the `ATTRIBUTES` registry:
+- `facet: true` — include in sidebar
+- `searchable: true` — add a typeahead search box in the panel (for high-cardinality attributes like `tags`)
+
+**Low-cardinality attributes** (`provider`, `model`, `operation`) use `searchable: false`. Their facet values are not loaded globally — they are the distinct values present in the **current query results**. The facet query runs the same WHERE clause as the main span query, grouped by the attribute:
+
+```sql
+SELECT attr_value, count() AS count
+FROM spans
+WHERE <current predicates + time range>
+GROUP BY attr_value
+ORDER BY count DESC
+```
+
+This means facet values and counts always reflect what is visible in the table. Checking a checkbox narrows the results; unchecking restores them.
+
+**High-cardinality attributes** (`tags`) use `searchable: true`. Distinct values from results could be in the thousands, so the panel shows the top 20 most frequent tags globally (not scoped to the current query) and offers a typeahead search for the rest. This is a deliberate trade-off: scoping tag facets to the current query would be too expensive for unbounded arrays.
+
+**TanStack DB collection** — one collection covers all attributes:
+
+```typescript
+// apps/web/src/db/collections.ts
+export const attributeFacetsCollection = createCollection<{
+  id: string        // `${attribute}::${value}`
+  attribute: string
+  value: string
+  count: number
+}>({ id: "attributeFacets" })
+```
+
+**Server functions** — two variants, one per facet mode:
+
+```typescript
+// apps/web/src/server/spans/get-attribute-facet-values.ts
+
+// Low-cardinality: one batched request for all static facet attributes.
+// Runs the current WHERE clause once in ClickHouse and returns a GROUP BY
+// per attribute — one round-trip regardless of how many facet attributes exist.
+export const getFacetValuesForQuery = createServerFn()
+  .validator(z.object({
+    attributes: z.array(attributeKeySchema),
+    predicates: predicatesSchema,
+    timeRange: timeRangeSchema.nullable(),
+  }))
+  .handler(async ({ data, context }) => {
+    // returns Record<AttributeKey, { value: string; count: number }[]>
+    return getSpanFacetValuesUseCase({
+      organizationId: context.organizationId,
+      attributes: data.attributes,
+      predicates: data.predicates,
+      timeRange: data.timeRange,
+    })
+  })
+
+// High-cardinality: global top N + optional search (not scoped to current query)
+export const getGlobalAttributeFacetValues = createServerFn()
+  .validator(z.object({
+    attribute: attributeKeySchema,
+    search: z.string().optional(),
+  }))
+  .handler(async ({ data, context }) => {
+    return getSpanGlobalFacetValuesUseCase({
+      organizationId: context.organizationId,
+      attribute: data.attribute,
+      search: data.search,
+      limit: 20,
+    })
+  })
+```
+
+**`useAttributeFacets` hook** — drives both facet modes from the store:
+
+```typescript
+// apps/web/src/components/filter-sidebar/use-attribute-facets.ts
+function useAttributeFacets() {
+  const db = useTanStackDB()
+  const { predicates, timeRange } = useFilterStore()
+
+  const staticFacets = Object.entries(ATTRIBUTES)
+    .filter(([, def]) => def.facet && !def.searchable)
+    .map(([key]) => key as AttributeKey)
+
+  const searchableFacets = Object.entries(ATTRIBUTES)
+    .filter(([, def]) => def.facet && def.searchable)
+    .map(([key]) => key as AttributeKey)
+
+  // Low-cardinality: one batched request whenever the current query changes
+  useEffect(() => {
+    getFacetValuesForQuery({ attributes: staticFacets, predicates, timeRange }).then((resultsByAttribute) => {
+      Object.entries(resultsByAttribute).forEach(([attribute, values]) => {
+        db.attributeFacetsCollection.setMany(values, { where: { attribute } })
+      })
+    })
+  }, [predicates, timeRange])
+
+  // High-cardinality: load top 20 globally on mount only
+  useEffect(() => {
+    searchableFacets.forEach((attribute) => {
+      getGlobalAttributeFacetValues({ attribute }).then((results) => {
+        db.attributeFacetsCollection.upsertMany(results)
+      })
+    })
+  }, [])
+
+  function search(attribute: AttributeKey, query: string) {
+    getGlobalAttributeFacetValues({ attribute, search: query }).then((results) => {
+      db.attributeFacetsCollection.setMany(results, { where: { attribute } })
+    })
+  }
+
+  function valuesFor(attribute: AttributeKey) {
+    return db.attributeFacetsCollection.filter((item) => item.attribute === attribute)
+  }
+
+  return { valuesFor, search }
+}
+```
+
+Selected values are always pinned at the top of a searchable facet list; search results fill the rest. Clearing the search restores the global top 20.
+
+#### Saving filters
+
+"Save Search" and "Save as Dataset" are plain buttons anywhere in the tree that read the current store state and call a server function. They are not coupled to any filter UI component:
+
+```typescript
+function SaveSearchButton() {
+  const { predicates, timeRange } = useFilterStore()
+
+  return (
+    <Button onClick={() => saveSearchServerFn({ predicates, timeRange })}>
+      Save search
+    </Button>
+  )
+}
+```
+
+For a dynamic dataset page, saving replaces the stored filter predicates and time range via a dedicated server action — the store state is the input, nothing more.
+
+### 4.6 Rendering Constants
+
+The filters package exports all constants needed to render a filter form. These are pure data — no React or UI dependencies — so they live in the domain package and can be consumed by both `apps/web` and any future SDK.
+
+**Operators:**
+
+```typescript
+export const OPERATORS = {
+  EQ:              "=",
+  NEQ:             "!=",
+  GT:              ">",
+  LT:              "<",
+  GTE:             ">=",
+  LTE:             "<=",
+  BETWEEN:         "between",
+  CONTAINS:        "contains",
+  NOT_CONTAINS:    "notContains",
+  STARTS_WITH:     "startsWith",
+  ENDS_WITH:       "endsWith",
+  MATCHES_REGEX:   "matchesRegex",
+  NOT_MATCHES_REGEX: "notMatchesRegex",
+  IN:              "in",
+  NOT_IN:          "notIn",
+  CONTAINS_ANY:    "containsAny",
+  CONTAINS_ALL:    "containsAll",
+  HAS_KEY:         "hasKey",
+  HAS_VALUE:       "hasValue",
+  IS_EMPTY:        "isEmpty",
+  IS_NOT_EMPTY:    "isNotEmpty",
+  IS_NULL:         "isNull",
+  IS_NOT_NULL:     "isNotNull",
+} as const
+```
+
+**Relative date presets:**
+
+The allowed values for `time_range` (both in the URL and in `filters.time_range` storage) are defined as a constant:
+
+```typescript
+export const TIME_RANGE_PRESETS = {
+  "1h":  "Last 1 hour",
+  "6h":  "Last 6 hours",
+  "12h": "Last 12 hours",
+  "24h": "Last 24 hours",
+  "7d":  "Last 7 days",
+  "14d": "Last 14 days",
+  "30d": "Last 30 days",
+  "90d": "Last 90 days",
+  "6mo": "Last 6 months",
+  "1y":  "Last 1 year",
+} as const
+
+export type TimeRangePreset = keyof typeof TIME_RANGE_PRESETS
+```
+
+**Attribute registry** — each attribute is defined explicitly with its type and the exact set of valid operators. Since span attributes are a known, bounded list, this is more precise than deriving operators from the type alone. The final attribute list will be completed once the span schema is stable.
+
+```typescript
+const NUMBER_OPS     = ["=", "!=", ">", "<", ">=", "<=", "between"] as const
+const DATETIME_OPS   = ["=", "!=", ">", "<", ">=", "<=", "between"] as const
+const STRING_OPS     = ["=", "!=", "contains", "notContains", "startsWith", "endsWith",
+                        "matchesRegex", "notMatchesRegex", "in", "notIn",
+                        "isEmpty", "isNotEmpty"] as const
+const STRING_ARR_OPS = ["contains", "notContains", "containsAny", "containsAll",
+                        "anyStartsWith", "anyEndsWith", "anyMatchesRegex",
+                        "isEmpty", "isNotEmpty"] as const
+const ID_OPS         = ["=", "!=", "in", "notIn"] as const
+
+export const ATTRIBUTES = {
+  // Known attributes
+  // `defaultOperator` drives the colon-notation shorthand (section 4.2)
+  // `facet` controls sidebar visibility; `searchable` adds typeahead to the facet panel
+  session_id:   { type: "string",   operators: ID_OPS,         defaultOperator: "=",           facet: false                    },
+  trace_id:     { type: "string",   operators: ID_OPS,         defaultOperator: "=",           facet: false                    },
+  project_id:   { type: "string",   operators: ID_OPS,         defaultOperator: "=",           facet: false                    },
+  api_key_slug: { type: "string",   operators: STRING_OPS,     defaultOperator: "=",           facet: true,  searchable: false },
+  tags:         { type: "string[]", operators: STRING_ARR_OPS, defaultOperator: "containsAny", facet: true,  searchable: true  },
+  // ... remaining attributes added once span schema is finalized
+} as const satisfies Record<string, AttributeDefinition>
+
+export type AttributeDefinition = {
+  type: AttributeType
+  operators: readonly Operator[]
+  defaultOperator: Operator
+  facet: boolean
+  searchable?: boolean  // only relevant when facet: true
+}
+```
+
+How each operator renders its value input is a `SpanFilterForm` concern in `apps/web`, not defined here.
+
+### 4.7 Package Location
+
+```
+packages/domain/filters/
+├── src/
+│   ├── entities/
+│   │   ├── predicate.ts      # Predicate, AttributeKey, Operator, FilterValue types + Zod schema
+│   │   ├── time-range.ts     # TIME_RANGE_PRESETS constant + TimeRangePreset type
+│   │   └── attributes.ts     # ATTRIBUTES registry + AttributeDefinition type
+│   ├── serialization.ts      # URL ↔ predicates and DB row ↔ predicates converters
+│   └── index.ts              # public exports
+├── package.json
+└── tsconfig.json
+```
+
+**`index.ts` exports:**
+
+```typescript
+// Types
+export type { Predicate, AttributeKey, Operator, FilterValue } from "./entities/predicate.ts"
+export type { AttributeDefinition } from "./entities/attributes.ts"
+
+// Constants
+export { TIME_RANGE_PRESETS } from "./entities/time-range.ts"
+export type { TimeRangePreset } from "./entities/time-range.ts"
+export { ATTRIBUTES } from "./entities/attributes.ts"
+
+// Serialization
+export { searchParamsToFilter, filterToSearchParams, rowsToFilter, filterToRows } from "./serialization.ts"
+```
+
+`searchParamsToFilter` validates its output internally — it parses the raw query string and guarantees the result is a valid `Predicate[]`, throwing a typed error if any predicate is malformed. The Zod schema that powers this validation lives in `entities/predicate.ts` alongside the TypeScript types. Apps receive either valid predicates or a clear error; they never handle raw unvalidated filter data.
+
+### 4.8 Dynamic Span Attributes
+
+The span table stores user-defined attributes in typed map columns: `attr_string`, `attr_int`, `attr_float`, `attr_bool`, and `resource_string`. These are populated at ingest time and are unbounded — any key may appear.
+
+Dynamic attributes are exposed in the same flat namespace as schema attributes — no prefix is needed. The resolution rule is:
+
+1. If the attribute key is found in the `ATTRIBUTES` registry → treat it as a schema column lookup.
+2. Otherwise → treat it as a dynamic map lookup and infer the ClickHouse map column from the predicate value and operator.
+
+The omnibar and filter form show schema attributes and dynamic attributes in one flat list. Users type `temperature`, `environment`, `url`, etc. directly.
+
+**URL examples:**
+
+```
+?query=environment:production
+?query=temperature:>0.5
+?query=environment:production temperature:>0.5
+```
+
+**Type inference rules:**
+
+The spans domain infers which map column to query from the parsed value:
+
+| Value / operator | Resolved column | Example |
+|---|---|---|
+| String value, equality/string ops | `attr_string` | `environment:production` |
+| Integer literal | `attr_int` | `retries:>3` |
+| Float literal (contains `.`) | `attr_float` | `temperature:>0.5` |
+| `true` or `false` literal | `attr_bool` | `enabled:true` |
+| Comparison operator (`>`, `<`, `>=`, `<=`) + integer | `attr_int` | `count:>=10` |
+| Comparison operator + float | `attr_float` | `score:>=0.9` |
+
+No cross-column OR needed. The value literal is unambiguous: `3` is an integer, `3.0` is a float, `true`/`false` is boolean, anything else is a string.
+
+```typescript
+// spans domain (ClickHouse translation)
+if (attribute in ATTRIBUTES) {
+  // schema column — handled by the static attribute path
+} else {
+  // dynamic map lookup — infer column from value/operator
+  const col = inferAttrColumn(value, operator)  // "attr_string" | "attr_int" | "attr_float" | "attr_bool"
+  return `${col}[${quoteString(attribute)}]`
+}
+```
+
+> **Note:** To avoid collision with schema column names, prefer OTel-namespaced keys for custom attributes at ingest time (e.g. `gen_ai.temperature`, `http.url`). The filter system accepts any key, but unnamespaced keys that clash with schema attribute names will always resolve to the schema column rather than the dynamic map.
+
+Dynamic attributes are **not** present in the `ATTRIBUTES` registry — they are an open namespace. The `SpanFilterForm` exposes an "attribute" input that accepts both known attribute keys (from `ATTRIBUTES`) and free-text dynamic keys.
+
+## 5. Open Questions
+
+1. **Attribute list finalization.** The canonical list of filterable span attributes is not yet fixed. The attribute registry in `attributes.ts` is the single place to add new filterable fields once the span schema stabilizes.
+2. **OR semantics.** For v1, all predicates combine with AND. OR support can be added later by wrapping predicates in a `{ or: [...] }` group envelope without breaking the existing grammar.
+3. **Typed dynamic attributes (v2).** Full resolution of dynamic keys to the correct typed map column (`attr_string`, `attr_int`, etc.) requires a key-type registry built at ingest time. In v1, all dynamic keys resolve to `attr_string`.


### PR DESCRIPTION
## Summary

This PR introduces the **Datasets** bounded context — a new domain for managing versioned evaluation datasets used in LLM testing, prompt engineering, and annotation workflows. It also includes an opportunistic migration from **Zod 3 → Zod 4** across `apps/web`.

### Data Model

The data model splits storage across **Postgres** (control-plane metadata) and **ClickHouse** (high-volume row data), following the same hybrid pattern the platform already uses for spans/telemetry.

#### Postgres (`latitude` schema)

| Table | Purpose |
|---|---|
| `datasets` | Dataset identity, org ownership, soft-delete, monotonic `current_version` counter |
| `dataset_versions` | Immutable audit log — one row per version bump, tracking rows inserted/updated/deleted, source, and actor |

Both tables follow project conventions: `cuid` PKs, `organizationRLSPolicy`, `timestamps()` spread, `tzTimestamp` for nullable dates. Versions are FK'd to datasets with `ON DELETE CASCADE`.

#### ClickHouse (`dataset_rows`)

| Column | Purpose |
|---|---|
| `row_id` | Stable row identity across versions |
| `xact_id` | Monotonic version number (matches Postgres `current_version`) |
| `_object_delete` | Tombstone flag for soft-deletes at the row level |
| `input` / `output` / `metadata` | Schemaless JSON payloads |

**Why this design?**

- **Temporal versioning via `xact_id`**: Every mutation appends a new row with an incremented `xact_id` rather than updating in place. This makes datasets fully versioned — you can query the state of a dataset "as of version N" by filtering `xact_id <= N` and collapsing with `argMax(col, xact_id)`. This is critical for reproducible evaluations: if a dataset changes between two eval runs, you can still compare results against the exact snapshot each run used.
- **ClickHouse for row storage**: Datasets can grow to millions of rows (think production traffic samples or large benchmark suites). ClickHouse's columnar storage and `MergeTree` engine handle this volume efficiently while Postgres would struggle with table bloat from the append-only versioning pattern.
- **Postgres for metadata**: Dataset identity, version audit log, and org ownership stay in Postgres where they benefit from transactions, foreign keys, and RLS — things ClickHouse doesn't support.
- **Partition by `(organization_id, toYYYYMM(created_at))`**: Ensures queries are always org-scoped (multi-tenancy) and time-bounded partitions allow efficient pruning.
- **`ORDER BY (organization_id, dataset_id, row_id, xact_id)`**: Optimised for the primary query pattern: "give me the latest state of all rows in dataset X for org Y".

#### Domain Layer (`@domain/datasets`)

New package with clean ports-and-adapters structure:
- **Entities**: `Dataset`, `DatasetVersion`, `DatasetRow` with branded IDs (`DatasetId`, `DatasetRowId`, `DatasetVersionId`)
- **Ports**: `DatasetRepository` (Postgres) and `DatasetRowRepository` (ClickHouse) as Effect `ServiceMap` services
- **Use-cases**: `createDataset`, `listDatasets`, `insertRows`, `listRows`, `getRowDetail`

#### Shared IDs (`@domain/shared`)

Added `DatasetId`, `DatasetRowId`, and `DatasetVersionId` branded types with factory functions.

### Zod 4 Migration

Upgraded `apps/web` from **Zod 3.24** to **Zod 4.3.6** (added to pnpm catalog). Key changes:

- **Removed `@tanstack/zod-adapter`**: TanStack Start 1.166+ natively supports Zod 4 schemas in `.inputValidator()` without a wrapper adapter. All server functions across `auth`, `api-keys`, `members`, `projects`, `spans`, and the new `datasets` functions now pass Zod schemas directly.
- **No schema syntax changes needed**: Zod 4 is backwards-compatible for the schema patterns used here (`z.object`, `z.string`, `z.number`, `.optional()`, `.default()`, `.nullable()`).

### RFC

Includes `rfcs/filters.md` — a design document for the shared filter grammar that will be used by datasets, annotation queues, and the traces UI to query spans in ClickHouse.

## Test plan

- [x] Run `pnpm check` and `pnpm typecheck` — both pass
- [x] Verify Postgres migration applies cleanly: `pnpm --filter @platform/db-postgres pg:migrate`
- [x] Verify ClickHouse migration applies cleanly: `pnpm --filter @platform/db-clickhouse ch:up`
- [x] Seed data works: `pnpm --filter @platform/db-postgres pg:seed && pnpm --filter @platform/db-clickhouse ch:seed`
- [x] Web app starts and datasets UI renders at `/projects/:id/datasets`
- [x] Confirm `@tanstack/zod-adapter` is fully removed and no import references remain

---

## Next
- [x] Upload datasets from CSV
- [ ] Edit fields in row details and make sure version is updated
- [ ] Delete rows and make sure version is updated
- [ ] Delete datasets
- [ ] Rename datasets
- [ ] Upload dataset from traces UI
- [ ] Dynamic datasets based on filters
- [ ] Download datasets as CSVs
- [ ] Keyset pagination of rows and pattern in our stack. Infinite pagination maybe. 
- [ ] Dataset filters? We need to talk