### PR TITLE
Vertex function response mismatch

### DIFF
--- a/packages/core/src/services/ai/providers/rules/VertexGoogle.test.ts
+++ b/packages/core/src/services/ai/providers/rules/VertexGoogle.test.ts
@@ -110,4 +110,79 @@ describe('applyGoogleVertexRules', () => {
       },
     ])
   })
+
+  describe('with multiple tool messages for one assistant turn', () => {
+    it('merges consecutive tool messages into one tool turn', () => {
+      const toolMessages = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Use both tools' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'toolA',
+              args: { x: 1 },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-2',
+              toolName: 'toolB',
+              args: { y: 2 },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'toolA',
+              result: { ok: true },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-2',
+              toolName: 'toolB',
+              result: { ok: true },
+            },
+          ],
+        },
+      ] as Message[]
+
+      const rules = applyProviderRules({
+        providerType,
+        messages: toolMessages,
+        config,
+      })
+
+      expect(rules.messages).toHaveLength(3)
+      expect(rules.messages[2]).toEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'toolA',
+            result: { ok: true },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'toolB',
+            result: { ok: true },
+          },
+        ],
+      })
+    })
+  })
 })

--- a/packages/core/src/services/ai/providers/rules/google.test.ts
+++ b/packages/core/src/services/ai/providers/rules/google.test.ts
@@ -102,4 +102,79 @@ describe('applyGoogleRules', () => {
       })
     })
   })
+
+  describe('with multiple tool messages for one assistant turn', () => {
+    it('merges consecutive tool messages into one tool turn', () => {
+      const toolMessages = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Use both tools' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'toolA',
+              args: { x: 1 },
+            },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-2',
+              toolName: 'toolB',
+              args: { y: 2 },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'toolA',
+              result: { ok: true },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-2',
+              toolName: 'toolB',
+              result: { ok: true },
+            },
+          ],
+        },
+      ] as Message[]
+
+      const rules = applyProviderRules({
+        providerType,
+        messages: toolMessages,
+        config,
+      })
+
+      expect(rules.messages).toHaveLength(3)
+      expect(rules.messages[2]).toEqual({
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'toolA',
+            result: { ok: true },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-2',
+            toolName: 'toolB',
+            result: { ok: true },
+          },
+        ],
+      })
+    })
+  })
 })

--- a/packages/core/src/services/ai/providers/rules/google.ts
+++ b/packages/core/src/services/ai/providers/rules/google.ts
@@ -1,4 +1,5 @@
 import { enforceAllSystemMessagesFirst } from './helpers/enforceAllSystemMessagesFirst'
+import { mergeConsecutiveToolMessages } from './helpers/mergeConsecutiveToolMessages'
 import { AppliedRules, ProviderRules } from './types'
 
 export function applyGoogleRules(appliedRule: AppliedRules): AppliedRules {
@@ -8,11 +9,13 @@ export function applyGoogleRules(appliedRule: AppliedRules): AppliedRules {
       'Google only supports system messages at the beggining of the conversation. All other system messages have been converted to user messages.',
   })
 
-  const minOneUserMessage = rules.messages.some((m) => m.role === 'user')
-  if (minOneUserMessage) return rules
+  const messages = mergeConsecutiveToolMessages(rules.messages)
+  const minOneUserMessage = messages.some((m) => m.role === 'user')
+  if (minOneUserMessage) return { ...rules, messages }
 
   return {
     ...rules,
+    messages,
     rules: [
       ...rules.rules,
       {

--- a/packages/core/src/services/ai/providers/rules/helpers/mergeConsecutiveToolMessages.ts
+++ b/packages/core/src/services/ai/providers/rules/helpers/mergeConsecutiveToolMessages.ts
@@ -1,0 +1,56 @@
+import type {
+  Message,
+  ToolMessage,
+  ToolResultContent,
+} from '@latitude-data/constants/messages'
+
+function hasToolCalls(message: Message) {
+  if (message.role !== 'assistant') return false
+  if (!Array.isArray(message.content)) return false
+
+  return message.content.some((content) => content.type === 'tool-call')
+}
+
+function mergeToolMessageContent(messages: ToolMessage[]): ToolResultContent[] {
+  return messages.flatMap((message) => message.content)
+}
+
+export function mergeConsecutiveToolMessages(messages: Message[]): Message[] {
+  const merged: Message[] = []
+
+  let index = 0
+  while (index < messages.length) {
+    const message = messages[index]!
+    if (!hasToolCalls(message)) {
+      merged.push(message)
+      index += 1
+      continue
+    }
+
+    merged.push(message)
+
+    const consecutiveToolMessages: ToolMessage[] = []
+    let nextIndex = index + 1
+
+    while (nextIndex < messages.length) {
+      const nextMessage = messages[nextIndex]!
+      if (nextMessage.role !== 'tool') break
+
+      consecutiveToolMessages.push(nextMessage)
+      nextIndex += 1
+    }
+
+    if (consecutiveToolMessages.length === 1) {
+      merged.push(consecutiveToolMessages[0]!)
+    } else if (consecutiveToolMessages.length > 1) {
+      merged.push({
+        role: 'tool',
+        content: mergeToolMessageContent(consecutiveToolMessages),
+      })
+    }
+
+    index = consecutiveToolMessages.length > 0 ? nextIndex : index + 1
+  }
+
+  return merged
+}

--- a/packages/core/src/services/ai/providers/rules/vertexGoogle.ts
+++ b/packages/core/src/services/ai/providers/rules/vertexGoogle.ts
@@ -1,4 +1,5 @@
 import { enforceAllSystemMessagesFirst } from './helpers/enforceAllSystemMessagesFirst'
+import { mergeConsecutiveToolMessages } from './helpers/mergeConsecutiveToolMessages'
 import { AppliedRules, ProviderRules } from './types'
 
 export function applyVertexGoogleRules(
@@ -9,10 +10,11 @@ export function applyVertexGoogleRules(
     message:
       'Google Vertex only supports system messages at the beggining of the conversation. All other system messages have been converted to user messages.',
   })
+  const messages = mergeConsecutiveToolMessages(rule.messages)
 
-  const roles = rule.messages.map((m) => m.role)
+  const roles = messages.map((m) => m.role)
   const onlySystemMessages = roles.every((r) => r === 'system')
-  if (!onlySystemMessages) return rule
+  if (!onlySystemMessages) return { ...rule, messages }
 
   const rules = [
     ...rule.rules,
@@ -24,6 +26,7 @@ export function applyVertexGoogleRules(
   ]
   return {
     ...rule,
+    messages,
     rules,
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Introduce a rule to merge consecutive tool messages for Google/Vertex providers to resolve `INVALID_ARGUMENT` errors caused by mismatched function call/response counts when replaying conversation turns to the Vertex API.

---
<p><a href="https://cursor.com/agents/bc-26fa7d93-06a8-4a09-998c-e1b342f40e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fa7d93-06a8-4a09-998c-e1b342f40e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->