### PR TITLE
Add OTEL-compatible span ingestion endpoint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 set -e
 
 pnpm format
+pnpm check:fix
 pnpm knip

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,6 @@
     "@hono/node-server": "catalog:",
     "@hono/swagger-ui": "^0.5.0",
     "@hono/zod-openapi": "^1.0.0",
-    "@platform/auth-better": "workspace:*",
     "@platform/cache-redis": "workspace:*",
     "@platform/db-clickhouse": "workspace:*",
     "@platform/db-postgres": "workspace:*",

--- a/apps/api/src/clients.ts
+++ b/apps/api/src/clients.ts
@@ -1,17 +1,15 @@
 import type { ClickHouseClient } from "@clickhouse/client"
-import { createBetterAuth } from "@platform/auth-better"
 import { createRedisClient, createRedisConnection } from "@platform/cache-redis"
 import type { RedisClient } from "@platform/cache-redis"
 import { createClickhouseClient } from "@platform/db-clickhouse"
 import { type PostgresClient, createPostgresClient } from "@platform/db-postgres"
-import { parseEnv, parseEnvOptional } from "@platform/env"
+import { parseEnv } from "@platform/env"
 import { Effect } from "effect"
 
 let postgresClientInstance: PostgresClient | undefined
 let adminPostgresClientInstance: PostgresClient | undefined
 let clickhouseInstance: ClickHouseClient | undefined
 let redisInstance: RedisClient | undefined
-let betterAuthInstance: ReturnType<typeof createBetterAuth> | undefined
 
 export const getPostgresClient = (): PostgresClient => {
   if (!postgresClientInstance) {
@@ -53,36 +51,4 @@ export const getRedisClient = (): RedisClient => {
     redisInstance = createRedisClient(redisConn)
   }
   return redisInstance
-}
-
-/**
- * Get or create the Better Auth instance.
- *
- * This is a singleton to ensure the same auth instance is used
- * across routes and middleware.
- */
-export const getBetterAuth = () => {
-  if (!betterAuthInstance) {
-    const { db } = getPostgresClient()
-    const baseUrl = Effect.runSync(parseEnv("LAT_BETTER_AUTH_URL", "string"))
-    const betterAuthSecret = Effect.runSync(parseEnv("LAT_BETTER_AUTH_SECRET", "string"))
-    const webUrl = Effect.runSync(parseEnv("LAT_WEB_URL", "string", "http://localhost:3000"))
-
-    // Parse trusted origins from comma-separated env var or fallback to webUrl
-    const trustedOriginsEnv = Effect.runSync(parseEnvOptional("LAT_TRUSTED_ORIGINS", "string"))
-    const trustedOrigins = trustedOriginsEnv
-      ? trustedOriginsEnv
-          .split(",")
-          .map((o) => o.trim())
-          .filter(Boolean)
-      : [webUrl]
-
-    betterAuthInstance = createBetterAuth({
-      db,
-      secret: betterAuthSecret,
-      baseUrl,
-      trustedOrigins,
-    })
-  }
-  return betterAuthInstance
 }

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,13 +1,9 @@
 import { OrganizationId, UnauthorizedError, UserId } from "@domain/shared"
-import {
-  type PostgresDb,
-  createApiKeyPostgresRepository,
-  createMembershipPostgresRepository,
-} from "@platform/db-postgres"
+import { type PostgresDb, createApiKeyPostgresRepository } from "@platform/db-postgres"
 import { hashToken } from "@repo/utils"
 import { Effect, Option } from "effect"
 import type { Context, MiddlewareHandler, Next } from "hono"
-import { getAdminPostgresClient, getBetterAuth } from "../clients.ts"
+import { getAdminPostgresClient } from "../clients.ts"
 import type { AuthContext } from "../types.ts"
 import { createTouchBuffer } from "./touch-buffer.ts"
 
@@ -160,27 +156,6 @@ const enforceMinimumTime = (startTime: number, minMs: number): Effect.Effect<voi
   return Effect.void
 }
 
-/**
- * Validate that a user is a member of the specified organization.
- * Returns true if membership is valid, false otherwise.
- */
-const validateOrganizationMembership = (
-  c: Context,
-  userId: string,
-  organizationId: string,
-): Effect.Effect<boolean, never> => {
-  const membershipRepository = createMembershipPostgresRepository(c.get("db"))
-  return membershipRepository.isMember(OrganizationId(organizationId), userId).pipe(Effect.orDie)
-}
-
-/**
- * Extract API key token from request headers.
- */
-const extractApiKeyToken = (c: Context): string | undefined => {
-  const apiKeyHeader = c.req.header("X-API-Key")
-  return apiKeyHeader || undefined
-}
-
 const extractBearerToken = (c: Context): string | undefined => {
   const authHeader = c.req.header("Authorization")
   if (!authHeader?.startsWith("Bearer ")) {
@@ -216,77 +191,31 @@ const authenticateWithApiKey = (
 }
 
 /**
- * Authenticate via JWT bearer token.
- */
-const authenticateWithJwt = (c: Context, token: string): Effect.Effect<AuthContext | null, never> => {
-  return Effect.gen(function* () {
-    const auth = getBetterAuth()
-    const headers = new Headers(c.req.raw.headers)
-    headers.set("authorization", `Bearer ${token}`)
-
-    const session = yield* Effect.tryPromise({
-      try: () => auth.api.getSession({ headers }),
-      catch: () => null,
-    }).pipe(Effect.orDie)
-
-    if (!session?.user) {
-      return null
-    }
-
-    const orgId = c.req.param("organizationId")
-    if (!orgId) {
-      return null
-    }
-
-    const isMember = yield* validateOrganizationMembership(c, session.user.id, orgId)
-    if (!isMember) {
-      return null
-    }
-
-    const authContext: AuthContext = {
-      userId: UserId(session.user.id),
-      organizationId: OrganizationId(orgId),
-      method: "jwt",
-    }
-
-    return authContext
-  }).pipe(Effect.orDie)
-}
-
-/**
- * Main authentication effect that tries all authentication methods.
+ * Authenticate via API key from the Authorization: Bearer header.
  */
 const authenticate = (c: Context, options?: AuthMiddlewareOptions): Effect.Effect<AuthContext, UnauthorizedError> => {
   return Effect.gen(function* () {
-    const apiKeyToken = extractApiKeyToken(c)
     const bearerToken = extractBearerToken(c)
 
-    let authContext: AuthContext | null = null
-
-    if (apiKeyToken) {
-      authContext = yield* authenticateWithApiKey(c, apiKeyToken, options)
-    } else if (bearerToken) {
-      authContext = yield* authenticateWithJwt(c, bearerToken)
-    }
-
-    if (!authContext) {
+    if (!bearerToken) {
       return yield* new UnauthorizedError({
         message: "Authentication required",
       })
     }
 
-    return authContext
+    const authContext = yield* authenticateWithApiKey(c, bearerToken, options)
+    if (authContext) return authContext
+
+    return yield* new UnauthorizedError({
+      message: "Invalid API key",
+    })
   })
 }
 
 /**
  * Create authentication middleware.
  *
- * This middleware validates requests using one of two methods:
- * 1. JWT Bearer token (Better Auth)
- * 2. API Key
- *
- * The middleware sets auth context on the Hono context for downstream handlers.
+ * Validates API keys sent via the Authorization: Bearer header.
  * Public routes should be excluded from this middleware.
  */
 interface AuthMiddlewareOptions {

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -42,7 +42,7 @@ export const registerCorsMiddleware = (app: Hono, options: RegisterCorsMiddlewar
         return null
       },
       allowMethods: ["GET", "POST", "PUT", "DELETE"],
-      allowHeaders: ["Content-Type", "Authorization", "X-API-Key"],
+      allowHeaders: ["Content-Type", "Authorization"],
       credentials: true,
       maxAge: 86400,
       exposeHeaders: ["X-RateLimit-Limit", "X-RateLimit-Remaining"],

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -42,9 +42,8 @@ registerRoutes({
 
 // Register security scheme via the OpenAPI registry
 app.openAPIRegistry.registerComponent("securitySchemes", "ApiKeyAuth", {
-  type: "apiKey",
-  in: "header",
-  name: "X-API-Key",
+  type: "http",
+  scheme: "bearer",
   description: "Organization-scoped API key",
 })
 
@@ -54,7 +53,7 @@ app.doc("/openapi.json", {
   info: {
     title: "Latitude API",
     version: "1.0.0",
-    description: "The Latitude public API. Authenticate using an API key via the `X-API-Key` header.",
+    description: "The Latitude public API. Authenticate using an API key via the `Authorization: Bearer` header.",
   },
   servers: [{ url: `http://localhost:${port}`, description: "Local development" }],
 })

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -23,7 +23,7 @@ export interface AuthContext {
   /** The organization ID for this request (from URL param or API key) */
   readonly organizationId: OrganizationId
   /** The authentication method that was used */
-  readonly method: "jwt" | "api-key"
+  readonly method: "api-key"
 }
 
 /**

--- a/apps/ingest/package.json
+++ b/apps/ingest/package.json
@@ -14,14 +14,19 @@
   },
   "dependencies": {
     "@clickhouse/client": "catalog:",
+    "@domain/shared": "workspace:*",
+    "@domain/spans": "workspace:*",
     "@hono/node-server": "catalog:",
+    "@platform/cache-redis": "workspace:*",
     "@platform/db-clickhouse": "workspace:*",
     "@platform/db-postgres": "workspace:*",
     "@platform/env": "workspace:*",
     "@repo/observability": "workspace:*",
+    "@repo/utils": "workspace:*",
     "dotenv": "catalog:",
     "effect": "catalog:",
     "hono": "catalog:",
+    "protobufjs": "catalog:",
     "tsx": "catalog:"
   }
 }

--- a/apps/ingest/src/clients.ts
+++ b/apps/ingest/src/clients.ts
@@ -1,15 +1,33 @@
 import type { ClickHouseClient } from "@clickhouse/client"
+import { createRedisClient, createRedisConnection } from "@platform/cache-redis"
+import type { RedisClient } from "@platform/cache-redis"
 import { createClickhouseClient } from "@platform/db-clickhouse"
-import { createPostgresPool } from "@platform/db-postgres"
+import { type PostgresClient, createPostgresClient } from "@platform/db-postgres"
+import { parseEnv } from "@platform/env"
+import { Effect } from "effect"
 
-let postgresPoolInstance: ReturnType<typeof createPostgresPool> | undefined
+let postgresClientInstance: PostgresClient | undefined
+let adminPostgresClientInstance: PostgresClient | undefined
 let clickhouseInstance: ClickHouseClient | undefined
+let redisInstance: RedisClient | undefined
 
-export const getPostgresPool = (): ReturnType<typeof createPostgresPool> => {
-  if (!postgresPoolInstance) {
-    postgresPoolInstance = createPostgresPool()
+export const getPostgresClient = (): PostgresClient => {
+  if (!postgresClientInstance) {
+    postgresClientInstance = createPostgresClient()
   }
-  return postgresPoolInstance
+  return postgresClientInstance
+}
+
+/**
+ * Admin Postgres connection that bypasses RLS.
+ * Used for cross-org lookups: API key auth and project resolution.
+ */
+export const getAdminPostgresClient = (): PostgresClient => {
+  if (!adminPostgresClientInstance) {
+    const adminUrl = Effect.runSync(parseEnv("LAT_ADMIN_DATABASE_URL", "string"))
+    adminPostgresClientInstance = createPostgresClient({ databaseUrl: adminUrl })
+  }
+  return adminPostgresClientInstance
 }
 
 export const getClickhouseClient = (): ClickHouseClient => {
@@ -17,4 +35,12 @@ export const getClickhouseClient = (): ClickHouseClient => {
     clickhouseInstance = createClickhouseClient()
   }
   return clickhouseInstance
+}
+
+export const getRedisClient = (): RedisClient => {
+  if (!redisInstance) {
+    const redisConn = createRedisConnection()
+    redisInstance = createRedisClient(redisConn)
+  }
+  return redisInstance
 }

--- a/apps/ingest/src/middleware/auth.ts
+++ b/apps/ingest/src/middleware/auth.ts
@@ -1,0 +1,118 @@
+import { createApiKeyPostgresRepository } from "@platform/db-postgres"
+import { hashToken } from "@repo/utils"
+import { Effect, Option } from "effect"
+import type { MiddlewareHandler } from "hono"
+import { getAdminPostgresClient, getRedisClient } from "../clients.ts"
+import type { IngestEnv } from "../types.ts"
+
+const MIN_VALIDATION_TIME_MS = 50
+const VALID_KEY_TTL_SECONDS = 300
+const INVALID_KEY_TTL_SECONDS = 5
+const REDIS_OPERATION_TIMEOUT_MS = 50
+
+const withTimeout = <T>(operation: Promise<T>, fallback: T): Promise<T> =>
+  Promise.race([
+    operation,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), REDIS_OPERATION_TIMEOUT_MS)),
+  ])
+
+const getApiKeyCacheKey = (tokenHash: string): string => `apikey:${tokenHash}`
+
+type ApiKeyResult = { organizationId: string; keyId: string }
+
+const isCachedResult = (value: unknown): value is ApiKeyResult | null => {
+  if (value === null) return true
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "organizationId" in value &&
+    "keyId" in value &&
+    typeof value.organizationId === "string" &&
+    typeof value.keyId === "string"
+  )
+}
+
+const getCachedApiKey = (tokenHash: string): Effect.Effect<ApiKeyResult | null | undefined> => {
+  const redis = getRedisClient()
+  const cacheKey = getApiKeyCacheKey(tokenHash)
+  return Effect.tryPromise({
+    try: async () => {
+      const cached = await withTimeout(redis.get(cacheKey), null)
+      if (!cached) return undefined
+      const parsed = JSON.parse(cached)
+      return isCachedResult(parsed) ? parsed : undefined
+    },
+    catch: () => undefined,
+  }).pipe(Effect.orDie)
+}
+
+const cacheApiKeyResult = (tokenHash: string, result: ApiKeyResult | null, ttl: number): Effect.Effect<void> => {
+  const redis = getRedisClient()
+  const cacheKey = getApiKeyCacheKey(tokenHash)
+  return Effect.tryPromise({
+    try: () => withTimeout(redis.setex(cacheKey, ttl, JSON.stringify(result)), undefined),
+    catch: () => undefined,
+  }).pipe(Effect.orDie)
+}
+
+const enforceMinimumTime = (startTime: number, minMs: number): Effect.Effect<void> => {
+  const elapsed = Date.now() - startTime
+  if (elapsed < minMs) {
+    return Effect.tryPromise({
+      try: () => new Promise<void>((resolve) => setTimeout(resolve, minMs - elapsed)),
+      catch: () => undefined,
+    }).pipe(Effect.orDie)
+  }
+  return Effect.void
+}
+
+const validateApiKey = (token: string): Effect.Effect<ApiKeyResult | null> => {
+  const adminDb = getAdminPostgresClient().db
+  const apiKeyRepo = createApiKeyPostgresRepository(adminDb)
+
+  return Effect.gen(function* () {
+    const startTime = Date.now()
+    const tokenHash = yield* hashToken(token)
+
+    const cached = yield* getCachedApiKey(tokenHash)
+    if (cached !== undefined) {
+      yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+      return cached
+    }
+
+    const apiKeyOption = yield* Effect.option(apiKeyRepo.findByTokenHash(tokenHash))
+
+    if (Option.isNone(apiKeyOption)) {
+      yield* cacheApiKeyResult(tokenHash, null, INVALID_KEY_TTL_SECONDS)
+      yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+      return null
+    }
+
+    const apiKey = apiKeyOption.value
+    const result: ApiKeyResult = { organizationId: apiKey.organizationId, keyId: apiKey.id }
+
+    yield* cacheApiKeyResult(tokenHash, result, VALID_KEY_TTL_SECONDS)
+    yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+    return result
+  }).pipe(Effect.orDie)
+}
+
+export const authMiddleware: MiddlewareHandler<IngestEnv> = async (c, next) => {
+  const authHeader = c.req.header("Authorization")
+  if (!authHeader?.startsWith("Bearer ")) {
+    return c.json({ error: "Authentication required. Use Authorization: Bearer <api-key>" }, 401)
+  }
+  const token = authHeader.slice(7)
+  if (!token) {
+    return c.json({ error: "Authentication required" }, 401)
+  }
+
+  const result = await Effect.runPromise(validateApiKey(token))
+  if (!result) {
+    return c.json({ error: "Invalid API key" }, 401)
+  }
+
+  c.set("organizationId", result.organizationId)
+  c.set("apiKeyId", result.keyId)
+  await next()
+}

--- a/apps/ingest/src/middleware/project.ts
+++ b/apps/ingest/src/middleware/project.ts
@@ -1,0 +1,38 @@
+import { ProjectId, isNotFoundError } from "@domain/shared"
+import { createProjectPostgresRepository, runCommand } from "@platform/db-postgres"
+import { Effect } from "effect"
+import type { MiddlewareHandler } from "hono"
+import { getPostgresClient } from "../clients.ts"
+import type { IngestEnv } from "../types.ts"
+
+/**
+ * Resolves the project from the X-Latitude-Project header (project ID).
+ * Must run after auth middleware (requires organizationId on context).
+ */
+export const projectMiddleware: MiddlewareHandler<IngestEnv> = async (c, next) => {
+  const projectId = c.req.header("X-Latitude-Project")
+  if (!projectId) {
+    return c.json({ error: "X-Latitude-Project header is required" }, 400)
+  }
+
+  const organizationId = c.get("organizationId")
+  const { db } = getPostgresClient()
+
+  try {
+    const project = await runCommand(
+      db,
+      organizationId,
+    )(async (txDb) => {
+      const repo = createProjectPostgresRepository(txDb)
+      return Effect.runPromise(repo.findById(ProjectId(projectId)))
+    })
+
+    c.set("projectId", project.id as string)
+    await next()
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return c.json({ error: "Project not found" }, 404)
+    }
+    throw error
+  }
+}

--- a/apps/ingest/src/otlp/proto.ts
+++ b/apps/ingest/src/otlp/proto.ts
@@ -1,0 +1,175 @@
+import protobuf from "protobufjs"
+import type { OtlpExportTraceServiceRequest } from "./types.ts"
+
+/**
+ * Protobuf schema for OTLP ExportTraceServiceRequest.
+ * Field IDs match the official opentelemetry-proto definitions exactly.
+ */
+const root = protobuf.Root.fromJSON({
+  nested: {
+    ExportTraceServiceRequest: {
+      fields: {
+        resourceSpans: { rule: "repeated", type: "ResourceSpans", id: 1 },
+      },
+    },
+    ResourceSpans: {
+      fields: {
+        resource: { type: "Resource", id: 1 },
+        scopeSpans: { rule: "repeated", type: "ScopeSpans", id: 2 },
+        schemaUrl: { type: "string", id: 3 },
+      },
+    },
+    Resource: {
+      fields: {
+        attributes: { rule: "repeated", type: "KeyValue", id: 1 },
+        droppedAttributesCount: { type: "uint32", id: 2 },
+      },
+    },
+    ScopeSpans: {
+      fields: {
+        scope: { type: "InstrumentationScope", id: 1 },
+        spans: { rule: "repeated", type: "Span", id: 2 },
+        schemaUrl: { type: "string", id: 3 },
+      },
+    },
+    InstrumentationScope: {
+      fields: {
+        name: { type: "string", id: 1 },
+        version: { type: "string", id: 2 },
+        attributes: { rule: "repeated", type: "KeyValue", id: 3 },
+        droppedAttributesCount: { type: "uint32", id: 4 },
+      },
+    },
+    Span: {
+      fields: {
+        traceId: { type: "bytes", id: 1 },
+        spanId: { type: "bytes", id: 2 },
+        traceState: { type: "string", id: 3 },
+        parentSpanId: { type: "bytes", id: 4 },
+        name: { type: "string", id: 5 },
+        kind: { type: "int32", id: 6 },
+        startTimeUnixNano: { type: "fixed64", id: 7 },
+        endTimeUnixNano: { type: "fixed64", id: 8 },
+        attributes: { rule: "repeated", type: "KeyValue", id: 9 },
+        droppedAttributesCount: { type: "uint32", id: 10 },
+        events: { rule: "repeated", type: "Event", id: 11 },
+        droppedEventsCount: { type: "uint32", id: 12 },
+        links: { rule: "repeated", type: "Link", id: 13 },
+        droppedLinksCount: { type: "uint32", id: 14 },
+        status: { type: "Status", id: 15 },
+        flags: { type: "fixed32", id: 16 },
+      },
+    },
+    Status: {
+      fields: {
+        message: { type: "string", id: 2 },
+        code: { type: "int32", id: 3 },
+      },
+    },
+    Event: {
+      fields: {
+        timeUnixNano: { type: "fixed64", id: 1 },
+        name: { type: "string", id: 2 },
+        attributes: { rule: "repeated", type: "KeyValue", id: 3 },
+        droppedAttributesCount: { type: "uint32", id: 4 },
+      },
+    },
+    Link: {
+      fields: {
+        traceId: { type: "bytes", id: 1 },
+        spanId: { type: "bytes", id: 2 },
+        traceState: { type: "string", id: 3 },
+        attributes: { rule: "repeated", type: "KeyValue", id: 4 },
+        droppedAttributesCount: { type: "uint32", id: 5 },
+        flags: { type: "fixed32", id: 6 },
+      },
+    },
+    KeyValue: {
+      fields: {
+        key: { type: "string", id: 1 },
+        value: { type: "AnyValue", id: 2 },
+      },
+    },
+    AnyValue: {
+      oneofs: {
+        value: {
+          oneof: ["stringValue", "boolValue", "intValue", "doubleValue", "arrayValue", "kvlistValue", "bytesValue"],
+        },
+      },
+      fields: {
+        stringValue: { type: "string", id: 1 },
+        boolValue: { type: "bool", id: 2 },
+        intValue: { type: "int64", id: 3 },
+        doubleValue: { type: "double", id: 4 },
+        arrayValue: { type: "ArrayValue", id: 5 },
+        kvlistValue: { type: "KeyValueList", id: 6 },
+        bytesValue: { type: "bytes", id: 7 },
+      },
+    },
+    ArrayValue: {
+      fields: {
+        values: { rule: "repeated", type: "AnyValue", id: 1 },
+      },
+    },
+    KeyValueList: {
+      fields: {
+        values: { rule: "repeated", type: "KeyValue", id: 1 },
+      },
+    },
+  },
+})
+
+const ExportTraceServiceRequestType = root.lookupType("ExportTraceServiceRequest")
+
+function bytesToHex(bytes: Uint8Array | number[]): string {
+  const arr = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+  let hex = ""
+  for (const b of arr) {
+    hex += b.toString(16).padStart(2, "0")
+  }
+  return hex
+}
+
+/**
+ * Recursively normalize a decoded protobuf object to match the OTLP/JSON shape:
+ * - Uint8Array bytes fields → lowercase hex strings
+ * - Long objects → decimal strings
+ */
+function normalizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value
+  if (value instanceof Uint8Array) return bytesToHex(value)
+  if (Array.isArray(value)) return value.map(normalizeValue)
+
+  // protobufjs Long objects have low/high/unsigned properties
+  if (typeof value === "object" && "low" in value && "high" in value) {
+    const long = value as { low: number; high: number; unsigned: boolean }
+    const bigint = BigInt(long.high >>> 0) * BigInt(2 ** 32) + BigInt(long.low >>> 0)
+    return bigint.toString()
+  }
+
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>
+    const normalized: Record<string, unknown> = {}
+    for (const key of Object.keys(obj)) {
+      normalized[key] = normalizeValue(obj[key])
+    }
+    return normalized
+  }
+
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return value
+  }
+
+  return value
+}
+
+export function decodeOtlpProtobuf(buffer: Uint8Array): OtlpExportTraceServiceRequest {
+  const message = ExportTraceServiceRequestType.decode(buffer)
+  const raw = ExportTraceServiceRequestType.toObject(message, {
+    arrays: true,
+    objects: true,
+    defaults: false,
+    oneofs: true,
+  })
+  return normalizeValue(raw) as OtlpExportTraceServiceRequest
+}

--- a/apps/ingest/src/otlp/transform.ts
+++ b/apps/ingest/src/otlp/transform.ts
@@ -1,0 +1,217 @@
+import { OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import type { SpanDetail, SpanKind, SpanStatusCode } from "@domain/spans"
+import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpResource, OtlpSpan } from "./types.ts"
+
+const INT_TO_SPAN_KIND: Record<number, SpanKind> = {
+  0: "unspecified",
+  1: "internal",
+  2: "server",
+  3: "client",
+  4: "producer",
+  5: "consumer",
+}
+
+const INT_TO_STATUS_CODE: Record<number, SpanStatusCode> = {
+  0: "unset",
+  1: "ok",
+  2: "error",
+}
+
+// Semantic convention attribute keys that map to dedicated span fields
+const EXTRACTED_ATTRIBUTES = new Set([
+  "gen_ai.operation.name",
+  "gen_ai.system",
+  "gen_ai.request.model",
+  "gen_ai.response.model",
+  "gen_ai.usage.input_tokens",
+  "gen_ai.usage.output_tokens",
+  "gen_ai.usage.cache_read_input_tokens",
+  "gen_ai.usage.reasoning_tokens",
+  "gen_ai.response.id",
+  "gen_ai.response.finish_reasons",
+  "gen_ai.conversation.id",
+  "error.type",
+])
+
+function nanosToDate(nanos: string | undefined): Date {
+  if (!nanos || nanos === "0") return new Date()
+  const ms = Number(BigInt(nanos) / BigInt(1_000_000))
+  return new Date(ms)
+}
+
+function extractStringAttr(attrs: readonly OtlpKeyValue[], key: string): string {
+  const kv = attrs.find((a) => a.key === key)
+  return kv?.value?.stringValue ?? ""
+}
+
+function extractIntAttr(attrs: readonly OtlpKeyValue[], key: string): number {
+  const kv = attrs.find((a) => a.key === key)
+  if (kv?.value?.intValue !== undefined) return Number(kv.value.intValue)
+  if (kv?.value?.doubleValue !== undefined) return Math.round(kv.value.doubleValue)
+  return 0
+}
+
+function extractStringArrayAttr(attrs: readonly OtlpKeyValue[], key: string): string[] {
+  const kv = attrs.find((a) => a.key === key)
+  if (!kv?.value?.arrayValue?.values) return []
+  return kv.value.arrayValue.values.filter((v) => v.stringValue !== undefined).map((v) => v.stringValue as string)
+}
+
+function resolveAnyValue(
+  value: OtlpAnyValue | undefined,
+): { type: "string" | "int" | "float" | "bool"; value: string | number | boolean } | null {
+  if (!value) return null
+  if (value.stringValue !== undefined) return { type: "string", value: value.stringValue }
+  if (value.boolValue !== undefined) return { type: "bool", value: value.boolValue }
+  if (value.intValue !== undefined) return { type: "int", value: Number(value.intValue) }
+  if (value.doubleValue !== undefined) return { type: "float", value: value.doubleValue }
+  return null
+}
+
+function extractResourceString(resource: OtlpResource | undefined): Record<string, string> {
+  if (!resource?.attributes) return {}
+  const result: Record<string, string> = {}
+  for (const attr of resource.attributes) {
+    if (attr.value?.stringValue !== undefined) {
+      result[attr.key] = attr.value.stringValue
+    }
+  }
+  return result
+}
+
+interface TransformContext {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly apiKeyId: string
+}
+
+function transformSpan({
+  span,
+  resource,
+  scopeName,
+  scopeVersion,
+  context,
+  ingestedAt,
+}: {
+  span: OtlpSpan
+  resource: OtlpResource | undefined
+  scopeName: string
+  scopeVersion: string
+  context: TransformContext
+  ingestedAt: Date
+}): SpanDetail {
+  const spanAttrs = span.attributes ?? []
+  const resourceAttrs = resource?.attributes ?? []
+
+  const statusCode = INT_TO_STATUS_CODE[span.status?.code ?? 0] ?? "unset"
+
+  // Extract well-known semantic convention attributes
+  const operation = extractStringAttr(spanAttrs, "gen_ai.operation.name")
+  const provider = extractStringAttr(spanAttrs, "gen_ai.system")
+  const model = extractStringAttr(spanAttrs, "gen_ai.request.model")
+  const responseModel = extractStringAttr(spanAttrs, "gen_ai.response.model")
+  const tokensInput = extractIntAttr(spanAttrs, "gen_ai.usage.input_tokens")
+  const tokensOutput = extractIntAttr(spanAttrs, "gen_ai.usage.output_tokens")
+  const tokensCacheRead = extractIntAttr(spanAttrs, "gen_ai.usage.cache_read_input_tokens")
+  const tokensReasoning = extractIntAttr(spanAttrs, "gen_ai.usage.reasoning_tokens")
+  const responseId = extractStringAttr(spanAttrs, "gen_ai.response.id")
+  const finishReasons = extractStringArrayAttr(spanAttrs, "gen_ai.response.finish_reasons")
+  const sessionId = extractStringAttr(spanAttrs, "gen_ai.conversation.id")
+  const errorType = statusCode === "error" ? extractStringAttr(spanAttrs, "error.type") : ""
+
+  const serviceName = extractStringAttr(resourceAttrs, "service.name")
+
+  // Split remaining attributes by value type
+  const attrString: Record<string, string> = {}
+  const attrInt: Record<string, number> = {}
+  const attrFloat: Record<string, number> = {}
+  const attrBool: Record<string, boolean> = {}
+
+  for (const attr of spanAttrs) {
+    if (EXTRACTED_ATTRIBUTES.has(attr.key)) continue
+    const resolved = resolveAnyValue(attr.value)
+    if (!resolved) continue
+    switch (resolved.type) {
+      case "string":
+        attrString[attr.key] = resolved.value as string
+        break
+      case "int":
+        attrInt[attr.key] = resolved.value as number
+        break
+      case "float":
+        attrFloat[attr.key] = resolved.value as number
+        break
+      case "bool":
+        attrBool[attr.key] = resolved.value as boolean
+        break
+    }
+  }
+
+  return {
+    organizationId: OrganizationId(context.organizationId),
+    projectId: ProjectId(context.projectId),
+    sessionId: SessionId(sessionId),
+    traceId: TraceId(span.traceId),
+    spanId: SpanId(span.spanId),
+    parentSpanId: span.parentSpanId ?? "",
+    apiKeyId: context.apiKeyId,
+    startTime: nanosToDate(span.startTimeUnixNano),
+    endTime: nanosToDate(span.endTimeUnixNano),
+    name: span.name,
+    serviceName,
+    kind: INT_TO_SPAN_KIND[span.kind ?? 0] ?? "unspecified",
+    statusCode,
+    statusMessage: span.status?.message ?? "",
+    traceFlags: span.flags ?? 0,
+    traceState: span.traceState ?? "",
+    errorType,
+    tags: [],
+    eventsJson: span.events?.length ? JSON.stringify(span.events) : "",
+    linksJson: span.links?.length ? JSON.stringify(span.links) : "",
+    operation,
+    provider,
+    model,
+    responseModel,
+    tokensInput,
+    tokensOutput,
+    tokensCacheRead,
+    tokensCacheCreate: 0,
+    tokensReasoning,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    costIsEstimated: false,
+    responseId,
+    finishReasons,
+    attrString,
+    attrInt,
+    attrFloat,
+    attrBool,
+    resourceString: extractResourceString(resource),
+    scopeName,
+    scopeVersion,
+    inputMessages: [],
+    outputMessages: [],
+    systemInstructions: "",
+    toolDefinitions: "",
+    ingestedAt,
+  }
+}
+
+export function transformOtlpToSpans(request: OtlpExportTraceServiceRequest, context: TransformContext): SpanDetail[] {
+  const spans: SpanDetail[] = []
+  const ingestedAt = new Date()
+
+  for (const resourceSpans of request.resourceSpans ?? []) {
+    const resource = resourceSpans.resource
+    for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
+      const scopeName = scopeSpans.scope?.name ?? ""
+      const scopeVersion = scopeSpans.scope?.version ?? ""
+      for (const span of scopeSpans.spans ?? []) {
+        spans.push(transformSpan({ span, resource, scopeName, scopeVersion, context, ingestedAt }))
+      }
+    }
+  }
+
+  return spans
+}

--- a/apps/ingest/src/otlp/types.ts
+++ b/apps/ingest/src/otlp/types.ts
@@ -1,0 +1,98 @@
+/**
+ * OTLP/JSON type definitions matching the OpenTelemetry proto spec.
+ * These represent the normalized shape after JSON parsing or protobuf decoding.
+ *
+ * Field names follow the OTLP/JSON camelCase convention.
+ * Numeric strings (timestamps, int64 values) are strings to preserve precision.
+ */
+
+export interface OtlpExportTraceServiceRequest {
+  readonly resourceSpans?: readonly OtlpResourceSpans[]
+}
+
+export interface OtlpResourceSpans {
+  readonly resource?: OtlpResource
+  readonly scopeSpans?: readonly OtlpScopeSpans[]
+  readonly schemaUrl?: string
+}
+
+export interface OtlpResource {
+  readonly attributes?: readonly OtlpKeyValue[]
+  readonly droppedAttributesCount?: number
+}
+
+interface OtlpScopeSpans {
+  readonly scope?: OtlpInstrumentationScope
+  readonly spans?: readonly OtlpSpan[]
+  readonly schemaUrl?: string
+}
+
+interface OtlpInstrumentationScope {
+  readonly name?: string
+  readonly version?: string
+  readonly attributes?: readonly OtlpKeyValue[]
+  readonly droppedAttributesCount?: number
+}
+
+export interface OtlpSpan {
+  readonly traceId: string
+  readonly spanId: string
+  readonly traceState?: string
+  readonly parentSpanId?: string
+  readonly name: string
+  readonly kind?: number
+  readonly startTimeUnixNano: string
+  readonly endTimeUnixNano: string
+  readonly attributes?: readonly OtlpKeyValue[]
+  readonly droppedAttributesCount?: number
+  readonly events?: readonly OtlpEvent[]
+  readonly droppedEventsCount?: number
+  readonly links?: readonly OtlpLink[]
+  readonly droppedLinksCount?: number
+  readonly status?: OtlpStatus
+  readonly flags?: number
+}
+
+export interface OtlpStatus {
+  readonly message?: string
+  readonly code?: number
+}
+
+export interface OtlpEvent {
+  readonly timeUnixNano?: string
+  readonly name?: string
+  readonly attributes?: readonly OtlpKeyValue[]
+  readonly droppedAttributesCount?: number
+}
+
+export interface OtlpLink {
+  readonly traceId?: string
+  readonly spanId?: string
+  readonly traceState?: string
+  readonly attributes?: readonly OtlpKeyValue[]
+  readonly droppedAttributesCount?: number
+  readonly flags?: number
+}
+
+export interface OtlpKeyValue {
+  readonly key: string
+  readonly value?: OtlpAnyValue
+}
+
+export interface OtlpAnyValue {
+  readonly stringValue?: string
+  readonly boolValue?: boolean
+  readonly intValue?: string
+  readonly doubleValue?: number
+  readonly arrayValue?: OtlpArrayValue
+  readonly kvlistValue?: OtlpKeyValueList
+  readonly bytesValue?: string
+}
+
+export interface OtlpArrayValue {
+  readonly values?: readonly OtlpAnyValue[]
+}
+
+export interface OtlpKeyValueList {
+  readonly values?: readonly OtlpKeyValue[]
+}

--- a/apps/ingest/src/routes/health.ts
+++ b/apps/ingest/src/routes/health.ts
@@ -3,7 +3,8 @@ import { healthcheckPostgres } from "@platform/db-postgres"
 import type { Effect as EffectType } from "effect"
 import { Effect } from "effect"
 import type { Hono } from "hono"
-import { getClickhouseClient, getPostgresPool } from "../clients.ts"
+import { getClickhouseClient, getPostgresClient } from "../clients.ts"
+import type { IngestEnv } from "../types.ts"
 
 type HealthcheckFailure = {
   readonly ok: false
@@ -20,14 +21,14 @@ const withFailure = <TSuccess extends { readonly ok: boolean }>(
 }
 
 interface HealthRouteContext {
-  app: Hono
+  app: Hono<IngestEnv>
 }
 
 export const registerHealthRoute = (context: HealthRouteContext) => {
   context.app.get("/health", async (c) => {
     const health = await Effect.runPromise(
       Effect.all({
-        postgres: withFailure(healthcheckPostgres(getPostgresPool())),
+        postgres: withFailure(healthcheckPostgres(getPostgresClient().pool)),
         clickhouse: withFailure(healthcheckClickhouse(getClickhouseClient())),
       }),
     )

--- a/apps/ingest/src/routes/index.ts
+++ b/apps/ingest/src/routes/index.ts
@@ -1,11 +1,13 @@
 import type { Hono } from "hono"
+import type { IngestEnv } from "../types.ts"
 import { registerHealthRoute } from "./health.ts"
+import { registerTracesRoute } from "./traces.ts"
 
 interface RoutesContext {
-  app: Hono
+  app: Hono<IngestEnv>
 }
 
 export const registerRoutes = (context: RoutesContext) => {
   registerHealthRoute(context)
-  // Additional routes can be registered here
+  registerTracesRoute(context)
 }

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -1,0 +1,45 @@
+import { createSpanClickhouseRepository } from "@platform/db-clickhouse"
+import { Effect } from "effect"
+import type { Hono } from "hono"
+import { getClickhouseClient } from "../clients.ts"
+import { authMiddleware } from "../middleware/auth.ts"
+import { projectMiddleware } from "../middleware/project.ts"
+import { decodeOtlpProtobuf } from "../otlp/proto.ts"
+import { transformOtlpToSpans } from "../otlp/transform.ts"
+import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
+import type { IngestEnv } from "../types.ts"
+
+interface TracesRouteContext {
+  app: Hono<IngestEnv>
+}
+
+export const registerTracesRoute = ({ app }: TracesRouteContext) => {
+  app.post("/v1/traces", authMiddleware, projectMiddleware, async (c) => {
+    const contentType = c.req.header("Content-Type") ?? "application/json"
+
+    let request: OtlpExportTraceServiceRequest
+    try {
+      if (contentType.includes("application/x-protobuf")) {
+        const body = await c.req.arrayBuffer()
+        request = decodeOtlpProtobuf(new Uint8Array(body))
+      } else {
+        request = (await c.req.json()) as OtlpExportTraceServiceRequest
+      }
+    } catch {
+      return c.json({ error: "Invalid OTLP payload" }, 400)
+    }
+
+    const spans = transformOtlpToSpans(request, {
+      organizationId: c.get("organizationId"),
+      projectId: c.get("projectId"),
+      apiKeyId: c.get("apiKeyId"),
+    })
+
+    if (spans.length > 0) {
+      const spanRepository = createSpanClickhouseRepository(getClickhouseClient())
+      await Effect.runPromise(spanRepository.insert(spans))
+    }
+
+    return c.json({})
+  })
+}

--- a/apps/ingest/src/server.ts
+++ b/apps/ingest/src/server.ts
@@ -3,10 +3,12 @@ import { fileURLToPath } from "node:url"
 import { serve } from "@hono/node-server"
 import { parseEnv } from "@platform/env"
 import { createLogger } from "@repo/observability"
+import { isHttpError, toHttpResponse } from "@repo/utils"
 import { config as loadDotenv } from "dotenv"
 import { Effect } from "effect"
 import { Hono } from "hono"
 import { registerRoutes } from "./routes/index.ts"
+import type { IngestEnv } from "./types.ts"
 
 const nodeEnv = process.env.NODE_ENV || "development"
 const envFilePath = fileURLToPath(new URL(`../../../.env.${nodeEnv}`, import.meta.url))
@@ -15,10 +17,20 @@ if (existsSync(envFilePath)) {
   loadDotenv({ path: envFilePath, quiet: true })
 }
 
-const app = new Hono()
+const app = new Hono<IngestEnv>()
 const port = Effect.runSync(parseEnv("LAT_INGEST_PORT", "number", 3002))
 
 const logger = createLogger("ingest")
+
+app.onError((err, c) => {
+  if (isHttpError(err)) {
+    const { status, body } = toHttpResponse(err)
+    return c.json(body, status as 400 | 401 | 403 | 404 | 500)
+  }
+
+  logger.error(err)
+  return c.json({ error: "Internal server error" }, 500)
+})
 
 registerRoutes({ app })
 

--- a/apps/ingest/src/types.ts
+++ b/apps/ingest/src/types.ts
@@ -1,0 +1,7 @@
+export interface IngestEnv {
+  Variables: {
+    organizationId: string
+    apiKeyId: string
+    projectId: string
+  }
+}

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -190,8 +190,8 @@ const toInsertRow = (span: SpanDetail) => ({
   span_id: span.spanId as string,
   parent_span_id: span.parentSpanId,
   api_key_id: span.apiKeyId,
-  start_time: span.startTime.toISOString(),
-  end_time: span.endTime.toISOString(),
+  start_time: toClickhouseDateTime(span.startTime),
+  end_time: toClickhouseDateTime(span.endTime),
   name: span.name,
   service_name: span.serviceName,
   kind: SPAN_KIND_TO_INT[span.kind],
@@ -229,7 +229,7 @@ const toInsertRow = (span: SpanDetail) => ({
   output_messages: JSON.stringify(span.outputMessages),
   system_instructions: span.systemInstructions,
   tool_definitions: span.toolDefinitions,
-  ingested_at: span.ingestedAt.toISOString(),
+  ingested_at: toClickhouseDateTime(span.ingestedAt),
 })
 
 export const createSpanClickhouseRepository = (client: ClickHouseClient): SpanRepository => ({

--- a/packages/platform/testkit/README.md
+++ b/packages/platform/testkit/README.md
@@ -153,7 +153,7 @@ Generates headers for API key authentication.
 
 ```typescript
 const headers = createApiKeyAuthHeaders(apiKey.token);
-// { "X-API-Key": "abc-123-xyz" }
+// { "Authorization": "Bearer abc-123-xyz" }
 ```
 
 #### `createBearerAuthHeaders(token)`

--- a/packages/platform/testkit/src/auth/auth-helpers.ts
+++ b/packages/platform/testkit/src/auth/auth-helpers.ts
@@ -15,7 +15,7 @@ export interface TestAuthContext {
  */
 export const createApiKeyAuthHeaders = (apiKeyToken: string): Record<string, string> => {
   return {
-    "X-API-Key": apiKeyToken,
+    Authorization: `Bearer ${apiKeyToken}`,
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     pg:
       specifier: 8.16.0
       version: 8.16.0
+    protobufjs:
+      specifier: 7.5.4
+      version: 7.5.4
     react:
       specifier: 19.2.4
       version: 19.2.4
@@ -143,9 +146,6 @@ importers:
       '@hono/zod-openapi':
         specifier: ^1.0.0
         version: 1.2.2(hono@4.9.12)(zod@4.3.6)
-      '@platform/auth-better':
-        specifier: workspace:*
-        version: link:../../packages/platform/auth-better
       '@platform/cache-redis':
         specifier: workspace:*
         version: link:../../packages/platform/cache-redis
@@ -204,9 +204,18 @@ importers:
       '@clickhouse/client':
         specifier: 'catalog:'
         version: 1.17.0
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../../packages/domain/shared
+      '@domain/spans':
+        specifier: workspace:*
+        version: link:../../packages/domain/spans
       '@hono/node-server':
         specifier: 'catalog:'
         version: 1.19.6(hono@4.9.12)
+      '@platform/cache-redis':
+        specifier: workspace:*
+        version: link:../../packages/platform/cache-redis
       '@platform/db-clickhouse':
         specifier: workspace:*
         version: link:../../packages/platform/db-clickhouse
@@ -219,6 +228,9 @@ importers:
       '@repo/observability':
         specifier: workspace:*
         version: link:../../packages/observability
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
       dotenv:
         specifier: 'catalog:'
         version: 17.3.1
@@ -228,6 +240,9 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.9.12
+      protobufjs:
+        specifier: 'catalog:'
+        version: 7.5.4
       tsx:
         specifier: 'catalog:'
         version: 4.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ catalog:
   react: 19.2.4
   react-dom: 19.2.4
   rosetta-ai: 2.0.0
+  protobufjs: 7.5.4
   tsx: 4.21.0
   turbo: 2.5.8
   typescript: 5.8.3


### PR DESCRIPTION
## Summary

Adds a `POST /v1/traces` endpoint to the ingestion server that accepts OTLP/JSON and OTLP/Protobuf payloads, authenticates via `Authorization: Bearer <api-key>`, resolves the target project from an `X-Latitude-Project` header, and inserts the resulting spans into ClickHouse.

The endpoint extracts GenAI semantic convention attributes (`gen_ai.system`, `gen_ai.request.model`, token usage, etc.) into dedicated span fields during ingestion. Traces are derived automatically via the existing ClickHouse materialized view — no separate trace write path is needed.

> [!NOTE]
> It is only extracting actual OTEL GenAI attributes. There is no "processing" of alternative standards yet. If the OTEL GenAI attribute is not there exactly as we expect, it is not extracted.
> Custom standard processing will be added to a future PR

Also changed api and ingest server auth to an Authorization header, instead of JWT.