### PR TITLE
Implement GitHub OAuth login flow in web auth pages

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -97,13 +97,9 @@ function LoginPage() {
     }
   }
 
-  const handleGoogleClick = () => {
-    void submitSocialSignIn("google")
-  }
+  const handleGoogleClick = () => submitSocialSignIn("google")
 
-  const handleGitHubClick = () => {
-    void submitSocialSignIn("github")
-  }
+  const handleGitHubClick = () => submitSocialSignIn("github")
 
   if (isSent) {
     return (
@@ -193,7 +189,6 @@ function LoginPage() {
           {/* OAuth buttons */}
           <div className="flex flex-col gap-2">
             <Button
-              type="button"
               variant="ghost"
               onClick={handleGoogleClick}
               disabled={isLoading}
@@ -204,7 +199,6 @@ function LoginPage() {
             </Button>
 
             <Button
-              type="button"
               size="lg"
               variant="ghost"
               onClick={handleGitHubClick}

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -128,13 +128,9 @@ function SignupPage() {
     }
   }
 
-  const handleGoogleClick = () => {
-    void submitSocialSignIn("google")
-  }
+  const handleGoogleClick = () => submitSocialSignIn("google")
 
-  const handleGitHubClick = () => {
-    void submitSocialSignIn("github")
-  }
+  const handleGitHubClick = () => submitSocialSignIn("github")
 
   if (isSent) {
     return (
@@ -256,7 +252,6 @@ function SignupPage() {
           {/* OAuth buttons */}
           <div className="flex flex-col gap-2">
             <Button
-              type="button"
               variant="ghost"
               onClick={handleGoogleClick}
               disabled={isLoading}
@@ -267,7 +262,6 @@ function SignupPage() {
             </Button>
 
             <Button
-              type="button"
               variant="ghost"
               onClick={handleGitHubClick}
               disabled={isLoading}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switched login and signup social auth from manual form POST submission to `authClient.signIn.social`, including GitHub provider support
- preserved CLI OAuth callback context by redirecting social login to `/auth/cli?session=...` when `cliSession` is present
- removed redundant `void` wrappers in social click handlers and removed explicit OAuth button `type="button"` props in login/signup routes

## Testing
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/web check`
- manual UI walkthrough on `/login` and `/signup` (GitHub OAuth button visible and wired; current env reports `Provider not found` because provider credentials are not configured)

## Notes
- to complete real GitHub OAuth redirects locally, set `LAT_GITHUB_CLIENT_ID` and `LAT_GITHUB_CLIENT_SECRET` in `.env.development`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-468c24f3-1554-4d60-999a-82a4dec397ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-468c24f3-1554-4d60-999a-82a4dec397ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

