### PR TITLE
Replace paginated traces table with infinite-scroll smart table

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -2,14 +2,7 @@ import { queryCollectionOptions } from "@tanstack/query-db-collection"
 import { createCollection, useLiveQuery } from "@tanstack/react-db"
 import { useQuery } from "@tanstack/react-query"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
-import {
-  getSpanDetail,
-  listSpansByTrace,
-  listTracesByProject,
-  type SpanDetailRecord,
-  type SpanRecord,
-  type TraceRecord,
-} from "./spans.functions.ts"
+import { getSpanDetail, listSpansByTrace, type SpanDetailRecord, type SpanRecord } from "./spans.functions.ts"
 
 const queryClient = getQueryClient()
 
@@ -43,29 +36,4 @@ export const useSpanDetail = ({ traceId, spanId }: { traceId: string; spanId: st
     queryKey: ["spanDetail", traceId, spanId],
     queryFn: () => getSpanDetail({ data: { traceId, spanId } }),
   })
-}
-
-const makeTracesCollection = (projectId: string) =>
-  createCollection(
-    queryCollectionOptions({
-      queryClient,
-      queryKey: ["traces", projectId],
-      queryFn: () => listTracesByProject({ data: { projectId } }),
-      getKey: (item: TraceRecord): string => item.traceId,
-    }),
-  )
-
-type TracesCollection = ReturnType<typeof makeTracesCollection>
-const projectCollectionsCache: Record<string, TracesCollection> = {}
-
-const getTracesCollection = (projectId: string): TracesCollection => {
-  if (!projectCollectionsCache[projectId]) {
-    projectCollectionsCache[projectId] = makeTracesCollection(projectId)
-  }
-  return projectCollectionsCache[projectId]
-}
-
-export const useTracesCollection = (projectId: string) => {
-  const collection = getTracesCollection(projectId)
-  return useLiveQuery((q) => q.from({ trace: collection }))
 }

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -1,7 +1,7 @@
-import { NotFoundError, OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
-import type { Span, SpanDetail, Trace } from "@domain/spans"
-import { SpanRepository, TraceRepository } from "@domain/spans"
-import { SpanRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { NotFoundError, OrganizationId, SpanId, TraceId } from "@domain/shared"
+import type { Span, SpanDetail } from "@domain/spans"
+import { SpanRepository } from "@domain/spans"
+import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -157,84 +157,4 @@ export const getSpanDetail = createServerFn({ method: "GET" })
       throw new NotFoundError({ entity: "Span", id: data.spanId })
     }
     return serializeSpanDetail(span)
-  })
-
-export interface TraceRecord {
-  readonly organizationId: string
-  readonly projectId: string
-  readonly traceId: string
-  readonly spanCount: number
-  readonly errorCount: number
-  readonly startTime: string
-  readonly endTime: string
-  readonly durationNs: number
-  readonly status: string
-  readonly tokensInput: number
-  readonly tokensOutput: number
-  readonly tokensCacheRead: number
-  readonly tokensCacheCreate: number
-  readonly tokensReasoning: number
-  readonly tokensTotal: number
-  readonly costInputMicrocents: number
-  readonly costOutputMicrocents: number
-  readonly costTotalMicrocents: number
-  readonly sessionId: string
-  readonly userId: string
-  readonly tags: readonly string[]
-  readonly metadata: Readonly<Record<string, string>>
-  readonly models: readonly string[]
-  readonly providers: readonly string[]
-  readonly serviceNames: readonly string[]
-  readonly rootSpanId: string
-  readonly rootSpanName: string
-}
-
-const serializeTrace = (trace: Trace): TraceRecord => ({
-  organizationId: trace.organizationId,
-  projectId: trace.projectId,
-  traceId: trace.traceId,
-  spanCount: trace.spanCount,
-  errorCount: trace.errorCount,
-  startTime: trace.startTime.toISOString(),
-  endTime: trace.endTime.toISOString(),
-  durationNs: trace.durationNs,
-  status: trace.status,
-  tokensInput: trace.tokensInput,
-  tokensOutput: trace.tokensOutput,
-  tokensCacheRead: trace.tokensCacheRead,
-  tokensCacheCreate: trace.tokensCacheCreate,
-  tokensReasoning: trace.tokensReasoning,
-  tokensTotal: trace.tokensTotal,
-  costInputMicrocents: trace.costInputMicrocents,
-  costOutputMicrocents: trace.costOutputMicrocents,
-  costTotalMicrocents: trace.costTotalMicrocents,
-  sessionId: trace.sessionId,
-  userId: trace.userId,
-  tags: trace.tags,
-  metadata: trace.metadata,
-  models: trace.models,
-  providers: trace.providers,
-  serviceNames: trace.serviceNames,
-  rootSpanId: trace.rootSpanId,
-  rootSpanName: trace.rootSpanName,
-})
-
-export const listTracesByProject = createServerFn({ method: "GET" })
-  .middleware([errorHandler])
-  .inputValidator(z.object({ projectId: z.string() }))
-  .handler(async ({ data }): Promise<TraceRecord[]> => {
-    const { organizationId } = await requireSession()
-    const orgId = OrganizationId(organizationId)
-    const traces = await Effect.runPromise(
-      Effect.gen(function* () {
-        const repo = yield* TraceRepository
-        return yield* repo.findByProjectId({
-          organizationId: orgId,
-          projectId: ProjectId(data.projectId),
-          options: { limit: 200 },
-        })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
-    )
-
-    return traces.map(serializeTrace)
   })

--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -1,0 +1,62 @@
+import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
+import { countTracesByProject, listTracesByProject, type TraceRecord } from "./traces.functions.ts"
+
+const BATCH_SIZE = 50
+
+export function useTracesInfiniteScroll({
+  projectId,
+  sorting,
+}: {
+  readonly projectId: string
+  readonly sorting: InfiniteTableSorting
+}) {
+  const {
+    data: paginatedData,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ["traces", projectId, sorting],
+    queryFn: ({ pageParam }) =>
+      listTracesByProject({
+        data: {
+          projectId,
+          limit: BATCH_SIZE,
+          cursor: pageParam,
+          sortBy: sorting.column,
+          sortDirection: sorting.direction,
+        },
+      }),
+    initialPageParam: undefined as { sortValue: string; traceId: string } | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  })
+
+  const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
+    () => ({
+      hasMore: hasNextPage,
+      isLoadingMore: isFetchingNextPage,
+      onLoadMore: fetchNextPage,
+    }),
+    [hasNextPage, isFetchingNextPage, fetchNextPage],
+  )
+
+  const data: readonly TraceRecord[] = useMemo(
+    () => paginatedData?.pages.flatMap((p) => p.traces) ?? [],
+    [paginatedData],
+  )
+
+  return { data, isLoading, infiniteScroll }
+}
+
+export function useTracesCount({ projectId }: { readonly projectId: string }) {
+  const { data: totalCount = 0, isLoading } = useQuery({
+    queryKey: ["traces-count", projectId],
+    queryFn: () => countTracesByProject({ data: { projectId } }),
+    staleTime: 30_000,
+  })
+
+  return { totalCount, isLoading }
+}

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -1,0 +1,140 @@
+import { OrganizationId, ProjectId } from "@domain/shared"
+import type { Trace } from "@domain/spans"
+import { TraceRepository } from "@domain/spans"
+import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { requireSession } from "../../server/auth.ts"
+import { getClickhouseClient } from "../../server/clients.ts"
+import { errorHandler } from "../../server/middlewares.ts"
+
+export interface TraceRecord {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly traceId: string
+  readonly spanCount: number
+  readonly errorCount: number
+  readonly startTime: string
+  readonly endTime: string
+  readonly durationNs: number
+  readonly status: string
+  readonly tokensInput: number
+  readonly tokensOutput: number
+  readonly tokensCacheRead: number
+  readonly tokensCacheCreate: number
+  readonly tokensReasoning: number
+  readonly tokensTotal: number
+  readonly costInputMicrocents: number
+  readonly costOutputMicrocents: number
+  readonly costTotalMicrocents: number
+  readonly sessionId: string
+  readonly userId: string
+  readonly tags: readonly string[]
+  readonly metadata: Readonly<Record<string, string>>
+  readonly models: readonly string[]
+  readonly providers: readonly string[]
+  readonly serviceNames: readonly string[]
+  readonly rootSpanId: string
+  readonly rootSpanName: string
+}
+
+const serializeTrace = (trace: Trace): TraceRecord => ({
+  organizationId: trace.organizationId,
+  projectId: trace.projectId,
+  traceId: trace.traceId,
+  spanCount: trace.spanCount,
+  errorCount: trace.errorCount,
+  startTime: trace.startTime.toISOString(),
+  endTime: trace.endTime.toISOString(),
+  durationNs: trace.durationNs,
+  status: trace.status,
+  tokensInput: trace.tokensInput,
+  tokensOutput: trace.tokensOutput,
+  tokensCacheRead: trace.tokensCacheRead,
+  tokensCacheCreate: trace.tokensCacheCreate,
+  tokensReasoning: trace.tokensReasoning,
+  tokensTotal: trace.tokensTotal,
+  costInputMicrocents: trace.costInputMicrocents,
+  costOutputMicrocents: trace.costOutputMicrocents,
+  costTotalMicrocents: trace.costTotalMicrocents,
+  sessionId: trace.sessionId,
+  userId: trace.userId,
+  tags: trace.tags,
+  metadata: trace.metadata,
+  models: trace.models,
+  providers: trace.providers,
+  serviceNames: trace.serviceNames,
+  rootSpanId: trace.rootSpanId,
+  rootSpanName: trace.rootSpanName,
+})
+
+const traceListCursorSchema = z.object({
+  sortValue: z.string(),
+  traceId: z.string(),
+})
+
+interface TraceListResult {
+  readonly traces: readonly TraceRecord[]
+  readonly hasMore: boolean
+  readonly nextCursor?: { readonly sortValue: string; readonly traceId: string }
+}
+
+export const listTracesByProject = createServerFn({ method: "GET" })
+  .middleware([errorHandler])
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      limit: z.number().optional(),
+      cursor: traceListCursorSchema.optional(),
+      sortBy: z.string().optional(),
+      sortDirection: z.enum(["asc", "desc"]).optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<TraceListResult> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    const page = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        return yield* repo.findByProjectId({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          options: {
+            limit: data.limit ?? 25,
+            ...(data.cursor ? { cursor: data.cursor } : {}),
+            ...(data.sortBy ? { sortBy: data.sortBy } : {}),
+            ...(data.sortDirection ? { sortDirection: data.sortDirection } : {}),
+          },
+        })
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+    )
+
+    if (!page.nextCursor) {
+      return { traces: page.items.map(serializeTrace), hasMore: page.hasMore }
+    }
+    return {
+      traces: page.items.map(serializeTrace),
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
+    }
+  })
+
+export const countTracesByProject = createServerFn({ method: "GET" })
+  .middleware([errorHandler])
+  .inputValidator(z.object({ projectId: z.string() }))
+  .handler(async ({ data }): Promise<number> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        return yield* repo.countByProjectId({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+        })
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+    )
+  })

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -1,23 +1,18 @@
 import {
   Button,
-  Checkbox,
-  Container,
-  Table,
-  TableBlankSlate,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-  TableSkeleton,
-  TableWithHeader,
+  InfiniteTable,
+  type InfiniteTableColumn,
+  type InfiniteTableSorting,
+  Input,
   Text,
+  Tooltip,
 } from "@repo/ui"
-import { formatCount, formatDuration, formatPrice } from "@repo/utils"
-import { createFileRoute, Link } from "@tanstack/react-router"
-import { Database } from "lucide-react"
-import { useMemo, useState } from "react"
-import { useTracesCollection } from "../../../../domains/spans/spans.collection.ts"
+import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { AppWindowIcon, CalendarIcon, ChevronDown, Columns2Icon, DatabaseIcon, FilterIcon } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
+import { useTracesCount, useTracesInfiniteScroll } from "../../../../domains/traces/traces.collection.ts"
+import type { TraceRecord } from "../../../../domains/traces/traces.functions.ts"
 import { useSelectableRows } from "../../../../lib/hooks/useSelectableRows.ts"
 import { AddToDatasetModal } from "./datasets/-components/add-to-dataset-modal.tsx"
 
@@ -30,103 +25,175 @@ function StatusBadge({ status }: { status: string }) {
   return <Text.H5 color={color}>{status.toUpperCase()}</Text.H5>
 }
 
+function TagBadge({ tag }: { tag: string }) {
+  return (
+    <span className="inline-flex shrink-0 items-center rounded-md bg-muted px-1.5 py-0.5 text-xs leading-4 font-medium text-muted-foreground">
+      {tag}
+    </span>
+  )
+}
+
+function TagList({ tags }: { tags: readonly string[] }) {
+  if (tags.length === 0) return <Text.H5 color="foregroundMuted">-</Text.H5>
+  return (
+    <div className="flex items-center justify-end gap-1 overflow-x-auto max-w-full">
+      {tags.map((tag) => (
+        <TagBadge key={tag} tag={tag} />
+      ))}
+    </div>
+  )
+}
+
+const DEFAULT_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
+
+const columns: InfiniteTableColumn<TraceRecord>[] = [
+  {
+    key: "startTime",
+    header: "Start Time",
+    sortKey: "startTime",
+    render: (t) => (
+      <Tooltip trigger={relativeTime(new Date(t.startTime))}>{new Date(t.startTime).toLocaleString()}</Tooltip>
+    ),
+  },
+  {
+    key: "name",
+    header: "Name",
+    render: (t) => t.rootSpanName || t.traceId.slice(0, 8),
+  },
+  {
+    key: "tags",
+    header: "Tags",
+    render: (t) => <TagList tags={t.tags} />,
+  },
+  {
+    key: "duration",
+    header: "Duration",
+    sortKey: "duration",
+    render: (t) => formatDuration(t.durationNs),
+  },
+  {
+    key: "cost",
+    header: "Cost",
+    sortKey: "cost",
+    render: (t) => formatPrice(t.costTotalMicrocents / 100_000_000),
+  },
+  {
+    key: "sessionId",
+    header: "Session ID",
+    render: (t) => t.sessionId,
+  },
+  {
+    key: "userId",
+    header: "User ID",
+    render: (t) => t.userId,
+  },
+  {
+    key: "status",
+    header: "Status",
+    render: (t) => <StatusBadge status={t.status} />,
+  },
+  {
+    key: "models",
+    header: "Models",
+    render: (t) => t.models.join(", "),
+  },
+  {
+    key: "spans",
+    header: "Spans",
+    sortKey: "spans",
+    render: (t) => (
+      <>
+        {formatCount(t.spanCount)}
+        {t.errorCount > 0 && <span className="text-destructive"> ({t.errorCount} err)</span>}
+      </>
+    ),
+  },
+]
+
 function TracesPage() {
   const { projectId } = Route.useParams()
-  const { data: rawTraces } = useTracesCollection(projectId)
-  const traces = useMemo(() => rawTraces?.slice().sort((a, b) => b.startTime.localeCompare(a.startTime)), [rawTraces])
+  const navigate = useNavigate()
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
+  const [sorting, setSorting] = useState<InfiniteTableSorting>(DEFAULT_SORTING)
 
-  const traceIds = traces?.map((t) => t.traceId) ?? []
+  const { data: traces, isLoading, infiniteScroll } = useTracesInfiniteScroll({ projectId, sorting })
+  const { totalCount } = useTracesCount({ projectId })
+
+  const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
   const selection = useSelectableRows({
     rowIds: traceIds,
-    totalRowCount: traceIds.length,
+    totalRowCount: totalCount,
   })
 
+  const getRowKey = useCallback((t: TraceRecord) => t.traceId, [])
+  const onRowClick = useCallback(
+    (t: TraceRecord) =>
+      navigate({
+        to: "/projects/$projectId/traces/$traceId/spans",
+        params: { projectId, traceId: t.traceId },
+      }),
+    [navigate, projectId],
+  )
+
   return (
-    <Container className="py-8">
-      <TableWithHeader
-        title="Traces"
-        actions={
-          selection.selectedCount > 0 ? (
-            <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
-              <Database className="h-4 w-4" />
-              <Text.H6>Add to Dataset ({selection.selectedCount})</Text.H6>
+    <div className="flex flex-col h-full gap-3">
+      <div className="flex flex-col p-6 pb-0 gap-3">
+        {/* Action buttons */}
+        <div className="flex flex-row gap-2 items-center justify-between">
+          <div className="flex flex-row gap-2 items-center">
+            <Button variant="outline" size="sm" flat disabled>
+              <AppWindowIcon className="h-4 w-4" />
+              <Text.H6>All logs</Text.H6>
+              <ChevronDown className="h-4 w-4" />
             </Button>
-          ) : undefined
-        }
-        table={
-          !traces ? (
-            <TableSkeleton cols={9} rows={5} />
-          ) : traces.length === 0 ? (
-            <TableBlankSlate description="No traces found for this project." />
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-10">
-                    <Checkbox checked={selection.headerState} onCheckedChange={() => selection.toggleAll()} />
-                  </TableHead>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Spans</TableHead>
-                  <TableHead>Models</TableHead>
-                  <TableHead>Tokens (in/out)</TableHead>
-                  <TableHead>Cost</TableHead>
-                  <TableHead>Duration</TableHead>
-                  <TableHead>Start Time</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {traces.map((trace) => (
-                  <TableRow key={trace.traceId}>
-                    <TableCell>
-                      <Checkbox
-                        checked={selection.isSelected(trace.traceId)}
-                        onCheckedChange={(checked) => selection.toggleRow(trace.traceId, checked)}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Link
-                        to="/projects/$projectId/traces/$traceId/spans"
-                        params={{ projectId, traceId: trace.traceId }}
-                        className="underline"
-                      >
-                        <Text.H5>{trace.rootSpanName || trace.traceId.slice(0, 8)}</Text.H5>
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={trace.status} />
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>
-                        {formatCount(trace.spanCount)}
-                        {trace.errorCount > 0 && <Text.H6 color="destructive"> ({trace.errorCount} err)</Text.H6>}
-                      </Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{trace.models.join(", ") || "—"}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>
-                        {formatCount(trace.tokensInput)} / {formatCount(trace.tokensOutput)}
-                      </Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{formatPrice(trace.costTotalMicrocents / 100_000_000)}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{formatDuration(trace.durationNs)}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5 color="foregroundMuted">{new Date(trace.startTime).toLocaleString()}</Text.H5>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )
-        }
-      />
+            <Button variant="outline" size="sm" flat disabled>
+              <CalendarIcon className="h-4 w-4" />
+              <Text.H6>Last 7 days</Text.H6>
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+            <Button variant="outline" size="sm" flat disabled>
+              <Columns2Icon className="h-4 w-4" />
+              <Text.H6>Columns</Text.H6>
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+            <Button variant="ghost" size="sm" flat disabled>
+              <FilterIcon className="h-4 w-4" />
+              <Text.H6>Filters</Text.H6>
+            </Button>
+            {selection.selectedCount > 0 && (
+              <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                <DatabaseIcon className="h-4 w-4" />
+                <Text.H6>Add to Dataset ({selection.selectedCount})</Text.H6>
+              </Button>
+            )}
+          </div>
+
+          <div className="flex flex-row gap-2 items-center">
+            <Input placeholder="Search traces" size="sm" className="w-60" disabled />
+          </div>
+        </div>
+
+        {/* Traces Summary */}
+        <div className="w-full flex flex-col bg-secondary rounded-lg p-4 min-h-[144px] items-center justify-center">
+          <Text.H5 color="foregroundMuted">Coming soon</Text.H5>
+        </div>
+      </div>
+
+      <div className="min-h-0 grow">
+        <InfiniteTable
+          className="p-6 pt-0"
+          data={traces}
+          isLoading={isLoading}
+          columns={columns}
+          getRowKey={getRowKey}
+          onRowClick={onRowClick}
+          selection={selection}
+          infiniteScroll={infiniteScroll}
+          sorting={sorting}
+          defaultSorting={DEFAULT_SORTING}
+          onSortChange={setSorting}
+        />
+      </div>
 
       <AddToDatasetModal
         open={addToDatasetOpen}
@@ -135,6 +202,6 @@ function TracesPage() {
         traceIds={selection.selectedRowIds}
         onSuccess={selection.clearSelections}
       />
-    </Container>
+    </div>
   )
 }

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -6,5 +6,11 @@ export { transformOtlpToSpans } from "./otlp/transform.ts"
 export type { OtlpExportTraceServiceRequest } from "./otlp/types.ts"
 export type { SpanListOptions, SpanRepositoryShape } from "./ports/span-repository.ts"
 export { SpanRepository } from "./ports/span-repository.ts"
-export type { TraceListOptions, TraceRepositoryShape } from "./ports/trace-repository.ts"
+export type {
+  TraceFilterOptions,
+  TraceListCursor,
+  TraceListOptions,
+  TraceListPage,
+  TraceRepositoryShape,
+} from "./ports/trace-repository.ts"
 export { TraceRepository } from "./ports/trace-repository.ts"

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -13,7 +13,13 @@ export interface TraceRepositoryShape {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly options: TraceListOptions
-  }): Effect.Effect<readonly Trace[], RepositoryError>
+  }): Effect.Effect<TraceListPage, RepositoryError>
+
+  countByProjectId(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly options?: TraceFilterOptions
+  }): Effect.Effect<number, RepositoryError>
 
   findByTraceId(input: {
     readonly organizationId: OrganizationId
@@ -28,11 +34,27 @@ export interface TraceRepositoryShape {
   }): Effect.Effect<readonly TraceDetail[], RepositoryError>
 }
 
-export interface TraceListOptions {
+export interface TraceFilterOptions {
   readonly startTimeFrom?: Date
   readonly startTimeTo?: Date
+}
+
+export interface TraceListCursor {
+  readonly sortValue: string
+  readonly traceId: string
+}
+
+export interface TraceListOptions extends TraceFilterOptions {
   readonly limit?: number
-  readonly offset?: number
+  readonly cursor?: TraceListCursor
+  readonly sortBy?: string
+  readonly sortDirection?: "asc" | "desc"
+}
+
+export interface TraceListPage {
+  readonly items: readonly Trace[]
+  readonly hasMore: boolean
+  readonly nextCursor?: TraceListCursor
 }
 
 export class TraceRepository extends ServiceMap.Service<TraceRepository, TraceRepositoryShape>()(

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -10,7 +10,7 @@ import {
   toRepositoryError,
   TraceId as toTraceId,
 } from "@domain/shared"
-import type { Trace, TraceDetail, TraceStatus } from "@domain/spans"
+import type { Trace, TraceDetail, TraceListPage, TraceStatus } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
 import { Effect, Layer } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
@@ -160,14 +160,40 @@ const toDomainTraceDetail = (row: TraceDetailRow): TraceDetail => {
   }
 }
 
+interface SortColumn {
+  readonly expr: string
+  readonly chType: string
+  readonly rowKey: keyof TraceListRow
+}
+
+const SORT_COLUMNS: Record<string, SortColumn> = {
+  startTime: { expr: "start_time", chType: "DateTime64(9, 'UTC')", rowKey: "start_time" },
+  duration: { expr: "duration_ns", chType: "Int64", rowKey: "duration_ns" },
+  cost: { expr: "cost_total_microcents", chType: "UInt64", rowKey: "cost_total_microcents" },
+  spans: { expr: "span_count", chType: "UInt64", rowKey: "span_count" },
+}
+
+const DEFAULT_SORT: SortColumn = SORT_COLUMNS.startTime as SortColumn
+
 export const TraceRepositoryLive = Layer.effect(
   TraceRepository,
   Effect.gen(function* () {
     const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
 
     return {
-      findByProjectId: ({ organizationId, projectId, options }) =>
-        chSqlClient
+      findByProjectId: ({ organizationId, projectId, options }) => {
+        const sort = SORT_COLUMNS[options.sortBy ?? ""] ?? DEFAULT_SORT
+        const orderDir = options.sortDirection === "asc" ? "ASC" : "DESC"
+        const cmp = orderDir === "DESC" ? "<" : ">"
+        const limit = options.limit ?? 50
+
+        const cursorClause = options.cursor
+          ? `HAVING (${sort.expr} ${cmp} {cursorSortValue:${sort.chType}}
+              OR (${sort.expr} = {cursorSortValue:${sort.chType}}
+                  AND trace_id ${cmp} {cursorTraceId:FixedString(32)}))`
+          : ""
+
+        return chSqlClient
           .query(async (client) => {
             const result = await client.query({
               query: `SELECT ${LIST_SELECT}
@@ -177,9 +203,9 @@ export const TraceRepositoryLive = Layer.effect(
                         AND ({hasStartFrom:Bool} = false OR min_start_time >= {startTimeFrom:DateTime64(9, 'UTC')})
                         AND ({hasStartTo:Bool} = false OR min_start_time <= {startTimeTo:DateTime64(9, 'UTC')})
                       GROUP BY organization_id, project_id, trace_id
-                      ORDER BY start_time DESC
-                      LIMIT {limit:UInt32}
-                      OFFSET {offset:UInt32}`,
+                      ${cursorClause}
+                      ORDER BY ${sort.expr} ${orderDir}, trace_id ${orderDir}
+                      LIMIT {limit:UInt32}`,
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
@@ -187,16 +213,64 @@ export const TraceRepositoryLive = Layer.effect(
                 startTimeFrom: toClickhouseDateTime(options.startTimeFrom) ?? "1970-01-01 00:00:00.000000000",
                 hasStartTo: options.startTimeTo !== undefined,
                 startTimeTo: toClickhouseDateTime(options.startTimeTo) ?? "2100-01-01 00:00:00.000000000",
-                limit: options.limit ?? 50,
-                offset: options.offset ?? 0,
+                limit: limit + 1,
+                ...(options.cursor
+                  ? {
+                      cursorSortValue: options.cursor.sortValue,
+                      cursorTraceId: options.cursor.traceId,
+                    }
+                  : {}),
               },
               format: "JSONEachRow",
             })
             return result.json<TraceListRow>()
           })
           .pipe(
-            Effect.map((rows) => rows.map(toBaseFields)),
+            Effect.map((rows): TraceListPage => {
+              const hasMore = rows.length > limit
+              const pageRows = hasMore ? rows.slice(0, limit) : rows
+              const items = pageRows.map(toBaseFields)
+              const last = hasMore ? pageRows[pageRows.length - 1] : undefined
+              if (!last) return { items, hasMore }
+              return {
+                items,
+                hasMore,
+                nextCursor: { sortValue: String(last[sort.rowKey]), traceId: last.trace_id },
+              }
+            }),
             Effect.mapError((error) => toRepositoryError(error, "findByProjectId")),
+          )
+      },
+
+      countByProjectId: ({ organizationId, projectId, options }) =>
+        chSqlClient
+          .query(async (client) => {
+            const result = await client.query({
+              query: `SELECT count() AS total
+                      FROM (
+                        SELECT trace_id
+                        FROM traces
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND ({hasStartFrom:Bool} = false OR min_start_time >= {startTimeFrom:DateTime64(9, 'UTC')})
+                          AND ({hasStartTo:Bool} = false OR min_start_time <= {startTimeTo:DateTime64(9, 'UTC')})
+                        GROUP BY organization_id, project_id, trace_id
+                      )`,
+              query_params: {
+                organizationId: organizationId as string,
+                projectId: projectId as string,
+                hasStartFrom: options?.startTimeFrom !== undefined,
+                startTimeFrom: toClickhouseDateTime(options?.startTimeFrom) ?? "1970-01-01 00:00:00.000000000",
+                hasStartTo: options?.startTimeTo !== undefined,
+                startTimeTo: toClickhouseDateTime(options?.startTimeTo) ?? "2100-01-01 00:00:00.000000000",
+              },
+              format: "JSONEachRow",
+            })
+            return result.json<{ total: string }>()
+          })
+          .pipe(
+            Effect.map((rows) => Number(rows[0]?.total ?? 0)),
+            Effect.mapError((error) => toRepositoryError(error, "countByProjectId")),
           ),
 
       findByTraceId: ({ organizationId, projectId, traceId }) =>

--- a/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
+++ b/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
@@ -39,7 +39,8 @@ const ch = setupTestClickHouse()
 
 function makeFakeTraceRepository(traces: TraceDetail[]): (typeof TraceRepository)["Service"] {
   return {
-    findByProjectId: () => Effect.succeed([]),
+    findByProjectId: () => Effect.succeed({ items: [], hasMore: false }),
+    countByProjectId: () => Effect.succeed(0),
     findByTraceId: () => Effect.succeed(null),
     findByTraceIds: () => Effect.succeed(traces),
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.481.0",
+    "@tanstack/react-virtual": "^3.13.23",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -1,0 +1,82 @@
+import { type KeyboardEvent, memo, useCallback } from "react"
+import { cn } from "../../utils/cn.ts"
+import { Checkbox, type CheckedState } from "../checkbox/checkbox.tsx"
+import { Text } from "../text/text.tsx"
+import type { InfiniteTableColumn } from "./types.ts"
+
+interface DataRowProps<T> {
+  row: T
+  rowKey: string
+  columns: InfiniteTableColumn<T>[]
+  isSelected?: boolean
+  onToggleRow?: (key: string, checked: CheckedState) => void
+  hasSelection: boolean
+  onClick?: (row: T) => void
+  dataIndex: number
+  measureRef: (node: Element | null) => void
+}
+
+function DataRowInner<T>({
+  row,
+  rowKey,
+  columns,
+  isSelected,
+  onToggleRow,
+  hasSelection,
+  onClick,
+  dataIndex,
+  measureRef,
+}: DataRowProps<T>) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTableRowElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        onClick?.(row)
+      }
+    },
+    [onClick, row],
+  )
+
+  return (
+    <tr
+      ref={measureRef}
+      data-index={dataIndex}
+      className={cn("bg-secondary transition-colors", {
+        "hover:bg-muted cursor-pointer": onClick,
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring": onClick,
+      })}
+      onClick={onClick ? () => onClick(row) : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? handleKeyDown : undefined}
+    >
+      {hasSelection && (
+        <td
+          className="px-4 py-2 text-right align-middle text-sm leading-5 font-normal whitespace-nowrap overflow-hidden text-ellipsis"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <Checkbox checked={isSelected ?? false} onCheckedChange={(checked) => onToggleRow?.(rowKey, checked)} />
+        </td>
+      )}
+      {columns.map((col) => {
+        const content = col.render(row)
+        return (
+          <td
+            key={col.key}
+            className="px-4 py-2 text-right align-middle text-sm leading-5 font-normal whitespace-nowrap overflow-hidden text-ellipsis"
+          >
+            {typeof content === "string" ? (
+              <Text.H5 noWrap ellipsis>
+                {content || "-"}
+              </Text.H5>
+            ) : (
+              content
+            )}
+          </td>
+        )
+      })}
+    </tr>
+  )
+}
+
+export const DataRow = memo(DataRowInner) as typeof DataRowInner

--- a/packages/ui/src/components/infinite-table/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/header-cell.tsx
@@ -1,0 +1,181 @@
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react"
+import { type ReactNode, useCallback, useLayoutEffect, useRef, useState } from "react"
+import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { cn } from "../../utils/cn.ts"
+import type { SortDirection } from "./types.ts"
+
+// Matches the `px-4` (16px × 2) applied to the <th>
+const TH_HORIZONTAL_PADDING = 32
+
+function ResizableHandle({
+  minWidth,
+  thRef,
+  disabled = false,
+}: {
+  minWidth: React.RefObject<number>
+  thRef: React.RefObject<HTMLTableCellElement | null>
+  disabled?: boolean
+}) {
+  const [dragging, setDragging] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+  const rafRef = useRef(0)
+
+  useMountEffect(() => {
+    return () => {
+      abortRef.current?.abort()
+      cancelAnimationFrame(rafRef.current)
+    }
+  })
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      const th = thRef.current
+      if (!th) return
+      const table = th.closest("table")
+      if (!table) return
+
+      const headerRow = th.parentElement
+      if (headerRow) {
+        for (const sibling of Array.from(headerRow.children) as HTMLTableCellElement[]) {
+          if (!sibling.style.width) {
+            sibling.style.width = `${sibling.offsetWidth}px`
+          }
+        }
+      }
+
+      abortRef.current?.abort()
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      const startX = e.clientX
+      const startColWidth = th.offsetWidth
+      const startTableWidth = table.offsetWidth
+      setDragging(true)
+
+      const onPointerMove = (ev: PointerEvent) => {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = requestAnimationFrame(() => {
+          const newColWidth = Math.max(minWidth.current, startColWidth + (ev.clientX - startX))
+          const tableDelta = newColWidth - startColWidth
+          th.style.width = `${newColWidth}px`
+          table.style.width = `${startTableWidth + tableDelta}px`
+        })
+      }
+
+      const onPointerUp = () => {
+        cancelAnimationFrame(rafRef.current)
+        setDragging(false)
+        controller.abort()
+        abortRef.current = null
+      }
+
+      document.addEventListener("pointermove", onPointerMove, { signal: controller.signal })
+      document.addEventListener("pointerup", onPointerUp, { signal: controller.signal })
+    },
+    [thRef],
+  )
+
+  return (
+    <div
+      role="none"
+      onPointerDown={disabled ? undefined : onPointerDown}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      className={cn(
+        "group/resize absolute right-0 top-0 h-full w-4 translate-x-1/2 z-10 select-none flex items-center justify-center",
+        {
+          "cursor-col-resize": !disabled,
+        },
+      )}
+    >
+      <div
+        className={cn("w-px h-7 bg-border transition-all pointer-events-none", {
+          "group-hover/resize:w-0.5 group-hover/resize:bg-accent-foreground/40": !disabled,
+          "w-0.5 bg-accent-foreground/40": dragging,
+        })}
+      />
+    </div>
+  )
+}
+
+function SortIcon({ direction }: { direction: SortDirection | null }) {
+  const cls = "h-3.5 w-3.5 shrink-0"
+  if (direction === "asc") return <ArrowUp className={cls} />
+  if (direction === "desc") return <ArrowDown className={cls} />
+  return <ArrowUpDown className={cn(cls, "opacity-40")} />
+}
+
+function ariaSort(direction: SortDirection | null | undefined): "ascending" | "descending" | "none" {
+  if (direction === "asc") return "ascending"
+  if (direction === "desc") return "descending"
+  return "none"
+}
+
+export function HeaderCell({
+  children,
+  resizable = true,
+  minWidth = 60,
+  className,
+  sortable,
+  sortDirection,
+  onSortClick,
+}: {
+  children: ReactNode
+  resizable?: boolean
+  minWidth?: number
+  className?: string
+  sortable?: boolean
+  sortDirection?: SortDirection | null
+  onSortClick?: () => void
+}) {
+  const thRef = useRef<HTMLTableCellElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const headerMinWidth = useRef(minWidth)
+
+  useLayoutEffect(() => {
+    const el = measureRef.current
+    if (!el) return
+    headerMinWidth.current = Math.max(minWidth, el.offsetWidth + TH_HORIZONTAL_PADDING)
+  }, [minWidth, children])
+
+  const measuredChildren = (
+    <span ref={measureRef} className="inline-flex items-center gap-1 w-fit">
+      {sortable && <SortIcon direction={sortDirection ?? null} />}
+      {children}
+    </span>
+  )
+
+  const content = sortable ? (
+    <button
+      type="button"
+      onClick={onSortClick}
+      className={cn(
+        "flex w-full h-full items-center justify-end truncate",
+        "bg-transparent border-none rounded-sm p-0",
+        "text-xs leading-4 text-muted-foreground",
+        "cursor-pointer select-none transition-colors hover:text-foreground",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      )}
+    >
+      {measuredChildren}
+    </button>
+  ) : (
+    <div className="flex items-center justify-end truncate">{measuredChildren}</div>
+  )
+
+  return (
+    <th
+      ref={thRef}
+      className={cn(
+        "relative h-12 text-right align-middle text-xs leading-4 font-medium text-muted-foreground",
+        "px-4", // matches TH_HORIZONTAL_PADDING
+        className,
+      )}
+      aria-sort={sortable ? ariaSort(sortDirection) : undefined}
+    >
+      {content}
+      <ResizableHandle minWidth={headerMinWidth} thRef={thRef} disabled={!resizable} />
+    </th>
+  )
+}

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -1,0 +1,208 @@
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { cn } from "../../utils/cn.ts"
+import { Checkbox } from "../checkbox/checkbox.tsx"
+import { Text } from "../text/text.tsx"
+import { DataRow } from "./data-row.tsx"
+import { HeaderCell } from "./header-cell.tsx"
+import type { InfiniteTableProps, SortDirection } from "./types.ts"
+
+const ROW_HEIGHT = 40
+const SKELETON_ROW_COUNT = 8
+
+function nextSortDirection(current: SortDirection | null): SortDirection | null {
+  if (current === null) return "desc"
+  if (current === "desc") return "asc"
+  return null
+}
+
+export function InfiniteTable<T>({
+  data,
+  isLoading,
+  columns,
+  getRowKey,
+  onRowClick,
+  selection,
+  infiniteScroll,
+  sorting,
+  defaultSorting,
+  onSortChange,
+  blankSlate,
+  className,
+}: InfiniteTableProps<T>) {
+  const colCount = columns.length + (selection ? 1 : 0)
+  const hasMore = infiniteScroll?.hasMore ?? false
+  const totalVirtualRows = data.length + (hasMore || (isLoading && data.length === 0) ? SKELETON_ROW_COUNT : 0)
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  const handleSortClick = useCallback(
+    (sortKey: string) => {
+      if (!onSortChange) return
+
+      const isDefaultColumn = defaultSorting?.column === sortKey
+      const currentDirection = sorting?.column === sortKey ? sorting.direction : null
+      const next = nextSortDirection(currentDirection)
+
+      if (isDefaultColumn) {
+        const dir = currentDirection === "desc" ? "asc" : "desc"
+        onSortChange({ column: sortKey, direction: dir })
+      } else if (next) {
+        onSortChange({ column: sortKey, direction: next })
+      } else if (defaultSorting) {
+        onSortChange(defaultSorting)
+      }
+
+      scrollContainerRef.current?.scrollTo({ top: 0 })
+    },
+    [sorting, defaultSorting, onSortChange],
+  )
+
+  const virtualizer = useVirtualizer({
+    count: totalVirtualRows,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 10,
+  })
+
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      if (!infiniteScroll || !hasMore || infiniteScroll.isLoadingMore) return
+      const target = e.currentTarget
+      const distanceToBottom = target.scrollHeight - target.scrollTop - target.clientHeight
+      if (distanceToBottom < ROW_HEIGHT * 5) {
+        infiniteScroll.onLoadMore()
+      }
+    },
+    [infiniteScroll, hasMore],
+  )
+
+  const virtualRows = virtualizer.getVirtualItems()
+
+  const rowKeys = useMemo(() => data.map(getRowKey), [data, getRowKey])
+
+  const tableRef = useRef<HTMLTableElement>(null)
+  const [layoutFixed, setLayoutFixed] = useState(false)
+
+  useLayoutEffect(() => {
+    if (layoutFixed || data.length === 0) return
+    const table = tableRef.current
+    if (!table) return
+
+    const headerRow = table.querySelector("thead tr")
+    if (!headerRow) return
+
+    for (const th of Array.from(headerRow.children) as HTMLTableCellElement[]) {
+      th.style.width = `${th.offsetWidth}px`
+    }
+    table.style.width = `${table.offsetWidth}px`
+    setLayoutFixed(true)
+  }, [layoutFixed, data.length])
+
+  const paddingTop = virtualRows[0]?.start ?? 0
+  const lastRow = virtualRows[virtualRows.length - 1]
+  const paddingBottom = lastRow ? virtualizer.getTotalSize() - lastRow.end : 0
+
+  const showBlankSlate = !isLoading && data.length === 0 && !layoutFixed
+
+  return (
+    <div className="flex flex-col h-full">
+      {showBlankSlate ? (
+        (blankSlate ?? (
+          <div className="rounded-lg w-full py-40 flex flex-col gap-4 items-center justify-center bg-linear-to-b from-secondary to-transparent px-4">
+            <Text.H5 align="center" display="block" color="foregroundMuted">
+              No data found.
+            </Text.H5>
+          </div>
+        ))
+      ) : (
+        <div ref={scrollContainerRef} onScroll={handleScroll} className={cn("flex-1 min-h-0 overflow-auto", className)}>
+          <table
+            ref={tableRef}
+            className={cn("min-w-full border-separate border-spacing-y-1", layoutFixed && "table-fixed")}
+          >
+            <thead className="sticky top-0 z-10 bg-background">
+              <tr>
+                {selection && (
+                  <HeaderCell resizable={false} className="w-10">
+                    <Checkbox checked={selection.headerState} onCheckedChange={() => selection.toggleAll()} />
+                  </HeaderCell>
+                )}
+                {columns.map((col, i) => {
+                  const isSortable = !!col.sortKey && !!onSortChange
+                  const sortDir = sorting && sorting.column === col.sortKey ? sorting.direction : null
+                  return (
+                    <HeaderCell
+                      key={col.key}
+                      resizable={col.resizable !== false && i < columns.length - 1}
+                      {...(col.minWidth !== undefined ? { minWidth: col.minWidth } : {})}
+                      {...(isSortable && col.sortKey
+                        ? {
+                            sortable: true,
+                            sortDirection: sortDir,
+                            onSortClick: () => handleSortClick(col.sortKey as string),
+                          }
+                        : {})}
+                    >
+                      {col.header}
+                    </HeaderCell>
+                  )
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {paddingTop > 0 && (
+                <tr>
+                  <td colSpan={colCount} style={{ height: paddingTop, padding: 0, border: "none" }} />
+                </tr>
+              )}
+              {virtualRows.map((virtualRow) => {
+                const index = virtualRow.index
+
+                if (index >= data.length) {
+                  const skeletonIndex = index - data.length
+                  return (
+                    <tr
+                      key={`skeleton-${skeletonIndex}`}
+                      ref={virtualizer.measureElement}
+                      data-index={virtualRow.index}
+                      className="bg-secondary"
+                      style={{ opacity: 1 - skeletonIndex / SKELETON_ROW_COUNT }}
+                    >
+                      <td colSpan={colCount} className="h-9" />
+                    </tr>
+                  )
+                }
+
+                const row = data[index]
+                const rowKey = rowKeys[index]
+                if (!row || rowKey === undefined) return null
+
+                return (
+                  <DataRow
+                    key={rowKey}
+                    row={row}
+                    rowKey={rowKey}
+                    columns={columns}
+                    hasSelection={!!selection}
+                    {...(selection
+                      ? { isSelected: selection.isSelected(rowKey), onToggleRow: selection.toggleRow }
+                      : {})}
+                    {...(onRowClick ? { onClick: onRowClick } : {})}
+                    dataIndex={virtualRow.index}
+                    measureRef={virtualizer.measureElement}
+                  />
+                )
+              })}
+              {paddingBottom > 0 && (
+                <tr>
+                  <td colSpan={colCount} style={{ height: paddingBottom, padding: 0, border: "none" }} />
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react"
+import type { CheckedState } from "../checkbox/checkbox.tsx"
+
+export interface InfiniteTableColumn<T> {
+  key: string
+  header: string
+  render: (row: T) => ReactNode
+  resizable?: boolean
+  minWidth?: number
+  sortKey?: string
+}
+
+export interface InfiniteTableSelection {
+  headerState: CheckedState
+  isSelected: (key: string) => boolean
+  toggleRow: (key: string, checked: CheckedState) => void
+  toggleAll: () => void
+}
+
+export interface InfiniteTableInfiniteScroll {
+  hasMore: boolean
+  isLoadingMore: boolean
+  onLoadMore: () => void
+}
+
+export type SortDirection = "asc" | "desc"
+
+export interface InfiniteTableSorting {
+  column: string
+  direction: SortDirection
+}
+
+export interface InfiniteTableProps<T> {
+  data: readonly T[]
+  isLoading?: boolean
+  columns: InfiniteTableColumn<T>[]
+  getRowKey: (row: T) => string
+  onRowClick?: (row: T) => void
+  selection?: InfiniteTableSelection
+  infiniteScroll?: InfiniteTableInfiniteScroll
+  sorting?: InfiniteTableSorting
+  defaultSorting?: InfiniteTableSorting
+  onSortChange?: (sorting: InfiniteTableSorting) => void
+  blankSlate?: ReactNode
+  className?: string
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -35,6 +35,14 @@ export {
 export { FormField, type FormFieldProps } from "./components/form-field/form-field.tsx"
 export { FormWrapper } from "./components/form-wrapper/form-wrapper.tsx"
 export { Icon, type IconProps, type IconSize } from "./components/icons/icons.tsx"
+export { InfiniteTable } from "./components/infinite-table/infinite-table.tsx"
+export type {
+  InfiniteTableColumn,
+  InfiniteTableInfiniteScroll,
+  InfiniteTableProps,
+  InfiniteTableSelection,
+  InfiniteTableSorting,
+} from "./components/infinite-table/types.ts"
 export { Input, type InputProps } from "./components/input/input.tsx"
 export { Label } from "./components/label/label.tsx"
 export { CloseTrigger, Modal, type ModalProps } from "./components/modal/modal.tsx"
@@ -71,6 +79,7 @@ export { Toaster } from "./components/toast/toaster.tsx"
 export { toast, useToast } from "./components/toast/useToast.ts"
 export { Tooltip, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from "./components/tooltip/tooltip.tsx"
 export { useMountEffect } from "./hooks/use-mount-effect.ts"
+// Lib
 export * from "./tokens/colors.ts"
 export * from "./tokens/font.ts"
 export * from "./tokens/opacity.ts"

--- a/packages/utils/src/relativeTime.test.ts
+++ b/packages/utils/src/relativeTime.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { relativeTime } from "./relativeTime.ts"
+
+describe("relativeTime", () => {
+  const SECONDS = 1000
+  const MINUTES = 60 * SECONDS
+  const HOURS = 60 * MINUTES
+  const DAYS = 24 * HOURS
+
+  const NOW = new Date(2000, 6, 31, 12, 0, 0) // Monday Jul 31, 2000 12:00:00
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("returns 'just now' for less than a minute", () => {
+    expect(relativeTime(new Date(NOW.getTime() - 3 * SECONDS))).toBe("just now")
+    expect(relativeTime(new Date(NOW.getTime() - 59 * SECONDS))).toBe("just now")
+  })
+
+  it("returns relative minutes for < 1 hour", () => {
+    expect(relativeTime(new Date(NOW.getTime() - 2 * MINUTES))).toBe("2 minutes ago")
+    expect(relativeTime(new Date(NOW.getTime() - 30 * MINUTES))).toBe("30 minutes ago")
+  })
+
+  it("returns relative hours for < 24 hours", () => {
+    expect(relativeTime(new Date(NOW.getTime() - 2 * HOURS))).toBe("2 hours ago")
+    expect(relativeTime(new Date(NOW.getTime() - 12 * HOURS))).toBe("12 hours ago")
+  })
+
+  it("returns 'Yesterday at {time}' for < 2 days", () => {
+    const result = relativeTime(new Date(NOW.getTime() - 30 * HOURS))
+    expect(result).toMatch(/^Yesterday at \d{1,2}:\d{2}\s[AP]M$/)
+  })
+
+  it("returns '{month} {day} at {time}' for 2 days to 10 months", () => {
+    const threeDays = relativeTime(new Date(NOW.getTime() - 3 * DAYS))
+    expect(threeDays).toMatch(/^July 28 at \d{1,2}:\d{2}\s[AP]M$/)
+
+    const thirtyDays = relativeTime(new Date(NOW.getTime() - 30 * DAYS))
+    expect(thirtyDays).toMatch(/^July 1 at \d{1,2}:\d{2}\s[AP]M$/)
+  })
+
+  it("returns '{month} {day}, {year} at {time}' for >= 10 months", () => {
+    // 365 days ago
+    const result = relativeTime(new Date(NOW.getTime() - 365 * DAYS))
+    expect(result).toMatch(/^August 1, 1999 at \d{1,2}:\d{2}\s[AP]M$/)
+  })
+
+  it("accepts string input", () => {
+    const dateStr = new Date(NOW.getTime() - 5 * MINUTES).toISOString()
+    expect(relativeTime(dateStr)).toBe("5 minutes ago")
+  })
+
+  it('returns "-" for null or undefined', () => {
+    expect(relativeTime(null)).toBe("-")
+    expect(relativeTime(undefined)).toBe("-")
+  })
+})

--- a/packages/utils/src/relativeTime.ts
+++ b/packages/utils/src/relativeTime.ts
@@ -1,34 +1,45 @@
-const MINUTE = 60
-const HOUR = MINUTE * 60
-const DAY = HOUR * 24
-const WEEK = DAY * 7
-const MONTH = DAY * 30
-const YEAR = DAY * 365
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+const TEN_MONTHS = 300 * DAY
 
-const DIVISIONS: { amount: number; name: Intl.RelativeTimeFormatUnit }[] = [
-  { amount: MINUTE, name: "seconds" },
-  { amount: HOUR, name: "minutes" },
-  { amount: DAY, name: "hours" },
-  { amount: WEEK, name: "days" },
-  { amount: MONTH, name: "weeks" },
-  { amount: YEAR, name: "months" },
-  { amount: Number.POSITIVE_INFINITY, name: "years" },
-]
+function formatTime(date: Date, locale: Intl.LocalesArgument) {
+  return new Intl.DateTimeFormat(locale, { hour: "numeric", minute: "2-digit" }).format(date)
+}
 
-const formatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" })
-
-export function relativeTime(date: Date | string | null | undefined): string {
-  if (!date) return "Never"
+export function relativeTime(date: Date | string | null | undefined, locale: Intl.LocalesArgument = "en"): string {
+  if (!date) return "-"
 
   const d = typeof date === "string" ? new Date(date) : date
-  const seconds = Math.round((d.getTime() - Date.now()) / 1000)
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const absDiffMs = Math.abs(diffMs)
+  const sign = diffMs >= 0 ? -1 : 1
 
-  for (const division of DIVISIONS) {
-    if (Math.abs(seconds) < division.amount) {
-      const value = Math.round(seconds / (DIVISIONS[DIVISIONS.indexOf(division) - 1]?.amount ?? 1))
-      return formatter.format(value, division.name)
-    }
+  if (absDiffMs < MINUTE) return "just now"
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+
+  if (absDiffMs < HOUR) {
+    return rtf.format(sign * Math.round(absDiffMs / MINUTE), "minute")
   }
 
-  return formatter.format(Math.round(seconds / YEAR), "years")
+  if (absDiffMs < DAY) {
+    return rtf.format(sign * Math.round(absDiffMs / HOUR), "hour")
+  }
+
+  const time = formatTime(d, locale)
+
+  if (absDiffMs < 2 * DAY) {
+    return `Yesterday at ${time}`
+  }
+
+  if (absDiffMs < TEN_MONTHS) {
+    const monthDay = new Intl.DateTimeFormat(locale, { month: "long", day: "numeric" }).format(d)
+    return `${monthDay} at ${time}`
+  }
+
+  const full = new Intl.DateTimeFormat(locale, { month: "long", day: "numeric", year: "numeric" }).format(d)
+  return `${full} at ${time}`
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -975,6 +975,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.23
+        version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4078,6 +4081,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.167.3':
     resolution: {integrity: sha512-M/CxrTGKk1fsySJjd+Pzpbi3YLDz+cJSutDjSTMy12owWlOgHV/I6kzR0UxyaBlHraM6XgMHNA0XdgsS1fa4Nw==}
     engines: {node: '>=20.19'}
@@ -4135,6 +4144,9 @@ packages:
 
   '@tanstack/store@0.9.1':
     resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
+
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@tanstack/virtual-file-routes@1.161.6':
     resolution: {integrity: sha512-EGWs9yvJA821pUkwkiZLQW89CzUumHyJy8NKq229BubyoWXfDw1oWnTJYSS/hhbLiwP9+KpopjeF5wWwnCCyeQ==}
@@ -10146,6 +10158,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.167.3':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -10264,6 +10282,8 @@ snapshots:
       '@tanstack/router-core': 1.167.3
 
   '@tanstack/store@0.9.1': {}
+
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@tanstack/virtual-file-routes@1.161.6': {}
 


### PR DESCRIPTION
## Summary

The main project view now displays a beautiful infinite table with ALL traces in the project.

Traces are loaded in batches of 50, with lazy loading on scrolling.

The UI is all managed by a new `InfiniteTable` component, which manages:
 - Loading state
 - Row virtualization for optimization
 - Column resizing
 - Column sorting


https://github.com/user-attachments/assets/e3b760ff-14da-47b1-a9fd-1e0cf5152922

