### PR TITLE
Preserve typed errors in EventsPublisher.publish

### DIFF
--- a/packages/domain/events/package.json
+++ b/packages/domain/events/package.json
@@ -12,5 +12,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",
     "check:fix": "biome check --fix src"
+  },
+  "dependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/domain/events/src/index.ts
+++ b/packages/domain/events/src/index.ts
@@ -1,3 +1,5 @@
+import type { Effect } from "effect"
+
 export interface DomainEvent<
   TName extends string = string,
   TPayload extends Record<string, unknown> = Record<string, unknown>,
@@ -13,6 +15,6 @@ export interface EventEnvelope<TEvent extends DomainEvent = DomainEvent> {
   readonly occurredAt: Date
 }
 
-export interface EventsPublisher {
-  publish(envelope: EventEnvelope): Promise<void>
+export interface EventsPublisher<TError = unknown> {
+  publish(envelope: EventEnvelope): Effect.Effect<void, TError>
 }

--- a/packages/platform/events-outbox/src/index.ts
+++ b/packages/platform/events-outbox/src/index.ts
@@ -53,9 +53,9 @@ const MARK_EVENTS_PUBLISHED = `
   WHERE id = ANY($1::text[])
 `
 
-const processBatchEffect = (
+const processBatchEffect = <TPublishError>(
   client: PoolClient,
-  publisher: EventsPublisher,
+  publisher: EventsPublisher<TPublishError>,
   batchSize: number,
 ): Effect.Effect<number, unknown, never> =>
   Effect.gen(function* () {
@@ -78,7 +78,7 @@ const processBatchEffect = (
         occurredAt: row.occurred_at,
       }
 
-      const publishResult = yield* Effect.result(Effect.tryPromise(() => publisher.publish(envelope)))
+      const publishResult = yield* Effect.result(publisher.publish(envelope))
 
       if (Result.isSuccess(publishResult)) {
         processedIds.push(row.id)
@@ -94,9 +94,9 @@ const processBatchEffect = (
     return processedIds.length
   })
 
-const pollEffect = (
+const pollEffect = <TPublishError>(
   config: PollingOutboxConsumerConfig,
-  publisher: EventsPublisher,
+  publisher: EventsPublisher<TPublishError>,
 ): Effect.Effect<number, unknown, never> =>
   Effect.gen(function* () {
     const client = yield* Effect.tryPromise(() => config.pool.connect())
@@ -121,9 +121,9 @@ const pollEffect = (
     return result
   })
 
-export const createPollingOutboxConsumer = (
+export const createPollingOutboxConsumer = <TPublishError>(
   config: PollingOutboxConsumerConfig,
-  publisher: EventsPublisher,
+  publisher: EventsPublisher<TPublishError>,
 ): Effect.Effect<OutboxConsumer, OutboxConsumerError> =>
   Effect.gen(function* () {
     let fiber: Fiber.Fiber<void, unknown> | null = null

--- a/packages/platform/queue-bullmq/src/events.ts
+++ b/packages/platform/queue-bullmq/src/events.ts
@@ -1,5 +1,5 @@
 import type { EventEnvelope, EventsPublisher } from "@domain/events"
-import type { MessageHandler, QueueMessage, QueuePublisher } from "@domain/queue"
+import type { MessageHandler, QueueMessage, QueuePublishError, QueuePublisher } from "@domain/queue"
 import { Effect } from "effect"
 import { z } from "zod"
 
@@ -44,9 +44,8 @@ export const mapEnvelopeToQueueMessage = (envelope: EventEnvelope): QueueMessage
   ]),
 })
 
-export const createEventsPublisher = (queuePublisher: QueuePublisher): EventsPublisher => ({
-  publish: (envelope: EventEnvelope) =>
-    Effect.runPromise(queuePublisher.publish("domain-events", mapEnvelopeToQueueMessage(envelope))),
+export const createEventsPublisher = (queuePublisher: QueuePublisher): EventsPublisher<QueuePublishError> => ({
+  publish: (envelope: EventEnvelope) => queuePublisher.publish("domain-events", mapEnvelopeToQueueMessage(envelope)),
 })
 
 export const createEventHandler = (handler: EventHandler): MessageHandler => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,7 +345,7 @@ importers:
         version: 1.166.14(crossws@0.4.4(srvx@0.11.12))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@24.10.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.0(a0f64e082d52cd31cdd77abd339b6d14)
+        version: 1.5.0(b747651743a1a857a2d4115075b1af49)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.0
@@ -558,7 +558,11 @@ importers:
         specifier: ^5.7.0
         version: 5.8.3
 
-  packages/domain/events: {}
+  packages/domain/events:
+    dependencies:
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.0
 
   packages/domain/models:
     dependencies:
@@ -683,7 +687,7 @@ importers:
         version: link:../env
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.0(a0f64e082d52cd31cdd77abd339b6d14)
+        version: 1.5.0(b747651743a1a857a2d4115075b1af49)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.0
@@ -7936,7 +7940,7 @@ snapshots:
   '@better-auth/stripe@1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(better-auth@1.5.0(a0f64e082d52cd31cdd77abd339b6d14))(better-call@1.3.2(zod@4.3.6))(stripe@20.4.0(@types/node@24.10.3))':
     dependencies:
       '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
-      better-auth: 1.5.0(a0f64e082d52cd31cdd77abd339b6d14)
+      better-auth: 1.5.0(b747651743a1a857a2d4115075b1af49)
       better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.4
       stripe: 20.4.0(@types/node@24.10.3)
@@ -10576,7 +10580,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.5.0(a0f64e082d52cd31cdd77abd339b6d14):
+  better-auth@1.5.0(b747651743a1a857a2d4115075b1af49):
     dependencies:
       '@better-auth/core': 1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.0(@better-auth/core@1.5.0(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(typescript@5.8.3))(@types/mssql@9.1.9(@azure/core-client@1.10.1))(@types/pg@8.16.0)(mssql@11.0.1(@azure/core-client@1.10.1))(mysql2@3.15.3)(pg@8.16.0)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.8.3))(valibot@1.2.0(typescript@5.8.3))(zod@4.3.6))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Changed `EventsPublisher.publish` in `@domain/events` to return `Effect.Effect<void, TError>` instead of `Promise<void>`.
- Updated the queue adapter publisher to return the queue publisher effect directly, preserving typed publish errors.
- Updated events outbox publishing flow to consume `publisher.publish` as an `Effect` (no Promise wrapping) and to keep publisher error typing through internal helpers.
- Rebases this branch on latest `main` per review request.

## Testing
- `pnpm --filter @domain/events typecheck`
- `pnpm --filter @platform/events-outbox typecheck`
- `pnpm --filter @platform/queue-bullmq typecheck`
- `pnpm --filter @platform/queue-bullmq test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a689d85-96cd-4bce-a541-db383af52b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a689d85-96cd-4bce-a541-db383af52b2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

