### PR TITLE
Trace Detail Drawer

### DIFF
--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -1,7 +1,13 @@
 import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
-import { countTracesByProject, listTracesByProject, type TraceRecord } from "./traces.functions.ts"
+import {
+  countTracesByProject,
+  getTraceDetail,
+  listTracesByProject,
+  type TraceDetailRecord,
+  type TraceRecord,
+} from "./traces.functions.ts"
 
 const BATCH_SIZE = 50
 
@@ -20,8 +26,8 @@ export function useTracesInfiniteScroll({
     isFetchingNextPage,
   } = useInfiniteQuery({
     queryKey: ["traces", projectId, sorting],
-    queryFn: ({ pageParam }) =>
-      listTracesByProject({
+    queryFn: async ({ pageParam }) => {
+      const result = await listTracesByProject({
         data: {
           projectId,
           limit: BATCH_SIZE,
@@ -29,9 +35,11 @@ export function useTracesInfiniteScroll({
           sortBy: sorting.column,
           sortDirection: sorting.direction,
         },
-      }),
+      })
+      return result ?? { traces: [], hasMore: false }
+    },
     initialPageParam: undefined as { sortValue: string; traceId: string } | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    getNextPageParam: (lastPage) => lastPage?.nextCursor,
   })
 
   const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
@@ -59,4 +67,11 @@ export function useTracesCount({ projectId }: { readonly projectId: string }) {
   })
 
   return { totalCount, isLoading }
+}
+
+export function useTraceDetail({ projectId, traceId }: { readonly projectId: string; readonly traceId: string }) {
+  return useQuery<TraceDetailRecord | null>({
+    queryKey: ["traceDetail", projectId, traceId],
+    queryFn: () => getTraceDetail({ data: { projectId, traceId } }),
+  })
 }

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -1,5 +1,5 @@
-import { OrganizationId, ProjectId } from "@domain/shared"
-import type { Trace } from "@domain/spans"
+import { OrganizationId, ProjectId, TraceId } from "@domain/shared"
+import type { Trace, TraceDetail } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
 import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { createServerFn } from "@tanstack/react-start"
@@ -69,6 +69,21 @@ const serializeTrace = (trace: Trace): TraceRecord => ({
   rootSpanName: trace.rootSpanName,
 })
 
+export interface TraceDetailRecord extends TraceRecord {
+  readonly systemInstructions: readonly object[]
+  readonly inputMessages: readonly object[]
+  readonly outputMessages: readonly object[]
+  readonly allMessages: readonly object[]
+}
+
+const serializeTraceDetail = (trace: TraceDetail): TraceDetailRecord => ({
+  ...serializeTrace(trace),
+  systemInstructions: trace.systemInstructions as readonly object[],
+  inputMessages: trace.inputMessages as readonly object[],
+  outputMessages: trace.outputMessages as readonly object[],
+  allMessages: trace.allMessages as readonly object[],
+})
+
 const traceListCursorSchema = z.object({
   sortValue: z.string(),
   traceId: z.string(),
@@ -135,6 +150,26 @@ export const countTracesByProject = createServerFn({ method: "GET" })
           organizationId: orgId,
           projectId: ProjectId(data.projectId),
         })
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+    )
+  })
+
+export const getTraceDetail = createServerFn({ method: "GET" })
+  .middleware([errorHandler])
+  .inputValidator(z.object({ projectId: z.string(), traceId: z.string() }))
+  .handler(async ({ data }): Promise<TraceDetailRecord | null> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* TraceRepository
+        const detail = yield* repo.findByTraceId({
+          organizationId: orgId,
+          projectId: ProjectId(data.projectId),
+          traceId: TraceId(data.traceId),
+        })
+        return detail ? serializeTraceDetail(detail) : null
       }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
     )
   })

--- a/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer.tsx
@@ -1,0 +1,112 @@
+import { Button, cn, DetailDrawer, Skeleton, type TabOption, Tabs, Text } from "@repo/ui"
+import { ArrowDownIcon, ArrowUpIcon, CopyIcon, GroupIcon, ListTreeIcon, MessagesSquareIcon } from "lucide-react"
+import { useState } from "react"
+import { useTraceDetail } from "../../../../../domains/traces/traces.collection.ts"
+import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
+import { ConversationTab } from "./trace-detail-drawer/tabs/conversation-tab.tsx"
+import { SpansTab } from "./trace-detail-drawer/tabs/spans-tab.tsx"
+import { TraceTab } from "./trace-detail-drawer/tabs/trace-tab.tsx"
+
+type TabId = "trace" | "conversation" | "spans"
+
+const TABS: TabOption<TabId>[] = [
+  { id: "trace", label: "Trace", icon: <GroupIcon className="w-4 h-4" /> },
+  { id: "conversation", label: "Conversation", icon: <MessagesSquareIcon className="w-4 h-4" /> },
+  { id: "spans", label: "Spans", icon: <ListTreeIcon className="w-4 h-4" /> },
+]
+
+export function TraceDetailDrawer({
+  traceId,
+  trace,
+  projectId,
+  onClose,
+}: {
+  readonly traceId: string
+  readonly trace?: TraceRecord | undefined
+  readonly projectId: string
+  readonly onClose: () => void
+}) {
+  const { data: traceDetail, isLoading: isDetailLoading } = useTraceDetail({
+    projectId,
+    traceId,
+  })
+  const isRecordLoading = !trace && !traceDetail
+  const traceRecord: TraceRecord | undefined = traceDetail ?? trace
+  const [activeTab, setActiveTab] = useState<TabId>("trace")
+
+  return (
+    <DetailDrawer
+      storeKey="trace-detail-drawer-width"
+      onClose={onClose}
+      actions={
+        <>
+          <Button flat variant="ghost" className="w-8 h-8 p-0" disabled>
+            <ArrowDownIcon className="w-4 h-4 text-muted-foreground" />
+          </Button>
+          <Button flat variant="ghost" className="w-8 h-8 p-0" disabled>
+            <ArrowUpIcon className="w-4 h-4 text-muted-foreground" />
+          </Button>
+        </>
+      }
+      header={
+        <>
+          <div className="flex flex-col gap-1">
+            <div className="flex flex-row items-center gap-2">
+              {isRecordLoading ? (
+                <Skeleton className="h-6 w-48" />
+              ) : (
+                <Text.H4>{traceRecord?.rootSpanName ?? "Unnamed Trace"}</Text.H4>
+              )}
+              {isRecordLoading ? (
+                <Skeleton className="h-6 w-12" />
+              ) : (
+                <span
+                  className={cn(
+                    "inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5",
+                    "text-xs leading-4 font-medium",
+                    "bg-muted text-muted-foreground",
+                    {
+                      "bg-red-500 text-white": traceRecord?.status === "error",
+                      "bg-green-500 text-white": traceRecord?.status === "success",
+                      "bg-yellow-500 text-white": traceRecord?.status === "warning",
+                    },
+                  )}
+                >
+                  {traceRecord?.status?.toUpperCase() ?? "UNKNOWN"}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1",
+                "text-xs leading-4 font-medium text-muted-foreground",
+                "hover:text-foreground cursor-pointer",
+              )}
+              onClick={() => {
+                navigator.clipboard.writeText(traceId)
+              }}
+            >
+              <Text.H6 color="foregroundMuted">{traceId}</Text.H6>
+              <CopyIcon className="w-4 h-4" />
+            </button>
+          </div>
+
+          <Tabs options={TABS} active={activeTab} onSelect={setActiveTab} />
+        </>
+      }
+    >
+      {activeTab === "trace" && (
+        <TraceTab
+          traceId={traceId}
+          traceRecord={traceRecord}
+          traceDetail={traceDetail}
+          isRecordLoading={isRecordLoading}
+          isDetailLoading={isDetailLoading}
+        />
+      )}
+      {activeTab === "conversation" && <ConversationTab />}
+      {activeTab === "spans" && <SpansTab key={traceId} projectId={projectId} traceId={traceId} />}
+    </DetailDrawer>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -1,0 +1,9 @@
+import { Text } from "@repo/ui"
+
+export function ConversationTab() {
+  return (
+    <div className="flex items-center justify-center py-6 flex-1">
+      <Text.H5 color="foregroundMuted">Coming soon ™</Text.H5>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -1,0 +1,56 @@
+import { Text } from "@repo/ui"
+import { formatPrice } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import { useSpansByTraceCollection } from "../../../../../../../domains/spans/spans.collection.ts"
+
+export function SpansTab({ projectId, traceId }: { readonly projectId: string; readonly traceId: string }) {
+  const { data: spans } = useSpansByTraceCollection(traceId)
+  const sorted = spans?.slice().sort((a, b) => a.startTime.localeCompare(b.startTime))
+
+  if (!sorted) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Text.H5 color="foregroundMuted">Loading spans...</Text.H5>
+      </div>
+    )
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Text.H5 color="foregroundMuted">No spans found</Text.H5>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-1 py-2 px-2 overflow-y-auto flex-1">
+      {sorted.map((span) => (
+        <Link
+          key={`${span.traceId}-${span.spanId}`}
+          to="/projects/$projectId/traces/$traceId/spans/$spanId"
+          params={{ projectId, traceId: span.traceId, spanId: span.spanId }}
+          className="flex flex-row items-center gap-3 rounded-md px-3 py-2 hover:bg-muted transition-colors"
+        >
+          <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+            <Text.H5 noWrap ellipsis>
+              {span.name}
+            </Text.H5>
+            <div className="flex flex-row gap-2">
+              <Text.H6 color="foregroundMuted">{span.kind.toUpperCase()}</Text.H6>
+              <Text.H6 color={span.statusCode === "error" ? "destructive" : "foregroundMuted"}>
+                {span.statusCode.toUpperCase()}
+              </Text.H6>
+            </div>
+          </div>
+          <div className="flex flex-col items-end gap-0.5 shrink-0">
+            {span.model && <Text.H6 color="foregroundMuted">{span.model}</Text.H6>}
+            {span.costTotalMicrocents > 0 && (
+              <Text.H6 color="foregroundMuted">{formatPrice(span.costTotalMicrocents / 100_000_000)}</Text.H6>
+            )}
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -1,0 +1,135 @@
+import { DetailSection, DetailSummary, Skeleton, Text } from "@repo/ui"
+import { formatDuration, formatPrice, relativeTime } from "@repo/utils"
+import { ArrowDownRightIcon, ArrowUpRightIcon, BrainIcon, MessageSquareIcon, TextIcon } from "lucide-react"
+import type { TraceDetailRecord, TraceRecord } from "../../../../../../../domains/traces/traces.functions.ts"
+
+export function TraceTab({
+  traceId,
+  traceRecord,
+  traceDetail,
+  isRecordLoading,
+  isDetailLoading,
+}: {
+  readonly traceId: string
+  readonly traceRecord: TraceRecord | undefined
+  readonly traceDetail: TraceDetailRecord | null | undefined
+  readonly isRecordLoading: boolean
+  readonly isDetailLoading: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-8 py-8 px-4 overflow-y-auto flex-1">
+      <DetailSummary
+        items={[
+          {
+            label: "Start Time",
+            value: traceRecord ? relativeTime(new Date(traceRecord.startTime)) : undefined,
+            isLoading: isRecordLoading,
+          },
+          {
+            label: "Duration",
+            value: traceRecord ? formatDuration(traceRecord.durationNs) : undefined,
+            isLoading: isRecordLoading,
+          },
+          {
+            label: "Cost",
+            value: traceRecord ? formatPrice(traceRecord.costTotalMicrocents / 100_000_000) : undefined,
+            isLoading: isRecordLoading,
+          },
+          {
+            label: "Trace ID",
+            value: traceRecord ? traceId : undefined,
+            copyable: true,
+            isLoading: isRecordLoading,
+          },
+          {
+            label: "Session ID",
+            value: traceRecord ? traceRecord.sessionId : undefined,
+            copyable: true,
+            isLoading: isRecordLoading,
+          },
+          {
+            label: "User ID",
+            value: traceRecord ? traceRecord.userId : undefined,
+            copyable: true,
+            isLoading: isRecordLoading,
+          },
+        ]}
+      />
+
+      {traceRecord ? (
+        <>
+          {traceRecord.tags.length > 0 && (
+            <div className="flex flex-col gap-1">
+              <Text.H6 color="foregroundMuted">Tags</Text.H6>
+              <div className="flex flex-row flex-wrap gap-1">
+                {traceRecord.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center rounded-md bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <DetailSection icon={<TextIcon className="w-4 h-4" />} label="Metadata">
+            <pre className="overflow-auto rounded bg-muted p-3 text-xs">
+              {JSON.stringify(traceRecord.metadata, null, 2)}
+            </pre>
+          </DetailSection>
+        </>
+      ) : (
+        <div className="grid grid-cols-2 gap-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      )}
+
+      <DetailSection icon={<BrainIcon className="w-4 h-4" />} label="System Instructions">
+        {isDetailLoading ? (
+          <Skeleton className="h-20 w-full" />
+        ) : traceDetail?.systemInstructions.length ? (
+          <pre className="overflow-auto rounded bg-muted p-3 text-xs">
+            {JSON.stringify(traceDetail.systemInstructions, null, 2)}
+          </pre>
+        ) : (
+          <Text.H6 color="foregroundMuted">No system instructions</Text.H6>
+        )}
+      </DetailSection>
+
+      <DetailSection icon={<ArrowDownRightIcon className="w-4 h-4" />} label="Input">
+        {isDetailLoading ? (
+          <Skeleton className="h-20 w-full" />
+        ) : traceDetail?.inputMessages.length ? (
+          <pre className="overflow-auto rounded bg-muted p-3 text-xs">
+            {JSON.stringify(traceDetail.inputMessages, null, 2)}
+          </pre>
+        ) : (
+          <Text.H6 color="foregroundMuted">No input messages</Text.H6>
+        )}
+      </DetailSection>
+
+      <DetailSection icon={<ArrowUpRightIcon className="w-4 h-4" />} label="Output">
+        {isDetailLoading ? (
+          <Skeleton className="h-20 w-full" />
+        ) : traceDetail?.outputMessages.length ? (
+          <pre className="overflow-auto rounded bg-muted p-3 text-xs">
+            {JSON.stringify(traceDetail.outputMessages, null, 2)}
+          </pre>
+        ) : (
+          <Text.H6 color="foregroundMuted">No output messages</Text.H6>
+        )}
+      </DetailSection>
+
+      <DetailSection icon={<MessageSquareIcon className="w-4 h-4" />} label="Annotations">
+        <Text.H6 color="foregroundMuted">Coming soon ™</Text.H6>
+      </DetailSection>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -11,13 +11,20 @@ import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/ut
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { AppWindowIcon, CalendarIcon, ChevronDown, Columns2Icon, DatabaseIcon, FilterIcon } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
+import { z } from "zod"
 import { useTracesCount, useTracesInfiniteScroll } from "../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../domains/traces/traces.functions.ts"
 import { useSelectableRows } from "../../../../lib/hooks/useSelectableRows.ts"
+import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
 import { AddToDatasetModal } from "./datasets/-components/add-to-dataset-modal.tsx"
+
+const tracesSearchSchema = z.object({
+  traceId: z.string().optional(),
+})
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/")({
   component: TracesPage,
+  validateSearch: tracesSearchSchema,
 })
 
 function StatusBadge({ status }: { status: string }) {
@@ -112,6 +119,7 @@ const columns: InfiniteTableColumn<TraceRecord>[] = [
 
 function TracesPage() {
   const { projectId } = Route.useParams()
+  const { traceId: activeTraceId } = Route.useSearch()
   const navigate = useNavigate()
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
   const [sorting, setSorting] = useState<InfiniteTableSorting>(DEFAULT_SORTING)
@@ -125,75 +133,96 @@ function TracesPage() {
     totalRowCount: totalCount,
   })
 
-  const getRowKey = useCallback((t: TraceRecord) => t.traceId, [])
-  const onRowClick = useCallback(
-    (t: TraceRecord) =>
-      navigate({
-        to: "/projects/$projectId/traces/$traceId/spans",
-        params: { projectId, traceId: t.traceId },
-      }),
-    [navigate, projectId],
+  const activeTrace = useMemo(
+    () => (activeTraceId ? traces.find((t) => t.traceId === activeTraceId) : undefined),
+    [activeTraceId, traces],
   )
 
+  const getRowKey = useCallback((t: TraceRecord) => t.traceId, [])
+
+  const onRowClick = useCallback(
+    (t: TraceRecord) => {
+      navigate({
+        to: ".",
+        search: t.traceId === activeTraceId ? {} : { traceId: t.traceId },
+        replace: true,
+      })
+    },
+    [navigate, activeTraceId],
+  )
+
+  const closeDrawer = useCallback(() => {
+    navigate({
+      to: ".",
+      search: {},
+      replace: true,
+    })
+  }, [navigate])
+
   return (
-    <div className="flex flex-col h-full gap-3">
-      <div className="flex flex-col p-6 pb-0 gap-3">
-        {/* Action buttons */}
-        <div className="flex flex-row gap-2 items-center justify-between">
-          <div className="flex flex-row gap-2 items-center">
-            <Button variant="outline" size="sm" flat disabled>
-              <AppWindowIcon className="h-4 w-4" />
-              <Text.H6>All logs</Text.H6>
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-            <Button variant="outline" size="sm" flat disabled>
-              <CalendarIcon className="h-4 w-4" />
-              <Text.H6>Last 7 days</Text.H6>
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-            <Button variant="outline" size="sm" flat disabled>
-              <Columns2Icon className="h-4 w-4" />
-              <Text.H6>Columns</Text.H6>
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="sm" flat disabled>
-              <FilterIcon className="h-4 w-4" />
-              <Text.H6>Filters</Text.H6>
-            </Button>
-            {selection.selectedCount > 0 && (
-              <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
-                <DatabaseIcon className="h-4 w-4" />
-                <Text.H6>Add to Dataset ({selection.selectedCount})</Text.H6>
+    <div className="flex flex-row h-full">
+      <div className="flex flex-col flex-1 min-w-0 gap-3">
+        <div className="flex flex-col p-6 pb-0 gap-3">
+          <div className="flex flex-row gap-2 items-center justify-between">
+            <div className="flex flex-row gap-2 items-center">
+              <Button variant="outline" size="sm" flat disabled>
+                <AppWindowIcon className="h-4 w-4" />
+                <Text.H6>All logs</Text.H6>
+                <ChevronDown className="h-4 w-4" />
               </Button>
-            )}
+              <Button variant="outline" size="sm" flat disabled>
+                <CalendarIcon className="h-4 w-4" />
+                <Text.H6>Last 7 days</Text.H6>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="sm" flat disabled>
+                <Columns2Icon className="h-4 w-4" />
+                <Text.H6>Columns</Text.H6>
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" size="sm" flat disabled>
+                <FilterIcon className="h-4 w-4" />
+                <Text.H6>Filters</Text.H6>
+              </Button>
+              {selection.selectedCount > 0 && (
+                <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                  <DatabaseIcon className="h-4 w-4" />
+                  <Text.H6>Add to Dataset ({selection.selectedCount})</Text.H6>
+                </Button>
+              )}
+            </div>
+
+            <div className="flex flex-row gap-2 items-center">
+              <Input placeholder="Search traces" size="sm" className="w-60" disabled />
+            </div>
           </div>
 
-          <div className="flex flex-row gap-2 items-center">
-            <Input placeholder="Search traces" size="sm" className="w-60" disabled />
+          <div className="w-full flex flex-col bg-secondary rounded-lg p-4 min-h-[144px] items-center justify-center">
+            <Text.H5 color="foregroundMuted">Coming soon</Text.H5>
           </div>
         </div>
 
-        {/* Traces Summary */}
-        <div className="w-full flex flex-col bg-secondary rounded-lg p-4 min-h-[144px] items-center justify-center">
-          <Text.H5 color="foregroundMuted">Coming soon</Text.H5>
+        <div className="min-h-0 grow">
+          <InfiniteTable
+            className="p-6 pt-0"
+            data={traces}
+            isLoading={isLoading}
+            columns={columns}
+            getRowKey={getRowKey}
+            onRowClick={onRowClick}
+            activeRowKey={activeTraceId}
+            selection={selection}
+            infiniteScroll={infiniteScroll}
+            sorting={sorting}
+            defaultSorting={DEFAULT_SORTING}
+            onSortChange={setSorting}
+          />
         </div>
       </div>
 
-      <div className="min-h-0 grow">
-        <InfiniteTable
-          className="p-6 pt-0"
-          data={traces}
-          isLoading={isLoading}
-          columns={columns}
-          getRowKey={getRowKey}
-          onRowClick={onRowClick}
-          selection={selection}
-          infiniteScroll={infiniteScroll}
-          sorting={sorting}
-          defaultSorting={DEFAULT_SORTING}
-          onSortChange={setSorting}
-        />
-      </div>
+      {activeTraceId && (
+        <TraceDetailDrawer traceId={activeTraceId} trace={activeTrace} projectId={projectId} onClose={closeDrawer} />
+      )}
 
       <AddToDatasetModal
         open={addToDatasetOpen}

--- a/apps/workers/src/workers/dataset-export.ts
+++ b/apps/workers/src/workers/dataset-export.ts
@@ -1,12 +1,12 @@
 import { csvExportHeader, DatasetRepository, DatasetRowRepository, rowsToCsvFragment } from "@domain/datasets"
 import { datasetExportTemplate, type EmailSender, type RenderedEmail, sendEmail } from "@domain/email"
 import type { MessageHandler, QueueConsumer, QueueMessage } from "@domain/queue"
-import { DatasetId, OrganizationId, putInDisk } from "@domain/shared"
+import { DatasetId, OrganizationId, putInDisk, type StorageDiskPort } from "@domain/shared"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { DatasetRowRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { DatasetRepositoryLive, type PostgresClient, withPostgres } from "@platform/db-postgres"
 import { createEmailTransportSender } from "@platform/email-transport"
-import { createStorageDisk, type StorageDisk } from "@platform/storage-object"
+import { createStorageDisk } from "@platform/storage-object"
 import { createLogger } from "@repo/observability"
 import { Data, Effect } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
@@ -24,7 +24,7 @@ const SIGNED_URL_EXPIRY_SECONDS = 7 * 24 * 60 * 60
 interface DatasetExportWorkerDependencies {
   readonly postgresClient?: PostgresClient
   readonly clickhouseClient?: ClickHouseClient
-  readonly disk?: StorageDisk
+  readonly disk?: StorageDiskPort
   readonly emailSender?: EmailSender
   readonly logger?: Pick<typeof logger, "info" | "error">
 }

--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -1,5 +1,5 @@
 import type { MessageHandler, QueueConsumer, QueueMessage } from "@domain/queue"
-import { deleteFromDisk, getFromDisk, OrganizationId } from "@domain/shared"
+import { deleteFromDisk, getFromDisk, OrganizationId, type StorageDiskPort } from "@domain/shared"
 import {
   decodeOtlpProtobuf,
   type OtlpExportTraceServiceRequest,
@@ -8,7 +8,6 @@ import {
 } from "@domain/spans"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
-import type { StorageDisk } from "@platform/storage-object"
 import { createLogger } from "@repo/observability"
 import { Effect } from "effect"
 import { getClickhouseClient, getStorageDisk } from "../clients.ts"
@@ -17,7 +16,7 @@ const logger = createLogger("span-ingestion")
 
 interface SpanIngestionWorkerDependencies {
   readonly clickhouseClient?: ClickHouseClient
-  readonly disk?: StorageDisk
+  readonly disk?: StorageDiskPort
   readonly logger?: Pick<typeof logger, "error">
 }
 

--- a/packages/ui/src/components/detail-drawer/detail-drawer.tsx
+++ b/packages/ui/src/components/detail-drawer/detail-drawer.tsx
@@ -1,0 +1,184 @@
+import { PanelRightCloseIcon } from "lucide-react"
+import { type KeyboardEvent, type ReactNode, useCallback, useRef, useState, useSyncExternalStore } from "react"
+import { useLocalStorage } from "../../hooks/use-local-storage.ts"
+import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { cn } from "../../utils/cn.ts"
+import { Button } from "../button/button.tsx"
+
+const DEFAULT_MIN_WIDTH = 360
+const DEFAULT_DEFAULT_WIDTH = 520
+const KEYBOARD_STEP = 20
+
+function subscribeToResize(cb: () => void) {
+  window.addEventListener("resize", cb)
+  return () => window.removeEventListener("resize", cb)
+}
+
+function getMaxWidth() {
+  return Math.floor(window.innerWidth / 2)
+}
+
+function useMaxWidth() {
+  return useSyncExternalStore(subscribeToResize, getMaxWidth, () => DEFAULT_DEFAULT_WIDTH)
+}
+
+function clampWidth(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function useDrawerWidth({
+  storeKey,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+}: {
+  storeKey: string | undefined
+  defaultWidth: number
+  minWidth: number
+  maxWidth: number
+}) {
+  const stored = useLocalStorage<number | null>({ key: storeKey, defaultValue: null })
+  const hasStore = storeKey !== undefined
+
+  const initialWidth = hasStore && stored.value !== null ? stored.value : defaultWidth
+  const [rawWidth, setRawWidth] = useState(initialWidth)
+
+  const width = clampWidth(rawWidth, minWidth, maxWidth)
+
+  const setWidth = useCallback(
+    (next: number) => {
+      setRawWidth(next)
+      if (hasStore) stored.setValue(next)
+    },
+    [hasStore, stored.setValue],
+  )
+
+  return { width, setWidth }
+}
+
+export function DetailDrawer({
+  onClose,
+  header,
+  actions,
+  children,
+  storeKey,
+  minWidth = DEFAULT_MIN_WIDTH,
+  defaultWidth = DEFAULT_DEFAULT_WIDTH,
+}: {
+  readonly onClose: () => void
+  readonly header?: ReactNode
+  readonly actions?: ReactNode
+  readonly children: ReactNode
+  readonly storeKey?: string
+  readonly minWidth?: number
+  readonly defaultWidth?: number
+}) {
+  const maxWidth = useMaxWidth()
+  const { width, setWidth } = useDrawerWidth({ storeKey, defaultWidth, minWidth, maxWidth })
+  const [isDragging, setIsDragging] = useState(false)
+  const startX = useRef(0)
+  const startWidth = useRef(0)
+  const moveHandlerRef = useRef<((e: MouseEvent) => void) | null>(null)
+  const upHandlerRef = useRef<(() => void) | null>(null)
+
+  const cleanupDrag = useCallback(() => {
+    if (moveHandlerRef.current) {
+      document.removeEventListener("mousemove", moveHandlerRef.current)
+      moveHandlerRef.current = null
+    }
+    if (upHandlerRef.current) {
+      document.removeEventListener("mouseup", upHandlerRef.current)
+      upHandlerRef.current = null
+    }
+  }, [])
+
+  useMountEffect(() => cleanupDrag)
+
+  const onDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      setIsDragging(true)
+      startX.current = e.clientX
+      startWidth.current = width
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        const delta = startX.current - moveEvent.clientX
+        setWidth(Math.max(minWidth, Math.min(maxWidth, startWidth.current + delta)))
+      }
+
+      const onMouseUp = () => {
+        setIsDragging(false)
+        cleanupDrag()
+      }
+
+      moveHandlerRef.current = onMouseMove
+      upHandlerRef.current = onMouseUp
+      document.addEventListener("mousemove", onMouseMove)
+      document.addEventListener("mouseup", onMouseUp)
+    },
+    [width, minWidth, maxWidth, setWidth, cleanupDrag],
+  )
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      let next: number | undefined
+      switch (e.key) {
+        case "ArrowLeft":
+          next = width + KEYBOARD_STEP
+          break
+        case "ArrowRight":
+          next = width - KEYBOARD_STEP
+          break
+        case "Home":
+          next = maxWidth
+          break
+        case "End":
+          next = minWidth
+          break
+        default:
+          return
+      }
+      e.preventDefault()
+      setWidth(next)
+    },
+    [width, minWidth, maxWidth, setWidth],
+  )
+
+  return (
+    <div className="flex flex-row h-full shrink-0" style={{ width }}>
+      {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panel"
+        aria-valuenow={width}
+        aria-valuemin={minWidth}
+        aria-valuemax={maxWidth}
+        aria-valuetext={`Panel width: ${width} pixels`}
+        tabIndex={0}
+        className={cn(
+          "relative cursor-col-resize shrink-0 border-l transition-colors",
+          "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
+          isDragging ? "border-primary" : "hover:border-primary",
+        )}
+        onMouseDown={onDragStart}
+        onKeyDown={onKeyDown}
+      />
+
+      <div className="flex flex-col flex-1 min-w-0 h-full bg-background">
+        <div className="flex flex-row items-center justify-between px-6 py-4 border-b shrink-0">
+          <div className="flex flex-row items-center gap-1">
+            <Button flat variant="outline" className="w-8 h-8 p-0" onClick={onClose}>
+              <PanelRightCloseIcon className="w-4 h-4 text-muted-foreground" />
+            </Button>
+            {actions}
+          </div>
+        </div>
+
+        {header && <div className="flex flex-col px-6 py-4 gap-5 border-b shrink-0">{header}</div>}
+
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/components/detail-drawer/detail-section.tsx
+++ b/packages/ui/src/components/detail-drawer/detail-section.tsx
@@ -1,0 +1,55 @@
+import { ChevronDown, ChevronLeft } from "lucide-react"
+import type { ReactNode } from "react"
+import { useState } from "react"
+import { useHover } from "../../hooks/use-hover.ts"
+import { cn } from "../../utils/cn.ts"
+import { Text } from "../text/text.tsx"
+
+function Header({
+  icon,
+  label,
+  open,
+  onClick,
+}: {
+  icon: ReactNode
+  label: string
+  open: boolean
+  onClick: () => void
+}) {
+  const [ref, hover] = useHover<HTMLButtonElement>()
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className="flex flex-row items-center gap-2 cursor-pointer text-muted-foreground hover:text-primary"
+      onClick={onClick}
+    >
+      {icon}
+      <Text.H6 color={hover ? "primary" : "foregroundMuted"}>{label}</Text.H6>
+
+      <hr className={cn("flex-1 border-t-2 border-dashed border-border mx-2", { "border-accent": hover })} />
+
+      {open ? <ChevronDown className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+    </button>
+  )
+}
+
+export function DetailSection({
+  icon,
+  label,
+  children,
+}: {
+  readonly icon: ReactNode
+  readonly label: string
+  readonly children: ReactNode
+}) {
+  const [open, setOpen] = useState(true)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Header icon={icon} label={label} open={open} onClick={() => setOpen((prev) => !prev)} />
+      {open && <div className="flex flex-col pl-2 max-h-60 overflow-y-auto">{children}</div>}
+    </div>
+  )
+}

--- a/packages/ui/src/components/detail-drawer/detail-summary.tsx
+++ b/packages/ui/src/components/detail-drawer/detail-summary.tsx
@@ -1,0 +1,80 @@
+import { CheckIcon, CopyIcon } from "lucide-react"
+import { useCallback, useRef, useState } from "react"
+import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { cn } from "../../utils/cn.ts"
+import { Icon } from "../icons/icons.tsx"
+import { Skeleton } from "../skeleton/skeleton.tsx"
+import { Text } from "../text/text.tsx"
+
+export type DetailSummaryItem = {
+  readonly label: string
+  readonly isLoading?: boolean
+  readonly value: string | undefined
+  readonly copyable?: boolean
+}
+
+function SummaryItemContent({
+  value,
+  isLoading,
+  copyable,
+}: {
+  value: string | undefined
+  isLoading: boolean
+  copyable: boolean
+}) {
+  const [isCopied, setIsCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useMountEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  })
+
+  const handleCopy = useCallback(() => {
+    if (copyable && value) {
+      navigator.clipboard.writeText(value)
+      setIsCopied(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setIsCopied(false), 2000)
+    }
+  }, [value, copyable])
+
+  if (isLoading) {
+    return <Skeleton className="h-4 w-24 inline-block" />
+  }
+
+  if (copyable && value) {
+    return (
+      <button
+        type="button"
+        className={cn("flex flex-row items-center gap-2", { "cursor-pointer hover:text-primary": copyable })}
+        onClick={handleCopy}
+      >
+        <Text.H5 color="foreground">{value}</Text.H5>
+        <Icon icon={isCopied ? CheckIcon : CopyIcon} size="sm" />
+      </button>
+    )
+  }
+
+  return <Text.H5 color="foreground">{value || "-"}</Text.H5>
+}
+
+function SummaryItem({ label, value, isLoading, copyable }: DetailSummaryItem) {
+  return (
+    <div className="flex flex-col gap-0.5 min-w-[120px]">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <SummaryItemContent value={value} isLoading={isLoading ?? false} copyable={copyable ?? false} />
+    </div>
+  )
+}
+
+export function DetailSummary({ items }: { readonly items: readonly DetailSummaryItem[] }) {
+  return (
+    <div className="flex flex-row flex-wrap gap-4">
+      {items.map((item) => (
+        <SummaryItem key={item.label} {...item} />
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -9,6 +9,7 @@ interface DataRowProps<T> {
   rowKey: string
   columns: InfiniteTableColumn<T>[]
   isSelected?: boolean
+  isActive?: boolean
   onToggleRow?: (key: string, checked: CheckedState) => void
   hasSelection: boolean
   onClick?: (row: T) => void
@@ -21,6 +22,7 @@ function DataRowInner<T>({
   rowKey,
   columns,
   isSelected,
+  isActive,
   onToggleRow,
   hasSelection,
   onClick,
@@ -42,7 +44,9 @@ function DataRowInner<T>({
       ref={measureRef}
       data-index={dataIndex}
       className={cn("bg-secondary transition-colors", {
+        "bg-accent": isActive,
         "hover:bg-muted cursor-pointer": onClick,
+        "hover:bg-accent": onClick && isActive,
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring": onClick,
       })}
       onClick={onClick ? () => onClick(row) : undefined}

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -22,6 +22,7 @@ export function InfiniteTable<T>({
   columns,
   getRowKey,
   onRowClick,
+  activeRowKey,
   selection,
   infiniteScroll,
   sorting,
@@ -185,6 +186,7 @@ export function InfiniteTable<T>({
                     rowKey={rowKey}
                     columns={columns}
                     hasSelection={!!selection}
+                    isActive={activeRowKey === rowKey}
                     {...(selection
                       ? { isSelected: selection.isSelected(rowKey), onToggleRow: selection.toggleRow }
                       : {})}

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -36,6 +36,7 @@ export interface InfiniteTableProps<T> {
   columns: InfiniteTableColumn<T>[]
   getRowKey: (row: T) => string
   onRowClick?: (row: T) => void
+  activeRowKey?: string
   selection?: InfiniteTableSelection
   infiniteScroll?: InfiniteTableInfiniteScroll
   sorting?: InfiniteTableSorting

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -1,0 +1,82 @@
+import { type KeyboardEvent, type ReactNode, useCallback, useRef } from "react"
+import { cn } from "../../utils/cn.ts"
+import { Text } from "../text/text.tsx"
+
+export type TabOption<T extends string = string> = {
+  readonly id: T
+  readonly label: string
+  readonly icon?: ReactNode
+}
+
+export function Tabs<T extends string>({
+  options,
+  active,
+  onSelect,
+}: {
+  readonly options: readonly TabOption<T>[]
+  readonly active: T
+  readonly onSelect: (id: T) => void
+}) {
+  const tabRefs = useRef<Map<T, HTMLButtonElement>>(new Map())
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const currentIndex = options.findIndex((o) => o.id === active)
+      let nextIndex: number | undefined
+
+      switch (e.key) {
+        case "ArrowLeft":
+          nextIndex = (currentIndex - 1 + options.length) % options.length
+          break
+        case "ArrowRight":
+          nextIndex = (currentIndex + 1) % options.length
+          break
+        case "Home":
+          nextIndex = 0
+          break
+        case "End":
+          nextIndex = options.length - 1
+          break
+        default:
+          return
+      }
+
+      e.preventDefault()
+      const next = options[nextIndex]
+      if (!next) return
+      onSelect(next.id)
+      tabRefs.current.get(next.id)?.focus()
+    },
+    [options, active, onSelect],
+  )
+
+  return (
+    <div className="flex flex-row gap-2" role="tablist" onKeyDown={onKeyDown}>
+      {options.map((option) => {
+        const isActive = active === option.id
+        return (
+          <button
+            key={option.id}
+            ref={(el) => {
+              if (el) tabRefs.current.set(option.id, el)
+              else tabRefs.current.delete(option.id)
+            }}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            className={cn(
+              "inline-flex items-center h-8 gap-1 px-2 rounded-md",
+              "text-xs leading-4 font-medium cursor-pointer",
+              isActive ? "bg-muted text-foreground" : "hover:bg-muted text-muted-foreground",
+            )}
+            onClick={() => onSelect(option.id)}
+          >
+            {option.icon}
+            <Text.H5 color={isActive ? "foreground" : "foregroundMuted"}>{option.label}</Text.H5>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/ui/src/hooks/use-hover.ts
+++ b/packages/ui/src/hooks/use-hover.ts
@@ -1,0 +1,26 @@
+import { useCallback, useRef, useState } from "react"
+
+export function useHover<T extends HTMLElement = HTMLElement>(): [ref: (node: T | null) => void, hovered: boolean] {
+  const [hovered, setHovered] = useState(false)
+  const prevNodeRef = useRef<T | null>(null)
+  const onEnter = useRef(() => setHovered(true))
+  const onLeave = useRef(() => setHovered(false))
+
+  const callbackRef = useCallback((node: T | null) => {
+    if (prevNodeRef.current) {
+      prevNodeRef.current.removeEventListener("mouseenter", onEnter.current)
+      prevNodeRef.current.removeEventListener("mouseleave", onLeave.current)
+    }
+
+    if (node) {
+      node.addEventListener("mouseenter", onEnter.current)
+      node.addEventListener("mouseleave", onLeave.current)
+    } else {
+      setHovered(false)
+    }
+
+    prevNodeRef.current = node
+  }, [])
+
+  return [callbackRef, hovered]
+}

--- a/packages/ui/src/hooks/use-local-storage.ts
+++ b/packages/ui/src/hooks/use-local-storage.ts
@@ -1,0 +1,96 @@
+import { useCallback, useSyncExternalStore } from "react"
+
+function buildKey(key: string): string {
+  return `latitude:${key}`
+}
+
+const isLocalStorageAvailable = (() => {
+  try {
+    const testKey = "__test__"
+    localStorage.setItem(testKey, testKey)
+    localStorage.removeItem(testKey)
+    return true
+  } catch {
+    return false
+  }
+})()
+
+function readValue<T>(key: string, defaultValue: T): T {
+  if (!isLocalStorageAvailable) return defaultValue
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw === null) return defaultValue
+    return JSON.parse(raw) as T
+  } catch {
+    return defaultValue
+  }
+}
+
+const cache = new Map<string, unknown>()
+const subscribers = new Map<string, Set<() => void>>()
+
+function subscribe(key: string, onStoreChange: () => void): () => void {
+  let set = subscribers.get(key)
+  if (!set) {
+    set = new Set()
+    subscribers.set(key, set)
+  }
+  set.add(onStoreChange)
+  return () => {
+    set.delete(onStoreChange)
+    if (set.size === 0) subscribers.delete(key)
+  }
+}
+
+function emitChange(key: string) {
+  for (const cb of subscribers.get(key) ?? []) cb()
+}
+
+type SetAction<T> = T | ((prev: T) => T)
+
+const NOOP_SET = () => {}
+
+export function useLocalStorage<T>({
+  key,
+  defaultValue,
+}: {
+  readonly key: string | undefined
+  readonly defaultValue: T
+}): {
+  readonly value: T
+  readonly setValue: (action: SetAction<T>) => void
+} {
+  const fullKey = key !== undefined ? buildKey(key) : undefined
+
+  const value = useSyncExternalStore(
+    (cb) => (fullKey ? subscribe(fullKey, cb) : () => {}),
+    () => {
+      if (!fullKey) return defaultValue
+      if (!cache.has(fullKey)) {
+        cache.set(fullKey, readValue(fullKey, defaultValue))
+      }
+      return cache.get(fullKey) as T
+    },
+    () => defaultValue,
+  )
+
+  const setValue = useCallback(
+    (action: SetAction<T>) => {
+      if (!fullKey) return
+      const current = cache.has(fullKey) ? (cache.get(fullKey) as T) : readValue(fullKey, defaultValue)
+      const next = action instanceof Function ? action(current) : action
+      cache.set(fullKey, next)
+      if (isLocalStorageAvailable) {
+        try {
+          localStorage.setItem(fullKey, JSON.stringify(next))
+        } catch {
+          // quota exceeded or unavailable
+        }
+      }
+      emitChange(fullKey)
+    },
+    [fullKey, defaultValue],
+  )
+
+  return { value, setValue: fullKey ? setValue : (NOOP_SET as (action: SetAction<T>) => void) }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,9 @@ export {
 export { Checkbox, type CheckedState } from "./components/checkbox/checkbox.tsx"
 export { Container, type ContainerSize } from "./components/container/container.tsx"
 export { CopyButton } from "./components/copy-button/index.tsx"
+export { DetailDrawer } from "./components/detail-drawer/detail-drawer.tsx"
+export { DetailSection } from "./components/detail-drawer/detail-section.tsx"
+export { DetailSummary, type DetailSummaryItem } from "./components/detail-drawer/detail-summary.tsx"
 export { DropdownMenu, type MenuOption, type TriggerButtonProps } from "./components/dropdown-menu/dropdown-menu.tsx"
 export {
   DropdownMenu as DropdownMenuRoot,
@@ -64,6 +67,7 @@ export { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 export { TableBlankSlate } from "./components/table-blank-slate/table-blank-slate.tsx"
 export { TableSkeleton } from "./components/table-skeleton/table-skeleton.tsx"
 export { TableWithHeader, TitleWithActions } from "./components/table-with-header/table-with-header.tsx"
+export { type TabOption, Tabs } from "./components/tabs/tabs.tsx"
 export { type Common as TextCommonProps, Text, TextAtom, type TextProps } from "./components/text/text.tsx"
 export type { ToastActionElement, ToastProps } from "./components/toast/toast.tsx"
 export {
@@ -78,6 +82,7 @@ export {
 export { Toaster } from "./components/toast/toaster.tsx"
 export { toast, useToast } from "./components/toast/useToast.ts"
 export { Tooltip, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from "./components/tooltip/tooltip.tsx"
+export { useHover } from "./hooks/use-hover.ts"
 export { useMountEffect } from "./hooks/use-mount-effect.ts"
 // Lib
 export * from "./tokens/colors.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a resizable detail drawer that opens from the traces table when a row is clicked, displaying trace metadata, spans, and a conversation placeholder across three tabs. The drawer is composed from new reusable `@repo/ui` primitives designed to be shared across future detail views (span detail, dataset row detail, etc.).

The drawer width is draggable and persisted to localStorage so it survives page navigations. Trace selection is driven by URL search params (`?traceId=...`), making individual trace views linkable and back-button friendly.

https://github.com/user-attachments/assets/ca007220-8b6c-4e70-a26a-1e9d400d7a27

### New `@repo/ui` primitives

- **`DetailDrawer`** — A side-panel container that sits alongside the main content area. Features a drag handle on its left edge for resizing (clamped between a configurable min width and half the viewport), a close button in a top toolbar with an `actions` slot for extra controls, and a sticky `header` slot above the scrollable body. Width is persisted via `storeKey` through the new `useLocalStorage` hook, and the max width reactively adjusts on window resize via `useSyncExternalStore`.

- **`DetailSection`** — A collapsible section used inside detail views. Renders an icon, label, and a dashed horizontal rule that stretches to fill available space, with a chevron indicator. The content area is scroll-constrained to `max-h-60` to prevent any single section from dominating the viewport.

- **`DetailSummary`** — A responsive key-value grid for displaying metadata at a glance (e.g. start time, duration, cost, trace ID). Each item supports a loading skeleton state and an optional copy-to-clipboard interaction with a brief check-mark confirmation.

- **`Tabs`** — A generic, type-safe tab bar (`Tabs<T extends string>`) accepting a `TabOption<T>[]` array with optional icons. Renders pill-shaped buttons with active/inactive visual states.

- **`useLocalStorage`** — A React hook wrapping `localStorage` with `useSyncExternalStore` for cross-component reactivity. Uses a module-level in-memory cache and subscriber registry so multiple call sites sharing the same key stay in sync without polling or storage events. All keys are namespaced under `latitude:` to avoid collisions. Gracefully degrades when localStorage is unavailable (SSR, quota exceeded).

### Trace detail drawer (`apps/web`)

- **`TraceDetailDrawer`** — Orchestrates the three tabs (Trace, Conversation, Spans) and manages the active tab via local state. Renders the trace name and status badge in the header, with a copyable trace ID. Fetches full trace detail data (`useTraceDetail`) when opened.

- **`TraceTab`** — Displays a `DetailSummary` grid (start time, duration, cost, trace/session/user IDs), tags, and collapsible `DetailSection`s for metadata JSON, system instructions, input messages, output messages, and an annotations placeholder.

- **`SpansTab`** — Lists all spans for the trace sorted by start time, each linking to the span detail route. Shows span name, kind, status, model, and cost.

- **`ConversationTab`** — Placeholder for a future conversation-style message view.

- **`traces.collection.ts`** — Added `useTraceDetail` query hook that fetches the full trace detail (messages, system instructions) for the selected trace.

- **`index.tsx` (TracesPage)** — Wired the drawer to open/close via the `traceId` URL search param, toggling on row click.

---

> [!NOTE]
> Trace Detail UI is still unfinished, but this PR is used to publish a progressive update, with the currently added primitives so that they can be used on Datasets too
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4f0e2cf-8fdd-4aba-82be-58b3fe40fe04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4f0e2cf-8fdd-4aba-82be-58b3fe40fe04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

