### PR TITLE
Prevent duplicate pending invitations per workspace

### DIFF
--- a/packages/domain/auth/src/index.ts
+++ b/packages/domain/auth/src/index.ts
@@ -23,6 +23,6 @@ export {
   MissingInviteDataError,
   MissingSignupProvisioningDataError,
 } from "./use-cases/complete-auth-intent.ts"
-export { createInviteIntentUseCase } from "./use-cases/create-invite-intent.ts"
+export { createInviteIntentUseCase, InviteAlreadyPendingError } from "./use-cases/create-invite-intent.ts"
 export { createLoginIntentUseCase, LoginUserNotFoundError } from "./use-cases/create-login-intent.ts"
 export { createSignupIntentUseCase } from "./use-cases/create-signup-intent.ts"

--- a/packages/domain/auth/src/use-cases/create-invite-intent.test.ts
+++ b/packages/domain/auth/src/use-cases/create-invite-intent.test.ts
@@ -1,0 +1,120 @@
+import { NotFoundError } from "@domain/shared"
+import { UserRepository } from "@domain/users"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { AuthIntentRepository, type PendingInvite } from "../ports/auth-intent-repository.ts"
+import type { AuthIntent } from "../types.ts"
+import { createInviteIntentUseCase, InviteAlreadyPendingError } from "./create-invite-intent.ts"
+
+interface FakeAuthIntentRepo {
+  readonly savedIntents: AuthIntent[]
+  readonly pendingInvitesByOrganizationId: Map<string, readonly PendingInvite[]>
+}
+
+const createFakeAuthIntentRepository = (fake: FakeAuthIntentRepo) => ({
+  save: (intent: AuthIntent) =>
+    Effect.sync(() => {
+      fake.savedIntents.push(intent)
+    }),
+  findById: (id: string) => Effect.fail(new NotFoundError({ entity: "AuthIntent", id })),
+  markConsumed: () => Effect.succeed(undefined),
+  findPendingInvitesByOrganizationId: (organizationId: string) =>
+    Effect.succeed(fake.pendingInvitesByOrganizationId.get(organizationId) ?? []),
+})
+
+const createFakeUserRepository = () => ({
+  findByEmail: (email: string) => Effect.fail(new NotFoundError({ entity: "User", id: email })),
+  setNameIfMissing: (_params: { userId: string; name: string }) => Effect.succeed(undefined),
+})
+
+const createTestLayers = (fakeAuthIntentRepo: FakeAuthIntentRepo) =>
+  Layer.mergeAll(
+    Layer.succeed(AuthIntentRepository, createFakeAuthIntentRepository(fakeAuthIntentRepo)),
+    Layer.succeed(UserRepository, createFakeUserRepository()),
+  )
+
+describe("createInviteIntentUseCase", () => {
+  it("creates an invite intent when no pending invite exists for the email in the organization", async () => {
+    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
+      savedIntents: [],
+      pendingInvitesByOrganizationId: new Map(),
+    }
+    const testLayers = createTestLayers(fakeAuthIntentRepo)
+
+    const intent = await Effect.runPromise(
+      createInviteIntentUseCase({
+        email: " Invited@Example.com ",
+        organizationId: "org_1",
+        organizationName: "Acme",
+        inviterName: "Alice",
+      }).pipe(Effect.provide(testLayers)),
+    )
+
+    expect(intent.email).toBe("invited@example.com")
+    expect(intent.type).toBe("invite")
+    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(1)
+    expect(fakeAuthIntentRepo.savedIntents[0]?.email).toBe("invited@example.com")
+  })
+
+  it("rejects duplicate pending invite for same email and organization", async () => {
+    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
+      savedIntents: [],
+      pendingInvitesByOrganizationId: new Map([
+        [
+          "org_1",
+          [
+            {
+              id: "intent_existing",
+              email: "INVITED@EXAMPLE.COM",
+              createdAt: new Date(),
+            },
+          ],
+        ],
+      ]),
+    }
+    const testLayers = createTestLayers(fakeAuthIntentRepo)
+
+    const error = await Effect.runPromise(
+      createInviteIntentUseCase({
+        email: " invited@example.com ",
+        organizationId: "org_1",
+        organizationName: "Acme",
+        inviterName: "Alice",
+      }).pipe(Effect.provide(testLayers), Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(InviteAlreadyPendingError)
+    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(0)
+  })
+
+  it("allows invite when pending invite exists for same email in another organization", async () => {
+    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
+      savedIntents: [],
+      pendingInvitesByOrganizationId: new Map([
+        [
+          "org_2",
+          [
+            {
+              id: "intent_existing",
+              email: "invited@example.com",
+              createdAt: new Date(),
+            },
+          ],
+        ],
+      ]),
+    }
+    const testLayers = createTestLayers(fakeAuthIntentRepo)
+
+    const intent = await Effect.runPromise(
+      createInviteIntentUseCase({
+        email: "invited@example.com",
+        organizationId: "org_1",
+        organizationName: "Acme",
+        inviterName: "Alice",
+      }).pipe(Effect.provide(testLayers)),
+    )
+
+    expect(intent.email).toBe("invited@example.com")
+    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(1)
+  })
+})

--- a/packages/domain/auth/src/use-cases/create-invite-intent.ts
+++ b/packages/domain/auth/src/use-cases/create-invite-intent.ts
@@ -1,8 +1,17 @@
+import { OrganizationId } from "@domain/shared"
 import { UserRepository } from "@domain/users"
-import { Effect } from "effect"
+import { Data, Effect } from "effect"
 import { createAuthIntent } from "../entities/auth-intent.ts"
 import { AuthIntentRepository } from "../ports/auth-intent-repository.ts"
 import { createInviteIntentData, normalizeEmail } from "./auth-intent-policy.ts"
+
+export class InviteAlreadyPendingError extends Data.TaggedError("InviteAlreadyPendingError")<{
+  readonly email: string
+  readonly organizationId: string
+}> {
+  readonly httpStatus = 409
+  readonly httpMessage = "User already has a pending invitation to this workspace"
+}
 
 export const createInviteIntentUseCase = (input: {
   email: string
@@ -20,6 +29,16 @@ export const createInviteIntentUseCase = (input: {
       organizationName: input.organizationName,
       inviterName: input.inviterName,
     })
+    const pendingInvites = yield* intents.findPendingInvitesByOrganizationId(OrganizationId(input.organizationId))
+    const hasPendingInvite = pendingInvites.some((invite) => normalizeEmail(invite.email) === email)
+
+    if (hasPendingInvite) {
+      return yield* new InviteAlreadyPendingError({
+        email,
+        organizationId: input.organizationId,
+      })
+    }
+
     const existingUser = yield* users
       .findByEmail(email)
       .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a guard in `createInviteIntentUseCase` to check existing pending invites for the same workspace
- return a typed 409 `InviteAlreadyPendingError` when the same email already has a pending invite in that workspace
- add unit tests covering normal invite creation, duplicate-in-workspace rejection, and allow-in-different-workspace behavior

## Testing
- `pnpm --filter @domain/auth exec vitest run src/use-cases/create-invite-intent.test.ts`
- `pnpm --filter @domain/auth check`
- `pnpm --filter @domain/auth typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21edf118-1003-46e2-8167-b1dbd6bfe71c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21edf118-1003-46e2-8167-b1dbd6bfe71c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

