### PR TITLE
feat: add reusable fake/mock factories for domain ports

### DIFF
--- a/packages/domain/auth/package.json
+++ b/packages/domain/auth/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/domain/auth/src/testing/fake-auth-intent-repository.ts
+++ b/packages/domain/auth/src/testing/fake-auth-intent-repository.ts
@@ -1,0 +1,44 @@
+import { NotFoundError } from "@domain/shared"
+import { Effect } from "effect"
+import type { AuthIntentRepository } from "../ports/auth-intent-repository.ts"
+import type { AuthIntent } from "../types.ts"
+
+type AuthIntentRepositoryShape = (typeof AuthIntentRepository)["Service"]
+
+export interface FakeAuthIntentState {
+  readonly intents: Map<string, AuthIntent>
+  readonly consumed: Map<string, { intentId: string; createdOrganizationId?: string }>
+}
+
+export const createFakeAuthIntentRepository = (overrides?: Partial<AuthIntentRepositoryShape>) => {
+  const intents = new Map<string, AuthIntent>()
+  const consumed = new Map<string, { intentId: string; createdOrganizationId?: string }>()
+
+  const repository: AuthIntentRepositoryShape = {
+    save: (intent) =>
+      Effect.sync(() => {
+        intents.set(intent.id, intent)
+      }),
+
+    findById: (id) =>
+      Effect.gen(function* () {
+        const intent = intents.get(id)
+        if (!intent) return yield* new NotFoundError({ entity: "AuthIntent", id })
+        return intent
+      }),
+
+    markConsumed: (params) =>
+      Effect.sync(() => {
+        consumed.set(params.intentId, params)
+        const intent = intents.get(params.intentId)
+        if (intent) {
+          intents.set(params.intentId, { ...intent, consumedAt: new Date() })
+        }
+      }),
+
+    findPendingInvitesByOrganizationId: () => Effect.succeed([]),
+    ...overrides,
+  }
+
+  return { repository, intents, consumed }
+}

--- a/packages/domain/auth/src/testing/index.ts
+++ b/packages/domain/auth/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { createFakeAuthIntentRepository, type FakeAuthIntentState } from "./fake-auth-intent-repository.ts"

--- a/packages/domain/auth/src/use-cases/complete-auth-intent.test.ts
+++ b/packages/domain/auth/src/use-cases/complete-auth-intent.test.ts
@@ -1,9 +1,13 @@
-import { type Membership, MembershipRepository, OrganizationRepository } from "@domain/organizations"
-import { NotFoundError, OrganizationId, SqlClient, toRepositoryError } from "@domain/shared"
+import { MembershipRepository, OrganizationRepository } from "@domain/organizations"
+import { createFakeMembershipRepository, createFakeOrganizationRepository } from "@domain/organizations/testing"
+import { SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
 import { UserRepository } from "@domain/users"
+import { createFakeUserRepository } from "@domain/users/testing"
 import { Effect, Exit, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { AuthIntentRepository } from "../ports/auth-intent-repository.ts"
+import { createFakeAuthIntentRepository } from "../testing/fake-auth-intent-repository.ts"
 import type { AuthIntent } from "../types.ts"
 import {
   AuthIntentEmailMismatchError,
@@ -21,7 +25,7 @@ const createTestAuthIntent = (overrides: Partial<AuthIntent> = {}): AuthIntent =
   email: "user@example.com",
   data: {},
   existingAccountAtRequest: false,
-  expiresAt: new Date(Date.now() + 3600000), // 1 hour from now
+  expiresAt: new Date(Date.now() + 3600000),
   consumedAt: null,
   createdOrganizationId: null,
   ...overrides,
@@ -34,198 +38,33 @@ const createTestSession = (overrides: { userId?: string; email?: string; name?: 
   ...overrides,
 })
 
-// --- Fake Repositories ---
-
-interface FakeAuthIntentRepo {
-  intents: Map<string, AuthIntent>
-  consumed: Map<string, { intentId: string; createdOrganizationId?: string }>
-}
-
-const createFakeAuthIntentRepository = (fake: FakeAuthIntentRepo) => ({
-  save: (intent: AuthIntent) =>
-    Effect.sync(() => {
-      fake.intents.set(intent.id, intent)
-    }),
-
-  findById: (id: string) =>
-    Effect.gen(function* () {
-      const intent = fake.intents.get(id)
-      if (!intent) {
-        return yield* new NotFoundError({ entity: "AuthIntent", id })
-      }
-      return intent
-    }),
-
-  markConsumed: (params: { intentId: string; createdOrganizationId?: string }) =>
-    Effect.sync(() => {
-      fake.consumed.set(params.intentId, params)
-      const intent = fake.intents.get(params.intentId)
-      if (intent) {
-        fake.intents.set(params.intentId, { ...intent, consumedAt: new Date() })
-      }
-    }),
-
-  findPendingInvitesByOrganizationId: () => Effect.succeed([] as const),
-})
-
-interface FakeUserRepo {
-  names: Map<string, string>
-}
-
-const createFakeUserRepository = (fake: FakeUserRepo) => ({
-  findByEmail: (_email: string) => Effect.fail(new NotFoundError({ entity: "User", id: _email })),
-
-  setNameIfMissing: (params: { userId: string; name: string }) =>
-    Effect.sync(() => {
-      if (params.name.trim()) {
-        fake.names.set(params.userId, params.name.trim())
-      }
-    }),
-})
-
-interface FakeMembershipRepo {
-  memberships: Map<string, Membership>
-}
-
-const createFakeMembershipRepository = (fake: FakeMembershipRepo) => ({
-  findById: (_id: string) => Effect.fail(new NotFoundError({ entity: "Membership", id: _id })),
-
-  findByOrganizationId: () => Effect.succeed([]),
-
-  findByUserId: () => Effect.succeed([]),
-
-  findByOrganizationAndUser: () => Effect.fail(new NotFoundError({ entity: "Membership", id: "" })),
-
-  findMembersWithUser: () => Effect.succeed([]),
-
-  isMember: () => Effect.succeed(false),
-
-  isAdmin: () => Effect.succeed(false),
-
-  save: (membership: Membership) =>
-    Effect.sync(() => {
-      fake.memberships.set(membership.id, membership)
-    }),
-
-  delete: () => Effect.succeed(undefined),
-})
-
-interface FakeOrganizationRepo {
-  organizations: Map<string, { id: string; name: string; slug: string }>
-  saved: { id: string; name: string; slug: string; creatorId: string }[]
-}
-
-const createFakeOrganizationRepository = (fake: FakeOrganizationRepo) => ({
-  findById: (id: OrganizationId) =>
-    Effect.gen(function* () {
-      const org = fake.organizations.get(id)
-      if (!org) {
-        return yield* new NotFoundError({ entity: "Organization", id })
-      }
-      return {
-        id: OrganizationId(org.id),
-        name: org.name,
-        slug: org.slug,
-        logo: null,
-        metadata: null,
-        creatorId: null,
-        currentSubscriptionId: null,
-        stripeCustomerId: null,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }
-    }),
-
-  findByUserId: () => Effect.succeed([]),
-
-  save: (org: {
-    id: OrganizationId
-    name: string
-    slug: string
-    logo: string | null
-    metadata: string | null
-    creatorId: string | null
-    currentSubscriptionId: string | null
-    stripeCustomerId: string | null
-    createdAt: Date
-    updatedAt: Date
-  }) =>
-    Effect.sync(() => {
-      fake.saved.push({
-        id: org.id,
-        name: org.name,
-        slug: org.slug,
-        creatorId: org.creatorId ?? "",
-      })
-      fake.organizations.set(org.id, { id: org.id, name: org.name, slug: org.slug })
-    }),
-
-  delete: () => Effect.succeed(undefined),
-
-  existsBySlug: () => Effect.succeed(false),
-})
-
 // --- Test Helpers ---
 
 const createTestLayers = () => {
-  const fakeAuthIntents: FakeAuthIntentRepo = {
-    intents: new Map(),
-    consumed: new Map(),
-  }
-  const fakeUsers: FakeUserRepo = {
-    names: new Map(),
-  }
-  const fakeMemberships: FakeMembershipRepo = {
-    memberships: new Map(),
-  }
+  const { repository: authIntentRepo, intents: fakeAuthIntents, consumed } = createFakeAuthIntentRepository()
+  const { repository: userRepo, namesSet: fakeUserNames } = createFakeUserRepository()
+  const { repository: membershipRepo, memberships: fakeMemberships } = createFakeMembershipRepository()
+  const { repository: organizationRepo, organizations: fakeOrganizations } = createFakeOrganizationRepository()
+  const fakeSqlClient = createFakeSqlClient()
 
-  const fakeOrganizations: FakeOrganizationRepo = {
-    organizations: new Map(),
-    saved: [],
-  }
-
-  const fakeSqlClient: import("@domain/shared").SqlClientShape = {
-    organizationId: OrganizationId("system"),
-    transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
-    query: <T>(_fn: (tx: unknown, organizationId: OrganizationId) => Promise<T>) =>
-      Effect.gen(function* () {
-        const result = yield* Effect.tryPromise({
-          try: () => Promise.resolve([] as unknown as T),
-          catch: (error) => toRepositoryError(error, "query"),
-        })
-        return result
-      }),
-  }
-
-  const AuthIntentRepositoryTest = Layer.succeed(AuthIntentRepository, createFakeAuthIntentRepository(fakeAuthIntents))
-
-  const UserRepositoryTest = Layer.succeed(UserRepository, createFakeUserRepository(fakeUsers))
-
-  const MembershipRepositoryTest = Layer.succeed(MembershipRepository, createFakeMembershipRepository(fakeMemberships))
-
-  const OrganizationRepositoryTest = Layer.succeed(
-    OrganizationRepository,
-    createFakeOrganizationRepository(fakeOrganizations),
+  const testLayers = Layer.mergeAll(
+    Layer.succeed(AuthIntentRepository, authIntentRepo),
+    Layer.succeed(UserRepository, userRepo),
+    Layer.succeed(MembershipRepository, membershipRepo),
+    Layer.succeed(OrganizationRepository, organizationRepo),
+    Layer.succeed(SqlClient, fakeSqlClient),
   )
-
-  const SqlClientTest = Layer.succeed(SqlClient, fakeSqlClient)
 
   return {
     fakeAuthIntents,
-    fakeUsers,
+    consumed,
+    fakeUserNames,
     fakeMemberships,
     fakeOrganizations,
-    testLayers: Layer.mergeAll(
-      AuthIntentRepositoryTest,
-      UserRepositoryTest,
-      MembershipRepositoryTest,
-      OrganizationRepositoryTest,
-      SqlClientTest,
-    ),
+    testLayers,
   }
 }
 
-// Helper to run effect and assert error type
 async function runAndExpectError<T, E>(
   program: Effect.Effect<T, E, never>,
   expectedError: new (...args: never[]) => E,
@@ -251,7 +90,7 @@ describe("completeAuthIntentUseCase", () => {
     const expiredIntent = createTestAuthIntent({
       expiresAt: new Date(Date.now() - 1000),
     })
-    fakeAuthIntents.intents.set(expiredIntent.id, expiredIntent)
+    fakeAuthIntents.set(expiredIntent.id, expiredIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -265,7 +104,7 @@ describe("completeAuthIntentUseCase", () => {
   it("returns AuthIntentEmailMismatchError when emails don't match", async () => {
     const { fakeAuthIntents, testLayers } = createTestLayers()
     const intent = createTestAuthIntent({ email: "user@example.com" })
-    fakeAuthIntents.intents.set(intent.id, intent)
+    fakeAuthIntents.set(intent.id, intent)
 
     const session = createTestSession({ email: "different@example.com" })
     const program = completeAuthIntentUseCase({
@@ -281,7 +120,7 @@ describe("completeAuthIntentUseCase", () => {
     const consumedIntent = createTestAuthIntent({
       consumedAt: new Date(),
     })
-    fakeAuthIntents.intents.set(consumedIntent.id, consumedIntent)
+    fakeAuthIntents.set(consumedIntent.id, consumedIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -295,9 +134,9 @@ describe("completeAuthIntentUseCase", () => {
   })
 
   it("handles login intent by marking it consumed", async () => {
-    const { fakeAuthIntents, testLayers } = createTestLayers()
+    const { fakeAuthIntents, consumed, testLayers } = createTestLayers()
     const loginIntent = createTestAuthIntent({ type: "login" })
-    fakeAuthIntents.intents.set(loginIntent.id, loginIntent)
+    fakeAuthIntents.set(loginIntent.id, loginIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -307,18 +146,18 @@ describe("completeAuthIntentUseCase", () => {
 
     await Effect.runPromise(program)
 
-    expect(fakeAuthIntents.consumed.size).toBe(1)
-    expect(fakeAuthIntents.consumed.get(loginIntent.id)?.intentId).toBe(loginIntent.id)
+    expect(consumed.size).toBe(1)
+    expect(consumed.get(loginIntent.id)?.intentId).toBe(loginIntent.id)
   })
 
   it("skips organization creation for signup when existingAccountAtRequest is true", async () => {
-    const { fakeAuthIntents, fakeOrganizations, testLayers } = createTestLayers()
+    const { fakeAuthIntents, consumed, fakeOrganizations, testLayers } = createTestLayers()
     const signupIntent = createTestAuthIntent({
       type: "signup",
       existingAccountAtRequest: true,
       data: {},
     })
-    fakeAuthIntents.intents.set(signupIntent.id, signupIntent)
+    fakeAuthIntents.set(signupIntent.id, signupIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -328,9 +167,9 @@ describe("completeAuthIntentUseCase", () => {
 
     await Effect.runPromise(program)
 
-    expect(fakeOrganizations.saved).toHaveLength(0)
-    expect(fakeAuthIntents.consumed.size).toBe(1)
-    expect(fakeAuthIntents.consumed.get(signupIntent.id)?.intentId).toBe(signupIntent.id)
+    expect(fakeOrganizations.size).toBe(0)
+    expect(consumed.size).toBe(1)
+    expect(consumed.get(signupIntent.id)?.intentId).toBe(signupIntent.id)
   })
 
   it("returns MissingInviteDataError when invite data is missing", async () => {
@@ -339,7 +178,7 @@ describe("completeAuthIntentUseCase", () => {
       type: "invite",
       data: {},
     })
-    fakeAuthIntents.intents.set(inviteIntent.id, inviteIntent)
+    fakeAuthIntents.set(inviteIntent.id, inviteIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -355,7 +194,7 @@ describe("completeAuthIntentUseCase", () => {
     const unknownIntent = createTestAuthIntent({
       type: "unknown" as "login",
     })
-    fakeAuthIntents.intents.set(unknownIntent.id, unknownIntent)
+    fakeAuthIntents.set(unknownIntent.id, unknownIntent)
 
     const session = createTestSession()
     const program = completeAuthIntentUseCase({
@@ -369,7 +208,7 @@ describe("completeAuthIntentUseCase", () => {
   it("normalizes email comparison (case insensitive)", async () => {
     const { fakeAuthIntents, testLayers } = createTestLayers()
     const intent = createTestAuthIntent({ email: "USER@EXAMPLE.COM" })
-    fakeAuthIntents.intents.set(intent.id, intent)
+    fakeAuthIntents.set(intent.id, intent)
 
     const session = createTestSession({ email: "user@example.com" })
     const program = completeAuthIntentUseCase({
@@ -379,7 +218,6 @@ describe("completeAuthIntentUseCase", () => {
 
     const exit = await Effect.runPromiseExit(program)
 
-    // Should not be an email mismatch error
     if (Exit.isFailure(exit)) {
       const reasons = (exit.cause as unknown as { reasons: Array<{ _tag: string; error: unknown }> }).reasons
       const failReason = reasons.find((r) => r._tag === "Fail")

--- a/packages/domain/auth/src/use-cases/create-invite-intent.test.ts
+++ b/packages/domain/auth/src/use-cases/create-invite-intent.test.ts
@@ -1,45 +1,37 @@
-import { NotFoundError } from "@domain/shared"
 import { UserRepository } from "@domain/users"
+import { createFakeUserRepository } from "@domain/users/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
 import { AuthIntentRepository, type PendingInvite } from "../ports/auth-intent-repository.ts"
+import { createFakeAuthIntentRepository } from "../testing/fake-auth-intent-repository.ts"
 import type { AuthIntent } from "../types.ts"
 import { createInviteIntentUseCase, InviteAlreadyPendingError } from "./create-invite-intent.ts"
 
-interface FakeAuthIntentRepo {
-  readonly savedIntents: AuthIntent[]
-  readonly pendingInvitesByOrganizationId: Map<string, readonly PendingInvite[]>
-}
+const createTestLayers = (options?: { pendingInvitesByOrganizationId?: Map<string, readonly PendingInvite[]> }) => {
+  const savedIntents: AuthIntent[] = []
+  const pendingByOrg = options?.pendingInvitesByOrganizationId ?? new Map()
 
-const createFakeAuthIntentRepository = (fake: FakeAuthIntentRepo) => ({
-  save: (intent: AuthIntent) =>
-    Effect.sync(() => {
-      fake.savedIntents.push(intent)
-    }),
-  findById: (id: string) => Effect.fail(new NotFoundError({ entity: "AuthIntent", id })),
-  markConsumed: () => Effect.succeed(undefined),
-  findPendingInvitesByOrganizationId: (organizationId: string) =>
-    Effect.succeed(fake.pendingInvitesByOrganizationId.get(organizationId) ?? []),
-})
+  const { repository: authIntentRepo } = createFakeAuthIntentRepository({
+    save: (intent) =>
+      Effect.sync(() => {
+        savedIntents.push(intent)
+      }),
+    findPendingInvitesByOrganizationId: (organizationId) => Effect.succeed(pendingByOrg.get(organizationId) ?? []),
+  })
 
-const createFakeUserRepository = () => ({
-  findByEmail: (email: string) => Effect.fail(new NotFoundError({ entity: "User", id: email })),
-  setNameIfMissing: (_params: { userId: string; name: string }) => Effect.succeed(undefined),
-})
+  const { repository: userRepo } = createFakeUserRepository()
 
-const createTestLayers = (fakeAuthIntentRepo: FakeAuthIntentRepo) =>
-  Layer.mergeAll(
-    Layer.succeed(AuthIntentRepository, createFakeAuthIntentRepository(fakeAuthIntentRepo)),
-    Layer.succeed(UserRepository, createFakeUserRepository()),
+  const testLayers = Layer.mergeAll(
+    Layer.succeed(AuthIntentRepository, authIntentRepo),
+    Layer.succeed(UserRepository, userRepo),
   )
+
+  return { savedIntents, testLayers }
+}
 
 describe("createInviteIntentUseCase", () => {
   it("creates an invite intent when no pending invite exists for the email in the organization", async () => {
-    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
-      savedIntents: [],
-      pendingInvitesByOrganizationId: new Map(),
-    }
-    const testLayers = createTestLayers(fakeAuthIntentRepo)
+    const { savedIntents, testLayers } = createTestLayers()
 
     const intent = await Effect.runPromise(
       createInviteIntentUseCase({
@@ -52,13 +44,12 @@ describe("createInviteIntentUseCase", () => {
 
     expect(intent.email).toBe("invited@example.com")
     expect(intent.type).toBe("invite")
-    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(1)
-    expect(fakeAuthIntentRepo.savedIntents[0]?.email).toBe("invited@example.com")
+    expect(savedIntents).toHaveLength(1)
+    expect(savedIntents[0]?.email).toBe("invited@example.com")
   })
 
   it("rejects duplicate pending invite for same email and organization", async () => {
-    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
-      savedIntents: [],
+    const { savedIntents, testLayers } = createTestLayers({
       pendingInvitesByOrganizationId: new Map([
         [
           "org_1",
@@ -71,8 +62,7 @@ describe("createInviteIntentUseCase", () => {
           ],
         ],
       ]),
-    }
-    const testLayers = createTestLayers(fakeAuthIntentRepo)
+    })
 
     const error = await Effect.runPromise(
       createInviteIntentUseCase({
@@ -84,12 +74,11 @@ describe("createInviteIntentUseCase", () => {
     )
 
     expect(error).toBeInstanceOf(InviteAlreadyPendingError)
-    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(0)
+    expect(savedIntents).toHaveLength(0)
   })
 
   it("allows invite when pending invite exists for same email in another organization", async () => {
-    const fakeAuthIntentRepo: FakeAuthIntentRepo = {
-      savedIntents: [],
+    const { savedIntents, testLayers } = createTestLayers({
       pendingInvitesByOrganizationId: new Map([
         [
           "org_2",
@@ -102,8 +91,7 @@ describe("createInviteIntentUseCase", () => {
           ],
         ],
       ]),
-    }
-    const testLayers = createTestLayers(fakeAuthIntentRepo)
+    })
 
     const intent = await Effect.runPromise(
       createInviteIntentUseCase({
@@ -115,6 +103,6 @@ describe("createInviteIntentUseCase", () => {
     )
 
     expect(intent.email).toBe("invited@example.com")
-    expect(fakeAuthIntentRepo.savedIntents).toHaveLength(1)
+    expect(savedIntents).toHaveLength(1)
   })
 })

--- a/packages/domain/events/package.json
+++ b/packages/domain/events/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/domain/events/src/testing/fake-events-publisher.ts
+++ b/packages/domain/events/src/testing/fake-events-publisher.ts
@@ -1,0 +1,16 @@
+import { Effect } from "effect"
+import type { EventEnvelope, EventsPublisher } from "../index.ts"
+
+export const createFakeEventsPublisher = <TError = never>(overrides?: Partial<EventsPublisher<TError>>) => {
+  const published: EventEnvelope[] = []
+
+  const publisher: EventsPublisher<TError> = {
+    publish: (envelope: EventEnvelope) => {
+      published.push(envelope)
+      return Effect.void
+    },
+    ...overrides,
+  } as EventsPublisher<TError>
+
+  return { publisher, published }
+}

--- a/packages/domain/events/src/testing/index.ts
+++ b/packages/domain/events/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { createFakeEventsPublisher } from "./fake-events-publisher.ts"

--- a/packages/domain/organizations/package.json
+++ b/packages/domain/organizations/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/domain/organizations/src/testing/fake-membership-repository.ts
+++ b/packages/domain/organizations/src/testing/fake-membership-repository.ts
@@ -1,0 +1,49 @@
+import { NotFoundError } from "@domain/shared"
+import { Effect } from "effect"
+import type { Membership } from "../entities/membership.ts"
+import type { MembershipRepository } from "../ports/membership-repository.ts"
+
+type MembershipRepositoryShape = (typeof MembershipRepository)["Service"]
+
+export const createFakeMembershipRepository = (overrides?: Partial<MembershipRepositoryShape>) => {
+  const memberships = new Map<string, Membership>()
+
+  const repository: MembershipRepositoryShape = {
+    findById: (id) => {
+      const m = memberships.get(id)
+      if (!m) return Effect.fail(new NotFoundError({ entity: "Membership", id }))
+      return Effect.succeed(m)
+    },
+
+    findByOrganizationId: (organizationId) =>
+      Effect.succeed([...memberships.values()].filter((m) => m.organizationId === organizationId)),
+
+    findByUserId: (userId) => Effect.succeed([...memberships.values()].filter((m) => m.userId === userId)),
+
+    findByOrganizationAndUser: (organizationId, userId) => {
+      const m = [...memberships.values()].find((m) => m.organizationId === organizationId && m.userId === userId)
+      if (!m) return Effect.fail(new NotFoundError({ entity: "Membership", id: "" }))
+      return Effect.succeed(m)
+    },
+
+    findMembersWithUser: () => Effect.succeed([]),
+
+    isMember: (organizationId, userId) =>
+      Effect.succeed([...memberships.values()].some((m) => m.organizationId === organizationId && m.userId === userId)),
+
+    isAdmin: () => Effect.succeed(false),
+
+    save: (membership) =>
+      Effect.sync(() => {
+        memberships.set(membership.id, membership)
+      }),
+
+    delete: (id) =>
+      Effect.sync(() => {
+        memberships.delete(id)
+      }),
+    ...overrides,
+  }
+
+  return { repository, memberships }
+}

--- a/packages/domain/organizations/src/testing/fake-organization-repository.ts
+++ b/packages/domain/organizations/src/testing/fake-organization-repository.ts
@@ -1,0 +1,35 @@
+import { NotFoundError, type OrganizationId } from "@domain/shared"
+import { Effect } from "effect"
+import type { Organization } from "../entities/organization.ts"
+import type { OrganizationRepository } from "../ports/organization-repository.ts"
+
+type OrganizationRepositoryShape = (typeof OrganizationRepository)["Service"]
+
+export const createFakeOrganizationRepository = (overrides?: Partial<OrganizationRepositoryShape>) => {
+  const organizations = new Map<OrganizationId, Organization>()
+
+  const repository: OrganizationRepositoryShape = {
+    findById: (id) => {
+      const org = organizations.get(id)
+      if (!org) return Effect.fail(new NotFoundError({ entity: "Organization", id }))
+      return Effect.succeed(org)
+    },
+
+    findByUserId: () => Effect.succeed([]),
+
+    save: (org) =>
+      Effect.sync(() => {
+        organizations.set(org.id, org)
+      }),
+
+    delete: (id) =>
+      Effect.sync(() => {
+        organizations.delete(id)
+      }),
+
+    existsBySlug: (slug) => Effect.succeed([...organizations.values()].some((o) => o.slug === slug)),
+    ...overrides,
+  }
+
+  return { repository, organizations }
+}

--- a/packages/domain/organizations/src/testing/index.ts
+++ b/packages/domain/organizations/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { createFakeMembershipRepository } from "./fake-membership-repository.ts"
+export { createFakeOrganizationRepository } from "./fake-organization-repository.ts"

--- a/packages/domain/queue/package.json
+++ b/packages/domain/queue/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check .",

--- a/packages/domain/queue/src/testing/fake-queue-publisher.ts
+++ b/packages/domain/queue/src/testing/fake-queue-publisher.ts
@@ -1,0 +1,22 @@
+import { Effect } from "effect"
+import type { QueueMessage, QueueName, QueuePublisherShape } from "../index.ts"
+
+export interface PublishedMessage {
+  readonly queue: QueueName
+  readonly message: { readonly body: Uint8Array; readonly key: string | null }
+}
+
+export const createFakeQueuePublisher = (overrides?: Partial<QueuePublisherShape>) => {
+  const published: PublishedMessage[] = []
+
+  const publisher: QueuePublisherShape = {
+    publish: (queue: QueueName, message: QueueMessage) => {
+      published.push({ queue, message: { body: message.body, key: message.key } })
+      return Effect.void
+    },
+    close: () => Effect.void,
+    ...overrides,
+  }
+
+  return { publisher, published }
+}

--- a/packages/domain/queue/src/testing/index.ts
+++ b/packages/domain/queue/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { createFakeQueuePublisher, type PublishedMessage } from "./fake-queue-publisher.ts"

--- a/packages/domain/shared/package.json
+++ b/packages/domain/shared/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/domain/shared/src/testing/fake-ch-sql-client.ts
+++ b/packages/domain/shared/src/testing/fake-ch-sql-client.ts
@@ -1,0 +1,15 @@
+import { Effect } from "effect"
+import type { ChSqlClientShape } from "../ch-sql-client.ts"
+import { toRepositoryError } from "../errors.ts"
+import type { OrganizationId } from "../id.ts"
+
+export const createFakeChSqlClient = (overrides?: Partial<ChSqlClientShape>): ChSqlClientShape => ({
+  organizationId: "fake-org" as OrganizationId,
+  transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+  query: <T>(_fn: (client: unknown, organizationId: OrganizationId) => Promise<T>) =>
+    Effect.tryPromise({
+      try: () => Promise.resolve([] as unknown as T),
+      catch: (error) => toRepositoryError(error, "query"),
+    }),
+  ...overrides,
+})

--- a/packages/domain/shared/src/testing/fake-sql-client.ts
+++ b/packages/domain/shared/src/testing/fake-sql-client.ts
@@ -1,0 +1,15 @@
+import { Effect } from "effect"
+import { toRepositoryError } from "../errors.ts"
+import type { OrganizationId } from "../id.ts"
+import type { SqlClientShape } from "../sql-client.ts"
+
+export const createFakeSqlClient = (overrides?: Partial<SqlClientShape>): SqlClientShape => ({
+  organizationId: "fake-org" as OrganizationId,
+  transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+  query: <T>(_fn: (tx: unknown, organizationId: OrganizationId) => Promise<T>) =>
+    Effect.tryPromise({
+      try: () => Promise.resolve([] as unknown as T),
+      catch: (error) => toRepositoryError(error, "query"),
+    }),
+  ...overrides,
+})

--- a/packages/domain/shared/src/testing/fake-storage-disk.ts
+++ b/packages/domain/shared/src/testing/fake-storage-disk.ts
@@ -1,0 +1,28 @@
+import type { StorageDiskPort } from "../storage.ts"
+
+export interface FakeStorageDiskState {
+  readonly written: { key: string; contents: string | Uint8Array }[]
+  readonly deleted: string[]
+}
+
+export const createFakeStorageDisk = (overrides?: Partial<StorageDiskPort>) => {
+  const written: FakeStorageDiskState["written"] = []
+  const deleted: FakeStorageDiskState["deleted"] = []
+
+  const disk: StorageDiskPort = {
+    put: async (key, contents) => {
+      written.push({ key, contents })
+    },
+    putStream: async () => {},
+    get: async () => "",
+    getBytes: async () => new Uint8Array(),
+    getStream: async () => new ReadableStream(),
+    delete: async (key) => {
+      deleted.push(key)
+    },
+    getSignedUrl: async () => "",
+    ...overrides,
+  }
+
+  return { disk, written, deleted }
+}

--- a/packages/domain/shared/src/testing/index.ts
+++ b/packages/domain/shared/src/testing/index.ts
@@ -1,0 +1,3 @@
+export { createFakeChSqlClient } from "./fake-ch-sql-client.ts"
+export { createFakeSqlClient } from "./fake-sql-client.ts"
+export { createFakeStorageDisk, type FakeStorageDiskState } from "./fake-storage-disk.ts"

--- a/packages/domain/spans/package.json
+++ b/packages/domain/spans/package.json
@@ -7,7 +7,8 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./otlp": "./src/otlp.ts"
+    "./otlp": "./src/otlp.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/domain/spans/src/testing/fake-span-repository.ts
+++ b/packages/domain/spans/src/testing/fake-span-repository.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import type { SpanDetail } from "../entities/span.ts"
+import type { SpanRepositoryShape } from "../ports/span-repository.ts"
+
+export const createFakeSpanRepository = (overrides?: Partial<SpanRepositoryShape>) => {
+  const inserted: SpanDetail[][] = []
+
+  const repository: SpanRepositoryShape = {
+    insert: (spans) => {
+      inserted.push([...spans])
+      return Effect.void
+    },
+    findByTraceId: () => Effect.succeed([]),
+    findByProjectId: () => Effect.succeed([]),
+    findBySpanId: () => Effect.succeed(null),
+    ...overrides,
+  }
+
+  return { repository, inserted }
+}

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect"
+import type { TraceRepositoryShape } from "../ports/trace-repository.ts"
+
+export const createFakeTraceRepository = (overrides?: Partial<TraceRepositoryShape>) => {
+  const repository: TraceRepositoryShape = {
+    findByProjectId: () => Effect.succeed({ items: [], hasMore: false }),
+    countByProjectId: () => Effect.succeed(0),
+    findByTraceId: () => Effect.succeed(null),
+    findByTraceIds: () => Effect.succeed([]),
+    ...overrides,
+  }
+
+  return { repository }
+}

--- a/packages/domain/spans/src/testing/index.ts
+++ b/packages/domain/spans/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { createFakeSpanRepository } from "./fake-span-repository.ts"
+export { createFakeTraceRepository } from "./fake-trace-repository.ts"

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -1,6 +1,8 @@
 import type { QueuePublisherShape } from "@domain/queue"
 import { QueuePublishError, QueuePublisher } from "@domain/queue"
+import { createFakeQueuePublisher } from "@domain/queue/testing"
 import { OrganizationId, ProjectId, StorageDisk, type StorageDiskPort, StorageError } from "@domain/shared"
+import { createFakeStorageDisk } from "@domain/shared/testing"
 import { Effect, Layer, Result } from "effect"
 import { describe, expect, it } from "vitest"
 import { ingestSpansUseCase } from "./ingest-spans.ts"
@@ -13,37 +15,6 @@ const validInput = {
   contentType: "application/json",
 }
 
-const createFakeDisk = () => {
-  const written: { key: string; contents: string | Uint8Array }[] = []
-  const deleted: string[] = []
-  const disk: StorageDiskPort = {
-    put: async (key, contents) => {
-      written.push({ key, contents })
-    },
-    putStream: async () => {},
-    get: async () => "",
-    getBytes: async () => new Uint8Array(),
-    getStream: async () => new ReadableStream(),
-    delete: async (key) => {
-      deleted.push(key)
-    },
-    getSignedUrl: async () => "",
-  }
-  return { disk, written, deleted }
-}
-
-const createFakePublisher = () => {
-  const published: { queue: string; message: { body: Uint8Array; key: string | null } }[] = []
-  const publisher: QueuePublisherShape = {
-    publish: (queue, message) => {
-      published.push({ queue, message: { body: message.body, key: message.key } })
-      return Effect.void
-    },
-    close: () => Effect.void,
-  }
-  return { publisher, published }
-}
-
 const runUseCase = (diskPort: StorageDiskPort, publisher: QueuePublisherShape) =>
   ingestSpansUseCase(validInput).pipe(
     Effect.provide(Layer.succeed(StorageDisk, diskPort)),
@@ -52,8 +23,8 @@ const runUseCase = (diskPort: StorageDiskPort, publisher: QueuePublisherShape) =
 
 describe("ingestSpansUseCase", () => {
   it("stores payload to disk and publishes queue message", async () => {
-    const { disk, written } = createFakeDisk()
-    const { publisher, published } = createFakePublisher()
+    const { disk, written } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
 
     await Effect.runPromise(runUseCase(disk, publisher))
 
@@ -68,8 +39,8 @@ describe("ingestSpansUseCase", () => {
   })
 
   it("uses protobuf extension for protobuf content type", async () => {
-    const { disk, written } = createFakeDisk()
-    const { publisher } = createFakePublisher()
+    const { disk, written } = createFakeStorageDisk()
+    const { publisher } = createFakeQueuePublisher()
 
     await Effect.runPromise(
       ingestSpansUseCase({ ...validInput, contentType: "application/x-protobuf" }).pipe(
@@ -82,23 +53,17 @@ describe("ingestSpansUseCase", () => {
   })
 
   it("fails with StorageError when disk write fails", async () => {
-    const failingDisk: StorageDiskPort = {
+    const { disk } = createFakeStorageDisk({
       put: async () => {
         throw new Error("disk unavailable")
       },
-      putStream: async () => {},
-      get: async () => "",
-      getBytes: async () => new Uint8Array(),
-      getStream: async () => new ReadableStream(),
-      delete: async () => {},
-      getSignedUrl: async () => "",
-    }
-    const { publisher, published } = createFakePublisher()
+    })
+    const { publisher, published } = createFakeQueuePublisher()
 
     const res = await Effect.runPromise(
       Effect.result(
         ingestSpansUseCase(validInput).pipe(
-          Effect.provide(Layer.succeed(StorageDisk, failingDisk)),
+          Effect.provide(Layer.succeed(StorageDisk, disk)),
           Effect.provide(Layer.succeed(QueuePublisher, publisher)),
         ),
       ),
@@ -113,17 +78,16 @@ describe("ingestSpansUseCase", () => {
   })
 
   it("fails with QueuePublishError and cleans up file when publish fails", async () => {
-    const { disk, written, deleted } = createFakeDisk()
-    const failingPublisher: QueuePublisherShape = {
+    const { disk, written, deleted } = createFakeStorageDisk()
+    const { publisher } = createFakeQueuePublisher({
       publish: (queue) => Effect.fail(new QueuePublishError({ cause: new Error("queue down"), queue })),
-      close: () => Effect.void,
-    }
+    })
 
     const res = await Effect.runPromise(
       Effect.result(
         ingestSpansUseCase(validInput).pipe(
           Effect.provide(Layer.succeed(StorageDisk, disk)),
-          Effect.provide(Layer.succeed(QueuePublisher, failingPublisher)),
+          Effect.provide(Layer.succeed(QueuePublisher, publisher)),
         ),
       ),
     )
@@ -142,23 +106,17 @@ describe("ingestSpansUseCase", () => {
   })
 
   it("does not publish when storage fails (sequential guarantee)", async () => {
-    const failingDisk: StorageDiskPort = {
+    const { disk } = createFakeStorageDisk({
       put: async () => {
         throw new Error("disk error")
       },
-      putStream: async () => {},
-      get: async () => "",
-      getBytes: async () => new Uint8Array(),
-      getStream: async () => new ReadableStream(),
-      delete: async () => {},
-      getSignedUrl: async () => "",
-    }
-    const { publisher, published } = createFakePublisher()
+    })
+    const { publisher, published } = createFakeQueuePublisher()
 
     await Effect.runPromise(
       Effect.result(
         ingestSpansUseCase(validInput).pipe(
-          Effect.provide(Layer.succeed(StorageDisk, failingDisk)),
+          Effect.provide(Layer.succeed(StorageDisk, disk)),
           Effect.provide(Layer.succeed(QueuePublisher, publisher)),
         ),
       ),
@@ -168,15 +126,14 @@ describe("ingestSpansUseCase", () => {
   })
 
   it("passes correct headers in queue message", async () => {
-    const { disk } = createFakeDisk()
+    const { disk } = createFakeStorageDisk()
     const capturedHeaders: Map<string, string>[] = []
-    const publisher: QueuePublisherShape = {
+    const { publisher } = createFakeQueuePublisher({
       publish: (_queue, message) => {
         capturedHeaders.push(new Map(message.headers))
         return Effect.void
       },
-      close: () => Effect.void,
-    }
+    })
 
     await Effect.runPromise(
       ingestSpansUseCase(validInput).pipe(

--- a/packages/domain/users/package.json
+++ b/packages/domain/users/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/domain/users/src/testing/fake-user-repository.ts
+++ b/packages/domain/users/src/testing/fake-user-repository.ts
@@ -1,0 +1,29 @@
+import { NotFoundError } from "@domain/shared"
+import { Effect } from "effect"
+import type { User } from "../entities/user.ts"
+import type { UserRepository } from "../ports/user-repository.ts"
+
+type UserRepositoryShape = (typeof UserRepository)["Service"]
+
+export const createFakeUserRepository = (overrides?: Partial<UserRepositoryShape>) => {
+  const users = new Map<string, User>()
+  const namesSet: { userId: string; name: string }[] = []
+
+  const repository: UserRepositoryShape = {
+    findByEmail: (email) => {
+      const user = [...users.values()].find((u) => u.email === email)
+      if (!user) return Effect.fail(new NotFoundError({ entity: "User", id: email }))
+      return Effect.succeed(user)
+    },
+
+    setNameIfMissing: (params) =>
+      Effect.sync(() => {
+        if (params.name.trim()) {
+          namesSet.push(params)
+        }
+      }),
+    ...overrides,
+  }
+
+  return { repository, users, namesSet }
+}

--- a/packages/domain/users/src/testing/index.ts
+++ b/packages/domain/users/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { createFakeUserRepository } from "./fake-user-repository.ts"

--- a/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
+++ b/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@domain/shared"
 import type { TraceDetail } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
+import { createFakeTraceRepository } from "@domain/spans/testing"
 import { DatasetRepositoryLive, postgresSchema, withPostgres } from "@platform/db-postgres"
 import { setupTestClickHouse, setupTestPostgres } from "@platform/testkit"
 import { Effect } from "effect"
@@ -37,13 +38,10 @@ const DATASET_ID = DatasetId("ds-add-traces-existing")
 const pg = setupTestPostgres()
 const ch = setupTestClickHouse()
 
-function makeFakeTraceRepository(traces: TraceDetail[]): (typeof TraceRepository)["Service"] {
-  return {
-    findByProjectId: () => Effect.succeed({ items: [], hasMore: false }),
-    countByProjectId: () => Effect.succeed(0),
-    findByTraceId: () => Effect.succeed(null),
+function makeFakeTraceRepository(traces: TraceDetail[]) {
+  return createFakeTraceRepository({
     findByTraceIds: () => Effect.succeed(traces),
-  }
+  }).repository
 }
 
 const runWithLive = <A, E>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements reusable test-helper factories for domain ports, replacing verbose inline fakes across the test suite. Each domain package now exposes a `/testing` sub-path with factory functions that provide working defaults, accept partial overrides, and track calls for assertions.

## Factories Created

| Package | Factory | Port |
|---------|---------|------|
| `@domain/shared/testing` | `createFakeStorageDisk` | `StorageDiskPort` |
| `@domain/shared/testing` | `createFakeSqlClient` | `SqlClientShape` |
| `@domain/shared/testing` | `createFakeChSqlClient` | `ChSqlClientShape` |
| `@domain/queue/testing` | `createFakeQueuePublisher` | `QueuePublisherShape` |
| `@domain/events/testing` | `createFakeEventsPublisher` | `EventsPublisher` |
| `@domain/spans/testing` | `createFakeSpanRepository` | `SpanRepositoryShape` |
| `@domain/spans/testing` | `createFakeTraceRepository` | `TraceRepositoryShape` |
| `@domain/auth/testing` | `createFakeAuthIntentRepository` | `AuthIntentRepository` |
| `@domain/users/testing` | `createFakeUserRepository` | `UserRepository` |
| `@domain/organizations/testing` | `createFakeMembershipRepository` | `MembershipRepository` |
| `@domain/organizations/testing` | `createFakeOrganizationRepository` | `OrganizationRepository` |

## Design

Each factory follows the same pattern:

1. **Working defaults** — every method returns a sensible no-op/empty value
2. **Partial overrides** — callers pass only the methods they care about
3. **Call tracking** — expose arrays (`written`, `deleted`, `published`, etc.) for assertions
4. **Test code isolation** — exported via `/testing` sub-path in `package.json`, never from the main entry point

### Example usage

```ts
// Happy path — default working disk
const { disk, written } = createFakeStorageDisk()

// Failure scenario — only override the method under test
const { disk } = createFakeStorageDisk({
  put: async () => { throw new Error("disk unavailable") },
})
```

## Tests Updated

Updated existing tests to use the new factories:
- `packages/domain/spans/src/use-cases/ingest-spans.test.ts`
- `packages/domain/auth/src/use-cases/complete-auth-intent.test.ts`
- `packages/domain/auth/src/use-cases/create-invite-intent.test.ts`
- `packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts`

## References

- PR discussion: https://github.com/latitude-dev/latitude-llm/pull/2461#discussion_r2124508068

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b44437e-74a1-4607-8920-724d4bcee796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b44437e-74a1-4607-8920-724d4bcee796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

