### PR TITLE
feat(observability): datadog environment-scoped bootstrap and web/start integration

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,6 +4,7 @@ import { serve } from "@hono/node-server"
 import { swaggerUI } from "@hono/swagger-ui"
 import { OpenAPIHono } from "@hono/zod-openapi"
 import { parseEnv } from "@platform/env"
+import { initializeObservability, shutdownObservability } from "@repo/observability"
 import { config as loadDotenv } from "dotenv"
 import { Effect } from "effect"
 import type { Hono } from "hono"
@@ -22,76 +23,88 @@ if (import.meta.url) {
   if (existsSync(envFilePath)) loadDotenv({ path: envFilePath, quiet: true })
 }
 
-const app = new OpenAPIHono()
-const port = Effect.runSync(parseEnv("LAT_API_PORT", "number", 3001))
+const startServer = async () => {
+  await initializeObservability({
+    serviceName: "api",
+  })
 
-// Register global error handler
-app.use(
-  honoLogger((message: string, ...rest: string[]) => {
-    console.log(message, ...rest)
-  }),
-)
-app.onError(honoErrorHandler)
+  const app = new OpenAPIHono()
+  const port = Effect.runSync(parseEnv("LAT_API_PORT", "number", 3001))
 
-// OpenAPIHono extends Hono — the cast is safe
-registerCorsMiddleware(app as unknown as Hono, { nodeEnv })
+  // Register global error handler
+  app.use(
+    honoLogger((message: string, ...rest: string[]) => {
+      console.log(message, ...rest)
+    }),
+  )
+  app.onError(honoErrorHandler)
 
-registerRoutes({
-  app,
-  database: getPostgresClient(),
-  clickhouse: getClickhouseClient(),
-  redis: getRedisClient(),
-})
+  // OpenAPIHono extends Hono — the cast is safe
+  registerCorsMiddleware(app as unknown as Hono, { nodeEnv })
 
-// Register security scheme via the OpenAPI registry
-app.openAPIRegistry.registerComponent("securitySchemes", "ApiKeyAuth", {
-  type: "http",
-  scheme: "bearer",
-  description: "Organization-scoped API key",
-})
+  registerRoutes({
+    app,
+    database: getPostgresClient(),
+    clickhouse: getClickhouseClient(),
+    redis: getRedisClient(),
+  })
 
-// OpenAPI spec
-app.doc("/openapi.json", {
-  openapi: "3.1.0",
-  info: {
-    title: "Latitude API",
-    version: "1.0.0",
-    description: "The Latitude public API. Authenticate using an API key via the `Authorization: Bearer` header.",
-  },
-  servers: [{ url: `http://localhost:${port}`, description: "Local development" }],
-})
+  // Register security scheme via the OpenAPI registry
+  app.openAPIRegistry.registerComponent("securitySchemes", "ApiKeyAuth", {
+    type: "http",
+    scheme: "bearer",
+    description: "Organization-scoped API key",
+  })
 
-// Swagger UI
-app.get("/docs", swaggerUI({ url: "/openapi.json" }))
+  // OpenAPI spec
+  app.doc("/openapi.json", {
+    openapi: "3.1.0",
+    info: {
+      title: "Latitude API",
+      version: "1.0.0",
+      description: "The Latitude public API. Authenticate using an API key via the `Authorization: Bearer` header.",
+    },
+    servers: [{ url: `http://localhost:${port}`, description: "Local development" }],
+  })
 
-// Graceful shutdown handler
-const handleShutdown = async (signal: string) => {
-  logger.info(`Received ${signal}, starting graceful shutdown...`)
+  // Swagger UI
+  app.get("/docs", swaggerUI({ url: "/openapi.json" }))
 
-  // Flush pending touch buffer updates
-  try {
-    await destroyTouchBuffer()
-    logger.info("Touch buffer flushed successfully")
-  } catch (error) {
-    logger.error(`Failed to flush touch buffer: ${error instanceof Error ? error.message : "Unknown error"}`)
+  // Graceful shutdown handler
+  const handleShutdown = async (signal: string) => {
+    logger.info(`Received ${signal}, starting graceful shutdown...`)
+
+    // Flush pending touch buffer updates
+    try {
+      await destroyTouchBuffer()
+      logger.info("Touch buffer flushed successfully")
+    } catch (error) {
+      logger.error(`Failed to flush touch buffer: ${error instanceof Error ? error.message : "Unknown error"}`)
+    }
+
+    await shutdownObservability()
+    logger.info("Graceful shutdown complete")
+    process.exit(0)
   }
 
-  logger.info("Graceful shutdown complete")
-  process.exit(0)
+  // Register shutdown handlers
+  process.on("SIGTERM", () => void handleShutdown("SIGTERM"))
+  process.on("SIGINT", () => void handleShutdown("SIGINT"))
+
+  serve(
+    {
+      fetch: app.fetch,
+      port,
+    },
+    (info) => {
+      logger.info(`api listening on http://localhost:${info.port}`)
+      logger.info(`OpenAPI spec: http://localhost:${info.port}/openapi.json`)
+      logger.info(`Swagger UI:   http://localhost:${info.port}/docs`)
+    },
+  )
 }
 
-// Register shutdown handlers
-process.on("SIGTERM", () => handleShutdown("SIGTERM"))
-process.on("SIGINT", () => handleShutdown("SIGINT"))
-
-serve(
-  {
-    fetch: app.fetch,
-    port,
-  },
-  (info) => {
-    logger.info(`api listening on http://localhost:${info.port}`)
-    logger.info(`OpenAPI spec: http://localhost:${info.port}/openapi.json`)
-    logger.info(`Swagger UI:   http://localhost:${info.port}/docs`)
-  },
-)
+void startServer().catch((error) => {
+  logger.error("Failed to start API server", error)
+  process.exit(1)
+})

--- a/apps/ingest/src/server.ts
+++ b/apps/ingest/src/server.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { serve } from "@hono/node-server"
 import { parseEnv } from "@platform/env"
-import { createLogger } from "@repo/observability"
+import { createLogger, initializeObservability, shutdownObservability } from "@repo/observability"
 import { isHttpError, toHttpResponse } from "@repo/utils"
 import { config as loadDotenv } from "dotenv"
 import { Effect } from "effect"
@@ -18,48 +18,65 @@ if (import.meta.url) {
   if (existsSync(envFilePath)) loadDotenv({ path: envFilePath, quiet: true })
 }
 
-const app = new Hono<IngestEnv>()
-const port = Effect.runSync(parseEnv("LAT_INGEST_PORT", "number", 3002))
+const start = async () => {
+  await initializeObservability({
+    serviceName: "ingest",
+  })
 
-const logger = createLogger("ingest")
+  const app = new Hono<IngestEnv>()
+  const port = Effect.runSync(parseEnv("LAT_INGEST_PORT", "number", 3002))
 
-app.onError((err, c) => {
-  if (isHttpError(err)) {
-    const { status, body } = toHttpResponse(err)
-    return c.json(body, status as 400 | 401 | 403 | 404 | 500)
-  }
+  const logger = createLogger("ingest")
 
-  logger.error(err)
-  return c.json({ error: "Internal server error" }, 500)
-})
-
-registerRoutes({ app })
-
-const server = serve(
-  {
-    fetch: app.fetch,
-    port,
-  },
-  (info) => {
-    logger.info(`ingest listening on http://localhost:${info.port}`)
-  },
-)
-
-const handleShutdown = async (signal: string) => {
-  logger.info(`Received ${signal}, shutting down ingest...`)
-  server.close()
-
-  try {
-    const publisher = await getQueuePublisher().catch(() => undefined)
-    if (publisher) {
-      await Effect.runPromise(publisher.close())
+  app.onError((err, c) => {
+    if (isHttpError(err)) {
+      const { status, body } = toHttpResponse(err)
+      return c.json(body, status as 400 | 401 | 403 | 404 | 500)
     }
-  } catch (error) {
-    logger.error("Error during shutdown", error)
+
+    logger.error(err)
+    return c.json({ error: "Internal server error" }, 500)
+  })
+
+  registerRoutes({ app })
+
+  const server = serve(
+    {
+      fetch: app.fetch,
+      port,
+    },
+    (info) => {
+      logger.info(`ingest listening on http://localhost:${info.port}`)
+    },
+  )
+
+  const handleShutdown = async (signal: string) => {
+    logger.info(`Received ${signal}, shutting down ingest...`)
+    server.close()
+
+    try {
+      const publisher = await getQueuePublisher().catch(() => undefined)
+      if (publisher) {
+        await Effect.runPromise(publisher.close())
+      }
+    } catch (error) {
+      logger.error("Error during shutdown", error)
+    }
+
+    await shutdownObservability()
+    process.exit(0)
   }
 
-  process.exit(0)
+  process.on("SIGTERM", () => {
+    void handleShutdown("SIGTERM")
+  })
+  process.on("SIGINT", () => {
+    void handleShutdown("SIGINT")
+  })
 }
 
-process.on("SIGTERM", () => handleShutdown("SIGTERM"))
-process.on("SIGINT", () => handleShutdown("SIGINT"))
+void start().catch((error) => {
+  const logger = createLogger("ingest")
+  logger.error("Failed to start ingest", error)
+  process.exit(1)
+})

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -9,7 +9,7 @@ import {
   createEventsPublisher,
   loadBullMqConfig,
 } from "@platform/queue-bullmq"
-import { createLogger } from "@repo/observability"
+import { createLogger, initializeObservability, shutdownObservability } from "@repo/observability"
 import { config as loadDotenv } from "dotenv"
 import { Effect } from "effect"
 import { getClickhouseClient, getPostgresClient } from "./clients.ts"
@@ -25,81 +25,97 @@ if (import.meta.url) {
   }
 }
 
-const pgClient = getPostgresClient(10)
-const logger = createLogger("workers")
-let ready = false
+const bootstrap = async () => {
+  await initializeObservability({
+    serviceName: "workers",
+  })
 
-const healthPort = Effect.runSync(parseEnv("LAT_WORKERS_HEALTH_PORT", "number", 9090))
-const healthServer = createServer((req, res) => {
-  if (req.url === "/health" && req.method === "GET") {
-    const status = ready ? 200 : 503
-    res.writeHead(status, { "Content-Type": "application/json" })
-    res.end(JSON.stringify({ status: ready ? "ok" : "starting" }))
-  } else {
-    res.writeHead(404)
-    res.end()
+  const pgClient = getPostgresClient(10)
+  const logger = createLogger("workers")
+  let ready = false
+
+  const healthPort = Effect.runSync(parseEnv("LAT_WORKERS_HEALTH_PORT", "number", 9090))
+  const healthServer = createServer((req, res) => {
+    if (req.url === "/health" && req.method === "GET") {
+      const status = ready ? 200 : 503
+      res.writeHead(status, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ status: ready ? "ok" : "starting" }))
+    } else {
+      res.writeHead(404)
+      res.end()
+    }
+  })
+
+  healthServer.listen(healthPort, () => {
+    logger.info(`workers health check listening on :${healthPort}/health`)
+  })
+
+  const initializeWorkers = async () => {
+    const bullMqConfig = Effect.runSync(loadBullMqConfig())
+    const queuePublisher = await Effect.runPromise(createBullMqQueuePublisher({ redis: bullMqConfig }))
+    const eventsPublisher = createEventsPublisher(queuePublisher)
+
+    const outboxConsumer = await Effect.runPromise(
+      createPollingOutboxConsumer(
+        {
+          pool: pgClient.pool,
+          pollIntervalMs: 1000,
+          batchSize: 100,
+        },
+        eventsPublisher,
+      ),
+    )
+
+    const queueConsumer = await Effect.runPromise(createBullMqQueueConsumer({ redis: bullMqConfig }))
+
+    createDomainEventsWorker(queueConsumer)
+    createSpanIngestionWorker(queueConsumer)
+    createDatasetExportWorker(queueConsumer)
+
+    await Effect.runPromise(outboxConsumer.start())
+    await Effect.runPromise(queueConsumer.start())
+
+    ready = true
+    logger.info("workers ready - outbox consumer and queue consumer started")
+
+    return { consumers: { outboxConsumer, queueConsumer }, queuePublisher }
   }
-})
 
-healthServer.listen(healthPort, () => {
-  logger.info(`workers health check listening on :${healthPort}/health`)
-})
+  const workersPromise = initializeWorkers().catch((error) => {
+    logger.error("Failed to initialize workers", error)
+    process.exit(1)
+  })
 
-const initializeWorkers = async () => {
-  const bullMqConfig = Effect.runSync(loadBullMqConfig())
-  const queuePublisher = await Effect.runPromise(createBullMqQueuePublisher({ redis: bullMqConfig }))
-  const eventsPublisher = createEventsPublisher(queuePublisher)
+  const handleShutdown = async (signal: string) => {
+    logger.info(`Received ${signal}, shutting down workers...`)
+    ready = false
+    healthServer.close()
 
-  const outboxConsumer = await Effect.runPromise(
-    createPollingOutboxConsumer(
-      {
-        pool: pgClient.pool,
-        pollIntervalMs: 1000,
-        batchSize: 100,
-      },
-      eventsPublisher,
-    ),
-  )
+    try {
+      const { consumers, queuePublisher } = await workersPromise
 
-  const queueConsumer = await Effect.runPromise(createBullMqQueueConsumer({ redis: bullMqConfig }))
+      await Effect.runPromise(consumers.outboxConsumer.stop())
+      await Effect.runPromise(consumers.queueConsumer.stop())
+      await Effect.runPromise(queuePublisher.close())
+    } catch (error) {
+      logger.error("Error during shutdown (workers may not have started)", error)
+    }
 
-  createDomainEventsWorker(queueConsumer)
-  createSpanIngestionWorker(queueConsumer)
-  createDatasetExportWorker(queueConsumer)
+    await shutdownObservability()
+    await pgClient.pool.end()
+    await getClickhouseClient().close()
+    process.exit(0)
+  }
 
-  await Effect.runPromise(outboxConsumer.start())
-  await Effect.runPromise(queueConsumer.start())
-
-  ready = true
-  logger.info("workers ready - outbox consumer and queue consumer started")
-
-  return { consumers: { outboxConsumer, queueConsumer }, queuePublisher }
+  process.on("SIGTERM", () => {
+    void handleShutdown("SIGTERM")
+  })
+  process.on("SIGINT", () => {
+    void handleShutdown("SIGINT")
+  })
 }
 
-const workersPromise = initializeWorkers().catch((error) => {
-  logger.error("Failed to initialize workers", error)
+void bootstrap().catch((error) => {
+  console.error(error)
   process.exit(1)
 })
-
-const handleShutdown = async (signal: string) => {
-  logger.info(`Received ${signal}, shutting down workers...`)
-  ready = false
-  healthServer.close()
-
-  try {
-    const { consumers, queuePublisher } = await workersPromise
-
-    await Effect.runPromise(consumers.outboxConsumer.stop())
-    await Effect.runPromise(consumers.queueConsumer.stop())
-    await Effect.runPromise(queuePublisher.close())
-  } catch (error) {
-    logger.error("Error during shutdown (workers may not have started)", error)
-  }
-
-  await pgClient.pool.end()
-  await getClickhouseClient().close()
-  process.exit(0)
-}
-
-process.on("SIGTERM", () => handleShutdown("SIGTERM"))
-process.on("SIGINT", () => handleShutdown("SIGINT"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement Datadog/OTLP observability via shared `@repo/observability`
- scope logs/traces by service and deployment environment
- wire observability startup/shutdown in app runtimes (`api`, `ingest`, `workers`, `workflows`) and TanStack Start web request middleware

## Key changes
- Added shared observability bootstrap API:
  - `initializeObservability({ serviceName })`
  - `shutdownObservability()`
- Added Datadog-compatible tracing + structured logging:
  - OTLP traces exporter with Datadog endpoint derivation (`LAT_DATADOG_API_KEY` + `LAT_DATADOG_SITE`) or explicit OTLP endpoint override
  - structured JSON logs with `env`, `service`, `ddtags`, `trace_id`, `span_id`
- Refactored `packages/observability` into single-responsibility modules:
  - `config.ts`, `logger.ts`, `otel.ts`, `state.ts`, `types.ts`, slim `index.ts`
- Web observability now follows TanStack middleware pattern:
  - global request middleware in `apps/web/src/start.ts`
  - `tanstackStart({ start: { entry: "./src/start.ts" } })` in `apps/web/vite.config.ts`
  - `apps/web/src/server/middlewares.ts` focuses on error normalization/logging only
- Added observability env docs in `.env.example`:
  - `LAT_OBSERVABILITY_ENABLED`
  - `LAT_OBSERVABILITY_ENVIRONMENT`
  - `LAT_OBSERVABILITY_SERVICE_NAME`
  - `LAT_DATADOG_API_KEY`, `LAT_DATADOG_SITE`
  - `LAT_OBSERVABILITY_OTLP_TRACES_ENDPOINT`, `LAT_OBSERVABILITY_OTLP_HEADERS`
- Fixed CJS build compatibility for runtime entrypoints by removing top-level await:
  - `apps/api/src/server.ts`
  - `apps/ingest/src/server.ts`
  - `apps/workers/src/server.ts`
  - replaced with async bootstrap functions + startup `.catch(...)`
- Updated `knip.json` web entries to include framework-resolved `apps/web/src/start.ts`

## Validation
- `pnpm --filter @repo/observability check`
- `pnpm --filter @repo/observability typecheck`
- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck`
- `pnpm --filter @app/workers check`
- `pnpm --filter @app/workers typecheck`
- `pnpm --filter @app/api build`
- `pnpm --filter @app/ingest build`
- `pnpm --filter @app/workers build`
- `pnpm --filter @app/api typecheck`
- `pnpm --filter @app/ingest typecheck`
- `pnpm --filter @app/workers typecheck`
- `pnpm knip
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbaa3243-0e2f-4dba-8dae-83e38d3f3f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbaa3243-0e2f-4dba-8dae-83e38d3f3f7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

