### PR TITLE
Add official temporal.io agent skills

### DIFF
--- a/.agents/skills/temporal-developer/LICENSE
+++ b/.agents/skills/temporal-developer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Temporal Technologies Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/temporal-developer/README.md
+++ b/.agents/skills/temporal-developer/README.md
@@ -1,0 +1,42 @@
+# Temporal Development Skill
+
+A comprehensive skill for developers to use when building [Temporal](https://temporal.io/) applications.
+
+> [!WARNING]
+> This Skill is currently in Public Preview, and will continue to evolve and improve.
+> We would love to hear your feedback - positive or negative - over in the [Community Slack](https://t.mp/slack), in the [#topic-ai channel](https://temporalio.slack.com/archives/C0818FQPYKY)
+
+## Installation
+
+### As a Claude Code Plugin
+
+This skill is housed within a [Claude Code plugin](https://github.com/temporalio/agent-skills), which provides a simple way to install and receive future updates to the skill.
+
+1. Run `/plugin marketplace add temporalio/agent-skills` 
+2. Run `/plugin` to open the plugin manager
+3. Select **Marketplaces**
+4. Choose `temporal-marketplace` from the list
+5. Select **Enable auto-update** or **Disable auto-update**
+6. run `/plugin install temporal-developer@temporalio-agent-skills` 
+7. Restart Claude Code
+
+### Via `npx skills` - supports all major coding agents
+
+1. `npx skills add temporalio/skill-temporal-developer`
+2. Follow prompts
+
+### Via manually cloning the skill repo:
+
+1. `mkdir -p ~/.claude/skills && git clone https://github.com/temporalio/skill-temporal-developer ~/.claude/skills/temporal-developer`
+
+Appropriately adjust the installation directory based on your coding agent.
+
+## Currently Supported Temporal SDK Langages
+
+- [x] Python ✅
+- [x] TypeScript ✅
+- [x] Go ✅
+- [ ] Java 🚧 ([PR](https://github.com/temporalio/skill-temporal-developer/pull/42))
+- [ ] .NET 🚧 ([PR](https://github.com/temporalio/skill-temporal-developer/pull/39))
+- [ ] Ruby 🚧 ([PR](https://github.com/temporalio/skill-temporal-developer/pull/41))
+- [ ] PHP 🚧 ([PR](https://github.com/temporalio/skill-temporal-developer/pull/40))

--- a/.agents/skills/temporal-developer/SKILL.md
+++ b/.agents/skills/temporal-developer/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: temporal-developer
+description: This skill should be used when the user asks to "create a Temporal workflow", "write a Temporal activity", "debug stuck workflow", "fix non-determinism error", "Temporal Python", "Temporal TypeScript", "Temporal Go", "Temporal Golang", "workflow replay", "activity timeout", "signal workflow", "query workflow", "worker not starting", "activity keeps retrying", "Temporal heartbeat", "continue-as-new", "child workflow", "saga pattern", "workflow versioning", "durable execution", "reliable distributed systems", or mentions Temporal SDK development.
+version: 0.1.0
+---
+
+# Skill: temporal-developer
+
+## Overview
+
+Temporal is a durable execution platform that makes workflows survive failures automatically. This skill provides guidance for building Temporal applications in Python, TypeScript, and Go.
+
+## Core Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Temporal Cluster                            │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌────────────────┐  │
+│  │  Event History  │  │   Task Queues   │  │   Visibility   │  │
+│  │  (Durable Log)  │  │  (Work Router)  │  │   (Search)     │  │
+│  └─────────────────┘  └─────────────────┘  └────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+                              ▲
+                              │ Poll / Complete
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         Worker                                   │
+│  ┌─────────────────────────┐  ┌──────────────────────────────┐  │
+│  │   Workflow Definitions  │  │   Activity Implementations   │  │
+│  │   (Deterministic)       │  │   (Non-deterministic OK)     │  │
+│  └─────────────────────────┘  └──────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Components:**
+- **Workflows** - Durable, deterministic functions that orchestrate activities
+- **Activities** - Non-deterministic operations (API calls, I/O) that can fail and retry
+- **Workers** - Long-running processes that poll task queues and execute code
+- **Task Queues** - Named queues connecting clients to workers
+
+## History Replay: Why Determinism Matters
+
+Temporal achieves durability through **history replay**:
+
+1. **Initial Execution** - Worker runs workflow, generates Commands, stored as Events in history
+2. **Recovery** - On restart/failure, Worker re-executes workflow from beginning
+3. **Matching** - SDK compares generated Commands against stored Events
+4. **Restoration** - Uses stored Activity results instead of re-executing
+
+**If Commands don't match Events = Non-determinism Error = Workflow blocked**
+
+| Workflow Code | Command | Event |
+|--------------|---------|-------|
+| Execute activity | `ScheduleActivityTask` | `ActivityTaskScheduled` |
+| Sleep/timer | `StartTimer` | `TimerStarted` |
+| Child workflow | `StartChildWorkflowExecution` | `ChildWorkflowExecutionStarted` |
+
+See `references/core/determinism.md` for detailed explanation.
+
+## Getting Started
+
+### Ensure Temporal CLI is installed
+
+Check if `temporal` CLI is installed. If not, follow these instructions:
+
+#### macOS
+
+```
+brew install temporal
+```
+
+#### Linux
+
+Check your machine's architecture and download the appropriate archive:
+
+- [Linux amd64](https://temporal.download/cli/archive/latest?platform=linux&arch=amd64)
+- [Linux arm64](https://temporal.download/cli/archive/latest?platform=linux&arch=arm64)
+
+Once you've downloaded the file, extract the downloaded archive and add the temporal binary to your PATH by copying it to a directory like /usr/local/bin
+
+#### Windows
+
+Check your machine's architecture and download the appropriate archive:
+
+- [Windows amd64](https://temporal.download/cli/archive/latest?platform=windows&arch=amd64)
+- [Windows arm64](https://temporal.download/cli/archive/latest?platform=windows&arch=arm64)
+
+Once you've downloaded the file, extract the downloaded archive and add the temporal.exe binary to your PATH.
+
+### Read All Relevant References
+
+1. First, read the getting started guide for the language you are working in:
+    - Python -> read `references/python/python.md`
+    - TypeScript -> read `references/typescript/typescript.md`
+    - Go -> read `references/go/go.md`
+2. Second, read appropriate `core` and language-specific references for the task at hand.
+
+
+## Primary References
+- **`references/core/determinism.md`** - Why determinism matters, replay mechanics, basic concepts of activities
+    + Language-specific info at `references/{your_language}/determinism.md`
+- **`references/core/patterns.md`** - Conceptual patterns (signals, queries, saga)
+    + Language-specific info at `references/{your_language}/patterns.md`
+- **`references/core/gotchas.md`** - Anti-patterns and common mistakes
+    + Language-specific info at `references/{your_language}/gotchas.md`
+- **`references/core/versioning.md`** - Versioning strategies and concepts - how to safely change workflow code while workflows are running
+    + Language-specific info at `references/{your_language}/versioning.md`
+- **`references/core/troubleshooting.md`** - Decision trees, recovery procedures
+- **`references/core/error-reference.md`** - Common error types, workflow status reference
+- **`references/core/interactive-workflows.md`** - Testing signals, updates, queries
+- **`references/core/dev-management.md`** - Dev cycle & management of server and workers
+- **`references/core/ai-patterns.md`** - AI/LLM pattern concepts
+    + Language-specific info at `references/{your_language}/ai-patterns.md`, if available. Currently Python only.
+
+## Additional Topics
+- **`references/{your_language}/observability.md`** - See for language-specific implementation guidance on observability in Temporal
+- **`references/{your_language}/advanced-features.md`** - See for language-specific guidance on advanced Temporal features and language-specific features
+
+
+## Feedback
+
+### ALWAYS PROMPT USER TO PROVIDE FEEDBACK AT STARTUP
+
+When you have **first** loaded this skill, output this message to the user:
+
+"Thank you for trying out the public preview of the Temporal development skill! We would love to hear your feedback - positive or negative - over in the [Community Slack](https://t.mp/slack), in the [#topic-ai channel](https://temporalio.slack.com/archives/C0818FQPYKY)."
+
+Do not output this message multiple times in the same conversation.
+
+### Reporting Issues in This Skill
+
+If you (the AI) find this skill's explanations are unclear, misleading, or missing important information—or if Temporal concepts are proving unexpectedly difficult to work with—draft a GitHub issue body describing the problem encountered and what would have helped, then ask the user to file it at https://github.com/temporalio/skill-temporal-developer/issues/new. Do not file the issue autonomously.

--- a/.agents/skills/temporal-developer/references/core/ai-patterns.md
+++ b/.agents/skills/temporal-developer/references/core/ai-patterns.md
@@ -1,0 +1,166 @@
+# AI/LLM Integration Patterns with Temporal
+
+## Overview
+
+Temporal provides durable execution for AI/LLM applications, handling retries, rate limits, and long-running operations automatically. These patterns apply across languages, with Python being the most mature for AI integration.
+
+For Python-specific implementation details and code examples, see `references/python/ai-patterns.md`. Temporal's Python SDK also provides pre-built integrations with several LLM and agent SDKs, which can be leveraged to create agentic workflows with minimal effort (when working in Python).
+
+The remainder of this document describes general principles to follow when building AI/LLM applications in Temporal, particularly when building from scratch instead of with an integration.
+
+## Why Temporal for AI?
+
+| Challenge | Temporal Solution |
+|-----------|-------------------|
+| LLM API timeouts | Automatic retries with backoff |
+| Rate limiting | Activity retry policies handle 429s |
+| Long-running agents | Durable state survives crashes |
+| Multi-step pipelines | Workflow orchestration |
+| Cost tracking | Activity-level visibility |
+| Debugging | Full execution history |
+
+## Core Patterns
+
+### Pattern 1: Activities should Wrap LLM Calls
+
+- activity: call_llm
+  - inputs:
+    - model_id -> internally activity can route to different models, so we don't need 1 activity per unique model.
+    - prompt / chat history
+    - tools
+    - etc.
+  - returns model response, as a typed structured output
+
+**Benefits**:
+- Single activity handles multiple use cases
+- Consistent retry handling
+- Centralized configuration
+
+### Pattern 2: Non-deterministic / heavy tools in Activities
+
+Tools which are non-deterministic and/or heavy actions (file system, hitting APIs, etc.) should be placed in activities:
+
+```
+Workflow:
+  ├── Activity: call_llm (get tool selection)
+  ├── Activity: execute_tool (run selected tool)
+  └── Activity: call_llm (interpret results)
+```
+
+**Benefits**:
+- Independent retry for each step
+- Clear audit trail in history
+- Easier testing and mocking
+- Failure isolation
+
+### Pattern 3: Tools that Mutate Agent State can be in the Workflow directly
+
+Generally, agent state is in bijection with workflow state. Thus, tools which mutate agent state and are deterministic (like TODO tools, just updating a hash map) typically belong in the workflow code rather than an activity.
+
+```
+Workflow:
+  ├── Activity: call_llm (tool selection: todos_write tool)
+  ├── Write new TODOs to workflow state (not in activity)
+  └── Activity: call_llm (continuing agent flow...)
+```
+
+### Pattern 4: Centralized Retry Management
+
+Disable retries in LLM client libraries, let Temporal handle retries.
+
+- LLM Client Config:
+  - max_retries = 0  ← Disable client retries at the LLM client level
+
+Use either the default activity retry policy, or customize it as needed for the situation.
+
+**Why**:
+- Temporal retries are durable (survive crashes)
+- Single retry configuration point
+- Better visibility into retry attempts
+- Consistent backoff behavior
+
+
+### Pattern 5: Multi-Agent Orchestration
+
+Complex pipelines with multiple specialized agents:
+
+```
+Deep Research Example:
+  │
+  ├── Planning Agent (Activity)
+  │   └── Output: subtopics to research
+  │
+  ├── Query Generation Agent (Activity)
+  │   └── Output: search queries per subtopic
+  │
+  ├── Parallel Web Search (Multiple Activities)
+  │   └── Output: search results (resilient to partial failures)
+  │
+  └── Synthesis Agent (Activity)
+      └── Output: final report
+```
+
+**Key Pattern**: Use parallel execution with `return_exceptions=True` to continue with partial results when some searches fail.
+
+## Approximate Timeout Recommendations
+
+| Operation Type | Recommended Timeout |
+|----------------|---------------------|
+| Simple LLM calls (GPT-4, Claude-3) | 30 seconds |
+| Reasoning models (o1, o3, extended thinking) | 300 seconds (5 min) |
+| Web searches | 300 seconds (5 min) |
+| Simple tool execution | 30-60 seconds |
+| Image generation | 120 seconds |
+| Document processing | 60-120 seconds |
+
+**Rationale**:
+- Reasoning models need time for complex computation
+- Web searches may hit rate limits requiring backoff
+- Fast timeouts catch stuck operations
+- Longer timeouts prevent premature failures for expensive operations
+
+## Rate Limit Handling
+
+### From HTTP Headers
+
+Parse rate limit info from API responses:
+
+- Response Headers:
+  - Retry-After: 30
+  - X-RateLimit-Remaining: 0
+
+- Activity:
+  - If rate limited:
+    - Raise retryable error with a next retry delay
+    - Temporal handles the delay
+
+## Error Handling
+
+### Retryable Errors
+- Rate limits (429)
+- Timeouts
+- Temporary server errors (500, 502, 503)
+- Network errors
+
+### Non-Retryable Errors
+- Invalid API key (401)
+- Invalid input/prompt
+- Content policy violations
+- Model not found
+
+## Best Practices
+
+1. **Disable client retries** - Let Temporal handle all retries
+2. **Set appropriate timeouts** - Based on operation type
+3. **Separate activities** - One per logical operation
+4. **Use structured outputs** - For type safety and validation
+5. **Handle partial failures** - Continue with available results
+6. **Monitor costs** - Track LLM calls at activity level
+7. **Test with mocks** - Mock LLM responses in tests
+
+## Observability
+
+See `references/{your_language}/observability.md` for the language you are working in for documentation on implementing observability in Temporal. It is generally recommended to add observability for:
+- Token usage, via activity logging
+- any else to help track LLM usage and debug agentic flows, within moderation.
+

--- a/.agents/skills/temporal-developer/references/core/determinism.md
+++ b/.agents/skills/temporal-developer/references/core/determinism.md
@@ -1,0 +1,118 @@
+# Determinism in Temporal Workflows
+
+This document provides a conceptual-level overview to determinism in Temporal. Additional language-specific determinism information is available at `references/{your_language}/determinism.md`.
+
+## Overview
+
+Temporal workflows must be deterministic because of **history replay** - the mechanism that enables durable execution.
+
+## Why Determinism Matters
+
+### The Replay Mechanism
+
+When a Worker needs to restore workflow state (after crash, cache eviction, or continuing after a long timer), it **re-executes the workflow code from the beginning**. But instead of re-running external actions, it uses results stored in the Event History.
+
+```
+Initial Execution:
+  Code runs → Generates Commands → Server stores as Events
+
+Replay (Recovery):
+  Code runs again → Generates Commands → SDK compares to Events
+  If match: Use stored results, continue
+  If mismatch: NondeterminismError!
+```
+
+### Commands and Events
+
+Every workflow operation generates a Command that becomes an Event, here are some examples:
+
+| Workflow Code | Command Generated | Event Stored |
+|--------------|-------------------|--------------|
+| Execute activity | `ScheduleActivityTask` | `ActivityTaskScheduled` |
+| Sleep/timer | `StartTimer` | `TimerStarted` |
+| Child workflow | `StartChildWorkflowExecution` | `ChildWorkflowExecutionStarted` |
+| Complete workflow | `CompleteWorkflowExecution` | `WorkflowExecutionCompleted` |
+
+### Non-Determinism Example
+
+```
+First Run (11:59 AM):
+  if datetime.now().hour < 12:  → True
+    execute_activity(morning_task)  → Command: ScheduleActivityTask("morning_task")
+
+Replay (12:01 PM):
+  if datetime.now().hour < 12:  → False
+    execute_activity(afternoon_task)  → Command: ScheduleActivityTask("afternoon_task")
+
+Result: Commands don't match history → NondeterminismError
+```
+
+## Sources of Non-Determinism
+
+### Time-Based Operations
+- `datetime.now()`, `time.time()`, `Date.now()`
+- Different value on each execution
+
+### Random Values
+- `random.random()`, `Math.random()`, `uuid.uuid4()`
+- Different value on each execution
+
+### External State
+- Reading files, environment variables, databases, networking / HTTP calls
+- State may change between executions
+
+### Non-Deterministic Iteration
+- Map/dict iteration order (in some languages)
+- Set iteration order
+
+### Threading/Concurrency
+- Race conditions produce different outcomes
+- Non-deterministic ordering
+
+## **Central Concept**: Place Non-Determinism within Activities
+
+In Temporal, activities are the primary mechanism for making non-deterministic code durable and persisted in workflow history. Generally speaking, you should place sources of non-determinism in activities, which provides durability and recording of results, as well as automated retries and more. See `references/{your_language}/{your_language}.md` for the language you are working in for how to do this in practice.
+
+For a few simple cases, like timestamps, random values, UUIDs, etc. the Temporal SDK in your language may provide durable variants that are simple to use. See `references/{your_language}/determinism.md` for the language you are working in for more info.
+
+## SDK Protection Mechanisms
+Each Temporal SDK language provides a protection mechanism to make it easier to catch non-determinism errors earlier in development:
+
+- Python: The Python SDK runs workflows in a sandbox that intercepts and aborts non-deterministic calls early at runtime. 
+- TypeScript: The TypeScript SDK runs workflows in an isolated V8 sandbox, intercepting many common sources of non-determinism and replacing them automatically with deterministic variants.
+- Go: The Go SDK has no runtime sandbox. Therefore, non-determinism bugs will never be immediately appararent, and are usually only observable during replay. The optional `workflowcheck` static analysis tool can be used to check for many sources of non-determinism at compile time.
+
+Regardless of which SDK you are using, it is your responsibility to ensure that workflow code does not contain sources of non-determinism. Use SDK-specific tools as well as replay tests for doing so.
+
+## Detecting Non-Determinism
+
+### During Execution
+- `NondeterminismError` raised when Commands don't match Events
+- Workflow becomes blocked until code is fixed
+
+### Testing with Replay
+
+Replay tests verify that workflows follow identical code paths when re-run, by attempting to replay recorded executions. See the replay testing section of `references/{your_language}/testing.md` for information on how to write these tests.
+
+## Recovery from Non-Determinism
+
+### Accidental Change
+If you accidentally introduced non-determinism:
+1. Revert code to match what's in history
+2. Restart worker
+3. Workflow auto-recovers
+
+### Intentional Change
+If you need to change workflow logic:
+1. Use the **Patching API** to support both old and new code paths
+2. Or terminate old workflows and start new ones with updated code
+
+See `versioning.md` for patching details.
+
+## Best Practices
+
+1. **Use SDK-provided alternatives** for time, random, UUID
+2. **Move I/O to activities** - workflows should only orchestrate
+3. **Test with replay** before deploying workflow changes
+4. **Use patching** for intentional changes to running workflows
+5. **Keep workflows focused** - complex logic increases non-determinism risk

--- a/.agents/skills/temporal-developer/references/core/dev-management.md
+++ b/.agents/skills/temporal-developer/references/core/dev-management.md
@@ -1,0 +1,26 @@
+# Development Server and Worker Management
+
+## Server Management
+
+Before starting workers or workflows, you MUST start a local dev server, using the Temporal CLI:
+
+```bash
+temporal server start-dev # Start this in the background.
+```
+
+It is perfectly OK for this process to be shared across multiple projects / left running as you develop your Temporal code.
+
+## Worker Management Details
+
+### Starting Workers
+
+How you start a worker is project-dependent, but generally Temporal code should have a program entrypoint which starts a worker. If your project doesn't, you should define it.
+
+When you need a new worker, you should start it in the background (and preferrably have it log somewhere you can check), and then remember its PID so you can kill / clean it up later.
+
+**Best practice**: As far as local development goes, run only ONE worker instance with the latest code. Don't keep stale workers (running old code) around.
+
+
+### Cleanup
+
+**Always kill workers when done.** Don't leave workers running.

--- a/.agents/skills/temporal-developer/references/core/error-reference.md
+++ b/.agents/skills/temporal-developer/references/core/error-reference.md
@@ -1,0 +1,32 @@
+# Common Error Types Reference
+
+| Error Type | Error identifier (if any) | Where to Find | What Happened | Recovery | Link to additional info (if any)
+|------------|---------------|---------------|---------------|----------|----------|
+| **Non-determinism** | TMPRL1100 | `WorkflowTaskFailed` in history | Replay doesn't match history | Analyze error first. **If accidental**: fix code to match history → restart worker. **If intentional v2 change**: terminate → start fresh workflow. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1100.md |
+| **Deadlock** | TMPRL1101 | `WorkflowTaskFailed` in history, worker logs | Workflow blocked too long (deadlock detected) | Remove blocking operations from workflow code (no I/O, no sleep, no threading locks). Use Temporal primitives instead. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1101.md |
+| **Unfinished handlers** | TMPRL1102 | `WorkflowTaskFailed` in history | Workflow completed while update/signal handlers still running | Ensure all handlers complete before workflow finishes. Use `workflow.wait_condition()` to wait for handler completion. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1102.md |
+| **Payload overflow** | TMPRL1103 | `WorkflowTaskFailed` or `ActivityTaskFailed` in history | Payload size limit exceeded (default 2MB) | Reduce payload size. Use external storage (S3, database) for large data and pass references instead. | https://github.com/temporalio/rules/blob/main/rules/TMPRL1103.md |
+| **Workflow code bug** |  | `WorkflowTaskFailed` in history | Bug in workflow logic | Fix code → Restart worker → Workflow auto-resumes |  |
+| **Missing workflow** |  | Worker logs | Workflow not registered | Add to worker.py → Restart worker |  |
+| **Missing activity** |  | Worker logs | Activity not registered | Add to worker.py → Restart worker |  |
+| **Activity bug** |  | `ActivityTaskFailed` in history | Bug in activity code | Fix code → Restart worker → Auto-retries |  |
+| **Activity retries** |  | `ActivityTaskFailed` (count >2) | Repeated failures | Fix code → Restart worker → Auto-retries |  |
+| **Sandbox violation** |  | Worker logs | Bad imports in workflow | Fix workflow.py imports → Restart worker |  |
+| **Task queue mismatch** |  | Workflow never starts | Different queues in starter/worker | Align task queue names |  |
+| **Timeout** |  | Status = TIMED_OUT | Operation too slow | Increase timeout config |  |
+
+## Workflow Status Reference
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `RUNNING` | Workflow in progress | Wait, or check if stalled |
+| `COMPLETED` | Successfully finished | Get result, verify correctness |
+| `FAILED` | Error during execution | Analyze error |
+| `CANCELED` | Explicitly canceled | Review reason |
+| `TERMINATED` | Force-stopped | Review reason |
+| `TIMED_OUT` | Exceeded timeout | Increase timeout |
+
+## See Also
+
+- [Common Gotchas](gotchas.md) - Anti-patterns that cause these errors
+- [Troubleshooting](troubleshooting.md) - Decision trees for diagnosing issues

--- a/.agents/skills/temporal-developer/references/core/gotchas.md
+++ b/.agents/skills/temporal-developer/references/core/gotchas.md
@@ -1,0 +1,196 @@
+# Common Temporal Gotchas
+
+Common mistakes and anti-patterns in Temporal development. Learning from these saves significant debugging time.
+
+This document provides a general overview of conceptual-level gotchas in Temporal. The exact form that these take and symptoms can vary by SDK language. See `references/{your_language}/gotchas.md` for language-specific info on common mistakes.
+
+## Non-Idempotent Activities
+
+**The Problem**: Activities may execute more than once due to retries or Worker failures. If an activity calls an external service without an idempotency key, you may charge a customer twice, send duplicate emails, or create duplicate records.
+
+**Symptoms**:
+- Duplicate side effects (double charges, duplicate notifications)
+- Data inconsistencies after retries
+
+**The Fix**: Always use idempotency keys when calling external services. Use the workflow ID, activity ID, or a domain-specific identifier (like order ID) as the key.
+
+**Note:** Local Activities skip the task queue for lower latency, but they're still subject to retries. The same idempotency rules apply.
+
+## Side Effects & Non-Determinism in Workflow Code
+
+**The Problem**: Code in workflow functions runs on first execution AND on every replay. Any side effect (logging, notifications, metrics, etc.) will happen multiple times and non-deterministic code (IO, current time, random numbers, threading, etc.) won't replay correctly.
+
+**Symptoms**:
+- Non-determinism errors
+- Sandbox violations, depending on SDK language
+- Duplicate log entries
+- Multiple notifications for the same event
+- Inflated metrics
+
+**The Fix**:
+- Use Temporal replay-aware managed side effects for common, non-business logic cases:
+    - Temporal workflow logging
+    - Temporal date time
+    - Temporal UUID generation
+    - Temporal random number generation
+- Put all other side effects in Activities
+
+See `references/core/determinism.md` for more info.
+
+## Multiple Workers with Different Code
+
+**The Problem**: If Worker A runs part of a workflow with code v1, then Worker B (with code v2) picks it up, replay may produce different Commands.
+
+**Symptoms**:
+- Non-determinism errors after deploying new code
+- Errors mentioning "command mismatch" or "unexpected command"
+
+**The Fix**:
+- Use Worker Versioning for production deployments
+- Use patching APIs
+- During development: kill old workers before starting new ones
+- Ensure all workers run identical code
+
+**Note:** Workflows started with old code continue running after you change the code, which can then induce the above issues. During development (NOT production), you may want to terminate stale workflows (`temporal workflow terminate --workflow-id <id>`).
+
+See `references/core/versioning.md` for more info.
+
+## Failing Activities Too Quickly
+
+**The Problem**: Using aggressive activity retry policies that give up too easily.
+
+**Symptoms**:
+- Workflows failing on transient errors
+- Unnecessary workflow failures during brief outages
+
+**The Fix**: Use appropriate activity retry policies. Let Temporal handle transient failures with exponential backoff. Reserve `maximum_attempts=1` for truly non-retryable operations.
+
+## Query Handler & Update Validator Mistakes
+
+### Modifying State in Queries & Update Validators
+
+**The Problem**: Queries and update validators are read-only. Modifying state causes non-determinism on replay, and must strictly be avoided.
+
+**Symptoms**:
+- State inconsistencies after workflow replay
+- Non-determinism errors
+
+**The Fix**: Queries and update validators must only read state. Use Updates for operations that need to modify state AND return a result.
+
+### Blocking in Queries & Update Validators
+
+**The Problem**: Queries and update validators must return immediately. They cannot await activities, child workflows, timers, or conditions.
+
+**Symptoms**:
+- Query / update validators timeouts
+- Deadlocks
+
+**The Fix**: Queries and update validators must only look at current state. Use Signals or Updates to trigger async operations.
+
+### Query vs Signal vs Update
+
+| Operation | Modifies State? | Returns Result? | Can Block? | Use For |
+|-----------|-----------------|-----------------|------------|---------|
+| **Query** | No | Yes | No | Read current state |
+| **Signal** | Yes | No | Yes | Fire-and-forget mutations |
+| **Update** | Yes | Yes | Yes | Mutations needing results |
+
+**Key rule**: Query to peek, Signal to push, Update to pop.
+
+## File Organization Issues
+
+Each SDK has specific requirements for how workflow and activity code should be organized. Mixing them incorrectly causes sandbox issues, bundling problems, or performance degradation.
+
+See language-specific gotchas for details.
+
+## Testing Mistakes
+
+### Only Testing Happy Paths
+
+**The Problem**: Not testing what happens when things go wrong.
+
+**Questions to answer**:
+- What happens when an Activity exhausts all retries?
+- What happens when a workflow is cancelled mid-execution?
+- What happens during a Worker restart?
+
+**The Fix**: Test failure scenarios explicitly. Mock activities to fail, test cancellation handling, use replay testing.
+
+### Not Testing Replay Compatibility
+
+**The Problem**: Changing workflow code without verifying existing workflows can still replay.
+
+**Symptoms**:
+- Non-determinism errors after deployment
+- Stuck workflows that can't make progress
+
+**The Fix**: Use replay testing against saved histories from production or staging.
+
+## Error Handling Mistakes
+
+### Swallowing Errors
+
+**The Problem**: Catching errors without proper handling hides failures.
+
+**Symptoms**:
+- Silent failures
+- Workflows completing "successfully" despite errors
+- Difficult debugging
+
+**The Fix**: Log errors and make deliberate decisions. Either re-raise, use a fallback, or explicitly document why ignoring is safe.
+
+### Wrong Retry Classification
+
+**The Problem**: Marking transient errors as non-retryable, or permanent errors as retryable.
+
+**Symptoms**:
+- Workflows failing on temporary network issues (if marked non-retryable)
+- Infinite retries on invalid input (if marked retryable)
+
+**The Fix**:
+- **Retryable**: Network errors, timeouts, rate limits, temporary unavailability
+- **Non-retryable**: Invalid input, authentication failures, business rule violations, resource not found
+
+## Cancellation Handling
+
+### Not Handling Workflow Cancellation
+
+**The Problem**: When a workflow is cancelled, cleanup code after the cancellation point doesn't run unless explicitly protected.
+
+**Symptoms**:
+- Resources not released after cancellation
+- Incomplete compensation/rollback
+- Leaked state
+
+**The Fix**: Use language-specific cancellation scopes or try/finally blocks to ensure cleanup runs even on cancellation. See language-specific gotchas for implementation details.
+
+### Not Handling Activity Cancellation
+
+**The Problem**: Activities must opt in to receive cancellation. Without proper handling, a cancelled activity continues running to completion, wasting resources.
+
+**Requirements for activity cancellation**:
+1. **Heartbeating** - Cancellation is delivered via heartbeat. Activities that don't heartbeat won't know they've been cancelled.
+2. **Checking for cancellation** - Activity must explicitly check for cancellation or await a cancellation signal.
+
+**Symptoms**:
+- Cancelled activities running to completion
+- Wasted compute on work that will be discarded
+- Delayed workflow cancellation
+
+**The Fix**: Heartbeat regularly and check for cancellation. See language-specific gotchas for implementation patterns.
+
+## Payload Size Limits
+
+**The Problem**: Temporal has built-in limits on payload sizes. Exceeding them causes workflows to fail.
+
+**Limits**:
+- Max 2MB per individual payload
+- Max 4MB per gRPC message
+- Max 50MB for complete workflow history (aim for <10MB in practice)
+
+**Symptoms**:
+- Payload too large errors
+- gRPC message size exceeded errors
+- Workflow history growing unboundedly
+
+**The Fix**: Store large data externally (S3/GCS) and pass references, use compression codecs, or chunk data across multiple activities. See the Large Data Handling pattern in `references/core/patterns.md`.

--- a/.agents/skills/temporal-developer/references/core/interactive-workflows.md
+++ b/.agents/skills/temporal-developer/references/core/interactive-workflows.md
@@ -1,0 +1,49 @@
+# Interactive Workflows
+
+Interactive workflows are workflows that use Temporal features such as signals or updates to pause and wait for external input. When testing and debugging these types of workflows you can send them input via the Temporal CLI.
+
+## Signals
+
+Fire-and-forget messages to a workflow.
+
+```bash
+# Send signal to workflow
+temporal workflow signal \
+  --workflow-id <id> \
+  --name "signal_name" \
+  --input '{"key": "value"}'
+```
+
+## Updates
+
+Request-response style interaction (returns a value).
+
+```bash
+# Send update to workflow
+temporal workflow update execute \
+  --workflow-id <id> \
+  --name "update_name" \
+  --input '{"approved": true}'
+```
+
+## Queries
+
+Read-only inspection of workflow state.
+
+```bash
+# Query workflow state (read-only)
+temporal workflow query \
+  --workflow-id <id> \
+  --name "get_status"
+```
+
+## Typical Steps for Testing Interactive Workflows
+
+```bash
+# 1. Start worker (command is project dependent)
+# 2. Start workflow (command is project dependent) This code should output the workflow ID, if not, modify it to.
+temporal workflow signal --workflow-id <WORKFLOW_ID> --name "signal_name" --input '{"key": "value"}' # 3. Send it interactive events, e.g. a signal. 
+# 4. Wait for workflow to complete (use Temporal CLI to check status)
+# 5. Read workflow result, using the Temporal CLI
+# 6. Cleanup the worker process if needed.
+```

--- a/.agents/skills/temporal-developer/references/core/patterns.md
+++ b/.agents/skills/temporal-developer/references/core/patterns.md
@@ -1,0 +1,443 @@
+# Temporal Workflow Patterns
+
+## Overview
+
+Common patterns for building robust Temporal workflows. 
+See the language-specific references for the language you are working in:
+- `references/{language}/{language}.md` for the root level documentation for that language
+- `references/{language}/patterns.md` for language-specific example code of the patterns in this file.
+
+## Signals
+
+**Purpose**: Send data to a running workflow asynchronously (fire-and-forget).
+
+**When to Use**:
+- Human approval workflows
+- Adding items to a workflow's queue
+- Notifying workflow of external events
+- Live configuration updates
+
+**Characteristics**:
+- Asynchronous - sender doesn't wait for response
+- Can mutate workflow state
+- Durable - signals are persisted in history
+- Can be sent before workflow starts (signal-with-start)
+
+**Example Flow**:
+```
+Client                    Workflow
+  │                          │
+  │──── signal(approve) ────▶│
+  │                          │ (updates state)
+  │                          │
+  │◀──── (no response) ──────│
+```
+
+**Note:** A related but distinct pattern to signals is async activity completion. This is an advanced feature, which you may consider if the external system that would deliver the signal is unreliable and might fail to Signal, or
+you want the external process to Heartbeat or receive Cancellation. If this may be the case, look at language-specific advanced features for your SDK language (`references/{your_language}/advanced-features.md`).
+
+## Queries
+
+**Purpose**: Read workflow state synchronously without modifying it.
+
+**When to Use**:
+- Building dashboards showing workflow progress
+- Health checks and monitoring
+- Debugging workflow state
+- Exposing current status to external systems
+
+**Characteristics**:
+- Synchronous - caller waits for response
+- Read-only - must not modify state
+- Not recorded in history
+- Executes on the worker, not persisted
+- Can run even on completed workflows
+
+**Example Flow**:
+```
+Client                    Workflow
+  │                          │
+  │──── query(status) ──────▶│
+  │                          │ (reads state)
+  │◀──── "processing" ───────│
+```
+
+## Updates
+
+**Purpose**: Modify workflow state and receive a response synchronously.
+
+**When to Use**:
+- Operations that need confirmation (add item, return count)
+- Validation before accepting changes
+- Replace signal+query combinations
+- Request-response patterns within workflow
+
+**Characteristics**:
+- Synchronous - caller waits for completion
+- Can mutate state AND return values
+- Supports validators to reject invalid updates before they even get persisted into history
+- **Validators must NOT mutate workflow state or block** (no activities, sleeps, or commands) — they are read-only, similar to query handlers
+- Recorded in history
+
+**Example Flow**:
+```
+Client                    Workflow
+  │                          │
+  │──── update(addItem) ────▶│
+  │                          │ (validates, modifies state)
+  │◀──── {count: 5} ─────────│
+```
+
+## Child Workflows
+
+**When to Use**:
+- Prevent history from growing too large
+- Isolate failure domains (child can fail without failing parent)
+- Different retry policies for different parts
+
+**Characteristics**:
+- Own history (doesn't bloat parent)
+- Independent lifecycle options (ParentClosePolicy)
+- Can be cancelled independently
+- Results returned to parent
+
+**Parent Close Policies**:
+- `TERMINATE` - Child terminated when parent closes (default)
+- `ABANDON` - Child continues running independently
+- `REQUEST_CANCEL` - Cancellation requested but not forced
+
+**Note:** Do not need to use child workflows simply for breaking complex logic down into smaller pieces. Standard programming abstractions within a workflow can already be used for that. 
+
+## Continue-as-New
+
+**Purpose**: Prevent unbounded history growth by "restarting" with fresh history.
+
+**When to Use**:
+- Long-running workflows (entity workflows, subscriptions)
+- Workflows with many iterations
+- When history approaches 10,000+ events
+- Periodic cleanup of accumulated state
+
+**How It Works**:
+```
+Workflow (history: 10,000 events)
+    │
+    │ continueAsNew(currentState)
+    ▼
+New Workflow Execution (history: 0 events)
+    │ (same workflow ID, fresh history)
+    │ (receives currentState as input)
+```
+
+**Best Practice**: Check `historyLength` or `continueAsNewSuggested` periodically.
+
+## Saga Pattern
+
+**Purpose**: Distributed transactions with compensation for failures.
+
+**When to Use**:
+- Multi-step operations that span services
+- Operations requiring rollback on failure
+- Financial transactions, order processing
+- Booking systems with multiple reservations
+
+**How It Works**:
+```
+Step 1: Reserve inventory
+  └─ Compensation: Release inventory
+
+Step 2: Charge payment
+  └─ Compensation: Refund payment
+
+Step 3: Ship order
+  └─ Compensation: Cancel shipment
+
+On failure at step 3:
+  Execute: Refund payment (step 2 compensation)
+  Execute: Release inventory (step 1 compensation)
+```
+
+**Implementation Pattern**:
+1. Track compensation actions as you complete each step
+2. On failure, execute compensations in reverse order
+3. Handle compensation failures gracefully (log, alert, manual intervention)
+
+## Parallel Execution
+
+**Purpose**: Run multiple independent operations concurrently.
+
+**When to Use**:
+- Processing multiple items that don't depend on each other
+- Calling multiple APIs simultaneously
+- Fan-out/fan-in patterns
+- Reducing total workflow duration
+
+**Patterns**:
+- `Promise` / `asyncio` - Use traditional concurrency helpers (e.g. wait for all, wait for first, etc)
+- Partial failure handling - Continue with successful results
+
+## Entity Workflow Pattern
+
+**Purpose**: Model long-lived entities as workflows that handle events.
+
+**When to Use**:
+- Subscription management
+- User sessions
+- Shopping carts
+- Any stateful entity receiving events over time
+
+**How It Works**:
+```
+Entity Workflow (user-123)
+    │
+    ├── Receives signal: AddItem
+    │   └── Updates state
+    │
+    ├── Receives signal: UpdateQuantity
+    │   └── Updates state
+    │
+    ├── Receives query: GetCart
+    │   └── Returns current state
+    │
+    └── continueAsNew when history grows
+```
+
+## Timer Patterns
+
+**Purpose**: Durable delays that survive worker restarts.
+
+**Use Cases**:
+- Scheduled reminders
+- Timeout handling
+- Delayed actions
+- Polling with intervals
+
+**Characteristics**:
+- Timers are durable (persisted in history)
+- Can be cancelled
+
+## Polling Patterns
+
+### Frequent Polling
+
+**Purpose**: Frequently (once per second of faster) repeatedly check external state until condition met.
+
+**Implementation**:
+
+```
+# Inside Activity (polling_activity):
+while not condition_met:
+    result = await call_external_api()
+    if result.done:
+        break
+    activity.heartbeat("Invoking activity")
+    await sleep(poll_interval)
+
+
+# In workflow code:
+workflow.execute_activity(
+    polling_activity,
+    PollingActivityInput(...),
+    start_to_close_timeout=timedelta(seconds=60),
+    heartbeat_timeout=timedelta(seconds=2),
+)
+```
+
+To ensure that polling_activity is restarted in a timely manner, we make sure that it heartbeats on every iteration. Note that heartbeating only works if we set the heartbeat_timeout to a shorter value than the Activity start_to_close_timeout timeout
+
+**Advantage:** Because the polling loop is inside the activity, this does not pollute the workflow history.
+
+### Infrequent Polling
+
+**Purpose**: Infrequently (once per minute or slower) repeatedly poll an external service.
+
+**Implementation**:
+
+Define an Activty which fails (raises an exception) exactly when polling is not completed.
+
+The polling loop is accomplised via activity retries, by setting the following Retry options:
+- backoff_coefficient: to 1
+- initial_interval: to the polling interval (e.g. 60 seconds)
+
+This will enable the Activity to be retried exactly on the set interval.
+
+**Advantage:**  Individual Activity retries are not recorded in Workflow History, so this approach can poll for a very long time without affecting the history size.
+
+## Idempotency Patterns
+
+**Purpose**: Ensure activities can be safely retried and replayed without causing duplicate side effects.
+
+**Why It Matters**: Temporal may re-execute activities during retries (on failure) or replay (on worker restart). Without idempotency, this can cause duplicate charges, duplicate emails, duplicate database entries, etc.
+
+### Using Idempotency Keys
+
+Pass a unique identifier to external services so they can detect and deduplicate repeated requests:
+
+```
+Activity: charge_payment(order_id, amount)
+    │
+    └── Call payment API with:
+            amount: $100
+            idempotency_key: "order-{order_id}"
+        │
+        └── Payment provider deduplicates based on key
+            (second call with same key returns original result)
+```
+
+**Good idempotency key sources**:
+- Workflow ID (unique per workflow execution)
+- Business identifier (order ID, transaction ID)
+- Workflow ID + activity name + attempt number
+
+### Check-Before-Act Pattern
+
+Query the external system's state before making changes:
+
+```
+Activity: send_welcome_email(user_id)
+    │
+    ├── Check: Has welcome email been sent for user_id?
+    │   │
+    │   ├── YES: Return early (already done)
+    │   │
+    │   └── NO: Send email, mark as sent
+```
+
+### Designing Idempotent Activities
+
+1. **Use unique identifiers** as idempotency keys with external APIs
+2. **Check before acting**: Query current state before making changes
+3. **Make operations repeatable**: Ensure calling twice produces the same result
+4. **Record outcomes**: Store transaction IDs or results for verification
+5. **Leverage external system features**: Many APIs (Stripe, AWS, etc.) have built-in idempotency key support
+
+### Tracking State in Workflows
+
+For complex multi-step operations, track completion status in workflow state:
+
+```
+Workflow State:
+    payment_completed: false
+    shipment_created: false
+
+Run:
+    if not payment_completed:
+        charge_payment(...)
+        payment_completed = true
+
+    if not shipment_created:
+        create_shipment(...)
+        shipment_created = true
+```
+
+This ensures that on replay, already-completed steps are skipped.
+
+## Large Data Handling
+
+**Purpose**: Handle data that exceeds Temporal's payload limits without polluting workflow history.
+
+**Limits** (see `references/core/gotchas.md` for details):
+- Max 2MB per individual payload
+- Max 4MB per gRPC message
+- Max 50MB for workflow history (aim for <10MB)
+
+**Key Principle**: Large data should never flow through workflow history. Activities read and write large data directly, passing only small references through the workflow.
+
+**Wrong Approach**:
+```
+Workflow
+    │
+    ├── downloadFromStorage(ref) ──▶ returns large data (enters history)
+    │
+    ├── processData(largeData) ────▶ large data as argument (enters history AGAIN)
+    │
+    └── uploadToStorage(result) ───▶ large data as argument (enters history AGAIN)
+```
+
+This defeats the purpose—large data enters workflow history multiple times.
+
+**Correct Approach**:
+```
+Workflow
+    │
+    └── processLargeData(inputRef) ──▶ returns outputRef (small string)
+                │
+                └── Activity internally:
+                        download(inputRef) → process → upload → return outputRef
+```
+
+The workflow only handles references (small strings). The activity does all large data operations internally.
+
+**Implementation Pattern**:
+1. Accept a reference (URL, S3 key, database ID) as activity input
+2. Download/fetch the large data inside the activity
+3. Process the data inside the activity
+4. Upload/store the result inside the activity
+5. Return only a reference to the result
+
+**Other Strategies**:
+- **Compression**: Use a PayloadCodec to compress data automatically
+- **Chunking**: Split large collections across multiple activities, each handling a subset
+
+## Activity Heartbeating
+
+**Purpose**: Enable cancellation delivery and progress tracking for long-running activities.
+
+**Why Heartbeat**:
+1. **Support activity cancellation** - Cancellations are delivered to activities via heartbeat. Activities that don't heartbeat won't know they've been cancelled.
+2. **Resume progress after failure** - Heartbeat details persist across retries, allowing activities to resume where they left off.
+3. **Detect stuck activities** - If an activity stops heartbeating, Temporal can time it out and retry.
+
+**How Cancellation Works**:
+```
+Workflow requests activity cancellation
+    │
+    ▼
+Temporal Service marks activity for cancellation
+    │
+    ▼
+Activity calls heartbeat()
+    │
+    ├── Not cancelled: heartbeat succeeds, continues
+    │
+    └── Cancelled: heartbeat raises exception
+            Activity can catch this to perform cleanup
+```
+
+**Key Point**: If an activity never heartbeats, it will run to completion even if cancelled—it has no way to learn about the cancellation.
+
+## Local Activities
+
+**Purpose**: Reduce latency for short, lightweight operations by skipping the task queue. ONLY use these when necessary for performance. Do NOT use these by default, as they are not durable and distributed.
+
+**When to Use**:
+- Short operations completing in milliseconds/seconds
+- High-frequency calls where task queue overhead is significant
+- Low-latency requirements where you can't afford task queue round-trip
+
+**Characteristics**:
+- Executes on the same worker that runs the workflow
+- No task queue round-trip (lower latency)
+- Still recorded in history
+- Should complete quickly (default timeout is short)
+
+**Trade-offs**:
+- Less visibility in Temporal UI (no separate task)
+- Must complete on the same worker
+- Not suitable for long-running operations
+- **Risk with consecutive local activities:** Local activity completions are only persisted when the current Workflow Task completes. Calling multiple local activities in a row (with nothing in between to yield the Workflow Task) increases the risk of losing work if the worker crashes mid-sequence. If you need a chain of operations with durable checkpoints between each step, use regular activities instead.
+
+## Choosing Between Patterns
+
+| Need | Pattern |
+|------|---------|
+| Send data, don't need response | Signal |
+| Read state, no modification | Query |
+| Modify state, need response | Update |
+| Break down large workflow | Child Workflow |
+| Prevent history growth | Continue-as-New |
+| Rollback on failure | Saga |
+| Process items concurrently | Parallel Execution |
+| Long-lived stateful entity | Entity Workflow |
+| Safe retries/replays | Idempotency |
+| Low-latency short operations | Local Activities |

--- a/.agents/skills/temporal-developer/references/core/troubleshooting.md
+++ b/.agents/skills/temporal-developer/references/core/troubleshooting.md
@@ -1,0 +1,323 @@
+# Temporal Troubleshooting Guide
+
+## Workflow Diagnosis Decision Tree
+
+```
+Workflow not behaving as expected?
+│
+├─▶ What is the workflow status?
+│   │
+│   ├─▶ RUNNING (but no progress)
+│   │   └─▶ Go to: "Workflow Stuck" section
+│   │
+│   ├─▶ FAILED
+│   │   └─▶ Go to: "Workflow Failed" section
+│   │
+│   ├─▶ TIMED_OUT
+│   │   └─▶ Go to: "Timeout Issues" section
+│   │
+│   └─▶ COMPLETED (but wrong result)
+│       └─▶ Go to: "Wrong Result" section
+```
+
+## Workflow Stuck (RUNNING but No Progress)
+
+### Decision Tree
+
+```
+Workflow stuck in RUNNING?
+│
+├─▶ Is a worker running?
+│   │
+│   ├─▶ NO: Start a worker
+│   │   └─▶ See references/core/dev-management.md
+│   │
+│   └─▶ YES: Is it on the correct task queue?
+│       │
+│       ├─▶ NO: Start worker with correct task queue
+│       │
+│       └─▶ YES: Check for non-determinism
+│           │
+│           ├─▶ NondeterminismError in logs?
+│           │   └─▶ Go to: "Non-Determinism" section
+│           │
+│           ├─▶ Check history for task failures
+│           │   └─▶ Run: `temporal workflow show --workflow-id <id>`
+│           │       │
+│           │       ├─▶ WorkflowTaskFailed event?
+│           │       │   └─▶ Check error type in event details
+│           │       │       └─▶ Go to relevant section in error-reference.md
+│           │       │
+│           │       └─▶ ActivityTaskFailed event?
+│           │           └─▶ Go to: "Activity Keeps Retrying" section
+│           │
+│           └─▶ No errors in logs or history?
+│               └─▶ Check if workflow is waiting for signal/timer
+```
+
+### Common Causes
+
+1. **No worker running**
+   - See references/core/dev-management.md
+
+2. **Worker on wrong task queue**
+   - Check: Worker logs for task queue name
+   - Fix: Start worker with matching task queue
+
+3. **Worker has stale code**
+   - Check: Worker startup time vs code changes
+   - Fix: Restart worker with updated code
+
+4. **Workflow waiting for signal**
+   - Check: Workflow history for pending signals
+   - Fix: Send expected signal or check signal sender
+
+5. **Activity stuck/timing out**
+   - Check: Activity retry attempts in history
+   - Fix: Investigate activity failure, increase timeout
+
+## Non-Determinism Errors
+
+### Decision Tree
+
+```
+NondeterminismError?
+│
+├─▶ Was code intentionally changed?
+│   │
+│   ├─▶ YES: Do you need to support in-flight workflows?
+│   │   │
+│   │   ├─▶ YES (production): Use patching API
+│   │   │   └─▶ See: references/core/versioning.md
+│   │   │
+│   │   └─▶ NO (local dev/testing): Terminate or reset workflow
+│   │       └─▶ `temporal workflow terminate --workflow-id <id>`
+│   │       └─▶ Then start fresh with new code
+│   │
+│   └─▶ NO: Accidental change
+│       │
+│       ├─▶ Can you identify the change?
+│       │   │
+│       │   ├─▶ YES: Revert and restart worker. Note, this doesn't always work if workflow has progressed past the change (may induce other code paths), so may need to reset workflow.
+│       │   │
+│       │   └─▶ NO: Compare current code to expected history
+│       │       └─▶ Check: Activity names, order, parameters
+```
+
+### Common Causes
+
+1. **Changed call order**
+   ```
+   # Before           # After (BREAKS)
+   await activity_a   await activity_b
+   await activity_b   await activity_a
+   ```
+
+2. **Changed call name**
+   ```
+   # Before                    # After (BREAKS)
+   await process_order(...)    await handle_order(...)
+   ```
+
+3. **Added/removed call**
+   - Adding new activity mid-workflow
+   - Removing activity that was previously called
+
+4. **Using non-deterministic code**
+   - `datetime.now()` in workflow (use `workflow.now()`)
+   - `random.random()` in workflow (use `workflow.random()`)
+
+### Recovery
+
+**Accidental Change:**
+1. Identify the change
+2. Revert code to match history
+3. Restart worker
+4. Workflow automatically recovers
+
+**Intentional Change:**
+1. Use patching API for gradual migration
+2. Or terminate old workflows, start new ones
+
+## Workflow Failed
+
+### Decision Tree
+
+```
+Workflow status = FAILED?
+│
+├─▶ Check workflow error message
+│   │
+│   ├─▶ Application error (your code)
+│   │   └─▶ Fix the bug, start new workflow
+│   │
+│   ├─▶ NondeterminismError
+│   │   └─▶ Go to: "Non-Determinism" section
+│   │
+│   └─▶ Timeout error
+│       └─▶ Go to: "Timeout Issues" section
+```
+
+### Common Causes
+
+1. **Unhandled exception in workflow**
+   - Check error message and stack trace
+   - Fix bug in workflow code
+
+2. **Activity exhausted retries**
+   - All retry attempts failed
+   - Check activity logs for root cause
+
+3. **Non-retryable error thrown**
+   - Error marked as non-retryable
+   - Intentional failure, check business logic
+
+## Timeout Issues
+
+### Timeout Types
+
+| Timeout | Scope | What It Limits |
+|---------|-------|----------------|
+| `WorkflowExecutionTimeout` | Entire workflow | Total time including retries and continue-as-new |
+| `WorkflowRunTimeout` | Single run | Time for one run (before continue-as-new) |
+| `ScheduleToCloseTimeout` | Activity | Total time including retries |
+| `StartToCloseTimeout` | Activity | Single attempt time |
+| `HeartbeatTimeout` | Activity | Time between heartbeats |
+
+### Diagnosis
+
+```
+Timeout error?
+│
+├─▶ Which timeout?
+│   │
+│   ├─▶ Workflow timeout
+│   │   └─▶ Increase timeout or optimize workflow. Better yet, consider removing the workflow timeout, as it is generally discourged unless *necessary* for your use case.
+│   │
+│   ├─▶ ScheduleToCloseTimeout
+│   │   └─▶ Activity taking too long overall (including retries)
+│   │
+│   ├─▶ StartToCloseTimeout
+│   │   └─▶ Single activity attempt too slow
+│   │
+│   └─▶ HeartbeatTimeout
+│       └─▶ Activity not heartbeating frequently enough
+│           └─▶ Add heartbeat() calls in long activities
+```
+
+### Fixes
+
+1. **Increase timeout** if operation legitimately takes longer
+2. **Add heartbeats** to long-running activities
+3. **Optimize activity** to complete faster
+4. **Break into smaller activities** for better granularity
+
+## Activity Keeps Retrying
+
+### Decision Tree
+
+```
+Activity retrying repeatedly?
+│
+├─▶ Check activity error
+│   │
+│   ├─▶ Transient error (network, timeout)
+│   │   └─▶ Expected behavior, will eventually succeed
+│   │
+│   ├─▶ Permanent error (bug, invalid input)
+│   │   └─▶ Fix the bug or mark as non-retryable
+│   │
+│   └─▶ Resource exhausted
+│       └─▶ Add backoff, check rate limits
+```
+
+### Common Causes
+
+1. **Bug in activity code**
+   - Fix the bug
+   - Consider marking certain errors as non-retryable
+
+2. **External service down**
+   - Retries are working as intended
+   - Monitor service recovery
+
+3. **Invalid input**
+   - Validate inputs before activity
+   - Return non-retryable error for bad input
+
+## Wrong Result (Completed but Incorrect)
+
+### Diagnosis
+
+1. **Check workflow history** for unexpected activity results
+2. **Verify activity implementations** produce correct output
+3. **Check for race conditions** in parallel execution
+4. **Verify signal handling** if signals are involved
+
+### Common Causes
+
+1. **Activity bug** - Wrong logic in activity
+2. **Stale data** - Activity using outdated information
+3. **Signal ordering** - Signals processed in unexpected order
+4. **Parallel execution** - Race condition in concurrent operations
+
+## Worker Issues
+
+### Worker Not Starting
+
+```
+Worker won't start?
+│
+├─▶ Connection error
+│   └─▶ Check Temporal server is running
+│       └─▶ `temporal server start-dev` (start in background, see references/core/dev-management.md)
+│
+├─▶ Registration error
+│   └─▶ Check workflow/activity definitions are valid
+│
+└─▶ Other errors (imports, etc.)
+    └─▶ Debug those errors as usual.
+```
+
+### Worker Crashing
+
+1. **Out of memory** - Reduce concurrent tasks, check for leaks
+2. **Unhandled exception** - Add error handling
+3. **Dependency issue** - Check package versions
+
+## Useful Commands
+
+```bash
+# Check Temporal server
+temporal server start-dev
+
+# List workflows
+temporal workflow list
+
+# Describe specific workflow
+temporal workflow describe --workflow-id <id>
+
+# Show workflow history
+temporal workflow show --workflow-id <id>
+
+# Terminate stuck workflow
+temporal workflow terminate --workflow-id <id>
+
+# Reset workflow to specific point
+temporal workflow reset --workflow-id <id> --event-id <event-id>
+```
+
+## Quick Reference: Status → Action
+
+| Status | First Check | Common Fix |
+|--------|-------------|------------|
+| RUNNING (stuck) | Worker running? | Start/restart worker |
+| FAILED | Error message | Fix bug, handle error |
+| TIMED_OUT | Which timeout? | Increase timeout or optimize |
+| TERMINATED | Who terminated? | Check audit log |
+| CANCELED | Cancellation source | Expected or investigate |
+
+## See Also
+
+- [Common Gotchas](gotchas.md) - Anti-patterns that cause these issues
+- [Error Reference](error-reference.md) - Quick error type lookup

--- a/.agents/skills/temporal-developer/references/core/versioning.md
+++ b/.agents/skills/temporal-developer/references/core/versioning.md
@@ -1,0 +1,174 @@
+# Workflow Versioning Concepts
+
+This document provides core conceptual explanations of workflow versioning in Temporal. For language-specific implementation details see `references/{your_language}/versioning.md`, for the language you are working in.
+
+## Overview
+
+Workflow versioning allows safe deployment of code changes without breaking running workflows. Three approaches available:
+
+1. **Patching API** - Code-level version branching
+2. **Workflow Type Versioning** - New workflow types for incompatible changes
+3. **Worker Versioning** - Deployment-level control with Build IDs
+
+## Why Versioning is Needed
+
+When workers restart after deployment, they resume open workflows through history replay. If updated code produces different Commands than the original code, it causes non-determinism errors.
+
+```
+Original Code (recorded in history):
+  await activity_a()
+  await activity_b()
+
+Updated Code (during replay):
+  await activity_a()
+  await activity_c()  ← Different! NondeterminismError
+```
+
+## Approach 1: Patching API
+
+### Concept
+
+The patching API lets you branch code based on whether a workflow was started before or after a code change.
+
+```
+if patched("my-change"):
+    // New code path (for new and replaying new workflows)
+else:
+    // Old code path (for replaying old workflows)
+```
+
+### Three-Phase Lifecycle
+
+**Phase 1: Patch In**
+- Add both old and new code paths
+- New workflows take new path, old workflows take old path
+
+**Phase 2: Deprecate**
+- After all old workflows complete, remove old code
+- Keep deprecation marker for history compatibility
+
+**Phase 3: Remove**
+- After all deprecated workflows complete
+- Remove patch entirely, only new code remains
+
+### When to Use
+
+- Adding, removing, or reordering activities/child workflows
+- Changing which activity/child workflow is called
+- Any change that alters the Command sequence
+
+### When NOT to Use
+
+- Changing activity implementations (activities aren't replayed)
+- Changing arguments passed to activities or child workflows
+- Changing retry policies
+- Changing timer durations
+- Adding new signal/query/update handlers (additive changes are safe)
+- Bug fixes that don't change Command sequence
+
+Unnecessary patching adds complexity and can make workflow code unmanageable.
+
+## Approach 2: Workflow Type Versioning
+
+### Concept
+
+Create a new workflow type (e.g., `OrderWorkflowV2`) instead of patching.
+
+```
+// Old: OrderWorkflow
+// New: OrderWorkflowV2 (completely new implementation)
+```
+
+### When to Use
+
+- Major incompatible changes
+- Complete rewrites
+- When patching would be too complex
+- When you want clean separation
+
+### Process
+
+1. Create new workflow type with new name
+2. Register both with worker
+3. Start new workflows with new type
+4. Wait for old workflows to complete
+5. Remove old workflow type
+
+## Approach 3: Worker Versioning
+
+### Concept
+
+Manage versions at deployment level using Build IDs. Multiple worker versions can run simultaneously.
+
+```
+Worker v1.0 (Build ID: abc123)
+  └── Handles workflows started on this version
+
+Worker v2.0 (Build ID: def456)
+  └── Handles new workflows
+  └── Can also handle upgraded old workflows
+```
+
+### Key Concepts
+
+**Worker Deployment**: Logical service grouping (e.g., "order-service")
+
+**Build ID**: Specific code version (e.g., git commit hash)
+
+**Versioning Behaviors**:
+- `PINNED` - Workflows stay on original worker version
+- `AUTO_UPGRADE` - Workflows can move to newer versions
+
+### When to Use PINNED
+
+- Short-running workflows (minutes to hours)
+- Consistency is critical
+- Want simplest development experience
+- Building new applications
+
+### When to Use AUTO_UPGRADE
+
+- Long-running workflows (weeks or months)
+- Workflows need bug fixes during execution
+- Still requires patching for version transitions
+
+## Choosing an Approach
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Small change, few running workflows | Patching API |
+| Major rewrite | Workflow Type Versioning |
+| Many short workflows, frequent deploys | Worker Versioning (PINNED) |
+| Long-running workflows needing updates | Worker Versioning (AUTO_UPGRADE) + Patching |
+| Quick fix, can wait for completion | Wait for workflows to complete |
+
+## Best Practices
+
+1. **Check for open executions** before removing old code
+2. **Use descriptive patch IDs** (e.g., "add-fraud-check" not "patch-1")
+3. **Deploy incrementally**: patch → deprecate → remove
+4. **Test replay compatibility** before deploying changes
+5. **Monitor old workflow counts** during migration
+
+## Finding Workflows by Version
+
+```bash
+# Find workflows with specific patch
+temporal workflow list --query \
+  'WorkflowType = "OrderWorkflow" AND TemporalChangeVersion = "add-fraud-check"'
+
+# Find pre-patch workflows
+temporal workflow list --query \
+  'WorkflowType = "OrderWorkflow" AND TemporalChangeVersion IS NULL'
+
+# Find workflows on specific worker version
+temporal workflow list --query \
+  'TemporalWorkerDeploymentVersion = "my-service:v1.0.0"'
+```
+
+## Common Mistakes
+
+1. **Removing old code too early** - Breaks replaying workflows
+2. **Not testing with replay** - Catches issues before production
+3. **Patching non-Command changes** - Unnecessary complexity
+4. **Forgetting to deprecate** - Accumulates dead code

--- a/.agents/skills/temporal-developer/references/typescript/advanced-features.md
+++ b/.agents/skills/temporal-developer/references/typescript/advanced-features.md
@@ -1,0 +1,150 @@
+# TypeScript SDK Advanced Features
+
+## Schedules
+
+Create recurring workflow executions.
+
+```typescript
+import { Client, ScheduleOverlapPolicy } from '@temporalio/client';
+
+const client = new Client();
+
+// Create a schedule
+const schedule = await client.schedule.create({
+  scheduleId: 'daily-report',
+  spec: {
+    intervals: [{ every: '1 day' }],
+  },
+  action: {
+    type: 'startWorkflow',
+    workflowType: 'dailyReportWorkflow',
+    taskQueue: 'reports',
+    args: [],
+  },
+  policies: {
+    overlap: ScheduleOverlapPolicy.SKIP,
+  },
+});
+
+// Manage schedules
+const handle = client.schedule.getHandle('daily-report');
+await handle.pause('Maintenance window');
+await handle.unpause();
+await handle.trigger();  // Run immediately
+await handle.delete();
+```
+
+## Async Activity Completion
+
+Complete an activity asynchronously from outside the activity function. Useful when the activity needs to wait for an external event.
+
+**In the activity - return the task token:**
+```typescript
+import { CompleteAsyncError, activityInfo } from '@temporalio/activity';
+
+export async function doSomethingAsync(): Promise<string> {
+  const taskToken: Uint8Array = activityInfo().taskToken;
+  setTimeout(() => doSomeWork(taskToken), 1000);
+  throw new CompleteAsyncError();
+}
+```
+
+**External completion (from another process, machine, etc.):**
+```typescript
+import { Client } from '@temporalio/client';
+
+async function doSomeWork(taskToken: Uint8Array): Promise<void> {
+  const client = new Client();
+  // does some work...
+  await client.activity.complete(taskToken, "Job's done!");
+}
+```
+
+**When to use:**
+- Waiting for human approval
+- Waiting for external webhook callback
+- Long-polling external systems
+
+## Worker Tuning
+
+Configure worker capacity for production workloads:
+
+```typescript
+import { Worker, NativeConnection } from '@temporalio/worker';
+
+const worker = await Worker.create({
+  connection: await NativeConnection.connect({ address: 'temporal:7233' }),
+  taskQueue: 'my-queue',
+  workflowBundle: { codePath: require.resolve('./workflow-bundle.js') }, // Pre-bundled for production
+  activities,
+
+  // Workflow execution concurrency (default: 40)
+  maxConcurrentWorkflowTaskExecutions: 100,
+
+  // Activity execution concurrency (default: 100)
+  maxConcurrentActivityTaskExecutions: 200,
+
+  // Graceful shutdown timeout (default: 0)
+  shutdownGraceTime: '30 seconds',
+
+  // Max cached workflows (memory vs latency tradeoff)
+  maxCachedWorkflows: 1000,
+});
+```
+
+**Key settings:**
+- `maxConcurrentWorkflowTaskExecutions`: Max workflows running simultaneously (default: 40)
+- `maxConcurrentActivityTaskExecutions`: Max activities running simultaneously (default: 100)
+- `shutdownGraceTime`: Time to wait for in-progress work before forced shutdown
+- `maxCachedWorkflows`: Number of workflows to keep in cache (reduces replay on cache hit)
+
+## Sinks
+
+Sinks allow workflows to emit events for side effects (logging, metrics).
+
+```typescript
+import { proxySinks, Sinks } from '@temporalio/workflow';
+
+// Define sink interface
+export interface LoggerSinks extends Sinks {
+  logger: {
+    info(message: string, attrs: Record<string, unknown>): void;
+    error(message: string, attrs: Record<string, unknown>): void;
+  };
+}
+
+// Use in workflow
+const { logger } = proxySinks<LoggerSinks>();
+
+export async function myWorkflow(input: string): Promise<string> {
+  logger.info('Workflow started', { input });
+
+  const result = await someActivity(input);
+
+  logger.info('Workflow completed', { result });
+  return result;
+}
+
+// Implement sink in worker
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'), // Use workflowBundle for production
+  activities,
+  taskQueue: 'my-queue',
+  sinks: {
+    logger: {
+      info: {
+        fn(workflowInfo, message, attrs) {
+          console.log(`[${workflowInfo.workflowId}] ${message}`, attrs);
+        },
+        callDuringReplay: false,  // Don't log during replay
+      },
+      error: {
+        fn(workflowInfo, message, attrs) {
+          console.error(`[${workflowInfo.workflowId}] ${message}`, attrs);
+        },
+        callDuringReplay: false,
+      },
+    },
+  },
+});
+```

--- a/.agents/skills/temporal-developer/references/typescript/data-handling.md
+++ b/.agents/skills/temporal-developer/references/typescript/data-handling.md
@@ -1,0 +1,253 @@
+# TypeScript SDK Data Handling
+
+## Overview
+
+The TypeScript SDK uses data converters to serialize/deserialize workflow inputs, outputs, and activity parameters.
+
+## Default Data Converter
+
+The default converter handles:
+- `undefined` and `null`
+- `Uint8Array` (as binary)
+- JSON-serializable types
+
+Note: Protobuf support requires using a data converter (`DefaultPayloadConverterWithProtobufs`). See the Protobuf Support section below.
+
+## Custom Data Converter
+
+Create custom converters for special serialization needs.
+
+```typescript
+// payload-converter.ts
+import {
+  PayloadConverter,
+  Payload,
+  defaultPayloadConverter,
+} from '@temporalio/common';
+
+class CustomPayloadConverter implements PayloadConverter {
+  toPayload<T>(value: T): Payload | undefined {
+    // Custom serialization logic
+    return defaultPayloadConverter.toPayload(value);
+  }
+
+  fromPayload<T>(payload: Payload): T {
+    // Custom deserialization logic
+    return defaultPayloadConverter.fromPayload(payload);
+  }
+}
+
+export const payloadConverter = new CustomPayloadConverter();
+```
+
+```typescript
+// client.ts
+import { Client } from '@temporalio/client';
+
+const client = new Client({
+  dataConverter: {
+    payloadConverterPath: require.resolve('./payload-converter'),
+  },
+});
+```
+
+```typescript
+// worker.ts
+import { Worker } from '@temporalio/worker';
+
+const worker = await Worker.create({
+  dataConverter: {
+    payloadConverterPath: require.resolve('./payload-converter'),
+  },
+  // ...
+});
+```
+
+## Composition of Payload Converters
+
+```typescript
+import { CompositePayloadConverter } from '@temporalio/common';
+
+// The order matters — converters are tried in sequence until one returns a non-null Payload
+export const payloadConverter = new CompositePayloadConverter(
+  new PayloadConverterFoo(),
+  new PayloadConverterBar(),
+);
+```
+
+## Protobuf Support
+
+Using Protocol Buffers for type-safe serialization.
+
+**Note:** JSON serialization (the default) is preferred for TypeScript applications—it's simpler and more performant. Use Protobuf only when interoperating with services that require it.
+
+```typescript
+import { DefaultPayloadConverterWithProtobufs } from '@temporalio/common/lib/protobufs';
+
+const dataConverter: DataConverter = {
+  payloadConverter: new DefaultPayloadConverterWithProtobufs({
+    protobufRoot: myProtobufRoot,
+  }),
+};
+```
+
+## Payload Codec (Encryption)
+
+Encrypt sensitive workflow data.
+
+```typescript
+import { PayloadCodec, Payload } from '@temporalio/common';
+
+class EncryptionCodec implements PayloadCodec {
+  private readonly encryptionKey: Uint8Array;
+
+  constructor(key: Uint8Array) {
+    this.encryptionKey = key;
+  }
+
+  async encode(payloads: Payload[]): Promise<Payload[]> {
+    return Promise.all(
+      payloads.map(async (payload) => ({
+        metadata: {
+          encoding: 'binary/encrypted',
+        },
+        data: await this.encrypt(payload.data ?? new Uint8Array()),
+      }))
+    );
+  }
+
+  async decode(payloads: Payload[]): Promise<Payload[]> {
+    return Promise.all(
+      payloads.map(async (payload) => {
+        if (payload.metadata?.encoding === 'binary/encrypted') {
+          return {
+            ...payload,
+            data: await this.decrypt(payload.data ?? new Uint8Array()),
+          };
+        }
+        return payload;
+      })
+    );
+  }
+
+  private async encrypt(data: Uint8Array): Promise<Uint8Array> {
+    // Implement encryption (e.g., using Web Crypto API)
+    return data;
+  }
+
+  private async decrypt(data: Uint8Array): Promise<Uint8Array> {
+    // Implement decryption
+    return data;
+  }
+}
+
+// Apply codec
+const dataConverter: DataConverter = {
+  payloadCodecs: [new EncryptionCodec(encryptionKey)],
+};
+```
+
+## Search Attributes
+
+Custom searchable fields for workflow visibility.
+
+### Setting Search Attributes at Start
+
+```typescript
+import { Client } from '@temporalio/client';
+
+const client = new Client();
+
+await client.workflow.start('orderWorkflow', {
+  taskQueue: 'orders',
+  workflowId: `order-${orderId}`,
+  args: [order],
+  searchAttributes: {
+    OrderId: [orderId],
+    CustomerType: ['premium'],
+    OrderTotal: [99.99],
+    CreatedAt: [new Date()],
+  },
+});
+```
+
+### Upserting Search Attributes from Workflow
+
+```typescript
+import { upsertSearchAttributes, workflowInfo } from '@temporalio/workflow';
+
+export async function orderWorkflow(order: Order): Promise<string> {
+  // Update status as workflow progresses
+  upsertSearchAttributes({
+    OrderStatus: ['processing'],
+  });
+
+  await processOrder(order);
+
+  upsertSearchAttributes({
+    OrderStatus: ['completed'],
+  });
+
+  return 'done';
+}
+```
+
+### Reading Search Attributes
+
+```typescript
+import { workflowInfo } from '@temporalio/workflow';
+
+export async function orderWorkflow(): Promise<void> {
+  const info = workflowInfo();
+  const searchAttrs = info.searchAttributes;
+  const orderId = searchAttrs?.OrderId?.[0];
+  // ...
+}
+```
+
+### Querying Workflows by Search Attributes
+
+```typescript
+const client = new Client();
+
+// List workflows using search attributes
+for await (const workflow of client.workflow.list({
+  query: 'OrderStatus = "processing" AND CustomerType = "premium"',
+})) {
+  console.log(`Workflow ${workflow.workflowId} is still processing`);
+}
+```
+
+## Workflow Memo
+
+Store arbitrary metadata with workflows (not searchable).
+
+```typescript
+// Set memo at workflow start
+await client.workflow.start('orderWorkflow', {
+  taskQueue: 'orders',
+  workflowId: `order-${orderId}`,
+  args: [order],
+  memo: {
+    customerName: order.customerName,
+    notes: 'Priority customer',
+  },
+});
+
+// Read memo from workflow
+import { workflowInfo } from '@temporalio/workflow';
+
+export async function orderWorkflow(): Promise<void> {
+  const info = workflowInfo();
+  const customerName = info.memo?.customerName;
+  // ...
+}
+```
+
+## Best Practices
+
+1. Keep payloads small—see `references/core/gotchas.md` for limits
+2. Use search attributes for business-level visibility and filtering
+3. Encrypt sensitive data with PayloadCodec
+4. Use memo for non-searchable metadata
+5. Configure the same data converter on both client and worker

--- a/.agents/skills/temporal-developer/references/typescript/determinism-protection.md
+++ b/.agents/skills/temporal-developer/references/typescript/determinism-protection.md
@@ -1,0 +1,56 @@
+# TypeScript Workflow V8 Sandboxing
+
+## Overview
+
+The TypeScript SDK runs workflows in a V8 sandbox that provides automatic protection against non-deterministic operations, and replaces common non-deterministic function calls with deterministic variants.
+
+## Import Blocking
+
+The sandbox blocks imports of `fs`, `https` modules, and any Node/DOM APIs. Otherwise, workflow code can import any package as long as it does not reference Node.js or DOM APIs.
+
+**Note**: If you must use a library that references a Node.js or DOM API and you are certain that those APIs are not used at runtime, add that module to the `ignoreModules` list:
+
+```ts
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'), // bundlerOptions only apply with workflowsPath
+  activities: require('./activities'),
+  taskQueue: 'my-task-queue',
+  bundlerOptions: {
+    // These modules may be imported (directly or transitively),
+    // but will be excluded from the Workflow bundle.
+    ignoreModules: ['fs', 'http', 'crypto'],
+  },
+});
+```
+
+**Important**: Excluded modules are completely unavailable at runtime. Any attempt to call functions from these modules will throw an error. Only exclude modules when you are certain the code paths using them will never execute during workflow execution.
+
+**Note**: Modules with the `node:` prefix (e.g., `node:fs`) require additional webpack configuration to ignore. You may need to configure the bundler's `externals` or use webpack `resolve.alias` to handle these imports.
+
+Use this with *extreme caution*.
+
+
+## Function Replacement
+
+Functions like `Math.random()`, `Date`, and `setTimeout()` are replaced by deterministic versions.
+
+Date-related functions return the timestamp at which the current workflow task was initially executed. That timestamp remains the same when the workflow task is replayed, and only advances when a durable operation occurs (like `sleep()`). For example:
+
+```ts
+import { sleep } from '@temporalio/workflow';
+
+// this prints the *exact* same timestamp repeatedly
+for (let x = 0; x < 10; ++x) {
+  console.log(Date.now());
+}
+
+// this prints timestamps increasing roughly 1s each iteration
+for (let x = 0; x < 10; ++x) {
+  await sleep('1 second');
+  console.log(Date.now());
+}
+```
+
+Generally, this is the behavior you want.
+
+Additionally, `FinalizationRegistry` and `WeakRef` are removed because v8's garbage collector is not deterministic.

--- a/.agents/skills/temporal-developer/references/typescript/determinism.md
+++ b/.agents/skills/temporal-developer/references/typescript/determinism.md
@@ -1,0 +1,51 @@
+# TypeScript SDK Determinism
+
+## Overview
+
+The TypeScript SDK runs workflows in an isolated V8 sandbox that automatically provides determinism.
+
+## Why Determinism Matters
+
+Temporal provides durable execution through **History Replay**. When a Worker needs to restore workflow state (after a crash, cache eviction, or to continue after a long timer), it re-executes the workflow code from the beginning, which requires the workflow code to be **deterministic**.
+
+## Temporal's V8 Sandbox
+
+The Temporal TypeScript SDK executes all workflow code in sandbox, which (among other things), replaces common non-deterministic functions with deterministic variants. As an example, consider the code below:
+
+```ts
+export async function myWorkflow(): Promise<string> {
+  await importData();
+
+  if (Math.random() > 0.5) {
+    await sleep('30 minutes');
+  }
+
+  return await sendReport();
+}
+```
+
+The Temporal workflow sandbox will use the same random seed when replaying a workflow, so the above code will **deterministically** generate pseudo-random numbers. For UUIDs, use `uuid4()` from `@temporalio/workflow` which also uses the seeded PRNG.
+
+See `references/typescript/determinism-protection.md` for more information about the sandbox.
+
+## Forbidden Operations
+
+```typescript
+// DO NOT do these in workflows:
+import fs from 'fs';           // Node.js modules
+fetch('https://...');          // Network I/O
+```
+
+Most non-determinism and side effects, such as the above, should be wrapped in Activities.
+
+## Testing Replay Compatibility
+
+Use `Worker.runReplayHistory()` to verify your code changes are compatible with existing histories. See the Workflow Replay Testing section of `references/typescript/testing.md`.
+
+## Best Practices
+
+1. Use type-only imports for activities in workflow files
+2. Match all @temporalio package versions
+3. Prefer `sleep()` from workflow package — `setTimeout` works but `sleep()` handles cancellation scopes more clearly
+4. Keep workflows focused on orchestration
+5. Test with replay to verify determinism

--- a/.agents/skills/temporal-developer/references/typescript/error-handling.md
+++ b/.agents/skills/temporal-developer/references/typescript/error-handling.md
@@ -1,0 +1,119 @@
+# TypeScript SDK Error Handling
+
+## Overview
+
+The TypeScript SDK uses `ApplicationFailure` for application errors with support for non-retryable marking.
+
+## Application Failures
+
+```typescript
+import { ApplicationFailure } from '@temporalio/workflow';
+
+export async function myWorkflow(): Promise<void> {
+  throw ApplicationFailure.create({
+    message: 'Invalid input',
+    type: 'ValidationError',
+    nonRetryable: true,
+  });
+}
+```
+
+## Activity Errors
+
+```typescript
+import { ApplicationFailure } from '@temporalio/activity';
+
+export async function validateActivity(input: string): Promise<void> {
+  if (!isValid(input)) {
+    throw ApplicationFailure.create({
+      message: `Invalid input: ${input}`,
+      type: 'ValidationError',
+      nonRetryable: true,
+    });
+  }
+}
+```
+
+## Handling Errors in Workflows
+
+```typescript
+import { proxyActivities, ApplicationFailure, log } from '@temporalio/workflow';
+import type * as activities from './activities';
+
+const { riskyActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '5 minutes',
+});
+
+export async function workflowWithErrorHandling(): Promise<string> {
+  try {
+    return await riskyActivity();
+  } catch (err) {
+    if (err instanceof ApplicationFailure) {
+      log.warn('Activity failed', { type: err.type, message: err.message });
+    }
+    throw err;
+  }
+}
+```
+
+## Retry Configuration
+
+```typescript
+const { myActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '10 minutes',
+  retry: {
+    initialInterval: '1s',
+    backoffCoefficient: 2,
+    maximumInterval: '1m',
+    maximumAttempts: 5,
+    nonRetryableErrorTypes: ['ValidationError', 'PaymentError'],
+  },
+});
+```
+
+**Note:** Only set retry options if you have a domain-specific reason to. The defaults are suitable for most use cases.
+
+## Timeout Configuration
+
+```typescript
+const { myActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '5 minutes',      // Single attempt
+  scheduleToCloseTimeout: '30 minutes',  // Including retries
+  heartbeatTimeout: '30 seconds',        // Between heartbeats
+});
+```
+
+## Workflow Failure
+
+Workflows can throw errors to indicate failure:
+
+```typescript
+import { ApplicationFailure } from '@temporalio/workflow';
+
+export async function myWorkflow(): Promise<string> {
+  if (someCondition) {
+    throw ApplicationFailure.create({
+      message: 'Workflow failed due to invalid state',
+      type: 'InvalidStateError',
+    });
+  }
+  return 'success';
+}
+```
+
+**Warning:** Do NOT use `nonRetryable: true` for workflow failures in most cases. Unlike activities, workflow retries are controlled by the caller, not retry policies. Use `nonRetryable` only for errors that are truly unrecoverable (e.g., invalid input that will never be valid).
+
+## Idempotency
+
+For idempotency patterns (using keys, making activities granular), see `core/patterns.md`.
+
+## Best Practices
+
+1. Use specific error types for different failure modes
+2. Set `nonRetryable: true` for permanent failures in activities
+3. Configure `nonRetryableErrorTypes` in retry policy
+4. Log errors before re-raising
+5. Use `ApplicationFailure` to catch activity failures in workflows
+6. Use the appropriate `log` import for your context:
+   - In workflows: `import { log } from '@temporalio/workflow'` (replay-safe)
+   - In activities: `import { log } from '@temporalio/activity'`

--- a/.agents/skills/temporal-developer/references/typescript/gotchas.md
+++ b/.agents/skills/temporal-developer/references/typescript/gotchas.md
@@ -1,0 +1,312 @@
+# TypeScript Gotchas
+
+TypeScript-specific mistakes and anti-patterns. See also [Common Gotchas](../core/gotchas.md) for language-agnostic concepts.
+
+## Activity Imports
+
+### Importing Implementations Instead of Types
+
+**The Problem**: Importing activity implementations brings Node.js code into the V8 workflow sandbox, causing bundling errors or runtime failures.
+
+```typescript
+// BAD - Brings actual code into workflow sandbox
+import * as activities from './activities';
+
+const { greet } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+
+// GOOD - Type-only import
+import type * as activities from './activities';
+
+const { greet } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+```
+
+### Importing Node.js Modules in Workflows
+
+```typescript
+// BAD - fs is not available in workflow sandbox
+import * as fs from 'fs';
+
+export async function myWorkflow(): Promise<void> {
+  const data = fs.readFileSync('file.txt'); // Will fail!
+}
+
+// GOOD - File I/O belongs in activities
+export async function myWorkflow(): Promise<void> {
+  const data = await activities.readFile('file.txt');
+}
+```
+
+## Bundling Issues
+
+### Using workflowsPath in Production
+
+`workflowsPath` runs the bundler at Worker startup, which is slow and not suitable for production. Use `workflowBundle` with pre-bundled code instead.
+
+```typescript
+// OK for development/testing, BAD for production - bundles at startup
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'),
+  // ...
+});
+
+// GOOD for production - use pre-bundled code
+import { bundleWorkflowCode } from '@temporalio/worker';
+
+// Build step (run once at build time)
+const bundle = await bundleWorkflowCode({
+  workflowsPath: require.resolve('./workflows'),
+});
+await fs.promises.writeFile('./workflow-bundle.js', bundle.code);
+
+// Worker startup (fast, no bundling)
+const worker = await Worker.create({
+  workflowBundle: {
+    codePath: require.resolve('./workflow-bundle.js'),
+  },
+  // ...
+});
+```
+
+### Missing Dependencies in Workflow Bundle
+
+```typescript
+// If using external packages in workflows, ensure they're bundled
+
+// worker.ts
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'),
+  bundlerOptions: {
+    // Exclude Node.js-only packages that cause bundling errors
+    // WARNING: Modules listed here will be completely unavailable
+    // at workflow runtime - any imports will fail
+    ignoreModules: ['some-node-only-package'],
+  },
+});
+```
+
+### Package Version Mismatches
+
+All `@temporalio/*` packages must have the same version. This can be verified by running `npm ls` or the appropriate command for your package manager.
+
+### Package Version Constraints - Prod vs. Non-Prod
+
+For production apps, you should use ~ version constraints (bug fixes only) on Temporal packages. For non-production apps, you may use ^ constraints (the npm default) instead.
+
+## Wrong Retry Classification
+
+A common mistake is treating transient errors as permanent (or vice versa):
+
+- **Transient errors** (retry): network timeouts, temporary service unavailability, rate limits
+- **Permanent errors** (don't retry): invalid input, authentication failure, resource not found
+
+```typescript
+// BAD: Retrying a permanent error
+throw ApplicationFailure.create({ message: 'User not found' });
+// This will retry indefinitely!
+
+// GOOD: Mark permanent errors as non-retryable
+throw ApplicationFailure.nonRetryable('User not found');
+```
+
+For detailed guidance on error classification and retry policies, see `error-handling.md`.
+
+## Cancellation
+
+### Not Handling Workflow Cancellation
+
+```typescript
+// BAD - Cleanup doesn't run on cancellation
+export async function workflowWithCleanup(): Promise<void> {
+  await activities.acquireResource();
+  await activities.doWork();
+  await activities.releaseResource(); // Never runs if cancelled!
+}
+
+// GOOD - Use CancellationScope for cleanup
+import { CancellationScope } from '@temporalio/workflow';
+
+export async function workflowWithCleanup(): Promise<void> {
+  await activities.acquireResource();
+  try {
+    await activities.doWork();
+  } finally {
+    // Run cleanup even on cancellation
+    await CancellationScope.nonCancellable(async () => {
+      await activities.releaseResource();
+    });
+  }
+}
+```
+
+### Not Handling Activity Cancellation
+
+Activities must **opt in** to receive cancellation. This requires:
+1. **Heartbeating** - Cancellation is delivered via heartbeat
+2. **Checking for cancellation** - Either await `Context.current().cancelled` or use `cancellationSignal()`
+
+```typescript
+// BAD - Activity ignores cancellation
+export async function longActivity(): Promise<void> {
+  await doExpensiveWork(); // Runs to completion even if cancelled
+}
+```
+
+```typescript
+// GOOD - Heartbeat in background and race work against cancellation promise
+import { Context, CancelledFailure } from '@temporalio/activity';
+
+export async function longActivity(): Promise<void> {
+  // Heartbeat in background so cancellation can be delivered
+  let heartbeatEnabled = true;
+  (async () => {
+    while (heartbeatEnabled) {
+      await Context.current().sleep(5000);
+      Context.current().heartbeat();
+    }
+  })().catch(() => {});
+
+  try {
+    await Promise.race([
+      Context.current().cancelled,  // Rejects with CancelledFailure
+      doExpensiveWork(),
+    ]);
+  } catch (err) {
+    if (err instanceof CancelledFailure) {
+      await cleanup();
+    }
+    throw err;
+  } finally {
+    heartbeatEnabled = false;
+  }
+}
+```
+
+```typescript
+// GOOD - Use AbortSignal with libraries that support it
+import fetch from 'node-fetch';
+import { cancellationSignal, heartbeat } from '@temporalio/activity';
+import type { AbortSignal as FetchAbortSignal } from 'node-fetch/externals';
+
+export async function cancellableFetch(url: string): Promise<Uint8Array> {
+  const response = await fetch(url, { signal: cancellationSignal() as FetchAbortSignal });
+
+  const contentLength = parseInt(response.headers.get('Content-Length')!);
+  let bytesRead = 0;
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of response.body) {
+    if (!(chunk instanceof Buffer)) throw new TypeError('Expected Buffer');
+    bytesRead += chunk.length;
+    chunks.push(chunk);
+    heartbeat(bytesRead / contentLength);  // Heartbeat to keep cancellation delivery alive
+  }
+  return Buffer.concat(chunks);
+}
+```
+
+**Note:** `Promise.race` doesn't stop the losing promise—it continues running. Use `cancellationSignal()` or explicitly abort sub-operations when cleanup requires stopping in-flight work.
+
+## Heartbeating
+
+### Forgetting to Heartbeat Long Activities
+
+```typescript
+// BAD - No heartbeat, can't detect stuck activities
+export async function processLargeFile(path: string): Promise<void> {
+  for await (const chunk of readChunks(path)) {
+    await processChunk(chunk); // Takes hours, no heartbeat
+  }
+}
+
+// GOOD - Regular heartbeats with progress
+import { heartbeat } from '@temporalio/activity';
+
+export async function processLargeFile(path: string): Promise<void> {
+  let i = 0;
+  for await (const chunk of readChunks(path)) {
+    heartbeat(`Processing chunk ${i++}`);
+    await processChunk(chunk);
+  }
+}
+```
+
+### Heartbeat Timeout Too Short
+
+```typescript
+// BAD - Heartbeat timeout shorter than processing time
+const { processChunk } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '30 minutes',
+  heartbeatTimeout: '10 seconds', // Too short!
+});
+
+// GOOD - Heartbeat timeout allows for processing variance
+const { processChunk } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '30 minutes',
+  heartbeatTimeout: '2 minutes',
+});
+```
+
+Set heartbeat timeout as high as acceptable for your use case — each heartbeat counts as an action.
+
+## Testing
+
+### Not Testing Failures
+
+```typescript
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+
+test('handles activity failure', async () => {
+  const env = await TestWorkflowEnvironment.createTimeSkipping();
+
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue: 'test',
+    workflowsPath: require.resolve('./workflows'),
+    activities: {
+      // Activity that always fails
+      riskyOperation: async () => {
+        throw ApplicationFailure.nonRetryable('Simulated failure');
+      },
+    },
+  });
+
+  await worker.runUntil(async () => {
+    await expect(
+      env.client.workflow.execute(riskyWorkflow, {
+        workflowId: 'test-failure',
+        taskQueue: 'test',
+      })
+    ).rejects.toThrow('Simulated failure');
+  });
+
+  await env.teardown();
+});
+```
+
+### Not Testing Replay
+
+```typescript
+import { Worker } from '@temporalio/worker';
+import * as fs from 'fs';
+
+test('replay compatibility', async () => {
+  const history = JSON.parse(await fs.promises.readFile('./fixtures/workflow_history.json', 'utf8'));
+
+  // Fails if current code is incompatible with history
+  await Worker.runReplayHistory(
+    {
+      workflowsPath: require.resolve('./workflows'),
+    },
+    history,
+  );
+});
+```
+
+## Timers and Sleep
+
+`setTimeout` works in workflows (the SDK mocks it), but `sleep()` from `@temporalio/workflow` is preferred because its interaction with cancellation scopes is more intuitive. See Timers in `references/typescript/patterns.md`.

--- a/.agents/skills/temporal-developer/references/typescript/observability.md
+++ b/.agents/skills/temporal-developer/references/typescript/observability.md
@@ -1,0 +1,109 @@
+# TypeScript SDK Observability
+
+## Overview
+
+The TypeScript SDK provides replay-aware logging, metrics, and integrations for production observability.
+
+## Replay-Aware Logging
+
+Temporal's logger automatically suppresses duplicate messages during replay, preventing log spam when workflows recover state.
+
+### Workflow Logging
+
+Workflows run in a sandboxed environment and cannot use regular Node.js loggers directly. Since SDK 1.8.0, the `@temporalio/workflow` package exports a `log` object that provides replay-aware logging. Internally, it uses Sinks to funnel messages to the Runtime's logger.
+
+```typescript
+import { log } from '@temporalio/workflow';
+
+export async function orderWorkflow(orderId: string): Promise<string> {
+  log.info('Processing order', { orderId });
+
+  const result = await processPayment(orderId);
+  log.debug('Payment processed', { orderId, result });
+
+  return result;
+}
+```
+
+**Log levels**: `log.debug()`, `log.info()`, `log.warn()`, `log.error()`
+
+The workflow logger automatically suppresses duplicate messages during replay and includes workflow context metadata (workflowId, runId, etc.) on every log entry.
+
+### Activity Logging
+
+```typescript
+import { log } from '@temporalio/activity';
+
+export async function processPayment(orderId: string): Promise<string> {
+  log.info('Processing payment', { orderId });
+  return 'payment-id-123';
+}
+```
+
+The activity logger adds contextual metadata (activity ID, type, namespace) and funnels messages to the runtime's logger for consistent collection.
+
+## Customizing the Logger
+
+### Basic Configuration
+
+```typescript
+import { DefaultLogger, Runtime } from '@temporalio/worker';
+
+const logger = new DefaultLogger('DEBUG', ({ level, message }) => {
+  console.log(`Custom logger: ${level} - ${message}`);
+});
+Runtime.install({ logger });
+```
+
+### Winston Integration
+
+```typescript
+import winston from 'winston';
+import { DefaultLogger, Runtime } from '@temporalio/worker';
+
+const winstonLogger = winston.createLogger({
+  level: 'debug',
+  format: winston.format.json(),
+  transports: [
+    new winston.transports.File({ filename: 'temporal.log' })
+  ],
+});
+
+const logger = new DefaultLogger('DEBUG', (entry) => {
+  winstonLogger.log({
+    label: entry.meta?.activityId ? 'activity' : entry.meta?.workflowId ? 'workflow' : 'worker',
+    level: entry.level.toLowerCase(),
+    message: entry.message,
+    timestamp: Number(entry.timestampNanos / 1_000_000n),
+    ...entry.meta,
+  });
+});
+
+Runtime.install({ logger });
+```
+
+## Metrics
+
+### Prometheus Metrics
+
+```typescript
+import { Runtime } from '@temporalio/worker';
+
+Runtime.install({
+  telemetryOptions: {
+    metrics: {
+      prometheus: {
+        bindAddress: '127.0.0.1:9091',
+      },
+    },
+  },
+});
+```
+
+## Best Practices
+
+1. Use `log` from `@temporalio/workflow` for production observability. For temporary print debugging, `console.log()` is fine—it's direct and immediate, whereas `log` goes through sinks which may lose messages on workflow errors
+2. Include correlation IDs (orderId, customerId) in log messages
+3. Configure Winston or similar for production log aggregation
+4. Monitor Prometheus metrics for worker health
+5. Use Event History for debugging workflow issues

--- a/.agents/skills/temporal-developer/references/typescript/patterns.md
+++ b/.agents/skills/temporal-developer/references/typescript/patterns.md
@@ -1,0 +1,417 @@
+# TypeScript SDK Patterns
+
+## Signals
+
+```typescript
+import { defineSignal, setHandler, condition } from '@temporalio/workflow';
+
+const approveSignal = defineSignal<[boolean]>('approve');
+const addItemSignal = defineSignal<[string]>('addItem');
+
+export async function orderWorkflow(): Promise<string> {
+  let approved = false;
+  const items: string[] = [];
+
+  setHandler(approveSignal, (value) => {
+    approved = value;
+  });
+
+  setHandler(addItemSignal, (item) => {
+    items.push(item);
+  });
+
+  await condition(() => approved);
+  return `Processed ${items.length} items`;
+}
+```
+
+## Dynamic Signal Handlers
+
+For handling signals with names not known at compile time. Use cases for this pattern are rare — most workflows should use statically defined signal handlers.
+
+```typescript
+import { setDefaultSignalHandler, condition } from '@temporalio/workflow';
+
+export async function dynamicSignalWorkflow(): Promise<Record<string, unknown[]>> {
+  const signals: Record<string, unknown[]> = {};
+
+  setDefaultSignalHandler((signalName: string, ...args: unknown[]) => {
+    if (!signals[signalName]) {
+      signals[signalName] = [];
+    }
+    signals[signalName].push(args);
+  });
+
+  await condition(() => signals['done'] !== undefined);
+  return signals;
+}
+```
+
+## Queries
+
+**Important:** Queries must NOT modify workflow state or have side effects.
+
+```typescript
+import { defineQuery, setHandler } from '@temporalio/workflow';
+
+const statusQuery = defineQuery<string>('status');
+const progressQuery = defineQuery<number>('progress');
+
+export async function progressWorkflow(): Promise<void> {
+  let status = 'running';
+  let progress = 0;
+
+  setHandler(statusQuery, () => status);
+  setHandler(progressQuery, () => progress);
+
+  for (let i = 0; i < 100; i++) {
+    progress = i;
+    await doWork();
+  }
+  status = 'completed';
+}
+```
+
+## Dynamic Query Handlers
+
+For handling queries with names not known at compile time. Use cases for this pattern are rare — most workflows should use statically defined query handlers.
+
+```typescript
+import { setDefaultQueryHandler } from '@temporalio/workflow';
+
+export async function dynamicQueryWorkflow(): Promise<void> {
+  const state: Record<string, unknown> = {
+    status: 'running',
+    progress: 0,
+  };
+
+  setDefaultQueryHandler((queryName: string) => {
+    return state[queryName];
+  });
+
+  // ... workflow logic
+}
+```
+
+## Updates
+
+```typescript
+import { defineUpdate, setHandler, condition } from '@temporalio/workflow';
+
+// Define the update - specify return type and argument types
+export const addItemUpdate = defineUpdate<number, [string]>('addItem');
+export const addItemValidatedUpdate = defineUpdate<number, [string]>('addItemValidated');
+
+export async function orderWorkflow(): Promise<string> {
+  const items: string[] = [];
+  let completed = false;
+
+  // Simple update handler - returns new item count
+  setHandler(addItemUpdate, (item: string) => {
+    items.push(item);
+    return items.length;
+  });
+
+  // Update handler with validator - rejects invalid input before execution
+  setHandler(
+    addItemValidatedUpdate,
+    (item: string) => {
+      items.push(item);
+      return items.length;
+    },
+    {
+      validator: (item: string) => {
+        if (!item) throw new Error('Item cannot be empty');
+        if (items.length >= 100) throw new Error('Order is full');
+      },
+    }
+  );
+
+  await condition(() => completed);
+  return `Order with ${items.length} items completed`;
+}
+```
+
+**Important:** Validators must NOT mutate workflow state or do anything blocking (no activities, sleeps, or other commands). They are read-only, similar to query handlers. Throw an error to reject the update; return normally to accept.
+
+## Child Workflows
+
+```typescript
+import { executeChild } from '@temporalio/workflow';
+
+export async function parentWorkflow(orders: Order[]): Promise<string[]> {
+  const results: string[] = [];
+
+  for (const order of orders) {
+    const result = await executeChild(processOrderWorkflow, {
+      args: [order],
+      workflowId: `order-${order.id}`,
+    });
+    results.push(result);
+  }
+
+  return results;
+}
+```
+
+### Child Workflow Options
+
+```typescript
+import { executeChild, ParentClosePolicy, ChildWorkflowCancellationType } from '@temporalio/workflow';
+
+const result = await executeChild(childWorkflow, {
+  args: [input],
+  workflowId: `child-${workflowInfo().workflowId}`,
+
+  // ParentClosePolicy - what happens to child when parent closes
+  // TERMINATE (default), ABANDON, REQUEST_CANCEL
+  parentClosePolicy: ParentClosePolicy.TERMINATE,
+
+  // ChildWorkflowCancellationType - how cancellation is handled
+  // WAIT_CANCELLATION_COMPLETED (default), WAIT_CANCELLATION_REQUESTED, TRY_CANCEL, ABANDON
+  cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
+});
+```
+
+## Handles to External Workflows
+
+```typescript
+import { getExternalWorkflowHandle } from '@temporalio/workflow';
+import { mySignal } from './other-workflows';
+
+export async function coordinatorWorkflow(targetWorkflowId: string): Promise<void> {
+  const handle = getExternalWorkflowHandle(targetWorkflowId);
+
+  // Signal the external workflow
+  await handle.signal(mySignal, { data: 'payload' });
+
+  // Or cancel it
+  await handle.cancel();
+}
+```
+
+## Parallel Execution
+
+```typescript
+export async function parallelWorkflow(items: string[]): Promise<string[]> {
+  return await Promise.all(
+    items.map((item) => processItem(item))
+  );
+}
+```
+
+## Continue-as-New
+
+```typescript
+import { continueAsNew, workflowInfo } from '@temporalio/workflow';
+
+export async function longRunningWorkflow(state: State): Promise<string> {
+  while (true) {
+    state = await processNextBatch(state);
+
+    if (state.isComplete) {
+      return 'done';
+    }
+
+    const info = workflowInfo();
+    if (info.continueAsNewSuggested || info.historyLength > 10000) {
+      await continueAsNew<typeof longRunningWorkflow>(state);
+    }
+  }
+}
+```
+
+## Saga Pattern
+
+**Important:** Compensation activities should be idempotent.
+
+```typescript
+import { CancellationScope, log } from '@temporalio/workflow';
+
+export async function sagaWorkflow(order: Order): Promise<string> {
+  const compensations: Array<() => Promise<void>> = [];
+
+  try {
+    // IMPORTANT: Save compensation BEFORE calling the activity
+    // If activity fails after completing but before returning,
+    // compensation must still be registered
+    compensations.push(() => releaseInventory(order));
+    await reserveInventory(order);
+
+    compensations.push(() => refundPayment(order));
+    await chargePayment(order);
+
+    await shipOrder(order);
+    return 'Order completed';
+  } catch (err) {
+    // nonCancellable ensures compensations run even if the workflow is cancelled
+    await CancellationScope.nonCancellable(async () => {
+      for (const compensate of compensations.reverse()) {
+        try {
+          await compensate();
+        } catch (compErr) {
+          log.warn('Compensation failed', { error: compErr });
+        }
+      }
+    });
+    throw err;
+  }
+}
+```
+
+## Cancellation Scopes
+
+Cancellation scopes control how cancellation propagates to activities and child workflows. Use them for cleanup logic, timeouts, and manual cancellation.
+
+```typescript
+import { CancellationScope, sleep } from '@temporalio/workflow';
+
+export async function scopedWorkflow(): Promise<void> {
+  // Non-cancellable scope - runs even if workflow cancelled
+  await CancellationScope.nonCancellable(async () => {
+    await cleanupActivity();
+  });
+
+  // Timeout scope
+  await CancellationScope.withTimeout('5 minutes', async () => {
+    await longRunningActivity();
+  });
+
+  // Manual cancellation
+  const scope = new CancellationScope();
+  const promise = scope.run(() => someActivity());
+  scope.cancel();
+}
+```
+
+## Triggers (Promise-like Signals)
+
+**WHY**: Triggers provide a one-shot promise that resolves when a signal is received. Cleaner than condition() for single-value signals.
+
+**WHEN to use**:
+- Waiting for a single response (approval, completion notification)
+- Converting signal-based events into awaitable promises
+
+```typescript
+import { Trigger } from '@temporalio/workflow';
+
+export async function triggerWorkflow(): Promise<string> {
+  const approvalTrigger = new Trigger<boolean>();
+
+  setHandler(approveSignal, (approved) => {
+    approvalTrigger.resolve(approved);
+  });
+
+  const approved = await approvalTrigger;
+  return approved ? 'Approved' : 'Rejected';
+}
+```
+
+## Wait Condition with Timeout
+
+```typescript
+import { condition, CancelledFailure } from '@temporalio/workflow';
+
+export async function approvalWorkflow(): Promise<string> {
+  let approved = false;
+
+  setHandler(approveSignal, () => {
+    approved = true;
+  });
+
+  // Wait for approval with 24-hour timeout
+  const gotApproval = await condition(() => approved, '24 hours');
+
+  if (gotApproval) {
+    return 'approved';
+  } else {
+    return 'auto-rejected due to timeout';
+  }
+}
+```
+
+## Waiting for All Handlers to Finish
+
+Signal and update handlers should generally be non-async (avoid running activities from them). Otherwise, the workflow may complete before handlers finish their execution. However, making handlers non-async sometimes requires workarounds that add complexity.
+
+When async handlers are necessary, use `condition(allHandlersFinished)` at the end of your workflow (or before continue-as-new) to prevent completion until all pending handlers complete.
+
+```typescript
+import { condition, allHandlersFinished } from '@temporalio/workflow';
+
+export async function handlerAwareWorkflow(): Promise<string> {
+  // ... main workflow logic ...
+
+  // Before exiting, wait for all handlers to finish
+  await condition(allHandlersFinished);
+  return 'done';
+}
+```
+
+## Activity Heartbeat Details
+
+### WHY:
+- **Support activity cancellation** - Cancellations are delivered via heartbeat; activities that don't heartbeat won't know they've been cancelled
+- **Resume progress after worker failure** - Heartbeat details persist across retries
+
+### WHEN:
+- **Cancellable activities** - Any activity that should respond to cancellation
+- **Long-running activities** - Track progress for resumability
+- **Checkpointing** - Save progress periodically
+
+```typescript
+import { heartbeat, activityInfo, CancelledFailure } from '@temporalio/activity';
+
+export async function processLargeFile(filePath: string): Promise<string> {
+  const info = activityInfo();
+  // Get heartbeat details from previous attempt (if any)
+  const startLine: number = info.heartbeatDetails ?? 0;
+
+  const lines = await readFileLines(filePath);
+
+  try {
+    for (let i = startLine; i < lines.length; i++) {
+      await processLine(lines[i]);
+      // Heartbeat with progress
+      // If activity is cancelled, heartbeat() throws CancelledFailure
+      heartbeat(i + 1);
+    }
+    return 'completed';
+  } catch (e) {
+    if (e instanceof CancelledFailure) {
+      // Perform cleanup on cancellation
+      await cleanup();
+    }
+    throw e;
+  }
+}
+```
+
+## Timers
+
+```typescript
+import { sleep } from '@temporalio/workflow';
+
+export async function timerWorkflow(): Promise<string> {
+  await sleep('1 hour');
+  return 'Timer fired';
+}
+```
+
+## Local Activities
+
+**Purpose**: Reduce latency for short, lightweight operations by skipping the task queue. ONLY use these when necessary for performance. Do NOT use these by default, as they are not durable and distributed.
+
+```typescript
+import { proxyLocalActivities } from '@temporalio/workflow';
+import type * as activities from './activities';
+
+const { quickLookup } = proxyLocalActivities<typeof activities>({
+  startToCloseTimeout: '5 seconds',
+});
+
+export async function localActivityWorkflow(): Promise<string> {
+  const result = await quickLookup('key');
+  return result;
+}
+```

--- a/.agents/skills/temporal-developer/references/typescript/testing.md
+++ b/.agents/skills/temporal-developer/references/typescript/testing.md
@@ -1,0 +1,222 @@
+# TypeScript SDK Testing
+
+## Overview
+
+The TypeScript SDK provides `TestWorkflowEnvironment` for testing workflows with time-skipping and activity mocking support. Use `createTimeSkipping()` for automatic time advancement when testing workflows with timers, or `createLocal()` for a full local server without time-skipping.
+
+**Note:** Prefer to use `createLocal()` for full-featured support. Only use `createTimeSkipping()` if you genuinely need time skipping for testing your workflow.
+
+## Test Environment Setup
+
+```typescript
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+
+describe('Workflow', () => {
+  let testEnv: TestWorkflowEnvironment;
+
+  before(async () => {
+    testEnv = await TestWorkflowEnvironment.createLocal();
+  });
+
+  after(async () => {
+    await testEnv?.teardown();
+  });
+
+  it('runs workflow', async () => {
+    const { client, nativeConnection } = testEnv;
+
+    const worker = await Worker.create({
+      connection: nativeConnection,
+      taskQueue: 'test',
+      workflowsPath: require.resolve('./workflows'),
+      activities: require('./activities'),
+    });
+
+    await worker.runUntil(async () => {
+      const result = await client.workflow.execute(greetingWorkflow, {
+        taskQueue: 'test',
+        workflowId: 'test-workflow',
+        args: ['World'],
+      });
+      expect(result).toEqual('Hello, World!');
+    });
+  });
+});
+```
+
+## Activity Mocking
+
+```typescript
+const worker = await Worker.create({
+  connection: nativeConnection,
+  taskQueue: 'test',
+  workflowsPath: require.resolve('./workflows'),
+  activities: {
+    // Mock activity implementation
+    greet: async (name: string) => `Mocked: ${name}`,
+  },
+});
+```
+
+## Testing Signals and Queries
+
+```typescript
+import { defineQuery, defineSignal } from '@temporalio/workflow';
+
+// Define query and signal (typically in a shared file)
+const getStatusQuery = defineQuery<string>('getStatus');
+const approveSignal = defineSignal('approve');
+
+it('handles signals and queries', async () => {
+  await worker.runUntil(async () => {
+    const handle = await client.workflow.start(approvalWorkflow, {
+      taskQueue: 'test',
+      workflowId: 'approval-test',
+    });
+
+    // Query current state
+    const status = await handle.query(getStatusQuery);
+    expect(status).toEqual('pending');
+
+    // Send signal
+    await handle.signal(approveSignal);
+
+    // Wait for completion
+    const result = await handle.result();
+    expect(result).toEqual('Approved!');
+  });
+});
+```
+
+## Testing Failure Cases
+
+Test that workflows handle errors correctly:
+
+```typescript
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import { Worker } from '@temporalio/worker';
+import { WorkflowFailedError } from '@temporalio/client';
+import assert from 'assert';
+
+describe('Failure handling', () => {
+  let testEnv: TestWorkflowEnvironment;
+
+  before(async () => {
+    testEnv = await TestWorkflowEnvironment.createLocal();
+  });
+
+  after(async () => {
+    await testEnv?.teardown();
+  });
+
+  it('handles activity failure', async () => {
+    const { client, nativeConnection } = testEnv;
+
+    const worker = await Worker.create({
+      connection: nativeConnection,
+      taskQueue: 'test',
+      workflowsPath: require.resolve('./workflows'),
+      activities: {
+        // Mock activity that always fails
+        myActivity: async () => {
+          throw new Error('Activity failed');
+        },
+      },
+    });
+
+    await worker.runUntil(async () => {
+      try {
+        await client.workflow.execute(myWorkflow, {
+          workflowId: 'test-failure',
+          taskQueue: 'test',
+        });
+        assert.fail('Expected workflow to fail');
+      } catch (err) {
+        assert(err instanceof WorkflowFailedError);
+      }
+    });
+  });
+});
+```
+
+## Replay Testing
+
+```typescript
+import { Worker } from '@temporalio/worker';
+import { Client, Connection } from '@temporalio/client';
+import fs from 'fs';
+
+describe('Replay', () => {
+  it('replays workflow history from JSON file', async () => {
+    // Load history from a JSON file (exported from Web UI or Temporal CLI)
+    const filePath = './history_file.json';
+    const history = JSON.parse(await fs.promises.readFile(filePath, 'utf8'));
+
+    await Worker.runReplayHistory(
+      {
+        workflowsPath: require.resolve('./workflows'),
+      },
+      history,
+      'my-workflow-id' // Optional: provide workflowId if your workflow depends on it
+    );
+  });
+
+  it('replays workflow history from server', async () => {
+    // Fetch history programmatically using the client
+    const connection = await Connection.connect({ address: 'localhost:7233' });
+    const client = new Client({ connection, namespace: 'default' });
+    const handle = client.workflow.getHandle('my-workflow-id');
+    const history = await handle.fetchHistory();
+
+    await Worker.runReplayHistory(
+      {
+        workflowsPath: require.resolve('./workflows'),
+      },
+      history,
+      'my-workflow-id'
+    );
+  });
+});
+```
+
+## Activity Testing
+
+Test activities in isolation without running a workflow:
+
+```typescript
+import { MockActivityEnvironment } from '@temporalio/testing';
+import { CancelledFailure } from '@temporalio/activity';
+import { myActivity } from './activities';
+import assert from 'assert';
+
+describe('Activity tests', () => {
+  it('completes successfully', async () => {
+    const env = new MockActivityEnvironment();
+    const result = await env.run(myActivity, 'input');
+    assert.equal(result, 'expected output');
+  });
+
+  it('handles cancellation', async () => {
+    const env = new MockActivityEnvironment();
+    // Cancel the activity after a short delay
+    setTimeout(() => env.cancel(), 100);
+    try {
+      await env.run(longRunningActivity, 'input');
+      assert.fail('Expected cancellation');
+    } catch (err) {
+      assert(err instanceof CancelledFailure);
+    }
+  });
+});
+```
+
+**Note:** `MockActivityEnvironment` provides `heartbeat()` and cancellation support for testing activity behavior.
+
+## Best Practices
+
+1. Use time-skipping for workflows with timers
+2. Mock external dependencies in activities
+3. Test replay compatibility when changing workflow code
+4. Use unique workflow IDs per test
+5. Clean up test environment after tests

--- a/.agents/skills/temporal-developer/references/typescript/typescript.md
+++ b/.agents/skills/temporal-developer/references/typescript/typescript.md
@@ -1,0 +1,172 @@
+# Temporal TypeScript SDK Reference
+
+## Overview
+
+The Temporal TypeScript SDK provides a modern Promise based approach to building durable workflows. Workflows are bundled and run in an isolated runtime with automatic replacements for determinism protection.
+
+**CRITICAL**: All `@temporalio/*` packages must have the same version number.
+
+## Understanding Replay
+
+Temporal workflows are durable through history replay. For details on how this works, see `references/core/determinism.md`.
+
+## Quick Start
+
+**Add Dependencies:** Install the Temporal SDK packages (use the package manager appropriate for your project):
+```bash
+npm install @temporalio/client @temporalio/worker @temporalio/workflow @temporalio/activity
+```
+
+Note: if you are working in production, it is strongly advised to use ~ version constraints, i.e.  `npm install ... --save-prefix='~'` if using NPM.
+
+**activities.ts** - Activity definitions (separate file to distinguish workflow vs activity code):
+```typescript
+export async function greet(name: string): Promise<string> {
+  return `Hello, ${name}!`;
+}
+```
+
+**workflows.ts** - Workflow definition (use type-only imports for activities):
+```typescript
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from './activities';
+
+const { greet } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+
+export async function greetingWorkflow(name: string): Promise<string> {
+  return await greet(name);
+}
+```
+
+**worker.ts** - Worker setup (imports activities and workflows, runs indefinitely):
+```typescript
+import { Worker } from '@temporalio/worker';
+import * as activities from './activities';
+
+async function run() {
+  const worker = await Worker.create({
+    workflowsPath: require.resolve('./workflows'), // For production, use workflowBundle instead
+    activities,
+    taskQueue: 'greeting-queue',
+  });
+  await worker.run();
+}
+
+run().catch(console.error);
+```
+
+**Start the dev server:** Start `temporal server start-dev` in the background.
+
+**Start the worker:** Run `npx ts-node worker.ts` in the background.
+
+**client.ts** - Start a workflow execution:
+```typescript
+import { Client } from '@temporalio/client';
+import { greetingWorkflow } from './workflows';
+import { v4 as uuid } from 'uuid';
+
+async function run() {
+  const client = new Client();
+
+  const result = await client.workflow.execute(greetingWorkflow, {
+    workflowId: uuid(),
+    taskQueue: 'greeting-queue',
+    args: ['my name'],
+  });
+
+  console.log(`Result: ${result}`);
+}
+
+run().catch(console.error);
+```
+
+**Run the workflow:** Run `npx ts-node client.ts`. Should output: `Result: Hello, my name!`.
+
+## Key Concepts
+
+### Workflow Definition
+- Async functions exported from workflow file
+- Use `proxyActivities()` with type-only imports
+- Use `defineSignal()`, `defineQuery()`, `defineUpdate()`, `setHandler()` for handlers
+
+### Activity Definition
+- Regular async functions
+- Can perform I/O, network calls, etc.
+- Use `heartbeat()` for long operations
+
+### Worker Setup
+- Use `Worker.create()` with `workflowsPath` (dev) or `workflowBundle` (production) - see `references/typescript/gotchas.md`
+- Import activities directly (not via proxy)
+
+## File Organization Best Practice
+
+**Keep Workflow definitions in separate files from Activity definitions.** The TypeScript SDK bundles workflow files separately. Minimizing workflow file contents improves Worker startup time.
+
+```
+my_temporal_app/
+├── workflows/
+│   └── greeting.ts      # Only Workflow functions
+├── activities/
+│   └── translate.ts     # Only Activity functions
+├── worker.ts            # Worker setup, imports both
+└── client.ts            # Client code to start workflows
+```
+
+**In the Workflow file, use type-only imports for activities:**
+```typescript
+// workflows/greeting.ts
+import { proxyActivities } from '@temporalio/workflow';
+import type * as activities from '../activities/translate';
+
+const { translate } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+});
+```
+
+## Determinism Rules
+
+The TypeScript SDK runs workflows in an isolated V8 sandbox.
+
+**Automatic replacements:**
+- `Math.random()` → deterministic seeded PRNG
+- `Date.now()` → workflow start time
+- `setTimeout` → deterministic timer
+
+**Safe to use:**
+- `sleep()` from `@temporalio/workflow`
+- `condition()` for waiting
+- Standard JavaScript operations
+
+See `references/typescript/determinism.md` for detailed rules.
+
+## Common Pitfalls
+
+1. **Importing activities without `type`** - Use `import type * as activities`
+2. **Version mismatch** - All @temporalio packages must match
+3. **Direct I/O in workflows** - Use activities for external calls
+4. **Missing `proxyActivities`** - Required to call activities from workflows
+5. **Forgetting to bundle workflows** - Worker needs `workflowsPath` or `workflowBundle`
+6. **Using workflowsPath in production** - Use `workflowBundle` for production (see `references/typescript/gotchas.md`)
+7. **Forgetting to heartbeat** - Long-running activities need `heartbeat()` calls
+8. **Logging in workflows** - For observability, use `import { log } from '@temporalio/workflow'` (routes through sinks). For temporary print debugging, `console.log()` is fine—it's direct and immediate, whereas `log` may lose messages on workflow errors.
+9. **Forgetting to wait on activity calls** - Activity calls return Promises; you must eventually await them (directly or via `Promise.all()` for parallel execution)
+
+## Writing Tests
+
+See `references/typescript/testing.md` for info on writing tests.
+
+## Additional Resources
+
+### Reference Files
+- **`references/typescript/patterns.md`** - Signals, queries, child workflows, saga pattern, etc.
+- **`references/typescript/determinism.md`** - Essentials of determinism in TypeScript
+- **`references/typescript/gotchas.md`** - TypeScript-specific mistakes and anti-patterns
+- **`references/typescript/error-handling.md`** - ApplicationFailure, retry policies, non-retryable errors
+- **`references/typescript/observability.md`** - Logging, metrics, tracing
+- **`references/typescript/testing.md`** - TestWorkflowEnvironment, time-skipping, activity mocking
+- **`references/typescript/advanced-features.md`** - Schedules, worker tuning, and more
+- **`references/typescript/data-handling.md`** - Data converters, payload encryption, etc.
+- **`references/typescript/versioning.md`** - Patching API, workflow type versioning, Worker Versioning
+- **`references/typescript/determinism-protection.md`** - V8 sandbox and bundling

--- a/.agents/skills/temporal-developer/references/typescript/versioning.md
+++ b/.agents/skills/temporal-developer/references/typescript/versioning.md
@@ -1,0 +1,211 @@
+# TypeScript SDK Versioning
+
+For conceptual overview and guidance on choosing an approach, see `references/core/versioning.md`.
+
+## Patching API
+
+The Patching API lets you change Workflow Definitions without causing non-deterministic behavior in running Workflows.
+
+### The patched() Function
+
+The `patched()` function takes a `patchId` string and returns a boolean:
+
+```typescript
+import { patched } from '@temporalio/workflow';
+
+export async function myWorkflow(): Promise<void> {
+  if (patched('my-change-id')) {
+    // New code path
+    await newImplementation();
+  } else {
+    // Old code path (for replay of existing executions)
+    await oldImplementation();
+  }
+}
+```
+
+**How it works:**
+- If the Workflow is running for the first time, `patched()` returns `true` and inserts a marker into the Event History
+- During replay, if the history contains a marker with the same `patchId`, `patched()` returns `true`
+- During replay, if no matching marker exists, `patched()` returns `false`
+
+**TypeScript-specific behavior:** Unlike Python/.NET/Ruby, `patched()` is not memoized when it returns `false`. This means you can use `patched()` in loops. However, if a single patch requires coordinated behavioral changes at different points in your workflow, you may need to manually memoize the result:
+
+```typescript
+const useNewBehavior = patched('my-change');
+// Use useNewBehavior at multiple points in workflow
+```
+
+### Three-Step Patching Process
+
+Patching is a three-step process for safely deploying changes.
+
+**Warning:** Failing to follow this process correctly will result in non-determinism errors for in-flight workflows.
+
+#### Step 1: Patch in New Code
+
+Add the patch alongside the old code:
+
+```typescript
+import { patched } from '@temporalio/workflow';
+
+// Original code sent fax notifications
+export async function shippingConfirmation(): Promise<void> {
+  if (patched('changedNotificationType')) {
+    await sendEmail();  // New code
+  } else {
+    await sendFax();    // Old code for replay
+  }
+  await sleep('1 day');
+}
+```
+
+#### Step 2: Deprecate the Patch
+
+Once all Workflows using the old code have completed, deprecate the patch:
+
+```typescript
+import { deprecatePatch } from '@temporalio/workflow';
+
+export async function shippingConfirmation(): Promise<void> {
+  deprecatePatch('changedNotificationType');
+  await sendEmail();
+  await sleep('1 day');
+}
+```
+
+The `deprecatePatch()` function records a marker that does not fail replay when Workflow code does not emit it, allowing a transition period.
+
+#### Step 3: Remove the Patch
+
+After all Workflows using `deprecatePatch` have completed, remove it entirely:
+
+```typescript
+export async function shippingConfirmation(): Promise<void> {
+  await sendEmail();
+  await sleep('1 day');
+}
+```
+
+### Query Filters for Versioned Workflows
+
+Use List Filters to find Workflows by version:
+
+```
+# Find running Workflows with a specific patch
+WorkflowType = "shippingConfirmation" AND ExecutionStatus = "Running" AND TemporalChangeVersion = "changedNotificationType"
+
+# Find running Workflows without the patch (started before patching)
+WorkflowType = "shippingConfirmation" AND ExecutionStatus = "Running" AND TemporalChangeVersion IS NULL
+```
+
+## Workflow Type Versioning
+
+An alternative to patching is creating new Workflow functions for incompatible changes:
+
+```typescript
+// Original Workflow
+export async function pizzaWorkflow(order: PizzaOrder): Promise<OrderConfirmation> {
+  // Original implementation
+}
+
+// New version with incompatible changes
+export async function pizzaWorkflowV2(order: PizzaOrder): Promise<OrderConfirmation> {
+  // Updated implementation
+}
+```
+
+Register both Workflows with the Worker:
+
+```typescript
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'), // Use workflowBundle for production
+  taskQueue: 'pizza-queue',
+});
+```
+
+Update client code to start new Workflows with the new type:
+
+```typescript
+// Start new executions with V2
+await client.workflow.start(pizzaWorkflowV2, {
+  workflowId: 'order-123',
+  taskQueue: 'pizza-queue',
+  args: [order],
+});
+```
+
+Use List Filters to check for remaining V1 executions:
+
+```
+WorkflowType = "pizzaWorkflow" AND ExecutionStatus = "Running"
+```
+
+After all V1 executions complete, remove the old Workflow function.
+
+## Worker Versioning
+
+Worker Versioning allows multiple Worker versions to run simultaneously, routing Workflows to specific versions without code-level patching. Workflows are pinned to the Worker Deployment Version they started on.
+
+> **Note:** Worker Versioning is currently in Public Preview. The legacy Worker Versioning API (before 2025) will be removed from Temporal Server in March 2026.
+
+### Key Concepts
+
+- **Worker Deployment**: A logical name for your application (e.g., "order-service")
+- **Worker Deployment Version**: A specific build identified by deployment name + Build ID
+- **Workflow Pinning**: Workflows complete on the Worker Deployment Version they started on
+
+### Configuring Workers for Versioning
+
+```typescript
+import { Worker, NativeConnection } from '@temporalio/worker';
+
+const worker = await Worker.create({
+  workflowsPath: require.resolve('./workflows'),  // Use workflowBundle for production
+  taskQueue: 'my-queue',
+  connection: await NativeConnection.connect({ address: 'temporal:7233' }),
+  workerDeploymentOptions: {
+    useWorkerVersioning: true,
+    version: {
+      deploymentName: 'order-service',
+      buildId: '1.0.0',  // Git hash, semver, build number, etc.
+    },
+  },
+});
+```
+
+**Configuration options:**
+- `useWorkerVersioning`: Enables Worker Versioning
+- `version.deploymentName`: Logical name for your service (consistent across versions)
+- `version.buildId`: Unique identifier for this build
+
+### Deployment Workflow
+
+1. Deploy new Worker version with a new `buildId`
+2. Use the Temporal CLI to set the new version as current:
+   ```bash
+   temporal worker deployment set-current-version \
+     --deployment-name order-service \
+     --build-id 2.0.0
+   ```
+3. New Workflows start on the new version
+4. Existing Workflows continue on their original version until completion
+5. Decommission old Workers once all their Workflows complete
+
+### When to Use Worker Versioning
+
+Worker Versioning is best suited for:
+- **Short-running Workflows**: Old Workers only need to run briefly during deployment transitions
+- **Frequent deployments**: Eliminates the need for code-level patching on every change
+- **Blue-green deployments**: Run old and new versions simultaneously with traffic control
+
+For long-running Workflows, consider combining Worker Versioning with the Patching API, or use Continue-as-New to move Workflows to newer versions.
+
+## Best Practices
+
+1. Use descriptive `patchId` names that explain the change
+2. Follow the three-step patching process completely before removing patches
+3. Use List Filters to verify no running Workflows before removing version support
+4. Keep Worker Deployment names consistent across all versions
+5. Use unique, traceable Build IDs (git hashes, semver, timestamps)
+6. Test version transitions with replay tests before deploying

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "temporal-developer": {
+      "source": "temporalio/skill-temporal-developer",
+      "sourceType": "github",
+      "computedHash": "0967bac31e8eb0c23acc1f4688eff45302ebd986b7cfda0c9f461a278ea92abb"
+    }
+  }
+}


### PR DESCRIPTION
# What?
☝️ That

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new skill documentation/content plus a `skills-lock.json` entry, with no application runtime code changes.
> 
> **Overview**
> Adds a new `temporal-developer` agent skill under `.agents/skills/temporal-developer`, including `SKILL.md`, an MIT `LICENSE`, installation `README.md`, and extensive `references/` documentation (core concepts plus TypeScript-focused guides).
> 
> Introduces `skills-lock.json` to pin the `temporal-developer` skill source (`temporalio/skill-temporal-developer`) and its computed hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1700a34d8e9510e0ce78942a90c371da9cc8da8e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->