### PR TITLE
Replace router navigate with useParamState for URL-backed UI state

### DIFF
--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -200,7 +200,7 @@ const listRowsCursorSchema = z.object({
   rowId: z.string(),
 })
 
-export const DATASET_ROW_SORT_COLUMNS = ["createdAt"] as const
+const DATASET_ROW_SORT_COLUMNS = ["createdAt"] as const
 
 export const listRowsQuery = createServerFn({ method: "GET" })
   .middleware([errorHandler])

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -35,7 +35,6 @@ function ListingLayout({ children, className }: ListingLayoutProps) {
   const aside = asideChild ? asideChild.props.children : null
 
   const main = <div className={cn("flex flex-col h-full gap-3", className)}>{content}</div>
-  if (aside == null) return main
   return (
     <div className="relative flex flex-row h-full">
       <div className="flex-1 min-w-0 flex flex-col">{main}</div>

--- a/apps/web/src/lib/hooks/useParamState.test.ts
+++ b/apps/web/src/lib/hooks/useParamState.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { useParamState } from "./useParamState.ts"
+
+function setUrl(search: string) {
+  window.history.replaceState(null, "", search || window.location.pathname)
+}
+
+afterEach(() => setUrl(""))
+
+function setup<T extends boolean | number | string>(paramKey: string, defaultValue: T) {
+  return renderHook(() => useParamState(paramKey, defaultValue))
+}
+
+describe("useParamState", () => {
+  describe("string params", () => {
+    it("returns defaultValue when param is absent", () => {
+      const { result } = setup("tab", "traces")
+      expect(result.current[0]).toBe("traces")
+    })
+
+    it("reads value from URL", () => {
+      setUrl("?tab=sessions")
+      const { result } = setup("tab", "traces")
+      expect(result.current[0]).toBe("sessions")
+    })
+
+    it("updates value and URL on set", async () => {
+      const { result } = setup("tab", "traces")
+      await act(() => result.current[1]("sessions"))
+      expect(result.current[0]).toBe("sessions")
+      expect(window.location.search).toBe("?tab=sessions")
+    })
+
+    it("removes param from URL when set to defaultValue", async () => {
+      setUrl("?tab=sessions")
+      const { result } = setup("tab", "traces")
+      await act(() => result.current[1]("traces"))
+      expect(result.current[0]).toBe("traces")
+      expect(window.location.search).toBe("")
+    })
+
+    it("supports functional updater", async () => {
+      setUrl("?count=hello")
+      const { result } = setup("greeting", "hi")
+      await act(() => result.current[1]((prev) => `${prev}!`))
+      expect(result.current[0]).toBe("hi!")
+    })
+  })
+
+  describe("boolean params", () => {
+    it("returns defaultValue when param is absent", () => {
+      const { result } = setup("open", false)
+      expect(result.current[0]).toBe(false)
+    })
+
+    it("parses 'true' correctly", () => {
+      setUrl("?open=true")
+      const { result } = setup("open", false)
+      expect(result.current[0]).toBe(true)
+    })
+
+    it("parses 'false' correctly", () => {
+      setUrl("?open=false")
+      const { result } = setup("open", true)
+      expect(result.current[0]).toBe(false)
+    })
+
+    it("falls back to defaultValue for invalid boolean strings", () => {
+      setUrl("?open=foo")
+      const { result } = setup("open", true)
+      expect(result.current[0]).toBe(true)
+    })
+
+    it("falls back to defaultValue for empty string", () => {
+      setUrl("?open=")
+      const { result } = setup("open", true)
+      expect(result.current[0]).toBe(true)
+    })
+
+    it("removes param when set to defaultValue", async () => {
+      setUrl("?open=true")
+      const { result } = setup("open", false)
+      await act(() => result.current[1](false))
+      expect(window.location.search).toBe("")
+    })
+  })
+
+  describe("number params", () => {
+    it("returns defaultValue when param is absent", () => {
+      const { result } = setup("page", 1)
+      expect(result.current[0]).toBe(1)
+    })
+
+    it("parses valid numbers", () => {
+      setUrl("?page=5")
+      const { result } = setup("page", 1)
+      expect(result.current[0]).toBe(5)
+    })
+
+    it("parses zero", () => {
+      setUrl("?page=0")
+      const { result } = setup("page", 1)
+      expect(result.current[0]).toBe(0)
+    })
+
+    it("parses negative numbers", () => {
+      setUrl("?offset=-10")
+      const { result } = setup("offset", 0)
+      expect(result.current[0]).toBe(-10)
+    })
+
+    it("parses floats", () => {
+      setUrl("?ratio=0.75")
+      const { result } = setup("ratio", 1)
+      expect(result.current[0]).toBe(0.75)
+    })
+
+    it("falls back to defaultValue for NaN", () => {
+      setUrl("?page=abc")
+      const { result } = setup("page", 1)
+      expect(result.current[0]).toBe(1)
+    })
+
+    it("falls back to defaultValue for empty string", () => {
+      setUrl("?page=")
+      const { result } = setup("page", 1)
+      expect(result.current[0]).toBe(1)
+    })
+  })
+
+  describe("default-value URL cleanup", () => {
+    it("does not put defaultValue in URL on initial render", () => {
+      setup("tab", "traces")
+      expect(window.location.search).toBe("")
+    })
+
+    it("preserves other params when removing one", async () => {
+      setUrl("?tab=sessions&page=3")
+      const { result } = setup("tab", "traces")
+      await act(() => result.current[1]("traces"))
+      expect(window.location.search).toContain("page=3")
+      expect(window.location.search).not.toContain("tab=")
+    })
+  })
+
+  describe("validate option", () => {
+    const isDirection = (v: string): v is "asc" | "desc" => v === "asc" || v === "desc"
+
+    it("returns valid values as-is", () => {
+      setUrl("?dir=asc")
+      const { result } = renderHook(() => useParamState("dir", "desc", { validate: isDirection }))
+      expect(result.current[0]).toBe("asc")
+    })
+
+    it("falls back to defaultValue for invalid values", () => {
+      setUrl("?dir=banana")
+      const { result } = renderHook(() => useParamState("dir", "desc", { validate: isDirection }))
+      expect(result.current[0]).toBe("desc")
+    })
+
+    it("returns defaultValue when param is absent", () => {
+      const { result } = renderHook(() => useParamState("dir", "desc", { validate: isDirection }))
+      expect(result.current[0]).toBe("desc")
+    })
+  })
+
+  describe("history mode", () => {
+    it("defaults to replace (no new history entry)", async () => {
+      const initialLength = window.history.length
+      const { result } = setup("tab", "traces")
+      await act(() => result.current[1]("sessions"))
+      expect(window.history.length).toBe(initialLength)
+    })
+
+    it("pushes a new history entry with history: 'push'", async () => {
+      const initialLength = window.history.length
+      const { result } = renderHook(() => useParamState("tab", "traces", { history: "push" }))
+      await act(() => result.current[1]("sessions"))
+      expect(window.history.length).toBe(initialLength + 1)
+    })
+  })
+
+  describe("batching", () => {
+    it("batches multiple writes into a single render", async () => {
+      let renderCount = 0
+      const { result } = renderHook(() => {
+        renderCount++
+        const [sortBy, setSortBy] = useParamState("sortBy", "name")
+        const [sortDir, setSortDir] = useParamState("sortDir", "asc")
+        return { sortBy, sortDir, setSortBy, setSortDir }
+      })
+
+      const countBefore = renderCount
+      await act(() => {
+        result.current.setSortBy("date")
+        result.current.setSortDir("desc")
+      })
+      const countAfter = renderCount
+
+      expect(result.current.sortBy).toBe("date")
+      expect(result.current.sortDir).toBe("desc")
+      expect(window.location.search).toContain("sortBy=date")
+      expect(window.location.search).toContain("sortDir=desc")
+      // Both params updated but only one re-render (not two)
+      expect(countAfter - countBefore).toBe(1)
+    })
+  })
+
+  describe("popstate synchronization", () => {
+    it("updates when popstate fires", async () => {
+      setUrl("?tab=sessions")
+      const { result } = setup("tab", "traces")
+      expect(result.current[0]).toBe("sessions")
+
+      await act(() => {
+        setUrl("?tab=other")
+        window.dispatchEvent(new PopStateEvent("popstate"))
+      })
+      expect(result.current[0]).toBe("other")
+    })
+  })
+})

--- a/apps/web/src/lib/hooks/useParamState.ts
+++ b/apps/web/src/lib/hooks/useParamState.ts
@@ -1,0 +1,200 @@
+import { type SetStateAction, useSyncExternalStore } from "react"
+
+/**
+ * useParamState — a useState-like hook backed by URL search parameters.
+ *
+ * Use this for ephemeral UI state that should be reflected in the URL (active
+ * tab, open panels, sort columns, selected row IDs, etc.). Do NOT use
+ * router.navigate for this — navigate is for actual page transitions (e.g.
+ * opening a dataset after creation). useParamState bypasses the router
+ * entirely, so it avoids TanStack Router's reconciliation overhead.
+ *
+ * Design decisions:
+ *
+ * - Uses `useSyncExternalStore` to treat the URL as an external store. This
+ *   is the React-blessed way to subscribe to non-React state; it handles
+ *   concurrent mode, avoids tearing, and provides an SSR snapshot.
+ *
+ * - The URL is the source of truth. Reads always parse `window.location.search`
+ *   so there's no stale-closure risk and no local state to sync.
+ *
+ * - When the resolved value equals `defaultValue`, the param is removed from
+ *   the URL entirely (via `Object.is` comparison), keeping URLs clean.
+ *
+ * - Writes are batched: multiple setters called in the same synchronous handler
+ *   (e.g. `setSortBy(x); setSortDirection(y)`) produce only one React render.
+ *   Each write updates `history` immediately so subsequent reads within the
+ *   same tick see the latest URL, but the subscriber notification is deferred
+ *   to a microtask so React processes all changes in a single pass.
+ */
+
+type ParamStateValue = boolean | number | string
+
+/**
+ * Widens literal types to their base type so the setter accepts any value of
+ * that base type, not just the exact literal passed as `defaultValue`.
+ * e.g. `useParamState("tab", "traces")` returns `[string, setter]` not
+ * `["traces", setter]`.
+ */
+type WidenLiteral<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : T
+
+const PARAM_STATE_CHANGE_EVENT = "param-state-change"
+
+/**
+ * Shared subscription function for `useSyncExternalStore`. Listens to:
+ * - `popstate`: browser back/forward navigation
+ * - `param-state-change`: our custom event dispatched after writes
+ *
+ * Because this function is referentially stable (module-level), every
+ * `useParamState` instance shares the same two listeners rather than
+ * each hook adding its own pair.
+ */
+function subscribe(onStoreChange: () => void) {
+  window.addEventListener("popstate", onStoreChange)
+  window.addEventListener(PARAM_STATE_CHANGE_EVENT, onStoreChange)
+  return () => {
+    window.removeEventListener("popstate", onStoreChange)
+    window.removeEventListener(PARAM_STATE_CHANGE_EVENT, onStoreChange)
+  }
+}
+
+/**
+ * Coerces a raw URL string value back to the type implied by `defaultValue`.
+ * Uses the defaultValue's runtime type to decide the parsing strategy:
+ * - boolean: accepts only `"true"` / `"false"`, falls back to defaultValue otherwise
+ * - number: `Number()` with NaN fallback to defaultValue
+ * - string: returned as-is
+ */
+function parseParamValue<T extends ParamStateValue>(rawValue: string, defaultValue: T): WidenLiteral<T> {
+  if (typeof defaultValue === "boolean") {
+    if (rawValue === "true") return true as WidenLiteral<T>
+    if (rawValue === "false") return false as WidenLiteral<T>
+    return defaultValue as WidenLiteral<T>
+  }
+
+  if (typeof defaultValue === "number") {
+    if (rawValue === "") return defaultValue as WidenLiteral<T>
+    const parsed = Number(rawValue)
+    return (Number.isNaN(parsed) ? defaultValue : parsed) as WidenLiteral<T>
+  }
+
+  return rawValue as WidenLiteral<T>
+}
+
+/** Reads a single param from the current URL, falling back to `defaultValue` if absent. */
+function readParam<T extends ParamStateValue>(paramKey: string, defaultValue: T): WidenLiteral<T> {
+  const params = new URLSearchParams(window.location.search)
+  const rawValue = params.get(paramKey)
+
+  if (rawValue === null) {
+    return defaultValue as unknown as WidenLiteral<T>
+  }
+
+  return parseParamValue(rawValue, defaultValue)
+}
+
+function buildUrl(params: URLSearchParams): string {
+  const search = params.toString()
+  return search
+    ? `${window.location.pathname}?${search}${window.location.hash}`
+    : `${window.location.pathname}${window.location.hash}`
+}
+
+/**
+ * Microtask-based batching flag. When multiple params are written in the same
+ * synchronous call stack (e.g. `setSortBy(); setSortDirection()`), the first
+ * write schedules a microtask to dispatch the change event. Subsequent writes
+ * in the same tick see the flag and skip scheduling, so only one event fires
+ * after all writes complete. This prevents intermediate renders with partially
+ * updated URLs and avoids duplicate network requests from query hooks.
+ */
+let flushScheduled = false
+
+/**
+ * Writes a single param to the URL and schedules a batched notification.
+ * The URL is updated synchronously (so reads within the same tick reflect
+ * the new value), but the event that triggers React re-renders is deferred
+ * to a microtask.
+ */
+function writeParam(paramKey: string, serialized: string | undefined, history: "push" | "replace") {
+  const params = new URLSearchParams(window.location.search)
+
+  if (serialized === undefined) {
+    params.delete(paramKey)
+  } else {
+    params.set(paramKey, serialized)
+  }
+
+  const url = buildUrl(params)
+
+  if (history === "push") {
+    window.history.pushState(window.history.state, "", url)
+  } else {
+    window.history.replaceState(window.history.state, "", url)
+  }
+
+  if (!flushScheduled) {
+    flushScheduled = true
+    queueMicrotask(() => {
+      flushScheduled = false
+      window.dispatchEvent(new Event(PARAM_STATE_CHANGE_EVENT))
+    })
+  }
+}
+
+type ParamStateOptions = {
+  /** Whether to push a new history entry or replace the current one. Defaults to "replace". */
+  history?: "push" | "replace"
+}
+
+/**
+ * Optional `validate` narrows the return type to a subset of `WidenLiteral<T>`.
+ * Pass a type guard and the hook will fall back to `defaultValue` when the URL
+ * contains a value that doesn't pass. This prevents invalid URL-tampered values
+ * from flowing into query keys or server calls, and eliminates unsafe `as` casts
+ * at the call site.
+ *
+ * @example
+ *   // Without validate — returns [string, setter]
+ *   const [tab, setTab] = useParamState("tab", "traces")
+ *
+ *   // With validate — returns ["asc" | "desc", setter]
+ *   const [dir, setDir] = useParamState("dir", "desc", {
+ *     validate: (v): v is "asc" | "desc" => v === "asc" || v === "desc",
+ *   })
+ */
+export function useParamState<T extends ParamStateValue, R extends WidenLiteral<T> = WidenLiteral<T>>(
+  paramKey: string,
+  defaultValue: T,
+  options?: ParamStateOptions & { validate?: (value: WidenLiteral<T>) => value is R },
+): [R, (next: SetStateAction<R>) => void] {
+  const historyMode = options?.history ?? "replace"
+  const validate = options?.validate
+
+  const value = useSyncExternalStore(
+    subscribe,
+    () => {
+      const parsed = readParam(paramKey, defaultValue)
+      // If validate rejects the parsed value (e.g. URL was manually tampered),
+      // fall back to defaultValue so downstream code never sees an invalid state.
+      if (validate && !validate(parsed)) return defaultValue as unknown as R
+      return parsed as R
+    },
+    () => defaultValue as unknown as R,
+  )
+
+  const setParamValue = (nextValue: SetStateAction<R>) => {
+    // Read from the URL (not from `value`) to get the latest state, since
+    // another setter in the same tick may have already updated the URL.
+    const currentValue = readParam(paramKey, defaultValue) as R
+    const resolvedValue = typeof nextValue === "function" ? (nextValue as (prev: R) => R)(currentValue) : nextValue
+
+    // When the value matches the default, remove the param from the URL
+    // to keep URLs clean (e.g. `?` instead of `?tab=traces`).
+    const serialized = Object.is(resolvedValue, defaultValue) ? undefined : String(resolvedValue)
+
+    writeParam(paramKey, serialized, historyMode)
+  }
+
+  return [value, setParamValue]
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/$datasetId.tsx
@@ -7,7 +7,7 @@ import {
   type InfiniteTableSorting,
   Input,
   Skeleton,
-  sortDirectionSchema,
+  type SortDirection,
   Text,
   toast,
 } from "@repo/ui"
@@ -16,10 +16,8 @@ import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { CirclePlus, Download, FileDownIcon, Trash2 } from "lucide-react"
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { z } from "zod"
 import { useDatasetRowsInfiniteScroll } from "../../../../../domains/datasets/datasets.collection.ts"
 import {
-  DATASET_ROW_SORT_COLUMNS,
   type DatasetRecord,
   type DatasetRowRecord,
   deleteDatasetRows,
@@ -33,6 +31,7 @@ import {
 } from "../../../../../domains/datasets/datasets.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
+import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { type BulkSelection, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { CsvImportView, type ParsedCsv } from "./-components/csv-import-view.tsx"
 import { createDraftRowRecord, isDatasetDraftRowId } from "./-components/dataset-draft-row.ts"
@@ -41,22 +40,8 @@ import { DeleteRowsModal } from "./-components/delete-rows-modal.tsx"
 import { RowDetailDrawer } from "./-components/row-detail-drawer.tsx"
 import { UploadBlankSlate } from "./-components/upload-blank-slate.tsx"
 
-const datasetDetailSearchSchema = z.object({
-  rid: z.string().optional(),
-  q: z.string().optional(),
-  sortBy: z.enum(DATASET_ROW_SORT_COLUMNS).optional(),
-  sortDirection: sortDirectionSchema.optional(),
-})
-
-type DatasetDetailSearch = z.infer<typeof datasetDetailSearchSchema>
-
 export const Route = createFileRoute("/_authenticated/projects/$projectId/datasets/$datasetId")({
   component: DatasetDetailPage,
-  validateSearch: (search: Record<string, unknown>) => {
-    const parsed = datasetDetailSearchSchema.safeParse(search)
-    if (!parsed.success) return {}
-    return parsed.data
-  },
 })
 
 const DEFAULT_ROW_SORTING: InfiniteTableSorting = {
@@ -98,7 +83,7 @@ const rowColumns: InfiniteTableColumn<DatasetRowRecord>[] = [
 
 function DatasetDetailPage() {
   const { projectId, datasetId } = Route.useParams()
-  const navigate = Route.useNavigate()
+  const [, setRid] = useParamState("rid", "")
 
   const { data: dataset, isLoading } = useQuery({
     queryKey: ["dataset", datasetId],
@@ -140,13 +125,7 @@ function DatasetDetailPage() {
         await qc.invalidateQueries({
           queryKey: ["datasetRowCount", datasetId],
         })
-        navigate({
-          search: (prev: DatasetDetailSearch) => ({
-            ...prev,
-            rid: result.rowId,
-          }),
-          replace: true,
-        })
+        setRid(result.rowId)
       } catch (e) {
         toast({
           variant: "destructive",
@@ -155,7 +134,7 @@ function DatasetDetailPage() {
         throw e
       }
     },
-    [datasetId, projectId, navigate],
+    [datasetId, projectId, setRid],
   )
 
   if (isLoading) {
@@ -277,17 +256,15 @@ function DatasetRowsView({
   dataset: DatasetRecord
   onImport: (csv: ParsedCsv) => void
 }) {
-  const navigate = Route.useNavigate()
-  const routeSearch = Route.useSearch()
-  const { rid } = routeSearch
-  const listQuery = routeSearch.q?.trim() ? routeSearch.q.trim() : undefined
-  const sorting: InfiniteTableSorting = useMemo(
-    () => ({
-      column: routeSearch.sortBy ?? DEFAULT_ROW_SORTING.column,
-      direction: routeSearch.sortDirection ?? DEFAULT_ROW_SORTING.direction,
-    }),
-    [routeSearch.sortBy, routeSearch.sortDirection],
-  )
+  const [rid, setRid] = useParamState("rid", "")
+  const [q, setQ] = useParamState("q", "")
+  const [sortBy, setSortBy] = useParamState("sortBy", DEFAULT_ROW_SORTING.column)
+  const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_ROW_SORTING.direction, {
+    validate: (v): v is SortDirection => v === "asc" || v === "desc",
+  })
+
+  const listQuery = q.trim() || undefined
+  const sorting: InfiniteTableSorting = { column: sortBy, direction: sortDirection }
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
@@ -325,15 +302,9 @@ function DatasetRowsView({
 
   useLayoutEffect(() => {
     if (rid && isDatasetDraftRowId(rid) && draftRow?.rowId !== rid) {
-      navigate({
-        search: (prev: DatasetDetailSearch) => {
-          const { rid: _r, ...rest } = prev
-          return rest
-        },
-        replace: true,
-      })
+      setRid("")
     }
-  }, [rid, draftRow, navigate])
+  }, [rid, draftRow, setRid])
 
   const { data: selectedRowFromQuery } = useQuery({
     queryKey: ["datasetRow", datasetId, rid],
@@ -345,18 +316,12 @@ function DatasetRowsView({
 
   const importFileRef = useRef<HTMLInputElement>(null)
 
-  const openRow = useCallback(
-    (row: DatasetRowRecord) => {
-      if (!isDatasetDraftRowId(row.rowId)) {
-        setDraftRow(null)
-      }
-      navigate({
-        search: (prev: DatasetDetailSearch) => ({ ...prev, rid: row.rowId }),
-        replace: true,
-      })
-    },
-    [navigate],
-  )
+  const openRow = (row: DatasetRowRecord) => {
+    if (!isDatasetDraftRowId(row.rowId)) {
+      setDraftRow(null)
+    }
+    setRid(row.rowId)
+  }
 
   const rowNavIndex = useMemo(() => (rid ? displayRows.findIndex((r) => r.rowId === rid) : -1), [rid, displayRows])
   const canNavigatePrev = rowNavIndex > 0
@@ -373,41 +338,23 @@ function DatasetRowsView({
     [rid, displayRows, openRow],
   )
 
-  const handleAddRow = useCallback(() => {
+  const handleAddRow = () => {
     const draft = createDraftRowRecord(datasetId)
     setDraftRow(draft)
-    navigate({
-      search: (prev: DatasetDetailSearch) => ({ ...prev, rid: draft.rowId }),
-      replace: true,
-    })
-  }, [datasetId, navigate])
+    setRid(draft.rowId)
+  }
 
-  const closeRow = useCallback(() => {
+  const closeRow = () => {
     if (rid && isDatasetDraftRowId(rid)) {
       setDraftRow(null)
     }
-    navigate({
-      search: (prev: DatasetDetailSearch) => {
-        const { rid: _rid, ...rest } = prev
-        return rest
-      },
-      replace: true,
-    })
-  }, [navigate, rid])
+    setRid("")
+  }
 
-  const handleSortChange = useCallback(
-    (next: InfiniteTableSorting) => {
-      navigate({
-        search: (prev: DatasetDetailSearch) => ({
-          ...prev,
-          sortBy: next.column as (typeof DATASET_ROW_SORT_COLUMNS)[number],
-          sortDirection: next.direction,
-        }),
-        replace: true,
-      })
-    },
-    [navigate],
-  )
+  const handleSortChange = (next: InfiniteTableSorting) => {
+    setSortBy(next.column)
+    setSortDirection(next.direction)
+  }
 
   const handleSaveRow = useCallback(
     async (data: { input: string; output: string; metadata: string }) => {
@@ -424,13 +371,7 @@ function DatasetRowsView({
             },
           })
           setDraftRow(null)
-          navigate({
-            search: (prev: DatasetDetailSearch) => ({
-              ...prev,
-              rid: result.rowId,
-            }),
-            replace: true,
-          })
+          setRid(result.rowId)
           getQueryClient().invalidateQueries({
             queryKey: ["datasets", projectId],
           })
@@ -471,7 +412,7 @@ function DatasetRowsView({
         setSaving(false)
       }
     },
-    [rid, datasetId, projectId, navigate],
+    [rid, datasetId, projectId, setRid],
   )
 
   const handleDeleteRows = useCallback(async () => {
@@ -620,22 +561,7 @@ function DatasetRowsView({
                 )}
               </Layout.ActionRowItem>
               <Layout.ActionRowItem>
-                <Input
-                  type="text"
-                  placeholder="Search rows..."
-                  value={routeSearch.q ?? ""}
-                  onChange={(e) => {
-                    const v = e.target.value
-                    navigate({
-                      search: (prev: DatasetDetailSearch) => {
-                        if (v.trim()) return { ...prev, q: v }
-                        const { q: _q, ...rest } = prev
-                        return rest
-                      },
-                      replace: true,
-                    })
-                  }}
-                />
+                <Input type="text" placeholder="Search rows..." value={q} onChange={(e) => setQ(e.target.value)} />
                 <Button flat variant="outline" size="sm" onClick={() => importFileRef.current?.click()}>
                   <FileDownIcon className="h-4 w-4" />
                   <Text.H6>Import</Text.H6>
@@ -664,7 +590,7 @@ function DatasetRowsView({
               columns={rowColumns}
               getRowKey={getRowKey}
               onRowClick={openRow}
-              activeRowKey={rid ?? undefined}
+              activeRowKey={rid}
               activeRowAutoScroll
               selection={selection}
               infiniteScroll={infiniteScroll}

--- a/apps/web/src/routes/_authenticated/projects/$projectId/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/datasets/index.tsx
@@ -6,33 +6,22 @@ import {
   InfiniteTable,
   type InfiniteTableColumn,
   type InfiniteTableSorting,
-  sortDirectionSchema,
+  type SortDirection,
   Tooltip,
   useToast,
 } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute } from "@tanstack/react-router"
-import { useCallback, useMemo, useState } from "react"
-import { z } from "zod"
+import { useCallback, useState } from "react"
 import { useDatasetsInfiniteScroll } from "../../../../../domains/datasets/datasets.collection.ts"
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
 import { createDatasetMutation } from "../../../../../domains/datasets/datasets.mutations.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
-
-const DATASET_LIST_SORT_COLUMNS = ["name", "updatedAt"] as const
-const datasetsListSearchSchema = z.object({
-  sortBy: z.enum(DATASET_LIST_SORT_COLUMNS).optional(),
-  sortDirection: sortDirectionSchema,
-})
+import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/datasets/")({
   component: DatasetsPage,
-  validateSearch: (search: Record<string, unknown>) => {
-    const parsed = datasetsListSearchSchema.safeParse(search)
-    if (!parsed.success) return {}
-    return parsed.data
-  },
 })
 
 const DEFAULT_SORTING: InfiniteTableSorting = {
@@ -64,31 +53,20 @@ const columns: InfiniteTableColumn<DatasetRecord>[] = [
 
 function DatasetsPage() {
   const { projectId } = Route.useParams()
-  const search = Route.useSearch()
   const navigate = Route.useNavigate()
   const { toast } = useToast()
   const [creating, setCreating] = useState(false)
 
-  const sorting: InfiniteTableSorting = useMemo(
-    () => ({
-      column: search.sortBy ?? DEFAULT_SORTING.column,
-      direction: search.sortDirection ?? DEFAULT_SORTING.direction,
-    }),
-    [search.sortBy, search.sortDirection],
-  )
+  const [sortBy, setSortBy] = useParamState("sortBy", DEFAULT_SORTING.column)
+  const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_SORTING.direction, {
+    validate: (v): v is SortDirection => v === "asc" || v === "desc",
+  })
+  const sorting: InfiniteTableSorting = { column: sortBy, direction: sortDirection }
 
-  const handleSortChange = useCallback(
-    (next: InfiniteTableSorting) => {
-      navigate({
-        params: { projectId },
-        search: {
-          sortBy: next.column,
-          sortDirection: next.direction,
-        },
-      })
-    },
-    [navigate, projectId],
-  )
+  const handleSortChange = (next: InfiniteTableSorting) => {
+    setSortBy(next.column)
+    setSortDirection(next.direction)
+  }
 
   const {
     data: datasets,

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -11,24 +11,15 @@ import {
   TextIcon,
 } from "lucide-react"
 import { useMemo, useState } from "react"
-import { z } from "zod"
 import { useTracesCount } from "../../../../domains/traces/traces.collection.ts"
 import { ListingLayout as Layout } from "../../../../layouts/ListingLayout/index.tsx"
+import { useParamState } from "../../../../lib/hooks/useParamState.ts"
 import { type BulkSelection, EMPTY_SELECTION, type SelectionState } from "../../../../lib/hooks/useSelectableRows.ts"
 import { SessionsView } from "./-components/sessions-view.tsx"
 import { TimeFilterDropdown } from "./-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
 import { TracesView } from "./-components/traces-view.tsx"
 import { AddToDatasetModal } from "./datasets/-components/add-to-dataset-modal.tsx"
-
-const searchSchema = z.object({
-  tab: z.enum(["traces", "sessions"]).optional(),
-  traceId: z.string().optional(),
-  filtersOpen: z.boolean().optional(),
-  filters: z.string().optional(),
-})
-
-type SearchParams = z.infer<typeof searchSchema>
 
 function parseFilters(raw?: string): FilterSet {
   if (!raw) return {}
@@ -79,23 +70,21 @@ function getBulkSelection(state: SelectionState<string>): BulkSelection<string> 
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/")({
   component: ProjectPage,
-  validateSearch: searchSchema,
 })
-
-type ActiveTab = "traces" | "sessions"
 
 function ProjectPage() {
   const { projectId } = Route.useParams()
-  const search = Route.useSearch()
-  const navigate = Route.useNavigate()
+  const [activeTab, setActiveTab] = useParamState("tab", "traces", {
+    validate: (v): v is "traces" | "sessions" => v === "traces" || v === "sessions",
+  })
+  const [filtersOpen, setFiltersOpen] = useParamState("filtersOpen", false)
+  const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
+  const [rawFilters, setRawFilters] = useParamState("filters", "")
 
-  const activeTab: ActiveTab = search.tab ?? "traces"
-  const filters = useMemo(() => parseFilters(search.filters), [search.filters])
-  const filtersOpen = search.filtersOpen ?? false
+  const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
   const hasActiveFilters = Object.keys(filters).length > 0
   const timeFrom = getTimeFilterValue(filters, "gte")
   const timeTo = getTimeFilterValue(filters, "lte")
-  const activeTraceId = search.traceId
 
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
@@ -108,39 +97,13 @@ function ProjectPage() {
   const selectedCount = getSelectedCount(selectionState, totalTraceCount)
   const bulkSelection = getBulkSelection(selectionState)
 
-  const onTabChange = (tab: ActiveTab) => {
-    navigate({
-      search: (prev: SearchParams) => ({
-        ...prev,
-        tab: tab === "traces" ? undefined : tab,
-      }),
-      replace: true,
-    })
-  }
-
   const onFiltersChange = (next: FilterSet) => {
-    navigate({
-      search: (prev: SearchParams) => ({
-        ...prev,
-        filtersOpen: true,
-        filters: serializeFilters(next),
-      }),
-      replace: true,
-    })
-  }
-
-  const onFiltersClose = () => {
-    navigate({
-      search: (prev: SearchParams) => ({ ...prev, filtersOpen: undefined }),
-      replace: true,
-    })
+    setFiltersOpen(true)
+    setRawFilters(serializeFilters(next) ?? "")
   }
 
   const onActiveTraceChange = (traceId: string | undefined) => {
-    navigate({
-      search: (prev: SearchParams) => ({ ...prev, traceId }),
-      replace: true,
-    })
+    setActiveTraceId(traceId ?? "")
   }
 
   const clearSelections = () => setSelectionState(EMPTY_SELECTION)
@@ -149,12 +112,12 @@ function ProjectPage() {
     projectId,
     filters,
     filtersOpen,
-    activeTraceId,
+    activeTraceId: activeTraceId || undefined,
     selectionState,
     onSelectionChange: setSelectionState,
     totalTraceCount,
     onFiltersChange,
-    onFiltersClose,
+    onFiltersClose: () => setFiltersOpen(false),
     onActiveTraceChange,
   }
 
@@ -182,13 +145,7 @@ function ProjectPage() {
                 } else {
                   delete next.startTime
                 }
-                navigate({
-                  search: (prev: SearchParams) => ({
-                    ...prev,
-                    filters: serializeFilters(next),
-                  }),
-                  replace: true,
-                })
+                setRawFilters(serializeFilters(next) ?? "")
               }}
             />
             <Button variant="outline" size="sm" flat disabled>
@@ -200,12 +157,7 @@ function ProjectPage() {
               variant={filtersOpen ? "outline" : "ghost"}
               size="sm"
               flat
-              onClick={() =>
-                navigate({
-                  search: (prev: SearchParams) => ({ ...prev, filtersOpen: !filtersOpen || undefined }),
-                  replace: true,
-                })
-              }
+              onClick={() => setFiltersOpen(!filtersOpen)}
             >
               <FilterIcon className="h-4 w-4" />
               Filters
@@ -233,7 +185,7 @@ function ProjectPage() {
                 },
               ]}
               active={activeTab}
-              onSelect={(id) => onTabChange(id as ActiveTab)}
+              onSelect={(id) => setActiveTab(id)}
             />
             <Input
               placeholder={activeTab === "sessions" ? "Search sessions" : "Search traces"}
@@ -258,11 +210,7 @@ function ProjectPage() {
 
       {activeTraceId ? (
         <Layout.Aside>
-          <TraceDetailDrawer
-            traceId={activeTraceId}
-            projectId={projectId}
-            onClose={() => onActiveTraceChange(undefined)}
-          />
+          <TraceDetailDrawer traceId={activeTraceId} projectId={projectId} onClose={() => setActiveTraceId("")} />
         </Layout.Aside>
       ) : null}
 


### PR DESCRIPTION
## Summary

Introduces a `useParamState` hook that manages ephemeral UI state (active tab, open panels, selected rows, sort columns) via URL search parameters using `useSyncExternalStore`, replacing the heavier `router.navigate` + `validateSearch` pattern that routed every state change through TanStack Router's reconciliation cycle.

`router.navigate` should be reserved for actual page navigation — e.g. navigating to a newly created dataset or opening a project page — not for toggling UI controls that happen to be reflected in the URL. For those cases, `useParamState` provides a lightweight `useState`-like API that reads and writes search params directly without involving the router.

Also fixes a pre-existing bug in `ListingLayout` where toggling the aside panel caused React to unmount and remount the entire content subtree (including tab animations) because the component returned a different root DOM structure depending on whether the aside was present.