### PR TITLE
spec: add Thrashing default annotation queue with flagger payload

### DIFF
--- a/specs/reliability.md
+++ b/specs/reliability.md
@@ -1038,7 +1038,6 @@ type ThrashingFlaggerPayload = {
   tool_call_summary: {
     total_calls: number;
     failed_calls: number;
-    unique_tools_called: number;
     repeated_tool_calls: Array<{ tool_name: string; call_count: number }>; // tools invoked more than once, sorted by call_count desc
     tools_available: string[]; // tool names declared in the trace context
     tools_used: string[]; // deduplicated tool names actually invoked


### PR DESCRIPTION
## Summary

- Adds **Thrashing** as a new system-created default annotation queue, covering agents that cycle between tools without making progress
- Includes description and instructions with a clear "do not use when" boundary (legitimate retries, converging iteration)
- Defines a structured `ThrashingFlaggerPayload` type with `tool_call_sequence` and `tool_call_summary` so the flagger can detect repetition and cycling patterns from span data rather than conversation messages alone

## Test plan

- [ ] Verify the Thrashing queue entry follows the same format as other system-created default queues
- [ ] Confirm `ThrashingFlaggerPayload` fields cover the necessary signals for detecting tool cycling (sequence, repetition counts, available vs used tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new queue definition and payload shape; no runtime behavior is modified in this PR.
> 
> **Overview**
> Adds a new system-created default annotation queue, **`Thrashing`**, to the reliability spec, defining when to flag traces where agents cycle through tools without progress.
> 
> Specifies a `ThrashingFlaggerPayload` schema (tool call sequence + summary stats, plus limited conversation/system prompt excerpts) so the thrashing flagger can be driven from span-tree/tool-call data rather than raw message text alone.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 686e895aecea139dc3618b24842cdb61f1127e16. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->