### PR TITLE
Add confirmation modal for project deletion

### DIFF
--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -55,6 +55,50 @@ function ProjectTitle({ name, projectSlug }: { name: string; projectSlug: string
   )
 }
 
+function DeleteProjectModal({ project, onClose }: { project: ProjectRecord; onClose: () => void }) {
+  const { toast } = useToast()
+  const [deleting, setDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    try {
+      await deleteProjectMutation(project.id).isPersisted.promise
+      toast({
+        title: "Success",
+        description: `Project "${project.name}" has been deleted.`,
+      })
+      onClose()
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error deleting project",
+        description: toUserMessage(error),
+      })
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      onOpenChange={onClose}
+      title="Delete Project"
+      description={`Are you sure you want to delete "${project.name}"? This action cannot be undone.`}
+      footer={
+        <div className="flex flex-row items-center gap-2">
+          <Button variant="outline" onClick={onClose} disabled={deleting}>
+            <Text.H5>Cancel</Text.H5>
+          </Button>
+          <Button variant="destructive" onClick={() => void handleDelete()} disabled={deleting}>
+            <Text.H5 color="white">{deleting ? "Deleting..." : "Delete Project"}</Text.H5>
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+
 function ProjectsTable({
   projects,
   statsByProjectId,
@@ -65,6 +109,7 @@ function ProjectsTable({
   isLoadingStats: boolean
 }) {
   const [projectToRename, setProjectToRename] = useState<ProjectRecord | null>(null)
+  const [projectToDelete, setProjectToDelete] = useState<ProjectRecord | null>(null)
   const router = useRouter()
 
   return (
@@ -124,7 +169,7 @@ function ProjectsTable({
                         label: "Delete",
                         type: "destructive",
                         onClick: () => {
-                          void deleteProjectMutation(project.id).isPersisted.promise
+                          setProjectToDelete(project)
                         },
                       },
                     ]}
@@ -142,6 +187,7 @@ function ProjectsTable({
       </Table>
 
       {projectToRename && <RenameProjectModal project={projectToRename} onClose={() => setProjectToRename(null)} />}
+      {projectToDelete && <DeleteProjectModal project={projectToDelete} onClose={() => setProjectToDelete(null)} />}
     </>
   )
 }


### PR DESCRIPTION
## Summary
Added a confirmation modal dialog for project deletion to prevent accidental deletion of projects. Previously, deleting a project would execute immediately without user confirmation.

## Key Changes
- Created new `DeleteProjectModal` component that displays a confirmation dialog before deleting a project
- The modal shows the project name and warns that the action cannot be undone
- Updated the delete action in the projects table to open the modal instead of immediately executing the deletion
- Added loading state ("Deleting...") to the delete button while the deletion is in progress
- Integrated toast notifications for success and error feedback
- Added `projectToDelete` state to `ProjectsTable` to manage modal visibility

## Implementation Details
- The modal follows the same pattern as the existing `RenameProjectModal` component
- Delete button is disabled during the deletion process to prevent multiple submissions
- Both Cancel and Delete buttons are disabled while deletion is in progress
- Error handling displays user-friendly error messages via toast notifications
- Modal automatically closes on successful deletion

https://claude.ai/code/session_01V2DFhbJg7XkS2ofGRNh1Pa