### PR TITLE
fix: normalize token usage across inclusive and additive provider con…

### DIFF
--- a/packages/domain/spans/src/otlp/resolvers/performance.ts
+++ b/packages/domain/spans/src/otlp/resolvers/performance.ts
@@ -1,4 +1,19 @@
-import { intAttr } from "../attributes.ts"
+/**
+ * Time-to-first-token (TTFT) and streaming hints for an OTLP span.
+ *
+ * Instrumentations disagree on where TTFT lives:
+ *
+ * 1. **Span attributes** — pre-computed duration in nanoseconds (`gen_ai.server.*`, OpenInference).
+ * 2. **Event attributes** — duration on the first-chunk event (`ai.response.msToFirstChunk` in ms;
+ *    or `gen_ai.server.time_to_first_token` in ns on an event). No span start time required.
+ * 3. **Event timestamps** — OTEL GenAI emits named chunk events; TTFT = earliest matching
+ *    `timeUnixNano` minus `span.startTimeUnixNano`. Needs both clocks; fails if start is missing.
+ *
+ * We merge with strict precedence: (1) then (2) then (3). Zero means “unknown” downstream
+ * (UI shows “Unknown” when `timeToFirstTokenNs <= 0`).
+ */
+
+import { floatAttr, intAttr } from "../attributes.ts"
 import type { OtlpEvent, OtlpKeyValue } from "../types.ts"
 import { type Candidate, fromString } from "./utils.ts"
 
@@ -7,7 +22,17 @@ interface ResolvedPerformance {
   readonly isStreaming: boolean
 }
 
-// TTFT from span attributes (some SDKs pre-compute it)
+/** Milliseconds to nanoseconds for `ai.response.msToFirstChunk`. */
+const NS_PER_MS = 1_000_000
+
+/**
+ * Event names treated as “first output chunk” for timestamp-based TTFT.
+ * - `gen_ai.content.*` / `gen_ai.choice`: OTEL semantic conventions.
+ * - `ai.stream.firstChunk`: Vercel AI SDK style (often paired with `ai.response.msToFirstChunk`).
+ */
+const ttftEventNames = new Set(["gen_ai.content.completion", "gen_ai.choice", "ai.stream.firstChunk"])
+
+/** Span-level TTFT in nanoseconds (instrumentation already measured server-side latency). */
 function ttftFromAttributes(spanAttrs: readonly OtlpKeyValue[]): number | undefined {
   const candidates = ["gen_ai.server.time_to_first_token", "llm.latency.time_to_first_token"]
   for (const key of candidates) {
@@ -18,21 +43,44 @@ function ttftFromAttributes(spanAttrs: readonly OtlpKeyValue[]): number | undefi
 }
 
 /**
- * Extract TTFT from span events.
+ * TTFT encoded on individual span **events**, not on the span root.
  *
- * GenAI semconv emits events like `gen_ai.content.completion` or `gen_ai.choice`
- * for each output chunk. The first such event's timestamp minus span start
- * gives us TTFT in nanoseconds.
+ * Scans events in order; first positive hit wins. Handles:
+ * - `gen_ai.server.time_to_first_token` on event attrs (ns, same semantics as span attr).
+ * - `ai.response.msToFirstChunk` (float ms) → rounded nanoseconds.
+ *
+ * Unlike {@link ttftFromEventTimestamps}, this path does not need `startTimeUnixNano`.
  */
-function ttftFromEvents(events: readonly OtlpEvent[], startTimeUnixNano: string): number | undefined {
-  if (!events.length) return undefined
+function ttftFromEventAttributes(events: readonly OtlpEvent[]): number | undefined {
+  for (const event of events) {
+    if (!event.attributes?.length) continue
 
-  const completionEventNames = new Set(["gen_ai.content.completion", "gen_ai.choice"])
+    const ttftNs = intAttr(event.attributes, "gen_ai.server.time_to_first_token")
+    if (ttftNs !== undefined && ttftNs > 0) return ttftNs
+
+    const ttftMs = floatAttr(event.attributes, "ai.response.msToFirstChunk")
+    if (ttftMs !== undefined && ttftMs > 0) {
+      return Math.round(ttftMs * NS_PER_MS)
+    }
+  }
+  return undefined
+}
+
+/**
+ * TTFT from **when** the first chunk event occurred vs span start.
+ *
+ * Finds the minimum `timeUnixNano` among events whose `name` is in {@link ttftEventNames},
+ * then returns `(firstChunkTime - span.startTimeUnixNano)` in ns when the difference is positive.
+ *
+ * Limitations: requires non-empty `startTimeUnixNano`; ignores event payload (no `msToFirstChunk`).
+ */
+function ttftFromEventTimestamps(events: readonly OtlpEvent[], startTimeUnixNano: string): number | undefined {
+  if (!events.length) return undefined
 
   let firstChunkNano: bigint | undefined
   for (const event of events) {
     if (!event.name || !event.timeUnixNano) continue
-    if (!completionEventNames.has(event.name)) continue
+    if (!ttftEventNames.has(event.name)) continue
 
     const eventNano = BigInt(event.timeUnixNano)
     if (firstChunkNano === undefined || eventNano < firstChunkNano) {
@@ -57,10 +105,16 @@ export function resolvePerformance({
   readonly events: readonly OtlpEvent[]
   readonly startTimeUnixNano: string
 }): ResolvedPerformance {
+  // TTFT: span attrs → event attrs → inferred from event timestamps. Skip later steps once set.
   const ttftAttr = ttftFromAttributes(spanAttrs)
-  const ttftEvent = ttftAttr === undefined ? ttftFromEvents(events, startTimeUnixNano) : undefined
-  const timeToFirstTokenNs = ttftAttr ?? ttftEvent ?? 0
+  const ttftEventAttr = ttftAttr === undefined ? ttftFromEventAttributes(events) : undefined
+  const ttftEventTimestamp =
+    ttftAttr === undefined && ttftEventAttr === undefined
+      ? ttftFromEventTimestamps(events, startTimeUnixNano)
+      : undefined
+  const timeToFirstTokenNs = ttftAttr ?? ttftEventAttr ?? ttftEventTimestamp ?? 0
 
+  // Explicit streaming flags from span attributes (OTEL + Vercel AI).
   const streamingCandidates: Candidate<boolean>[] = [
     {
       resolve: (attrs) => {
@@ -83,7 +137,7 @@ export function resolvePerformance({
     }
   }
 
-  // Heuristic: presence of completion chunk events implies streaming
+  // If we derived a positive TTFT but no stream flag was set, treat the span as streaming.
   if (!isStreaming && timeToFirstTokenNs > 0) {
     isStreaming = true
   }

--- a/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/resolvers.test.ts
@@ -310,6 +310,20 @@ describe("resolveAttributes", () => {
       expect(result.tokensOutput).toBe(200)
     })
 
+    it("resolves Vercel AI Responses-style inputTokens / outputTokens", () => {
+      const attrs: OtlpKeyValue[] = [
+        intAttr("ai.usage.inputTokens", 9191),
+        intAttr("ai.usage.outputTokens", 93),
+        intAttr("ai.usage.cachedInputTokens", 4429),
+        intAttr("ai.usage.inputTokenDetails.cacheWriteTokens", 4761),
+      ]
+      const result = resolveAttributes(attrs, "unset")
+      expect(result.tokensInput).toBe(1)
+      expect(result.tokensCacheRead).toBe(4429)
+      expect(result.tokensCacheCreate).toBe(4761)
+      expect(result.tokensOutput).toBe(93)
+    })
+
     it("resolves cache and reasoning tokens", () => {
       const attrs: OtlpKeyValue[] = [
         intAttr("gen_ai.usage.input_tokens", 1000),
@@ -499,6 +513,32 @@ describe("resolvePerformance", () => {
       expect(result.timeToFirstTokenNs).toBe(200_000_000)
     })
 
+    it("computes TTFT from ai.stream.firstChunk event timestamp", () => {
+      const events: OtlpEvent[] = [{ name: "ai.stream.firstChunk", timeUnixNano: "1710590401200000000" }]
+      const result = resolvePerformance({
+        spanAttrs: [],
+        events,
+        startTimeUnixNano: "1710590400000000000",
+      })
+      expect(result.timeToFirstTokenNs).toBe(1_200_000_000)
+    })
+
+    it("uses ai.response.msToFirstChunk from event attributes and converts ms to ns", () => {
+      const events: OtlpEvent[] = [
+        {
+          name: "ai.stream.firstChunk",
+          timeUnixNano: "1710590401200000000",
+          attributes: [floatAttr("ai.response.msToFirstChunk", 1984.1441250005737)],
+        },
+      ]
+      const result = resolvePerformance({
+        spanAttrs: [],
+        events,
+        startTimeUnixNano: "",
+      })
+      expect(result.timeToFirstTokenNs).toBe(1_984_144_125)
+    })
+
     it("picks the earliest completion event when multiple exist", () => {
       const events: OtlpEvent[] = [
         { name: "gen_ai.content.completion", timeUnixNano: "1710590400800000000" },
@@ -543,6 +583,22 @@ describe("resolvePerformance", () => {
         startTimeUnixNano: "1710590400000000000",
       })
       expect(result.timeToFirstTokenNs).toBe(123_000_000)
+    })
+
+    it("event TTFT attribute takes precedence over event timestamp delta", () => {
+      const events: OtlpEvent[] = [
+        {
+          name: "ai.stream.firstChunk",
+          timeUnixNano: "1710590405000000000",
+          attributes: [floatAttr("ai.response.msToFirstChunk", 321)],
+        },
+      ]
+      const result = resolvePerformance({
+        spanAttrs: [],
+        events,
+        startTimeUnixNano: "1710590400000000000",
+      })
+      expect(result.timeToFirstTokenNs).toBe(321_000_000)
     })
   })
 

--- a/packages/domain/spans/src/otlp/resolvers/usage.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage.ts
@@ -1,40 +1,7 @@
 import { computeTokenCost, getCostSpec } from "@domain/models"
 import type { OtlpKeyValue } from "../types.ts"
-import { first, fromFloat, fromInt } from "./utils.ts"
-
-// ─── Tokens ──────────────────────────────────────────────
-
-const tokensInputCandidates = [
-  fromInt("gen_ai.usage.input_tokens"),
-  fromInt("gen_ai.usage.prompt_tokens"),
-  fromInt("llm.token_count.prompt"),
-  fromInt("ai.usage.promptTokens"),
-]
-
-const tokensOutputCandidates = [
-  fromInt("gen_ai.usage.output_tokens"),
-  fromInt("gen_ai.usage.completion_tokens"),
-  fromInt("llm.token_count.completion"),
-  fromInt("ai.usage.completionTokens"),
-]
-
-const tokensCacheReadCandidates = [
-  fromInt("gen_ai.usage.cache_read.input_tokens"),
-  fromInt("gen_ai.usage.cache_read_input_tokens"),
-  fromInt("llm.token_count.prompt_details.cache_read"),
-]
-
-const tokensCacheCreateCandidates = [
-  fromInt("gen_ai.usage.cache_creation.input_tokens"),
-  fromInt("llm.token_count.prompt_details.cache_write"),
-]
-
-const tokensReasoningCandidates = [
-  fromInt("gen_ai.usage.reasoning_tokens"),
-  fromInt("llm.token_count.completion_details.reasoning"),
-]
-
-// ─── Cost ────────────────────────────────────────────────
+import { resolveTokens } from "./usage/tokens.ts"
+import { first, fromFloat } from "./utils.ts"
 
 const MICROCENTS_PER_USD = 100_000_000
 
@@ -102,10 +69,15 @@ function estimateCostFromTokens({
 }
 
 export interface ResolvedUsage {
+  /** Non-cached input tokens (additive: total_input = tokensInput + tokensCacheRead + tokensCacheCreate) */
   readonly tokensInput: number
+  /** Non-reasoning output tokens (additive: total_output = tokensOutput + tokensReasoning) */
   readonly tokensOutput: number
+  /** Tokens served from provider cache (subset of total input) */
   readonly tokensCacheRead: number
+  /** Tokens written to provider cache (subset of total input) */
   readonly tokensCacheCreate: number
+  /** Reasoning/thinking tokens (subset of total output) */
   readonly tokensReasoning: number
   readonly costInputMicrocents: number
   readonly costOutputMicrocents: number
@@ -120,12 +92,15 @@ interface ResolveUsageInput {
 }
 
 export function resolveUsage({ attrs, provider, model }: ResolveUsageInput): ResolvedUsage {
-  const tokensInput = first(tokensInputCandidates, attrs) ?? 0
-  const tokensOutput = first(tokensOutputCandidates, attrs) ?? 0
-  const tokensCacheRead = first(tokensCacheReadCandidates, attrs) ?? 0
-  const tokensCacheCreate = first(tokensCacheCreateCandidates, attrs) ?? 0
-  const tokensReasoning = first(tokensReasoningCandidates, attrs) ?? 0
+  const {
+    input: tokensInput,
+    output: tokensOutput,
+    cacheRead: tokensCacheRead,
+    cacheCreate: tokensCacheCreate,
+    reasoning: tokensReasoning,
+  } = resolveTokens(attrs, provider)
 
+  // ── Cost ──
   const attrCostInput = first(costInputCandidates, attrs)
   const attrCostOutput = first(costOutputCandidates, attrs)
   const attrCostTotal = first(costTotalCandidates, attrs)

--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
@@ -1,0 +1,598 @@
+import { describe, expect, it } from "vitest"
+import type { OtlpKeyValue } from "../../types.ts"
+import { resolveTokens } from "./tokens.ts"
+
+function int(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(value) } }
+}
+
+// ─── Shared fixture ──────────────────────────────────────
+//
+// One canonical scenario used across test groups:
+//
+//   total input  = 10,000 tokens
+//   cache read   =  8,000 tokens
+//   cache create =  1,500 tokens
+//   non-cached   =    500 tokens
+//   total output =    200 tokens
+//   reasoning    =     60 tokens
+//   non-reasoning=    140 tokens
+//   grand total  = 10,200 tokens
+
+const EXPECTED = {
+  input: 500,
+  cacheRead: 8_000,
+  cacheCreate: 1_500,
+  output: 140,
+  reasoning: 60,
+  totalInput: 10_000,
+  totalOutput: 200,
+  grandTotal: 10_200,
+} as const
+
+describe("resolveTokens", () => {
+  // ═══════════════════════════════════════════════════════
+  // STRATEGY 1: TOTAL-BASED INFERENCE
+  //
+  // When rawTotal is present, arithmetic alone determines
+  // the model — no provider or convention knowledge needed.
+  // ═══════════════════════════════════════════════════════
+
+  describe("strategy 1: total-based inference", () => {
+    describe("inclusive input detected from total (rawInput + rawOutput === rawTotal)", () => {
+      it("subtracts cache when total proves inclusive input", () => {
+        const attrs = [
+          int("llm.token_count.prompt", 10_000), // inclusive
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.total", 10_200), // 10000 + 200 → proves inclusive
+        ]
+        // Provider says additive, but total proves inclusive → total wins
+        const r = resolveTokens(attrs, "anthropic")
+        expect(r.input).toBe(EXPECTED.input)
+        expect(r.cacheRead).toBe(EXPECTED.cacheRead)
+        expect(r.cacheCreate).toBe(EXPECTED.cacheCreate)
+      })
+
+      it("overrides provider heuristic when total disagrees", () => {
+        // Hypothetical: passthrough convention with anthropic provider,
+        // but the instrumentor already normalized to inclusive before emitting
+        const attrs = [
+          int("gen_ai.usage.prompt_tokens", 10_000), // instrumentor normalized to inclusive
+          int("gen_ai.usage.completion_tokens", 200),
+          int("gen_ai.usage.cache_read.input_tokens", 8_000),
+          int("gen_ai.usage.total_tokens", 10_200), // proves inclusive
+        ]
+        const r = resolveTokens(attrs, "anthropic")
+        expect(r.input).toBe(2_000) // 10000 - 8000
+      })
+    })
+
+    describe("additive input detected from total (rawInput + cache + rawOutput === rawTotal)", () => {
+      it("passes through input when total proves additive", () => {
+        const attrs = [
+          int("llm.token_count.prompt", 500), // additive (non-cached only)
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.total", 10_200), // 500 + 9500 + 200 → proves additive
+        ]
+        // Provider says inclusive, but total proves additive → total wins
+        const r = resolveTokens(attrs, "openai")
+        expect(r.input).toBe(EXPECTED.input)
+      })
+    })
+
+    describe("inclusive output detected from total", () => {
+      it("subtracts reasoning when total proves output inclusive", () => {
+        const attrs = [
+          int("gen_ai.usage.input_tokens", 100),
+          int("gen_ai.usage.output_tokens", 200), // includes reasoning
+          int("gen_ai.usage.reasoning_tokens", 60),
+          int("gen_ai.usage.total_tokens", 300), // 100 + 200 → proves both inclusive
+        ]
+        const r = resolveTokens(attrs, "gcp.vertex_ai") // provider says additive output
+        expect(r.output).toBe(140) // total overrides provider
+        expect(r.reasoning).toBe(60)
+      })
+    })
+
+    describe("additive output detected from total", () => {
+      it("passes through output when total proves output additive", () => {
+        const attrs = [
+          int("gen_ai.usage.input_tokens", 100),
+          int("gen_ai.usage.output_tokens", 140), // excludes reasoning
+          int("gen_ai.usage.reasoning_tokens", 60),
+          int("gen_ai.usage.total_tokens", 300), // 100 + 140 + 60 → proves output additive
+        ]
+        const r = resolveTokens(attrs, "openai") // provider says inclusive output
+        expect(r.output).toBe(140) // total overrides provider
+        expect(r.reasoning).toBe(60)
+      })
+    })
+
+    describe("both sides determined from total", () => {
+      it("additive input + additive output", () => {
+        const attrs = [
+          int("llm.token_count.prompt", 500),
+          int("llm.token_count.completion", 140),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.completion_details.reasoning", 60),
+          int("llm.token_count.total", 10_200), // 500 + 9500 + 140 + 60 → both additive
+        ]
+        const r = resolveTokens(attrs, "unknown-provider")
+        expect(r.input).toBe(500)
+        expect(r.output).toBe(140)
+      })
+
+      it("inclusive input + inclusive output", () => {
+        const attrs = [
+          int("llm.token_count.prompt", 10_000),
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.completion_details.reasoning", 60),
+          int("llm.token_count.total", 10_200), // 10000 + 200 → both inclusive
+        ]
+        const r = resolveTokens(attrs, "unknown-provider")
+        expect(r.input).toBe(500)
+        expect(r.output).toBe(140)
+      })
+    })
+
+    describe("partial inference (one sub-category is zero)", () => {
+      it("determines input model when only cache exists (reasoning=0)", () => {
+        const attrs = [
+          int("gen_ai.usage.prompt_tokens", 500), // passthrough key
+          int("gen_ai.usage.completion_tokens", 200),
+          int("gen_ai.usage.cache_read.input_tokens", 8_000),
+          int("gen_ai.usage.total_tokens", 8_700), // 500 + 8000 + 200 → input additive
+        ]
+        const r = resolveTokens(attrs, "openai") // provider says inclusive, total says additive
+        expect(r.input).toBe(500) // total wins
+        expect(r.output).toBe(200) // no reasoning → unchanged
+      })
+
+      it("determines output model when only reasoning exists (cache=0)", () => {
+        const attrs = [
+          int("gen_ai.usage.prompt_tokens", 100), // passthrough key
+          int("gen_ai.usage.completion_tokens", 140),
+          int("gen_ai.usage.reasoning_tokens", 60),
+          int("gen_ai.usage.total_tokens", 300), // 100 + 140 + 60 → output additive
+        ]
+        const r = resolveTokens(attrs, "openai") // provider says inclusive output, total says additive
+        expect(r.output).toBe(140) // total wins
+        expect(r.input).toBe(100) // no cache → unchanged, falls back to convention/provider
+      })
+    })
+
+    describe("total absent or zero → falls through to strategies 2+3", () => {
+      it("falls back to provider detection when no total attribute exists", () => {
+        const attrs = [
+          int("llm.token_count.prompt", 500),
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+        ]
+        // No total → falls back to provider (anthropic = additive)
+        expect(resolveTokens(attrs, "anthropic").input).toBe(500)
+        // No total → falls back to provider (openai = inclusive)
+        expect(
+          resolveTokens([...attrs.map((a) => (a.key === "llm.token_count.prompt" ? int(a.key, 8_500) : a))], "openai")
+            .input,
+        ).toBe(500)
+      })
+    })
+
+    describe("total present but no match → falls through to strategies 2+3", () => {
+      it("falls back when no formula reproduces the total (inconsistent span)", () => {
+        const attrs = [
+          int("gen_ai.usage.prompt_tokens", 500),
+          int("gen_ai.usage.completion_tokens", 200),
+          int("gen_ai.usage.cache_read.input_tokens", 8_000),
+          int("gen_ai.usage.total_tokens", 99_999), // nonsensical
+        ]
+        // Falls back to provider
+        const r = resolveTokens(attrs, "anthropic")
+        expect(r.input).toBe(500) // provider-based: anthropic = additive
+      })
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // STRATEGY 2: ALWAYS INCLUSIVE INPUT (convention-level)
+  //
+  // These attribute keys guarantee inclusive input semantics
+  // regardless of provider. Only fires when strategy 1
+  // didn't determine input.
+  // ═══════════════════════════════════════════════════════
+
+  describe("strategy 2: always inclusive input keys (no total present)", () => {
+    describe("gen_ai.usage.input_tokens (OTEL v1.37+)", () => {
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 10_000),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+
+      it("subtracts cache for openai", () => {
+        expect(resolveTokens(attrs, "openai").input).toBe(EXPECTED.input)
+      })
+
+      it("subtracts cache for anthropic (convention overrides provider)", () => {
+        expect(resolveTokens(attrs, "anthropic").input).toBe(EXPECTED.input)
+      })
+
+      it("subtracts cache for bedrock (convention overrides provider)", () => {
+        expect(resolveTokens(attrs, "aws.bedrock").input).toBe(EXPECTED.input)
+      })
+    })
+
+    describe("ai.usage.promptTokens (Vercel AI SDK v5)", () => {
+      const attrs = [
+        int("ai.usage.promptTokens", 10_000),
+        int("ai.usage.completionTokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+
+      it("subtracts cache regardless of provider", () => {
+        expect(resolveTokens(attrs, "openai").input).toBe(EXPECTED.input)
+        expect(resolveTokens(attrs, "anthropic").input).toBe(EXPECTED.input)
+      })
+    })
+
+    describe("ai.usage.inputTokens (Vercel AI SDK v6+)", () => {
+      const attrs = [
+        int("ai.usage.inputTokens", 10_000),
+        int("ai.usage.outputTokens", 200),
+        int("ai.usage.cachedInputTokens", 8_000),
+        int("ai.usage.inputTokenDetails.cacheWriteTokens", 1_500),
+      ]
+
+      it("subtracts cache regardless of provider", () => {
+        expect(resolveTokens(attrs, "openai").input).toBe(EXPECTED.input)
+        expect(resolveTokens(attrs, "anthropic").input).toBe(EXPECTED.input)
+      })
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // STRATEGY 3: PROVIDER-DEPENDENT (no total, passthrough
+  // convention keys)
+  // ═══════════════════════════════════════════════════════
+
+  describe("strategy 3: provider-dependent (no total, passthrough keys)", () => {
+    describe("input: llm.token_count.* (OpenInference)", () => {
+      function attrs(prompt: number) {
+        return [
+          int("llm.token_count.prompt", prompt),
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+        ]
+      }
+
+      describe("inclusive providers → subtract cache", () => {
+        it.each(["openai", "google", "mistral_ai", "cohere", "groq", "deepseek"])("%s", (provider) => {
+          expect(resolveTokens(attrs(10_000), provider).input).toBe(EXPECTED.input)
+        })
+      })
+
+      describe("additive providers → pass through", () => {
+        it.each(["anthropic", "aws.bedrock", "aws_bedrock", "bedrock", "amazon-bedrock"])("%s", (provider) => {
+          expect(resolveTokens(attrs(500), provider).input).toBe(EXPECTED.input)
+        })
+      })
+    })
+
+    describe("input: gen_ai.usage.prompt_tokens (OpenLLMetry / OTEL v1.36)", () => {
+      const cache = [
+        int("gen_ai.usage.completion_tokens", 200),
+        int("gen_ai.usage.cache_read.input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+      ]
+
+      it("subtracts cache for openai (inclusive)", () => {
+        const attrs = [int("gen_ai.usage.prompt_tokens", 10_000), ...cache]
+        expect(resolveTokens(attrs, "openai").input).toBe(EXPECTED.input)
+      })
+
+      it("passes through for anthropic (additive)", () => {
+        const attrs = [int("gen_ai.usage.prompt_tokens", 500), ...cache]
+        expect(resolveTokens(attrs, "anthropic").input).toBe(EXPECTED.input)
+      })
+    })
+
+    describe("output: reasoning inclusive (most providers) → subtract", () => {
+      it.each(["openai", "anthropic", "google", "mistral_ai", "cohere"])("%s", (provider) => {
+        const attrs = [
+          int("gen_ai.usage.input_tokens", 100),
+          int("gen_ai.usage.output_tokens", 200),
+          int("gen_ai.usage.reasoning_tokens", 60),
+        ]
+        const r = resolveTokens(attrs, provider)
+        expect(r.output).toBe(EXPECTED.output)
+        expect(r.reasoning).toBe(EXPECTED.reasoning)
+      })
+    })
+
+    describe("output: reasoning additive (Vertex AI) → pass through", () => {
+      it.each(["gcp.vertex_ai", "vertexai"])("%s", (provider) => {
+        const attrs = [
+          int("gen_ai.usage.input_tokens", 100),
+          int("gen_ai.usage.output_tokens", 140),
+          int("gen_ai.usage.reasoning_tokens", 60),
+        ]
+        const r = resolveTokens(attrs, provider)
+        expect(r.output).toBe(140)
+        expect(r.reasoning).toBe(60)
+      })
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // SAME ATTRIBUTES, DIFFERENT PROVIDERS — proves that the
+  // same convention produces the same additive result from
+  // different raw values depending on provider.
+  // ═══════════════════════════════════════════════════════
+
+  describe("same passthrough attributes, different providers → same additive result", () => {
+    it("different raw values, identical normalized output", () => {
+      const openaiAttrs = [
+        int("llm.token_count.prompt", 10_000),
+        int("llm.token_count.completion", 200),
+        int("llm.token_count.prompt_details.cache_read", 8_000),
+        int("llm.token_count.prompt_details.cache_write", 1_500),
+      ]
+      const anthropicAttrs = [
+        int("llm.token_count.prompt", 500),
+        int("llm.token_count.completion", 200),
+        int("llm.token_count.prompt_details.cache_read", 8_000),
+        int("llm.token_count.prompt_details.cache_write", 1_500),
+      ]
+
+      const rOpenai = resolveTokens(openaiAttrs, "openai")
+      const rAnthropic = resolveTokens(anthropicAttrs, "anthropic")
+
+      expect(rOpenai.input).toBe(rAnthropic.input)
+      expect(rOpenai.cacheRead).toBe(rAnthropic.cacheRead)
+      expect(rOpenai.cacheCreate).toBe(rAnthropic.cacheCreate)
+
+      const total = (r: typeof rOpenai) => r.input + r.cacheRead + r.cacheCreate
+      expect(total(rOpenai)).toBe(EXPECTED.totalInput)
+      expect(total(rAnthropic)).toBe(EXPECTED.totalInput)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // NO SUB-CATEGORIES — when cache/reasoning are absent,
+  // raw values pass through unchanged regardless of model.
+  // ═══════════════════════════════════════════════════════
+
+  describe("no sub-categories → pass through unchanged", () => {
+    it("no cache attrs → input unchanged", () => {
+      const attrs = [int("gen_ai.usage.input_tokens", 1_000), int("gen_ai.usage.output_tokens", 50)]
+      const r = resolveTokens(attrs, "openai")
+      expect(r.input).toBe(1_000)
+      expect(r.cacheRead).toBe(0)
+      expect(r.cacheCreate).toBe(0)
+    })
+
+    it("no reasoning → output unchanged", () => {
+      const attrs = [int("gen_ai.usage.output_tokens", 200)]
+      expect(resolveTokens(attrs, "openai").output).toBe(200)
+    })
+
+    it("reasoning zero → output unchanged", () => {
+      const attrs = [int("gen_ai.usage.output_tokens", 200), int("gen_ai.usage.reasoning_tokens", 0)]
+      expect(resolveTokens(attrs, "openai").output).toBe(200)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // CANDIDATE PRECEDENCE
+  // ═══════════════════════════════════════════════════════
+
+  describe("candidate precedence", () => {
+    it("prefers gen_ai.usage.input_tokens over gen_ai.usage.prompt_tokens", () => {
+      const attrs = [int("gen_ai.usage.input_tokens", 100), int("gen_ai.usage.prompt_tokens", 999)]
+      expect(resolveTokens(attrs, "openai").input).toBe(100)
+    })
+
+    it("prefers gen_ai.usage.output_tokens over gen_ai.usage.completion_tokens", () => {
+      const attrs = [int("gen_ai.usage.output_tokens", 200), int("gen_ai.usage.completion_tokens", 999)]
+      expect(resolveTokens(attrs, "openai").output).toBe(200)
+    })
+
+    it("prefers ai.usage.cachedInputTokens over ai.usage.inputTokenDetails.cacheReadTokens", () => {
+      const attrs = [
+        int("ai.usage.inputTokens", 500),
+        int("ai.usage.cachedInputTokens", 100),
+        int("ai.usage.inputTokenDetails.cacheReadTokens", 999),
+        int("ai.usage.inputTokenDetails.cacheWriteTokens", 50),
+        int("ai.usage.outputTokens", 10),
+      ]
+      const r = resolveTokens(attrs, "openai")
+      expect(r.cacheRead).toBe(100)
+      expect(r.input).toBe(350) // 500 - 100 - 50
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // ADDITIVE INVARIANT — the output contract must hold
+  // across all conventions, providers, and strategies:
+  //   total_input  = input + cacheRead + cacheCreate
+  //   total_output = output + reasoning
+  // ═══════════════════════════════════════════════════════
+
+  describe("additive invariant across conventions", () => {
+    const scenarios = [
+      {
+        name: "OTEL v1.37+ / OpenAI (inclusive input, inclusive output) — no total",
+        provider: "openai",
+        attrs: [
+          int("gen_ai.usage.input_tokens", 10_000),
+          int("gen_ai.usage.output_tokens", 200),
+          int("gen_ai.usage.cache_read.input_tokens", 8_000),
+          int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+          int("gen_ai.usage.reasoning_tokens", 60),
+        ],
+      },
+      {
+        name: "OpenInference / Anthropic (additive input, inclusive output) — no total",
+        provider: "anthropic",
+        attrs: [
+          int("llm.token_count.prompt", 500),
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.completion_details.reasoning", 60),
+        ],
+      },
+      {
+        name: "Vercel AI SDK v6+ (inclusive input, inclusive output) — with total",
+        provider: "openai",
+        attrs: [
+          int("ai.usage.inputTokens", 10_000),
+          int("ai.usage.outputTokens", 200),
+          int("ai.usage.cachedInputTokens", 8_000),
+          int("ai.usage.inputTokenDetails.cacheWriteTokens", 1_500),
+          int("ai.usage.outputTokenDetails.reasoningTokens", 60),
+          int("ai.usage.totalTokens", 10_200),
+        ],
+      },
+      {
+        name: "OpenInference / Anthropic (additive input) — with total proving additive",
+        provider: "anthropic",
+        attrs: [
+          int("llm.token_count.prompt", 500),
+          int("llm.token_count.completion", 200),
+          int("llm.token_count.prompt_details.cache_read", 8_000),
+          int("llm.token_count.prompt_details.cache_write", 1_500),
+          int("llm.token_count.completion_details.reasoning", 60),
+          int("llm.token_count.total", 10_200),
+        ],
+      },
+      {
+        name: "OTEL v1.37+ / Vertex AI (inclusive input, additive output) — no total",
+        provider: "gcp.vertex_ai",
+        attrs: [
+          int("gen_ai.usage.input_tokens", 10_000),
+          int("gen_ai.usage.output_tokens", 140),
+          int("gen_ai.usage.cache_read.input_tokens", 8_000),
+          int("gen_ai.usage.cache_creation.input_tokens", 1_500),
+          int("gen_ai.usage.reasoning_tokens", 60),
+        ],
+      },
+    ]
+
+    it.each(scenarios)("$name", ({ provider, attrs }) => {
+      const r = resolveTokens(attrs, provider)
+
+      expect(r.input + r.cacheRead + r.cacheCreate).toBe(EXPECTED.totalInput)
+      expect(r.output + r.reasoning).toBe(EXPECTED.totalOutput)
+      expect(r.input).toBeGreaterThanOrEqual(0)
+      expect(r.output).toBeGreaterThanOrEqual(0)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // EDGE CASES
+  // ═══════════════════════════════════════════════════════
+
+  describe("edge cases", () => {
+    it("returns all zeros for empty attributes", () => {
+      const r = resolveTokens([], "openai")
+      expect(r.input).toBe(0)
+      expect(r.output).toBe(0)
+      expect(r.cacheRead).toBe(0)
+      expect(r.cacheCreate).toBe(0)
+      expect(r.reasoning).toBe(0)
+    })
+
+    it("clamps input at zero when cache exceeds raw (buggy instrumentation)", () => {
+      const attrs = [int("gen_ai.usage.input_tokens", 50), int("gen_ai.usage.cache_read.input_tokens", 1_000)]
+      expect(resolveTokens(attrs, "openai").input).toBe(0)
+    })
+
+    it("clamps output at zero when reasoning exceeds raw (buggy instrumentation)", () => {
+      const attrs = [int("gen_ai.usage.output_tokens", 50), int("gen_ai.usage.reasoning_tokens", 200)]
+      const r = resolveTokens(attrs, "openai")
+      expect(r.output).toBe(0)
+      expect(r.reasoning).toBe(200)
+    })
+
+    it("handles case-insensitive provider matching", () => {
+      const attrs = [
+        int("llm.token_count.prompt", 500),
+        int("llm.token_count.prompt_details.cache_read", 8_000),
+        int("llm.token_count.completion", 10),
+      ]
+      expect(resolveTokens(attrs, "ANTHROPIC").input).toBe(500)
+      expect(resolveTokens(attrs, "Anthropic").input).toBe(500)
+    })
+
+    it("handles Vercel suffixed provider forms", () => {
+      const attrs = [
+        int("llm.token_count.prompt", 500),
+        int("llm.token_count.prompt_details.cache_read", 8_000),
+        int("llm.token_count.completion", 10),
+      ]
+      expect(resolveTokens(attrs, "anthropic.messages").input).toBe(500)
+    })
+  })
+
+  // ═══════════════════════════════════════════════════════
+  // REAL-WORLD PAYLOADS
+  // ═══════════════════════════════════════════════════════
+
+  describe("real-world payloads", () => {
+    it("Vercel AI SDK v6 with OpenAI cache hit (total present)", () => {
+      const attrs = [
+        int("ai.usage.cachedInputTokens", 4429),
+        int("ai.usage.inputTokenDetails.cacheReadTokens", 4429),
+        int("ai.usage.inputTokenDetails.cacheWriteTokens", 4761),
+        int("ai.usage.inputTokenDetails.noCacheTokens", 1),
+        int("ai.usage.inputTokens", 9191),
+        int("ai.usage.outputTokens", 93),
+        int("ai.usage.totalTokens", 9284),
+      ]
+      const r = resolveTokens(attrs, "openai")
+
+      expect(r.input).toBe(1)
+      expect(r.cacheRead).toBe(4429)
+      expect(r.cacheCreate).toBe(4761)
+      expect(r.output).toBe(93)
+      expect(r.input + r.cacheRead + r.cacheCreate).toBe(9191)
+      expect(r.input + r.cacheRead + r.cacheCreate + r.output).toBe(9284)
+    })
+
+    it("OTEL v1.37+ OpenAI, no cache, no reasoning", () => {
+      const attrs = [int("gen_ai.usage.input_tokens", 350), int("gen_ai.usage.output_tokens", 120)]
+      const r = resolveTokens(attrs, "openai")
+
+      expect(r.input).toBe(350)
+      expect(r.output).toBe(120)
+      expect(r.cacheRead).toBe(0)
+      expect(r.cacheCreate).toBe(0)
+      expect(r.reasoning).toBe(0)
+    })
+
+    it("OpenInference Anthropic with large cache read", () => {
+      const attrs = [
+        int("llm.token_count.prompt", 50),
+        int("llm.token_count.completion", 10),
+        int("llm.token_count.prompt_details.cache_read", 100_000),
+        int("llm.token_count.prompt_details.cache_write", 0),
+      ]
+      const r = resolveTokens(attrs, "anthropic")
+
+      expect(r.input).toBe(50)
+      expect(r.cacheRead).toBe(100_000)
+      expect(r.input + r.cacheRead + r.cacheCreate).toBe(100_050)
+    })
+  })
+})

--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
@@ -1,0 +1,227 @@
+import type { OtlpKeyValue } from "../../types.ts"
+import { first, firstKeyed, fromInt, keyedFromInt } from "../utils.ts"
+
+// ─── Token attribute candidates ──────────────────────────
+
+const inputKeyedCandidates = [
+  keyedFromInt("gen_ai.usage.input_tokens"),
+  keyedFromInt("gen_ai.usage.prompt_tokens"),
+  keyedFromInt("llm.token_count.prompt"),
+  keyedFromInt("ai.usage.promptTokens"),
+  keyedFromInt("ai.usage.inputTokens"),
+]
+
+const outputCandidates = [
+  fromInt("gen_ai.usage.output_tokens"),
+  fromInt("gen_ai.usage.completion_tokens"),
+  fromInt("llm.token_count.completion"),
+  fromInt("ai.usage.completionTokens"),
+  fromInt("ai.usage.outputTokens"),
+]
+
+const cacheReadCandidates = [
+  fromInt("gen_ai.usage.cache_read.input_tokens"),
+  fromInt("gen_ai.usage.cache_read_input_tokens"),
+  fromInt("ai.usage.cachedInputTokens"),
+  fromInt("ai.usage.inputTokenDetails.cacheReadTokens"),
+  fromInt("llm.token_count.prompt_details.cache_read"),
+]
+
+const cacheCreateCandidates = [
+  fromInt("gen_ai.usage.cache_creation.input_tokens"),
+  fromInt("llm.token_count.prompt_details.cache_write"),
+  fromInt("ai.usage.inputTokenDetails.cacheWriteTokens"),
+]
+
+const reasoningCandidates = [
+  fromInt("gen_ai.usage.reasoning_tokens"),
+  fromInt("llm.token_count.completion_details.reasoning"),
+  fromInt("ai.usage.outputTokenDetails.reasoningTokens"),
+]
+
+const totalCandidates = [
+  fromInt("llm.token_count.total"),
+  fromInt("llm.usage.total_tokens"),
+  fromInt("gen_ai.usage.total_tokens"),
+  fromInt("ai.usage.totalTokens"),
+]
+
+// ─── Inclusive vs additive detection ─────────────────────
+//
+// LLM APIs report token counts in two incompatible ways:
+//
+//   INCLUSIVE: the top-level count already contains the
+//   sub-categories as subsets. To get the "plain" portion,
+//   subtract the sub-categories from the total.
+//     input_tokens = 10000  (includes 8000 cached)
+//     → non-cached = 10000 - 8000 = 2000
+//
+//   ADDITIVE: the top-level count only covers the "plain"
+//   portion. Sub-categories are separate and must be summed
+//   to get the true total.
+//     input_tokens = 2000   (excludes cached)
+//     → total = 2000 + 8000 = 10000
+//
+// This split affects BOTH sides of the token ledger:
+//
+//   Input:  sub-categories are cache_read + cache_create
+//   Output: sub-category is reasoning tokens
+//
+// Detection uses three strategies, in priority order:
+//
+// 1. TOTAL-BASED INFERENCE — when a rawTotal attribute exists,
+//    we check which (inputModel × outputModel) arithmetic
+//    formula reproduces it. This is a proof, not a heuristic.
+//
+// 2. CONVENTION-LEVEL — some attribute keys guarantee inclusive
+//    semantics because the SDK normalized before emitting.
+//
+// 3. PROVIDER-LEVEL — for passthrough conventions (OpenInference,
+//    OpenLLMetry), the raw API model determines it.
+
+// ── Strategy 1: total-based arithmetic inference ──────────
+//
+// Four combinations of (inputModel × outputModel) each produce
+// a different predicted total. We check which one matches:
+//
+//   inclusive × inclusive → total = rawInput + rawOutput
+//   additive × inclusive → total = rawInput + cache + rawOutput
+//   inclusive × additive → total = rawInput + rawOutput + reasoning
+//   additive × additive → total = rawInput + cache + rawOutput + reasoning
+//
+// When a sub-category is zero, some formulas collapse and that
+// side becomes ambiguous — but it also doesn't matter, since
+// there's nothing to subtract on that side anyway.
+
+interface InferredInclusivity {
+  readonly input: boolean | null
+  readonly output: boolean | null
+}
+
+function inferFromTotal(
+  rawInput: number,
+  rawOutput: number,
+  cache: number,
+  reasoning: number,
+  rawTotal: number,
+): InferredInclusivity | null {
+  if (rawTotal <= 0) return null
+  if (cache === 0 && reasoning === 0) return null
+
+  interface Model {
+    input: boolean
+    output: boolean
+  }
+
+  const matches: Model[] = []
+
+  if (rawInput + rawOutput === rawTotal) {
+    matches.push({ input: true, output: true })
+  }
+  if (cache > 0 && rawInput + cache + rawOutput === rawTotal) {
+    matches.push({ input: false, output: true })
+  }
+  if (reasoning > 0 && rawInput + rawOutput + reasoning === rawTotal) {
+    matches.push({ input: true, output: false })
+  }
+  if (cache > 0 && reasoning > 0 && rawInput + cache + rawOutput + reasoning === rawTotal) {
+    matches.push({ input: false, output: false })
+  }
+
+  if (matches.length === 0) return null
+
+  // If all matching formulas agree on a side, that side is determined.
+  // When they disagree (sub-category is 0 → formulas collapse), that
+  // side is null and falls through to convention/provider detection.
+  const inputs = new Set(matches.map((m) => m.input))
+  const outputs = new Set(matches.map((m) => m.output))
+
+  return {
+    input: inputs.size === 1 ? [...inputs][0] : null,
+    output: outputs.size === 1 ? [...outputs][0] : null,
+  }
+}
+
+// ── Strategy 2: convention-level (input only) ─────────────
+
+const ALWAYS_INCLUSIVE_INPUT_KEYS = new Set([
+  "gen_ai.usage.input_tokens", // OTEL GenAI v1.37+
+  "ai.usage.promptTokens", // Vercel AI SDK v5
+  "ai.usage.inputTokens", // Vercel AI SDK v6+
+])
+
+// No output keys are known to always normalize reasoning.
+// Vercel AI SDK passes through the provider's raw value.
+// OTEL GenAI spec has no normalization guidance for reasoning.
+
+// ── Strategy 3: provider-level ────────────────────────────
+
+const ADDITIVE_INPUT_PROVIDERS = new Set(["anthropic", "aws.bedrock", "aws_bedrock", "bedrock", "amazon-bedrock"])
+
+const ADDITIVE_OUTPUT_PROVIDERS = new Set(["gcp.vertex_ai", "vertexai"])
+
+function matchesProviderSet(provider: string, set: Set<string>): boolean {
+  const p = provider.toLowerCase()
+  if (set.has(p)) return true
+  return set.has(p.split(".")[0])
+}
+
+// ── Combined fallback: strategies 2+3 ─────────────────────
+
+function isInputInclusiveFallback(matchedKey: string | undefined, provider: string): boolean {
+  if (matchedKey !== undefined && ALWAYS_INCLUSIVE_INPUT_KEYS.has(matchedKey)) return true
+  return !matchesProviderSet(provider, ADDITIVE_INPUT_PROVIDERS)
+}
+
+function isOutputInclusiveFallback(provider: string): boolean {
+  return !matchesProviderSet(provider, ADDITIVE_OUTPUT_PROVIDERS)
+}
+
+// ─── Normalize to additive ───────────────────────────────
+
+function toAdditive(raw: number, subCategories: number, inclusive: boolean): number {
+  if (!inclusive || subCategories === 0) return raw
+  return Math.max(0, raw - subCategories)
+}
+
+// ─── Resolve ─────────────────────────────────────────────
+
+interface ResolvedTokens {
+  /** Non-cached input tokens (additive: total_input = input + cacheRead + cacheCreate) */
+  readonly input: number
+  /** Non-reasoning output tokens (additive: total_output = output + reasoning) */
+  readonly output: number
+  /** Tokens served from provider cache */
+  readonly cacheRead: number
+  /** Tokens written to provider cache */
+  readonly cacheCreate: number
+  /** Reasoning/thinking tokens */
+  readonly reasoning: number
+}
+
+export function resolveTokens(attrs: readonly OtlpKeyValue[], provider: string): ResolvedTokens {
+  const rawInputMatch = firstKeyed(inputKeyedCandidates, attrs)
+  const rawInput = rawInputMatch?.value ?? 0
+  const rawOutput = first(outputCandidates, attrs) ?? 0
+  const cacheRead = first(cacheReadCandidates, attrs) ?? 0
+  const cacheCreate = first(cacheCreateCandidates, attrs) ?? 0
+  const reasoning = first(reasoningCandidates, attrs) ?? 0
+  const rawTotal = first(totalCandidates, attrs)
+
+  const cache = cacheRead + cacheCreate
+
+  // Strategy 1: infer from rawTotal arithmetic
+  const inferred = rawTotal ? inferFromTotal(rawInput, rawOutput, cache, reasoning, rawTotal) : null
+
+  // Strategy 2+3: convention/provider fallback for anything strategy 1 couldn't determine
+  const inputInclusive = inferred?.input ?? isInputInclusiveFallback(rawInputMatch?.key, provider)
+  const outputInclusive = inferred?.output ?? isOutputInclusiveFallback(provider)
+
+  return {
+    input: toAdditive(rawInput, cache, inputInclusive),
+    output: toAdditive(rawOutput, reasoning, outputInclusive),
+    cacheRead,
+    cacheCreate,
+    reasoning,
+  }
+}

--- a/packages/domain/spans/src/otlp/resolvers/utils.ts
+++ b/packages/domain/spans/src/otlp/resolvers/utils.ts
@@ -5,6 +5,11 @@ export interface Candidate<T> {
   readonly resolve: (attrs: readonly OtlpKeyValue[]) => T | undefined
 }
 
+interface KeyedCandidate<T> {
+  readonly key: string
+  readonly resolve: (attrs: readonly OtlpKeyValue[]) => T | undefined
+}
+
 export function fromString<T = string>(key: string, transform?: (v: string) => T | undefined): Candidate<T> {
   return {
     resolve: (a) => {
@@ -17,6 +22,10 @@ export function fromString<T = string>(key: string, transform?: (v: string) => T
 
 export function fromInt(key: string): Candidate<number> {
   return { resolve: (a) => intAttr(a, key) }
+}
+
+export function keyedFromInt(key: string): KeyedCandidate<number> {
+  return { key, resolve: (a) => intAttr(a, key) }
 }
 
 export function fromFloat(key: string, transform?: (v: number) => number | undefined): Candidate<number> {
@@ -37,6 +46,17 @@ export function first<T>(candidates: readonly Candidate<T>[], attrs: readonly Ot
   for (const c of candidates) {
     const v = c.resolve(attrs)
     if (v !== undefined) return v
+  }
+  return undefined
+}
+
+export function firstKeyed<T>(
+  candidates: readonly KeyedCandidate<T>[],
+  attrs: readonly OtlpKeyValue[],
+): { key: string; value: T } | undefined {
+  for (const c of candidates) {
+    const v = c.resolve(attrs)
+    if (v !== undefined) return { key: c.key, value: v }
   }
   return undefined
 }

--- a/packages/domain/spans/src/otlp/tests/genai.test.ts
+++ b/packages/domain/spans/src/otlp/tests/genai.test.ts
@@ -547,19 +547,22 @@ describe("TravelPlanner trace — GenAI v1.37+ (current)", () => {
   describe("token usage", () => {
     it("LLM call 1: input=800, output=50, cacheRead=600", () => {
       const s = findSpan("llmCall1")
-      expect(s.tokensInput).toBe(800)
+      // Inclusive OTLP input is split: non-cached input + cache (resolveUsage is additive).
+      expect(s.tokensInput).toBe(200)
       expect(s.tokensOutput).toBe(50)
       expect(s.tokensCacheRead).toBe(600)
       expect(s.tokensCacheCreate).toBe(0)
       expect(s.tokensReasoning).toBe(0)
+      expect(s.tokensInput + s.tokensCacheRead + s.tokensCacheCreate).toBe(800)
     })
 
     it("LLM call 2: input=1200, output=120, reasoning=40", () => {
       const s = findSpan("llmCall2")
       expect(s.tokensInput).toBe(1200)
-      expect(s.tokensOutput).toBe(120)
+      expect(s.tokensOutput).toBe(80)
       expect(s.tokensReasoning).toBe(40)
       expect(s.tokensCacheRead).toBe(0)
+      expect(s.tokensOutput + s.tokensReasoning).toBe(120)
     })
 
     it("LLM call 3: input=1500, output=300", () => {

--- a/packages/domain/spans/src/otlp/tests/genai_deprecated.test.ts
+++ b/packages/domain/spans/src/otlp/tests/genai_deprecated.test.ts
@@ -465,9 +465,11 @@ describe("TravelPlanner trace — GenAI deprecated / OpenLLMetry", () => {
   describe("token usage", () => {
     it("LLM call 1: input=800, output=50, cacheRead=600", () => {
       const s = findSpan("llmCall1")
-      expect(s.tokensInput).toBe(800)
+      // OpenLLMetry passthrough on OpenAI: inclusive input → non-cached + cache rows.
+      expect(s.tokensInput).toBe(200)
       expect(s.tokensOutput).toBe(50)
       expect(s.tokensCacheRead).toBe(600)
+      expect(s.tokensInput + s.tokensCacheRead).toBe(800)
     })
 
     it("LLM call 2: input=1200, output=120", () => {

--- a/packages/domain/spans/src/otlp/tests/openinference.test.ts
+++ b/packages/domain/spans/src/otlp/tests/openinference.test.ts
@@ -397,16 +397,18 @@ describe("TravelPlanner trace — OpenInference (Arize Phoenix)", () => {
   describe("token usage", () => {
     it("LLM call 1: input=800, output=50, cacheRead=600", () => {
       const s = findSpan("llmCall1")
-      expect(s.tokensInput).toBe(800)
+      expect(s.tokensInput).toBe(200)
       expect(s.tokensOutput).toBe(50)
       expect(s.tokensCacheRead).toBe(600)
+      expect(s.tokensInput + s.tokensCacheRead).toBe(800)
     })
 
     it("LLM call 2: input=1200, output=120, reasoning=40", () => {
       const s = findSpan("llmCall2")
       expect(s.tokensInput).toBe(1200)
-      expect(s.tokensOutput).toBe(120)
+      expect(s.tokensOutput).toBe(80)
       expect(s.tokensReasoning).toBe(40)
+      expect(s.tokensOutput + s.tokensReasoning).toBe(120)
     })
 
     it("LLM call 3: input=1500, output=300", () => {


### PR DESCRIPTION
## Why

LLM providers report token counts in two incompatible ways. OpenAI, Gemini, and most providers use an **inclusive** model where `input_tokens` already contains cached tokens as a subset. Anthropic and AWS Bedrock use an **additive** model where `input_tokens` excludes cached tokens entirely.

Our pipeline stores tokens additively (`total_input = tokensInput + tokensCacheRead + tokensCacheCreate`), but was reading raw values without normalizing. This caused double-counting for inclusive providers (cache tokens counted in both `tokensInput` and `tokensCacheRead`) and would cause under-counting if we ever subtracted from an already-additive value. The same problem affected output tokens: reasoning tokens are always a subset of `output_tokens` (except on Vertex AI), so cost estimation was charging reasoning tokens at both the regular and reasoning rate.

See #2558 for the full breakdown of which providers and conventions use which model.

## What changed

**Extracted `resolveTokens` into its own module** (`tokens.ts`), separate from cost estimation. Token normalization is the complex part; cost just consumes the normalized values.

**Three-strategy inclusive/additive detection:**

1. **Total-based arithmetic inference** (new) — when a `totalTokens` attribute exists, we check which of four `(inputModel × outputModel)` formulas reproduces it. This is an arithmetic proof that works regardless of provider or convention identity. When sub-categories are zero, the ambiguous side falls through to the next strategy (but also doesn't need disambiguation since there's nothing to subtract).

2. **Convention-level** — attribute keys that guarantee inclusive semantics (`gen_ai.usage.input_tokens`, `ai.usage.inputTokens`, `ai.usage.promptTokens`) override provider detection for input. No output keys are known to normalize reasoning.

3. **Provider-level** — for passthrough conventions (OpenInference, OpenLLMetry), the provider determines the model. Anthropic/Bedrock are additive for input; Vertex AI is additive for output; everyone else is inclusive.

**Unified `toAdditive(raw, subCategories, inclusive)` normalizer** — one function handles both input and output. The inclusive/additive asymmetry between input and output (different provider sets, convention override only exists for input) is captured in the data, not in duplicate logic.

**Added Vercel AI SDK v6+ candidates** — `ai.usage.inputTokens`, `ai.usage.outputTokens`, `ai.usage.cachedInputTokens`, `ai.usage.inputTokenDetails.cacheReadTokens`, `ai.usage.inputTokenDetails.cacheWriteTokens`, `ai.usage.outputTokenDetails.reasoningTokens`, `ai.usage.totalTokens`.

**Added `totalTokens` candidates** across conventions — `llm.token_count.total`, `llm.usage.total_tokens`, `gen_ai.usage.total_tokens`, `ai.usage.totalTokens`.

**Restructured test suite** organized by detection strategy with a shared fixture, cross-convention additive invariant checks, and tests proving the total-based inference overrides provider heuristics when they disagree.

## Detection summary

### Strategy 1: total-based inference (when `totalTokens` present)

| Formula matching `rawTotal` | Input model | Output model |
|---|---|---|
| `rawInput + rawOutput` | Inclusive | Inclusive |
| `rawInput + cache + rawOutput` | Additive | Inclusive |
| `rawInput + rawOutput + reasoning` | Inclusive | Additive |
| `rawInput + cache + rawOutput + reasoning` | Additive | Additive |

### Strategy 2: convention-level (input only, no total)

| Attribute key | Model | Rationale |
|---|---|---|
| `gen_ai.usage.input_tokens` (OTEL v1.37+) | Always inclusive | Spec mandates |
| `ai.usage.inputTokens` (Vercel v6+) | Always inclusive | SDK normalizes |
| `ai.usage.promptTokens` (Vercel v5) | Always inclusive | SDK normalizes |

### Strategy 3: provider-level (passthrough conventions, no total)

**Input:**

| Provider | Model |
|---|---|
| Anthropic, AWS Bedrock | Additive |
| Everything else | Inclusive |

**Output:**

| Provider | Model |
|---|---|
| Vertex AI (`gcp.vertex_ai`, `vertexai`) | Additive |
| Everything else | Inclusive |