### PR TITLE
Improve session detection

### DIFF
--- a/packages/domain/spans/src/otlp/resolvers/identity.ts
+++ b/packages/domain/spans/src/otlp/resolvers/identity.ts
@@ -47,14 +47,19 @@ export const responseModelCandidates = [
 ]
 
 export const sessionIdCandidates = [
-  fromString("gen_ai.conversation.id"), // GenAI semconv
+  fromString("session.id"), // OpenInference / Arize Phoenix. Also, OTEL standard for sessions.
+  fromString("gen_ai.session.id"), // Proposed, not accepted yet.
   fromString("langfuse.session.id"), // Langfuse
-  fromString("session.id"), // OpenInference / Arize Phoenix
   fromString("traceloop.association.properties.session_id"), // Traceloop / OpenLLMetry
   fromString("langsmith.trace.session_id"), // LangSmith
   fromString("session_id"), // Datadog / HoneyHive
+
+  // Fallbacks
+  // These do not actually represent sessions, they represent specific threads.
+  // However, it is still a good fallback to have, at least for single-threaded sessions.
   fromString("wandb.thread_id"), // W&B Weave
   fromString("ai.telemetry.metadata.threadId"), // Opik (via Vercel AI SDK metadata)
+  fromString("gen_ai.conversation.id"), // GenAI semconv
 ]
 
 export const userIdCandidates = [


### PR DESCRIPTION
## SESSIONS ≠ CONVERSATIONS

Basically this: https://github.com/open-telemetry/semantic-conventions/issues/2883

A conversation is a list of messages. Over different interactions, the same conversation can grow. That's why we can identify conversations with IDs, which OTEL GenAI semconv defines as `gen_ai.conversation.id` (described in the spec as "the unique identifier for a conversation (session, thread)").

However, this is not the same as a session.

A session is a group of executions over the same context: the same user talking to the same agent instance. These sound similar, but they break apart in multi-agent scenarios:

A user sends a message to a chatbot assistant. The assistant, before responding, spawns a sub-agent and has a separate exchange with it. That sub-agent conversation has its own `gen_ai.conversation.id`. So within the same TRACE (and the same SESSION) there are now two different CONVERSATIONS with two different conversation IDs.

OTEL already has a generic [session.id](https://opentelemetry.io/docs/specs/semconv/general/session/) attribute that covers this. It's defined as a unique identifier included in all logs, events, and spans during a session's lifecycle, with support for session continuation via `session.previous_id`. There's an open issue suggesting a GenAI-specific `gen_ai.session.id`, but it will probably be closed in favor of the existing generic `session.id`.

Because of this, I added both `session.id` and a prospective `gen_ai.session.id` as extraction sources for the session identifier.

This semantic distinction between conversations and sessions only matters for sessions that contain more than one conversation. Otherwise, there's no practical difference. That's why I've kept `gen_ai.conversation.id` as a fallback: most instrumentations will only set that, and for single-conversation sessions it works just fine.
But if a session DOES contain multiple conversations and only defines conversation IDs, traces will be grouped incorrectly, with the same traces showing up under multiple conversations in the UI.