### PR TITLE
chore(ci): upload sourcemaps to Datadog on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,8 +210,54 @@ jobs:
           done
           exit "${ec}"
 
+  staging-upload-sourcemaps:
+    needs: staging-build
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      deployment: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build all apps
+        run: pnpm --filter "@app/*" build
+        env:
+          NODE_ENV: production
+          VITE_LAT_API_URL: ${{ vars.VITE_LAT_API_URL }}
+          VITE_LAT_WEB_URL: ${{ vars.VITE_LAT_WEB_URL }}
+
+      - name: Upload sourcemaps to Datadog
+        run: |
+          RELEASE=${{ needs.staging-build.outputs.image_tag }}
+          pnpm dlx @datadog/datadog-ci sourcemaps upload apps/web/.output/public \
+            --service web \
+            --release-version "$RELEASE" \
+            --minified-path-prefix ${{ vars.VITE_LAT_WEB_URL }}
+          for SERVICE in api ingest workers workflows; do
+            pnpm dlx @datadog/datadog-ci sourcemaps upload "apps/${SERVICE}/dist" \
+              --service "$SERVICE" \
+              --release-version "$RELEASE" \
+              --minified-path-prefix "/app/apps/${SERVICE}/dist"
+          done
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_SITE: ${{ vars.DATADOG_SITE }}
+
   staging-deploy-complete:
-    needs: staging-apply
+    needs: [staging-apply, staging-upload-sourcemaps]
     runs-on: ubuntu-latest
     environment: staging
     steps:
@@ -400,8 +446,54 @@ jobs:
           done
           exit "${ec}"
 
+  production-upload-sourcemaps:
+    needs: production-build
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      deployment: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build all apps
+        run: pnpm --filter "@app/*" build
+        env:
+          NODE_ENV: production
+          VITE_LAT_API_URL: ${{ vars.VITE_LAT_API_URL }}
+          VITE_LAT_WEB_URL: ${{ vars.VITE_LAT_WEB_URL }}
+
+      - name: Upload sourcemaps to Datadog
+        run: |
+          RELEASE=${{ needs.production-build.outputs.image_tag }}
+          pnpm dlx @datadog/datadog-ci sourcemaps upload apps/web/.output/public \
+            --service web \
+            --release-version "$RELEASE" \
+            --minified-path-prefix ${{ vars.VITE_LAT_WEB_URL }}
+          for SERVICE in api ingest workers workflows; do
+            pnpm dlx @datadog/datadog-ci sourcemaps upload "apps/${SERVICE}/dist" \
+              --service "$SERVICE" \
+              --release-version "$RELEASE" \
+              --minified-path-prefix "/app/apps/${SERVICE}/dist"
+          done
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          DATADOG_SITE: ${{ vars.DATADOG_SITE }}
+
   production-deploy-complete:
-    needs: production-apply
+    needs: [production-apply, production-upload-sourcemaps]
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
     },
   },
   build: {
+    sourcemap: true,
     rolldownOptions: {
       // These are Node.js-only packages that must never appear in client chunks.
       // Vite follows dynamic imports in @repo/observability/otel.ts and would


### PR DESCRIPTION
## Summary

- Enable `sourcemap: true` in `apps/web/vite.config.ts` so Vite generates `.js.map` files alongside minified client assets
- Add `staging-upload-sourcemaps` and `production-upload-sourcemaps` jobs to `deploy.yml` that run in parallel with the ECS rollout after each build
- All five services are covered: `web` (browser sourcemaps) and `api`, `ingest`, `workers`, `workflows` (Node.js server sourcemaps — tsup already had `sourcemap: true`)
- Release version is tagged with the same image SHA (`sha-XXXXXXXX`) used for the Docker release, so Datadog can correlate stack frames to the right build

## Required secrets/vars per GitHub environment

| Name | Type | Example |
|---|---|---|
| `DATADOG_API_KEY` | secret | — |
| `DATADOG_SITE` | variable | `datadoghq.eu` |

## Test plan

- [x] Verify `DATADOG_API_KEY` and `DATADOG_SITE` are set on both `staging` and `production` GitHub environments
- [x] Trigger a staging deploy and confirm the `staging-upload-sourcemaps` job completes successfully
- [x] Check [Datadog RUM Debug Symbols](https://app.datadoghq.com/source-code/setup/rum) that sourcemaps appear under the correct service and release version

🤖 Generated with [Claude Code](https://claude.com/claude-code)