### PR TITLE
refactor(observability): add browser entry point via package exports condition

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -5,6 +5,13 @@
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "browser": "./src/browser.ts",
+      "node": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "biome check src",

--- a/packages/observability/src/browser.ts
+++ b/packages/observability/src/browser.ts
@@ -1,0 +1,38 @@
+/**
+ * Browser entry point for @repo/observability.
+ *
+ * This file is selected over index.ts when the package is resolved in a
+ * browser context. It is wired up via the "browser" condition in package.json:
+ *
+ *   "exports": { ".": { "browser": "./src/browser.ts", "node": "./src/index.ts" } }
+ *
+ * Vite includes "browser" in its default resolve conditions for client builds,
+ * so it automatically picks this file instead of index.ts when bundling for
+ * the browser (dev server and production).
+ *
+ * WHY THIS EXISTS:
+ * index.ts imports otel.ts, which in turn imports Node.js-only OTel packages
+ * (@opentelemetry/sdk-node, @opentelemetry/auto-instrumentations-node, etc.).
+ * Those packages use Node.js APIs (e.g. util.inherits) at module evaluation
+ * time, so loading them in the browser throws immediately.
+ *
+ * TanStack Start includes start.ts in the client bundle (with server callback
+ * bodies stripped but module-level imports preserved), so @repo/observability
+ * ends up in the browser module graph. This file provides a safe, no-op
+ * alternative: same public API, no Node.js-only dependencies.
+ *
+ * @opentelemetry/api is intentionally kept — it is isomorphic and safe to use
+ * in the browser (it provides no-op stubs when no SDK is initialised).
+ */
+import type { Span, Tracer } from "@opentelemetry/api"
+import { SpanStatusCode, trace } from "@opentelemetry/api"
+import { createLogger as createLoggerWithState } from "./logger.ts"
+import { getObservabilityState } from "./state.ts"
+import type { InitializeObservabilityOptions } from "./types.ts"
+
+export type { Span, Tracer }
+export { trace, SpanStatusCode }
+
+export const createLogger = (scope: string) => createLoggerWithState(getObservabilityState(), scope)
+export const initializeObservability = async (_opts: InitializeObservabilityOptions): Promise<void> => {}
+export const shutdownObservability = async (): Promise<void> => {}

--- a/packages/observability/src/otel.ts
+++ b/packages/observability/src/otel.ts
@@ -1,3 +1,6 @@
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { NodeSDK } from "@opentelemetry/sdk-node"
 import type { TracesConfig } from "./types.ts"
 
 const appendResourceAttribute = (key: string, value: string) => {
@@ -17,10 +20,6 @@ export const startTracing = async ({
   serviceName: string
   environment: string
 }): Promise<() => Promise<void>> => {
-  const { getNodeAutoInstrumentations } = await import("@opentelemetry/auto-instrumentations-node")
-  const { OTLPTraceExporter } = await import("@opentelemetry/exporter-trace-otlp-http")
-  const { NodeSDK } = await import("@opentelemetry/sdk-node")
-
   process.env.OTEL_SERVICE_NAME = serviceName
   process.env.DD_SERVICE = serviceName
   process.env.DD_ENV = environment


### PR DESCRIPTION
## Summary

- Adds `browser.ts` to `@repo/observability` — a browser-safe stub with the same public API as `index.ts` but without any Node.js-only OTel dependencies
- Wires it up via the `"browser"` condition in `package.json` exports so Vite automatically picks it for client builds without extra config
- Switches `otel.ts` from dynamic `await import(...)` back to static imports, since it is now only ever loaded in Node.js context

## Why

TanStack Start includes `start.ts` in the client bundle (server callback bodies are stripped but module-level imports are preserved). This means `@repo/observability` ends up in the browser module graph. `otel.ts` statically imports packages like `@opentelemetry/sdk-node` and `@opentelemetry/auto-instrumentations-node` that call `util.inherits` at module evaluation time — crashing the browser with `TypeError: util.inherits is not a function`.

## How the fix works

Vite includes `"browser"` in its default resolve conditions for client builds. Adding `"browser": "./src/browser.ts"` to the `exports` field causes Vite to resolve `@repo/observability` to `browser.ts` (no OTel deps) in the browser, while the server continues to use `index.ts` (full OTel) via the `"node"` condition.

## Test plan

- [x] Dev server loads without `util.inherits` errors in the browser console
- [x] OTel tracing still initialises correctly on the server when `LAT_OBSERVABILITY_ENABLED=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)