### PR TITLE
fix(ui): InfiniteTable row a11y (AGE-20)

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -388,6 +388,18 @@ export function SessionsView({
     }
   }
 
+  const getRowAriaLabel = useCallback(
+    (row: SessionTableRow) => {
+      if (row.kind === "session") {
+        const id = row.session.sessionId
+        return expandedIds.has(id) ? `Collapse session ${id}` : `Expand session ${id}`
+      }
+      const short = row.trace.rootSpanName || row.trace.traceId.slice(0, 8)
+      return row.trace.traceId === activeTraceId ? `Deselect trace ${short}` : `View trace ${short}`
+    },
+    [expandedIds, activeTraceId],
+  )
+
   const getExpandedRows = (row: SessionTableRow): ExpandedRows<SessionTableRow> => {
     if (row.kind !== "session") return { data: [] }
     const entry = traceMap.get(row.session.sessionId)
@@ -416,6 +428,7 @@ export function SessionsView({
           columns={columns}
           getRowKey={getRowKey}
           onRowClick={onRowClick}
+          getRowAriaLabel={getRowAriaLabel}
           {...(activeTraceId ? { activeRowKey: activeTraceId } : {})}
           selection={selection}
           infiniteScroll={infiniteScroll}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -9,7 +9,7 @@ import {
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { type RefObject, useMemo, useState } from "react"
+import { type RefObject, useCallback, useMemo, useState } from "react"
 import { useTraceMetrics, useTracesInfiniteScroll } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
@@ -192,6 +192,14 @@ export function TracesView({
     onActiveTraceChange(t.traceId === activeTraceId ? undefined : t.traceId)
   }
 
+  const getRowAriaLabel = useCallback(
+    (t: TraceRecord) => {
+      const short = t.rootSpanName || t.traceId.slice(0, 8)
+      return t.traceId === activeTraceId ? `Deselect trace ${short}` : `View trace ${short}`
+    },
+    [activeTraceId],
+  )
+
   // J/K hotkeys: navigate through traces. Disabled when spans tab is active (span tree takes over J/K).
   const jkEnabled = activeDrawerTab !== "spans"
   useHotkeys([
@@ -234,6 +242,7 @@ export function TracesView({
           columns={columns}
           getRowKey={(t: TraceRecord) => t.traceId}
           onRowClick={onRowClick}
+          getRowAriaLabel={getRowAriaLabel}
           {...(activeTraceId ? { activeRowKey: activeTraceId } : {})}
           selection={selection}
           infiniteScroll={infiniteScroll}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
@@ -327,6 +327,16 @@ function DatasetRowsView({
     setRid(row.rowId)
   }
 
+  const getRowAriaLabel = useCallback(
+    (r: DatasetRowRecord) => {
+      const idx = displayRows.findIndex((row) => row.rowId === r.rowId)
+      const n = idx >= 0 ? idx + 1 : null
+      const position = n != null ? `row ${n}` : "row"
+      return r.rowId === rid ? `Close details for ${position}` : `View details for ${position}`
+    },
+    [displayRows, rid],
+  )
+
   const rowNavIndex = useMemo(() => (rid ? displayRows.findIndex((r) => r.rowId === rid) : -1), [rid, displayRows])
   const canNavigatePrev = rowNavIndex > 0
   const canNavigateNext = rowNavIndex >= 0 && rowNavIndex < displayRows.length - 1
@@ -611,6 +621,7 @@ function DatasetRowsView({
               columns={rowColumns}
               getRowKey={getRowKey}
               onRowClick={openRow}
+              getRowAriaLabel={getRowAriaLabel}
               activeRowKey={rid}
               activeRowAutoScroll
               selection={selection}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -88,6 +88,8 @@ function DatasetsPage() {
     [navigate, projectSlug],
   )
 
+  const getRowAriaLabel = useCallback((d: DatasetRecord) => `Open dataset ${d.name}`, [])
+
   const handleCreate = useCallback(async () => {
     setCreating(true)
     try {
@@ -129,6 +131,8 @@ function DatasetsPage() {
             columns={columns}
             getRowKey={getRowKey}
             onRowClick={onRowClick}
+            rowInteractionRole="link"
+            getRowAriaLabel={getRowAriaLabel}
             infiniteScroll={infiniteScroll}
             sorting={sorting}
             defaultSorting={DEFAULT_SORTING}

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -17,6 +17,8 @@ interface DataRowProps<T> {
   isExpandable?: boolean
   isExpanded?: boolean
   onClick?: (row: T) => void
+  rowInteractionRole?: "button" | "link"
+  rowAriaLabel?: string
   dataIndex: number
   isSubRow?: boolean
 }
@@ -33,6 +35,8 @@ function DataRowInner<T>({
   isExpandable,
   isExpanded,
   onClick,
+  rowInteractionRole = "button",
+  rowAriaLabel,
   dataIndex,
   isSubRow,
 }: DataRowProps<T>) {
@@ -46,16 +50,26 @@ function DataRowInner<T>({
     [onClick, row],
   )
 
+  const isClickable = Boolean(onClick)
+  const interactiveRole = isClickable ? rowInteractionRole : undefined
+  const isExpandToggleRow = Boolean(isClickable && isExpandable && !isSubRow)
+  const ariaExpanded = isExpandToggleRow ? Boolean(isExpanded) : undefined
+  const ariaPressed = isClickable && interactiveRole === "button" && !isExpandToggleRow ? Boolean(isActive) : undefined
+
   return (
     <tr
       data-index={dataIndex}
+      role={interactiveRole}
+      {...(isClickable && rowAriaLabel ? { "aria-label": rowAriaLabel } : {})}
+      {...(ariaExpanded !== undefined ? { "aria-expanded": ariaExpanded } : {})}
+      {...(ariaPressed !== undefined ? { "aria-pressed": ariaPressed } : {})}
       className={cn({
         "bg-secondary": !isSubRow && !isExpanded,
         "bg-muted": isExpanded && !isActive,
         "bg-accent": isActive,
         "hover:bg-muted cursor-pointer": onClick && !isExpanded && !isActive,
         "hover:bg-accent cursor-pointer": onClick && (isExpanded || isActive),
-        "focus-visible:outline-none": onClick,
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset": isClickable,
       })}
       onClick={onClick ? () => onClick(row) : undefined}
       onMouseDown={onClick ? (e) => e.preventDefault() : undefined}

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -25,6 +25,8 @@ export function InfiniteTable<T>({
   columns,
   getRowKey,
   onRowClick,
+  rowInteractionRole = "button",
+  getRowAriaLabel,
   activeRowKey,
   activeRowAutoScroll = false,
   selection,
@@ -230,7 +232,13 @@ export function InfiniteTable<T>({
                           onToggleRow: selection.toggleRow,
                         }
                       : {})}
-                    {...(onRowClick ? { onClick: onRowClick } : {})}
+                    {...(onRowClick
+                      ? {
+                          onClick: onRowClick,
+                          rowInteractionRole,
+                          ...(getRowAriaLabel ? { rowAriaLabel: getRowAriaLabel(row) } : {}),
+                        }
+                      : {})}
                     dataIndex={virtualRow.index}
                   />
                   {expanded?.isLoading &&
@@ -258,7 +266,13 @@ export function InfiniteTable<T>({
                                 onToggleRow: selection.toggleRow,
                               }
                             : {})}
-                          {...(onRowClick ? { onClick: onRowClick } : {})}
+                          {...(onRowClick
+                            ? {
+                                onClick: onRowClick,
+                                rowInteractionRole,
+                                ...(getRowAriaLabel ? { rowAriaLabel: getRowAriaLabel(subRow) } : {}),
+                              }
+                            : {})}
                           dataIndex={virtualRow.index}
                           isSubRow
                         />

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -39,12 +39,11 @@ export interface ExpandedRows<T> {
   isLoading?: boolean
 }
 
-export interface InfiniteTableProps<T> {
+export interface InfiniteTableSharedProps<T> {
   data: readonly T[]
   isLoading?: boolean
   columns: InfiniteTableColumn<T>[]
   getRowKey: (row: T) => string
-  onRowClick?: (row: T) => void
   activeRowKey?: string
   activeRowAutoScroll?: boolean
   selection?: InfiniteTableSelection
@@ -57,3 +56,16 @@ export interface InfiniteTableProps<T> {
   expandedRowKeys?: ReadonlySet<string>
   getExpandedRows?: (row: T) => ExpandedRows<T>
 }
+
+export type InfiniteTableProps<T> =
+  | (InfiniteTableSharedProps<T> & {
+      onRowClick: (row: T) => void
+      getRowAriaLabel: (row: T) => string
+      /** Semantic role for clickable rows (`link` when the action navigates). Defaults to `button`. */
+      rowInteractionRole?: "button" | "link"
+    })
+  | (InfiniteTableSharedProps<T> & {
+      onRowClick?: undefined
+      getRowAriaLabel?: undefined
+      rowInteractionRole?: undefined
+    })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [AGE-20](https://linear.app) / closes accessibility gaps for clickable `InfiniteTable` rows (traces, sessions, datasets).

## Changes

- **`DataRow`**: When `onClick` is set, rows get `role` (`button` or `link`), `aria-label` from `getRowAriaLabel`, `aria-expanded` for expandable session rows, `aria-pressed` for trace-style selection toggles (non-expand rows), and a visible `focus-visible` ring (`ring-2 ring-ring ring-inset`) aligned with other `@repo/ui` controls.
- **`InfiniteTable` props**: Discriminated union — `getRowAriaLabel` is **required** whenever `onRowClick` is provided. Optional `rowInteractionRole` (`link` for route navigation; default `button`).
- **Call sites**: Wired labels for traces, sessions (session expand/collapse + trace rows), dataset list (`link` + open dataset), and dataset row detail table.

## Testing

- `pnpm exec tsc -p packages/ui/tsconfig.json --noEmit`
- `pnpm exec tsc -p apps/web/tsconfig.json --noEmit`
- `pnpm run check` + `pnpm run test` in `packages/ui`

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-20](https://linear.app/latitude/issue/AGE-20/make-tracessessions-table-rows-accessible-and-properly-clickable)

<div><a href="https://cursor.com/agents/bc-f880b03e-57b7-4e3a-9c1a-3fe9bf0e3c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f880b03e-57b7-4e3a-9c1a-3fe9bf0e3c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

