### PR TITLE
fix(web): guard JSON.parse in raw telemetry sections to prevent UI crash

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
@@ -15,6 +15,15 @@ export function isNonEmptyJson(json: string): boolean {
   return json !== "" && json !== "[]" && json !== "{}" && json !== "null"
 }
 
+export function tryParseJson(value: string): unknown | null {
+  if (!value) return null
+  try {
+    return JSON.parse(value)
+  } catch {
+    return null
+  }
+}
+
 export function JsonBlock({ value }: { readonly value: unknown }) {
   const formatted = useMemo(() => JSON.stringify(value, null, 2), [value])
   return <CodeBlock value={formatted} copyable />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/raw-telemetry-sections.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/raw-telemetry-sections.tsx
@@ -2,7 +2,7 @@ import { DetailSection, Text } from "@repo/ui"
 import { CodeIcon, LayersIcon, LinkIcon, ZapIcon } from "lucide-react"
 import { useMemo } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { isNonEmptyJson, JsonBlock } from "./helpers.tsx"
+import { JsonBlock, tryParseJson } from "./helpers.tsx"
 
 export function RawTelemetrySections({
   span,
@@ -13,14 +13,8 @@ export function RawTelemetrySections({
 }) {
   const hasAttrs = Object.keys(mergedAttrs).length > 0
   const hasResourceAttrs = Object.keys(span.resourceString).length > 0
-  const parsedEvents = useMemo(
-    () => (isNonEmptyJson(span.eventsJson) ? JSON.parse(span.eventsJson) : null),
-    [span.eventsJson],
-  )
-  const parsedLinks = useMemo(
-    () => (isNonEmptyJson(span.linksJson) ? JSON.parse(span.linksJson) : null),
-    [span.linksJson],
-  )
+  const parsedEvents = useMemo(() => tryParseJson(span.eventsJson), [span.eventsJson])
+  const parsedLinks = useMemo(() => tryParseJson(span.linksJson), [span.linksJson])
 
   return (
     <>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/tool-execution-section.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/tool-execution-section.tsx
@@ -2,16 +2,7 @@ import { CopyButton, DetailSection, DetailSummary, Text } from "@repo/ui"
 import { ArrowDownRightIcon, ArrowUpRightIcon, WrenchIcon } from "lucide-react"
 import { useMemo } from "react"
 import type { SpanDetailRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { JsonBlock } from "./helpers.tsx"
-
-function tryParseJson(value: string): unknown | null {
-  if (!value) return null
-  try {
-    return JSON.parse(value)
-  } catch {
-    return null
-  }
-}
+import { JsonBlock, tryParseJson } from "./helpers.tsx"
 
 export function isToolExecutionSpan(span: SpanDetailRecord): boolean {
   return (


### PR DESCRIPTION
## Problem

Was debugging a trace detail view that kept crashing in our self-hosted deployment and traced it back to `RawTelemetrySections`. The component uses `isNonEmptyJson()` before calling `JSON.parse()` on `eventsJson` and `linksJson`, but `isNonEmptyJson` only checks for empty/trivial strings (`""`, `"[]"`, `"{}"`, `"null"`) — it doesn't validate that the string is actually valid JSON.

When a span has truncated or malformed JSON in its events or links fields (which can happen during ingestion failures or storage corruption), `JSON.parse` throws an uncaught `SyntaxError` that crashes the entire trace detail panel.

## Fix

Noticed that the sibling `ToolExecutionSection` component already handles this correctly with a local `tryParseJson` helper that wraps `JSON.parse` in a try-catch and returns `null` on failure. The same pattern is also used in `column-mapping.ts`, `vercel.ts`, `genai.ts`, and the span/trace repositories.

This change:
1. Moves `tryParseJson` from `tool-execution-section.tsx` into the shared `helpers.tsx` module (where `isNonEmptyJson` and `JsonBlock` already live)
2. Updates `RawTelemetrySections` to use `tryParseJson` instead of the unguarded `isNonEmptyJson` + `JSON.parse` combination
3. Updates `ToolExecutionSection` to import from the shared helper instead of defining its own copy

When JSON is valid, behavior is identical. When JSON is malformed, the component now gracefully shows "No events" / "No links" instead of crashing.

## Changes

- `helpers.tsx` — add `tryParseJson` export
- `raw-telemetry-sections.tsx` — use `tryParseJson` for `eventsJson` and `linksJson`
- `tool-execution-section.tsx` — remove local `tryParseJson`, import from helpers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI robustness change: JSON parsing for span telemetry is now guarded to avoid runtime crashes when events/links/tool payloads contain malformed JSON.
> 
> **Overview**
> Prevents the trace detail drawer from crashing on malformed span JSON by introducing a shared `tryParseJson` helper and using it in `RawTelemetrySections` for `eventsJson`/`linksJson`.
> 
> Deduplicates logic by removing the local JSON parse wrapper in `ToolExecutionSection` and importing the shared helper instead, keeping behavior the same for valid JSON while failing gracefully for invalid input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cdae48a31927e15f44aca05831a2fae2fa7b9de. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->