### PR TITLE
fix(auth): handle corrupted Redis cache in API key validation

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -59,8 +59,14 @@ const getCachedApiKey = (
     try: async () => {
       const cached = await withTimeout(redis.get(cacheKey), null)
       if (!cached) return undefined
-      const parsed = JSON.parse(cached)
-      return isCachedApiKeyResult(parsed) ? parsed : undefined
+      try {
+        const parsed = JSON.parse(cached)
+        return isCachedApiKeyResult(parsed) ? parsed : undefined
+      } catch {
+        // Corrupted cache entry — treat as cache miss so the caller
+        // falls through to the database lookup instead of crashing.
+        return undefined
+      }
     },
     catch: () => undefined,
   }).pipe(Effect.orDie)

--- a/apps/ingest/src/middleware/auth.ts
+++ b/apps/ingest/src/middleware/auth.ts
@@ -40,8 +40,14 @@ const getCachedApiKey = (tokenHash: string): Effect.Effect<ApiKeyResult | null |
     try: async () => {
       const cached = await withTimeout(redis.get(cacheKey), null)
       if (!cached) return undefined
-      const parsed = JSON.parse(cached)
-      return isCachedResult(parsed) ? parsed : undefined
+      try {
+        const parsed = JSON.parse(cached)
+        return isCachedResult(parsed) ? parsed : undefined
+      } catch {
+        // Corrupted cache entry — treat as cache miss so the caller
+        // falls through to the database lookup instead of crashing.
+        return undefined
+      }
     },
     catch: () => undefined,
   }).pipe(Effect.orDie)


### PR DESCRIPTION
## Problem

Noticed while reading through the auth middleware that `getCachedApiKey` in both the API and ingest services parses Redis cache values with `JSON.parse` but doesn't handle parse failures. The function is wrapped in `Effect.tryPromise` with `catch: () => undefined`, piped through `Effect.orDie`:

```typescript
return Effect.tryPromise({
  try: async () => {
    const cached = await withTimeout(redis.get(cacheKey), null)
    if (!cached) return undefined
    const parsed = JSON.parse(cached)  // throws on corrupted data
    return isCachedResult(parsed) ? parsed : undefined
  },
  catch: () => undefined,
}).pipe(Effect.orDie)
```

When `JSON.parse` throws (e.g. corrupted cache entry, partial write, encoding issue), the async function rejects, `catch` maps it to `undefined`, creating `Effect.fail(undefined)`, and then `Effect.orDie` converts that into an unrecoverable defect. This crashes the auth middleware and returns a 500 to the client instead of falling back to the database lookup.

This is inconsistent with the existing graceful degradation design — `withTimeout` already handles Redis unavailability by returning a fallback value, but corrupted data in an available Redis isn't handled.

## Fix

Added a try-catch around `JSON.parse` inside the `try` callback so that corrupted cache entries return `undefined` (treated as a cache miss) rather than throwing. The caller then falls through to the database path as intended.

The same safe-parse pattern is already used elsewhere in the codebase:
- `column-mapping.ts` — try-catch with fallback
- `vercel.ts`, `genai.ts` — try-catch returning `undefined`
- `trace-repository.ts`, `span-repository.ts` — try-catch returning `[]`

## Changes

- `apps/api/src/middleware/auth.ts` — wrap cache JSON.parse in try-catch
- `apps/ingest/src/middleware/auth.ts` — same fix (identical code path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches API-key authentication middleware in both `api` and `ingest`; while change is small and defensive, it affects a security-critical request path and could alter behavior on unexpected Redis values.
> 
> **Overview**
> API key validation in both `apps/api` and `apps/ingest` now **safely handles corrupted Redis cache entries** by wrapping `JSON.parse` in a local try/catch.
> 
> On parse failure, the cache is treated as a miss (returning `undefined`) so the middleware falls back to the database lookup instead of dying via `Effect.orDie` and returning a 500.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c3c342a172eff3f81eaa147c92613016f2b259. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->