### PR TITLE
AGE-23: Sync Google profile photos and show in nav avatar

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
 })
 
-function UserAvatar({ name }: { name: string }) {
+function UserAvatar({ name, imageUrl }: { name: string; imageUrl?: string | null }) {
   const trimmed = name.trim()
   const initials =
     trimmed.length === 0
@@ -46,6 +46,14 @@ function UserAvatar({ name }: { name: string }) {
           .toUpperCase() || trimmed.slice(0, 2).toUpperCase()
 
   const { style, className } = useHashColor(name)
+
+  if (imageUrl?.trim()) {
+    return (
+      <div className="w-6 h-6 rounded-full overflow-hidden shrink-0 bg-muted">
+        <img src={imageUrl} alt="" className="size-full object-cover" referrerPolicy="no-referrer" />
+      </div>
+    )
+  }
 
   return (
     <div className={cn("w-6 h-6 rounded-full flex items-center justify-center", className)} style={style}>
@@ -213,7 +221,7 @@ function NavHeader() {
           trigger={() => (
             <DropdownMenuTrigger asChild>
               <button type="button" className="cursor-pointer">
-                <UserAvatar name={user.name?.trim() ? user.name : user.email} />
+                <UserAvatar name={user.name?.trim() ? user.name : user.email} imageUrl={user.image} />
               </button>
             </DropdownMenuTrigger>
           )}

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -112,10 +112,12 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
     socialProviders: {
       ...(googleClientId &&
         googleClientSecret && {
-          google: {
+          google: async () => ({
             clientId: googleClientId,
             clientSecret: googleClientSecret,
-          },
+            /** Keep `users.image` in sync with Google profile photos on each sign-in. */
+            overrideUserInfoOnSignIn: true,
+          }),
         }),
       ...(githubClientId &&
         githubClientSecret && {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Use Google account profile photos when users sign in with Google.

### Changes

1. **Better Auth (`create-better-auth.ts`)**  
   Google OAuth is configured with `overrideUserInfoOnSignIn: true` via an async provider options factory (required by Better Auth’s `SocialProviders` typing). On each Google sign-in, Better Auth refreshes the user row from the provider, including `picture` mapped to `users.image`.

2. **Web (`_authenticated.tsx`)**  
   The header `UserAvatar` shows `session.user.image` when set (with `referrerPolicy="no-referrer"` so Google-hosted avatars load reliably), otherwise keeps the existing initials fallback.

### Testing

- `pnpm run typecheck` in `@platform/db-postgres` and `@app/web`
- `biome check` on touched files

### Notes

Existing Google users without `image` populated will get it on their next Google sign-in. Magic link / email users are unchanged (initials only unless they set an image elsewhere).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-23](https://linear.app/latitude/issue/AGE-23/fetch-user-avatars-from-google-accounts-when-applicable)

<div><a href="https://cursor.com/agents/bc-8a07e182-65bc-40ac-b378-4a0cd5367c38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a07e182-65bc-40ac-b378-4a0cd5367c38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

