### PR TITLE
fix(a11y): resolve Biome a11y suppressions (AGE-36)

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -25,7 +25,7 @@ export function SpanTree({
   readonly onToggleMinimized: () => void
   readonly isActive: boolean
 }) {
-  const containerRef = useRef<HTMLDivElement | null>(null)
+  const containerRef = useRef<HTMLElement | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
   const { treeWidth, isDragging, onPointerDown, onKeyDown } = useResizablePanel({ containerRef })
@@ -101,9 +101,9 @@ export function SpanTree({
   ])
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: passive mouse tracking for waterfall cursor
-    <div
+    <section
       ref={containerRef}
+      aria-label="Span tree and waterfall"
       className={cn("relative flex flex-col overflow-hidden", isMinimized ? "shrink-0" : "flex-1")}
       style={isMinimized ? { maxHeight: MINIMIZED_MAX_HEIGHT } : undefined}
       onMouseMove={onMouseMove}
@@ -180,10 +180,8 @@ export function SpanTree({
       {/* Waterfall time cursor */}
       <WaterfallCursorOverlay treeWidth={resolvedTreeWidth} cursorX={cursorX} cursorTimeLabel={cursorTimeLabel} />
 
-      {/* Resize handle */}
-      {/* biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events */}
-      <div
-        role="separator"
+      {/* Resize handle — native <hr> satisfies useSemanticElements for role="separator" */}
+      <hr
         aria-orientation="vertical"
         aria-label="Resize span tree panel"
         aria-valuenow={resolvedTreeWidth}
@@ -191,7 +189,7 @@ export function SpanTree({
         aria-valuemax={containerRef.current ? containerRef.current.offsetWidth - MIN_WATERFALL_WIDTH : 9999}
         tabIndex={0}
         className={cn(
-          "absolute top-0 bottom-0 w-px cursor-col-resize z-10 touch-none",
+          "absolute top-0 bottom-0 w-px h-auto border-0 m-0 cursor-col-resize z-10 touch-none",
           "hover:bg-primary transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
           "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
@@ -201,7 +199,7 @@ export function SpanTree({
         onPointerDown={onPointerDown}
         onKeyDown={onKeyDown}
       />
-    </div>
+    </section>
   )
 }
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -55,10 +55,10 @@ export const TreeRow = memo(function TreeRow({
   const durationMs = new Date(node.span.endTime).getTime() - new Date(node.span.startTime).getTime()
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: div with role="button" avoids invalid nested <button> elements
     <div
-      role="button"
+      role="treeitem"
       tabIndex={0}
+      aria-selected={isSelected}
       data-span-id={node.span.spanId}
       className={cn(
         "flex flex-row items-center shrink-0 cursor-pointer transition-colors",

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/use-resizable-panel.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/use-resizable-panel.ts
@@ -8,7 +8,7 @@ import {
   MIN_WATERFALL_WIDTH,
 } from "./helpers.ts"
 
-export function useResizablePanel({ containerRef }: { containerRef: React.RefObject<HTMLDivElement | null> }) {
+export function useResizablePanel({ containerRef }: { containerRef: React.RefObject<HTMLElement | null> }) {
   const [treeWidth, setTreeWidth] = useState<number | null>(null)
   const [isDragging, setIsDragging] = useState(false)
   const startX = useRef(0)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
@@ -32,14 +32,14 @@ export function useWaterfallCursor({
   treeWidth,
   timeRange,
 }: {
-  containerRef: React.RefObject<HTMLDivElement | null>
+  containerRef: React.RefObject<HTMLElement | null>
   treeWidth: number
   timeRange: TraceTimeRange
 }) {
   const [cursorX, setCursorX] = useState<number | null>(null)
 
   const onMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
+    (e: React.MouseEvent<HTMLElement>) => {
       if (!containerRef.current) return
       const rect = containerRef.current.getBoundingClientRect()
       const x = e.clientX - rect.left

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/upload-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/upload-blank-slate.tsx
@@ -96,10 +96,8 @@ export function UploadBlankSlate({
           </Layout.Actions>
           <Layout.List>
             <div className="flex flex-col gap-4 flex-1 min-h-0">
-              {/* biome-ignore lint/a11y/useSemanticElements: drop zone requires div for drag events */}
-              <div
-                role="button"
-                tabIndex={0}
+              <section
+                aria-label="CSV file drop zone"
                 className={`flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed p-16 transition-colors ${
                   isDragOver ? "border-primary bg-primary/5" : "border-border"
                 }`}
@@ -109,9 +107,6 @@ export function UploadBlankSlate({
                 }}
                 onDragLeave={() => setIsDragOver(false)}
                 onDrop={handleDrop}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") fileInputRef.current?.click()
-                }}
               >
                 {parsing ? (
                   <>
@@ -149,7 +144,7 @@ export function UploadBlankSlate({
                     />
                   </>
                 )}
-              </div>
+              </section>
             </div>
           </Layout.List>
         </Layout.Content>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/upload-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/upload-blank-slate.tsx
@@ -1,7 +1,13 @@
 import { parseDatasetCsv } from "@domain/datasets"
 import { Button, Icon, Modal, Text, toast } from "@repo/ui"
 import { CirclePlus, FileUp, ImportIcon, Loader2, Save } from "lucide-react"
-import { useCallback, useRef, useState } from "react"
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useRef,
+  useState,
+} from "react"
 import type { DatasetRecord } from "../../../../../../domains/datasets/datasets.functions.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import type { ParsedCsv } from "./csv-import-view.tsx"
@@ -83,6 +89,26 @@ export function UploadBlankSlate({
     [handleFile],
   )
 
+  const onDropZoneClick = useCallback(
+    (e: ReactMouseEvent<HTMLElement>) => {
+      if (parsing) return
+      if ((e.target as HTMLElement).closest("button")) return
+      fileInputRef.current?.click()
+    },
+    [parsing],
+  )
+
+  const onDropZoneKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLElement>) => {
+      if (parsing) return
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        fileInputRef.current?.click()
+      }
+    },
+    [parsing],
+  )
+
   return (
     <>
       <Layout>
@@ -100,7 +126,9 @@ export function UploadBlankSlate({
                 aria-label="CSV file drop zone"
                 className={`flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed p-16 transition-colors ${
                   isDragOver ? "border-primary bg-primary/5" : "border-border"
-                }`}
+                } ${parsing ? "" : "cursor-pointer"}`}
+                onClick={onDropZoneClick}
+                onKeyDown={onDropZoneKeyDown}
                 onDragOver={(e) => {
                   e.preventDefault()
                   setIsDragOver(true)

--- a/packages/ui/src/components/detail-drawer/detail-drawer.tsx
+++ b/packages/ui/src/components/detail-drawer/detail-drawer.tsx
@@ -177,9 +177,7 @@ export function DetailDrawer({
   )
 
   const resizeHandle = (
-    // biome-ignore lint/a11y/useSemanticElements: resize handle requires div for drag events
-    <div
-      role="separator"
+    <hr
       aria-orientation="vertical"
       aria-label="Resize panel"
       aria-valuenow={width}
@@ -188,7 +186,7 @@ export function DetailDrawer({
       aria-valuetext={`Panel width: ${width} pixels`}
       tabIndex={0}
       className={cn(
-        "relative cursor-col-resize shrink-0 transition-colors",
+        "relative w-px h-auto border-0 m-0 cursor-col-resize shrink-0 transition-colors",
         "before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5 before:content-['']",
         resizeFrom === "left" ? "border-l" : "border-r",
         isDragging ? "border-primary" : "hover:border-primary",

--- a/packages/ui/src/components/detail-drawer/detail-drawer.tsx
+++ b/packages/ui/src/components/detail-drawer/detail-drawer.tsx
@@ -177,6 +177,9 @@ export function DetailDrawer({
   )
 
   const resizeHandle = (
+    // Native <hr> fixes Biome useSemanticElements (implicit separator). UA styles default
+    // <hr> to full width + margins; in this flex row we need a 1px-wide vertical grip, so
+    // w-px / border-0 / m-0 / h-auto mirror the old div+single-border layout.
     <hr
       aria-orientation="vertical"
       aria-label="Resize panel"

--- a/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
@@ -47,9 +47,7 @@ export function ToolCallBlock({
         "border-destructive": isError,
       })}
     >
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: row is a pointer-only hit target; chevron Button handles keyboard disclosure */}
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: same — toggle is available via the chevron control */}
-      <div className="flex flex-row items-center gap-2 px-3 py-2 cursor-pointer hover:bg-muted/50" onClick={toggleOpen}>
+      <div className="flex flex-row items-center gap-2 px-3 py-2">
         <WrenchIcon className="w-3.5 h-3.5 text-muted-foreground" />
         <span className="flex-1 text-left">
           <Text.Mono size="h6">{call.name}</Text.Mono>

--- a/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
@@ -48,10 +48,25 @@ export function ToolCallBlock({
       })}
     >
       <div className="flex flex-row items-center gap-2 px-3 py-2">
-        <WrenchIcon className="w-3.5 h-3.5 text-muted-foreground" />
-        <span className="flex-1 text-left">
-          <Text.Mono size="h6">{call.name}</Text.Mono>
-        </span>
+        <button
+          type="button"
+          className={cn(
+            "flex min-w-0 flex-1 flex-row items-center gap-2 rounded-md py-0.5 -my-0.5 -ml-1 pl-1 pr-2 text-left cursor-pointer transition-colors",
+            "hover:bg-muted/50",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background",
+          )}
+          onClick={toggleOpen}
+          aria-expanded={open}
+          aria-controls={panelId}
+          aria-label={open ? `Hide details for tool call ${call.name}` : `Show details for tool call ${call.name}`}
+        >
+          <WrenchIcon className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 text-left">
+            <Text.Mono size="h6" ellipsis display="block">
+              {call.name}
+            </Text.Mono>
+          </span>
+        </button>
         <ToolCallStatusIcon result={result} />
         {call.id && <CopyButton value={call.id} tooltip={call.id} />}
         {onNavigateToSpan && (
@@ -59,10 +74,7 @@ export function ToolCallBlock({
             trigger={
               <button
                 type="button"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onNavigateToSpan()
-                }}
+                onClick={onNavigateToSpan}
                 className="flex items-center text-muted-foreground hover:text-foreground cursor-pointer"
               >
                 <ScanSearchIcon className="w-4 h-4" />
@@ -77,10 +89,7 @@ export function ToolCallBlock({
           variant="ghost"
           size="icon"
           className="shrink-0 text-muted-foreground hover:text-foreground"
-          onClick={(e) => {
-            e.stopPropagation()
-            toggleOpen()
-          }}
+          onClick={toggleOpen}
           aria-expanded={open}
           aria-controls={panelId}
           aria-label={open ? "Hide tool call details" : "Show tool call details"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [AGE-36](https://linear.app) / [GitHub #2609](https://github.com/latitude-dev/latitude-llm/issues/2609) by removing the six targeted `biome-ignore` comments for `useSemanticElements`, `noStaticElementInteractions`, and `useKeyWithClickEvents`, and fixing the underlying patterns instead.

## Changes

- **Span tree (`span-tree/index.tsx`)**: Replaced the outer tracking `div` with a labeled `<section>` so passive `onMouseMove` / `onMouseLeave` no longer trip `noStaticElementInteractions`. Replaced the vertical resize `div role="separator"` with `<hr>` (implicit separator; no redundant `role`) plus layout classes (`border-0`, `h-auto`, `m-0`, `w-px`).
- **Tree rows (`tree-row.tsx`)**: Switched row container to `role="treeitem"` with `aria-selected` and kept the nested expand `<button>`—valid for Biome and closer to a tree pattern than `role="button"` wrapping a button.
- **Refs (`waterfall.tsx`, `use-resizable-panel.ts`)**: Widened `containerRef` to `HTMLElement` so the section ref type-checks.
- **Dataset upload (`upload-blank-slate.tsx`)**: Labeled `<section>` for drag-and-drop; **click** on the dashed area (excluding **Choose file** / **Add row**) opens the hidden file input again. `onKeyDown` (Enter/Space) pairs with `onClick` for Biome `useKeyWithClickEvents` without `tabIndex` on `<section>` (which would trip `noNoninteractiveTabindex`). **Choose file** and **Add row** stay the primary explicit controls.
- **Detail drawer (`detail-drawer.tsx`)**: Resize handle is now `<hr>` with the same ARIA value props and mouse/keyboard behavior.
- **Tool call block (`tool-call-block.tsx`)**: The wrench + tool name is a real `<button type="button">` that toggles the panel (`aria-expanded` / `aria-controls`), with hover/focus styles—restores clickable header UX without `div` + `onClick` or Biome suppressions. Chevron still toggles; span navigation is a sibling control (no nested buttons).

## Verification

- `pnpm exec biome check` on touched files
- `pnpm --filter @repo/ui typecheck` and `pnpm --filter ./apps/web typecheck`

## UX

- Tool call header: click the **wrench + name** area or the chevron to expand/collapse (both are proper buttons; keyboard works on both).
- Dataset CSV area: drag-and-drop unchanged; clicking empty padding / chrome opens the file picker; clicking **Choose file** or **Add row** only runs that control (no double-open).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGE-36](https://linear.app/latitude/issue/AGE-36/p3-biome-ignore-comments-review-accessibility-rules)

<div><a href="https://cursor.com/agents/bc-8bce872c-7c43-45f5-b78b-8adad25e0373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bce872c-7c43-45f5-b78b-8adad25e0373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

