### PR TITLE
Annotation queue item toolbar

### DIFF
--- a/apps/web/src/components/hotkey-badge.tsx
+++ b/apps/web/src/components/hotkey-badge.tsx
@@ -1,10 +1,13 @@
+import { Text } from "@repo/ui"
 import { formatForDisplay, type RegisterableHotkey } from "@tanstack/react-hotkeys"
 
-export function HotkeyBadge({ hotkey }: { hotkey: RegisterableHotkey }) {
+export function HotkeyBadge({ hotkey }: { readonly hotkey: RegisterableHotkey }) {
   const label = formatForDisplay(hotkey)
   return (
-    <kbd className="ml-1.5 inline-flex items-center rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] leading-none text-muted-foreground">
-      {label}
-    </kbd>
+    <div className="flex items-center px-1 border border-current/30 rounded">
+      <Text.H7 asChild color="inherit">
+        <kbd>{label}</kbd>
+      </Text.H7>
+    </div>
   )
 }

--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items.collection.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items.collection.ts
@@ -1,10 +1,19 @@
 import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { useCallback, useEffect, useMemo } from "react"
+import { annotationQueueQueryKey } from "../annotation-queues/annotation-queues.collection.ts"
+import { annotationsByTraceQueryKey } from "../annotations/annotations.collection.ts"
+import { listAnnotationsByTrace } from "../annotations/annotations.functions.ts"
+import { traceDetailQueryKey } from "../traces/traces.collection.ts"
+import { getTraceDetail } from "../traces/traces.functions.ts"
 import {
   type AnnotationQueueItemRecord,
+  completeQueueItem,
   getAnnotationQueueItemDetail,
+  getQueueItemNavigation,
   listAnnotationQueueItemsByQueue,
+  uncompleteQueueItem,
 } from "./annotation-queue-items.functions.ts"
 
 const BATCH_SIZE = 50
@@ -13,6 +22,15 @@ export const ANNOTATION_QUEUE_ITEMS_DEFAULT_SORTING: InfiniteTableSorting = {
   column: "status",
   direction: "asc",
 }
+
+const annotationQueueItemsQueryKey = (projectId: string, queueId: string) =>
+  ["annotation-queue-items", projectId, queueId] as const
+
+const annotationQueueItemQueryKey = (projectId: string, queueId: string, itemId: string) =>
+  ["annotation-queue-item", projectId, queueId, itemId] as const
+
+const queueItemNavigationQueryKey = (projectId: string, queueId: string, itemId: string) =>
+  ["queue-item-navigation", projectId, queueId, itemId] as const
 
 export function useAnnotationQueueItemsInfiniteScroll({
   projectId,
@@ -30,7 +48,7 @@ export function useAnnotationQueueItemsInfiniteScroll({
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ["annotation-queue-items", projectId, queueId, sorting.column, sorting.direction],
+    queryKey: [...annotationQueueItemsQueryKey(projectId, queueId), sorting.column, sorting.direction],
     queryFn: async ({ pageParam }) => {
       const sortBy = sorting.column === "createdAt" ? "createdAt" : "status"
       const sortDirection =
@@ -83,8 +101,140 @@ export function useAnnotationQueueItem({
   readonly enabled?: boolean
 }) {
   return useQuery({
-    queryKey: ["annotation-queue-item", projectId, queueId, itemId],
+    queryKey: annotationQueueItemQueryKey(projectId, queueId, itemId),
     queryFn: () => getAnnotationQueueItemDetail({ data: { projectId, queueId, itemId } }),
     enabled: enabled && projectId.length > 0 && queueId.length > 0 && itemId.length > 0,
   })
+}
+
+function usePrefetchNavigationItems({
+  projectId,
+  queueId,
+  previousItemId,
+  nextItemId,
+}: {
+  readonly projectId: string
+  readonly queueId: string
+  readonly previousItemId: string | null | undefined
+  readonly nextItemId: string | null | undefined
+}) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!projectId) return
+
+    const prefetchItem = async (adjacentItemId: string | null | undefined) => {
+      if (!adjacentItemId) return
+
+      const item = await queryClient.fetchQuery({
+        queryKey: annotationQueueItemQueryKey(projectId, queueId, adjacentItemId),
+        queryFn: () => getAnnotationQueueItemDetail({ data: { projectId, queueId, itemId: adjacentItemId } }),
+        staleTime: 120_000,
+      })
+
+      if (!item?.traceId) return
+
+      queryClient.prefetchQuery({
+        queryKey: traceDetailQueryKey(projectId, item.traceId),
+        queryFn: () => getTraceDetail({ data: { projectId, traceId: item.traceId } }),
+        staleTime: 120_000,
+      })
+
+      queryClient.prefetchQuery({
+        queryKey: annotationsByTraceQueryKey(projectId, item.traceId),
+        queryFn: () => listAnnotationsByTrace({ data: { projectId, traceId: item.traceId, draftMode: "include" } }),
+        staleTime: 120_000,
+      })
+    }
+
+    prefetchItem(previousItemId)
+    prefetchItem(nextItemId)
+  }, [queryClient, projectId, queueId, previousItemId, nextItemId])
+}
+
+export function useQueueItemNavigation({
+  projectSlug,
+  projectId,
+  queueId,
+  itemId,
+  onQueueAllComplete,
+}: {
+  readonly projectSlug: string
+  readonly projectId: string
+  readonly queueId: string
+  readonly itemId: string
+  readonly onQueueAllComplete?: () => void
+}) {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const { data: navigation, isLoading } = useQuery({
+    queryKey: queueItemNavigationQueryKey(projectId, queueId, itemId),
+    queryFn: () => getQueueItemNavigation({ data: { projectId, queueId, itemId } }),
+    enabled: projectId.length > 0 && queueId.length > 0 && itemId.length > 0,
+  })
+
+  usePrefetchNavigationItems({
+    projectId,
+    queueId,
+    previousItemId: navigation?.previousItemId,
+    nextItemId: navigation?.nextItemId,
+  })
+
+  const invalidateQueries = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queueItemNavigationQueryKey(projectId, queueId, itemId) })
+    queryClient.invalidateQueries({ queryKey: annotationQueueItemQueryKey(projectId, queueId, itemId) })
+    queryClient.invalidateQueries({ queryKey: annotationQueueQueryKey(projectId, queueId) })
+    queryClient.invalidateQueries({ queryKey: annotationQueueItemsQueryKey(projectId, queueId) })
+  }, [queryClient, projectId, queueId, itemId])
+
+  const completeMutation = useMutation({
+    mutationFn: () => completeQueueItem({ data: { projectId, queueId, itemId } }),
+    onSuccess: (result) => {
+      invalidateQueries()
+      if (result.nextItemId) {
+        navigate({
+          to: "/projects/$projectSlug/annotation-queues/$queueId/items/$itemId",
+          params: { projectSlug, queueId, itemId: result.nextItemId },
+        })
+      } else {
+        onQueueAllComplete?.()
+      }
+    },
+  })
+
+  const uncompleteMutation = useMutation({
+    mutationFn: () => uncompleteQueueItem({ data: { projectId, queueId, itemId } }),
+    onSuccess: () => {
+      invalidateQueries()
+    },
+  })
+
+  const navigateTo = useCallback(
+    (targetItemId: string | null) => {
+      if (!targetItemId) return
+      navigate({
+        to: "/projects/$projectSlug/annotation-queues/$queueId/items/$itemId",
+        params: { projectSlug, queueId, itemId: targetItemId },
+      })
+    },
+    [navigate, projectSlug, queueId],
+  )
+
+  return {
+    previousItemId: navigation?.previousItemId ?? null,
+    nextItemId: navigation?.nextItemId ?? null,
+    currentIndex: navigation?.currentIndex ?? 0,
+    totalItems: navigation?.totalItems ?? 0,
+    isLoading,
+    navigateToPrevious: useCallback(
+      () => navigateTo(navigation?.previousItemId ?? null),
+      [navigateTo, navigation?.previousItemId],
+    ),
+    navigateToNext: useCallback(() => navigateTo(navigation?.nextItemId ?? null), [navigateTo, navigation?.nextItemId]),
+    complete: completeMutation.mutate,
+    uncomplete: uncompleteMutation.mutate,
+    isCompleting: completeMutation.isPending,
+    isUncompleting: uncompleteMutation.isPending,
+  }
 }

--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
@@ -3,8 +3,10 @@ import {
   type AnnotationQueueItemListOptions,
   type AnnotationQueueItemListSortBy,
   AnnotationQueueItemRepository,
+  completeQueueItemUseCase,
   requestBulkQueueItems,
   type TraceSelection,
+  uncompleteQueueItemUseCase,
 } from "@domain/annotation-queues"
 import { AnnotationQueueId, filterSetSchema, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { TraceRepository } from "@domain/spans"
@@ -257,6 +259,123 @@ export const getAnnotationQueueItemDetail = createServerFn({ method: "GET" })
           ...toItemRecord(item),
           traceDisplayName,
         }
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+interface QueueItemNavigationResult {
+  readonly previousItemId: string | null
+  readonly nextItemId: string | null
+  readonly currentIndex: number
+  readonly totalItems: number
+}
+
+export const getQueueItemNavigation = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      queueId: z.string(),
+      itemId: z.string(),
+    }),
+  )
+  .handler(async ({ data }): Promise<QueueItemNavigationResult> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const pg = getPostgresClient()
+
+    const layer = AnnotationQueueItemRepositoryLive.pipe(Layer.provideMerge(SqlClientLive(pg, orgId)))
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const itemRepo = yield* AnnotationQueueItemRepository
+
+        const [adjacent, position] = yield* Effect.all([
+          itemRepo.getAdjacentItems({
+            projectId,
+            queueId: data.queueId,
+            currentItemId: data.itemId,
+          }),
+          itemRepo.getQueuePosition({
+            projectId,
+            queueId: data.queueId,
+            currentItemId: data.itemId,
+          }),
+        ])
+
+        return {
+          previousItemId: adjacent.previousItemId,
+          nextItemId: adjacent.nextItemId,
+          currentIndex: position.currentIndex,
+          totalItems: position.totalItems,
+        }
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+export const completeQueueItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      queueId: z.string(),
+      itemId: z.string(),
+    }),
+  )
+  .handler(async ({ data }): Promise<{ nextItemId: string | null }> => {
+    const { organizationId, userId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const pg = getPostgresClient()
+
+    const layer = Layer.mergeAll(AnnotationQueueItemRepositoryLive, AnnotationQueueRepositoryLive).pipe(
+      Layer.provideMerge(SqlClientLive(pg, orgId)),
+    )
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const itemRepo = yield* AnnotationQueueItemRepository
+
+        yield* completeQueueItemUseCase({
+          projectId,
+          queueId: data.queueId,
+          itemId: data.itemId,
+          userId,
+        })
+
+        const nextItemId = yield* itemRepo.getNextUncompletedItem({
+          projectId,
+          queueId: data.queueId,
+          currentItemId: data.itemId,
+        })
+
+        return { nextItemId }
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+export const uncompleteQueueItem = createServerFn({ method: "POST" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      queueId: z.string(),
+      itemId: z.string(),
+    }),
+  )
+  .handler(async ({ data }): Promise<void> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const projectId = ProjectId(data.projectId)
+    const pg = getPostgresClient()
+
+    const layer = Layer.mergeAll(AnnotationQueueItemRepositoryLive, AnnotationQueueRepositoryLive).pipe(
+      Layer.provideMerge(SqlClientLive(pg, orgId)),
+    )
+
+    await Effect.runPromise(
+      uncompleteQueueItemUseCase({
+        projectId,
+        queueId: data.queueId,
+        itemId: data.itemId,
       }).pipe(Effect.provide(layer)),
     )
   })

--- a/apps/web/src/domains/annotation-queues/annotation-queues.collection.ts
+++ b/apps/web/src/domains/annotation-queues/annotation-queues.collection.ts
@@ -10,6 +10,9 @@ import {
 
 const BATCH_SIZE = 50
 
+export const annotationQueueQueryKey = (projectId: string, queueId: string) =>
+  ["annotation-queue", projectId, queueId] as const
+
 export const ANNOTATION_QUEUES_DEFAULT_SORTING: InfiniteTableSorting = {
   column: "createdAt",
   direction: "desc",
@@ -81,7 +84,7 @@ export function useAnnotationQueue({
   readonly enabled?: boolean
 }) {
   return useQuery({
-    queryKey: ["annotation-queue", projectId, queueId],
+    queryKey: annotationQueueQueryKey(projectId, queueId),
     queryFn: () => getAnnotationQueueByProject({ data: { projectId, queueId } }),
     enabled: enabled && projectId.length > 0 && queueId.length > 0,
   })

--- a/apps/web/src/domains/annotations/annotations.collection.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.ts
@@ -18,6 +18,14 @@ type DeleteAnnotationInput = Parameters<typeof deleteAnnotation>[0]["data"]
 /** Trace-scoped annotation lists default to including drafts so reload/refetch still shows in-progress rows (`draftedAt` set). */
 const DEFAULT_TRACE_DRAFT_MODE = "include" as const
 
+export const annotationsByTraceQueryKey = (
+  projectId: string,
+  traceId: string,
+  limit?: number,
+  offset?: number,
+  draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
+) => ["annotations", "trace", projectId, traceId, limit, offset, draftMode] as const
+
 export function useAnnotationsByTrace({
   projectId,
   traceId,
@@ -36,7 +44,7 @@ export function useAnnotationsByTrace({
   const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
 
   return useQuery({
-    queryKey: ["annotations", "trace", projectId, traceId, limit, offset, effectiveDraftMode],
+    queryKey: annotationsByTraceQueryKey(projectId, traceId, limit, offset, effectiveDraftMode),
     queryFn: () =>
       listAnnotationsByTrace({
         data: { projectId, traceId, limit, offset, draftMode: effectiveDraftMode },

--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -57,6 +57,9 @@ const toListResult = (page: ScoreListPage) => ({
 
 type AnnotationListResult = ReturnType<typeof toListResult>
 
+/** Annotations created from a queue must pass queue.id as sourceId; otherwise defaults to "UI". */
+const getSourceId = (queueId: string | undefined) => queueId ?? "UI"
+
 export const createAnnotation = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
@@ -64,6 +67,7 @@ export const createAnnotation = createServerFn({ method: "POST" })
       traceId: z.string().length(32),
       spanId: z.string().optional(),
       sessionId: z.string().optional(),
+      queueId: z.string().optional(),
       value: z.number(),
       passed: z.boolean(),
       feedback: z.string().min(1),
@@ -83,7 +87,7 @@ export const createAnnotation = createServerFn({ method: "POST" })
       writeDraftAnnotationUseCase({
         organizationId: organizationId,
         projectId: ProjectId(data.projectId),
-        sourceId: "UI",
+        sourceId: getSourceId(data.queueId),
         traceId: data.traceId,
         spanId: data.spanId ?? null,
         sessionId: data.sessionId ?? null,
@@ -112,6 +116,7 @@ export const updateAnnotation = createServerFn({ method: "POST" })
       scoreId: z.string(),
       projectId: z.string(),
       traceId: z.string().length(32),
+      queueId: z.string().optional(),
       value: z.number(),
       passed: z.boolean(),
       feedback: z.string().min(1),
@@ -131,7 +136,7 @@ export const updateAnnotation = createServerFn({ method: "POST" })
         organizationId: organizationId,
         id: ScoreId(data.scoreId),
         projectId: ProjectId(data.projectId),
-        sourceId: "UI",
+        sourceId: getSourceId(data.queueId),
         traceId: data.traceId,
         issueId: data.issueId ?? null,
         value: data.value,

--- a/apps/web/src/domains/traces/traces.collection.ts
+++ b/apps/web/src/domains/traces/traces.collection.ts
@@ -18,6 +18,8 @@ import {
   type TraceRecord,
 } from "./traces.functions.ts"
 
+export const traceDetailQueryKey = (projectId: string, traceId: string) => ["traceDetail", projectId, traceId] as const
+
 const BATCH_SIZE = 50
 
 export function useTracesInfiniteScroll({
@@ -168,7 +170,7 @@ export function useTraceDetail({
   readonly enabled?: boolean
 }) {
   return useQuery({
-    queryKey: ["traceDetail", projectId, traceId],
+    queryKey: traceDetailQueryKey(projectId, traceId),
     // getTraceDetail returns `never` at the type level to satisfy TanStack Start's
     // Serialize constraint (see traces.functions.ts); cast back to the actual type
     queryFn: async () => {

--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -264,7 +264,9 @@ export function AppSidebar({
                 </Button>
               }
             >
-              {collapsed ? "Expand" : "Collapse"} <HotkeyBadge hotkey="Mod+B" />
+              <div className="flex items-center gap-1">
+                {collapsed ? "Expand" : "Collapse"} <HotkeyBadge hotkey="Mod+B" />
+              </div>
             </Tooltip>
           </div>
           {!collapsed && subtitle ? <div className="min-w-0">{subtitle}</div> : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/message-annotation-trigger.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/message-annotation-trigger.tsx
@@ -18,6 +18,7 @@ export function MessageAnnotationTrigger({
   spanId,
   annotations,
   annotators,
+  onClose,
 }: {
   readonly messageIndex: number
   readonly projectId: string
@@ -25,8 +26,16 @@ export function MessageAnnotationTrigger({
   readonly spanId?: string | undefined
   readonly annotations: readonly AnnotationRecord[]
   readonly annotators: readonly Annotator[]
+  readonly onClose?: (() => void) | undefined
 }) {
   const [open, setOpen] = useState(false)
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen)
+    if (!nextOpen) {
+      onClose?.()
+    }
+  }
   const { createAnnotation, updateAnnotation, isCreatePending, isUpdatePending } = useTraceAnnotationsData({
     projectId,
     traceId,
@@ -45,7 +54,7 @@ export function MessageAnnotationTrigger({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
@@ -1,4 +1,5 @@
 import { cn, Skeleton, Text } from "@repo/ui"
+import { useAnnotationQueue } from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
 import {
   useAnnotationsByTrace,
   useCreateAnnotation,
@@ -12,11 +13,13 @@ import { isGlobalAnnotation } from "./hooks/use-annotation-navigation.ts"
 export function TraceAnnotationsList({
   projectId,
   traceId,
+  queueId,
   selectedAnnotationId,
   onAnnotationClick,
 }: {
   readonly projectId: string
   readonly traceId: string
+  readonly queueId?: string | undefined
   readonly selectedAnnotationId?: string | undefined
   readonly onAnnotationClick?: ((annotation: AnnotationRecord) => void) | undefined
 }) {
@@ -24,6 +27,11 @@ export function TraceAnnotationsList({
     projectId,
     traceId,
     draftMode: "include",
+  })
+  const { data: queue, isLoading: queueLoading } = useAnnotationQueue({
+    projectId,
+    queueId: queueId ?? "",
+    enabled: !!queueId,
   })
 
   const createMutation = useCreateAnnotation()
@@ -38,6 +46,7 @@ export function TraceAnnotationsList({
     createMutation.mutate({
       projectId,
       traceId,
+      queueId,
       value: data.passed ? 1 : 0,
       passed: data.passed,
       feedback: data.comment || " ",
@@ -53,6 +62,7 @@ export function TraceAnnotationsList({
       scoreId: annotation.id,
       projectId,
       traceId,
+      queueId,
       value: data.passed ? 1 : 0,
       passed: data.passed,
       feedback: data.comment || " ",
@@ -62,6 +72,21 @@ export function TraceAnnotationsList({
 
   return (
     <div className="flex flex-col flex-1 overflow-y-auto custom-scrollbar p-6 gap-6">
+      {queueId && (
+        <>
+          <div className="flex flex-col">
+            <Text.H5M>Instructions</Text.H5M>
+            {queueLoading ? (
+              <Skeleton className="h-12 w-full" />
+            ) : (
+              <Text.H5 color="foregroundMuted">
+                {queue?.instructions?.trim() ? queue.instructions : "No instructions provided for this queue"}
+              </Text.H5>
+            )}
+          </div>
+          <hr className="border border-border border-dashed" />
+        </>
+      )}
       <div className="flex flex-col">
         <div className="flex items-center gap-1">
           <Text.H5M>Annotations</Text.H5M>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -19,6 +19,7 @@ function ConversationContent({
   isActive,
   scrollContainerRef,
   textSelectionPopoverControlsRef,
+  onPopoverClose,
 }: {
   readonly traceDetail: TraceDetailRecord
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
@@ -26,6 +27,7 @@ function ConversationContent({
   readonly isActive: boolean
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null> | undefined
   readonly textSelectionPopoverControlsRef?: MutableRefObject<TextSelectionPopoverControls | null> | undefined
+  readonly onPopoverClose?: (() => void) | undefined
 }) {
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = scrollContainerRef ?? internalScrollRef
@@ -122,6 +124,7 @@ function ConversationContent({
                 spanId={spanMaps?.messageSpanMap[messageIndex]}
                 annotations={data?.annotations ?? []}
                 annotators={data?.annotators ?? []}
+                onClose={onPopoverClose}
               />
             )
           }}
@@ -137,7 +140,10 @@ function ConversationContent({
           isUpdateLoading={isUpdatePending}
           onSave={createTextSelectionAnnotation}
           onUpdate={updateTextSelectionAnnotation}
-          onClose={closeAnnotationPopover}
+          onClose={() => {
+            closeAnnotationPopover()
+            onPopoverClose?.()
+          }}
         />
       </div>
       <div className="absolute top-4 right-4 z-10">
@@ -169,6 +175,7 @@ export function ConversationTab({
   isActive,
   scrollContainerRef,
   textSelectionPopoverControlsRef,
+  onPopoverClose,
 }: {
   readonly traceDetail: TraceDetailRecord | null | undefined
   readonly isDetailLoading: boolean
@@ -179,6 +186,8 @@ export function ConversationTab({
   /** Optional ref to the scroll container. Used for external scroll control (e.g., annotation navigation). */
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null> | undefined
   readonly textSelectionPopoverControlsRef?: MutableRefObject<TextSelectionPopoverControls | null> | undefined
+  /** Optional callback when annotation popover closes. Used to clear selection state. */
+  readonly onPopoverClose?: (() => void) | undefined
 }) {
   if (isDetailLoading) {
     return (
@@ -206,6 +215,7 @@ export function ConversationTab({
       projectId={projectId}
       scrollContainerRef={scrollContainerRef}
       textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
+      onPopoverClose={onPopoverClose}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
@@ -1,4 +1,4 @@
-import { DetailDrawer, Text } from "@repo/ui"
+import { DetailDrawer, DetailSummary, Text } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useEffect, useRef, useSyncExternalStore } from "react"
@@ -18,6 +18,8 @@ import { TraceAnnotationsList } from "../../../-components/annotations/trace-ann
 import { ConversationTab } from "../../../-components/trace-detail-drawer/tabs/conversation-tab.tsx"
 import { TraceTab } from "../../../-components/trace-detail-drawer/tabs/trace-tab.tsx"
 import { QueueItemLeafBreadcrumb } from "../../-components/queue-item-leaf-breadcrumb.tsx"
+import { QueueItemStatusBadge } from "../../-components/queue-item-status-badge.tsx"
+import { QueueItemToolbar } from "../../-components/queue-item-toolbar.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId")({
   staticData: {
@@ -51,7 +53,7 @@ function AnnotationQueueItemDetailPage() {
   const textSelectionPopoverControlsRef = useRef<TextSelectionPopoverControls | null>(null)
   const [selectedAnnotationId, setSelectedAnnotationId] = useParamState("annotationId", "")
 
-  const { data: project } = useProjectsCollection(
+  const { data: project, isLoading: projectLoading } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),
     [projectSlug],
   )
@@ -112,6 +114,10 @@ function AnnotationQueueItemDetailPage() {
   const isDetailLoading = hasTraceParams && traceDetailLoading
   const traceNotFound = hasTraceParams && !traceDetailLoading && traceDetail === null
 
+  if (projectLoading || !projectId) {
+    return null
+  }
+
   if (projectId.length > 0 && !itemLoading && itemDetail === null) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-4 p-8">
@@ -145,48 +151,82 @@ function AnnotationQueueItemDetailPage() {
   }
 
   return (
-    <div className="flex flex-row h-full w-full overflow-hidden">
-      <DetailDrawer
-        storeKey="aq-item-left-panel"
-        minWidth={LEFT_MIN_WIDTH}
-        defaultWidth={LEFT_DEFAULT_WIDTH}
-        maxWidth={leftMaxWidth}
-        resizeFrom="right"
-      >
-        <TraceTab
-          traceId={traceId}
-          traceRecord={traceDetail ?? undefined}
-          traceDetail={traceDetail}
-          isRecordLoading={isRecordLoading}
-          isDetailLoading={isDetailLoading}
-          defaultSectionsOpen={false}
-        />
-      </DetailDrawer>
+    <div className="flex flex-col h-full w-full overflow-hidden">
+      <div className="flex flex-row flex-1 min-h-0 overflow-hidden">
+        <DetailDrawer
+          storeKey="aq-item-left-panel"
+          minWidth={LEFT_MIN_WIDTH}
+          defaultWidth={LEFT_DEFAULT_WIDTH}
+          maxWidth={leftMaxWidth}
+          resizeFrom="right"
+        >
+          <div className="flex flex-col gap-6 py-6 px-4 border-b border-border">
+            <DetailSummary
+              items={[
+                {
+                  label: "Trace",
+                  value: itemDetail?.traceDisplayName,
+                  isLoading: itemLoading,
+                },
+              ]}
+            />
+            <div className="flex flex-col gap-0.5">
+              <Text.H6 color="foregroundMuted">Status</Text.H6>
+              {itemLoading ? (
+                <div className="h-5 w-20 bg-muted animate-pulse rounded" />
+              ) : itemDetail ? (
+                <div>
+                  <QueueItemStatusBadge row={itemDetail} />
+                </div>
+              ) : null}
+            </div>
+          </div>
+          <TraceTab
+            traceId={traceId}
+            traceRecord={traceDetail ?? undefined}
+            traceDetail={traceDetail}
+            isRecordLoading={isRecordLoading}
+            isDetailLoading={isDetailLoading}
+            defaultSectionsOpen={false}
+          />
+        </DetailDrawer>
 
-      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <ConversationTab
-          isActive
-          traceDetail={traceDetail}
-          isDetailLoading={isDetailLoading || itemLoading}
-          projectId={projectId}
-          scrollContainerRef={scrollContainerRef}
-          textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
-        />
+        <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+          <ConversationTab
+            isActive
+            traceDetail={traceDetail}
+            isDetailLoading={isDetailLoading || itemLoading}
+            projectId={projectId}
+            scrollContainerRef={scrollContainerRef}
+            textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
+            onPopoverClose={() => setSelectedAnnotationId("")}
+          />
+        </div>
+
+        <DetailDrawer
+          minWidth={RIGHT_MIN_WIDTH}
+          defaultWidth={rightDefaultWidth}
+          maxWidth={rightMaxWidth}
+          resizeFrom="left"
+        >
+          <TraceAnnotationsList
+            projectId={projectId}
+            traceId={traceId}
+            queueId={queueId}
+            selectedAnnotationId={selectedAnnotationId}
+            onAnnotationClick={handleAnnotationClick}
+          />
+        </DetailDrawer>
       </div>
 
-      <DetailDrawer
-        minWidth={RIGHT_MIN_WIDTH}
-        defaultWidth={rightDefaultWidth}
-        maxWidth={rightMaxWidth}
-        resizeFrom="left"
-      >
-        <TraceAnnotationsList
-          projectId={projectId}
-          traceId={traceId}
-          selectedAnnotationId={selectedAnnotationId}
-          onAnnotationClick={handleAnnotationClick}
-        />
-      </DetailDrawer>
+      <QueueItemToolbar
+        projectSlug={projectSlug}
+        projectId={projectId}
+        queueId={queueId}
+        itemId={itemId}
+        traceId={traceId}
+        isCompleted={!!itemDetail?.completedAt}
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/queue-item-toolbar.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/queue-item-toolbar.tsx
@@ -1,0 +1,167 @@
+import { QUEUE_REVIEW_HOTKEYS } from "@domain/annotation-queues"
+import { Button, Icon, Modal, Text, Tooltip } from "@repo/ui"
+import { useHotkeys } from "@tanstack/react-hotkeys"
+import { useNavigate } from "@tanstack/react-router"
+import { ArrowBigLeftIcon, ArrowBigRightIcon, Plus } from "lucide-react"
+import { useState } from "react"
+import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
+import { useQueueItemNavigation } from "../../../../../../domains/annotation-queue-items/annotation-queue-items.collection.ts"
+import { AddToDatasetModal } from "../../datasets/-components/add-to-dataset-modal.tsx"
+
+interface QueueItemToolbarProps {
+  readonly projectSlug: string
+  readonly projectId: string
+  readonly queueId: string
+  readonly itemId: string
+  readonly traceId: string
+  readonly isCompleted: boolean
+}
+
+export function QueueItemToolbar({
+  projectSlug,
+  projectId,
+  queueId,
+  itemId,
+  traceId,
+  isCompleted,
+}: QueueItemToolbarProps) {
+  const [datasetModalOpen, setDatasetModalOpen] = useState(false)
+  const [allCompleteModalOpen, setAllCompleteModalOpen] = useState(false)
+  const navigate = useNavigate()
+
+  const {
+    previousItemId,
+    nextItemId,
+    currentIndex,
+    totalItems,
+    navigateToPrevious,
+    navigateToNext,
+    complete,
+    uncomplete,
+    isCompleting,
+    isUncompleting,
+  } = useQueueItemNavigation({
+    projectSlug,
+    projectId,
+    queueId,
+    itemId,
+    onQueueAllComplete: () => setAllCompleteModalOpen(true),
+  })
+
+  const handleCompletionToggle = () => {
+    if (isCompleted) {
+      uncomplete()
+    } else {
+      complete()
+    }
+  }
+
+  useHotkeys([
+    {
+      hotkey: QUEUE_REVIEW_HOTKEYS.previousItem,
+      callback: navigateToPrevious,
+      options: { enabled: !!previousItemId },
+    },
+    {
+      hotkey: QUEUE_REVIEW_HOTKEYS.nextItem,
+      callback: navigateToNext,
+      options: { enabled: !!nextItemId },
+    },
+    {
+      hotkey: QUEUE_REVIEW_HOTKEYS.markComplete,
+      callback: handleCompletionToggle,
+      options: { enabled: !isCompleting && !isUncompleting },
+    },
+    {
+      hotkey: QUEUE_REVIEW_HOTKEYS.addToDataset,
+      callback: () => setDatasetModalOpen(true),
+    },
+  ])
+
+  const selection = { mode: "selected" as const, rowIds: [traceId] }
+  const isBusy = isCompleting || isUncompleting
+
+  const completionButton = (
+    <Button
+      variant={isCompleted ? "outline" : "default"}
+      size="sm"
+      onClick={handleCompletionToggle}
+      disabled={isBusy}
+      isLoading={isBusy}
+    >
+      {isCompleted ? "Uncomplete" : "Complete"}
+      <HotkeyBadge hotkey={QUEUE_REVIEW_HOTKEYS.markComplete} />
+    </Button>
+  )
+
+  return (
+    <>
+      <div className="flex items-center justify-between border-t bg-background px-4 py-2">
+        <Button variant="outline" size="sm" onClick={() => setDatasetModalOpen(true)}>
+          <Icon icon={Plus} size="sm" />
+          Add to dataset
+          <HotkeyBadge hotkey={QUEUE_REVIEW_HOTKEYS.addToDataset} />
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <Text.H6 color="foregroundMuted">
+            {currentIndex} of {totalItems}
+          </Text.H6>
+
+          <Button variant="outline" onClick={navigateToPrevious} disabled={!previousItemId} aria-label="Previous item">
+            <Icon icon={ArrowBigLeftIcon} size="sm" color="foreground" />
+            <HotkeyBadge hotkey={QUEUE_REVIEW_HOTKEYS.previousItem} />
+          </Button>
+
+          <Button variant="outline" onClick={navigateToNext} disabled={!nextItemId} aria-label="Next item">
+            <HotkeyBadge hotkey={QUEUE_REVIEW_HOTKEYS.nextItem} />
+            <Icon icon={ArrowBigRightIcon} size="sm" />
+          </Button>
+
+          {isCompleted ? (
+            completionButton
+          ) : (
+            <Tooltip trigger={completionButton} asChild>
+              Mark as complete and move to the next pending item
+            </Tooltip>
+          )}
+        </div>
+      </div>
+
+      <AddToDatasetModal
+        open={datasetModalOpen}
+        onOpenChange={setDatasetModalOpen}
+        projectId={projectId}
+        selection={selection}
+        selectedCount={1}
+        onSuccess={() => setDatasetModalOpen(false)}
+      />
+
+      <Modal
+        open={allCompleteModalOpen}
+        onOpenChange={setAllCompleteModalOpen}
+        title="🎉 All items completed!"
+        description="There are no more pending items in this annotation queue."
+        dismissible
+        footer={
+          <>
+            <Button variant="outline" onClick={() => setAllCompleteModalOpen(false)}>
+              Close
+            </Button>
+            <Button
+              onClick={() => {
+                setAllCompleteModalOpen(false)
+                navigate({
+                  to: "/projects/$projectSlug/annotation-queues/$queueId",
+                  params: { projectSlug, queueId },
+                })
+              }}
+            >
+              View list
+            </Button>
+          </>
+        }
+      />
+    </>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
@@ -74,17 +74,6 @@ function AnnotationQueuesPage() {
         ),
       },
       {
-        key: "instructions",
-        header: "Instructions",
-        minWidth: 220,
-        width: 360,
-        render: (q) => (
-          <Text.H5 color="foregroundMuted" display="block" lineClamp={3}>
-            {q.instructions?.trim() ? q.instructions : "—"}
-          </Text.H5>
-        ),
-      },
-      {
         key: "createdAt",
         header: "Created",
         sortKey: "createdAt",

--- a/apps/workers/src/workers/annotation-scores.ts
+++ b/apps/workers/src/workers/annotation-scores.ts
@@ -1,9 +1,11 @@
+import { markReviewStartedUseCase } from "@domain/annotation-queues"
 import { publishHumanAnnotationUseCase } from "@domain/annotations"
 import type { QueueConsumer } from "@domain/queue"
 import { WorkflowStarter, type WorkflowStarterShape } from "@domain/queue"
+import { ScoreRepository } from "@domain/scores"
 import { OrganizationId, type ScoreId } from "@domain/shared"
 import type { PostgresClient } from "@platform/db-postgres"
-import { ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { AnnotationQueueItemRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { createLogger } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getPostgresClient } from "../clients.ts"
@@ -37,6 +39,31 @@ export const createAnnotationScoresWorker = ({ consumer, workflowStarter, postgr
           Effect.sync(() =>
             logger.error(`Annotation publication failed for ${payload.projectId}/${payload.scoreId}`, error),
           ),
+        ),
+        Effect.asVoid,
+      ),
+
+    markReviewStarted: (payload) =>
+      Effect.gen(function* () {
+        const scoreRepo = yield* ScoreRepository
+        const score = yield* scoreRepo.findById(payload.scoreId as ScoreId)
+
+        const count = yield* markReviewStartedUseCase({ score })
+
+        if (count > 0) {
+          logger.info(`Marked ${count} queue item(s) as in-progress for trace ${score.traceId}`)
+        }
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(ScoreRepositoryLive, AnnotationQueueItemRepositoryLive),
+          pgClient,
+          OrganizationId(payload.organizationId),
+        ),
+        Effect.catchTag("NotFoundError", () =>
+          Effect.sync(() => logger.warn(`Score ${payload.scoreId} not found, skipping markReviewStarted`)),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() => logger.error(`markReviewStarted failed for score ${payload.scoreId}`, error)),
         ),
         Effect.asVoid,
       ),

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -239,7 +239,7 @@ describe("domain-events dispatcher", () => {
     expect(published[0]?.options?.debounceMs).toBe(ISSUE_REFRESH_DEBOUNCE_MS)
   })
 
-  it("routes ScoreCreated to issues:discovery and debounced annotation-scores publish", async () => {
+  it("routes ScoreCreated to issues:discovery, annotation-scores publish, and markReviewStarted", async () => {
     const { consumer, published } = setupDispatcher()
 
     const envelope = makeEnvelope("ScoreCreated", {
@@ -276,6 +276,19 @@ describe("domain-events dispatcher", () => {
         },
         options: {
           debounceMs: SCORE_PUBLICATION_DEBOUNCE,
+        },
+      },
+      {
+        queue: "annotation-scores",
+        task: "markReviewStarted",
+        payload: {
+          organizationId: "org-1",
+          projectId: "proj-1",
+          scoreId: "score-3",
+          issueId: null,
+        },
+        options: {
+          dedupeKey: "annotation-scores:mark-review-started:score-3",
         },
       },
     ])

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -83,6 +83,9 @@ export const createDomainEventsWorker = ({
         pub.publish("annotation-scores", "publishHumanAnnotation", event.payload, {
           debounceMs: SCORE_PUBLICATION_DEBOUNCE, // 5 minutes
         }),
+        pub.publish("annotation-scores", "markReviewStarted", event.payload, {
+          dedupeKey: `annotation-scores:mark-review-started:${event.payload.scoreId}`,
+        }),
       ]),
 
     ScoreAssignedToIssue: (event) =>

--- a/apps/workflows/src/activities/annotation-publication-activities.ts
+++ b/apps/workflows/src/activities/annotation-publication-activities.ts
@@ -54,11 +54,9 @@ export const writePublishedAnnotationScore = async (input: {
         )
 
       if (score.source !== "annotation") {
-        return yield* Effect.fail(
-          new BadRequestError({
-            message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
-          }),
-        )
+        return yield* new BadRequestError({
+          message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
+        })
       }
 
       const toWrite = mergeEnrichmentIntoAnnotationScoreForPublication(score as AnnotationScore, {

--- a/packages/domain/annotation-queues/src/constants.ts
+++ b/packages/domain/annotation-queues/src/constants.ts
@@ -67,11 +67,10 @@ export const ANNOTATION_QUEUE_SLUG_MAX_LENGTH = 140
 // ---------------------------------------------------------------------------
 
 export const QUEUE_REVIEW_HOTKEYS = {
-  previousItem: "Shift+J",
-  nextItem: "Shift+K",
-  markComplete: "Shift+Enter",
+  previousItem: "Shift+H",
+  nextItem: "Shift+L",
+  markComplete: "Mod+Enter",
   addToDataset: "Shift+D",
-  newAnnotation: "Shift+A",
 } as const
 
 // ---------------------------------------------------------------------------

--- a/packages/domain/annotation-queues/src/errors.ts
+++ b/packages/domain/annotation-queues/src/errors.ts
@@ -9,3 +9,24 @@ export class TooManyTracesSelectedError extends Data.TaggedError("TooManyTracesS
     return `Selection contains ${this.count} traces, but the limit is ${this.limit}`
   }
 }
+
+export class QueueItemNotFoundError extends Data.TaggedError("QueueItemNotFoundError")<{
+  readonly itemId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "Queue item not found"
+}
+
+export class QueueItemAlreadyCompletedError extends Data.TaggedError("QueueItemAlreadyCompletedError")<{
+  readonly itemId: string
+}> {
+  readonly httpStatus = 409
+  readonly httpMessage = "Queue item is already completed"
+}
+
+export class QueueItemNotCompletedError extends Data.TaggedError("QueueItemNotCompletedError")<{
+  readonly itemId: string
+}> {
+  readonly httpStatus = 409
+  readonly httpMessage = "Queue item is not completed"
+}

--- a/packages/domain/annotation-queues/src/index.ts
+++ b/packages/domain/annotation-queues/src/index.ts
@@ -44,6 +44,7 @@ export {
   matchesToolCallErrorsSystemQueue,
 } from "./helpers.ts"
 export {
+  type AdjacentItems,
   type AnnotationQueueItemListCursor,
   type AnnotationQueueItemListOptions,
   type AnnotationQueueItemListPage,
@@ -52,8 +53,14 @@ export {
   type AnnotationQueueItemRepositoryShape,
   type BulkInsertAnnotationQueueItemInput,
   type FindAnnotationQueueItemInput,
+  type GetAdjacentItemsInput,
+  type GetNextUncompletedItemInput,
+  type GetQueuePositionInput,
   type InsertAnnotationQueueItemInput,
   type ListAnnotationQueueItemsInput,
+  type ListByTraceIdInput,
+  type QueuePosition,
+  type UpdateAnnotationQueueItemInput,
 } from "./ports/annotation-queue-item-repository.ts"
 export {
   type AnnotationQueueListCursor,
@@ -64,10 +71,16 @@ export {
   type AnnotationQueueRepositoryShape,
   type FindBySlugInput,
   type FindSystemQueueBySlugInput,
+  type IncrementCompletedItemsInput,
   type ListAnnotationQueuesInput,
   type ListSystemQueuesInput,
 } from "./ports/annotation-queue-repository.ts"
 export { type AddTracesToQueueError, addTracesToQueue } from "./use-cases/add-traces-to-queue.ts"
+export {
+  type CompleteQueueItemError,
+  type CompleteQueueItemInput,
+  completeQueueItemUseCase,
+} from "./use-cases/complete-queue-item.ts"
 export {
   type DraftSystemQueueAnnotationError,
   type DraftSystemQueueAnnotationOutput,
@@ -81,6 +94,10 @@ export {
   getProjectSystemQueuesUseCase,
   type SystemQueueCacheEntry,
 } from "./use-cases/get-project-system-queues.ts"
+export {
+  type MarkReviewStartedInput,
+  markReviewStartedUseCase,
+} from "./use-cases/mark-review-started.ts"
 export {
   type PersistSystemQueueAnnotationError,
   type PersistSystemQueueAnnotationInput,
@@ -117,3 +134,8 @@ export {
   systemQueueAnnotateOutputSchema,
   systemQueueAnnotatorOutputSchema,
 } from "./use-cases/system-queue-annotator-contracts.ts"
+export {
+  type UncompleteQueueItemError,
+  type UncompleteQueueItemInput,
+  uncompleteQueueItemUseCase,
+} from "./use-cases/uncomplete-queue-item.ts"

--- a/packages/domain/annotation-queues/src/ports/annotation-queue-item-repository.ts
+++ b/packages/domain/annotation-queues/src/ports/annotation-queue-item-repository.ts
@@ -1,4 +1,4 @@
-import type { ProjectId, RepositoryError, TraceId } from "@domain/shared"
+import type { NotFoundError, ProjectId, RepositoryError, TraceId } from "@domain/shared"
 import { type Effect, ServiceMap } from "effect"
 import type { AnnotationQueueItem } from "../entities/annotation-queue-items.ts"
 
@@ -53,6 +53,48 @@ export interface BulkInsertAnnotationQueueItemInput {
   readonly items: ReadonlyArray<{ readonly traceId: TraceId; readonly traceCreatedAt: Date }>
 }
 
+export interface GetAdjacentItemsInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly currentItemId: string
+}
+
+export interface AdjacentItems {
+  readonly previousItemId: string | null
+  readonly nextItemId: string | null
+}
+
+export interface GetQueuePositionInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly currentItemId: string
+}
+
+export interface QueuePosition {
+  readonly currentIndex: number
+  readonly totalItems: number
+}
+
+export interface UpdateAnnotationQueueItemInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly itemId: string
+  readonly completedAt?: Date | null
+  readonly completedBy?: string | null
+  readonly reviewStartedAt?: Date | null
+}
+
+export interface GetNextUncompletedItemInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly currentItemId: string
+}
+
+export interface ListByTraceIdInput {
+  readonly projectId: ProjectId
+  readonly traceId: string
+}
+
 export interface AnnotationQueueItemRepositoryShape {
   listByQueue(input: ListAnnotationQueueItemsInput): Effect.Effect<AnnotationQueueItemListPage, RepositoryError>
   findById(input: FindAnnotationQueueItemInput): Effect.Effect<AnnotationQueueItem | null, RepositoryError>
@@ -70,6 +112,15 @@ export interface AnnotationQueueItemRepositoryShape {
   bulkInsertIfNotExists(
     input: BulkInsertAnnotationQueueItemInput,
   ): Effect.Effect<{ insertedCount: number }, RepositoryError>
+  listByTraceId(input: ListByTraceIdInput): Effect.Effect<readonly AnnotationQueueItem[], RepositoryError>
+  getAdjacentItems(input: GetAdjacentItemsInput): Effect.Effect<AdjacentItems, RepositoryError>
+  getQueuePosition(input: GetQueuePositionInput): Effect.Effect<QueuePosition, RepositoryError>
+  update(input: UpdateAnnotationQueueItemInput): Effect.Effect<AnnotationQueueItem, RepositoryError | NotFoundError>
+  /**
+   * Finds the first uncompleted item in the queue ordered by `traceCreatedAt DESC`.
+   * Returns null if all items in the queue are completed.
+   */
+  getNextUncompletedItem(input: GetNextUncompletedItemInput): Effect.Effect<string | null, RepositoryError>
 }
 
 export class AnnotationQueueItemRepository extends ServiceMap.Service<

--- a/packages/domain/annotation-queues/src/ports/annotation-queue-repository.ts
+++ b/packages/domain/annotation-queues/src/ports/annotation-queue-repository.ts
@@ -50,6 +50,12 @@ export interface ListSystemQueuesInput {
   readonly projectId: ProjectId
 }
 
+export interface IncrementCompletedItemsInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly delta: number
+}
+
 export interface AnnotationQueueRepositoryShape {
   listByProject(input: ListAnnotationQueuesInput): Effect.Effect<AnnotationQueueListPage, RepositoryError>
   findByIdInProject(input: {
@@ -70,13 +76,17 @@ export interface AnnotationQueueRepositoryShape {
   insertIfNotExists(queue: AnnotationQueue): Effect.Effect<boolean, RepositoryError>
   /**
    * Atomically increment the totalItems counter for a queue by the given delta (defaults to 1).
-   * Returns the updated queue.
    */
   incrementTotalItems(input: {
     projectId: ProjectId
     queueId: string
     delta?: number
   }): Effect.Effect<AnnotationQueue, RepositoryError>
+  /**
+   * Adjust the completedItems counter by delta (positive to increment, negative to decrement).
+   * The counter is clamped to prevent going below zero.
+   */
+  incrementCompletedItems(input: IncrementCompletedItemsInput): Effect.Effect<void, RepositoryError>
 }
 
 export class AnnotationQueueRepository extends ServiceMap.Service<

--- a/packages/domain/annotation-queues/src/testing/fake-annotation-queue-item-repository.ts
+++ b/packages/domain/annotation-queues/src/testing/fake-annotation-queue-item-repository.ts
@@ -1,12 +1,127 @@
+import { AnnotationQueueId, AnnotationQueueItemId, generateId, NotFoundError } from "@domain/shared"
 import { Effect } from "effect"
+import type { AnnotationQueueItem } from "../entities/annotation-queue-items.ts"
 import type { AnnotationQueueItemRepositoryShape } from "../ports/annotation-queue-item-repository.ts"
 
 export const createFakeAnnotationQueueItemRepository = (
-  overrides?: Partial<AnnotationQueueItemRepositoryShape>,
-): AnnotationQueueItemRepositoryShape => ({
-  listByQueue: () => Effect.succeed({ items: [], hasMore: false }),
-  findById: () => Effect.succeed(null),
-  insertIfNotExists: () => Effect.succeed(true),
-  bulkInsertIfNotExists: ({ items }) => Effect.succeed({ insertedCount: items.length }),
-  ...overrides,
-})
+  seedOrOverrides?: readonly AnnotationQueueItem[] | Partial<AnnotationQueueItemRepositoryShape>,
+  maybeOverrides?: Partial<AnnotationQueueItemRepositoryShape>,
+) => {
+  const seed = Array.isArray(seedOrOverrides) ? seedOrOverrides : []
+  const overrides = Array.isArray(seedOrOverrides) ? maybeOverrides : seedOrOverrides
+
+  const items = new Map<string, AnnotationQueueItem>(seed.map((item) => [item.id, item] as const))
+
+  const repository: AnnotationQueueItemRepositoryShape = {
+    insertIfNotExists: ({ projectId, queueId, traceId, traceCreatedAt }) =>
+      Effect.sync(() => {
+        const exists = [...items.values()].some(
+          (i) => i.projectId === projectId && i.queueId === queueId && i.traceId === traceId,
+        )
+        if (exists) return false
+
+        const now = new Date()
+        const newItem: AnnotationQueueItem = {
+          id: AnnotationQueueItemId(generateId()),
+          organizationId: "",
+          projectId,
+          queueId: AnnotationQueueId(queueId),
+          traceId,
+          traceCreatedAt,
+          completedAt: null,
+          completedBy: null,
+          reviewStartedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        }
+        items.set(newItem.id, newItem)
+        return true
+      }),
+
+    listByQueue: ({ projectId, queueId, options }) =>
+      Effect.sync(() => {
+        const filtered = [...items.values()].filter((i) => i.projectId === projectId && i.queueId === queueId)
+        const limit = options?.limit ?? 50
+        return {
+          items: filtered.slice(0, limit),
+          hasMore: filtered.length > limit,
+        }
+      }),
+
+    listByTraceId: ({ projectId, traceId }) =>
+      Effect.sync(() => [...items.values()].filter((i) => i.projectId === projectId && i.traceId === traceId)),
+
+    findById: ({ projectId, queueId, itemId }) =>
+      Effect.sync(() => {
+        const item = items.get(itemId)
+        if (!item || item.projectId !== projectId || item.queueId !== queueId) return null
+        return item
+      }),
+
+    getAdjacentItems: () =>
+      Effect.sync(() => ({
+        previousItemId: null,
+        nextItemId: null,
+      })),
+
+    getQueuePosition: () =>
+      Effect.sync(() => ({
+        currentIndex: 1,
+        totalItems: items.size,
+      })),
+
+    getNextUncompletedItem: ({ queueId }) =>
+      Effect.sync(() => {
+        const uncompleted = [...items.values()].find((i) => i.queueId === queueId && !i.completedAt)
+        return uncompleted?.id ?? null
+      }),
+
+    update: ({ projectId, queueId, itemId, completedAt, completedBy, reviewStartedAt }) =>
+      Effect.gen(function* () {
+        const item = items.get(itemId)
+        if (!item || item.projectId !== projectId || item.queueId !== queueId) {
+          return yield* new NotFoundError({ entity: "AnnotationQueueItem", id: itemId })
+        }
+        const updated: AnnotationQueueItem = {
+          ...item,
+          ...(completedAt !== undefined && { completedAt }),
+          ...(completedBy !== undefined && { completedBy }),
+          ...(reviewStartedAt !== undefined && { reviewStartedAt }),
+          updatedAt: new Date(),
+        }
+        items.set(itemId, updated)
+        return updated
+      }),
+    bulkInsertIfNotExists: ({ projectId, queueId, items: inputItems }) => {
+      let insertedCount = 0
+      for (const { traceId, traceCreatedAt } of inputItems) {
+        const exists = [...items.values()].some(
+          (i) => i.projectId === projectId && i.queueId === queueId && i.traceId === traceId,
+        )
+        if (exists) continue
+
+        const now = new Date()
+        const newItem: AnnotationQueueItem = {
+          id: AnnotationQueueItemId(generateId()),
+          organizationId: "",
+          projectId,
+          queueId: AnnotationQueueId(queueId),
+          traceId,
+          traceCreatedAt,
+          completedAt: null,
+          completedBy: null,
+          reviewStartedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        }
+        items.set(newItem.id, newItem)
+        insertedCount++
+      }
+      return Effect.succeed({ insertedCount })
+    },
+
+    ...overrides,
+  }
+
+  return { repository, items }
+}

--- a/packages/domain/annotation-queues/src/testing/fake-annotation-queue-repository.ts
+++ b/packages/domain/annotation-queues/src/testing/fake-annotation-queue-repository.ts
@@ -4,21 +4,75 @@ import type { AnnotationQueue } from "../entities/annotation-queue.ts"
 import type { AnnotationQueueRepositoryShape } from "../ports/annotation-queue-repository.ts"
 
 export const createFakeAnnotationQueueRepository = (
-  overrides?: Partial<AnnotationQueueRepositoryShape>,
-): { repository: AnnotationQueueRepositoryShape; getLastSavedQueue: () => AnnotationQueue | undefined } => {
-  let lastSavedQueue: AnnotationQueue | undefined
+  seedOrOverrides?: readonly AnnotationQueue[] | Partial<AnnotationQueueRepositoryShape>,
+  maybeOverrides?: Partial<AnnotationQueueRepositoryShape>,
+) => {
+  const seed = Array.isArray(seedOrOverrides) ? seedOrOverrides : []
+  const overrides = Array.isArray(seedOrOverrides) ? maybeOverrides : seedOrOverrides
+
+  const queues = new Map<string, AnnotationQueue>(seed.map((queue) => [queue.id, queue] as const))
 
   const repository: AnnotationQueueRepositoryShape = {
-    listByProject: () => Effect.succeed({ items: [], hasMore: false }),
-    findByIdInProject: () => Effect.succeed(null),
-    findBySlugInProject: () => Effect.succeed(null),
-    listSystemQueuesByProject: () => Effect.succeed([]),
-    findSystemQueueBySlugInProject: () => Effect.succeed(null),
+    listByProject: ({ projectId, options }) =>
+      Effect.sync(() => {
+        const filtered = [...queues.values()].filter((q) => q.projectId === projectId && !q.deletedAt)
+        const limit = options?.limit ?? 50
+        return {
+          items: filtered.slice(0, limit),
+          hasMore: filtered.length > limit,
+        }
+      }),
+
+    listSystemQueuesByProject: ({ projectId }) =>
+      Effect.sync(() => [...queues.values()].filter((q) => q.projectId === projectId && q.system && !q.deletedAt)),
+
+    findByIdInProject: ({ projectId, queueId }) =>
+      Effect.sync(() => {
+        const queue = queues.get(queueId)
+        if (!queue || queue.projectId !== projectId || queue.deletedAt) return null
+        return queue
+      }),
+
+    findBySlugInProject: ({ projectId, queueSlug }) =>
+      Effect.sync(() => {
+        const queue = [...queues.values()].find(
+          (q) => q.projectId === projectId && q.slug === queueSlug && !q.deletedAt,
+        )
+        return queue ?? null
+      }),
+
+    findSystemQueueBySlugInProject: ({ projectId, queueSlug }) =>
+      Effect.sync(() => {
+        const queue = [...queues.values()].find(
+          (q) => q.projectId === projectId && q.slug === queueSlug && q.system && !q.deletedAt,
+        )
+        return queue ?? null
+      }),
+
     save: (queue) =>
       Effect.sync(() => {
-        lastSavedQueue = queue
+        queues.set(queue.id, queue)
       }),
-    insertIfNotExists: () => Effect.succeed(true),
+
+    insertIfNotExists: (queue) =>
+      Effect.sync(() => {
+        if (queues.has(queue.id)) return false
+        queues.set(queue.id, queue)
+        return true
+      }),
+
+    incrementCompletedItems: ({ queueId, delta }) =>
+      Effect.sync(() => {
+        const queue = queues.get(queueId)
+        if (queue) {
+          queues.set(queueId, {
+            ...queue,
+            completedItems: Math.max(0, queue.completedItems + delta),
+            updatedAt: new Date(),
+          })
+        }
+      }),
+
     incrementTotalItems: ({ queueId, delta = 1 }) =>
       Effect.succeed({
         id: AnnotationQueueId(queueId),
@@ -37,8 +91,18 @@ export const createFakeAnnotationQueueRepository = (
         createdAt: new Date(),
         updatedAt: new Date(),
       }),
+
     ...overrides,
   }
 
-  return { repository, getLastSavedQueue: () => lastSavedQueue }
+  let lastSavedQueue: AnnotationQueue | null = null
+  const originalSave = repository.save
+  repository.save = (queue) => {
+    lastSavedQueue = queue
+    return originalSave(queue)
+  }
+
+  const getLastSavedQueue = () => lastSavedQueue
+
+  return { repository, queues, getLastSavedQueue }
 }

--- a/packages/domain/annotation-queues/src/use-cases/add-traces-to-queue.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/add-traces-to-queue.test.ts
@@ -40,7 +40,7 @@ const createTestLayer = (overrides?: {
   queueRepo?: Partial<AnnotationQueueRepositoryShape>
 }) => {
   const { repository: traceRepository } = createFakeTraceRepository(overrides?.traceRepo)
-  const itemRepository = createFakeAnnotationQueueItemRepository(overrides?.itemRepo)
+  const { repository: itemRepository } = createFakeAnnotationQueueItemRepository(overrides?.itemRepo)
   const { repository: queueRepository } = createFakeAnnotationQueueRepository(overrides?.queueRepo)
 
   const fakeSqlClient: SqlClientShape<unknown> = {

--- a/packages/domain/annotation-queues/src/use-cases/complete-queue-item.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/complete-queue-item.test.ts
@@ -1,0 +1,178 @@
+import {
+  AnnotationQueueId,
+  AnnotationQueueItemId,
+  OrganizationId,
+  ProjectId,
+  SqlClient,
+  type SqlClientShape,
+  TraceId,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AnnotationQueue } from "../entities/annotation-queue.ts"
+import type { AnnotationQueueItem } from "../entities/annotation-queue-items.ts"
+import { QueueItemAlreadyCompletedError, QueueItemNotFoundError } from "../errors.ts"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
+import { createFakeAnnotationQueueItemRepository } from "../testing/fake-annotation-queue-item-repository.ts"
+import { createFakeAnnotationQueueRepository } from "../testing/fake-annotation-queue-repository.ts"
+import { completeQueueItemUseCase } from "./complete-queue-item.ts"
+
+const ORG_ID = OrganizationId("oooooooooooooooooooooooo")
+const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
+const QUEUE_ID = AnnotationQueueId("qqqqqqqqqqqqqqqqqqqqqqqq")
+const ITEM_ID = AnnotationQueueItemId("iiiiiiiiiiiiiiiiiiiiiiii")
+const USER_ID = "uuuuuuuuuuuuuuuuuuuuuuuu"
+
+const createPassthroughSqlClient = (): SqlClientShape => {
+  const sqlClient: SqlClientShape = {
+    organizationId: ORG_ID,
+    transaction: (effect) => effect.pipe(Effect.provideService(SqlClient, sqlClient)),
+    query: () => Effect.die("Unexpected direct SQL query in unit test"),
+  }
+  return sqlClient
+}
+
+const makeQueue = (overrides?: Partial<AnnotationQueue>): AnnotationQueue => ({
+  id: QUEUE_ID,
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  system: false,
+  name: "Test Queue",
+  slug: "test-queue",
+  description: "",
+  instructions: "",
+  settings: {},
+  assignees: [],
+  totalItems: 2,
+  completedItems: 0,
+  deletedAt: null,
+  createdAt: new Date("2025-04-01T10:00:00.000Z"),
+  updatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  ...overrides,
+})
+
+const makeItem = (overrides?: Partial<AnnotationQueueItem>): AnnotationQueueItem => ({
+  id: ITEM_ID,
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  queueId: QUEUE_ID,
+  traceId: TraceId("tttttttttttttttttttttttttttttttt"),
+  traceCreatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  completedAt: null,
+  completedBy: null,
+  reviewStartedAt: null,
+  createdAt: new Date("2025-04-01T10:00:00.000Z"),
+  updatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  ...overrides,
+})
+
+describe("completeQueueItemUseCase", () => {
+  it("completes a pending item successfully", async () => {
+    const item = makeItem()
+    const queue = makeQueue()
+    const { repository: itemRepo, items } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const result = await Effect.runPromise(
+      completeQueueItemUseCase({
+        projectId: PROJECT_ID,
+        queueId: QUEUE_ID,
+        itemId: item.id,
+        userId: USER_ID,
+      }).pipe(
+        Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+        Effect.provideService(AnnotationQueueRepository, queueRepo),
+        Effect.provideService(SqlClient, createPassthroughSqlClient()),
+      ),
+    )
+
+    expect(result.completedAt).not.toBeNull()
+    expect(result.completedBy).toBe(USER_ID)
+    expect(items.get(item.id)?.completedAt).not.toBeNull()
+  })
+
+  it("increments the queue's completedItems counter", async () => {
+    const item = makeItem()
+    const queue = makeQueue({ completedItems: 5 })
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo, queues } = createFakeAnnotationQueueRepository([queue])
+
+    await Effect.runPromise(
+      completeQueueItemUseCase({
+        projectId: PROJECT_ID,
+        queueId: QUEUE_ID,
+        itemId: item.id,
+        userId: USER_ID,
+      }).pipe(
+        Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+        Effect.provideService(AnnotationQueueRepository, queueRepo),
+        Effect.provideService(SqlClient, createPassthroughSqlClient()),
+      ),
+    )
+
+    expect(queues.get(QUEUE_ID)?.completedItems).toBe(6)
+  })
+
+  it("fails with QueueItemNotFoundError when item does not exist", async () => {
+    const queue = makeQueue()
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const err = await Effect.runPromise(
+      Effect.match(
+        completeQueueItemUseCase({
+          projectId: PROJECT_ID,
+          queueId: QUEUE_ID,
+          itemId: "nonexistent",
+          userId: USER_ID,
+        }).pipe(
+          Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+          Effect.provideService(AnnotationQueueRepository, queueRepo),
+          Effect.provideService(SqlClient, createPassthroughSqlClient()),
+        ),
+        {
+          onFailure: (e) => e,
+          onSuccess: () => {
+            throw new Error("expected failure")
+          },
+        },
+      ),
+    )
+
+    expect(err).toBeInstanceOf(QueueItemNotFoundError)
+  })
+
+  it("fails with QueueItemAlreadyCompletedError when item already completed", async () => {
+    const item = makeItem({
+      completedAt: new Date("2025-04-02T00:00:00.000Z"),
+      completedBy: USER_ID,
+    })
+    const queue = makeQueue()
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const err = await Effect.runPromise(
+      Effect.match(
+        completeQueueItemUseCase({
+          projectId: PROJECT_ID,
+          queueId: QUEUE_ID,
+          itemId: item.id,
+          userId: USER_ID,
+        }).pipe(
+          Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+          Effect.provideService(AnnotationQueueRepository, queueRepo),
+          Effect.provideService(SqlClient, createPassthroughSqlClient()),
+        ),
+        {
+          onFailure: (e) => e,
+          onSuccess: () => {
+            throw new Error("expected failure")
+          },
+        },
+      ),
+    )
+
+    expect(err).toBeInstanceOf(QueueItemAlreadyCompletedError)
+  })
+})

--- a/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
@@ -1,0 +1,55 @@
+import { type ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { QueueItemAlreadyCompletedError, QueueItemNotFoundError } from "../errors.ts"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
+
+export interface CompleteQueueItemInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly itemId: string
+  readonly userId: string
+}
+
+export type CompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemAlreadyCompletedError
+
+export const completeQueueItemUseCase = (input: CompleteQueueItemInput) =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    const itemRepo = yield* AnnotationQueueItemRepository
+    const queueRepo = yield* AnnotationQueueRepository
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const item = yield* itemRepo.findById({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          itemId: input.itemId,
+        })
+
+        if (!item) {
+          return yield* new QueueItemNotFoundError({ itemId: input.itemId })
+        }
+
+        if (item.completedAt) {
+          return yield* new QueueItemAlreadyCompletedError({ itemId: input.itemId })
+        }
+
+        const updated = yield* itemRepo.update({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          itemId: input.itemId,
+          completedAt: new Date(),
+          completedBy: input.userId,
+        })
+
+        yield* queueRepo.incrementCompletedItems({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          delta: 1,
+        })
+
+        return updated
+      }),
+    )
+  })

--- a/packages/domain/annotation-queues/src/use-cases/mark-review-started.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/mark-review-started.test.ts
@@ -1,0 +1,202 @@
+import type { Score } from "@domain/scores"
+import { ScoreRepository } from "@domain/scores"
+import { createFakeScoreRepository } from "@domain/scores/testing"
+import { ProjectId, TraceId } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AnnotationQueueItem } from "../entities/annotation-queue-items.ts"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+import { createFakeAnnotationQueueItemRepository } from "../testing/fake-annotation-queue-item-repository.ts"
+import { markReviewStartedUseCase } from "./mark-review-started.ts"
+
+const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
+const ORG_ID = "oooooooooooooooooooooooo"
+const QUEUE_ID = "qqqqqqqqqqqqqqqqqqqqqqqq"
+const TRACE_ID = "t".repeat(32)
+
+function makeItem(overrides: Partial<AnnotationQueueItem> = {}): AnnotationQueueItem {
+  return {
+    id: "item_001_000000000000000000",
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    queueId: QUEUE_ID,
+    traceId: TraceId(TRACE_ID),
+    traceCreatedAt: new Date("2025-04-01T10:00:00.000Z"),
+    completedAt: null,
+    completedBy: null,
+    reviewStartedAt: null,
+    createdAt: new Date("2025-04-01T10:00:00.000Z"),
+    updatedAt: new Date("2025-04-01T10:00:00.000Z"),
+    ...overrides,
+  } as AnnotationQueueItem
+}
+
+function makeScore(overrides: Partial<Score> = {}): Score {
+  return {
+    id: "ssssssssssssssssssssssss",
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID as string,
+    sessionId: null,
+    traceId: TRACE_ID,
+    spanId: null,
+    source: "annotation",
+    sourceId: "UI",
+    simulationId: null,
+    issueId: null,
+    value: 1,
+    passed: true,
+    feedback: "Good",
+    metadata: {},
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: new Date(),
+    annotatorId: "uuuuuuuuuuuuuuuuuuuuuuuu",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Score
+}
+
+function createTestLayers(options: {
+  readonly items?: readonly AnnotationQueueItem[]
+  readonly existingAnnotationCount?: number
+}) {
+  const { repository: itemRepo, items } = createFakeAnnotationQueueItemRepository(options.items ?? [])
+  const { repository: scoreRepo } = createFakeScoreRepository()
+
+  const annotationCount = options.existingAnnotationCount ?? 0
+  const fakeAnnotations = Array.from({ length: annotationCount }, (_, i) => ({ id: `existing_${i}` }) as never)
+
+  const ScoreRepositoryTest = Layer.succeed(ScoreRepository, {
+    ...scoreRepo,
+    listByTraceId: () =>
+      Effect.succeed({
+        items: fakeAnnotations,
+        hasMore: false,
+        limit: 2,
+        offset: 0,
+      }),
+  })
+
+  const ItemRepositoryTest = Layer.succeed(AnnotationQueueItemRepository, itemRepo)
+
+  return {
+    items,
+    layer: Layer.mergeAll(ScoreRepositoryTest, ItemRepositoryTest),
+  }
+}
+
+describe("markReviewStartedUseCase", () => {
+  it("marks queue items as in progress when only one annotation exists (the just-created one)", async () => {
+    const pendingItem = makeItem()
+    const { layer, items } = createTestLayers({
+      items: [pendingItem],
+      existingAnnotationCount: 1,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore(),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(1)
+    const updatedItem = items.get(pendingItem.id)
+    expect(updatedItem?.reviewStartedAt).not.toBeNull()
+  })
+
+  it("does not mark items when more than one annotation exists", async () => {
+    const pendingItem = makeItem()
+    const { layer, items } = createTestLayers({
+      items: [pendingItem],
+      existingAnnotationCount: 2,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore(),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(0)
+    const updatedItem = items.get(pendingItem.id)
+    expect(updatedItem?.reviewStartedAt).toBeNull()
+  })
+
+  it("returns 0 when no pending items exist for the trace", async () => {
+    const inProgressItem = makeItem({ reviewStartedAt: new Date() })
+    const { layer } = createTestLayers({
+      items: [inProgressItem],
+      existingAnnotationCount: 1,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore(),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(0)
+  })
+
+  it("returns 0 when score is not an annotation", async () => {
+    const pendingItem = makeItem()
+    const { layer, items } = createTestLayers({
+      items: [pendingItem],
+      existingAnnotationCount: 1,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore({ source: "evaluation" }),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(0)
+    const updatedItem = items.get(pendingItem.id)
+    expect(updatedItem?.reviewStartedAt).toBeNull()
+  })
+
+  it("returns 0 when score has no traceId", async () => {
+    const pendingItem = makeItem()
+    const { layer, items } = createTestLayers({
+      items: [pendingItem],
+      existingAnnotationCount: 1,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore({ traceId: null }),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(0)
+    const updatedItem = items.get(pendingItem.id)
+    expect(updatedItem?.reviewStartedAt).toBeNull()
+  })
+
+  it("does not mark completed items even if reviewStartedAt is null", async () => {
+    const completedItem = makeItem({
+      completedAt: new Date(),
+      completedBy: "uuuuuuuuuuuuuuuuuuuuuuuu",
+      reviewStartedAt: null,
+    })
+    const { layer, items } = createTestLayers({
+      items: [completedItem],
+      existingAnnotationCount: 1,
+    })
+
+    const count = await Effect.runPromise(
+      markReviewStartedUseCase({
+        score: makeScore(),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(0)
+    const updatedItem = items.get(completedItem.id)
+    expect(updatedItem?.reviewStartedAt).toBeNull()
+  })
+})

--- a/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
+++ b/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
@@ -1,0 +1,69 @@
+import { listTraceAnnotationsUseCase } from "@domain/annotations"
+import type { Score } from "@domain/scores"
+import { ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+
+export interface MarkReviewStartedInput {
+  readonly score: Score
+}
+
+/**
+ * Marks all pending annotation queue items containing the given trace as "in progress".
+ * Only marks if this is the first annotation for the trace.
+ *
+ * Since this runs asynchronously via worker after the annotation is persisted,
+ * we check for `count > 1` (the just-created annotation is already counted).
+ *
+ * Skips if the score is not an annotation or has no traceId.
+ */
+export const markReviewStartedUseCase = (input: MarkReviewStartedInput) =>
+  Effect.gen(function* () {
+    const { score } = input
+
+    if (score.source !== "annotation") return 0
+    if (!score.traceId) return 0
+
+    const projectId = ProjectId(score.projectId)
+    const traceId = score.traceId
+
+    const existingAnnotations = yield* listTraceAnnotationsUseCase({
+      projectId: projectId as unknown as string,
+      traceId,
+      limit: 2,
+      draftMode: "include",
+    })
+
+    if (existingAnnotations.items.length > 1) {
+      return 0
+    }
+
+    const itemRepo = yield* AnnotationQueueItemRepository
+
+    const items = yield* itemRepo.listByTraceId({
+      projectId,
+      traceId,
+    })
+
+    const pendingItems = items.filter((item) => item.completedAt === null && item.reviewStartedAt === null)
+
+    if (pendingItems.length === 0) {
+      return 0
+    }
+
+    const now = new Date()
+
+    yield* Effect.forEach(
+      pendingItems,
+      (item) =>
+        itemRepo.update({
+          projectId,
+          queueId: item.queueId,
+          itemId: item.id,
+          reviewStartedAt: now,
+        }),
+      { concurrency: "unbounded" },
+    )
+
+    return pendingItems.length
+  })

--- a/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.test.ts
@@ -1,0 +1,174 @@
+import {
+  AnnotationQueueId,
+  AnnotationQueueItemId,
+  OrganizationId,
+  ProjectId,
+  SqlClient,
+  type SqlClientShape,
+  TraceId,
+} from "@domain/shared"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AnnotationQueue } from "../entities/annotation-queue.ts"
+import type { AnnotationQueueItem } from "../entities/annotation-queue-items.ts"
+import { QueueItemNotCompletedError, QueueItemNotFoundError } from "../errors.ts"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
+import { createFakeAnnotationQueueItemRepository } from "../testing/fake-annotation-queue-item-repository.ts"
+import { createFakeAnnotationQueueRepository } from "../testing/fake-annotation-queue-repository.ts"
+import { uncompleteQueueItemUseCase } from "./uncomplete-queue-item.ts"
+
+const ORG_ID = OrganizationId("oooooooooooooooooooooooo")
+const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
+const QUEUE_ID = AnnotationQueueId("qqqqqqqqqqqqqqqqqqqqqqqq")
+const ITEM_ID = AnnotationQueueItemId("iiiiiiiiiiiiiiiiiiiiiiii")
+const USER_ID = "uuuuuuuuuuuuuuuuuuuuuuuu"
+
+const createPassthroughSqlClient = (): SqlClientShape => {
+  const sqlClient: SqlClientShape = {
+    organizationId: ORG_ID,
+    transaction: (effect) => effect.pipe(Effect.provideService(SqlClient, sqlClient)),
+    query: () => Effect.die("Unexpected direct SQL query in unit test"),
+  }
+  return sqlClient
+}
+
+const makeQueue = (overrides?: Partial<AnnotationQueue>): AnnotationQueue => ({
+  id: QUEUE_ID,
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  system: false,
+  name: "Test Queue",
+  slug: "test-queue",
+  description: "",
+  instructions: "",
+  settings: {},
+  assignees: [],
+  totalItems: 2,
+  completedItems: 1,
+  deletedAt: null,
+  createdAt: new Date("2025-04-01T10:00:00.000Z"),
+  updatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  ...overrides,
+})
+
+const makeItem = (overrides?: Partial<AnnotationQueueItem>): AnnotationQueueItem => ({
+  id: ITEM_ID,
+  organizationId: ORG_ID,
+  projectId: PROJECT_ID,
+  queueId: QUEUE_ID,
+  traceId: TraceId("tttttttttttttttttttttttttttttttt"),
+  traceCreatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  completedAt: new Date("2025-04-02T00:00:00.000Z"),
+  completedBy: USER_ID,
+  reviewStartedAt: null,
+  createdAt: new Date("2025-04-01T10:00:00.000Z"),
+  updatedAt: new Date("2025-04-01T10:00:00.000Z"),
+  ...overrides,
+})
+
+describe("uncompleteQueueItemUseCase", () => {
+  it("uncompletes a completed item successfully", async () => {
+    const item = makeItem()
+    const queue = makeQueue()
+    const { repository: itemRepo, items } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const result = await Effect.runPromise(
+      uncompleteQueueItemUseCase({
+        projectId: PROJECT_ID,
+        queueId: QUEUE_ID,
+        itemId: item.id,
+      }).pipe(
+        Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+        Effect.provideService(AnnotationQueueRepository, queueRepo),
+        Effect.provideService(SqlClient, createPassthroughSqlClient()),
+      ),
+    )
+
+    expect(result.completedAt).toBeNull()
+    expect(result.completedBy).toBeNull()
+    expect(items.get(item.id)?.completedAt).toBeNull()
+  })
+
+  it("decrements the queue's completedItems counter", async () => {
+    const item = makeItem()
+    const queue = makeQueue({ completedItems: 5 })
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo, queues } = createFakeAnnotationQueueRepository([queue])
+
+    await Effect.runPromise(
+      uncompleteQueueItemUseCase({
+        projectId: PROJECT_ID,
+        queueId: QUEUE_ID,
+        itemId: item.id,
+      }).pipe(
+        Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+        Effect.provideService(AnnotationQueueRepository, queueRepo),
+        Effect.provideService(SqlClient, createPassthroughSqlClient()),
+      ),
+    )
+
+    expect(queues.get(QUEUE_ID)?.completedItems).toBe(4)
+  })
+
+  it("fails with QueueItemNotFoundError when item does not exist", async () => {
+    const queue = makeQueue()
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const err = await Effect.runPromise(
+      Effect.match(
+        uncompleteQueueItemUseCase({
+          projectId: PROJECT_ID,
+          queueId: QUEUE_ID,
+          itemId: "nonexistent",
+        }).pipe(
+          Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+          Effect.provideService(AnnotationQueueRepository, queueRepo),
+          Effect.provideService(SqlClient, createPassthroughSqlClient()),
+        ),
+        {
+          onFailure: (e) => e,
+          onSuccess: () => {
+            throw new Error("expected failure")
+          },
+        },
+      ),
+    )
+
+    expect(err).toBeInstanceOf(QueueItemNotFoundError)
+  })
+
+  it("fails with QueueItemNotCompletedError when item is not completed", async () => {
+    const item = makeItem({
+      completedAt: null,
+      completedBy: null,
+    })
+    const queue = makeQueue()
+    const { repository: itemRepo } = createFakeAnnotationQueueItemRepository([item])
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([queue])
+
+    const err = await Effect.runPromise(
+      Effect.match(
+        uncompleteQueueItemUseCase({
+          projectId: PROJECT_ID,
+          queueId: QUEUE_ID,
+          itemId: item.id,
+        }).pipe(
+          Effect.provideService(AnnotationQueueItemRepository, itemRepo),
+          Effect.provideService(AnnotationQueueRepository, queueRepo),
+          Effect.provideService(SqlClient, createPassthroughSqlClient()),
+        ),
+        {
+          onFailure: (e) => e,
+          onSuccess: () => {
+            throw new Error("expected failure")
+          },
+        },
+      ),
+    )
+
+    expect(err).toBeInstanceOf(QueueItemNotCompletedError)
+  })
+})

--- a/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
@@ -1,0 +1,54 @@
+import { type ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { QueueItemNotCompletedError, QueueItemNotFoundError } from "../errors.ts"
+import { AnnotationQueueItemRepository } from "../ports/annotation-queue-item-repository.ts"
+import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
+
+export interface UncompleteQueueItemInput {
+  readonly projectId: ProjectId
+  readonly queueId: string
+  readonly itemId: string
+}
+
+export type UncompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemNotCompletedError
+
+export const uncompleteQueueItemUseCase = (input: UncompleteQueueItemInput) =>
+  Effect.gen(function* () {
+    const sqlClient = yield* SqlClient
+    const itemRepo = yield* AnnotationQueueItemRepository
+    const queueRepo = yield* AnnotationQueueRepository
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const item = yield* itemRepo.findById({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          itemId: input.itemId,
+        })
+
+        if (!item) {
+          return yield* new QueueItemNotFoundError({ itemId: input.itemId })
+        }
+
+        if (!item.completedAt) {
+          return yield* new QueueItemNotCompletedError({ itemId: input.itemId })
+        }
+
+        const updated = yield* itemRepo.update({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          itemId: input.itemId,
+          completedAt: null,
+          completedBy: null,
+        })
+
+        yield* queueRepo.incrementCompletedItems({
+          projectId: input.projectId,
+          queueId: input.queueId,
+          delta: -1,
+        })
+
+        return updated
+      }),
+    )
+  })

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -102,6 +102,11 @@ const _registry = {
       readonly projectId: string
       readonly scoreId: string
     }
+    markReviewStarted: {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly scoreId: string
+    }
   }>(),
 
   "live-evaluations": payloads<{

--- a/packages/domain/scores/src/constants.ts
+++ b/packages/domain/scores/src/constants.ts
@@ -1,6 +1,6 @@
 export const SCORE_SOURCES = ["evaluation", "annotation", "custom"] as const
 
-export const ANNOTATION_SCORE_PARTIAL_SOURCE_IDS = ["UI", "API", "AGENT"] as const
+export const ANNOTATION_SCORE_PARTIAL_SOURCE_IDS = ["UI", "API"] as const
 
 export const SCORE_SOURCE_ID_MAX_LENGTH = 128
 

--- a/packages/platform/db-postgres/src/repositories/annotation-queue-item-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/annotation-queue-item-repository.test.ts
@@ -125,7 +125,8 @@ describe("AnnotationQueueItemRepositoryLive", () => {
         projectId: PROJECT_ID,
         queueId: QUEUE_ID,
         traceId: makeTrace("pend1"),
-        traceCreatedAt: new Date("2025-03-30T09:00:00.000Z"),
+        // traceCreatedAt is NEWER but createdAt is OLDER - tests that we sort by traceCreatedAt
+        traceCreatedAt: new Date("2025-03-30T12:00:00.000Z"),
         completedAt: null,
         completedBy: null,
         reviewStartedAt: null,
@@ -138,7 +139,8 @@ describe("AnnotationQueueItemRepositoryLive", () => {
         projectId: PROJECT_ID,
         queueId: QUEUE_ID,
         traceId: makeTrace("pend2"),
-        traceCreatedAt: new Date("2025-03-30T12:00:00.000Z"),
+        // traceCreatedAt is OLDER but createdAt is NEWER - tests that we sort by traceCreatedAt
+        traceCreatedAt: new Date("2025-03-30T09:00:00.000Z"),
         completedAt: null,
         completedBy: null,
         reviewStartedAt: null,
@@ -181,9 +183,9 @@ describe("AnnotationQueueItemRepositoryLive", () => {
 
       const ranks = page.items.map((i) => annotationQueueItemStatusRankFromTimestamps(i.completedAt, i.reviewStartedAt))
       expect(ranks).toEqual([0, 0, 1, 2])
-      // Within rank 0: createdAt desc, so newer pending before older
-      expect(page.items[0].traceId).toEqual(TraceId(makeTrace("pend2")))
-      expect(page.items[1].traceId).toEqual(TraceId(makeTrace("pend1")))
+      // Within rank 0: traceCreatedAt desc - pend1 has newer traceCreatedAt (12:00) than pend2 (09:00)
+      expect(page.items[0].traceId).toEqual(TraceId(makeTrace("pend1")))
+      expect(page.items[1].traceId).toEqual(TraceId(makeTrace("pend2")))
       expect(page.items[2].traceId).toEqual(TraceId(makeTrace("prog")))
       expect(page.items[3].traceId).toEqual(TraceId(makeTrace("done")))
     })
@@ -272,7 +274,10 @@ describe("AnnotationQueueItemRepositoryLive", () => {
                 sortBy: "status",
                 sortDirection: "asc",
                 limit: 5,
-                cursor: { sortValue: new Date().toISOString(), id: makeId("it_pend_new") },
+                cursor: {
+                  sortValue: new Date().toISOString(),
+                  id: makeId("it_pend_new"),
+                },
               },
             })
           }).pipe(withPostgres(AnnotationQueueItemRepositoryLive, pg.adminPostgresClient, ORG_ID)),
@@ -343,13 +348,34 @@ describe("AnnotationQueueItemRepositoryLive", () => {
     it("first insert creates one queue item and returns true", async () => {
       const traceId = TraceId(makeTrace("new_item"))
       const traceCreatedAt = new Date("2025-04-01T10:00:00.000Z")
+      const TEST_QUEUE_ID = makeId("insert_test_q1")
+
+      const db = pg.db
+      const base = new Date()
+      await db.insert(annotationQueues).values({
+        id: TEST_QUEUE_ID,
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        system: false,
+        name: "Insert test queue 1",
+        slug: "insert-test-queue-1",
+        description: "",
+        instructions: "",
+        settings: emptySettings,
+        assignees: [],
+        totalItems: 0,
+        completedItems: 0,
+        deletedAt: null,
+        createdAt: base,
+        updatedAt: base,
+      })
 
       const wasInserted = await runWithLive(
         Effect.gen(function* () {
           const repo = yield* AnnotationQueueItemRepository
           return yield* repo.insertIfNotExists({
             projectId: PROJECT_ID,
-            queueId: QUEUE_ID,
+            queueId: TEST_QUEUE_ID,
             traceId,
             traceCreatedAt,
           })
@@ -363,7 +389,7 @@ describe("AnnotationQueueItemRepositoryLive", () => {
           const repo = yield* AnnotationQueueItemRepository
           const page = yield* repo.listByQueue({
             projectId: PROJECT_ID,
-            queueId: QUEUE_ID,
+            queueId: TEST_QUEUE_ID,
             options: { limit: 100 },
           })
           return page.items.find((i) => i.traceId === traceId)
@@ -371,7 +397,7 @@ describe("AnnotationQueueItemRepositoryLive", () => {
       )
 
       expect(item).toBeDefined()
-      expect(item?.queueId).toBe(QUEUE_ID)
+      expect(item?.queueId).toBe(TEST_QUEUE_ID)
       expect(item?.traceId).toBe(traceId)
       expect(item?.completedAt).toBeNull()
       expect(item?.completedBy).toBeNull()
@@ -381,13 +407,34 @@ describe("AnnotationQueueItemRepositoryLive", () => {
     it("duplicate insert is idempotent and returns false", async () => {
       const traceId = TraceId(makeTrace("dup_item"))
       const traceCreatedAt = new Date("2025-04-01T10:00:00.000Z")
+      const TEST_QUEUE_ID = makeId("insert_test_q2")
+
+      const db = pg.db
+      const base = new Date()
+      await db.insert(annotationQueues).values({
+        id: TEST_QUEUE_ID,
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        system: false,
+        name: "Insert test queue 2",
+        slug: "insert-test-queue-2",
+        description: "",
+        instructions: "",
+        settings: emptySettings,
+        assignees: [],
+        totalItems: 0,
+        completedItems: 0,
+        deletedAt: null,
+        createdAt: base,
+        updatedAt: base,
+      })
 
       const firstInsert = await runWithLive(
         Effect.gen(function* () {
           const repo = yield* AnnotationQueueItemRepository
           return yield* repo.insertIfNotExists({
             projectId: PROJECT_ID,
-            queueId: QUEUE_ID,
+            queueId: TEST_QUEUE_ID,
             traceId,
             traceCreatedAt,
           })
@@ -400,7 +447,7 @@ describe("AnnotationQueueItemRepositoryLive", () => {
           const repo = yield* AnnotationQueueItemRepository
           return yield* repo.insertIfNotExists({
             projectId: PROJECT_ID,
-            queueId: QUEUE_ID,
+            queueId: TEST_QUEUE_ID,
             traceId,
             traceCreatedAt,
           })
@@ -413,7 +460,7 @@ describe("AnnotationQueueItemRepositoryLive", () => {
           const repo = yield* AnnotationQueueItemRepository
           return yield* repo.listByQueue({
             projectId: PROJECT_ID,
-            queueId: QUEUE_ID,
+            queueId: TEST_QUEUE_ID,
             options: { limit: 100 },
           })
         }),
@@ -900,6 +947,302 @@ describe("AnnotationQueueItemRepositoryLive", () => {
         }).pipe(withPostgres(AnnotationQueueRepositoryLive, pg.adminPostgresClient, ORG_ID)),
       )
       expect(finalQueue?.totalItems).toBe(4)
+    })
+  })
+
+  describe("getAdjacentItems", () => {
+    it("returns prev and next for item in middle of list", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getAdjacentItems({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_pend_new"),
+          })
+        }),
+      )
+
+      // Order is by traceCreatedAt DESC: it_pend_old (12:00) → it_pend_new (09:00) → it_prog → it_done
+      expect(result.previousItemId).toBe(makeId("it_pend_old"))
+      expect(result.nextItemId).toBe(makeId("it_prog"))
+    })
+
+    it("returns null for prev when on first item in list order", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getAdjacentItems({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_pend_old"),
+          })
+        }),
+      )
+
+      // it_pend_old has newer traceCreatedAt so it's first
+      expect(result.previousItemId).toBeNull()
+      expect(result.nextItemId).toBe(makeId("it_pend_new"))
+    })
+
+    it("returns null for next when on last item in list order", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getAdjacentItems({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_done"),
+          })
+        }),
+      )
+
+      expect(result.previousItemId).toBe(makeId("it_prog"))
+      expect(result.nextItemId).toBeNull()
+    })
+
+    it("returns null for both when item not found", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getAdjacentItems({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("nonexistent"),
+          })
+        }),
+      )
+
+      expect(result.previousItemId).toBeNull()
+      expect(result.nextItemId).toBeNull()
+    })
+  })
+
+  describe("getQueuePosition", () => {
+    it("returns position 1 for first item in list order", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getQueuePosition({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            // it_pend_old has newer traceCreatedAt so it's first
+            currentItemId: makeId("it_pend_old"),
+          })
+        }),
+      )
+
+      expect(result.currentIndex).toBe(1)
+      expect(result.totalItems).toBe(4)
+    })
+
+    it("returns correct position for middle item", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getQueuePosition({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_prog"),
+          })
+        }),
+      )
+
+      expect(result.currentIndex).toBe(3)
+      expect(result.totalItems).toBe(4)
+    })
+
+    it("returns position 4 for last item", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getQueuePosition({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_done"),
+          })
+        }),
+      )
+
+      expect(result.currentIndex).toBe(4)
+      expect(result.totalItems).toBe(4)
+    })
+
+    it("returns 0 index when item not found", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getQueuePosition({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("nonexistent"),
+          })
+        }),
+      )
+
+      expect(result.currentIndex).toBe(0)
+      expect(result.totalItems).toBe(4)
+    })
+  })
+
+  describe("getNextUncompletedItem", () => {
+    it("returns first uncompleted item in list order", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getNextUncompletedItem({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_done"),
+          })
+        }),
+      )
+
+      // it_pend_old has newer traceCreatedAt so it's first uncompleted
+      expect(result).toBe(makeId("it_pend_old"))
+    })
+
+    it("returns first uncompleted even when called from uncompleted item", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getNextUncompletedItem({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("it_pend_new"),
+          })
+        }),
+      )
+
+      // it_pend_old has newer traceCreatedAt so it's first uncompleted
+      expect(result).toBe(makeId("it_pend_old"))
+    })
+
+    it("returns first uncompleted when current item not found", async () => {
+      const result = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.getNextUncompletedItem({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            currentItemId: makeId("nonexistent"),
+          })
+        }),
+      )
+
+      // it_pend_old has newer traceCreatedAt so it's first uncompleted
+      expect(result).toBe(makeId("it_pend_old"))
+    })
+  })
+
+  describe("update", () => {
+    it("updates completedAt and completedBy", async () => {
+      const userId = makeId("uu_updater")
+      const completedAt = new Date("2025-05-01T00:00:00.000Z")
+
+      const updated = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.update({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            itemId: makeId("it_prog"),
+            completedAt,
+            completedBy: userId,
+          })
+        }),
+      )
+
+      expect(updated.completedAt).toEqual(completedAt)
+      expect(updated.completedBy).toBe(userId)
+    })
+
+    it("clears completedAt and completedBy when set to null", async () => {
+      const updated = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.update({
+            projectId: PROJECT_ID,
+            queueId: QUEUE_ID,
+            itemId: makeId("it_done"),
+            completedAt: null,
+            completedBy: null,
+          })
+        }),
+      )
+
+      expect(updated.completedAt).toBeNull()
+      expect(updated.completedBy).toBeNull()
+    })
+
+    it("fails with NotFoundError for non-existent item", async () => {
+      const err = await Effect.runPromise(
+        Effect.match(
+          Effect.gen(function* () {
+            const repo = yield* AnnotationQueueItemRepository
+            return yield* repo.update({
+              projectId: PROJECT_ID,
+              queueId: QUEUE_ID,
+              itemId: makeId("nonexistent"),
+              completedAt: new Date(),
+              completedBy: makeId("uu_user"),
+            })
+          }).pipe(withPostgres(AnnotationQueueItemRepositoryLive, pg.adminPostgresClient, ORG_ID)),
+          {
+            onFailure: (e) => e,
+            onSuccess: () => {
+              throw new Error("expected failure")
+            },
+          },
+        ),
+      )
+
+      expect(err._tag).toBe("NotFoundError")
+    })
+  })
+
+  describe("listByTraceId", () => {
+    it("returns items matching the traceId", async () => {
+      const items = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.listByTraceId({
+            projectId: PROJECT_ID,
+            traceId: makeTrace("pend1"),
+          })
+        }),
+      )
+
+      expect(items.length).toBe(1)
+      expect(items[0]?.traceId).toBe(makeTrace("pend1"))
+    })
+
+    it("returns empty array when no items match the traceId", async () => {
+      const items = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.listByTraceId({
+            projectId: PROJECT_ID,
+            traceId: makeTrace("nonexistent"),
+          })
+        }),
+      )
+
+      expect(items.length).toBe(0)
+    })
+
+    it("respects projectId scoping", async () => {
+      const items = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueItemRepository
+          return yield* repo.listByTraceId({
+            projectId: OTHER_PROJECT_ID,
+            traceId: makeTrace("pend2"),
+          })
+        }),
+      )
+
+      expect(items.length).toBe(0)
     })
   })
 })

--- a/packages/platform/db-postgres/src/repositories/annotation-queue-item-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/annotation-queue-item-repository.ts
@@ -6,7 +6,7 @@ import {
   annotationQueueItemSchema,
   annotationQueueItemStatusRankFromTimestamps,
 } from "@domain/annotation-queues"
-import { RepositoryError, SqlClient, type SqlClientShape, TraceId } from "@domain/shared"
+import { NotFoundError, RepositoryError, SqlClient, type SqlClientShape, TraceId } from "@domain/shared"
 import { createId } from "@paralleldrive/cuid2"
 import { and, asc, desc, eq, gt, lt, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
@@ -39,7 +39,10 @@ const toDomainItem = (row: typeof annotationQueueItems.$inferSelect): Annotation
 const resolveSort = (
   sortBy: AnnotationQueueItemListSortBy | undefined,
   sortDirection: "asc" | "desc" | undefined,
-): { sortBy: AnnotationQueueItemListSortBy; sortDirection: "asc" | "desc" } => ({
+): {
+  sortBy: AnnotationQueueItemListSortBy
+  sortDirection: "asc" | "desc"
+} => ({
   sortBy: sortBy ?? "status",
   sortDirection: sortDirection ?? "asc",
 })
@@ -172,7 +175,10 @@ export const AnnotationQueueItemRepositoryLive = Layer.effect(
         const cursorClause = options.cursor ? cursorWhere(sortBy, sortDirection, options.cursor) : undefined
         if (options.cursor && cursorClause === null) {
           return Effect.fail(
-            new RepositoryError({ operation: "listByQueue", cause: new Error("Invalid item list cursor") }),
+            new RepositoryError({
+              operation: "listByQueue",
+              cause: new Error("Invalid item list cursor"),
+            }),
           )
         }
 
@@ -277,6 +283,154 @@ export const AnnotationQueueItemRepositoryLive = Layer.effect(
 
           return { insertedCount: result.length }
         }).pipe(Effect.mapError((cause) => new RepositoryError({ operation: "bulkInsertIfNotExists", cause }))),
+      listByTraceId: ({ projectId, traceId }) =>
+        sqlClient
+          .query((db, organizationId) =>
+            db
+              .select()
+              .from(annotationQueueItems)
+              .where(
+                and(
+                  eq(annotationQueueItems.organizationId, organizationId),
+                  eq(annotationQueueItems.projectId, projectId),
+                  eq(annotationQueueItems.traceId, traceId),
+                ),
+              ),
+          )
+          .pipe(
+            Effect.map((rows) => rows.map(toDomainItem)),
+            Effect.mapError((cause) => new RepositoryError({ operation: "listByTraceId", cause })),
+          ),
+
+      getAdjacentItems: ({ projectId, queueId, currentItemId }) =>
+        sqlClient
+          .query((db, organizationId) => {
+            const orderClauseSql = sql`${statusRankSql} ASC, ${annotationQueueItems.traceCreatedAt} DESC, ${annotationQueueItems.id} DESC`
+
+            return db.execute<{ prev_id: string | null; next_id: string | null }>(sql`
+              WITH ranked AS (
+                SELECT
+                  ${annotationQueueItems.id} AS id,
+                  LAG(${annotationQueueItems.id}) OVER (ORDER BY ${orderClauseSql}) AS prev_id,
+                  LEAD(${annotationQueueItems.id}) OVER (ORDER BY ${orderClauseSql}) AS next_id
+                FROM ${annotationQueueItems}
+                WHERE ${annotationQueueItems.organizationId} = ${organizationId}
+                  AND ${annotationQueueItems.projectId} = ${projectId}
+                  AND ${annotationQueueItems.queueId} = ${queueId}
+              )
+              SELECT prev_id, next_id FROM ranked WHERE id = ${currentItemId}
+            `)
+          })
+          .pipe(
+            Effect.map((result) => {
+              const row = result.rows[0]
+              return {
+                previousItemId: row?.prev_id ?? null,
+                nextItemId: row?.next_id ?? null,
+              }
+            }),
+            Effect.mapError((cause) => new RepositoryError({ operation: "getAdjacentItems", cause })),
+          ),
+
+      getQueuePosition: ({ projectId, queueId, currentItemId }) =>
+        sqlClient
+          .query((db, organizationId) => {
+            const orderClauseSql = sql`${statusRankSql} ASC, ${annotationQueueItems.traceCreatedAt} DESC, ${annotationQueueItems.id} DESC`
+
+            return db.execute<{ row_num: number | null; total: number }>(sql`
+              WITH ranked AS (
+                SELECT
+                  ${annotationQueueItems.id} AS id,
+                  ROW_NUMBER() OVER (ORDER BY ${orderClauseSql}) AS row_num,
+                  COUNT(*) OVER () AS total
+                FROM ${annotationQueueItems}
+                WHERE ${annotationQueueItems.organizationId} = ${organizationId}
+                  AND ${annotationQueueItems.projectId} = ${projectId}
+                  AND ${annotationQueueItems.queueId} = ${queueId}
+              )
+              SELECT
+                (SELECT row_num FROM ranked WHERE id = ${currentItemId}) AS row_num,
+                COALESCE((SELECT total FROM ranked LIMIT 1), 0) AS total
+            `)
+          })
+          .pipe(
+            Effect.map((result) => {
+              const row = result.rows[0]
+              return {
+                currentIndex: row?.row_num ?? 0,
+                totalItems: row?.total ?? 0,
+              }
+            }),
+            Effect.mapError((cause) => new RepositoryError({ operation: "getQueuePosition", cause })),
+          ),
+
+      update: ({ projectId, queueId, itemId, completedAt, completedBy, reviewStartedAt }) =>
+        sqlClient
+          .query((db, organizationId) =>
+            db
+              .update(annotationQueueItems)
+              .set({
+                ...(completedAt !== undefined && { completedAt }),
+                ...(completedBy !== undefined && { completedBy }),
+                ...(reviewStartedAt !== undefined && { reviewStartedAt }),
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(annotationQueueItems.organizationId, organizationId),
+                  eq(annotationQueueItems.projectId, projectId),
+                  eq(annotationQueueItems.queueId, queueId),
+                  eq(annotationQueueItems.id, itemId),
+                ),
+              )
+              .returning(),
+          )
+          .pipe(
+            Effect.flatMap((rows) => {
+              const updated = rows[0]
+              if (!updated) {
+                return Effect.fail(
+                  new NotFoundError({
+                    entity: "AnnotationQueueItem",
+                    id: itemId,
+                  }),
+                )
+              }
+              return Effect.succeed(toDomainItem(updated))
+            }),
+            Effect.mapError((cause) => {
+              if (cause instanceof NotFoundError) return cause
+              return new RepositoryError({ operation: "update", cause })
+            }),
+          ),
+
+      getNextUncompletedItem: ({ projectId, queueId, currentItemId: _currentItemId }) =>
+        sqlClient
+          .query((db, organizationId) =>
+            db
+              .select({ id: annotationQueueItems.id })
+              .from(annotationQueueItems)
+              .where(
+                and(
+                  eq(annotationQueueItems.organizationId, organizationId),
+                  eq(annotationQueueItems.projectId, projectId),
+                  eq(annotationQueueItems.queueId, queueId),
+                  sql`${annotationQueueItems.completedAt} IS NULL`,
+                ),
+              )
+              .orderBy(desc(annotationQueueItems.traceCreatedAt), desc(annotationQueueItems.id))
+              .limit(1),
+          )
+          .pipe(
+            Effect.map((rows) => rows[0]?.id ?? null),
+            Effect.mapError(
+              (cause) =>
+                new RepositoryError({
+                  operation: "getNextUncompletedItem",
+                  cause,
+                }),
+            ),
+          ),
     } satisfies AnnotationQueueItemRepositoryShape
   }),
 )

--- a/packages/platform/db-postgres/src/repositories/annotation-queue-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/annotation-queue-repository.test.ts
@@ -269,6 +269,95 @@ describe("AnnotationQueueRepositoryLive", () => {
     })
   })
 
+  describe("incrementCompletedItems", () => {
+    it("increments the counter by positive delta", async () => {
+      const before = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_old") })
+        }),
+      )
+      expect(before?.completedItems).toBe(3)
+
+      await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          yield* repo.incrementCompletedItems({
+            projectId: PROJECT_ID,
+            queueId: makeId("q_old"),
+            delta: 2,
+          })
+        }),
+      )
+
+      const after = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_old") })
+        }),
+      )
+      expect(after?.completedItems).toBe(5)
+    })
+
+    it("decrements the counter by negative delta", async () => {
+      const before = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_mid") })
+        }),
+      )
+      expect(before?.completedItems).toBe(8)
+
+      await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          yield* repo.incrementCompletedItems({
+            projectId: PROJECT_ID,
+            queueId: makeId("q_mid"),
+            delta: -3,
+          })
+        }),
+      )
+
+      const after = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_mid") })
+        }),
+      )
+      expect(after?.completedItems).toBe(5)
+    })
+
+    it("does not go below zero", async () => {
+      const before = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_new") })
+        }),
+      )
+      expect(before?.completedItems).toBe(0)
+
+      await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          yield* repo.incrementCompletedItems({
+            projectId: PROJECT_ID,
+            queueId: makeId("q_new"),
+            delta: -5,
+          })
+        }),
+      )
+
+      const after = await runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AnnotationQueueRepository
+          return yield* repo.findByIdInProject({ projectId: PROJECT_ID, queueId: makeId("q_new") })
+        }),
+      )
+      expect(after?.completedItems).toBe(0)
+    })
+  })
+
   describe("cache eviction", () => {
     it("evicts the project system-queue cache after save", async () => {
       const deletedKeys: string[] = []

--- a/packages/platform/db-postgres/src/repositories/annotation-queue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/annotation-queue-repository.ts
@@ -133,7 +133,10 @@ const tailToCursor = (sortBy: AnnotationQueueListSortBy, tail: typeof annotation
   if (sortBy === "completedItems") {
     return { sortValue: String(tail.completedItems), id: tail.id } as const
   }
-  return { sortValue: String(Math.max(0, tail.totalItems - tail.completedItems)), id: tail.id } as const
+  return {
+    sortValue: String(Math.max(0, tail.totalItems - tail.completedItems)),
+    id: tail.id,
+  } as const
 }
 
 const evictSystemQueueCache = (queue: Pick<AnnotationQueue, "organizationId" | "projectId">) =>
@@ -154,7 +157,10 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
         const cursorClause = options.cursor ? cursorWhere(sortBy, sortDirection, options.cursor) : undefined
         if (options.cursor && cursorClause === null) {
           return Effect.fail(
-            new RepositoryError({ operation: "listByProject", cause: new Error("Invalid queue list cursor") }),
+            new RepositoryError({
+              operation: "listByProject",
+              cause: new Error("Invalid queue list cursor"),
+            }),
           )
         }
 
@@ -184,7 +190,10 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
               const tail = pageRows[pageRows.length - 1]
               const nextCursor =
                 hasMore && tail !== undefined
-                  ? (tailToCursor(sortBy, tail) as { sortValue: string; id: string })
+                  ? (tailToCursor(sortBy, tail) as {
+                      sortValue: string
+                      id: string
+                    })
                   : undefined
               return {
                 items,
@@ -241,7 +250,13 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
               const row = rows[0]
               return row !== undefined ? toDomainQueue(row) : null
             }),
-            Effect.mapError((cause) => new RepositoryError({ operation: "findBySlugInProject", cause })),
+            Effect.mapError(
+              (cause) =>
+                new RepositoryError({
+                  operation: "findBySlugInProject",
+                  cause,
+                }),
+            ),
           ),
 
       listSystemQueuesByProject: ({ projectId }) =>
@@ -262,7 +277,13 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
           )
           .pipe(
             Effect.map((rows) => rows.map(toDomainQueue)),
-            Effect.mapError((cause) => new RepositoryError({ operation: "listSystemQueuesByProject", cause })),
+            Effect.mapError(
+              (cause) =>
+                new RepositoryError({
+                  operation: "listSystemQueuesByProject",
+                  cause,
+                }),
+            ),
           ),
 
       findSystemQueueBySlugInProject: ({ projectId, queueSlug }) =>
@@ -286,7 +307,13 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
               const row = rows[0]
               return row !== undefined ? toDomainQueue(row) : null
             }),
-            Effect.mapError((cause) => new RepositoryError({ operation: "findSystemQueueBySlugInProject", cause })),
+            Effect.mapError(
+              (cause) =>
+                new RepositoryError({
+                  operation: "findSystemQueueBySlugInProject",
+                  cause,
+                }),
+            ),
           ),
 
       save: (queue) =>
@@ -405,9 +432,39 @@ export const AnnotationQueueRepositoryLive = Layer.effect(
             Effect.mapError((cause) =>
               cause instanceof RepositoryError
                 ? cause
-                : new RepositoryError({ operation: "incrementTotalItems", cause }),
+                : new RepositoryError({
+                    operation: "incrementTotalItems",
+                    cause,
+                  }),
             ),
             Effect.tap((queue) => evictSystemQueueCache(queue)),
+          ),
+      incrementCompletedItems: ({ projectId, queueId, delta }) =>
+        sqlClient
+          .query((db, organizationId) =>
+            db
+              .update(annotationQueues)
+              .set({
+                completedItems: sql`GREATEST(0, ${annotationQueues.completedItems} + ${delta})`,
+                updatedAt: new Date(),
+              })
+              .where(
+                and(
+                  eq(annotationQueues.organizationId, organizationId),
+                  eq(annotationQueues.projectId, projectId),
+                  eq(annotationQueues.id, queueId),
+                ),
+              ),
+          )
+          .pipe(
+            Effect.asVoid,
+            Effect.mapError(
+              (cause) =>
+                new RepositoryError({
+                  operation: "incrementCompletedItems",
+                  cause,
+                }),
+            ),
           ),
     } satisfies AnnotationQueueRepositoryShape
   }),

--- a/packages/ui/src/components/popover/primitives.tsx
+++ b/packages/ui/src/components/popover/primitives.tsx
@@ -24,7 +24,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-lg dark:shadow-black/60 outline-none",
+          "w-72 rounded-lg border border-border dark:border-white/15 bg-popover text-popover-foreground p-3 shadow-popover outline-none",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",

--- a/packages/ui/src/components/text/text.tsx
+++ b/packages/ui/src/components/text/text.tsx
@@ -184,6 +184,11 @@ namespace Text {
   })
   H6B.displayName = "Text.H6B"
 
+  export const H7 = forwardRef<HTMLHeadingElement, Common>(function H7(props, ref) {
+    return <TextAtom ref={ref as React.Ref<HTMLElement>} size="h7" {...props} />
+  })
+  H7.displayName = "Text.H7"
+
   export type MonoProps = {
     children: ReactNode
     color?: TextColor
@@ -198,6 +203,7 @@ namespace Text {
     textTransform?: "none" | "uppercase" | "lowercase"
     whiteSpace?: WhiteSpace
     wordBreak?: WordBreak
+    asChild?: boolean
   }
 
   export const Mono = forwardRef<HTMLSpanElement, MonoProps>(function MonoFont(
@@ -215,13 +221,15 @@ namespace Text {
       weight = "normal",
       ellipsis = false,
       display = "inline",
+      asChild = false,
     },
     ref,
   ) {
     const sizeClass = font.size[size]
+    const Comp = asChild ? Slot : "span"
 
     return (
-      <span
+      <Comp
         ref={ref}
         className={cn(
           sizeClass,
@@ -242,7 +250,7 @@ namespace Text {
         )}
       >
         {children}
-      </span>
+      </Comp>
     )
   })
   Mono.displayName = "Text.Mono"

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -183,6 +183,7 @@
   --animate-text-gradient: gradient-animation 3s linear infinite;
   --animate-shine: shine 12s linear infinite;
   --animate-glow: glow 3s ease-in-out infinite;
+  --shadow-popover: var(--shadow-popover);
 }
 
 /* CSS variables for theming */
@@ -232,6 +233,10 @@
   --chart-3: 197 37% 24%;
   --chart-4: 43 74% 66%;
   --chart-5: 27 87% 67%;
+  --shadow-popover:
+    0px 1px 3px 0px hsl(var(--background-shadow) / 0.1),
+    0px 1px 2px -1px hsl(var(--background-shadow) / 0.1),
+    0px 0px 6px 0px hsl(var(--background-shadow) / 0.04);
 }
 
 .dark {
@@ -278,6 +283,10 @@
   --chart-3: 30 80% 55%;
   --chart-4: 280 65% 60%;
   --chart-5: 340 75% 55%;
+  --shadow-popover:
+    0px 2px 4px 0px hsl(var(--background-shadow) / 0.4),
+    0px 1px 3px -1px hsl(var(--background-shadow) / 0.3),
+    0px 0px 8px 0px hsl(var(--background-shadow) / 0.2);
 }
 
 /* Base styles */

--- a/packages/ui/src/tokens/colors.ts
+++ b/packages/ui/src/tokens/colors.ts
@@ -28,6 +28,7 @@ export const colors = {
     destructive: "hover:border-destructive",
   },
   textColors: {
+    inherit: "text-inherit",
     white: "text-white",
     foreground: "text-foreground",
     background: "text-background",


### PR DESCRIPTION
## TODO
- [x] Moving to next and prev trace bottom toolbar -> keybindings
- [x] Add trace to dataset -> keybindings
- [x] 🐛 Instructions are not visible in sidebar
- [x] When adding the first annotation mark as in progress
- [x] fix popover boxshadow

## Next
- [x] Create annotation queue from batch selection of traces. Limit max traces added to last 2 months or 2000 items. [Done here](https://github.com/latitude-dev/latitude-llm/pull/2704)
- [x] Implenment live annotation queues with filters [done here](https://github.com/latitude-dev/latitude-llm/pull/2723)
- [x] Implement multi assign users to queues selector in queues list page.
- [x] Document (already in spec but understand and make sure is clear) when and how an annotation can be edited or removed. 
- [x] Show `rawFeedback` somehow in the annotation
- [x] :bug: Fix delete annotation. Missing deletion from centroid in weaviate and postgresql.
- [ ] Show draft icon 
- [x] Implement `Reject` and `Approve` 
- [x] Implement `Agent` and `API` procedence meta tag
- [ ] Filtering annotation queues. Talk with Danil and @geclos about how and what filters are necessary.
