### PR TITLE
fix(ai-vercel): use AWS provider chain for Bedrock

### DIFF
--- a/packages/platform/ai-vercel/package.json
+++ b/packages/platform/ai-vercel/package.json
@@ -16,6 +16,7 @@
     "@ai-sdk/amazon-bedrock": "5.0.0-beta.27",
     "@ai-sdk/anthropic": "4.0.0-beta.23",
     "@ai-sdk/openai": "4.0.0-beta.12",
+    "@aws-sdk/credential-providers": "3.1027.0",
     "@domain/ai": "workspace:*",
     "@platform/ai-latitude": "workspace:*",
     "@platform/env": "workspace:*",

--- a/packages/platform/ai-vercel/src/ai.test.ts
+++ b/packages/platform/ai-vercel/src/ai.test.ts
@@ -1,11 +1,27 @@
 import { AICredentialError } from "@domain/ai"
 import { Effect, Result } from "effect"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { fromNodeProviderChainMock } = vi.hoisted(() => ({
+  fromNodeProviderChainMock: vi.fn(() =>
+    Promise.resolve({
+      accessKeyId: "provider-chain-access-key",
+      secretAccessKey: "provider-chain-secret-key",
+    }),
+  ),
+}))
+
+vi.mock("@aws-sdk/credential-providers", () => ({
+  fromNodeProviderChain: fromNodeProviderChainMock,
+}))
+
 import { createProviderModel } from "./ai.ts"
 
 const originalAwsRegion = process.env.LAT_AWS_REGION
 const originalAwsAccessKeyId = process.env.LAT_AWS_ACCESS_KEY_ID
 const originalAwsSecretAccessKey = process.env.LAT_AWS_SECRET_ACCESS_KEY
+const originalAwsSessionToken = process.env.LAT_AWS_SESSION_TOKEN
+const originalAwsBearerTokenBedrock = process.env.LAT_AWS_BEARER_TOKEN_BEDROCK
 const originalAnthropicApiKey = process.env.LAT_ANTHROPIC_API_KEY
 const originalOpenAiApiKey = process.env.LAT_OPENAI_API_KEY
 
@@ -13,14 +29,19 @@ beforeEach(() => {
   process.env.LAT_AWS_REGION = "us-east-1"
   process.env.LAT_AWS_ACCESS_KEY_ID = "test-access-key"
   process.env.LAT_AWS_SECRET_ACCESS_KEY = "test-secret-key"
+  delete process.env.LAT_AWS_SESSION_TOKEN
+  delete process.env.LAT_AWS_BEARER_TOKEN_BEDROCK
   process.env.LAT_ANTHROPIC_API_KEY = "sk-ant-test"
   process.env.LAT_OPENAI_API_KEY = "sk-openai-test"
+  fromNodeProviderChainMock.mockClear()
 })
 
 afterEach(() => {
   process.env.LAT_AWS_REGION = originalAwsRegion
   process.env.LAT_AWS_ACCESS_KEY_ID = originalAwsAccessKeyId
   process.env.LAT_AWS_SECRET_ACCESS_KEY = originalAwsSecretAccessKey
+  process.env.LAT_AWS_SESSION_TOKEN = originalAwsSessionToken
+  process.env.LAT_AWS_BEARER_TOKEN_BEDROCK = originalAwsBearerTokenBedrock
   process.env.LAT_ANTHROPIC_API_KEY = originalAnthropicApiKey
   process.env.LAT_OPENAI_API_KEY = originalOpenAiApiKey
 })
@@ -46,6 +67,21 @@ describe("createProviderModel", () => {
 
     expect(model).toBeDefined()
     expect(typeof model).toBe("object")
+    expect(fromNodeProviderChainMock).not.toHaveBeenCalled()
+  })
+
+  it("uses the AWS SDK credential provider chain for Bedrock when explicit credentials are absent", async () => {
+    delete process.env.LAT_AWS_ACCESS_KEY_ID
+    delete process.env.LAT_AWS_SECRET_ACCESS_KEY
+    delete process.env.LAT_AWS_SESSION_TOKEN
+
+    const model = await Effect.runPromise(
+      createProviderModel("amazon-bedrock", "anthropic.claude-sonnet-4-20250514-v1:0"),
+    )
+
+    expect(model).toBeDefined()
+    expect(typeof model).toBe("object")
+    expect(fromNodeProviderChainMock).toHaveBeenCalledTimes(1)
   })
 
   it("succeeds with a language model for anthropic", async () => {

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -1,6 +1,7 @@
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import {
   AICredentialError,
   AIError,
@@ -90,6 +91,8 @@ const createBedrockProvider = (): Effect.Effect<ReturnType<typeof createAmazonBe
         mapCredentialError("Amazon Bedrock credentials are invalid: LAT_AWS_BEARER_TOKEN_BEDROCK must be a string."),
       ),
     )
+    const shouldUseCredentialProviderChain =
+      apiKey === undefined && accessKeyId === undefined && secretAccessKey === undefined && sessionToken === undefined
 
     return createAmazonBedrock({
       region,
@@ -99,6 +102,11 @@ const createBedrockProvider = (): Effect.Effect<ReturnType<typeof createAmazonBe
             accessKeyId,
             secretAccessKey,
             ...(sessionToken !== undefined ? { sessionToken } : {}),
+          }
+        : {}),
+      ...(shouldUseCredentialProviderChain
+        ? {
+            credentialProvider: fromNodeProviderChain(),
           }
         : {}),
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1054,6 +1054,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 4.0.0-beta.12
         version: 4.0.0-beta.12(zod@4.3.6)
+      '@aws-sdk/credential-providers':
+        specifier: 3.1027.0
+        version: 3.1027.0
       '@domain/ai':
         specifier: workspace:*
         version: link:../../domain/ai
@@ -10993,7 +10996,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/client-ecs@3.1027.0':
     dependencies:
@@ -11176,7 +11178,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-env@3.972.25':
     dependencies:
@@ -11306,7 +11307,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-    optional: true
 
   '@aws-sdk/eventstream-handler-node@3.972.13':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@aws-sdk/credential-providers` to `@platform/ai-vercel` and wire Bedrock to use `fromNodeProviderChain()` when explicit AWS credentials are absent
- preserve the existing explicit access key, session token, and bearer token paths so fallback only applies when no direct Bedrock credentials are configured
- add tests covering both the explicit-credential path and the provider-chain fallback path

## Validation
- `pnpm --filter @platform/ai-vercel test`
- `pnpm --filter @platform/ai-vercel typecheck`
- `pnpm --filter @platform/ai-vercel check`

## Notes
- partial explicit AWS credential env configuration remains an existing edge case and is not changed by this PR