### PR TITLE
Qa fixes

### DIFF
--- a/.agents/skills/web-frontend/SKILL.md
+++ b/.agents/skills/web-frontend/SKILL.md
@@ -132,16 +132,48 @@ export const useProjectsCollection = (...) => useLiveQuery(...)
 
 Collection files live in `apps/web/src/domains/*/collection.ts`.
 
-**Route guards** — Use `beforeLoad` for auth checks and redirects:
+**Route middleware vs route data**
+
+- Use `beforeLoad` for middleware-style checks that should block the route tree early: auth redirects, authorization gates, and other preconditions.
+- Use `loader` for data the route or layout actually renders. This keeps rendered data in TanStack Router's loader lifecycle, so it can use `staleTime`, `useLoaderData({ select })`, and avoid unnecessary refetching on same-route search-param navigations.
+- If the same lookup is both your guard and your rendered data source, prefer doing that work in `loader` once instead of duplicating it across `beforeLoad` and `loader`.
+- When multiple descendant routes need parent loader data, prefer a small route-scoped wrapper around `getRouteApi("...")` instead of repeating the route id string in every file.
+
+```typescript
+export const Route = createFileRoute("/admin")({
+  beforeLoad: async () => {
+    const session = await getSession()
+    if (!session?.user.isAdmin) throw redirect({ to: "/" })
+  },
+})
+```
 
 ```typescript
 export const Route = createFileRoute("/_authenticated")({
-  beforeLoad: async () => {
+  staleTime: Infinity,
+  loader: async () => {
     const session = await getSession()
     if (!session) throw redirect({ to: "/login" })
-    return { user: session.user }
+
+    const sessionData = session.session as Record<string, unknown>
+    const organizationId =
+      typeof sessionData.activeOrganizationId === "string" ? sessionData.activeOrganizationId : null
+    if (!organizationId) throw redirect({ to: "/welcome" })
+
+    return {
+      user: session.user,
+      organizationId,
+    }
   },
 })
+```
+
+```typescript
+const authenticatedRoute = getRouteApi("/_authenticated")
+
+export function useAuthenticatedUser() {
+  return authenticatedRoute.useLoaderData({ select: (data) => data.user })
+}
 ```
 
 **Key rules:**

--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -3,8 +3,10 @@ import { extractLeadingEmoji } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { Link, useMatches } from "@tanstack/react-router"
 import { ChevronDown, ChevronRight, ChevronsUp, PanelLeft, PanelLeftClose } from "lucide-react"
-import { type ReactNode, useCallback, useState } from "react"
+import { type ReactElement, type ReactNode, useCallback, useState } from "react"
 import { HotkeyBadge } from "../../components/hotkey-badge.tsx"
+
+type NavItemIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>
 
 function ProjectEmoji({ name }: { name: string }) {
   const [emoji] = extractLeadingEmoji(name)
@@ -14,6 +16,142 @@ function ProjectEmoji({ name }: { name: string }) {
     <div className="w-6 h-6 rounded-lg bg-white border border-border flex items-center justify-center shrink-0">
       <span className="text-sm leading-none">{emoji}</span>
     </div>
+  )
+}
+
+function NavItemTooltipWrapper({
+  collapsed,
+  label,
+  children,
+}: {
+  collapsed: boolean
+  label: string
+  children: ReactElement
+}) {
+  if (!collapsed) return children
+
+  return (
+    <Tooltip asChild trigger={children} side="right">
+      {label}
+    </Tooltip>
+  )
+}
+
+function NavItemDisclosureIcon({ expanded, className }: { expanded: boolean; className?: string }) {
+  return (
+    <Icon icon={expanded ? ChevronDown : ChevronRight} size="sm" color="foregroundMuted" className={className ?? ""} />
+  )
+}
+
+function NavItemActionWrapper({
+  to,
+  collapsed,
+  label,
+  rowClassName,
+  hasChildren,
+  expanded,
+  onToggle,
+  children,
+}: {
+  to: string | undefined
+  collapsed: boolean
+  label: string
+  rowClassName: string
+  hasChildren: boolean
+  expanded: boolean
+  onToggle: () => void
+  children: ReactNode
+}) {
+  const disclosureIcon = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6 rounded-md p-0 group-hover:bg-transparent"
+      onClick={onToggle}
+      aria-label={expanded ? `Collapse ${label}` : `Expand ${label}`}
+      aria-expanded={expanded}
+    >
+      <NavItemDisclosureIcon expanded={expanded} />
+    </Button>
+  )
+
+  const content = to ? (
+    <div
+      className={cn(rowClassName, "flex items-center", {
+        "justify-center": collapsed,
+        "gap-1": !collapsed,
+      })}
+      title={collapsed ? label : undefined}
+    >
+      <Link
+        to={to}
+        className={cn("flex items-center", {
+          "h-full w-full justify-center": collapsed,
+          "min-w-0 flex-1 gap-2": !collapsed,
+        })}
+        aria-label={collapsed ? label : undefined}
+      >
+        {children}
+      </Link>
+      {hasChildren ? disclosureIcon : null}
+    </div>
+  ) : (
+    <button
+      type="button"
+      onClick={hasChildren ? onToggle : undefined}
+      className={cn(rowClassName, "flex w-full items-center text-left", {
+        "justify-center": collapsed,
+        "gap-2": !collapsed,
+      })}
+      title={collapsed ? label : undefined}
+      aria-expanded={hasChildren ? expanded : undefined}
+      aria-label={collapsed ? label : undefined}
+    >
+      {children}
+      {hasChildren ? disclosureIcon : null}
+    </button>
+  )
+
+  return (
+    <NavItemTooltipWrapper collapsed={collapsed} label={label}>
+      {content}
+    </NavItemTooltipWrapper>
+  )
+}
+
+function NavItemContent({
+  icon,
+  label,
+  active,
+  badge,
+  collapsed = false,
+}: {
+  icon: NavItemIcon
+  label: string
+  active?: boolean | undefined
+  badge?: number | undefined
+  collapsed?: boolean | undefined
+}) {
+  return (
+    <>
+      <Icon icon={icon} size="sm" className={active ? "text-accent-foreground" : "text-muted-foreground"} />
+      {!collapsed ? (
+        <>
+          <Text.H5M color={active ? "accentForeground" : "foregroundMuted"} ellipsis className="min-w-0 flex-1">
+            {label}
+          </Text.H5M>
+          {badge !== undefined && badge > 0 ? (
+            <span className="inline-flex items-center gap-0.5 rounded-md border border-destructive/10 bg-destructive-muted px-1.5 py-0.5">
+              <Icon icon={ChevronsUp} size="xs" color="destructive" />
+              <Text.H6 color="destructive" weight="medium">
+                {badge}
+              </Text.H6>
+            </span>
+          ) : null}
+        </>
+      ) : null}
+    </>
   )
 }
 
@@ -27,7 +165,7 @@ export function NavItem({
   defaultExpanded = false,
   collapsed = false,
 }: {
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
+  icon: NavItemIcon
   label: string
   to?: string
   active?: boolean
@@ -37,72 +175,32 @@ export function NavItem({
   collapsed?: boolean
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded)
-  const hasChildren = !!children && !collapsed
-
-  const chevron = hasChildren ? (
-    expanded ? (
-      <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
-    ) : (
-      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-    )
-  ) : null
-
-  const rowContent = (
-    <div
-      className={cn("flex cursor-pointer items-center gap-2 rounded-lg transition-colors", {
-        "h-10 w-10 justify-center": collapsed,
-        "px-2 py-2": !collapsed,
-        "bg-accent/10": active,
-        "hover:bg-muted": !active,
-      })}
-      title={collapsed ? label : undefined}
-    >
-      <Icon icon={icon} size="sm" className={active ? "text-accent-foreground" : "text-muted-foreground"} />
-      {!collapsed && (
-        <>
-          <Text.H5M color={active ? "accentForeground" : "foregroundMuted"} ellipsis className="flex-1 min-w-0">
-            {label}
-          </Text.H5M>
-          {badge !== undefined && badge > 0 && (
-            <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-destructive-muted border border-destructive/10">
-              <ChevronsUp className="h-3 w-3 text-destructive" />
-              <Text.H6 color="destructive" weight="medium">
-                {badge}
-              </Text.H6>
-            </span>
-          )}
-          {to ? (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                setExpanded((v) => !v)
-              }}
-              className="shrink-0"
-            >
-              {chevron}
-            </button>
-          ) : (
-            chevron
-          )}
-        </>
-      )}
-    </div>
+  const hasChildren = Boolean(children) && !collapsed
+  const rowClassName = cn("rounded-lg transition-colors", {
+    "h-10 w-10": collapsed,
+    "px-2 py-2": !collapsed,
+    "bg-accent/10": active,
+    "hover:bg-muted": !active,
+  })
+  const navItemContent = (
+    <NavItemContent icon={icon} label={label} active={active} badge={badge} collapsed={collapsed} />
   )
+  const toggleExpanded = () => setExpanded((value) => !value)
 
   return (
     <div className="flex flex-col">
-      {to ? (
-        <Link to={to} className="block">
-          {rowContent}
-        </Link>
-      ) : (
-        <button type="button" onClick={() => hasChildren && setExpanded((v) => !v)} className="w-full text-left">
-          {rowContent}
-        </button>
-      )}
-      {hasChildren && expanded && <div className="flex flex-col pl-6 gap-0.5 pt-0.5">{children}</div>}
+      <NavItemActionWrapper
+        to={to}
+        collapsed={collapsed}
+        label={label}
+        rowClassName={rowClassName}
+        hasChildren={hasChildren}
+        expanded={expanded}
+        onToggle={toggleExpanded}
+      >
+        {navItemContent}
+      </NavItemActionWrapper>
+      {hasChildren && expanded ? <div className="flex flex-col gap-0.5 pl-6 pt-0.5">{children}</div> : null}
     </div>
   )
 }

--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -1,10 +1,11 @@
 import { Button, cn, Icon, Text, Tooltip, useLocalStorage } from "@repo/ui"
 import { extractLeadingEmoji } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { Link, useMatches } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import { ChevronDown, ChevronRight, ChevronsUp, PanelLeft, PanelLeftClose } from "lucide-react"
-import { type ReactElement, type ReactNode, useCallback, useState } from "react"
+import { type ReactElement, type ReactNode, useState } from "react"
 import { HotkeyBadge } from "../../components/hotkey-badge.tsx"
+import { useHasMatchStaticData } from "../../lib/hooks/use-router-selectors.ts"
 
 type NavItemIcon = React.ComponentType<React.SVGProps<SVGSVGElement>>
 
@@ -206,8 +207,7 @@ export function NavItem({
 }
 
 function useShouldCollapseSidebar() {
-  const matches = useMatches()
-  return matches.some((m) => (m.staticData as { collapseSidebar?: boolean } | undefined)?.collapseSidebar === true)
+  return useHasMatchStaticData((staticData) => staticData?.collapseSidebar === true)
 }
 export function AppSidebar({
   title,
@@ -226,6 +226,7 @@ export function AppSidebar({
   const collapsed = collapsedPreference ?? autoCollapse
   const toggleCollapsed = () => setCollapsedPreference((value) => !(value ?? autoCollapse))
   useHotkeys([{ hotkey: "Mod+B", callback: toggleCollapsed }])
+
   return (
     <aside
       className={cn("flex h-full shrink-0 flex-col border-r border-border transition-all duration-200", {

--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, Icon, Text, Tooltip, useValueWithDefault } from "@repo/ui"
+import { Button, cn, Icon, Text, Tooltip, useLocalStorage } from "@repo/ui"
 import { extractLeadingEmoji } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { Link, useMatches } from "@tanstack/react-router"
@@ -219,8 +219,12 @@ export function AppSidebar({
   children: (props: { collapsed: boolean }) => ReactNode
 }) {
   const autoCollapse = useShouldCollapseSidebar()
-  const [collapsed, setCollapsed] = useValueWithDefault(autoCollapse)
-  const toggleCollapsed = useCallback(() => setCollapsed(!collapsed), [collapsed, setCollapsed])
+  const { value: collapsedPreference, setValue: setCollapsedPreference } = useLocalStorage<boolean | null>({
+    key: "app-sidebar-collapsed",
+    defaultValue: null,
+  })
+  const collapsed = collapsedPreference ?? autoCollapse
+  const toggleCollapsed = () => setCollapsedPreference((value) => !(value ?? autoCollapse))
   useHotkeys([{ hotkey: "Mod+B", callback: toggleCollapsed }])
   return (
     <aside

--- a/apps/web/src/lib/hooks/use-router-selectors.ts
+++ b/apps/web/src/lib/hooks/use-router-selectors.ts
@@ -1,0 +1,45 @@
+import { useRouterState } from "@tanstack/react-router"
+
+type MatchStaticData = Record<string, unknown> | undefined
+
+/**
+ * Prefer selector-based router subscriptions in layout chrome.
+ *
+ * `useMatches()` subscribes the component to the router's full matches array,
+ * and unscoped `useRouterState()` subscribes to the full router state. In
+ * shared UI like sidebars and breadcrumbs, that means search-only updates can
+ * rerender components even when the tiny value they care about has not changed.
+ *
+ * These helpers keep callers focused on the smallest router-derived value they
+ * actually render, which lets TanStack Router preserve those components when
+ * that selected value stays equal across a navigation.
+ */
+export function useHasMatchStaticData(predicate: (staticData: MatchStaticData) => boolean) {
+  return useRouterState({
+    select: (state) =>
+      state.matches.some((match) => {
+        return predicate(match.staticData as MatchStaticData)
+      }),
+  })
+}
+
+/**
+ * Collects the ids of active matches whose `staticData` passes the predicate.
+ * Returning match ids keeps the selected value stable and JSON-serializable.
+ */
+export function useMatchIdsWithStaticData(predicate: (staticData: MatchStaticData) => boolean) {
+  return useRouterState({
+    select: (state) =>
+      state.matches.flatMap((match) => {
+        return predicate(match.staticData as MatchStaticData) ? [match.id] : []
+      }),
+  })
+}
+
+/**
+ * Same idea for pathname-only consumers: avoid subscribing to the full router
+ * state when a component only needs the current pathname to render.
+ */
+export function usePathname() {
+  return useRouterState({ select: (state) => state.location.pathname })
+}

--- a/apps/web/src/lib/hooks/useParamState.test.ts
+++ b/apps/web/src/lib/hooks/useParamState.test.ts
@@ -1,12 +1,51 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+type MockNavigateOptions = {
+  to: string
+  replace?: boolean
+  search?: Record<string, unknown> | ((prev: Record<string, unknown>) => Record<string, unknown>)
+}
+
+/**
+ * Minimal TanStack Router mock for this hook. We only need `navigate()` and we
+ * model it by updating the current URL search string the same way the hook
+ * expects in production.
+ */
+const mockNavigate = vi.fn(async ({ replace, search }: MockNavigateOptions) => {
+  const prevSearch = Object.fromEntries(new URLSearchParams(window.location.search).entries())
+  const nextSearch = typeof search === "function" ? search(prevSearch) : (search ?? prevSearch)
+  const nextParams = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(nextSearch)) {
+    if (value === undefined) continue
+    nextParams.set(key, String(value))
+  }
+
+  const nextUrl = nextParams.toString()
+    ? `${window.location.pathname}?${nextParams.toString()}${window.location.hash}`
+    : `${window.location.pathname}${window.location.hash}`
+
+  if (replace) {
+    window.history.replaceState(null, "", nextUrl)
+  } else {
+    window.history.pushState(null, "", nextUrl)
+  }
+})
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouter: () => ({
+    navigate: mockNavigate,
+  }),
+}))
+
 import { useParamState } from "./useParamState.ts"
 
 /**
- * `useParamState` notifies subscribers in a microtask after URL writes. Plain
- * `act(() => setX())` can finish before that microtask runs, which produces
- * React "not wrapped in act(...)" noise. Flush microtasks inside `act`.
+ * `useParamState` now updates local React state immediately, but still mirrors
+ * the URL in a microtask. Flush microtasks inside `act` when a test needs to
+ * observe the final URL.
  */
 async function actWithParamFlush(fn: () => void) {
   await act(async () => {
@@ -15,11 +54,12 @@ async function actWithParamFlush(fn: () => void) {
   })
 }
 
-function setUrl(search: string) {
-  window.history.replaceState(null, "", search || window.location.pathname)
+function setUrl(search: string, pathname = window.location.pathname) {
+  window.history.replaceState(null, "", search ? `${pathname}${search}` : pathname)
 }
 
-afterEach(() => setUrl(""))
+afterEach(() => setUrl("", "/"))
+afterEach(() => mockNavigate.mockClear())
 
 function setup<T extends boolean | number | string>(paramKey: string, defaultValue: T) {
   return renderHook(() => useParamState(paramKey, defaultValue))
@@ -42,6 +82,32 @@ describe("useParamState", () => {
       const { result } = setup("tab", "traces")
       await actWithParamFlush(() => result.current[1]("sessions"))
       expect(result.current[0]).toBe("sessions")
+      expect(window.location.search).toBe("?tab=sessions")
+    })
+
+    it("commits search updates against the current absolute pathname", async () => {
+      setUrl("", "/projects/demo")
+      const { result } = setup("tab", "traces")
+
+      await actWithParamFlush(() => result.current[1]("sessions"))
+
+      expect(mockNavigate).toHaveBeenCalledWith(expect.objectContaining({ to: "/projects/demo" }))
+    })
+
+    it("updates local state before the URL flush runs", async () => {
+      const { result } = setup("tab", "traces")
+
+      act(() => {
+        result.current[1]("sessions")
+      })
+
+      expect(result.current[0]).toBe("sessions")
+      expect(window.location.search).toBe("")
+
+      await act(async () => {
+        await Promise.resolve()
+      })
+
       expect(window.location.search).toBe("?tab=sessions")
     })
 
@@ -221,7 +287,32 @@ describe("useParamState", () => {
     })
   })
 
-  describe("popstate synchronization", () => {
+  describe("shared store synchronization", () => {
+    it("keeps hooks with the same param key in sync", async () => {
+      const first = renderHook(() => useParamState("tab", "traces"))
+      const second = renderHook(() => useParamState("tab", "traces"))
+
+      await actWithParamFlush(() => first.result.current[1]("sessions"))
+
+      expect(first.result.current[0]).toBe("sessions")
+      expect(second.result.current[0]).toBe("sessions")
+      expect(window.location.search).toBe("?tab=sessions")
+    })
+  })
+
+  describe("location synchronization", () => {
+    it("updates when history.replaceState changes the URL", async () => {
+      const { result } = setup("tab", "traces")
+      expect(result.current[0]).toBe("traces")
+
+      await act(async () => {
+        window.history.replaceState(null, "", "?tab=other")
+        await Promise.resolve()
+      })
+
+      expect(result.current[0]).toBe("other")
+    })
+
     it("updates when popstate fires", async () => {
       setUrl("?tab=sessions")
       const { result } = setup("tab", "traces")

--- a/apps/web/src/lib/hooks/useParamState.ts
+++ b/apps/web/src/lib/hooks/useParamState.ts
@@ -1,32 +1,5 @@
-import { type SetStateAction, useSyncExternalStore } from "react"
-
-/**
- * useParamState — a useState-like hook backed by URL search parameters.
- *
- * Use this for ephemeral UI state that should be reflected in the URL (active
- * tab, open panels, sort columns, selected row IDs, etc.). Do NOT use
- * router.navigate for this — navigate is for actual page transitions (e.g.
- * opening a dataset after creation). useParamState bypasses the router
- * entirely, so it avoids TanStack Router's reconciliation overhead.
- *
- * Design decisions:
- *
- * - Uses `useSyncExternalStore` to treat the URL as an external store. This
- *   is the React-blessed way to subscribe to non-React state; it handles
- *   concurrent mode, avoids tearing, and provides an SSR snapshot.
- *
- * - The URL is the source of truth. Reads always parse `window.location.search`
- *   so there's no stale-closure risk and no local state to sync.
- *
- * - When the resolved value equals `defaultValue`, the param is removed from
- *   the URL entirely (via `Object.is` comparison), keeping URLs clean.
- *
- * - Writes are batched: multiple setters called in the same synchronous handler
- *   (e.g. `setSortBy(x); setSortDirection(y)`) produce only one React render.
- *   Each write updates `history` immediately so subsequent reads within the
- *   same tick see the latest URL, but the subscriber notification is deferred
- *   to a microtask so React processes all changes in a single pass.
- */
+import { useRouter } from "@tanstack/react-router"
+import { type SetStateAction, useEffect, useRef, useState } from "react"
 
 type ParamStateValue = boolean | number | string
 
@@ -38,25 +11,41 @@ type ParamStateValue = boolean | number | string
  */
 type WidenLiteral<T> = T extends string ? string : T extends number ? number : T extends boolean ? boolean : T
 
-const PARAM_STATE_CHANGE_EVENT = "param-state-change"
+type ParamStateSyncDetail = {
+  paramKey: string
+  rawValue: string | null
+  sourceId: number
+}
 
 /**
- * Shared subscription function for `useSyncExternalStore`. Listens to:
- * - `popstate`: browser back/forward navigation
- * - `param-state-change`: our custom event dispatched after writes
- *
- * Because this function is referentially stable (module-level), every
- * `useParamState` instance shares the same two listeners rather than
- * each hook adding its own pair.
+ * Pending URL writes are keyed by param so several setters in the same tick can
+ * collapse into a single router navigation.
  */
-function subscribe(onStoreChange: () => void) {
-  window.addEventListener("popstate", onStoreChange)
-  window.addEventListener(PARAM_STATE_CHANGE_EVENT, onStoreChange)
-  return () => {
-    window.removeEventListener("popstate", onStoreChange)
-    window.removeEventListener(PARAM_STATE_CHANGE_EVENT, onStoreChange)
-  }
+type PendingUrlUpdate = {
+  searchValue: ParamStateValue | null
+  history: "push" | "replace"
 }
+
+/** Broadcast name used to fan out same-key updates to hook instances in this tab. */
+const PARAM_STATE_SYNC_EVENT = "param-state-sync"
+/** Broadcast name used to notify hooks when any history write changes the URL. */
+const LOCATION_CHANGE_EVENT = "param-state-location-change"
+/** In-memory snapshot of the latest raw value for each known param key. */
+const latestRawValuesByKey = new Map<string, string | null>()
+/** Queue of URL writes waiting to be flushed after React has updated local state. */
+const pendingUrlUpdates = new Map<string, PendingUrlUpdate>()
+
+/** Ensures the history monkey-patch is installed only once per page. */
+let historyPatched = false
+/** Guards the microtask that flushes pending URL updates. */
+let urlFlushScheduled = false
+/** Invalidates stale flush microtasks after external navigation wins. */
+let urlFlushVersion = 0
+/** Simple instance id generator so senders can ignore their own sync events. */
+let nextSourceId = 0
+
+/** Narrow router shape used by this hook when committing URL changes. */
+type ParamStateRouter = Pick<ReturnType<typeof useRouter>, "navigate">
 
 /**
  * Coerces a raw URL string value back to the type implied by `defaultValue`.
@@ -81,11 +70,33 @@ function parseParamValue<T extends ParamStateValue>(rawValue: string, defaultVal
   return rawValue as WidenLiteral<T>
 }
 
-/** Reads a single param from the current URL, falling back to `defaultValue` if absent. */
-function readParam<T extends ParamStateValue>(paramKey: string, defaultValue: T): WidenLiteral<T> {
-  const params = new URLSearchParams(window.location.search)
-  const rawValue = params.get(paramKey)
+/** Reads a raw search param string directly from the current browser URL. */
+function readRawParam(paramKey: string) {
+  return new URLSearchParams(window.location.search).get(paramKey)
+}
 
+/**
+ * Returns the freshest raw value we know for a param.
+ * While a local write is still pending, the in-memory snapshot wins; otherwise
+ * the browser URL becomes authoritative again.
+ */
+function getCurrentRawValue(paramKey: string) {
+  if (pendingUrlUpdates.has(paramKey) && latestRawValuesByKey.has(paramKey)) {
+    return latestRawValuesByKey.get(paramKey) ?? null
+  }
+
+  const rawValue = readRawParam(paramKey)
+  latestRawValuesByKey.set(paramKey, rawValue)
+  return rawValue
+}
+
+/** Updates the in-memory snapshot so newly mounted hooks see the latest local value. */
+function setCurrentRawValue(paramKey: string, rawValue: string | null) {
+  latestRawValuesByKey.set(paramKey, rawValue)
+}
+
+/** Reads a single param value, falling back to `defaultValue` if absent. */
+function readParam<T extends ParamStateValue>(rawValue: string | null, defaultValue: T): WidenLiteral<T> {
   if (rawValue === null) {
     return defaultValue as unknown as WidenLiteral<T>
   }
@@ -93,53 +104,108 @@ function readParam<T extends ParamStateValue>(paramKey: string, defaultValue: T)
   return parseParamValue(rawValue, defaultValue)
 }
 
-function buildUrl(params: URLSearchParams): string {
-  const search = params.toString()
-  return search
-    ? `${window.location.pathname}?${search}${window.location.hash}`
-    : `${window.location.pathname}${window.location.hash}`
+/**
+ * Applies the optional runtime validator so malformed URL values never escape
+ * into component state.
+ */
+function resolveValue<T extends ParamStateValue, R extends WidenLiteral<T>>(
+  rawValue: string | null,
+  defaultValue: T,
+  validate?: (value: WidenLiteral<T>) => value is R,
+) {
+  const parsed = readParam(rawValue, defaultValue)
+  if (validate && !validate(parsed)) return defaultValue as unknown as R
+  return parsed as R
 }
 
 /**
- * Microtask-based batching flag. When multiple params are written in the same
- * synchronous call stack (e.g. `setSortBy(); setSortDirection()`), the first
- * write schedules a microtask to dispatch the change event. Subsequent writes
- * in the same tick see the flag and skip scheduling, so only one event fires
- * after all writes complete. This prevents intermediate renders with partially
- * updated URLs and avoids duplicate network requests from query hooks.
+ * Flushes all queued URL writes through TanStack Router so search updates follow
+ * the router's supported navigation lifecycle instead of mutating history
+ * behind its back.
  */
-let flushScheduled = false
+function flushPendingUrlUpdates(router: ParamStateRouter, flushVersion: number) {
+  if (pendingUrlUpdates.size === 0) return
 
-/**
- * Writes a single param to the URL and schedules a batched notification.
- * The URL is updated synchronously (so reads within the same tick reflect
- * the new value), but the event that triggers React re-renders is deferred
- * to a microtask.
- */
-function writeParam(paramKey: string, serialized: string | undefined, history: "push" | "replace") {
-  const params = new URLSearchParams(window.location.search)
+  const updates = Array.from(pendingUrlUpdates.entries())
+  const replace = !updates.some(([, update]) => update.history === "push")
+  const currentPathname = window.location.pathname || "/"
 
-  if (serialized === undefined) {
-    params.delete(paramKey)
-  } else {
-    params.set(paramKey, serialized)
-  }
-
-  const url = buildUrl(params)
-
-  if (history === "push") {
-    window.history.pushState(window.history.state, "", url)
-  } else {
-    window.history.replaceState(window.history.state, "", url)
-  }
-
-  if (!flushScheduled) {
-    flushScheduled = true
-    queueMicrotask(() => {
-      flushScheduled = false
-      window.dispatchEvent(new Event(PARAM_STATE_CHANGE_EVENT))
+  void router
+    .navigate({
+      // Use the concrete current pathname instead of "." because relative
+      // current-route navigation can resolve against pathless layout routes.
+      to: currentPathname,
+      replace,
+      resetScroll: false,
+      hashScrollIntoView: false,
+      search: (prev: Record<string, unknown>) => {
+        const nextSearch = { ...prev } as Record<string, unknown>
+        for (const [paramKey, update] of updates) {
+          if (update.searchValue === null) {
+            delete nextSearch[paramKey]
+          } else {
+            nextSearch[paramKey] = update.searchValue
+          }
+        }
+        return nextSearch
+      },
     })
-  }
+    .finally(() => {
+      if (flushVersion !== urlFlushVersion) return
+      pendingUrlUpdates.clear()
+    })
+}
+
+/** Discards queued URL writes when the browser location changes externally. */
+function cancelPendingUrlFlush() {
+  pendingUrlUpdates.clear()
+  urlFlushScheduled = false
+  urlFlushVersion++
+}
+
+/** Queues a param write so the URL can update after local React state has updated. */
+function scheduleUrlFlush(
+  router: ParamStateRouter,
+  paramKey: string,
+  searchValue: ParamStateValue | null,
+  history: "push" | "replace",
+) {
+  const existing = pendingUrlUpdates.get(paramKey)
+  pendingUrlUpdates.set(paramKey, {
+    searchValue,
+    history: existing?.history === "push" || history === "push" ? "push" : "replace",
+  })
+
+  if (urlFlushScheduled) return
+
+  urlFlushScheduled = true
+  const scheduledVersion = ++urlFlushVersion
+  queueMicrotask(() => {
+    if (scheduledVersion !== urlFlushVersion) return
+
+    urlFlushScheduled = false
+    flushPendingUrlUpdates(router, scheduledVersion)
+  })
+}
+
+/** Installs a single history patch so direct `pushState`/`replaceState` calls are observable. */
+function ensureLocationTracking() {
+  if (historyPatched) return
+
+  const originalPushState = window.history.pushState.bind(window.history)
+  const originalReplaceState = window.history.replaceState.bind(window.history)
+
+  window.history.pushState = ((...args) => {
+    originalPushState(...args)
+    window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT))
+  }) as History["pushState"]
+
+  window.history.replaceState = ((...args) => {
+    originalReplaceState(...args)
+    window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT))
+  }) as History["replaceState"]
+
+  historyPatched = true
 }
 
 type ParamStateOptions = {
@@ -168,32 +234,90 @@ export function useParamState<T extends ParamStateValue, R extends WidenLiteral<
   defaultValue: T,
   options?: ParamStateOptions & { validate?: (value: WidenLiteral<T>) => value is R },
 ): [R, (next: SetStateAction<R>) => void] {
+  /** Router instance used to commit supported same-route search updates. */
+  const router = useRouter()
+  /** Chosen history mode for URL mirroring; local state updates always remain synchronous. */
   const historyMode = options?.history ?? "replace"
+  /** Optional caller-provided guard that narrows the returned value type. */
   const validate = options?.validate
+  /** Stable instance id so same-key broadcasts can skip the sender. */
+  const [sourceId] = useState(() => nextSourceId++)
+  /** The rendered value lives in local React state for immediate UI response. */
+  const [value, setValue] = useState<R>(() => resolveValue(getCurrentRawValue(paramKey), defaultValue, validate))
+  /** Tracks the latest committed value so functional updaters stay in sync across events. */
+  const valueRef = useRef(value)
+  valueRef.current = value
+  /** Holds the latest validator without forcing browser listener re-subscription. */
+  const validateRef = useRef(validate)
+  validateRef.current = validate
 
-  const value = useSyncExternalStore(
-    subscribe,
-    () => {
-      const parsed = readParam(paramKey, defaultValue)
-      // If validate rejects the parsed value (e.g. URL was manually tampered),
-      // fall back to defaultValue so downstream code never sees an invalid state.
-      if (validate && !validate(parsed)) return defaultValue as unknown as R
-      return parsed as R
-    },
-    () => defaultValue as unknown as R,
-  )
+  // TODO(frontend-use-effect-policy): this hook must subscribe to browser events to mirror URL/history state.
+  useEffect(() => {
+    ensureLocationTracking()
 
+    /**
+     * Applies an incoming raw value from either the browser URL or a sibling
+     * hook instance, updating both the shared snapshot and local React state.
+     */
+    const syncFromRawValue = (rawValue: string | null) => {
+      setCurrentRawValue(paramKey, rawValue)
+      const nextValue = resolveValue(rawValue, defaultValue, validateRef.current)
+      if (Object.is(valueRef.current, nextValue)) return
+
+      valueRef.current = nextValue
+      setValue(nextValue)
+    }
+
+    /** Handles synchronous same-tab broadcasts from other `useParamState` instances. */
+    const handleSyncEvent = (event: Event) => {
+      const detail = (event as CustomEvent<ParamStateSyncDetail>).detail
+      if (detail.paramKey !== paramKey) return
+      if (detail.sourceId === sourceId) return
+
+      syncFromRawValue(detail.rawValue)
+    }
+
+    /** Re-reads the current URL after back/forward or direct history mutations. */
+    const handleLocationChange = () => {
+      const nextRawValue = readRawParam(paramKey)
+      cancelPendingUrlFlush()
+      syncFromRawValue(nextRawValue)
+    }
+
+    syncFromRawValue(getCurrentRawValue(paramKey))
+    window.addEventListener(PARAM_STATE_SYNC_EVENT, handleSyncEvent)
+    window.addEventListener(LOCATION_CHANGE_EVENT, handleLocationChange)
+    window.addEventListener("popstate", handleLocationChange)
+
+    return () => {
+      window.removeEventListener(PARAM_STATE_SYNC_EVENT, handleSyncEvent)
+      window.removeEventListener(LOCATION_CHANGE_EVENT, handleLocationChange)
+      window.removeEventListener("popstate", handleLocationChange)
+    }
+  }, [defaultValue, paramKey, sourceId])
+
+  /** Updates local state immediately, then mirrors that change to peers and the URL. */
   const setParamValue = (nextValue: SetStateAction<R>) => {
-    // Read from the URL (not from `value`) to get the latest state, since
-    // another setter in the same tick may have already updated the URL.
-    const currentValue = readParam(paramKey, defaultValue) as R
+    const currentValue = valueRef.current
     const resolvedValue = typeof nextValue === "function" ? (nextValue as (prev: R) => R)(currentValue) : nextValue
+    const isDefaultValue = Object.is(resolvedValue, defaultValue)
+    const rawValue = isDefaultValue ? null : String(resolvedValue)
+    const searchValue = isDefaultValue ? null : (resolvedValue as ParamStateValue)
+    if (getCurrentRawValue(paramKey) === rawValue) return
 
-    // When the value matches the default, remove the param from the URL
-    // to keep URLs clean (e.g. `?` instead of `?tab=traces`).
-    const serialized = Object.is(resolvedValue, defaultValue) ? undefined : String(resolvedValue)
-
-    writeParam(paramKey, serialized, historyMode)
+    setCurrentRawValue(paramKey, rawValue)
+    valueRef.current = resolvedValue
+    setValue(resolvedValue)
+    window.dispatchEvent(
+      new CustomEvent<ParamStateSyncDetail>(PARAM_STATE_SYNC_EVENT, {
+        detail: {
+          paramKey,
+          rawValue,
+          sourceId,
+        },
+      }),
+    )
+    scheduleUrlFlush(router, paramKey, searchValue, historyMode)
   }
 
   return [value, setParamValue]

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -7,6 +7,7 @@ const routerLogger = createLogger("web")
 export function getRouter() {
   const router = createTanStackRouter({
     routeTree,
+    defaultStructuralSharing: true,
     defaultNotFoundComponent: () => {
       const currentPath = typeof window !== "undefined" ? window.location.pathname : ""
       if (currentPath) routerLogger.error(`[Router 404] Path not found: ${currentPath}`)

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -9,7 +9,14 @@ import { BreadcrumbTrail } from "./_authenticated/-components/breadcrumb-trail.t
 
 export const Route = createFileRoute("/_authenticated")({
   ssr: "data-only",
-  beforeLoad: async () => {
+  staleTime: Infinity,
+  remountDeps: () => "authenticated-layout",
+  // Keep rendered layout data in `loader` instead of `beforeLoad`.
+  // `beforeLoad` is best for middleware-style redirects/preconditions, while
+  // `loader` participates in TanStack Router's cache (`staleTime`) and can be
+  // consumed via `useLoaderData({ select })` without refetching on same-route
+  // search-param navigations.
+  loader: async () => {
     const session = await getSession()
     if (!session) {
       throw redirect({ to: "/login" })
@@ -54,7 +61,8 @@ function ThemeToggle() {
 }
 
 function NavHeader() {
-  const { user, organizationId } = Route.useRouteContext()
+  const user = Route.useLoaderData({ select: (data) => data.user })
+  const organizationId = Route.useLoaderData({ select: (data) => data.organizationId })
   const { data: allOrgs } = useOrganizationsCollection()
   const org = allOrgs?.find((o) => o.id === organizationId)
   const hasMultipleOrgs = (allOrgs?.length ?? 0) > 1
@@ -152,7 +160,7 @@ function AuthenticatedLayout() {
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <NavHeader />
-      <main className="w-full flex-grow min-h-0 h-full relative overflow-y-auto">
+      <main className="w-full grow min-h-0 h-full relative overflow-y-auto">
         <Outlet />
       </main>
     </div>

--- a/apps/web/src/routes/_authenticated/-components/breadcrumb-trail.tsx
+++ b/apps/web/src/routes/_authenticated/-components/breadcrumb-trail.tsx
@@ -1,5 +1,6 @@
-import { useMatches } from "@tanstack/react-router"
+import { useRouter } from "@tanstack/react-router"
 import type { ComponentType } from "react"
+import { useMatchIdsWithStaticData } from "../../../lib/hooks/use-router-selectors.ts"
 import { BreadcrumbSeparator } from "./breadcrumb-ui.tsx"
 
 /**
@@ -9,18 +10,20 @@ import { BreadcrumbSeparator } from "./breadcrumb-ui.tsx"
  * `BreadcrumbText`, and `BreadcrumbSeparator` from `breadcrumb-ui.tsx`.
  */
 export function BreadcrumbTrail() {
-  const matches = useMatches()
-  const crumbs = matches.filter(
-    (m): m is typeof m & { staticData: { breadcrumb: ComponentType } } =>
-      m.staticData !== undefined && typeof (m.staticData as { breadcrumb?: unknown }).breadcrumb === "function",
-  )
+  const router = useRouter()
+  const crumbIds = useMatchIdsWithStaticData((staticData) => typeof staticData?.breadcrumb === "function")
+  const crumbs = router.state.matches.flatMap((match) => {
+    if (!crumbIds.includes(match.id)) return []
+    const staticData = match.staticData as { breadcrumb?: unknown } | undefined
+    if (typeof staticData?.breadcrumb !== "function") return []
+    return [{ id: match.id, Breadcrumb: staticData.breadcrumb as ComponentType }]
+  })
 
   return (
     <>
-      {crumbs.map((match) => {
-        const Breadcrumb = match.staticData.breadcrumb
+      {crumbs.map(({ id, Breadcrumb }) => {
         return (
-          <span key={match.id} className="flex items-center gap-2 min-w-0">
+          <span key={id} className="flex items-center gap-2 min-w-0">
             <BreadcrumbSeparator />
             <Breadcrumb />
           </span>

--- a/apps/web/src/routes/_authenticated/-route-data.ts
+++ b/apps/web/src/routes/_authenticated/-route-data.ts
@@ -1,0 +1,20 @@
+import { getRouteApi } from "@tanstack/react-router"
+
+/**
+ * Centralizes access to the authenticated layout route's loader data.
+ *
+ * Keeping `getRouteApi("/_authenticated")` here avoids scattering the string
+ * route id across descendant routes and lets those files avoid importing the
+ * parent `Route` object directly.
+ */
+const authenticatedRoute = getRouteApi("/_authenticated")
+
+/** Reads the authenticated user from the parent route's cached loader data. */
+export function useAuthenticatedUser() {
+  return authenticatedRoute.useLoaderData({ select: (data) => data.user })
+}
+
+/** Reads the active organization id from the parent route's cached loader data. */
+export function useAuthenticatedOrganizationId() {
+  return authenticatedRoute.useLoaderData({ select: (data) => data.organizationId })
+}

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../domains/projects/projects.collection.ts"
 import type { ProjectRecord } from "../../domains/projects/projects.functions.ts"
 import { toUserMessage } from "../../lib/errors.ts"
+import { useAuthenticatedOrganizationId } from "./-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/")({
   component: DashboardPage,
@@ -325,7 +326,7 @@ function CreateProjectModal({ open, onClose }: { open: boolean; onClose: () => v
 
 function DashboardPageContent() {
   const [createOpen, setCreateOpen] = useState(false)
-  const { organizationId } = Route.useRouteContext()
+  const organizationId = useAuthenticatedOrganizationId()
   const { data: org } = useOrganizationsCollection((orgs) =>
     orgs.where(({ organizations }) => eq(organizations.id, organizationId)).findOne(),
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -9,8 +9,14 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug")({
   staticData: {
     breadcrumb: ProjectBreadcrumbSegment,
   },
+  staleTime: Infinity,
+  remountDeps: ({ params }) => params,
   component: ProjectLayout,
-  beforeLoad: async ({ params }) => {
+  // Keep the rendered project record in `loader` so TanStack Router can cache
+  // it across same-route search-param navigations. `beforeLoad` is better for
+  // middleware-only checks, while descendants can read cached loader data with
+  // `useLoaderData({ select })`.
+  loader: async ({ params }) => {
     try {
       const project = await getProjectBySlug({
         data: { slug: params.projectSlug },
@@ -23,8 +29,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug")({
 })
 
 function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; projectSlug: string }) {
-  const routerState = useRouterState()
-  const pathname = routerState.location.pathname
+  const pathname = useRouterState({ select: (state) => state.location.pathname })
 
   const isTracesActive =
     pathname === `/projects/${projectSlug}` ||
@@ -34,6 +39,7 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
   const isDatasetsActive = pathname.startsWith(`/projects/${projectSlug}/datasets`)
   const isSettingsActive = pathname.startsWith(`/projects/${projectSlug}/settings`)
   const isAnnotationQueuesActive = pathname.startsWith(`/projects/${projectSlug}/annotation-queues`)
+
   return (
     <AppSidebar
       title={project.name}
@@ -84,7 +90,7 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
 
 function ProjectLayout() {
   const { projectSlug } = Route.useParams()
-  const { project } = Route.useRouteContext()
+  const project = Route.useLoaderData({ select: (data) => data.project })
   return (
     <div className="flex h-full">
       <ProjectSidebar project={project} projectSlug={projectSlug} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { TraceId } from "@domain/shared"
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { AnnotationRecord } from "../../../../../../../domains/annotations/annotations.functions.ts"
+import { useAnnotationNavigation } from "./use-annotation-navigation.ts"
+import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
+
+function createRect(left: number, bottom: number): DOMRect {
+  return {
+    x: left,
+    y: bottom - 20,
+    width: 80,
+    height: 20,
+    top: bottom - 20,
+    right: left + 80,
+    bottom,
+    left,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+function createAnnotationRecord(): AnnotationRecord {
+  return {
+    id: "ann-text-1",
+    organizationId: "org-1",
+    projectId: "proj-1",
+    sessionId: null,
+    traceId: TraceId("trace-1"),
+    spanId: null,
+    source: "annotation",
+    sourceId: "UI",
+    simulationId: null,
+    issueId: null,
+    value: 1,
+    passed: true,
+    feedback: "Looks good",
+    metadata: {
+      rawFeedback: "Looks good",
+      messageIndex: 1,
+      partIndex: 0,
+      startOffset: 0,
+      endOffset: 12,
+    },
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: null,
+    annotatorId: "user-1",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  }
+}
+
+describe("useAnnotationNavigation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    vi.stubGlobal("cancelAnimationFrame", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ""
+  })
+
+  it("opens and repositions the text-selection popover before smooth scroll ends", () => {
+    const container = document.createElement("div")
+    const partRoot = document.createElement("div")
+    partRoot.setAttribute("data-part-index", "0")
+
+    const textElement = document.createElement("button")
+    textElement.setAttribute("data-annotation-id", "ann-text-1")
+    let currentRect = createRect(40, 140)
+    textElement.getBoundingClientRect = () => currentRect
+    textElement.scrollIntoView = vi.fn()
+    const clickSpy = vi.spyOn(textElement, "click")
+
+    partRoot.appendChild(textElement)
+    container.appendChild(partRoot)
+    document.body.appendChild(container)
+
+    const openExistingAnnotationPopover = vi.fn<TextSelectionPopoverControls["openExistingAnnotationPopover"]>()
+    const updateTextSelectionPopoverPosition =
+      vi.fn<TextSelectionPopoverControls["updateTextSelectionPopoverPosition"]>()
+    const textSelectionPopoverControlsRef = {
+      current: {
+        openExistingAnnotationPopover,
+        updateTextSelectionPopoverPosition,
+      } satisfies TextSelectionPopoverControls,
+    }
+
+    const annotation = createAnnotationRecord()
+
+    const { result } = renderHook(() =>
+      useAnnotationNavigation({
+        scrollContainerRef: { current: container },
+        textSelectionPopoverControlsRef,
+      }),
+    )
+
+    act(() => {
+      result.current.scrollToAnnotation(annotation)
+    })
+
+    expect(openExistingAnnotationPopover).toHaveBeenCalledWith(annotation, { x: 40, y: 140 })
+    expect(clickSpy).not.toHaveBeenCalled()
+
+    currentRect = createRect(72, 220)
+    act(() => {
+      container.dispatchEvent(new Event("scroll"))
+    })
+
+    expect(updateTextSelectionPopoverPosition).toHaveBeenLastCalledWith({ x: 72, y: 220 })
+
+    act(() => {
+      container.dispatchEvent(new Event("scrollend"))
+    })
+
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(updateTextSelectionPopoverPosition).toHaveBeenLastCalledWith({ x: 72, y: 220 })
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef } from "react"
 import type { AnnotationRecord } from "../../../../../../../domains/annotations/annotations.functions.ts"
+import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 
 const HIGHLIGHT_BOX_SHADOW = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
 const HIGHLIGHT_DURATION_MS = 4000
+const POPOVER_VIEWPORT_PADDING = 24
 
 export function isGlobalAnnotation(annotation: AnnotationRecord): boolean {
   return annotation.metadata.messageIndex === undefined
@@ -13,12 +15,21 @@ interface UseAnnotationNavigationOptions {
   onSwitchToConversation?: () => void
   /** Whether the conversation view is currently active/visible. When false, uses pending navigation. */
   isConversationActive?: boolean
+  textSelectionPopoverControlsRef?: React.RefObject<TextSelectionPopoverControls | null>
+}
+
+interface ScrollToElementOptions {
+  readonly element: HTMLElement
+  readonly clickTarget: HTMLElement | null
+  readonly annotation: AnnotationRecord
+  readonly openTextSelectionPopoverImmediately?: boolean
 }
 
 export function useAnnotationNavigation({
   scrollContainerRef,
   onSwitchToConversation,
   isConversationActive = true,
+  textSelectionPopoverControlsRef,
 }: UseAnnotationNavigationOptions) {
   const pendingAnnotationRef = useRef<AnnotationRecord | null>(null)
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -27,6 +38,7 @@ export function useAnnotationNavigation({
   const currentPopoverCardRef = useRef<HTMLElement | null>(null)
   const observerRef = useRef<MutationObserver | null>(null)
   const observerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const popoverPositionSyncCleanupRef = useRef<(() => void) | null>(null)
 
   const clearObserver = useCallback(() => {
     if (observerRef.current) {
@@ -50,6 +62,11 @@ export function useAnnotationNavigation({
     }
   }, [])
 
+  const clearPopoverPositionSync = useCallback(() => {
+    popoverPositionSyncCleanupRef.current?.()
+    popoverPositionSyncCleanupRef.current = null
+  }, [])
+
   const clearHighlight = useCallback(() => {
     if (highlightTimeoutRef.current) {
       clearTimeout(highlightTimeoutRef.current)
@@ -64,8 +81,9 @@ export function useAnnotationNavigation({
   const clearAll = useCallback(() => {
     clearHighlight()
     clearPopoverCardHighlight()
+    clearPopoverPositionSync()
     clearObserver()
-  }, [clearHighlight, clearPopoverCardHighlight, clearObserver])
+  }, [clearHighlight, clearPopoverCardHighlight, clearPopoverPositionSync, clearObserver])
 
   useEffect(() => () => clearAll(), [clearAll])
 
@@ -154,23 +172,104 @@ export function useAnnotationNavigation({
     [clearPopoverCardHighlight, clearObserver],
   )
 
-  const scrollToElement = useCallback(
-    (element: HTMLElement, clickTarget: HTMLElement | null, annotationId: string) => {
-      const container = scrollContainerRef.current
+  const getTextSelectionPopoverPosition = useCallback((element: HTMLElement, annotationId: string) => {
+    const partRoot = element.closest("[data-part-index]") ?? document.body
+    const segments = partRoot.querySelectorAll<HTMLElement>(`[data-annotation-id="${annotationId}"]`)
 
-      const afterScroll = () => {
+    let left = Number.POSITIVE_INFINITY
+    let bottom = Number.NEGATIVE_INFINITY
+
+    if (segments.length > 0) {
+      for (const segment of segments) {
+        const rect = segment.getBoundingClientRect()
+        if (rect.left < left) left = rect.left
+        if (rect.bottom > bottom) bottom = rect.bottom
+      }
+    } else {
+      const rect = element.getBoundingClientRect()
+      left = rect.left
+      bottom = rect.bottom
+    }
+
+    const maxX = Math.max(POPOVER_VIEWPORT_PADDING, window.innerWidth - POPOVER_VIEWPORT_PADDING)
+    const maxY = Math.max(POPOVER_VIEWPORT_PADDING, window.innerHeight - POPOVER_VIEWPORT_PADDING)
+
+    return {
+      x: Math.min(Math.max(left, POPOVER_VIEWPORT_PADDING), maxX),
+      y: Math.min(Math.max(bottom, POPOVER_VIEWPORT_PADDING), maxY),
+    }
+  }, [])
+
+  const syncTextSelectionPopoverPosition = useCallback(
+    (container: HTMLElement, element: HTMLElement, annotationId: string) => {
+      const controls = textSelectionPopoverControlsRef?.current
+      if (!controls) return
+
+      clearPopoverPositionSync()
+
+      let frameId: number | null = null
+      const updatePosition = () => {
+        controls.updateTextSelectionPopoverPosition(getTextSelectionPopoverPosition(element, annotationId))
+      }
+      const onScroll = () => {
+        if (frameId !== null) return
+        frameId = requestAnimationFrame(() => {
+          frameId = null
+          updatePosition()
+        })
+      }
+
+      container.addEventListener("scroll", onScroll, { passive: true })
+      updatePosition()
+
+      popoverPositionSyncCleanupRef.current = () => {
+        container.removeEventListener("scroll", onScroll)
+        if (frameId !== null) {
+          cancelAnimationFrame(frameId)
+        }
+      }
+    },
+    [textSelectionPopoverControlsRef, clearPopoverPositionSync, getTextSelectionPopoverPosition],
+  )
+
+  const scrollToElement = useCallback(
+    ({ element, clickTarget, annotation, openTextSelectionPopoverImmediately = false }: ScrollToElementOptions) => {
+      const container = scrollContainerRef.current
+      clearPopoverPositionSync()
+
+      if (openTextSelectionPopoverImmediately) {
+        const controls = textSelectionPopoverControlsRef?.current
+        if (controls) {
+          controls.openExistingAnnotationPopover(annotation, getTextSelectionPopoverPosition(element, annotation.id))
+          highlightAnnotationInPopover(annotation.id)
+          if (container) {
+            syncTextSelectionPopoverPosition(container, element, annotation.id)
+          }
+        }
+      }
+
+      const openAndSelectAnnotation = () => {
+        clearPopoverPositionSync()
         applyHighlight(element)
 
-        if (clickTarget) {
-          const popover = document.querySelector("[data-radix-popper-content-wrapper]")
-          const cardInPopover = popover?.querySelector(`[data-annotation-card-id="${annotationId}"]`)
+        const popover = document.querySelector("[data-radix-popper-content-wrapper]")
+        const cardInPopover = popover?.querySelector(`[data-annotation-card-id="${annotation.id}"]`)
 
-          if (cardInPopover) {
-            highlightAnnotationInPopover(annotationId)
-          } else {
-            clickTarget.click()
-            highlightAnnotationInPopover(annotationId)
-          }
+        if (cardInPopover) {
+          highlightAnnotationInPopover(annotation.id)
+          return
+        }
+
+        const controls = textSelectionPopoverControlsRef?.current
+        if (openTextSelectionPopoverImmediately && controls) {
+          controls.updateTextSelectionPopoverPosition(getTextSelectionPopoverPosition(element, annotation.id))
+          highlightAnnotationInPopover(annotation.id)
+          return
+        }
+
+        if (clickTarget) {
+          clickTarget.click()
+          highlightAnnotationInPopover(annotation.id)
         }
       }
 
@@ -180,7 +279,7 @@ export function useAnnotationNavigation({
           if (handled) return
           handled = true
           container.removeEventListener("scrollend", onScrollEnd)
-          afterScroll()
+          openAndSelectAnnotation()
         }
 
         container.addEventListener("scrollend", onScrollEnd)
@@ -190,10 +289,18 @@ export function useAnnotationNavigation({
         setTimeout(onScrollEnd, 600)
       } else {
         element.scrollIntoView({ behavior: "instant", block: "center" })
-        afterScroll()
+        openAndSelectAnnotation()
       }
     },
-    [scrollContainerRef, applyHighlight, highlightAnnotationInPopover],
+    [
+      scrollContainerRef,
+      textSelectionPopoverControlsRef,
+      clearPopoverPositionSync,
+      applyHighlight,
+      getTextSelectionPopoverPosition,
+      highlightAnnotationInPopover,
+      syncTextSelectionPopoverPosition,
+    ],
   )
 
   const findAndScrollToAnnotation = useCallback(
@@ -210,7 +317,12 @@ export function useAnnotationNavigation({
       if (isTextSelection) {
         const textElement = container.querySelector<HTMLElement>(`[data-annotation-id="${annotation.id}"]`)
         if (textElement) {
-          scrollToElement(textElement, textElement, annotation.id)
+          scrollToElement({
+            element: textElement,
+            clickTarget: textElement,
+            annotation,
+            openTextSelectionPopoverImmediately: true,
+          })
           return true
         }
 
@@ -219,7 +331,12 @@ export function useAnnotationNavigation({
           if (element) {
             obs.disconnect()
             observerRef.current = null
-            scrollToElement(element, element, annotation.id)
+            scrollToElement({
+              element,
+              clickTarget: element,
+              annotation,
+              openTextSelectionPopoverImmediately: true,
+            })
           }
         })
 
@@ -239,7 +356,11 @@ export function useAnnotationNavigation({
           `[data-message-annotation-trigger="${messageIndex}"]`,
         )
         if (messageElement) {
-          scrollToElement(messageElement, triggerElement, annotation.id)
+          scrollToElement({
+            element: messageElement,
+            clickTarget: triggerElement,
+            annotation,
+          })
           return true
         }
       }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.ts
@@ -20,6 +20,11 @@ interface UseAnnotationPopoverOptions {
   readonly getSpanIdForMessage?: (messageIndex: number) => string | undefined
 }
 
+export interface TextSelectionPopoverControls {
+  readonly openExistingAnnotationPopover: (annotation: AnnotationRecord, position: { x: number; y: number }) => void
+  readonly updateTextSelectionPopoverPosition: (position: { x: number; y: number }) => void
+}
+
 export function useAnnotationPopover({
   projectId,
   traceId,
@@ -47,8 +52,30 @@ export function useAnnotationPopover({
     [isActive],
   )
 
+  const openExistingAnnotationPopover = useCallback(
+    (annotation: AnnotationRecord, position: { x: number; y: number }) => {
+      openAnnotationPopover({
+        kind: "existing",
+        annotation,
+        position,
+        passed: annotation.passed,
+        comment: annotation.feedback ?? "",
+        issueId: annotation.issueId,
+      })
+    },
+    [openAnnotationPopover],
+  )
+
   const closeAnnotationPopover = useCallback(() => {
     setPopoverState(null)
+  }, [])
+
+  const updateTextSelectionPopoverPosition = useCallback((position: { x: number; y: number }) => {
+    setPopoverState((current) => {
+      if (!current) return current
+      if (current.position.x === position.x && current.position.y === position.y) return current
+      return { ...current, position }
+    })
   }, [])
 
   const highlightRangesWithHandlers: HighlightRange[] = useMemo(() => {
@@ -58,19 +85,10 @@ export function useAnnotationPopover({
 
       return {
         ...range,
-        onClick: (position: { x: number; y: number }) => {
-          openAnnotationPopover({
-            kind: "existing",
-            annotation,
-            position,
-            passed: annotation.passed,
-            comment: annotation.feedback ?? "",
-            issueId: annotation.issueId,
-          })
-        },
+        onClick: (position: { x: number; y: number }) => openExistingAnnotationPopover(annotation, position),
       }
     })
-  }, [highlightRanges, annotations, openAnnotationPopover])
+  }, [highlightRanges, annotations, openExistingAnnotationPopover])
 
   const handleTextSelect = useCallback(
     (anchor: TextSelectionAnchor, position: { x: number; y: number }) => {
@@ -84,14 +102,7 @@ export function useAnnotationPopover({
       if (existing?.id) {
         const annotation = annotations.find((a) => a.id === existing.id)
         if (annotation) {
-          openAnnotationPopover({
-            kind: "existing",
-            annotation,
-            position,
-            passed: annotation.passed,
-            comment: annotation.feedback ?? "",
-            issueId: annotation.issueId,
-          })
+          openExistingAnnotationPopover(annotation, position)
           return
         }
       }
@@ -104,7 +115,7 @@ export function useAnnotationPopover({
         issueId: null,
       })
     },
-    [highlightRanges, annotations, openAnnotationPopover],
+    [highlightRanges, annotations, openAnnotationPopover, openExistingAnnotationPopover],
   )
 
   const isPopoverLoading = isCreatePending || isUpdatePending || isDeletePending
@@ -158,7 +169,9 @@ export function useAnnotationPopover({
     isPopoverLoading,
     isPopoverEditable,
     openAnnotationPopover,
+    openExistingAnnotationPopover,
     closeAnnotationPopover,
+    updateTextSelectionPopoverPosition,
     handleTextSelect,
     textSelectionPopoverPosition,
     textSelectionAnnotations,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -216,6 +216,7 @@ export function SessionsView({
         key: "startTime",
         header: "Start Time",
         sortKey: "startTime",
+        width: 180,
         render: (row) => {
           const time = field(row, "startTime")
           return (
@@ -228,6 +229,7 @@ export function SessionsView({
       {
         key: "name",
         header: "Name",
+        width: 180,
         render: (row) => {
           if (row.kind === "session") return EMPTY_CELL
           return row.trace.rootSpanName || row.trace.traceId.slice(0, 8)
@@ -236,12 +238,14 @@ export function SessionsView({
       {
         key: "tags",
         header: "Tags",
+        width: 150,
         render: (row) => <TagList tags={field(row, "tags")} />,
       },
       {
         key: "duration",
         header: "Duration",
         align: "end",
+        width: 120,
         render: (row) => {
           if (row.kind === "session") return EMPTY_CELL
           return formatDuration(row.trace.durationNs)
@@ -258,6 +262,7 @@ export function SessionsView({
         key: "ttft",
         header: "Time To First Token",
         align: "end",
+        width: 162,
         render: (row) => {
           if (row.kind === "session") return EMPTY_CELL
           return row.trace.timeToFirstTokenNs > 0 ? formatDuration(row.trace.timeToFirstTokenNs) : "-"
@@ -268,6 +273,7 @@ export function SessionsView({
         header: "Cost",
         align: "end",
         sortKey: "cost",
+        width: 130,
         render: (row) => formatPrice(field(row, "costTotalMicrocents") / 100_000_000),
         renderSubheader: () => (
           <TableMetricSubheader
@@ -280,6 +286,7 @@ export function SessionsView({
       {
         key: "sessionId",
         header: "Session ID",
+        width: 160,
         render: (row) => {
           if (row.kind === "session") {
             if (onActiveSessionChange) {
@@ -304,11 +311,13 @@ export function SessionsView({
       {
         key: "userId",
         header: "User ID",
+        width: 160,
         render: (row) => field(row, "userId"),
       },
       {
         key: "models",
         header: "Models",
+        width: 160,
         render: (row) => {
           const providers = field(row, "providers")
           const models = field(row, "models")
@@ -337,6 +346,7 @@ export function SessionsView({
         header: "Spans",
         align: "end",
         sortKey: "spans",
+        width: 110,
         render: (row) => {
           const spanCount = field(row, "spanCount")
           const errorCount = field(row, "errorCount")

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -27,6 +27,7 @@ import { useTraceDetail } from "../../../../../domains/traces/traces.collection.
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { isGlobalAnnotation, useAnnotationNavigation } from "./annotations/hooks/use-annotation-navigation.ts"
+import type { TextSelectionPopoverControls } from "./annotations/hooks/use-annotation-popover.ts"
 import { TraceAnnotationsList } from "./annotations/trace-annotations-list.tsx"
 import { ConversationTab } from "./trace-detail-drawer/tabs/conversation-tab.tsx"
 import { SpansTab } from "./trace-detail-drawer/tabs/spans-tab.tsx"
@@ -87,11 +88,13 @@ export function TraceDetailDrawer({
   const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(() => new Set(["trace"]))
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const textSelectionPopoverControlsRef = useRef<TextSelectionPopoverControls | null>(null)
 
   const { scrollToAnnotation, executePendingScroll } = useAnnotationNavigation({
     scrollContainerRef,
     onSwitchToConversation: () => handleSetActiveTab("conversation"),
     isConversationActive: activeTab === "conversation",
+    textSelectionPopoverControlsRef,
   })
 
   useMountEffect(() => {
@@ -255,6 +258,7 @@ export function TraceDetailDrawer({
             projectId={projectId}
             isActive={activeTab === "conversation"}
             scrollContainerRef={scrollContainerRef}
+            textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
           />
         )}
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -1,11 +1,14 @@
 import { Conversation, ScrollNavigator, type ScrollNavigatorHandle, Skeleton, Text } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { type RefObject, useCallback, useRef } from "react"
+import { type MutableRefObject, type RefObject, useCallback, useRef } from "react"
 import { HotkeyBadge } from "../../../../../../../components/hotkey-badge.tsx"
 import { useConversationSpanMaps } from "../../../../../../../domains/spans/spans.collection.ts"
 import type { TraceDetailRecord } from "../../../../../../../domains/traces/traces.functions.ts"
 import { AnnotationPopover } from "../../annotations/annotation-popover.tsx"
-import { useAnnotationPopover } from "../../annotations/hooks/use-annotation-popover.ts"
+import {
+  type TextSelectionPopoverControls,
+  useAnnotationPopover,
+} from "../../annotations/hooks/use-annotation-popover.ts"
 import { useTraceAnnotationsData } from "../../annotations/hooks/use-trace-annotations-data.ts"
 import { MessageAnnotationTrigger } from "../../annotations/message-annotation-trigger.tsx"
 
@@ -15,12 +18,14 @@ function ConversationContent({
   projectId,
   isActive,
   scrollContainerRef,
+  textSelectionPopoverControlsRef,
 }: {
   readonly traceDetail: TraceDetailRecord
   readonly navigateToSpan?: ((spanId: string) => void) | undefined
   readonly projectId: string
   readonly isActive: boolean
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null> | undefined
+  readonly textSelectionPopoverControlsRef?: MutableRefObject<TextSelectionPopoverControls | null> | undefined
 }) {
   const internalScrollRef = useRef<HTMLDivElement>(null)
   const scrollRef = scrollContainerRef ?? internalScrollRef
@@ -55,17 +60,26 @@ function ConversationContent({
   const {
     highlightRanges,
     handleTextSelect,
+    openExistingAnnotationPopover,
     textSelectionPopoverPosition,
     textSelectionAnnotations,
     createTextSelectionAnnotation,
     updateTextSelectionAnnotation,
     closeAnnotationPopover,
+    updateTextSelectionPopoverPosition,
   } = useAnnotationPopover({
     projectId,
     traceId: traceDetail.traceId,
     isActive,
     getSpanIdForMessage,
   })
+
+  if (textSelectionPopoverControlsRef) {
+    textSelectionPopoverControlsRef.current = {
+      openExistingAnnotationPopover,
+      updateTextSelectionPopoverPosition,
+    }
+  }
 
   const messageActions =
     navigateToSpan && spanMaps && Object.keys(spanMaps.messageSpanMap).length > 0
@@ -154,6 +168,7 @@ export function ConversationTab({
   projectId,
   isActive,
   scrollContainerRef,
+  textSelectionPopoverControlsRef,
 }: {
   readonly traceDetail: TraceDetailRecord | null | undefined
   readonly isDetailLoading: boolean
@@ -163,6 +178,7 @@ export function ConversationTab({
   readonly isActive: boolean
   /** Optional ref to the scroll container. Used for external scroll control (e.g., annotation navigation). */
   readonly scrollContainerRef?: RefObject<HTMLDivElement | null> | undefined
+  readonly textSelectionPopoverControlsRef?: MutableRefObject<TextSelectionPopoverControls | null> | undefined
 }) {
   if (isDetailLoading) {
     return (
@@ -189,6 +205,7 @@ export function ConversationTab({
       navigateToSpan={navigateToSpan}
       projectId={projectId}
       scrollContainerRef={scrollContainerRef}
+      textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
     />
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -73,6 +73,7 @@ export function TracesView({
         key: "startTime",
         header: "Start Time",
         sortKey: "startTime",
+        width: 180,
         render: (t) => (
           <Tooltip asChild trigger={<span>{relativeTime(new Date(t.startTime))}</span>}>
             {new Date(t.startTime).toLocaleString()}
@@ -82,11 +83,13 @@ export function TracesView({
       {
         key: "name",
         header: "Name",
+        width: 180,
         render: (t) => t.rootSpanName || t.traceId.slice(0, 8),
       },
       {
         key: "tags",
         header: "Tags",
+        width: 150,
         render: (t) => <TagList tags={t.tags} />,
       },
       {
@@ -94,6 +97,7 @@ export function TracesView({
         header: "Duration",
         align: "end",
         sortKey: "duration",
+        width: 120,
         render: (t) => formatDuration(t.durationNs),
         renderSubheader: () => (
           <TableMetricSubheader rollup={traceMetrics?.durationNs} format="duration" isLoading={metricsLoading} />
@@ -104,6 +108,7 @@ export function TracesView({
         header: "Time To First Token",
         align: "end",
         sortKey: "ttft",
+        width: 162,
         render: (t) => (t.timeToFirstTokenNs > 0 ? formatDuration(t.timeToFirstTokenNs) : "-"),
         renderSubheader: () => (
           <TableMetricSubheader
@@ -120,6 +125,7 @@ export function TracesView({
         header: "Cost",
         align: "end",
         sortKey: "cost",
+        width: 130,
         render: (t) => formatPrice(t.costTotalMicrocents / 100_000_000),
         renderSubheader: () => (
           <TableMetricSubheader rollup={traceMetrics?.costTotalMicrocents} format="price" isLoading={metricsLoading} />
@@ -128,16 +134,19 @@ export function TracesView({
       {
         key: "sessionId",
         header: "Session ID",
+        width: 160,
         render: (t) => t.sessionId,
       },
       {
         key: "userId",
         header: "User ID",
+        width: 160,
         render: (t) => t.userId,
       },
       {
         key: "models",
         header: "Models",
+        width: 160,
         render: (t) => (
           <div className="flex items-center gap-1.5">
             {t.providers.map((p) => (
@@ -162,6 +171,7 @@ export function TracesView({
         header: "Spans",
         align: "end",
         sortKey: "spans",
+        width: 110,
         render: (t) => (
           <>
             {formatCount(t.spanCount)}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-route-data.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-route-data.ts
@@ -1,0 +1,15 @@
+import { getRouteApi } from "@tanstack/react-router"
+
+/**
+ * Centralizes access to the project layout route's loader data.
+ *
+ * This keeps the `getRouteApi("/_authenticated/projects/$projectSlug")`
+ * string in one place and lets descendant routes consume the parent loader
+ * data without importing the parent `Route` module directly.
+ */
+const projectRoute = getRouteApi("/_authenticated/projects/$projectSlug")
+
+/** Reads the active project from the parent route's cached loader data. */
+export function useRouteProject() {
+  return projectRoute.useLoaderData({ select: (data) => data.project })
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
@@ -12,6 +12,7 @@ import {
   isGlobalAnnotation,
   useAnnotationNavigation,
 } from "../../../-components/annotations/hooks/use-annotation-navigation.ts"
+import type { TextSelectionPopoverControls } from "../../../-components/annotations/hooks/use-annotation-popover.ts"
 import { TraceAnnotationsList } from "../../../-components/annotations/trace-annotations-list.tsx"
 import { ConversationTab } from "../../../-components/trace-detail-drawer/tabs/conversation-tab.tsx"
 import { TraceTab } from "../../../-components/trace-detail-drawer/tabs/trace-tab.tsx"
@@ -46,6 +47,7 @@ function AnnotationQueueItemDetailPage() {
   const { projectSlug, queueId, itemId } = Route.useParams()
   const windowWidth = useWindowWidth()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const textSelectionPopoverControlsRef = useRef<TextSelectionPopoverControls | null>(null)
   const [selectedAnnotationId, setSelectedAnnotationId] = useParamState("annotationId", "")
 
   const { data: project } = useProjectsCollection(
@@ -79,6 +81,7 @@ function AnnotationQueueItemDetailPage() {
 
   const { scrollToAnnotation } = useAnnotationNavigation({
     scrollContainerRef,
+    textSelectionPopoverControlsRef,
   })
 
   const hasHandledDeepLinkRef = useRef(false)
@@ -166,6 +169,7 @@ function AnnotationQueueItemDetailPage() {
           isDetailLoading={isDetailLoading || itemLoading}
           projectId={projectId}
           scrollContainerRef={scrollContainerRef}
+          textSelectionPopoverControlsRef={textSelectionPopoverControlsRef}
         />
       </div>
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId.tsx
@@ -46,7 +46,7 @@ function AnnotationQueueItemDetailPage() {
   const { projectSlug, queueId, itemId } = Route.useParams()
   const windowWidth = useWindowWidth()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const [selectedAnnotationId, setSelectedAnnotationId] = useParamState("annotationId", "", { history: "push" })
+  const [selectedAnnotationId, setSelectedAnnotationId] = useParamState("annotationId", "")
 
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
@@ -34,6 +34,7 @@ import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/in
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { type BulkSelection, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
+import { useRouteProject } from "../-route-data.ts"
 import { CsvImportView, type ParsedCsv } from "./-components/csv-import-view.tsx"
 import { createDraftRowRecord, isDatasetDraftRowId } from "./-components/dataset-draft-row.ts"
 import { DatasetNameEdit } from "./-components/dataset-name-edit.tsx"
@@ -84,7 +85,7 @@ const rowColumns: InfiniteTableColumn<DatasetRowRecord>[] = [
 
 function DatasetDetailPage() {
   const { datasetId } = Route.useParams()
-  const { project } = Route.useRouteContext()
+  const project = useRouteProject()
   const [, setRid] = useParamState("rid", "")
 
   const { data: dataset, isLoading } = useQuery({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -19,6 +19,7 @@ import { createDatasetMutation } from "../../../../../domains/datasets/datasets.
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { useRouteProject } from "../-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/datasets/")({
   component: DatasetsPage,
@@ -53,7 +54,7 @@ const columns: InfiniteTableColumn<DatasetRecord>[] = [
 
 function DatasetsPage() {
   const { projectSlug } = Route.useParams()
-  const { project } = Route.useRouteContext()
+  const project = useRouteProject()
   const navigate = Route.useNavigate()
   const { toast } = useToast()
   const [creating, setCreating] = useState(false)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { useIssuesCollection } from "../../../../../domains/issues/issues.collection.ts"
 import type { IssueRecord } from "../../../../../domains/issues/issues.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { useRouteProject } from "../-route-data.ts"
 import { IssueEvaluationActions } from "./-components/issue-evaluation-actions.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/issues/")({
@@ -11,7 +12,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/issu
 })
 
 function IssuesPage() {
-  const { project } = Route.useRouteContext()
+  const project = useRouteProject()
   const { data, isLoading } = useIssuesCollection(project.id)
   const issues = data ?? []
   const columns = useMemo(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/settings.tsx
@@ -3,6 +3,7 @@ import { eq } from "@tanstack/react-db"
 import { createFileRoute } from "@tanstack/react-router"
 import { updateProjectMutation, useProjectsCollection } from "../../../../domains/projects/projects.collection.ts"
 import { ListingLayout as Layout } from "../../../../layouts/ListingLayout/index.tsx"
+import { useRouteProject } from "./-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/settings")({
   component: ProjectSettingsPage,
@@ -10,7 +11,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sett
 
 function ProjectSettingsPage() {
   const { projectSlug } = Route.useParams()
-  const { project: routeProject } = Route.useRouteContext()
+  const routeProject = useRouteProject()
 
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),

--- a/apps/web/src/routes/_authenticated/settings.tsx
+++ b/apps/web/src/routes/_authenticated/settings.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 import { Building2, Key, ShieldAlert, UserRound, Users } from "lucide-react"
 import { AppSidebar, NavItem } from "../../layouts/AppSidebar/index.tsx"
+import { usePathname } from "../../lib/hooks/use-router-selectors.ts"
 
 export const Route = createFileRoute("/_authenticated/settings")({
   component: SettingsLayout,
@@ -15,8 +16,7 @@ const navItems = [
 ] as const
 
 function SettingsLayout() {
-  const routerState = useRouterState()
-  const pathname = routerState.location.pathname
+  const pathname = usePathname()
   return (
     <div className="flex h-full">
       <AppSidebar title="Settings">

--- a/apps/web/src/routes/_authenticated/settings/account.tsx
+++ b/apps/web/src/routes/_authenticated/settings/account.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react"
 import { deleteCurrentUser, updateUserName } from "../../../domains/sessions/session.functions.ts"
 import { authClient } from "../../../lib/auth-client.ts"
 import { toUserMessage } from "../../../lib/errors.ts"
+import { useAuthenticatedUser } from "../-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/settings/account")({
   component: AccountSettingsPage,
@@ -65,7 +66,7 @@ function DeleteAccountConfirmModal({ open, setOpen }: { open: boolean; setOpen: 
 }
 
 function AccountSettingsPage() {
-  const { user } = Route.useRouteContext()
+  const user = useAuthenticatedUser()
   const { toast } = useToast()
   const router = useRouter()
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null)

--- a/apps/web/src/routes/_authenticated/settings/issues.tsx
+++ b/apps/web/src/routes/_authenticated/settings/issues.tsx
@@ -6,13 +6,14 @@ import {
   updateOrganizationMutation,
   useOrganizationsCollection,
 } from "../../../domains/organizations/organizations.collection.ts"
+import { useAuthenticatedOrganizationId } from "../-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/settings/issues")({
   component: IssuesSettingsPage,
 })
 
 function IssuesSettingsPage() {
-  const { organizationId } = Route.useRouteContext()
+  const organizationId = useAuthenticatedOrganizationId()
   const { toast } = useToast()
   const { data: org } = useOrganizationsCollection((orgs) =>
     orgs.where(({ organizations }) => eq(organizations.id, organizationId)).findOne(),

--- a/apps/web/src/routes/_authenticated/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/settings/members.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../../domains/members/members.collection.ts"
 import type { MemberRecord } from "../../../domains/members/members.functions.ts"
 import { toUserMessage } from "../../../lib/errors.ts"
+import { useAuthenticatedUser } from "../-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/settings/members")({
   component: MembersSettingsPage,
@@ -436,7 +437,7 @@ function MembersTable({
 }
 
 function MembersSettingsPage() {
-  const { user } = Route.useRouteContext()
+  const user = useAuthenticatedUser()
   const [inviteOpen, setInviteOpen] = useState(false)
   const { data, isLoading } = useMembersCollection()
   const members = data ?? []

--- a/apps/web/src/routes/_authenticated/settings/organization.tsx
+++ b/apps/web/src/routes/_authenticated/settings/organization.tsx
@@ -10,13 +10,14 @@ import {
 } from "../../../domains/organizations/organizations.collection.ts"
 import { createOrganization } from "../../../domains/organizations/organizations.functions.ts"
 import { toUserMessage } from "../../../lib/errors.ts"
+import { useAuthenticatedOrganizationId } from "../-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/settings/organization")({
   component: OrganizationSettingsPage,
 })
 
 function OrganizationNameSection() {
-  const { organizationId } = Route.useRouteContext()
+  const organizationId = useAuthenticatedOrganizationId()
   const { toast } = useToast()
   const { data: org } = useOrganizationsCollection((orgs) =>
     orgs.where(({ organizations }) => eq(organizations.id, organizationId)).findOne(),

--- a/apps/web/src/routes/auth/invite.tsx
+++ b/apps/web/src/routes/auth/invite.tsx
@@ -14,8 +14,9 @@ const invitationSearchParams = z.object({
 
 export const Route = createFileRoute("/auth/invite")({
   validateSearch: invitationSearchParams,
-  loader: async ({ search }) => {
-    const preview = await getInvitationPreview({ data: { invitationId: search.invitationId } })
+  loaderDeps: ({ search }) => ({ invitationId: search.invitationId }),
+  loader: async ({ deps: { invitationId } }) => {
+    const preview = await getInvitationPreview({ data: { invitationId } })
     if (!preview) {
       throw redirect({ to: "/" })
     }
@@ -25,7 +26,7 @@ export const Route = createFileRoute("/auth/invite")({
       throw redirect({
         to: "/login",
         search: {
-          redirect: `/auth/invite?invitationId=${search.invitationId}`,
+          redirect: `/auth/invite?invitationId=${invitationId}`,
           email: preview.inviteeEmail,
         },
       })
@@ -93,7 +94,7 @@ function InvitePage() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-background">
-      <div className="flex flex-col gap-y-6 max-w-[22rem] w-full">
+      <div className="flex flex-col gap-y-6 max-w-88 w-full">
         <div className="flex flex-col items-center justify-center gap-y-6">
           <LatitudeLogo />
           <div className="flex flex-col items-center justify-center gap-y-2">
@@ -147,7 +148,7 @@ function InvitePage() {
                 size="full"
                 type="submit"
                 disabled={isSubmitting}
-                className="relative w-full inline-flex items-center justify-center rounded-lg text-sm font-semibold leading-5 text-white bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none h-9 px-3 py-2 shadow-[inset_0px_0px_0px_1px_rgba(0,0,0,0.4)] active:translate-y-[1px] active:shadow-none transition-all"
+                className="relative w-full inline-flex items-center justify-center rounded-lg text-sm font-semibold leading-5 text-white bg-primary hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none h-9 px-3 py-2 shadow-[inset_0px_0px_0px_1px_rgba(0,0,0,0.4)] active:translate-y-px active:shadow-none transition-all"
               >
                 {isSubmitting ? "Accepting…" : "Accept invitation"}
               </Button>

--- a/apps/web/src/routes/auth/invite.tsx
+++ b/apps/web/src/routes/auth/invite.tsx
@@ -14,7 +14,7 @@ const invitationSearchParams = z.object({
 
 export const Route = createFileRoute("/auth/invite")({
   validateSearch: invitationSearchParams,
-  beforeLoad: async ({ search }) => {
+  loader: async ({ search }) => {
     const preview = await getInvitationPreview({ data: { invitationId: search.invitationId } })
     if (!preview) {
       throw redirect({ to: "/" })
@@ -38,7 +38,7 @@ export const Route = createFileRoute("/auth/invite")({
 
 function InvitePage() {
   const { invitationId } = Route.useSearch()
-  const { invitationPreview, session } = Route.useRouteContext()
+  const { invitationPreview, session } = Route.useLoaderData()
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string>()

--- a/apps/web/src/routes/welcome/index.tsx
+++ b/apps/web/src/routes/welcome/index.tsx
@@ -29,7 +29,7 @@ interface Organization {
 
 export const Route = createFileRoute("/welcome/")({
   component: WelcomePage,
-  beforeLoad: async () => {
+  loader: async () => {
     const session = await getSession()
     if (!session) {
       throw redirect({ to: "/login" })
@@ -51,7 +51,7 @@ export const Route = createFileRoute("/welcome/")({
 function WelcomePage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string>()
-  const { organizations } = Route.useRouteContext()
+  const { organizations } = Route.useLoaderData()
   const router = useRouter()
 
   const handleSelectOrg = async (orgId: string) => {

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -37,7 +37,7 @@ export function HeaderCell({
   align?: "start" | "end"
   resizable?: boolean
   minWidth?: number
-  /** Preferred column width (px); sets `th` width / minWidth for initial table layout. */
+  /** Preferred starting width (px); the first layout lock keeps at least this width. */
   width?: number
   className?: string
   sortable?: boolean
@@ -71,7 +71,10 @@ export function HeaderCell({
 
   const thStyle =
     preferredWidth !== undefined
-      ? ({ width: preferredWidth, minWidth: Math.max(minWidth, preferredWidth) } as const)
+      ? ({
+          width: preferredWidth,
+          ...(minWidth > 60 ? { minWidth } : {}),
+        } as const)
       : minWidth > 60
         ? ({ minWidth } as const)
         : undefined

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -11,7 +11,7 @@ export interface InfiniteTableColumn<T> {
   resizable?: boolean
   /** Minimum width (px); used for resize limits and header measurement. */
   minWidth?: number
-  /** Preferred default width (px) for this column; applied to the header cell so `table-fixed` allocates space. */
+  /** Preferred starting width (px) for the first layout lock; the column can later be resized smaller. */
   width?: number
   sortKey?: string
   /** Optional second header row cell; use for summaries. Keep controls `stopPropagation` if the column is sortable. */

--- a/packages/ui/src/components/infinite-table/use-header-layout-lock.test.ts
+++ b/packages/ui/src/components/infinite-table/use-header-layout-lock.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import type { InfiniteTableColumn } from "./types.ts"
+import { resolveLockedHeaderLayout } from "./use-header-layout-lock.ts"
+
+type Row = { id: string }
+
+function buildColumn(
+  key: string,
+  overrides: Partial<InfiniteTableColumn<Row>> = {},
+): InfiniteTableColumn<Row> {
+  return {
+    key,
+    header: key,
+    render: () => null,
+    ...overrides,
+  }
+}
+
+describe("resolveLockedHeaderLayout", () => {
+  it("keeps explicit widths as the starting floor for data columns", () => {
+    const layout = resolveLockedHeaderLayout({
+      headerCells: [{ offsetWidth: 32 }, { offsetWidth: 120 }, { offsetWidth: 80 }],
+      columns: [buildColumn("name", { width: 150 }), buildColumn("status", { width: 60 })],
+      leadingColumnCount: 1,
+      measuredTableWidth: 232,
+    })
+
+    expect(layout.lockedHeaderWidths).toEqual([32, 150, 80])
+    expect(layout.lockedTableWidth).toBe(262)
+  })
+
+  it("preserves larger measured widths when a column naturally grows", () => {
+    const layout = resolveLockedHeaderLayout({
+      headerCells: [{ offsetWidth: 220 }, { offsetWidth: 140 }],
+      columns: [buildColumn("name", { width: 160 }), buildColumn("status", { width: 120 })],
+      leadingColumnCount: 0,
+      measuredTableWidth: 360,
+    })
+
+    expect(layout.lockedHeaderWidths).toEqual([220, 140])
+    expect(layout.lockedTableWidth).toBe(360)
+  })
+})

--- a/packages/ui/src/components/infinite-table/use-header-layout-lock.test.ts
+++ b/packages/ui/src/components/infinite-table/use-header-layout-lock.test.ts
@@ -4,10 +4,7 @@ import { resolveLockedHeaderLayout } from "./use-header-layout-lock.ts"
 
 type Row = { id: string }
 
-function buildColumn(
-  key: string,
-  overrides: Partial<InfiniteTableColumn<Row>> = {},
-): InfiniteTableColumn<Row> {
+function buildColumn(key: string, overrides: Partial<InfiniteTableColumn<Row>> = {}): InfiniteTableColumn<Row> {
   return {
     key,
     header: key,

--- a/packages/ui/src/components/infinite-table/use-header-layout-lock.ts
+++ b/packages/ui/src/components/infinite-table/use-header-layout-lock.ts
@@ -1,11 +1,42 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react"
 import type { InfiniteTableColumn } from "./types.ts"
 
+interface MeasurableHeaderCell {
+  offsetWidth: number
+}
+
 interface UseHeaderLayoutLockParams<T> {
   columns: InfiniteTableColumn<T>[]
   hasSelection: boolean
   hasExpansion: boolean
   hasSubheaderRow: boolean
+}
+
+interface ResolveLockedHeaderLayoutParams<T> {
+  headerCells: readonly MeasurableHeaderCell[]
+  columns: readonly InfiniteTableColumn<T>[]
+  leadingColumnCount: number
+  measuredTableWidth: number
+}
+
+export function resolveLockedHeaderLayout<T>({
+  headerCells,
+  columns,
+  leadingColumnCount,
+  measuredTableWidth,
+}: ResolveLockedHeaderLayoutParams<T>) {
+  const lockedHeaderWidths = headerCells.map((headerCell, headerIndex) => {
+    const column = columns[headerIndex - leadingColumnCount]
+    return Math.max(headerCell.offsetWidth, column?.width ?? 0)
+  })
+
+  return {
+    lockedHeaderWidths,
+    lockedTableWidth: Math.max(
+      measuredTableWidth,
+      lockedHeaderWidths.reduce((totalWidth, width) => totalWidth + width, 0),
+    ),
+  }
 }
 
 export function useHeaderLayoutLock<T>({
@@ -16,6 +47,7 @@ export function useHeaderLayoutLock<T>({
 }: UseHeaderLayoutLockParams<T>) {
   const tableRef = useRef<HTMLTableElement>(null)
   const [layoutFixed, setLayoutFixed] = useState(false)
+  const leadingColumnCount = (hasSelection ? 1 : 0) + (hasExpansion ? 1 : 0)
   const headerLayoutKey = useMemo(() => {
     const columnSignature = columns
       .map((col) =>
@@ -71,10 +103,17 @@ export function useHeaderLayoutLock<T>({
         return
       }
 
-      for (const th of headerCells) {
-        th.style.width = `${th.offsetWidth}px`
+      const { lockedHeaderWidths, lockedTableWidth } = resolveLockedHeaderLayout({
+        headerCells,
+        columns,
+        leadingColumnCount,
+        measuredTableWidth: table.offsetWidth,
+      })
+
+      for (const [index, th] of headerCells.entries()) {
+        th.style.width = `${lockedHeaderWidths[index]}px`
       }
-      table.style.width = `${table.offsetWidth}px`
+      table.style.width = `${lockedTableWidth}px`
       setLayoutFixed(true)
     }
 

--- a/packages/ui/src/components/scroll-navigator/scroll-navigator.test.ts
+++ b/packages/ui/src/components/scroll-navigator/scroll-navigator.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest"
+import { resolveNavigationTarget } from "./scroll-navigator.tsx"
+
+const scrollPaddingTop = 16
+
+const metrics = [
+  { top: 32, bottom: 132 },
+  { top: 156, bottom: 356 },
+  { top: 380, bottom: 480 },
+] as const
+
+describe("resolveNavigationTarget", () => {
+  it("returns null when there are no items", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics: [],
+        scrollTop: 0,
+        clientHeight: 200,
+        scrollHeight: 200,
+        direction: "down",
+        scrollPaddingTop,
+      }),
+    ).toBeNull()
+  })
+
+  it("scrolls up to the clipped item's top before moving to the previous item", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 220,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "up",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 1, top: 140 })
+  })
+
+  it("scrolls down to the next item's top when the current top item is clipped", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 220,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "down",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 2, top: 364 })
+  })
+
+  it("moves between adjacent item tops when the current item is already aligned", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 156,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "up",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 0, top: 16 })
+
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 156,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "down",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 2, top: 364 })
+  })
+
+  it("treats the first fully visible item as current when the viewport top is between items", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 140,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "up",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 0, top: 16 })
+
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 140,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "down",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 2, top: 364 })
+  })
+
+  it("clamps the next item target to the container's max scroll position", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 156,
+        clientHeight: 200,
+        scrollHeight: 520,
+        direction: "down",
+        scrollPaddingTop,
+      }),
+    ).toEqual({ index: 2, top: 320 })
+  })
+
+  it("clamps to zero when padding would scroll above the start", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 156,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "up",
+        scrollPaddingTop: 48,
+      }),
+    ).toEqual({ index: 0, top: 0 })
+  })
+
+  it("advances from a pending target index instead of recomputing from the live scroll position", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 140,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "down",
+        scrollPaddingTop,
+        fromIndex: 1,
+      }),
+    ).toEqual({ index: 2, top: 364 })
+  })
+
+  it("lets reverse clicks subtract from the pending target index", () => {
+    expect(
+      resolveNavigationTarget({
+        metrics,
+        scrollTop: 220,
+        clientHeight: 200,
+        scrollHeight: 700,
+        direction: "up",
+        scrollPaddingTop,
+        fromIndex: 2,
+      }),
+    ).toEqual({ index: 1, top: 140 })
+  })
+})

--- a/packages/ui/src/components/scroll-navigator/scroll-navigator.tsx
+++ b/packages/ui/src/components/scroll-navigator/scroll-navigator.tsx
@@ -2,8 +2,10 @@ import { Button, Icon, Tooltip, useMountEffect } from "@repo/ui"
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 import { type ReactNode, type Ref, type RefObject, useImperativeHandle, useRef, useState } from "react"
 
+type ScrollDirection = "up" | "down"
+
 export interface ScrollNavigatorHandle {
-  navigate(direction: "up" | "down"): void
+  navigate(direction: ScrollDirection): void
 }
 
 interface ScrollNavigatorProps {
@@ -11,6 +13,7 @@ interface ScrollNavigatorProps {
   readonly itemRefs: RefObject<(HTMLDivElement | null)[]>
   readonly prevLabel?: ReactNode
   readonly nextLabel?: ReactNode
+  readonly scrollPaddingTop?: number
   readonly ref?: Ref<ScrollNavigatorHandle> | undefined
 }
 
@@ -19,10 +22,25 @@ type ItemMetric = {
   readonly bottom: number
 }
 
-type GapMetric = {
+type NavigationTarget = {
+  readonly index: number
   readonly top: number
-  readonly bottom: number
 }
+
+type ResolveNavigationTargetArgs = {
+  readonly metrics: readonly ItemMetric[]
+  readonly scrollTop: number
+  readonly clientHeight: number
+  readonly scrollHeight: number
+  readonly direction: ScrollDirection
+  readonly scrollPaddingTop?: number
+  readonly fromIndex?: number
+  readonly epsilon?: number
+}
+
+const DEFAULT_SCROLL_PADDING_TOP = 16
+const NAVIGATION_EPSILON = 2
+const PENDING_TARGET_RESET_DELAY_MS = 120
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value))
@@ -43,21 +61,135 @@ function getItemMetrics(refs: readonly (HTMLDivElement | null)[], container: HTM
   }, [])
 }
 
-function getGapMetrics(metrics: readonly ItemMetric[]): GapMetric[] {
-  const gaps: GapMetric[] = []
-
-  for (let i = 0; i < metrics.length - 1; i++) {
-    gaps.push({
-      top: metrics[i].bottom,
-      bottom: metrics[i + 1].top,
-    })
-  }
-
-  return gaps
+function getCurrentItemIndex(metrics: readonly ItemMetric[], scrollTop: number, epsilon: number) {
+  const currentIndex = metrics.findIndex((metric) => metric.bottom > scrollTop + epsilon)
+  return currentIndex >= 0 ? currentIndex : metrics.length - 1
 }
 
-function isWithinRange(value: number, start: number, end: number, epsilon: number) {
-  return value >= start - epsilon && value <= end + epsilon
+function resolveTargetTop({
+  metrics,
+  targetIndex,
+  clientHeight,
+  scrollHeight,
+  scrollPaddingTop,
+}: {
+  readonly metrics: readonly ItemMetric[]
+  readonly targetIndex: number
+  readonly clientHeight: number
+  readonly scrollHeight: number
+  readonly scrollPaddingTop: number
+}) {
+  const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
+  const targetItem = metrics[targetIndex]
+
+  if (!targetItem) return clamp(targetIndex <= 0 ? 0 : maxScrollTop, 0, maxScrollTop)
+
+  return clamp(targetItem.top - scrollPaddingTop, 0, maxScrollTop)
+}
+
+export function resolveNavigationTarget({
+  metrics,
+  scrollTop,
+  clientHeight,
+  scrollHeight,
+  direction,
+  scrollPaddingTop = DEFAULT_SCROLL_PADDING_TOP,
+  fromIndex,
+  epsilon = NAVIGATION_EPSILON,
+}: ResolveNavigationTargetArgs) {
+  if (metrics.length === 0) return null
+
+  const lastIndex = metrics.length - 1
+  const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
+  if (fromIndex !== undefined) {
+    const baseIndex = clamp(fromIndex, 0, lastIndex)
+
+    if (direction === "down") {
+      const targetIndex = Math.min(baseIndex + 1, lastIndex)
+      return {
+        index: targetIndex,
+        top:
+          baseIndex === lastIndex
+            ? maxScrollTop
+            : resolveTargetTop({
+                metrics,
+                targetIndex,
+                clientHeight,
+                scrollHeight,
+                scrollPaddingTop,
+              }),
+      } satisfies NavigationTarget
+    }
+
+    const targetIndex = Math.max(baseIndex - 1, 0)
+    return {
+      index: targetIndex,
+      top:
+        baseIndex === 0
+          ? 0
+          : resolveTargetTop({
+              metrics,
+              targetIndex,
+              clientHeight,
+              scrollHeight,
+              scrollPaddingTop,
+            }),
+    } satisfies NavigationTarget
+  }
+
+  const currentIndex = getCurrentItemIndex(metrics, scrollTop, epsilon)
+  const currentItem = metrics[currentIndex]
+
+  if (!currentItem) return null
+
+  const isTopOverflowing = currentItem.top < scrollTop - epsilon
+
+  if (direction === "down") {
+    if (currentIndex >= lastIndex) {
+      return { index: lastIndex, top: maxScrollTop } satisfies NavigationTarget
+    }
+
+    const targetIndex = currentIndex + 1
+    return {
+      index: targetIndex,
+      top: resolveTargetTop({
+        metrics,
+        targetIndex,
+        clientHeight,
+        scrollHeight,
+        scrollPaddingTop,
+      }),
+    } satisfies NavigationTarget
+  }
+
+  if (isTopOverflowing) {
+    return {
+      index: currentIndex,
+      top: resolveTargetTop({
+        metrics,
+        targetIndex: currentIndex,
+        clientHeight,
+        scrollHeight,
+        scrollPaddingTop,
+      }),
+    } satisfies NavigationTarget
+  }
+
+  if (currentIndex <= 0) {
+    return { index: 0, top: 0 } satisfies NavigationTarget
+  }
+
+  const targetIndex = currentIndex - 1
+  return {
+    index: targetIndex,
+    top: resolveTargetTop({
+      metrics,
+      targetIndex,
+      clientHeight,
+      scrollHeight,
+      scrollPaddingTop,
+    }),
+  } satisfies NavigationTarget
 }
 
 function NavigatorButtons({
@@ -116,17 +248,47 @@ function NavigatorButtons({
   )
 }
 
-export function ScrollNavigator({ scrollContainerRef, itemRefs, prevLabel, nextLabel, ref }: ScrollNavigatorProps) {
-  const rafRef = useRef(0)
+export function ScrollNavigator({
+  scrollContainerRef,
+  itemRefs,
+  prevLabel,
+  nextLabel,
+  scrollPaddingTop = DEFAULT_SCROLL_PADDING_TOP,
+  ref,
+}: ScrollNavigatorProps) {
+  const scrollStateRafRef = useRef(0)
+  const pendingTargetRef = useRef<NavigationTarget | null>(null)
+  const pendingTargetResetTimeoutRef = useRef<number | null>(null)
   const [hasOverflow, setHasOverflow] = useState(false)
   const [canScrollUp, setCanScrollUp] = useState(false)
   const [canScrollDown, setCanScrollDown] = useState(false)
 
   const updateScrollStateRef = useRef<(() => void) | null>(null)
 
+  const clearPendingTarget = () => {
+    pendingTargetRef.current = null
+
+    if (pendingTargetResetTimeoutRef.current !== null) {
+      window.clearTimeout(pendingTargetResetTimeoutRef.current)
+      pendingTargetResetTimeoutRef.current = null
+    }
+  }
+
+  const schedulePendingTargetReset = () => {
+    if (pendingTargetResetTimeoutRef.current !== null) {
+      window.clearTimeout(pendingTargetResetTimeoutRef.current)
+    }
+
+    pendingTargetResetTimeoutRef.current = window.setTimeout(() => {
+      pendingTargetResetTimeoutRef.current = null
+      pendingTargetRef.current = null
+    }, PENDING_TARGET_RESET_DELAY_MS)
+  }
+
   updateScrollStateRef.current = () => {
     const container = scrollContainerRef?.current
     if (!container) {
+      clearPendingTarget()
       setHasOverflow(false)
       setCanScrollUp(false)
       setCanScrollDown(false)
@@ -136,6 +298,14 @@ export function ScrollNavigator({ scrollContainerRef, itemRefs, prevLabel, nextL
     const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
     const scrollTop = container.scrollTop
     const epsilon = 1
+
+    if (pendingTargetRef.current) {
+      if (Math.abs(scrollTop - pendingTargetRef.current.top) <= epsilon) {
+        clearPendingTarget()
+      } else {
+        schedulePendingTargetReset()
+      }
+    }
 
     setHasOverflow(maxScrollTop > epsilon)
     setCanScrollUp(scrollTop > epsilon)
@@ -151,23 +321,29 @@ export function ScrollNavigator({ scrollContainerRef, itemRefs, prevLabel, nextL
     }
 
     const onScroll = () => {
-      cancelAnimationFrame(rafRef.current)
-      rafRef.current = requestAnimationFrame(updateScrollState)
+      cancelAnimationFrame(scrollStateRafRef.current)
+      scrollStateRafRef.current = requestAnimationFrame(updateScrollState)
+    }
+
+    const onResize = () => {
+      clearPendingTarget()
+      updateScrollState()
     }
 
     updateScrollState()
 
     container.addEventListener("scroll", onScroll, { passive: true })
-    window.addEventListener("resize", updateScrollState)
+    window.addEventListener("resize", onResize)
 
     return () => {
       container.removeEventListener("scroll", onScroll)
-      window.removeEventListener("resize", updateScrollState)
-      cancelAnimationFrame(rafRef.current)
+      window.removeEventListener("resize", onResize)
+      clearPendingTarget()
+      cancelAnimationFrame(scrollStateRafRef.current)
     }
   })
 
-  const navigate = (direction: "up" | "down") => {
+  const navigate = (direction: ScrollDirection) => {
     const container = scrollContainerRef?.current
     if (!container) return
 
@@ -177,64 +353,36 @@ export function ScrollNavigator({ scrollContainerRef, itemRefs, prevLabel, nextL
     const metrics = getItemMetrics(refs, container)
     if (metrics.length === 0) return
 
-    const gaps = getGapMetrics(metrics)
-    const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
     const scrollTop = container.scrollTop
-    const viewportTop = scrollTop
-    const viewportBottom = scrollTop + container.clientHeight
-    const epsilon = 2
+    const pendingTarget = pendingTargetRef.current
+    const activePendingTarget = pendingTarget && Math.abs(scrollTop - pendingTarget.top) > 1 ? pendingTarget : null
 
-    let targetTop = scrollTop
-
-    if (direction === "down") {
-      if (viewportBottom >= container.scrollHeight - epsilon) return
-
-      let targetGap: GapMetric | null = null
-
-      for (const gap of gaps) {
-        const bottomIsOnThisGap = isWithinRange(viewportBottom, gap.top, gap.bottom, epsilon)
-
-        if (bottomIsOnThisGap) continue
-        if (gap.top > viewportBottom + epsilon) {
-          targetGap = gap
-          break
-        }
-      }
-
-      if (targetGap) {
-        targetTop = targetGap.bottom - container.clientHeight
-      } else {
-        targetTop = maxScrollTop
-      }
-    } else {
-      if (viewportTop <= epsilon) return
-
-      let targetGap: GapMetric | null = null
-
-      for (let i = gaps.length - 1; i >= 0; i--) {
-        const gap = gaps[i]
-        const topIsOnThisGap = isWithinRange(viewportTop, gap.top, gap.bottom, epsilon)
-
-        if (topIsOnThisGap) continue
-        if (gap.bottom < viewportTop - epsilon) {
-          targetGap = gap
-          break
-        }
-      }
-
-      if (targetGap) {
-        targetTop = targetGap.top
-      } else {
-        targetTop = 0
-      }
+    if (pendingTarget && !activePendingTarget) {
+      clearPendingTarget()
     }
 
-    targetTop = clamp(targetTop, 0, maxScrollTop)
+    const target = resolveNavigationTarget({
+      metrics,
+      scrollTop,
+      clientHeight: container.clientHeight,
+      scrollHeight: container.scrollHeight,
+      direction,
+      scrollPaddingTop,
+      ...(activePendingTarget ? { fromIndex: activePendingTarget.index } : {}),
+    })
 
-    if (Math.abs(targetTop - scrollTop) <= 1) return
+    if (target === null) return
+
+    if (Math.abs(target.top - scrollTop) <= 1) {
+      clearPendingTarget()
+      return
+    }
+
+    pendingTargetRef.current = target
+    schedulePendingTargetReset()
 
     container.scrollTo({
-      top: targetTop,
+      top: target.top,
       behavior: "smooth",
     })
   }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -146,6 +146,7 @@ export { toast, useToast } from "./components/toast/useToast.ts"
 export { Tooltip, TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from "./components/tooltip/tooltip.tsx"
 export { hashToHue, useHashColor } from "./hooks/use-hash-color.ts"
 export { useHover } from "./hooks/use-hover.ts"
+export { useLocalStorage } from "./hooks/use-local-storage.ts"
 export { useMountEffect } from "./hooks/use-mount-effect.ts"
 export { useValueWithDefault } from "./hooks/use-value-with-default.ts"
 // Lib


### PR DESCRIPTION
### Minimum starting width for Traces table columns
The Traces table will no longer be rendered with columns that are too narrow. Now they will always have a useful width on load (user can still make them smaller)

### Fix conversation scroll buttons behaviour
Scroll buttons in conversation will now work as expected, scrolling to the next/previous message until it is on top of the scrollable area

### Add tooltip to collapsed sidebar items
When the main app sidebar is collapsed, hovering over the items will now display a tooltip

### Store sidebar collapse preference
The app sidebar collapsed state is now stored to localStorage, as per user preference

### Fix unnecessary remounts when changing URL params
We're using URL params to store the state of many parts of the UI. Due to Tanstack default behaviour, every time any of the URL params changed, it triggered a full refetch of the whole page, even though the data was already available. This makes the page needlessly less performant. Tanstack Routes and Hooks have been configured to fix this issue

### Fix ~1s delay when selecting an annotation from Annotation Queue's Item Detail
Selecting an annotation from an  Annotation Queue's Item Detail sidebar performs a smooth scroll to get the annotation into view, and waited for the scroll to end before opening the popover. Now, those are done at the same time