### PR TITLE
Phase 13 PR2: implement live evaluation enqueue flow

### DIFF
--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -17,6 +17,7 @@
     "@domain/api-keys": "workspace:*",
     "@domain/datasets": "workspace:*",
     "@domain/email": "workspace:*",
+    "@domain/evaluations": "workspace:*",
     "@domain/events": "workspace:*",
     "@domain/issues": "workspace:*",
     "@domain/queue": "workspace:*",

--- a/apps/workers/src/workers/live-evaluations.test.ts
+++ b/apps/workers/src/workers/live-evaluations.test.ts
@@ -1,0 +1,540 @@
+import {
+  buildLiveEvaluationExecuteScopeDedupeKey,
+  buildLiveEvaluationExecuteTraceDedupeKey,
+  defaultEvaluationTrigger,
+  type EvaluationTurn,
+  emptyEvaluationAlignment,
+  evaluationSchema,
+  shouldSampleLiveEvaluation,
+  toLiveEvaluationDebounceMs,
+} from "@domain/evaluations"
+import type { QueueConsumer, QueueName, TaskHandlers } from "@domain/queue"
+import { createFakeQueuePublisher } from "@domain/queue/testing"
+import { scoreSchema } from "@domain/scores"
+import { evaluations } from "@platform/db-postgres/schema/evaluations"
+import { scores } from "@platform/db-postgres/schema/scores"
+import { setupTestClickHouse, setupTestPostgres } from "@platform/testkit"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { createLiveEvaluationsWorker } from "./live-evaluations.ts"
+
+type AnyTaskHandlers = Record<string, (payload: unknown) => Effect.Effect<void, unknown>>
+
+class TestQueueConsumer implements QueueConsumer {
+  private readonly registered = new Map<QueueName, AnyTaskHandlers>()
+
+  subscribe<T extends QueueName>(queue: T, handlers: TaskHandlers<T>): void {
+    this.registered.set(queue, handlers as unknown as AnyTaskHandlers)
+  }
+
+  start() {
+    return Effect.void
+  }
+
+  stop() {
+    return Effect.void
+  }
+
+  async dispatchTask(queue: QueueName, task: string, payload: unknown): Promise<void> {
+    const handlers = this.registered.get(queue)
+    if (!handlers) throw new Error(`No handlers registered for queue ${queue}`)
+    const handler = handlers[task]
+    if (!handler) throw new Error(`No handler for task ${task} on queue ${queue}`)
+    await Effect.runPromise(handler(payload))
+  }
+}
+
+const pg = setupTestPostgres()
+const ch = setupTestClickHouse()
+
+const ORGANIZATION_ID = "o".repeat(24)
+const ISSUE_ID = "i".repeat(24)
+const API_KEY_ID = "k".repeat(24)
+const TIMESTAMP = new Date("2026-04-10T12:00:00.000Z")
+const NON_SAMPLED_EVALUATION_ALPHABET = "klmnopqrstuvwxyz"
+
+const fill = (character: string, length: number) => character.repeat(length)
+
+const toClickHouseTimestamp = (value: Date) => value.toISOString().replace("T", " ").replace("Z", "000")
+
+const toMessageJson = (role: "user" | "assistant", content: string) =>
+  JSON.stringify([{ role, parts: [{ type: "text", content }] }])
+
+const toSystemJson = (content: string) => JSON.stringify([{ type: "text", content }])
+
+const makeTraceRow = (input: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly spanId: string
+  readonly sessionId?: string
+  readonly tags?: string[]
+}) => ({
+  organization_id: ORGANIZATION_ID,
+  project_id: input.projectId,
+  session_id: input.sessionId ?? "",
+  user_id: "",
+  trace_id: input.traceId,
+  span_id: input.spanId,
+  parent_span_id: "",
+  api_key_id: API_KEY_ID,
+  simulation_id: "",
+  start_time: toClickHouseTimestamp(TIMESTAMP),
+  end_time: toClickHouseTimestamp(new Date(TIMESTAMP.getTime() + 4_000)),
+  name: "chat gpt-4o",
+  service_name: "acme-support-agent",
+  kind: 1,
+  status_code: 1,
+  status_message: "",
+  error_type: "",
+  tags: input.tags ?? ["lifecycle"],
+  metadata: {
+    environment: "production",
+    story: "live-evaluations-worker-test",
+  },
+  operation: "chat",
+  provider: "openai",
+  model: "gpt-4o",
+  response_model: "gpt-4o-2024-08-06",
+  tokens_input: 64,
+  tokens_output: 48,
+  tokens_cache_read: 0,
+  tokens_cache_create: 0,
+  tokens_reasoning: 0,
+  cost_input_microcents: 1_600,
+  cost_output_microcents: 4_800,
+  cost_total_microcents: 6_400,
+  cost_is_estimated: 1,
+  time_to_first_token_ns: 180_000_000,
+  is_streaming: 0,
+  response_id: `seed-${input.spanId}`,
+  finish_reasons: ["stop"],
+  input_messages: toMessageJson("user", "Summarize the deployment checklist."),
+  output_messages: toMessageJson("assistant", "Verify migrations, deploy, and monitor."),
+  system_instructions: toSystemJson("You are a helpful assistant."),
+  tool_definitions: "",
+  tool_call_id: "",
+  tool_name: "",
+  tool_input: "",
+  tool_output: "",
+  attr_string: {},
+  attr_int: {},
+  attr_float: {},
+  attr_bool: {},
+  resource_string: { "service.name": "acme-support-agent" },
+  scope_name: "openai-instrumentation",
+  scope_version: "1.0.0",
+})
+
+const makeEvaluationRow = (input: {
+  readonly id: string
+  readonly projectId: string
+  readonly filter?: Record<string, unknown>
+  readonly sampling?: number
+  readonly turn?: EvaluationTurn
+  readonly debounce?: number
+}) =>
+  evaluationSchema.parse({
+    id: input.id,
+    organizationId: ORGANIZATION_ID,
+    projectId: input.projectId,
+    issueId: ISSUE_ID,
+    name: `evaluation-${input.id.slice(0, 6)}`,
+    description: "Worker test live evaluation",
+    script: "export default async function evaluate() { return { value: 1 } }",
+    trigger: {
+      ...defaultEvaluationTrigger(),
+      filter: input.filter ?? {},
+      sampling: input.sampling ?? 100,
+      turn: input.turn ?? "every",
+      debounce: input.debounce ?? 0,
+    },
+    alignment: emptyEvaluationAlignment("worker-test-hash"),
+    alignedAt: TIMESTAMP,
+    archivedAt: null,
+    deletedAt: null,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  })
+
+const makeScoreRow = (input: {
+  readonly id: string
+  readonly projectId: string
+  readonly evaluationId: string
+  readonly traceId: string
+  readonly sessionId?: string | null
+}) =>
+  scoreSchema.parse({
+    id: input.id,
+    organizationId: ORGANIZATION_ID,
+    projectId: input.projectId,
+    sessionId: input.sessionId ?? null,
+    traceId: input.traceId,
+    spanId: null,
+    source: "evaluation",
+    sourceId: input.evaluationId,
+    simulationId: null,
+    issueId: null,
+    value: 0.95,
+    passed: true,
+    feedback: "already scored",
+    metadata: { evaluationHash: "worker-test-hash" },
+    error: null,
+    errored: false,
+    duration: 1_000_000,
+    tokens: 200,
+    cost: 500,
+    draftedAt: null,
+    annotatorId: null,
+    createdAt: TIMESTAMP,
+    updatedAt: TIMESTAMP,
+  })
+
+const insertTraceRows = async (rows: Array<Record<string, unknown>>) => {
+  await ch.client.insert({
+    table: "spans",
+    values: rows,
+    format: "JSONEachRow",
+  })
+}
+
+const insertEvaluations = async (rows: Array<ReturnType<typeof makeEvaluationRow>>) => {
+  await pg.db.insert(evaluations).values(rows)
+}
+
+const insertScores = async (rows: Array<ReturnType<typeof makeScoreRow>>) => {
+  await pg.db.insert(scores).values(rows)
+}
+
+const setupWorker = () => {
+  const consumer = new TestQueueConsumer()
+  const { publisher, published } = createFakeQueuePublisher()
+
+  createLiveEvaluationsWorker({
+    consumer,
+    publisher,
+    postgresClient: pg.appPostgresClient,
+    clickhouseClient: ch.client,
+  })
+
+  return { consumer, published }
+}
+
+async function findNonSampledEvaluationId(input: {
+  readonly projectId: string
+  readonly traceId: string
+  readonly excludedIds?: ReadonlySet<string>
+}): Promise<string> {
+  for (const character of NON_SAMPLED_EVALUATION_ALPHABET) {
+    const evaluationId = character.repeat(24)
+    if (input.excludedIds?.has(evaluationId)) {
+      continue
+    }
+
+    const shouldSample = await shouldSampleLiveEvaluation({
+      organizationId: ORGANIZATION_ID,
+      projectId: input.projectId,
+      evaluationId,
+      traceId: input.traceId,
+      sampling: 1,
+    })
+
+    if (!shouldSample) {
+      return evaluationId
+    }
+  }
+
+  throw new Error("Expected a non-sampled evaluation id for worker sampling coverage")
+}
+
+describe("createLiveEvaluationsWorker", () => {
+  it("publishes only matching eligible evaluations and skips paused, filter-mismatched, and non-sampled ones", async () => {
+    const projectId = fill("p", 24)
+    const traceId = fill("a", 32)
+    const matchingEvaluationId = fill("a", 24)
+    const pausedEvaluationId = fill("b", 24)
+    const mismatchedEvaluationId = fill("c", 24)
+    const nonSampledEvaluationId = await findNonSampledEvaluationId({
+      projectId,
+      traceId,
+      excludedIds: new Set([matchingEvaluationId, pausedEvaluationId, mismatchedEvaluationId]),
+    })
+
+    await insertTraceRows([
+      makeTraceRow({
+        projectId,
+        traceId,
+        spanId: fill("a", 16),
+        tags: ["lifecycle"],
+      }),
+    ])
+    await insertEvaluations([
+      makeEvaluationRow({
+        id: matchingEvaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+      }),
+      makeEvaluationRow({
+        id: pausedEvaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        sampling: 0,
+      }),
+      makeEvaluationRow({
+        id: mismatchedEvaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["annotation"] }] },
+      }),
+      makeEvaluationRow({
+        id: nonSampledEvaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        sampling: 1,
+      }),
+    ])
+
+    const { consumer, published } = setupWorker()
+
+    await consumer.dispatchTask("live-evaluations", "enqueue", {
+      organizationId: ORGANIZATION_ID,
+      projectId,
+      traceId,
+    })
+
+    expect(published).toEqual([
+      {
+        queue: "live-evaluations",
+        task: "execute",
+        payload: {
+          organizationId: ORGANIZATION_ID,
+          projectId,
+          evaluationId: matchingEvaluationId,
+          traceId,
+        },
+        options: {
+          dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+            organizationId: ORGANIZATION_ID,
+            projectId,
+            evaluationId: matchingEvaluationId,
+            traceId,
+          }),
+        },
+      },
+    ])
+  })
+
+  it("publishes debounced every-turn tasks using session scope when the trace has a session id", async () => {
+    const projectId = fill("q", 24)
+    const traceId = fill("b", 32)
+    const evaluationId = fill("d", 24)
+    const sessionId = "session-live-evaluations-worker"
+    const debounceSeconds = 15
+
+    await insertTraceRows([
+      makeTraceRow({
+        projectId,
+        traceId,
+        spanId: fill("b", 16),
+        sessionId,
+        tags: ["lifecycle"],
+      }),
+    ])
+    await insertEvaluations([
+      makeEvaluationRow({
+        id: evaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        turn: "every",
+        debounce: debounceSeconds,
+      }),
+    ])
+
+    const { consumer, published } = setupWorker()
+
+    await consumer.dispatchTask("live-evaluations", "enqueue", {
+      organizationId: ORGANIZATION_ID,
+      projectId,
+      traceId,
+    })
+
+    expect(published).toEqual([
+      {
+        queue: "live-evaluations",
+        task: "execute",
+        payload: {
+          organizationId: ORGANIZATION_ID,
+          projectId,
+          evaluationId,
+          traceId,
+        },
+        options: {
+          dedupeKey: buildLiveEvaluationExecuteScopeDedupeKey({
+            organizationId: ORGANIZATION_ID,
+            projectId,
+            evaluationId,
+            traceId,
+            sessionId,
+          }),
+          debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+        },
+      },
+    ])
+  })
+
+  it("publishes debounced every-turn tasks using trace scope when the trace has no session id", async () => {
+    const projectId = fill("r", 24)
+    const traceId = fill("c", 32)
+    const evaluationId = fill("e", 24)
+    const debounceSeconds = 20
+
+    await insertTraceRows([
+      makeTraceRow({
+        projectId,
+        traceId,
+        spanId: fill("c", 16),
+        tags: ["lifecycle"],
+      }),
+    ])
+    await insertEvaluations([
+      makeEvaluationRow({
+        id: evaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        turn: "every",
+        debounce: debounceSeconds,
+      }),
+    ])
+
+    const { consumer, published } = setupWorker()
+
+    await consumer.dispatchTask("live-evaluations", "enqueue", {
+      organizationId: ORGANIZATION_ID,
+      projectId,
+      traceId,
+    })
+
+    expect(published).toEqual([
+      {
+        queue: "live-evaluations",
+        task: "execute",
+        payload: {
+          organizationId: ORGANIZATION_ID,
+          projectId,
+          evaluationId,
+          traceId,
+        },
+        options: {
+          dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+            organizationId: ORGANIZATION_ID,
+            projectId,
+            evaluationId,
+            traceId,
+          }),
+          debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+        },
+      },
+    ])
+  })
+
+  it("skips first-turn evaluations when a canonical score already exists in the current session scope", async () => {
+    const projectId = fill("s", 24)
+    const traceId = fill("d", 32)
+    const priorTraceId = fill("e", 32)
+    const evaluationId = fill("f", 24)
+    const sessionId = "session-live-evaluations-first-turn"
+
+    await insertTraceRows([
+      makeTraceRow({
+        projectId,
+        traceId,
+        spanId: fill("d", 16),
+        sessionId,
+        tags: ["lifecycle"],
+      }),
+    ])
+    await insertEvaluations([
+      makeEvaluationRow({
+        id: evaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        turn: "first",
+      }),
+    ])
+    await insertScores([
+      makeScoreRow({
+        id: fill("g", 24),
+        projectId,
+        evaluationId,
+        traceId: priorTraceId,
+        sessionId,
+      }),
+    ])
+
+    const { consumer, published } = setupWorker()
+
+    await consumer.dispatchTask("live-evaluations", "enqueue", {
+      organizationId: ORGANIZATION_ID,
+      projectId,
+      traceId,
+    })
+
+    expect(published).toEqual([])
+  })
+
+  it("publishes last-turn evaluations as scope-scoped debounced execute tasks", async () => {
+    const projectId = fill("t", 24)
+    const traceId = fill("f", 32)
+    const evaluationId = fill("h", 24)
+    const sessionId = "session-live-evaluations-last-turn"
+    const debounceSeconds = 30
+
+    await insertTraceRows([
+      makeTraceRow({
+        projectId,
+        traceId,
+        spanId: fill("e", 16),
+        sessionId,
+        tags: ["lifecycle"],
+      }),
+    ])
+    await insertEvaluations([
+      makeEvaluationRow({
+        id: evaluationId,
+        projectId,
+        filter: { tags: [{ op: "in", value: ["lifecycle"] }] },
+        turn: "last",
+        debounce: debounceSeconds,
+      }),
+    ])
+
+    const { consumer, published } = setupWorker()
+
+    await consumer.dispatchTask("live-evaluations", "enqueue", {
+      organizationId: ORGANIZATION_ID,
+      projectId,
+      traceId,
+    })
+
+    expect(published).toEqual([
+      {
+        queue: "live-evaluations",
+        task: "execute",
+        payload: {
+          organizationId: ORGANIZATION_ID,
+          projectId,
+          evaluationId,
+          traceId,
+        },
+        options: {
+          dedupeKey: buildLiveEvaluationExecuteScopeDedupeKey({
+            organizationId: ORGANIZATION_ID,
+            projectId,
+            evaluationId,
+            traceId,
+            sessionId,
+          }),
+          debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+        },
+      },
+    ])
+  })
+})

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -2,9 +2,9 @@ import { enqueueLiveEvaluationsUseCase } from "@domain/evaluations"
 import type { QueueConsumer } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
-import { EvaluationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { EvaluationRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { createLogger } from "@repo/observability"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
 const logger = createLogger("live-evaluations")
@@ -28,7 +28,11 @@ export const createLiveEvaluationsWorker = ({ consumer }: LiveEvaluationsDeps) =
   consumer.subscribe("live-evaluations", {
     enqueue: (payload: EnqueuePayload) =>
       enqueueLiveEvaluationsUseCase(payload).pipe(
-        withPostgres(EvaluationRepositoryLive, pgClient, OrganizationId(payload.organizationId)),
+        withPostgres(
+          Layer.mergeAll(EvaluationRepositoryLive, ScoreRepositoryLive),
+          pgClient,
+          OrganizationId(payload.organizationId),
+        ),
         withClickHouse(TraceRepositoryLive, chClient, OrganizationId(payload.organizationId)),
         Effect.tap((result) =>
           Effect.sync(() => {
@@ -45,7 +49,6 @@ export const createLiveEvaluationsWorker = ({ consumer }: LiveEvaluationsDeps) =
             logger.info("Live evaluation enqueue completed", {
               organizationId: payload.organizationId,
               projectId: payload.projectId,
-              traceId: payload.traceId,
               ...result.summary,
             })
           }),

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -1,8 +1,19 @@
+import { enqueueLiveEvaluationsUseCase } from "@domain/evaluations"
 import type { QueueConsumer } from "@domain/queue"
+import { OrganizationId } from "@domain/shared"
+import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { EvaluationRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { createLogger } from "@repo/observability"
 import { Effect } from "effect"
+import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
 const logger = createLogger("live-evaluations")
+
+interface EnqueuePayload {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly traceId: string
+}
 
 interface LiveEvaluationsDeps {
   consumer: QueueConsumer
@@ -11,8 +22,46 @@ interface LiveEvaluationsDeps {
 // TODO(eval-sandbox): when implementing live evaluation execution, use the same extract-and-call
 // approach from executeEvaluationScript for MVP, then migrate to sandboxed JS runtime.
 export const createLiveEvaluationsWorker = ({ consumer }: LiveEvaluationsDeps) => {
+  const pgClient = getPostgresClient()
+  const chClient = getClickhouseClient()
+
   consumer.subscribe("live-evaluations", {
-    enqueue: () => Effect.sync(() => logger.info("Stub handler for live-evaluations:enqueue")),
+    enqueue: (payload: EnqueuePayload) =>
+      enqueueLiveEvaluationsUseCase(payload).pipe(
+        withPostgres(EvaluationRepositoryLive, pgClient, OrganizationId(payload.organizationId)),
+        withClickHouse(TraceRepositoryLive, chClient, OrganizationId(payload.organizationId)),
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            if (result.action === "skipped") {
+              logger.info("Live evaluation enqueue skipped", {
+                organizationId: payload.organizationId,
+                projectId: payload.projectId,
+                traceId: payload.traceId,
+                reason: result.reason,
+              })
+              return
+            }
+
+            logger.info("Live evaluation enqueue completed", {
+              organizationId: payload.organizationId,
+              projectId: payload.projectId,
+              traceId: payload.traceId,
+              ...result.summary,
+            })
+          }),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() =>
+            logger.error("Live evaluation enqueue failed", {
+              organizationId: payload.organizationId,
+              projectId: payload.projectId,
+              traceId: payload.traceId,
+              error,
+            }),
+          ),
+        ),
+        Effect.asVoid,
+      ),
     execute: () => Effect.sync(() => logger.info("Stub handler for live-evaluations:execute")),
   })
 }

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -6,8 +6,8 @@ import {
 } from "@domain/evaluations"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
-import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
-import { EvaluationRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { type ClickHouseClient, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { EvaluationRepositoryLive, type PostgresClient, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { createLogger } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
@@ -25,6 +25,8 @@ interface EnqueuePayload {
 interface LiveEvaluationsDeps {
   consumer: QueueConsumer
   publisher: QueuePublisherShape
+  postgresClient?: PostgresClient
+  clickhouseClient?: ClickHouseClient
 }
 
 const buildEnqueueLogContext = (payload: EnqueuePayload) => ({
@@ -37,9 +39,14 @@ const buildEnqueueLogContext = (payload: EnqueuePayload) => ({
 
 // TODO(eval-sandbox): when implementing live evaluation execution, use the same extract-and-call
 // approach from executeEvaluationScript for MVP, then migrate to sandboxed JS runtime.
-export const createLiveEvaluationsWorker = ({ consumer, publisher }: LiveEvaluationsDeps) => {
-  const pgClient = getPostgresClient()
-  const chClient = getClickhouseClient()
+export const createLiveEvaluationsWorker = ({
+  consumer,
+  publisher,
+  postgresClient,
+  clickhouseClient,
+}: LiveEvaluationsDeps) => {
+  const pgClient = postgresClient ?? getPostgresClient()
+  const chClient = clickhouseClient ?? getClickhouseClient()
   const liveEvaluationQueuePublisher = {
     publishExecute: ({ organizationId, projectId, evaluationId, traceId, dedupeKey, debounceMs }) => {
       const publishOptions =

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -13,6 +13,8 @@ import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
 const logger = createLogger("live-evaluations")
+const LIVE_EVALUATIONS_QUEUE = "live-evaluations" as const
+const LIVE_EVALUATIONS_ENQUEUE_TASK = "enqueue" as const
 
 interface EnqueuePayload {
   readonly organizationId: string
@@ -24,6 +26,14 @@ interface LiveEvaluationsDeps {
   consumer: QueueConsumer
   publisher: QueuePublisherShape
 }
+
+const buildEnqueueLogContext = (payload: EnqueuePayload) => ({
+  queue: LIVE_EVALUATIONS_QUEUE,
+  task: LIVE_EVALUATIONS_ENQUEUE_TASK,
+  organizationId: payload.organizationId,
+  projectId: payload.projectId,
+  traceId: payload.traceId,
+})
 
 // TODO(eval-sandbox): when implementing live evaluation execution, use the same extract-and-call
 // approach from executeEvaluationScript for MVP, then migrate to sandboxed JS runtime.
@@ -66,7 +76,7 @@ export const createLiveEvaluationsWorker = ({ consumer, publisher }: LiveEvaluat
     },
   } satisfies LiveEvaluationQueuePublisherShape
 
-  consumer.subscribe("live-evaluations", {
+  consumer.subscribe(LIVE_EVALUATIONS_QUEUE, {
     enqueue: (payload: EnqueuePayload) =>
       enqueueLiveEvaluationsUseCase(payload).pipe(
         withPostgres(
@@ -80,27 +90,31 @@ export const createLiveEvaluationsWorker = ({ consumer, publisher }: LiveEvaluat
           Effect.sync(() => {
             if (result.action === "skipped") {
               logger.info("Live evaluation enqueue skipped", {
-                organizationId: payload.organizationId,
-                projectId: payload.projectId,
-                traceId: payload.traceId,
+                ...buildEnqueueLogContext(payload),
+                outcome: result.action,
                 reason: result.reason,
               })
               return
             }
 
             logger.info("Live evaluation enqueue completed", {
-              organizationId: payload.organizationId,
-              projectId: payload.projectId,
-              ...result.summary,
+              ...buildEnqueueLogContext(payload),
+              outcome: result.action,
+              sessionId: result.summary.sessionId,
+              activeEvaluationsScanned: result.summary.activeEvaluationsScanned,
+              filterMatchedCount: result.summary.filterMatchedCount,
+              skippedPausedCount: result.summary.skippedPausedCount,
+              skippedSamplingCount: result.summary.skippedSamplingCount,
+              skippedTurnCount: result.summary.skippedTurnCount,
+              publishedExecuteCount: result.summary.publishedExecuteCount,
             })
           }),
         ),
         Effect.tapError((error) =>
           Effect.sync(() =>
             logger.error("Live evaluation enqueue failed", {
-              organizationId: payload.organizationId,
-              projectId: payload.projectId,
-              traceId: payload.traceId,
+              ...buildEnqueueLogContext(payload),
+              outcome: "failed",
               error,
             }),
           ),

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -1,5 +1,10 @@
-import { enqueueLiveEvaluationsUseCase } from "@domain/evaluations"
-import type { QueueConsumer } from "@domain/queue"
+import {
+  enqueueLiveEvaluationsUseCase,
+  LiveEvaluationQueuePublishError,
+  LiveEvaluationQueuePublisher,
+  type LiveEvaluationQueuePublisherShape,
+} from "@domain/evaluations"
+import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { EvaluationRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
@@ -17,13 +22,49 @@ interface EnqueuePayload {
 
 interface LiveEvaluationsDeps {
   consumer: QueueConsumer
+  publisher: QueuePublisherShape
 }
 
 // TODO(eval-sandbox): when implementing live evaluation execution, use the same extract-and-call
 // approach from executeEvaluationScript for MVP, then migrate to sandboxed JS runtime.
-export const createLiveEvaluationsWorker = ({ consumer }: LiveEvaluationsDeps) => {
+export const createLiveEvaluationsWorker = ({ consumer, publisher }: LiveEvaluationsDeps) => {
   const pgClient = getPostgresClient()
   const chClient = getClickhouseClient()
+  const liveEvaluationQueuePublisher = {
+    publishExecute: ({ organizationId, projectId, evaluationId, traceId, dedupeKey, debounceMs }) => {
+      const publishOptions =
+        dedupeKey === undefined
+          ? debounceMs === undefined
+            ? undefined
+            : { debounceMs }
+          : debounceMs === undefined
+            ? { dedupeKey }
+            : { dedupeKey, debounceMs }
+
+      return publisher
+        .publish(
+          "live-evaluations",
+          "execute",
+          {
+            organizationId,
+            projectId,
+            evaluationId,
+            traceId,
+          },
+          publishOptions,
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new LiveEvaluationQueuePublishError({
+                evaluationId,
+                traceId,
+                cause,
+              }),
+          ),
+        )
+    },
+  } satisfies LiveEvaluationQueuePublisherShape
 
   consumer.subscribe("live-evaluations", {
     enqueue: (payload: EnqueuePayload) =>
@@ -34,6 +75,7 @@ export const createLiveEvaluationsWorker = ({ consumer }: LiveEvaluationsDeps) =
           OrganizationId(payload.organizationId),
         ),
         withClickHouse(TraceRepositoryLive, chClient, OrganizationId(payload.organizationId)),
+        Effect.provide(Layer.succeed(LiveEvaluationQueuePublisher, liveEvaluationQueuePublisher)),
         Effect.tap((result) =>
           Effect.sync(() => {
             if (result.action === "skipped") {

--- a/packages/domain/evaluations/package.json
+++ b/packages/domain/evaluations/package.json
@@ -20,6 +20,7 @@
     "@domain/ai": "workspace:*",
     "@domain/models": "workspace:*",
     "@domain/optimizations": "workspace:*",
+    "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "effect": "catalog:",

--- a/packages/domain/evaluations/src/entities/evaluation.ts
+++ b/packages/domain/evaluations/src/entities/evaluation.ts
@@ -15,12 +15,31 @@ import {
 export const evaluationTurnSchema = z.enum(EVALUATION_TURNS)
 export type EvaluationTurn = z.infer<typeof evaluationTurnSchema>
 
-export const evaluationTriggerSchema = z.object({
-  filter: filterSetSchema, // trace/session filter over the shared trace field registry; `{}` matches all traces
-  turn: evaluationTurnSchema, // runs on the first, every, or last ingested trace/turn
-  debounce: z.number().int().nonnegative(), // debounce time in seconds
-  sampling: z.number().min(0).max(100), // percentage [0, 100]
-})
+function validateEvaluationTrigger(
+  trigger: {
+    readonly turn: EvaluationTurn
+    readonly debounce: number
+  },
+  ctx: z.core.$RefinementCtx<unknown>,
+) {
+  if (trigger.turn === "last" && trigger.debounce === 0) {
+    ctx.addIssue({
+      code: "custom",
+      message: "`turn = last` requires `debounce > 0`",
+      path: ["debounce"],
+      input: trigger.debounce,
+    })
+  }
+}
+
+export const evaluationTriggerSchema = z
+  .object({
+    filter: filterSetSchema, // trace/session filter over the shared trace field registry; `{}` matches all traces
+    turn: evaluationTurnSchema, // runs on the first, every, or last ingested trace/turn
+    debounce: z.number().int().nonnegative(), // debounce time in seconds
+    sampling: z.number().min(0).max(100), // percentage [0, 100]
+  })
+  .superRefine(validateEvaluationTrigger)
 
 export type EvaluationTrigger = z.infer<typeof evaluationTriggerSchema>
 

--- a/packages/domain/evaluations/src/errors.ts
+++ b/packages/domain/evaluations/src/errors.ts
@@ -43,3 +43,12 @@ export class LiveEvaluationExecutionError extends Data.TaggedError("LiveEvaluati
     return this.message
   }
 }
+
+export class LiveEvaluationQueuePublishError extends Data.TaggedError("LiveEvaluationQueuePublishError")<{
+  readonly evaluationId: string
+  readonly traceId: string
+  readonly cause?: unknown
+}> {
+  readonly httpStatus = 503
+  readonly httpMessage = "Failed to enqueue live evaluation execution"
+}

--- a/packages/domain/evaluations/src/helpers.test.ts
+++ b/packages/domain/evaluations/src/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { type ConfusionMatrix, evaluationSchema } from "./entities/evaluation.ts"
+import { type ConfusionMatrix, evaluationSchema, evaluationTriggerSchema } from "./entities/evaluation.ts"
 import { EvaluationDeletedError } from "./errors.ts"
 import {
   addConfusionMatrixObservation,
@@ -147,6 +147,29 @@ describe("evaluation lifecycle helpers", () => {
 })
 
 describe("live evaluation trigger helpers", () => {
+  it("requires a positive debounce for last-turn evaluations", () => {
+    const result = evaluationTriggerSchema.safeParse({
+      filter: {},
+      turn: "last",
+      debounce: 0,
+      sampling: 10,
+    })
+
+    expect(result.success).toBe(false)
+    if (result.success) {
+      throw new Error("Expected `turn = last` with `debounce = 0` to be rejected")
+    }
+
+    expect(result.error.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "`turn = last` requires `debounce > 0`",
+          path: ["debounce"],
+        }),
+      ]),
+    )
+  })
+
   it("marks an active non-paused evaluation as eligible for live execution", () => {
     expect(getLiveEvaluationEligibility(makeEvaluation())).toEqual({ eligible: true })
   })

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -151,6 +151,13 @@ export { generateBaselineDraftUseCase } from "./use-cases/alignment/generate-bas
 export { loadAlignmentStateUseCase } from "./use-cases/alignment/load-alignment-state.ts"
 export { persistAlignmentResultUseCase } from "./use-cases/alignment/persist-alignment-result.ts"
 export {
+  type EnqueueLiveEvaluationsError,
+  type EnqueueLiveEvaluationsInput,
+  type EnqueueLiveEvaluationsResult,
+  type EnqueueLiveEvaluationsSummary,
+  enqueueLiveEvaluationsUseCase,
+} from "./use-cases/live/enqueue-live-evaluations.ts"
+export {
   type ExecuteLiveEvaluationError,
   executeLiveEvaluationUseCase,
   type LiveEvaluationConversationInput,

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -58,6 +58,7 @@ export {
   EvaluationManualRealignmentRateLimitedError,
   EvaluationNotFoundError,
   LiveEvaluationExecutionError,
+  LiveEvaluationQueuePublishError,
 } from "./errors.ts"
 export {
   addConfusionMatrixObservation,
@@ -118,6 +119,11 @@ export {
   type EvaluationRepositoryShape,
   evaluationListLifecycleSchema,
 } from "./ports/evaluation-repository.ts"
+export {
+  LiveEvaluationQueuePublisher,
+  type LiveEvaluationQueuePublisherShape,
+  type PublishLiveEvaluationExecuteInput,
+} from "./ports/live-evaluation-queue-publisher.ts"
 export {
   EVALUATION_CONVERSATION_PLACEHOLDER,
   EVALUATION_SCRIPT_RUNTIME_MODEL,

--- a/packages/domain/evaluations/src/ports/live-evaluation-queue-publisher.ts
+++ b/packages/domain/evaluations/src/ports/live-evaluation-queue-publisher.ts
@@ -1,0 +1,22 @@
+import { type Effect, ServiceMap } from "effect"
+import type { LiveEvaluationQueuePublishError } from "../errors.ts"
+
+export interface PublishLiveEvaluationExecuteInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly evaluationId: string
+  readonly traceId: string
+  readonly dedupeKey?: string
+  readonly debounceMs?: number
+}
+
+export interface LiveEvaluationQueuePublisherShape {
+  readonly publishExecute: (
+    input: PublishLiveEvaluationExecuteInput,
+  ) => Effect.Effect<void, LiveEvaluationQueuePublishError>
+}
+
+export class LiveEvaluationQueuePublisher extends ServiceMap.Service<
+  LiveEvaluationQueuePublisher,
+  LiveEvaluationQueuePublisherShape
+>()("@domain/evaluations/LiveEvaluationQueuePublisher") {}

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
@@ -1,0 +1,199 @@
+import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
+import { type TraceDetail, TraceRepository } from "@domain/spans"
+import { createFakeTraceRepository } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { defaultEvaluationTrigger, emptyEvaluationAlignment, evaluationSchema } from "../../entities/evaluation.ts"
+import {
+  type EvaluationListPage,
+  EvaluationRepository,
+  type EvaluationRepositoryShape,
+} from "../../ports/evaluation-repository.ts"
+import { enqueueLiveEvaluationsUseCase } from "./enqueue-live-evaluations.ts"
+
+const INPUT = {
+  organizationId: "a".repeat(24),
+  projectId: "b".repeat(24),
+  traceId: "c".repeat(32),
+} as const
+
+function makeTraceDetail(): TraceDetail {
+  return {
+    organizationId: OrganizationId(INPUT.organizationId),
+    projectId: ProjectId(INPUT.projectId),
+    traceId: TraceId(INPUT.traceId),
+    spanCount: 3,
+    errorCount: 0,
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:01.000Z"),
+    durationNs: 1,
+    timeToFirstTokenNs: 0,
+    tokensInput: 120,
+    tokensOutput: 80,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 200,
+    costInputMicrocents: 50,
+    costOutputMicrocents: 25,
+    costTotalMicrocents: 75,
+    sessionId: SessionId("session"),
+    userId: ExternalUserId("user"),
+    simulationId: SimulationId(""),
+    tags: [],
+    metadata: {},
+    models: ["gpt-4o-mini"],
+    providers: ["openai"],
+    serviceNames: ["web"],
+    rootSpanId: SpanId("r".repeat(16)),
+    rootSpanName: "root",
+    systemInstructions: [{ type: "text", text: "You are a careful assistant." }],
+    inputMessages: [],
+    outputMessages: [],
+    allMessages: [],
+  }
+}
+
+function makeEvaluation(id: string) {
+  return evaluationSchema.parse({
+    id,
+    organizationId: INPUT.organizationId,
+    projectId: INPUT.projectId,
+    issueId: "i".repeat(24),
+    name: `Eval ${id.slice(-4)}`,
+    description: "Live evaluation",
+    script: "export default async function evaluate() { return { score: 1 } }",
+    trigger: defaultEvaluationTrigger(),
+    alignment: emptyEvaluationAlignment("hash"),
+    alignedAt: new Date("2026-01-01T00:00:00.000Z"),
+    archivedAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  })
+}
+
+function createEvaluationRepository(
+  listByProjectId: EvaluationRepositoryShape["listByProjectId"],
+): EvaluationRepositoryShape {
+  return {
+    findById: () => Effect.die("Unexpected call to findById"),
+    save: () => Effect.die("Unexpected call to save"),
+    listByProjectId,
+    listByIssueId: () => Effect.die("Unexpected call to listByIssueId"),
+    archive: () => Effect.die("Unexpected call to archive"),
+    unarchive: () => Effect.die("Unexpected call to unarchive"),
+    softDelete: () => Effect.die("Unexpected call to softDelete"),
+    archiveByIssueId: () => Effect.die("Unexpected call to archiveByIssueId"),
+  }
+}
+
+describe("enqueueLiveEvaluationsUseCase", () => {
+  it("skips when the ended trace no longer exists", async () => {
+    const { repository: traceRepository } = createFakeTraceRepository()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.die("Active evaluations should not be listed when the trace is missing"),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          Layer.merge(
+            Layer.succeed(TraceRepository, traceRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "trace-not-found",
+      traceId: INPUT.traceId,
+    })
+  })
+
+  it("loads the trace and paginates active evaluations", async () => {
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+    })
+
+    const recordedCalls: Array<{
+      readonly projectId: string
+      readonly lifecycle: string | undefined
+      readonly limit: number | undefined
+      readonly offset: number
+    }> = []
+
+    const pages = new Map<number, EvaluationListPage>([
+      [
+        0,
+        {
+          items: [makeEvaluation("e".repeat(24))],
+          hasMore: true,
+          limit: 100,
+          offset: 0,
+        },
+      ],
+      [
+        100,
+        {
+          items: [makeEvaluation("f".repeat(24))],
+          hasMore: false,
+          limit: 100,
+          offset: 100,
+        },
+      ],
+    ])
+
+    const evaluationRepository = createEvaluationRepository(({ projectId, options }) => {
+      recordedCalls.push({
+        projectId,
+        lifecycle: options?.lifecycle,
+        limit: options?.limit,
+        offset: options?.offset ?? 0,
+      })
+
+      return Effect.succeed(pages.get(options?.offset ?? 0) ?? pages.get(100)!)
+    })
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          Layer.merge(
+            Layer.succeed(TraceRepository, traceRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+          ),
+        ),
+      ),
+    )
+
+    expect(recordedCalls).toEqual([
+      {
+        projectId: INPUT.projectId,
+        lifecycle: "active",
+        limit: 100,
+        offset: 0,
+      },
+      {
+        projectId: INPUT.projectId,
+        lifecycle: "active",
+        limit: 100,
+        offset: 100,
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 2,
+        filterMatchedCount: 0,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 0,
+      },
+    })
+  })
+})

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
@@ -1,9 +1,17 @@
+import { ScoreRepository } from "@domain/scores"
+import { createFakeScoreRepository } from "@domain/scores/testing"
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import { type TraceDetail, TraceRepository } from "@domain/spans"
 import { createFakeTraceRepository } from "@domain/spans/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
-import { defaultEvaluationTrigger, emptyEvaluationAlignment, evaluationSchema } from "../../entities/evaluation.ts"
+import {
+  defaultEvaluationTrigger,
+  type Evaluation,
+  emptyEvaluationAlignment,
+  evaluationSchema,
+} from "../../entities/evaluation.ts"
+import { shouldSampleLiveEvaluation } from "../../helpers.ts"
 import {
   type EvaluationListPage,
   EvaluationRepository,
@@ -57,7 +65,9 @@ function makeTraceDetail(): TraceDetail {
 function makeEvaluation(
   id: string,
   options?: {
+    readonly filter?: Evaluation["trigger"]["filter"]
     readonly sampling?: number
+    readonly turn?: Evaluation["trigger"]["turn"]
   },
 ) {
   const trigger = defaultEvaluationTrigger()
@@ -72,7 +82,9 @@ function makeEvaluation(
     script: "export default async function evaluate() { return { score: 1 } }",
     trigger: {
       ...trigger,
+      ...(options?.filter !== undefined ? { filter: options.filter } : {}),
       ...(options?.sampling !== undefined ? { sampling: options.sampling } : {}),
+      ...(options?.turn !== undefined ? { turn: options.turn } : {}),
     },
     alignment: emptyEvaluationAlignment("hash"),
     alignedAt: new Date("2026-01-01T00:00:00.000Z"),
@@ -98,20 +110,60 @@ function createEvaluationRepository(
   }
 }
 
+function createRepositoriesLayer(input: {
+  readonly traceRepository: ReturnType<typeof createFakeTraceRepository>["repository"]
+  readonly evaluationRepository: EvaluationRepositoryShape
+  readonly scoreRepository?: ReturnType<typeof createFakeScoreRepository>["repository"]
+}) {
+  return Layer.mergeAll(
+    Layer.succeed(TraceRepository, input.traceRepository),
+    Layer.succeed(EvaluationRepository, input.evaluationRepository),
+    Layer.succeed(ScoreRepository, input.scoreRepository ?? createFakeScoreRepository().repository),
+  )
+}
+
+async function findNonSampledEvaluationIds(count: number): Promise<string[]> {
+  const matches: string[] = []
+  const alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+  for (const character of alphabet) {
+    if (matches.length === count) {
+      return matches
+    }
+
+    const evaluationId = character.repeat(24)
+    const shouldSample = await shouldSampleLiveEvaluation({
+      organizationId: INPUT.organizationId,
+      projectId: INPUT.projectId,
+      evaluationId,
+      traceId: INPUT.traceId,
+      sampling: 1,
+    })
+
+    if (!shouldSample) {
+      matches.push(evaluationId)
+    }
+  }
+
+  throw new Error(`Expected ${count} non-sampled evaluation ids for deterministic sampling tests`)
+}
+
 describe("enqueueLiveEvaluationsUseCase", () => {
   it("skips when the ended trace no longer exists", async () => {
     const { repository: traceRepository } = createFakeTraceRepository()
     const evaluationRepository = createEvaluationRepository(() =>
       Effect.die("Active evaluations should not be listed when the trace is missing"),
     )
+    const { repository: scoreRepository } = createFakeScoreRepository()
 
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          Layer.merge(
-            Layer.succeed(TraceRepository, traceRepository),
-            Layer.succeed(EvaluationRepository, evaluationRepository),
-          ),
+          createRepositoriesLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+          }),
         ),
       ),
     )
@@ -124,9 +176,22 @@ describe("enqueueLiveEvaluationsUseCase", () => {
   })
 
   it("loads the trace and paginates active evaluations", async () => {
+    const recordedFilterCalls: Array<{
+      readonly traceId: string
+      readonly filterIds: readonly string[]
+    }> = []
     const { repository: traceRepository } = createFakeTraceRepository({
       findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: ({ traceId, filterSets }) => {
+        recordedFilterCalls.push({
+          traceId,
+          filterIds: filterSets.map((filterSet) => filterSet.filterId),
+        })
+
+        return Effect.succeed(filterSets.map((filterSet) => filterSet.filterId))
+      },
     })
+    const { repository: scoreRepository } = createFakeScoreRepository()
 
     const recordedCalls: Array<{
       readonly projectId: string
@@ -139,7 +204,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
       [
         0,
         {
-          items: [makeEvaluation("e".repeat(24))],
+          items: [makeEvaluation("e".repeat(24), { sampling: 100 })],
           hasMore: true,
           limit: 100,
           offset: 0,
@@ -148,7 +213,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
       [
         100,
         {
-          items: [makeEvaluation("f".repeat(24))],
+          items: [makeEvaluation("f".repeat(24), { sampling: 100 })],
           hasMore: false,
           limit: 100,
           offset: 100,
@@ -175,10 +240,11 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          Layer.merge(
-            Layer.succeed(TraceRepository, traceRepository),
-            Layer.succeed(EvaluationRepository, evaluationRepository),
-          ),
+          createRepositoriesLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+          }),
         ),
       ),
     )
@@ -197,13 +263,19 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         offset: 100,
       },
     ])
+    expect(recordedFilterCalls).toEqual([
+      {
+        traceId: INPUT.traceId,
+        filterIds: ["e".repeat(24), "f".repeat(24)],
+      },
+    ])
     expect(result).toEqual({
       action: "completed",
       summary: {
         traceId: INPUT.traceId,
         sessionId: "session",
         activeEvaluationsScanned: 2,
-        filterMatchedCount: 0,
+        filterMatchedCount: 2,
         skippedPausedCount: 0,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
@@ -215,11 +287,14 @@ describe("enqueueLiveEvaluationsUseCase", () => {
   it("counts sampling=0 evaluations as paused skips", async () => {
     const { repository: traceRepository } = createFakeTraceRepository({
       findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: ({ filterSets }) =>
+        Effect.succeed(filterSets.map((filterSet) => filterSet.filterId)),
     })
+    const { repository: scoreRepository } = createFakeScoreRepository()
 
     const evaluationRepository = createEvaluationRepository(() =>
       Effect.succeed({
-        items: [makeEvaluation("e".repeat(24)), makeEvaluation("f".repeat(24), { sampling: 0 })],
+        items: [makeEvaluation("e".repeat(24), { sampling: 100 }), makeEvaluation("f".repeat(24), { sampling: 0 })],
         hasMore: false,
         limit: 100,
         offset: 0,
@@ -229,10 +304,11 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          Layer.merge(
-            Layer.succeed(TraceRepository, traceRepository),
-            Layer.succeed(EvaluationRepository, evaluationRepository),
-          ),
+          createRepositoriesLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+          }),
         ),
       ),
     )
@@ -243,10 +319,129 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         traceId: INPUT.traceId,
         sessionId: "session",
         activeEvaluationsScanned: 2,
-        filterMatchedCount: 0,
+        filterMatchedCount: 1,
         skippedPausedCount: 1,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
+        publishedExecuteCount: 0,
+      },
+    })
+  })
+
+  it("applies filters before sampling and turn checks", async () => {
+    const [matchingEvaluationId, nonMatchingEvaluationId] = await findNonSampledEvaluationIds(2)
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([matchingEvaluationId]),
+    })
+    const turnCheckCalls: Array<{
+      readonly evaluationId: string
+      readonly traceId: string
+      readonly sessionId: string | null | undefined
+    }> = []
+    const { repository: scoreRepository } = createFakeScoreRepository({
+      existsByEvaluationIdAndScope: ({ evaluationId, traceId, sessionId }) => {
+        turnCheckCalls.push({ evaluationId, traceId, sessionId })
+        return Effect.succeed(true)
+      },
+    })
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [
+          makeEvaluation(matchingEvaluationId, { sampling: 1, turn: "first" }),
+          makeEvaluation(nonMatchingEvaluationId, { sampling: 1, turn: "first" }),
+        ],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createRepositoriesLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+          }),
+        ),
+      ),
+    )
+
+    expect(turnCheckCalls).toEqual([])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 2,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 1,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 0,
+      },
+    })
+  })
+
+  it("applies first-turn scope checks after sampling", async () => {
+    const evaluationId = "g".repeat(24)
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const turnCheckCalls: Array<{
+      readonly projectId: string
+      readonly evaluationId: string
+      readonly traceId: string
+      readonly sessionId: string | null | undefined
+    }> = []
+    const { repository: scoreRepository } = createFakeScoreRepository({
+      existsByEvaluationIdAndScope: ({ projectId, evaluationId, traceId, sessionId }) => {
+        turnCheckCalls.push({ projectId, evaluationId, traceId, sessionId })
+        return Effect.succeed(true)
+      },
+    })
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "first" })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createRepositoriesLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+          }),
+        ),
+      ),
+    )
+
+    expect(turnCheckCalls).toEqual([
+      {
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: INPUT.traceId,
+        sessionId: "session",
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 1,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 1,
         publishedExecuteCount: 0,
       },
     })

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
@@ -11,12 +11,22 @@ import {
   emptyEvaluationAlignment,
   evaluationSchema,
 } from "../../entities/evaluation.ts"
-import { shouldSampleLiveEvaluation } from "../../helpers.ts"
+import {
+  buildLiveEvaluationExecuteScopeDedupeKey,
+  buildLiveEvaluationExecuteTraceDedupeKey,
+  shouldSampleLiveEvaluation,
+  toLiveEvaluationDebounceMs,
+} from "../../helpers.ts"
 import {
   type EvaluationListPage,
   EvaluationRepository,
   type EvaluationRepositoryShape,
 } from "../../ports/evaluation-repository.ts"
+import {
+  LiveEvaluationQueuePublisher,
+  type LiveEvaluationQueuePublisherShape,
+  type PublishLiveEvaluationExecuteInput,
+} from "../../ports/live-evaluation-queue-publisher.ts"
 import { enqueueLiveEvaluationsUseCase } from "./enqueue-live-evaluations.ts"
 
 const INPUT = {
@@ -65,6 +75,7 @@ function makeTraceDetail(): TraceDetail {
 function makeEvaluation(
   id: string,
   options?: {
+    readonly debounce?: number
     readonly filter?: Evaluation["trigger"]["filter"]
     readonly sampling?: number
     readonly turn?: Evaluation["trigger"]["turn"]
@@ -82,6 +93,7 @@ function makeEvaluation(
     script: "export default async function evaluate() { return { score: 1 } }",
     trigger: {
       ...trigger,
+      ...(options?.debounce !== undefined ? { debounce: options.debounce } : {}),
       ...(options?.filter !== undefined ? { filter: options.filter } : {}),
       ...(options?.sampling !== undefined ? { sampling: options.sampling } : {}),
       ...(options?.turn !== undefined ? { turn: options.turn } : {}),
@@ -110,15 +122,34 @@ function createEvaluationRepository(
   }
 }
 
-function createRepositoriesLayer(input: {
+function createLiveEvaluationQueuePublisher(overrides?: Partial<LiveEvaluationQueuePublisherShape>) {
+  const published: PublishLiveEvaluationExecuteInput[] = []
+
+  const queuePublisher: LiveEvaluationQueuePublisherShape = {
+    publishExecute: (input) => {
+      published.push(input)
+      return Effect.void
+    },
+    ...overrides,
+  }
+
+  return { queuePublisher, published }
+}
+
+function createUseCaseLayer(input: {
   readonly traceRepository: ReturnType<typeof createFakeTraceRepository>["repository"]
   readonly evaluationRepository: EvaluationRepositoryShape
   readonly scoreRepository?: ReturnType<typeof createFakeScoreRepository>["repository"]
+  readonly liveEvaluationQueuePublisher?: LiveEvaluationQueuePublisherShape
 }) {
   return Layer.mergeAll(
     Layer.succeed(TraceRepository, input.traceRepository),
     Layer.succeed(EvaluationRepository, input.evaluationRepository),
     Layer.succeed(ScoreRepository, input.scoreRepository ?? createFakeScoreRepository().repository),
+    Layer.succeed(
+      LiveEvaluationQueuePublisher,
+      input.liveEvaluationQueuePublisher ?? createLiveEvaluationQueuePublisher().queuePublisher,
+    ),
   )
 }
 
@@ -155,14 +186,16 @@ describe("enqueueLiveEvaluationsUseCase", () => {
       Effect.die("Active evaluations should not be listed when the trace is missing"),
     )
     const { repository: scoreRepository } = createFakeScoreRepository()
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
 
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          createRepositoriesLayer({
+          createUseCaseLayer({
             traceRepository,
             evaluationRepository,
             scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
           }),
         ),
       ),
@@ -173,6 +206,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
       reason: "trace-not-found",
       traceId: INPUT.traceId,
     })
+    expect(published).toEqual([])
   })
 
   it("loads the trace and paginates active evaluations", async () => {
@@ -192,6 +226,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
       },
     })
     const { repository: scoreRepository } = createFakeScoreRepository()
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
 
     const recordedCalls: Array<{
       readonly projectId: string
@@ -240,10 +275,11 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          createRepositoriesLayer({
+          createUseCaseLayer({
             traceRepository,
             evaluationRepository,
             scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
           }),
         ),
       ),
@@ -269,6 +305,32 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         filterIds: ["e".repeat(24), "f".repeat(24)],
       },
     ])
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId: "e".repeat(24),
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId: "e".repeat(24),
+          traceId: INPUT.traceId,
+        }),
+      },
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId: "f".repeat(24),
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId: "f".repeat(24),
+          traceId: INPUT.traceId,
+        }),
+      },
+    ])
     expect(result).toEqual({
       action: "completed",
       summary: {
@@ -279,7 +341,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         skippedPausedCount: 0,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
-        publishedExecuteCount: 0,
+        publishedExecuteCount: 2,
       },
     })
   })
@@ -291,6 +353,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         Effect.succeed(filterSets.map((filterSet) => filterSet.filterId)),
     })
     const { repository: scoreRepository } = createFakeScoreRepository()
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
 
     const evaluationRepository = createEvaluationRepository(() =>
       Effect.succeed({
@@ -304,15 +367,30 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          createRepositoriesLayer({
+          createUseCaseLayer({
             traceRepository,
             evaluationRepository,
             scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
           }),
         ),
       ),
     )
 
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId: "e".repeat(24),
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId: "e".repeat(24),
+          traceId: INPUT.traceId,
+        }),
+      },
+    ])
     expect(result).toEqual({
       action: "completed",
       summary: {
@@ -323,7 +401,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         skippedPausedCount: 1,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
-        publishedExecuteCount: 0,
+        publishedExecuteCount: 1,
       },
     })
   })
@@ -345,6 +423,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         return Effect.succeed(true)
       },
     })
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
     const evaluationRepository = createEvaluationRepository(() =>
       Effect.succeed({
         items: [
@@ -360,16 +439,18 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          createRepositoriesLayer({
+          createUseCaseLayer({
             traceRepository,
             evaluationRepository,
             scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
           }),
         ),
       ),
     )
 
     expect(turnCheckCalls).toEqual([])
+    expect(published).toEqual([])
     expect(result).toEqual({
       action: "completed",
       summary: {
@@ -403,6 +484,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         return Effect.succeed(true)
       },
     })
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
     const evaluationRepository = createEvaluationRepository(() =>
       Effect.succeed({
         items: [makeEvaluation(evaluationId, { sampling: 100, turn: "first" })],
@@ -415,10 +497,11 @@ describe("enqueueLiveEvaluationsUseCase", () => {
     const result = await Effect.runPromise(
       enqueueLiveEvaluationsUseCase(INPUT).pipe(
         Effect.provide(
-          createRepositoriesLayer({
+          createUseCaseLayer({
             traceRepository,
             evaluationRepository,
             scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
           }),
         ),
       ),
@@ -432,6 +515,7 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         sessionId: "session",
       },
     ])
+    expect(published).toEqual([])
     expect(result).toEqual({
       action: "completed",
       summary: {
@@ -443,6 +527,191 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         skippedSamplingCount: 0,
         skippedTurnCount: 1,
         publishedExecuteCount: 0,
+      },
+    })
+  })
+
+  it("publishes first-turn execute tasks when no prior scope score exists", async () => {
+    const evaluationId = "h".repeat(24)
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const { repository: scoreRepository } = createFakeScoreRepository({
+      existsByEvaluationIdAndScope: () => Effect.succeed(false),
+    })
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "first" })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createUseCaseLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
+          }),
+        ),
+      ),
+    )
+
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: INPUT.traceId,
+        }),
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 1,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 1,
+      },
+    })
+  })
+
+  it("publishes scope-scoped debounced execute tasks for every-turn debounce", async () => {
+    const evaluationId = "i".repeat(24)
+    const debounceSeconds = 15
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const { repository: scoreRepository } = createFakeScoreRepository()
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "every", debounce: debounceSeconds })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createUseCaseLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
+          }),
+        ),
+      ),
+    )
+
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteScopeDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: INPUT.traceId,
+          sessionId: "session",
+        }),
+        debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 1,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 1,
+      },
+    })
+  })
+
+  it("publishes scope-scoped debounced execute tasks for last-turn evaluations", async () => {
+    const evaluationId = "j".repeat(24)
+    const debounceSeconds = 30
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const { repository: scoreRepository } = createFakeScoreRepository()
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "last", debounce: debounceSeconds })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createUseCaseLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
+          }),
+        ),
+      ),
+    )
+
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteScopeDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: INPUT.traceId,
+          sessionId: "session",
+        }),
+        debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 1,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 1,
       },
     })
   })

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
@@ -54,7 +54,14 @@ function makeTraceDetail(): TraceDetail {
   }
 }
 
-function makeEvaluation(id: string) {
+function makeEvaluation(
+  id: string,
+  options?: {
+    readonly sampling?: number
+  },
+) {
+  const trigger = defaultEvaluationTrigger()
+
   return evaluationSchema.parse({
     id,
     organizationId: INPUT.organizationId,
@@ -63,7 +70,10 @@ function makeEvaluation(id: string) {
     name: `Eval ${id.slice(-4)}`,
     description: "Live evaluation",
     script: "export default async function evaluate() { return { score: 1 } }",
-    trigger: defaultEvaluationTrigger(),
+    trigger: {
+      ...trigger,
+      ...(options?.sampling !== undefined ? { sampling: options.sampling } : {}),
+    },
     alignment: emptyEvaluationAlignment("hash"),
     alignedAt: new Date("2026-01-01T00:00:00.000Z"),
     archivedAt: null,
@@ -154,7 +164,12 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         offset: options?.offset ?? 0,
       })
 
-      return Effect.succeed(pages.get(options?.offset ?? 0) ?? pages.get(100)!)
+      const page = pages.get(options?.offset ?? 0) ?? pages.get(100)
+      if (page === undefined) {
+        return Effect.die("Expected a seeded evaluation page")
+      }
+
+      return Effect.succeed(page)
     })
 
     const result = await Effect.runPromise(
@@ -190,6 +205,46 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         activeEvaluationsScanned: 2,
         filterMatchedCount: 0,
         skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 0,
+      },
+    })
+  })
+
+  it("counts sampling=0 evaluations as paused skips", async () => {
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+    })
+
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation("e".repeat(24)), makeEvaluation("f".repeat(24), { sampling: 0 })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          Layer.merge(
+            Layer.succeed(TraceRepository, traceRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 2,
+        filterMatchedCount: 0,
+        skippedPausedCount: 1,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
         publishedExecuteCount: 0,

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts
@@ -35,11 +35,11 @@ const INPUT = {
   traceId: "c".repeat(32),
 } as const
 
-function makeTraceDetail(): TraceDetail {
+function makeTraceDetail(overrides?: Partial<Pick<TraceDetail, "projectId" | "traceId" | "sessionId">>): TraceDetail {
   return {
     organizationId: OrganizationId(INPUT.organizationId),
-    projectId: ProjectId(INPUT.projectId),
-    traceId: TraceId(INPUT.traceId),
+    projectId: overrides?.projectId ?? ProjectId(INPUT.projectId),
+    traceId: overrides?.traceId ?? TraceId(INPUT.traceId),
     spanCount: 3,
     errorCount: 0,
     startTime: new Date("2026-01-01T00:00:00.000Z"),
@@ -55,7 +55,7 @@ function makeTraceDetail(): TraceDetail {
     costInputMicrocents: 50,
     costOutputMicrocents: 25,
     costTotalMicrocents: 75,
-    sessionId: SessionId("session"),
+    sessionId: overrides?.sessionId ?? SessionId("session"),
     userId: ExternalUserId("user"),
     simulationId: SimulationId(""),
     tags: [],
@@ -590,6 +590,170 @@ describe("enqueueLiveEvaluationsUseCase", () => {
         publishedExecuteCount: 1,
       },
     })
+  })
+
+  it("publishes trace-scoped debounced execute tasks for first-turn debounce", async () => {
+    const evaluationId = "k".repeat(24)
+    const debounceSeconds = 45
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const { repository: scoreRepository } = createFakeScoreRepository({
+      existsByEvaluationIdAndScope: () => Effect.succeed(false),
+    })
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "first", debounce: debounceSeconds })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase(INPUT).pipe(
+        Effect.provide(
+          createUseCaseLayer({
+            traceRepository,
+            evaluationRepository,
+            scoreRepository,
+            liveEvaluationQueuePublisher: queuePublisher,
+          }),
+        ),
+      ),
+    )
+
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: INPUT.traceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: INPUT.traceId,
+        }),
+        debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+      },
+    ])
+    expect(result).toEqual({
+      action: "completed",
+      summary: {
+        traceId: INPUT.traceId,
+        sessionId: "session",
+        activeEvaluationsScanned: 1,
+        filterMatchedCount: 1,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 1,
+      },
+    })
+  })
+
+  it("keeps first-turn debounce trace-scoped across multiple eligible traces in one session", async () => {
+    const evaluationId = "l".repeat(24)
+    const debounceSeconds = 45
+    const firstTraceId = "m".repeat(32)
+    const secondTraceId = "n".repeat(32)
+    const sharedSessionId = SessionId("shared-first-debounce")
+    const turnCheckCalls: Array<{
+      readonly projectId: string
+      readonly evaluationId: string
+      readonly traceId: string
+      readonly sessionId: string | null | undefined
+    }> = []
+    const { repository: traceRepository } = createFakeTraceRepository({
+      findByTraceId: ({ traceId }) =>
+        Effect.succeed(
+          makeTraceDetail({
+            traceId,
+            sessionId: sharedSessionId,
+          }),
+        ),
+      listMatchingFilterIdsByTraceId: () => Effect.succeed([evaluationId]),
+    })
+    const { repository: scoreRepository } = createFakeScoreRepository({
+      existsByEvaluationIdAndScope: ({ projectId, evaluationId, traceId, sessionId }) => {
+        turnCheckCalls.push({ projectId, evaluationId, traceId, sessionId })
+        return Effect.succeed(false)
+      },
+    })
+    const { queuePublisher, published } = createLiveEvaluationQueuePublisher()
+    const evaluationRepository = createEvaluationRepository(() =>
+      Effect.succeed({
+        items: [makeEvaluation(evaluationId, { sampling: 100, turn: "first", debounce: debounceSeconds })],
+        hasMore: false,
+        limit: 100,
+        offset: 0,
+      }),
+    )
+    const useCaseLayer = createUseCaseLayer({
+      traceRepository,
+      evaluationRepository,
+      scoreRepository,
+      liveEvaluationQueuePublisher: queuePublisher,
+    })
+
+    await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase({
+        ...INPUT,
+        traceId: firstTraceId,
+      }).pipe(Effect.provide(useCaseLayer)),
+    )
+    await Effect.runPromise(
+      enqueueLiveEvaluationsUseCase({
+        ...INPUT,
+        traceId: secondTraceId,
+      }).pipe(Effect.provide(useCaseLayer)),
+    )
+
+    expect(turnCheckCalls).toEqual([
+      {
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: firstTraceId,
+        sessionId: "shared-first-debounce",
+      },
+      {
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: secondTraceId,
+        sessionId: "shared-first-debounce",
+      },
+    ])
+    expect(published).toEqual([
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: firstTraceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: firstTraceId,
+        }),
+        debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+      },
+      {
+        organizationId: INPUT.organizationId,
+        projectId: INPUT.projectId,
+        evaluationId,
+        traceId: secondTraceId,
+        dedupeKey: buildLiveEvaluationExecuteTraceDedupeKey({
+          organizationId: INPUT.organizationId,
+          projectId: INPUT.projectId,
+          evaluationId,
+          traceId: secondTraceId,
+        }),
+        debounceMs: toLiveEvaluationDebounceMs(debounceSeconds),
+      },
+    ])
   })
 
   it("publishes scope-scoped debounced execute tasks for every-turn debounce", async () => {

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -3,8 +3,19 @@ import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domai
 import { TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import type { Evaluation } from "../../entities/evaluation.ts"
-import { getLiveEvaluationEligibility, shouldSampleLiveEvaluation } from "../../helpers.ts"
+import type { LiveEvaluationQueuePublishError } from "../../errors.ts"
+import {
+  buildLiveEvaluationExecuteScopeDedupeKey,
+  buildLiveEvaluationExecuteTraceDedupeKey,
+  getLiveEvaluationEligibility,
+  shouldSampleLiveEvaluation,
+  toLiveEvaluationDebounceMs,
+} from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
+import {
+  LiveEvaluationQueuePublisher,
+  type PublishLiveEvaluationExecuteInput,
+} from "../../ports/live-evaluation-queue-publisher.ts"
 
 const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
 
@@ -36,7 +47,7 @@ export type EnqueueLiveEvaluationsResult =
       readonly summary: EnqueueLiveEvaluationsSummary
     }
 
-export type EnqueueLiveEvaluationsError = RepositoryError
+export type EnqueueLiveEvaluationsError = RepositoryError | LiveEvaluationQueuePublishError
 
 const listAllActiveEvaluations = ({ projectId }: { readonly projectId: ProjectId }) =>
   Effect.gen(function* () {
@@ -64,9 +75,74 @@ const listAllActiveEvaluations = ({ projectId }: { readonly projectId: ProjectId
     }
   })
 
+const buildExecutePublication = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly traceId: string
+  readonly sessionId?: string | null
+  readonly evaluation: Evaluation
+}): PublishLiveEvaluationExecuteInput => {
+  const debounceMs = toLiveEvaluationDebounceMs(input.evaluation.trigger.debounce)
+  const traceDedupeKey = buildLiveEvaluationExecuteTraceDedupeKey({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    evaluationId: input.evaluation.id,
+    traceId: input.traceId,
+  })
+  const scopeDedupeKey = buildLiveEvaluationExecuteScopeDedupeKey({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    evaluationId: input.evaluation.id,
+    traceId: input.traceId,
+    ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+  })
+
+  if (input.evaluation.trigger.turn === "every" && debounceMs === undefined) {
+    return {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      evaluationId: input.evaluation.id,
+      traceId: input.traceId,
+      dedupeKey: traceDedupeKey,
+    }
+  }
+
+  if (input.evaluation.trigger.turn === "last") {
+    return {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      evaluationId: input.evaluation.id,
+      traceId: input.traceId,
+      dedupeKey: scopeDedupeKey,
+      ...(debounceMs !== undefined ? { debounceMs } : {}),
+    }
+  }
+
+  if (input.evaluation.trigger.turn === "every" && debounceMs !== undefined) {
+    return {
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      evaluationId: input.evaluation.id,
+      traceId: input.traceId,
+      dedupeKey: scopeDedupeKey,
+      debounceMs,
+    }
+  }
+
+  return {
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    evaluationId: input.evaluation.id,
+    traceId: input.traceId,
+    dedupeKey: traceDedupeKey,
+    ...(debounceMs !== undefined ? { debounceMs } : {}),
+  }
+}
+
 export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput) =>
   Effect.gen(function* () {
     const scoreRepository = yield* ScoreRepository
+    const liveEvaluationQueuePublisher = yield* LiveEvaluationQueuePublisher
     const traceRepository = yield* TraceRepository
     const traceDetail = yield* traceRepository
       .findByTraceId({
@@ -140,9 +216,20 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
     }
 
     let skippedTurnCount = 0
+    let publishedExecuteCount = 0
 
     for (const evaluation of sampledEvaluations) {
       if (evaluation.trigger.turn !== "first") {
+        yield* liveEvaluationQueuePublisher.publishExecute(
+          buildExecutePublication({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            traceId: input.traceId,
+            sessionId: traceDetail.sessionId ?? null,
+            evaluation,
+          }),
+        )
+        publishedExecuteCount += 1
         continue
       }
 
@@ -155,7 +242,19 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
 
       if (alreadyExists) {
         skippedTurnCount += 1
+        continue
       }
+
+      yield* liveEvaluationQueuePublisher.publishExecute(
+        buildExecutePublication({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          traceId: input.traceId,
+          sessionId: traceDetail.sessionId ?? null,
+          evaluation,
+        }),
+      )
+      publishedExecuteCount += 1
     }
 
     return {
@@ -168,11 +267,11 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
         skippedPausedCount,
         skippedSamplingCount,
         skippedTurnCount,
-        publishedExecuteCount: 0,
+        publishedExecuteCount,
       },
     } satisfies EnqueueLiveEvaluationsResult
   }) as Effect.Effect<
     EnqueueLiveEvaluationsResult,
     EnqueueLiveEvaluationsError,
-    TraceRepository | EvaluationRepository | ScoreRepository
+    TraceRepository | EvaluationRepository | LiveEvaluationQueuePublisher | ScoreRepository
   >

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -1,0 +1,102 @@
+import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
+import { TraceRepository } from "@domain/spans"
+import { Effect } from "effect"
+import type { Evaluation } from "../../entities/evaluation.ts"
+import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
+
+const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
+
+export interface EnqueueLiveEvaluationsInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly traceId: string
+}
+
+export interface EnqueueLiveEvaluationsSummary {
+  readonly traceId: string
+  readonly sessionId: string | null
+  readonly activeEvaluationsScanned: number
+  readonly filterMatchedCount: number
+  readonly skippedPausedCount: number
+  readonly skippedSamplingCount: number
+  readonly skippedTurnCount: number
+  readonly publishedExecuteCount: number
+}
+
+export type EnqueueLiveEvaluationsResult =
+  | {
+      readonly action: "skipped"
+      readonly reason: "trace-not-found"
+      readonly traceId: string
+    }
+  | {
+      readonly action: "completed"
+      readonly summary: EnqueueLiveEvaluationsSummary
+    }
+
+export type EnqueueLiveEvaluationsError = RepositoryError
+
+const listAllActiveEvaluations = ({ projectId }: { readonly projectId: ProjectId }) =>
+  Effect.gen(function* () {
+    const evaluationRepository = yield* EvaluationRepository
+    const evaluations: Evaluation[] = []
+    let offset = 0
+
+    while (true) {
+      const page = yield* evaluationRepository.listByProjectId({
+        projectId,
+        options: {
+          lifecycle: "active",
+          limit: ACTIVE_EVALUATION_SCAN_PAGE_SIZE,
+          offset,
+        },
+      })
+
+      evaluations.push(...page.items)
+
+      if (!page.hasMore) {
+        return evaluations
+      }
+
+      offset += page.limit
+    }
+  })
+
+export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput) =>
+  Effect.gen(function* () {
+    const traceRepository = yield* TraceRepository
+    const traceDetail = yield* traceRepository
+      .findByTraceId({
+        organizationId: OrganizationId(input.organizationId),
+        projectId: ProjectId(input.projectId),
+        traceId: TraceId(input.traceId),
+      })
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+
+    if (traceDetail === null) {
+      return {
+        action: "skipped",
+        reason: "trace-not-found",
+        traceId: input.traceId,
+      } satisfies EnqueueLiveEvaluationsResult
+    }
+
+    const activeEvaluations = yield* listAllActiveEvaluations({
+      projectId: traceDetail.projectId,
+    })
+
+    // Later PR2 steps will fill these counters by applying filter, sampling, and turn logic.
+    return {
+      action: "completed",
+      summary: {
+        traceId: traceDetail.traceId,
+        sessionId: traceDetail.sessionId ?? null,
+        activeEvaluationsScanned: activeEvaluations.length,
+        filterMatchedCount: 0,
+        skippedPausedCount: 0,
+        skippedSamplingCount: 0,
+        skippedTurnCount: 0,
+        publishedExecuteCount: 0,
+      },
+    } satisfies EnqueueLiveEvaluationsResult
+  }) as Effect.Effect<EnqueueLiveEvaluationsResult, EnqueueLiveEvaluationsError, TraceRepository | EvaluationRepository>

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -1,8 +1,9 @@
+import { ScoreRepository } from "@domain/scores"
 import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
 import { TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import type { Evaluation } from "../../entities/evaluation.ts"
-import { getLiveEvaluationEligibility } from "../../helpers.ts"
+import { getLiveEvaluationEligibility, shouldSampleLiveEvaluation } from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 
 const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
@@ -65,6 +66,7 @@ const listAllActiveEvaluations = ({ projectId }: { readonly projectId: ProjectId
 
 export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput) =>
   Effect.gen(function* () {
+    const scoreRepository = yield* ScoreRepository
     const traceRepository = yield* TraceRepository
     const traceDetail = yield* traceRepository
       .findByTraceId({
@@ -85,28 +87,92 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
     const activeEvaluations = yield* listAllActiveEvaluations({
       projectId: traceDetail.projectId,
     })
-    const skippedPausedCount = activeEvaluations.reduce((count, evaluation) => {
-      const eligibility = getLiveEvaluationEligibility(evaluation)
-
-      if (!eligibility.eligible && eligibility.reason === "paused") {
+    const evaluationEligibility = activeEvaluations.map((evaluation) => ({
+      evaluation,
+      eligibility: getLiveEvaluationEligibility(evaluation),
+    }))
+    const skippedPausedCount = evaluationEligibility.reduce((count, item) => {
+      if (!item.eligibility.eligible && item.eligibility.reason === "paused") {
         return count + 1
       }
 
       return count
     }, 0)
+    const eligibleEvaluations = evaluationEligibility.flatMap((item) => {
+      if (item.eligibility.eligible) {
+        return [item.evaluation]
+      }
 
-    // Later PR2 steps will fill these counters by applying filter, sampling, and turn logic.
+      return []
+    })
+    const matchingFilterIds = yield* traceRepository.listMatchingFilterIdsByTraceId({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: traceDetail.projectId,
+      traceId: traceDetail.traceId,
+      filterSets: eligibleEvaluations.map((evaluation) => ({
+        filterId: evaluation.id,
+        filters: evaluation.trigger.filter,
+      })),
+    })
+    const matchingFilterIdSet = new Set(matchingFilterIds)
+    const filterMatchedEvaluations = eligibleEvaluations.filter((evaluation) => matchingFilterIdSet.has(evaluation.id))
+    const filterMatchedCount = filterMatchedEvaluations.length
+    const sampledEvaluations: Evaluation[] = []
+    let skippedSamplingCount = 0
+
+    for (const evaluation of filterMatchedEvaluations) {
+      const shouldSample = yield* Effect.tryPromise(() =>
+        shouldSampleLiveEvaluation({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          evaluationId: evaluation.id,
+          traceId: input.traceId,
+          sampling: evaluation.trigger.sampling,
+        }),
+      ).pipe(Effect.orDie)
+
+      if (!shouldSample) {
+        skippedSamplingCount += 1
+        continue
+      }
+
+      sampledEvaluations.push(evaluation)
+    }
+
+    let skippedTurnCount = 0
+
+    for (const evaluation of sampledEvaluations) {
+      if (evaluation.trigger.turn !== "first") {
+        continue
+      }
+
+      const alreadyExists = yield* scoreRepository.existsByEvaluationIdAndScope({
+        projectId: traceDetail.projectId,
+        evaluationId: evaluation.id,
+        traceId: traceDetail.traceId,
+        sessionId: traceDetail.sessionId ?? null,
+      })
+
+      if (alreadyExists) {
+        skippedTurnCount += 1
+      }
+    }
+
     return {
       action: "completed",
       summary: {
         traceId: traceDetail.traceId,
         sessionId: traceDetail.sessionId ?? null,
         activeEvaluationsScanned: activeEvaluations.length,
-        filterMatchedCount: 0,
+        filterMatchedCount,
         skippedPausedCount,
-        skippedSamplingCount: 0,
-        skippedTurnCount: 0,
+        skippedSamplingCount,
+        skippedTurnCount,
         publishedExecuteCount: 0,
       },
     } satisfies EnqueueLiveEvaluationsResult
-  }) as Effect.Effect<EnqueueLiveEvaluationsResult, EnqueueLiveEvaluationsError, TraceRepository | EvaluationRepository>
+  }) as Effect.Effect<
+    EnqueueLiveEvaluationsResult,
+    EnqueueLiveEvaluationsError,
+    TraceRepository | EvaluationRepository | ScoreRepository
+  >

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -108,13 +108,17 @@ const buildExecutePublication = (input: {
   }
 
   if (input.evaluation.trigger.turn === "last") {
+    if (debounceMs === undefined) {
+      throw new Error("`turn = last` requires `debounce > 0` before enqueue publication")
+    }
+
     return {
       organizationId: input.organizationId,
       projectId: input.projectId,
       evaluationId: input.evaluation.id,
       traceId: input.traceId,
       dedupeKey: scopeDedupeKey,
-      ...(debounceMs !== undefined ? { debounceMs } : {}),
+      debounceMs,
     }
   }
 

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -2,6 +2,7 @@ import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domai
 import { TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import type { Evaluation } from "../../entities/evaluation.ts"
+import { getLiveEvaluationEligibility } from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 
 const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
@@ -84,6 +85,15 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
     const activeEvaluations = yield* listAllActiveEvaluations({
       projectId: traceDetail.projectId,
     })
+    const skippedPausedCount = activeEvaluations.reduce((count, evaluation) => {
+      const eligibility = getLiveEvaluationEligibility(evaluation)
+
+      if (!eligibility.eligible && eligibility.reason === "paused") {
+        return count + 1
+      }
+
+      return count
+    }, 0)
 
     // Later PR2 steps will fill these counters by applying filter, sampling, and turn logic.
     return {
@@ -93,7 +103,7 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
         sessionId: traceDetail.sessionId ?? null,
         activeEvaluationsScanned: activeEvaluations.length,
         filterMatchedCount: 0,
-        skippedPausedCount: 0,
+        skippedPausedCount,
         skippedSamplingCount: 0,
         skippedTurnCount: 0,
         publishedExecuteCount: 0,

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -48,6 +48,13 @@ export interface TraceRepositoryShape {
     readonly filters?: FilterSet
   }): Effect.Effect<boolean, RepositoryError>
 
+  listMatchingFilterIdsByTraceId(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly traceId: TraceId
+    readonly filterSets: readonly TraceFilterSetMatchCandidate[]
+  }): Effect.Effect<readonly string[], RepositoryError>
+
   listByTraceIds(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
@@ -64,6 +71,11 @@ export interface TraceRepositoryShape {
 }
 
 export type TraceDistinctColumn = "tags" | "models" | "providers" | "serviceNames"
+
+export interface TraceFilterSetMatchCandidate {
+  readonly filterId: string
+  readonly filters?: FilterSet
+}
 
 export interface TraceListCursor {
   readonly sortValue: string

--- a/packages/domain/spans/src/testing/fake-trace-repository.ts
+++ b/packages/domain/spans/src/testing/fake-trace-repository.ts
@@ -10,6 +10,7 @@ export const createFakeTraceRepository = (overrides?: Partial<TraceRepositorySha
     histogramByProjectId: () => Effect.succeed([]),
     findByTraceId: () => Effect.fail(new NotFoundError({ entity: "Trace", id: "" })),
     matchesFiltersByTraceId: () => Effect.succeed(false),
+    listMatchingFilterIdsByTraceId: () => Effect.succeed([]),
     listByTraceIds: () => Effect.succeed([]),
     distinctFilterValues: () => Effect.succeed([]),
     ...overrides,

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -10,6 +10,7 @@ import { TraceRepository, type TraceRepositoryShape } from "@domain/spans"
 import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { scoreSeeders } from "../seeds/scores/index.ts"
 import { fixedTraceSeeders } from "../seeds/spans/fixed-traces.ts"
 import { withClickHouse } from "../with-clickhouse.ts"
 import { TraceRepositoryLive } from "./trace-repository.ts"
@@ -17,10 +18,16 @@ import { TraceRepositoryLive } from "./trace-repository.ts"
 const ORG_ID = OrganizationId(SEED_ORG_ID)
 const PROJECT_ID = ProjectId(SEED_PROJECT_ID)
 const TRACE_ID = SEED_LIFECYCLE_TRACE_IDS[0] as TraceId
+const SCORED_TRACE_ID = SEED_LIFECYCLE_TRACE_IDS[3] as TraceId
 const firstFixedTraceSeeder = fixedTraceSeeders[0]
+const firstScoreSeeder = scoreSeeders[0]
 
 if (firstFixedTraceSeeder === undefined) {
   throw new Error("Expected at least one fixed trace seeder")
+}
+
+if (firstScoreSeeder === undefined) {
+  throw new Error("Expected at least one score seeder")
 }
 
 const ch = setupTestClickHouse()
@@ -38,6 +45,7 @@ describe("TraceRepository", () => {
 
   beforeEach(async () => {
     await Effect.runPromise(firstFixedTraceSeeder.run({ client: ch.client }))
+    await Effect.runPromise(firstScoreSeeder.run({ client: ch.client }))
   })
 
   describe("matchesFiltersByTraceId", () => {
@@ -84,6 +92,87 @@ describe("TraceRepository", () => {
       )
 
       expect(matches).toBe(false)
+    })
+  })
+
+  describe("listMatchingFilterIdsByTraceId", () => {
+    it("returns the filter ids that match one trace", async () => {
+      const filterIds = await Effect.runPromise(
+        repo.listMatchingFilterIdsByTraceId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: TRACE_ID,
+          filterSets: [
+            { filterId: "all", filters: {} },
+            {
+              filterId: "lifecycle-tag",
+              filters: {
+                tags: [{ op: "in", value: ["lifecycle"] }],
+              },
+            },
+            {
+              filterId: "annotation-tag",
+              filters: {
+                tags: [{ op: "in", value: ["annotation"] }],
+              },
+            },
+          ],
+        }),
+      )
+
+      expect(filterIds).toEqual(["all", "lifecycle-tag"])
+    })
+
+    it("supports independent score-backed filters in the same batch", async () => {
+      const filterIds = await Effect.runPromise(
+        repo.listMatchingFilterIdsByTraceId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: SCORED_TRACE_ID,
+          filterSets: [
+            {
+              filterId: "errored-evaluation-score",
+              filters: {
+                "score.errored": [{ op: "eq", value: true }],
+                "score.source": [{ op: "eq", value: "evaluation" }],
+              },
+            },
+            {
+              filterId: "annotation-score",
+              filters: {
+                "score.source": [{ op: "eq", value: "annotation" }],
+              },
+            },
+            {
+              filterId: "passed-evaluation-score",
+              filters: {
+                "score.passed": [{ op: "eq", value: true }],
+                "score.source": [{ op: "eq", value: "evaluation" }],
+              },
+            },
+          ],
+        }),
+      )
+
+      expect(filterIds).toEqual(["errored-evaluation-score", "annotation-score"])
+    })
+
+    it("returns an empty list when the trace does not exist", async () => {
+      const filterIds = await Effect.runPromise(
+        repo.listMatchingFilterIdsByTraceId({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          traceId: "ffffffffffffffffffffffffffffffff" as TraceId,
+          filterSets: [
+            {
+              filterId: "all",
+              filters: {},
+            },
+          ],
+        }),
+      )
+
+      expect(filterIds).toEqual([])
     })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -249,7 +249,12 @@ const SORT_COLUMNS: Record<string, SortColumn> = {
   spans: { expr: "span_count", chType: "UInt64", rowKey: "span_count" },
 }
 
-function buildTraceFilterClauses(filters: FilterSet | undefined): {
+function buildTraceFilterClauses(
+  filters: FilterSet | undefined,
+  options?: {
+    readonly paramPrefix?: string
+  },
+): {
   /** HAVING clauses for the trace GROUP BY. */
   havingClauses: string[]
   /** WHERE clauses to add before GROUP BY (e.g. score subquery). */
@@ -263,14 +268,23 @@ function buildTraceFilterClauses(filters: FilterSet | undefined): {
   const { telemetryFilters, scoreFilters } = splitScoreFilters(filters)
 
   const telemetry = telemetryFilters
-    ? buildClickHouseWhere(telemetryFilters, TRACE_FIELD_REGISTRY)
+    ? buildClickHouseWhere(
+        telemetryFilters,
+        TRACE_FIELD_REGISTRY,
+        options?.paramPrefix ? { paramPrefix: options.paramPrefix } : undefined,
+      )
     : { clauses: [], params: {} }
 
   let whereClauses: string[] = []
   let scoreParams: Record<string, unknown> = {}
 
   if (scoreFilters) {
-    const result = buildScoreRollupSubquery("trace_id", scoreFilters, false)
+    const result = buildScoreRollupSubquery(
+      "trace_id",
+      scoreFilters,
+      false,
+      options?.paramPrefix ? { paramPrefix: `${options.paramPrefix}_s` } : undefined,
+    )
     whereClauses = [result.subquery]
     scoreParams = result.params
   }
@@ -279,6 +293,22 @@ function buildTraceFilterClauses(filters: FilterSet | undefined): {
     havingClauses: telemetry.clauses,
     whereClauses,
     params: { ...telemetry.params, ...scoreParams },
+  }
+}
+
+function buildTraceFilterCondition(
+  filters: FilterSet | undefined,
+  paramPrefix: string,
+): {
+  condition: string
+  params: Record<string, unknown>
+} {
+  const { havingClauses, whereClauses, params } = buildTraceFilterClauses(filters, { paramPrefix })
+  const clauses = [...whereClauses, ...havingClauses]
+
+  return {
+    condition: clauses.length > 0 ? clauses.map((clause) => `(${clause})`).join(" AND ") : "1",
+    params,
   }
 }
 
@@ -380,9 +410,6 @@ export const TraceRepositoryLive = Layer.effect(
         )
     }
 
-    // TODO(phase-13): add a batched variant for checking one trace against
-    // multiple independent FilterSets in one query so enqueue can reuse the
-    // grouped trace row across many evaluation trigger checks.
     const matchesFiltersByTraceId: TraceRepositoryShape["matchesFiltersByTraceId"] = ({
       organizationId,
       projectId,
@@ -421,6 +448,61 @@ export const TraceRepositoryLive = Layer.effect(
         .pipe(
           Effect.map((rows) => Number(rows[0]?.total ?? 0) > 0),
           Effect.mapError((error) => toRepositoryError(error, "matchesFiltersByTraceId")),
+        )
+    }
+
+    const listMatchingFilterIdsByTraceId: TraceRepositoryShape["listMatchingFilterIdsByTraceId"] = ({
+      organizationId,
+      projectId,
+      traceId,
+      filterSets,
+    }) => {
+      if (filterSets.length === 0) {
+        return Effect.succeed([])
+      }
+
+      const queryParams: Record<string, unknown> = {
+        organizationId: organizationId as string,
+        projectId: projectId as string,
+        traceId,
+      }
+
+      const matchExpressions = filterSets.map(({ filterId, filters }, index) => {
+        const { condition, params } = buildTraceFilterCondition(filters, `batch_${index}`)
+        const filterIdParam = `filter_id_${index}`
+
+        Object.assign(queryParams, params, { [filterIdParam]: filterId })
+
+        return `if(${condition}, {${filterIdParam}:String}, '')`
+      })
+
+      return chSqlClient
+        .query(async (client) => {
+          const result = await client.query({
+            query: `SELECT matched_filter_id
+                    FROM (
+                      SELECT arrayJoin([
+                        ${matchExpressions.join(",\n                        ")}
+                      ]) AS matched_filter_id
+                      FROM (
+                        SELECT ${LIST_SELECT}
+                        FROM traces
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND trace_id = {traceId:FixedString(32)}
+                        GROUP BY organization_id, project_id, trace_id
+                        LIMIT 1
+                      )
+                    )
+                    WHERE matched_filter_id != ''`,
+            query_params: queryParams,
+            format: "JSONEachRow",
+          })
+          return result.json<{ matched_filter_id: string }>()
+        })
+        .pipe(
+          Effect.map((rows) => rows.map((row) => row.matched_filter_id)),
+          Effect.mapError((error) => toRepositoryError(error, "listMatchingFilterIdsByTraceId")),
         )
     }
 
@@ -598,6 +680,8 @@ export const TraceRepositoryLive = Layer.effect(
           ),
 
       matchesFiltersByTraceId,
+
+      listMatchingFilterIdsByTraceId,
 
       listByTraceIds,
 

--- a/packages/platform/db-clickhouse/src/score-filter-subquery.test.ts
+++ b/packages/platform/db-clickhouse/src/score-filter-subquery.test.ts
@@ -95,4 +95,16 @@ describe("buildScoreRollupSubquery", () => {
 
     expect(subquery).not.toContain("simulation_id = ''")
   })
+
+  it("uses a custom parameter prefix when requested", () => {
+    const scoreFilters: FilterSet = {
+      "score.source": [{ op: "eq", value: "evaluation" }],
+    }
+
+    const { params } = buildScoreRollupSubquery("trace_id", scoreFilters, false, {
+      paramPrefix: "batch_1_s",
+    })
+
+    expect(Object.keys(params)).toEqual(["batch_1_s_0"])
+  })
 })

--- a/packages/platform/db-clickhouse/src/score-filter-subquery.ts
+++ b/packages/platform/db-clickhouse/src/score-filter-subquery.ts
@@ -47,11 +47,16 @@ export function buildScoreRollupSubquery(
   groupColumn: "trace_id" | "session_id",
   scoreFilters: FilterSet,
   excludeSimulations: boolean,
+  options?: {
+    readonly paramPrefix?: string
+  },
 ): {
   subquery: string
   params: Record<string, unknown>
 } {
-  const { clauses, params } = buildClickHouseWhere(scoreFilters, SCORE_FIELD_REGISTRY, { paramPrefix: "s" })
+  const { clauses, params } = buildClickHouseWhere(scoreFilters, SCORE_FIELD_REGISTRY, {
+    paramPrefix: options?.paramPrefix ?? "s",
+  })
 
   const simClause = excludeSimulations ? " AND simulation_id = ''" : ""
   const scoreWhere = clauses.length > 0 ? ` AND ${clauses.join(" AND ")}` : ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,9 @@ importers:
       '@domain/optimizations':
         specifier: workspace:*
         version: link:../optimizations
+      '@domain/scores':
+        specifier: workspace:*
+        version: link:../scores
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,6 +472,9 @@ importers:
       '@domain/email':
         specifier: workspace:*
         version: link:../../packages/domain/email
+      '@domain/evaluations':
+        specifier: workspace:*
+        version: link:../../packages/domain/evaluations
       '@domain/events':
         specifier: workspace:*
         version: link:../../packages/domain/events

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, `P13-PR2-6`, `P13-PR2-7`, and `P13-PR2-8` are now landed on `phase-13-part-2`; remaining work is the explicit `turn = first` plus debounce behavior lock.
+**Status**: complete. `live-evaluations:enqueue` now has the full PR 2 selection, publication, logging, worker coverage, and explicit `turn = first` plus debounce behavior lock landed on `phase-13-part-2`.
 
 **Responsibilities**:
 
@@ -149,6 +149,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
 - `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and publishes `live-evaluations:execute` with turn-aware trace-vs-scope dedupe/debounce options
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.test.ts` now explicitly locks `turn = first` plus debounce as a delayed trace-scoped publication, so repeated eligible traces do not accidentally collapse into `last`-style scope coalescing before a canonical score exists
 - `apps/workers/src/workers/live-evaluations.ts` now logs structured enqueue outcomes with queue/task metadata plus scan, skip, and publish counters from the domain summary
 - `apps/workers/src/workers/live-evaluations.test.ts` now covers matching, skip paths, deterministic sampling, session-vs-trace scope, `first` / `every` / `last` turn behavior, and the resulting execute publication options against in-memory Postgres and ClickHouse
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
@@ -167,7 +168,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - `turn = first` checks `ScoreRepository.existsByEvaluationIdAndScope()` only after the trace has passed filter and sampling
 - `turn = every` without debounce publishes a trace-scoped execute task; `turn = every` with debounce coalesces by scope so the latest eligible trace wins after inactivity
 - `turn = last` always publishes a scope-scoped debounced execute task so the latest eligible trace in that scope wins after inactivity
-- `turn = first` with debounce must be covered explicitly so it delays the first eligible execution without accidentally widening into `last`
+- `turn = first` with debounce still publishes a delayed trace-scoped execute task after the scope check; repeated eligible traces stay trace-scoped until a canonical score exists rather than coalescing into `last`-style scope debounce
 - PR 2 stops at selection, task publication, logging, and tests; it does not wire AI services or persist scores
 
 **Suggested implementation order**:
@@ -188,7 +189,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [x] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
 - [x] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
-- [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
+- [x] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
 
 **Exit gate**:
 

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, `P13-PR2-6`, and `P13-PR2-7` are now landed on `phase-13-part-2`; remaining work is worker-level enqueue coverage and the explicit `turn = first` plus debounce behavior lock.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, `P13-PR2-6`, `P13-PR2-7`, and `P13-PR2-8` are now landed on `phase-13-part-2`; remaining work is the explicit `turn = first` plus debounce behavior lock.
 
 **Responsibilities**:
 
@@ -150,6 +150,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
 - `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and publishes `live-evaluations:execute` with turn-aware trace-vs-scope dedupe/debounce options
 - `apps/workers/src/workers/live-evaluations.ts` now logs structured enqueue outcomes with queue/task metadata plus scan, skip, and publish counters from the domain summary
+- `apps/workers/src/workers/live-evaluations.test.ts` now covers matching, skip paths, deterministic sampling, session-vs-trace scope, `first` / `every` / `last` turn behavior, and the resulting execute publication options against in-memory Postgres and ClickHouse
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -186,7 +187,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [x] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [x] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
-- [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
+- [x] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
 - [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
 
 **Exit gate**:

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, and `P13-PR2-9` are now landed as the foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, and `P13-PR2-4` are now landed as the foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
 
 **Responsibilities**:
 
@@ -148,7 +148,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 **Starting point**:
 
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
-- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail` and paginates active evaluations, but intentionally stops before filter/sampling/turn evaluation and execute-task publication
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, and counts paused (`sampling = 0`) skips, but intentionally stops before filter/sampling/turn evaluation and execute-task publication
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -181,7 +181,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-2**: Load the ended trace detail with `TraceRepository.findByTraceId()` so trigger checks can use `sessionId` and current trace context
 - [x] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
 - [x] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
-- [ ] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
+- [x] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
 - [ ] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -44,6 +44,7 @@ Make issue-linked evaluations execute on live traffic after trace completion and
 
 - `packages/domain/evaluations/src/entities/evaluation.ts` already defines `trigger`, `alignment`, lifecycle timestamps, and helpers like `isActiveEvaluation()` and `isPausedEvaluation()`
 - `packages/domain/evaluations/src/runtime/evaluation-execution.ts` already exposes `executeEvaluationScript()` for the MVP extract-and-call execution bridge
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` already exposes the enqueue domain seam that reloads one ended trace, scans active evaluations, and returns a structured summary for worker logging and tests
 - `packages/domain/evaluations/src/runtime/evaluation-execution.ts` already fixes the MVP hosted model to Latitude-managed OpenAI `gpt-5.4`
 - `packages/platform/ai-vercel/src/ai.ts` already provides the hosted Vercel AI SDK adapter through `AIGenerateLive`
 - `packages/domain/scores/src/use-cases/write-score.ts` already performs canonical Postgres-first writes and immediate analytics sync for immutable scores
@@ -58,7 +59,7 @@ Make issue-linked evaluations execute on live traffic after trace completion and
 ### Not Yet Implemented
 
 - `apps/workers/src/workers/live-traces.ts` is still a stub and does not publish `TraceEnded`
-- `apps/workers/src/workers/live-evaluations.ts` is still a stub and does not implement `enqueue` or `execute`
+- `apps/workers/src/workers/live-evaluations.ts` now wires `enqueue` through the new domain use case, but trigger evaluation, execute-task publication, and the `execute` handler are still not implemented
 - `apps/workers/src/workers/live-annotation-queues.ts` is still a stub, which matters for rollout once `TraceEnded` becomes real
 
 ## Locked Decisions
@@ -134,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: ready to start. The ownership, implementation approach, and test plan are now defined for `phase-13-part-2`.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, and `P13-PR2-3` are now landed as a safe foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
 
 **Responsibilities**:
 
@@ -146,7 +147,8 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Starting point**:
 
-- `apps/workers/src/workers/live-evaluations.ts` still has stub `enqueue` and `execute` handlers
+- `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail` and paginates active evaluations, but intentionally stops before filter/sampling/turn evaluation and execute-task publication
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -157,6 +159,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 - introduce `enqueueLiveEvaluationsUseCase` under `packages/domain/evaluations/src/use-cases/live/` so trigger selection and publication rules do not live in the worker
 - keep `apps/workers/src/workers/live-evaluations.ts` as the composition root for `QueuePublisher`, `EvaluationRepositoryLive`, `ScoreRepositoryLive`, `TraceRepositoryLive`, logging, and queue subscription
+- the first PR 2 increment may land a safe foundation that only reloads the trace, scans active evaluations, and returns a structured summary before the real trigger-selection and publication logic is added
 - delegate all trigger filter semantics to `TraceRepository`; neither the domain helper layer nor the worker may re-implement `FilterSet` matching
 - apply trigger gates in exact order: `filter`, then `sampling`, then `turn` / `debounce`
 - `turn = first` checks `ScoreRepository.existsByEvaluationIdAndScope()` only after the trace has passed filter and sampling
@@ -174,9 +177,9 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **To-Do**:
 
-- [ ] **P13-PR2-1**: Replace the `enqueue` stub in `apps/workers/src/workers/live-evaluations.ts` by wiring a thin worker wrapper around the new enqueue use case
-- [ ] **P13-PR2-2**: Load the ended trace detail with `TraceRepository.findByTraceId()` so trigger checks can use `sessionId` and current trace context
-- [ ] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
+- [x] **P13-PR2-1**: Replace the `enqueue` stub in `apps/workers/src/workers/live-evaluations.ts` by wiring a thin worker wrapper around the new enqueue use case
+- [x] **P13-PR2-2**: Load the ended trace detail with `TraceRepository.findByTraceId()` so trigger checks can use `sessionId` and current trace context
+- [x] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
 - [ ] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
 - [ ] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, and `P13-PR2-6` are now landed on `phase-13-part-2`; remaining work is enqueue-path logging, worker-level enqueue coverage, and the explicit `turn = first` plus debounce behavior lock.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, `P13-PR2-6`, and `P13-PR2-7` are now landed on `phase-13-part-2`; remaining work is worker-level enqueue coverage and the explicit `turn = first` plus debounce behavior lock.
 
 **Responsibilities**:
 
@@ -149,6 +149,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
 - `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and publishes `live-evaluations:execute` with turn-aware trace-vs-scope dedupe/debounce options
+- `apps/workers/src/workers/live-evaluations.ts` now logs structured enqueue outcomes with queue/task metadata plus scan, skip, and publish counters from the domain summary
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -184,7 +185,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
 - [x] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [x] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
-- [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
+- [x] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
 - [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
 - [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
 

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, and `P13-PR2-5` are now landed as the foundation on `phase-13-part-2`; remaining work is execute-task publication, enqueue-path logging, and worker-level enqueue coverage.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, `P13-PR2-5`, and `P13-PR2-6` are now landed on `phase-13-part-2`; remaining work is enqueue-path logging, worker-level enqueue coverage, and the explicit `turn = first` plus debounce behavior lock.
 
 **Responsibilities**:
 
@@ -148,7 +148,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 **Starting point**:
 
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
-- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and still intentionally stops before execute-task publication
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and publishes `live-evaluations:execute` with turn-aware trace-vs-scope dedupe/debounce options
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -183,7 +183,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
 - [x] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
 - [x] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
-- [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
+- [x] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
 - [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
 - [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -86,9 +86,11 @@ Make issue-linked evaluations execute on live traffic after trace completion and
 
 ## Start Here
 
-Implementation starts with **PR 1**.
+Implementation started with **PR 1**, and **PR 1 is now complete**.
 
 PR 1 is the semantic foundation for the rest of the phase: it locks the trigger rules, the idempotency model, and the execution seam so PR 2, PR 3, and PR 4 can implement workers without guessing.
+
+Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 ## Implementation Plan
 
@@ -132,21 +134,56 @@ PR 1 is the semantic foundation for the rest of the phase: it locks the trigger 
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
+**Status**: ready to start. The ownership, implementation approach, and test plan are now defined for `phase-13-part-2`.
+
 **Responsibilities**:
 
 - own the project-scoped evaluation scan for one ended trace
+- keep worker code orchestration-only by moving enqueue decision logic into `@domain/evaluations`
 - apply trigger evaluation in the required order: `filter`, then `sampling`, then `turn` / `debounce`
 - publish the correct `live-evaluations:execute` tasks and no others
 - add the enqueue-path logs and worker-level tests
-- **P13-PR2-1**: Replace the `enqueue` stub in `apps/workers/src/workers/live-evaluations.ts`
-- **P13-PR2-2**: Load the ended trace detail needed for trigger checks
-- **P13-PR2-3**: List active evaluations project-wide and skip archived or deleted rows
-- **P13-PR2-4**: Treat `sampling = 0` as paused and skip those evaluations
-- **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
-- **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including dedupe/debounce where required
-- **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
-- **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, turn semantics, and execute publication
-- **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched trace-repository read that evaluates multiple independent evaluation FilterSets in one query rather than one query per evaluation
+
+**Starting point**:
+
+- `apps/workers/src/workers/live-evaluations.ts` still has stub `enqueue` and `execute` handlers
+- `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
+- `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
+- `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
+- `ScoreRepository.existsByEvaluationIdAndScope()` is already the canonical persisted-state read for `turn = first`
+- `TraceRepository.matchesFiltersByTraceId()` already exposes the canonical single-filter check, but PR 2 still needs the batched one-trace/many-filter variant for performance
+
+**Implementation notes**:
+
+- introduce `enqueueLiveEvaluationsUseCase` under `packages/domain/evaluations/src/use-cases/live/` so trigger selection and publication rules do not live in the worker
+- keep `apps/workers/src/workers/live-evaluations.ts` as the composition root for `QueuePublisher`, `EvaluationRepositoryLive`, `ScoreRepositoryLive`, `TraceRepositoryLive`, logging, and queue subscription
+- delegate all trigger filter semantics to `TraceRepository`; neither the domain helper layer nor the worker may re-implement `FilterSet` matching
+- apply trigger gates in exact order: `filter`, then `sampling`, then `turn` / `debounce`
+- `turn = first` checks `ScoreRepository.existsByEvaluationIdAndScope()` only after the trace has passed filter and sampling
+- `turn = every` without debounce publishes a trace-scoped execute task; `turn = every` with debounce coalesces by scope so the latest eligible trace wins after inactivity
+- `turn = last` always publishes a scope-scoped debounced execute task so the latest eligible trace in that scope wins after inactivity
+- `turn = first` with debounce must be covered explicitly so it delays the first eligible execution without accidentally widening into `last`
+- PR 2 stops at selection, task publication, logging, and tests; it does not wire AI services or persist scores
+
+**Suggested implementation order**:
+
+1. extend `TraceRepository` with the batched one-trace/many-filter read and add the ClickHouse adapter tests first
+2. add `enqueueLiveEvaluationsUseCase` in `@domain/evaluations`, returning a structured summary that worker logs and tests can assert against
+3. wire `apps/workers/src/workers/live-evaluations.ts` to the new use case with Postgres and ClickHouse layers plus `QueuePublisher`
+4. add worker-level enqueue tests covering matching, skipping, turn semantics, and `live-evaluations:execute` publication
+
+**To-Do**:
+
+- [ ] **P13-PR2-1**: Replace the `enqueue` stub in `apps/workers/src/workers/live-evaluations.ts` by wiring a thin worker wrapper around the new enqueue use case
+- [ ] **P13-PR2-2**: Load the ended trace detail with `TraceRepository.findByTraceId()` so trigger checks can use `sessionId` and current trace context
+- [ ] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
+- [ ] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
+- [ ] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
+- [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
+- [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
+- [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
+- [ ] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
+- [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
 
 **Exit gate**:
 
@@ -163,20 +200,20 @@ PR 1 is the semantic foundation for the rest of the phase: it locks the trigger 
 - wire the hosted AI adapter without breaking the domain execution seam from PR 1
 - enforce duplicate-result prevention for `(evaluationId, traceId)`
 - own execution logging, AI telemetry, and result-persistence tests
-- **P13-PR3-1**: Replace the `execute` stub in `apps/workers/src/workers/live-evaluations.ts`
-- **P13-PR3-2**: Wire hosted execution through `withAi(AIGenerateLive, ...)` while preserving the domain executor seam
-- **P13-PR3-3**: Load the evaluation, trace detail, and issue context needed for one live run
-- **P13-PR3-4**: Convert `TraceDetail.allMessages` into the MVP conversation input used by the hosted evaluator
-- **P13-PR3-5**: Recheck canonical state before execution so retries or duplicate tasks cannot create a second result for the same `(evaluationId, traceId)`
-- **P13-PR3-6**: Persist results through `writeScoreUseCase` with:
+- [ ] **P13-PR3-1**: Replace the `execute` stub in `apps/workers/src/workers/live-evaluations.ts`
+- [ ] **P13-PR3-2**: Wire hosted execution through `withAi(AIGenerateLive, ...)` while preserving the domain executor seam
+- [ ] **P13-PR3-3**: Load the evaluation, trace detail, and issue context needed for one live run
+- [ ] **P13-PR3-4**: Convert `TraceDetail.allMessages` into the MVP conversation input used by the hosted evaluator
+- [ ] **P13-PR3-5**: Recheck canonical state before execution so retries or duplicate tasks cannot create a second result for the same `(evaluationId, traceId)`
+- [ ] **P13-PR3-6**: Persist results through `writeScoreUseCase` with:
   - `source = "evaluation"`
   - `sourceId = evaluation.id`
   - `metadata.evaluationHash = evaluation.alignment.evaluationHash`
-- **P13-PR3-7**: Implement direct `issue_id` assignment at write time for issue-linked monitor failures
-- **P13-PR3-8**: Preserve correct `error -> errored` semantics plus persisted duration, token, and cost accounting
-- **P13-PR3-9**: Add structured execute-path logging for evaluation id, trace id, session id when present, result kind, score id, issue assignment path, tokens, cost, and duration
-- **P13-PR3-10**: Attach AI telemetry with a stable span name such as `evaluation.live.execute` and attributes including `evaluationId`, `projectId`, and `traceId`
-- **P13-PR3-11**: Add tests for passed, failed, and errored monitor results plus analytics save timing
+- [ ] **P13-PR3-7**: Implement direct `issue_id` assignment at write time for issue-linked monitor failures
+- [ ] **P13-PR3-8**: Preserve correct `error -> errored` semantics plus persisted duration, token, and cost accounting
+- [ ] **P13-PR3-9**: Add structured execute-path logging for evaluation id, trace id, session id when present, result kind, score id, issue assignment path, tokens, cost, and duration
+- [ ] **P13-PR3-10**: Attach AI telemetry with a stable span name such as `evaluation.live.execute` and attributes including `evaluationId`, `projectId`, and `traceId`
+- [ ] **P13-PR3-11**: Add tests for passed, failed, and errored monitor results plus analytics save timing
 
 **Exit gate**:
 
@@ -195,11 +232,11 @@ PR 1 is the semantic foundation for the rest of the phase: it locks the trigger 
 - own the rollout behavior for the sibling `TraceEnded` consumers that wake up at the same time
 - add end-to-end coverage for the live-monitoring pipeline
 - reconcile docs with the final Phase 13 behavior
-- **P13-PR4-1**: Replace the `live-traces:end` stub in `apps/workers/src/workers/live-traces.ts`
-- **P13-PR4-2**: Publish `TraceEnded` through `createEventsPublisher(queuePublisher)` when the debounce window elapses
-- **P13-PR4-3**: Confirm constructor and bootstrap wiring still compose cleanly in `apps/workers/src/server.ts`
-- **P13-PR4-4**: Decide and implement the rollout behavior for sibling `TraceEnded` consumers, especially `live-annotation-queues:curate`, so Phase 13 does not accidentally ship partial unrelated behavior
-- **P13-PR4-5**: Add end-to-end tests for:
+- [ ] **P13-PR4-1**: Replace the `live-traces:end` stub in `apps/workers/src/workers/live-traces.ts`
+- [ ] **P13-PR4-2**: Publish `TraceEnded` through `createEventsPublisher(queuePublisher)` when the debounce window elapses
+- [ ] **P13-PR4-3**: Confirm constructor and bootstrap wiring still compose cleanly in `apps/workers/src/server.ts`
+- [ ] **P13-PR4-4**: Decide and implement the rollout behavior for sibling `TraceEnded` consumers, especially `live-annotation-queues:curate`, so Phase 13 does not accidentally ship partial unrelated behavior
+- [ ] **P13-PR4-5**: Add end-to-end tests for:
   - debounce reset behavior
   - `TraceEnded -> enqueue`
   - downstream execute behavior
@@ -208,8 +245,8 @@ PR 1 is the semantic foundation for the rest of the phase: it locks the trigger 
   - direct issue assignment
   - analytics save timing
   - persisted duration, token, and cost accounting
-- **P13-PR4-6**: Reconcile docs drift around issue-linked monitor failures versus direct write-time issue assignment
-- **P13-PR4-7**: Mark this tracker with the final rollout behavior, final trigger semantics, and final docs updated once activation lands
+- [ ] **P13-PR4-6**: Reconcile docs drift around issue-linked monitor failures versus direct write-time issue assignment
+- [ ] **P13-PR4-7**: Mark this tracker with the final rollout behavior, final trigger semantics, and final docs updated once activation lands
 
 **Exit gate**:
 

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, and `P13-PR2-4` are now landed as the foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, `P13-PR2-9`, `P13-PR2-4`, and `P13-PR2-5` are now landed as the foundation on `phase-13-part-2`; remaining work is execute-task publication, enqueue-path logging, and worker-level enqueue coverage.
 
 **Responsibilities**:
 
@@ -148,7 +148,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 **Starting point**:
 
 - `apps/workers/src/workers/live-evaluations.ts` now has a thin `enqueue` wrapper around `enqueueLiveEvaluationsUseCase`, while `execute` remains a stub
-- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, and counts paused (`sampling = 0`) skips, but intentionally stops before filter/sampling/turn evaluation and execute-task publication
+- `packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts` now reloads `TraceDetail`, paginates active evaluations, skips paused (`sampling = 0`) monitors, applies `filter -> sampling -> turn` in order, and still intentionally stops before execute-task publication
 - `apps/workers/src/workers/domain-events.ts` already fans out `TraceEnded -> live-evaluations:enqueue`
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
@@ -182,7 +182,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
 - [x] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
 - [x] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
-- [ ] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
+- [x] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
 - [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -59,7 +59,7 @@ Make issue-linked evaluations execute on live traffic after trace completion and
 ### Not Yet Implemented
 
 - `apps/workers/src/workers/live-traces.ts` is still a stub and does not publish `TraceEnded`
-- `apps/workers/src/workers/live-evaluations.ts` now wires `enqueue` through the new domain use case, but trigger evaluation, execute-task publication, and the `execute` handler are still not implemented
+- `apps/workers/src/workers/live-evaluations.ts` now wires `enqueue` through the new domain use case and publishes `live-evaluations:execute`, but the `execute` handler and the actual evaluation execution + score persistence path are still not implemented
 - `apps/workers/src/workers/live-annotation-queues.ts` is still a stub, which matters for rollout once `TraceEnded` becomes real
 
 ## Locked Decisions

--- a/specs/phase-13.md
+++ b/specs/phase-13.md
@@ -135,7 +135,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 
 **Intent**: implement selection and task publication while keeping the upstream trace-end signal dormant.
 
-**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, and `P13-PR2-3` are now landed as a safe foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
+**Status**: in progress. `P13-PR2-1`, `P13-PR2-2`, `P13-PR2-3`, and `P13-PR2-9` are now landed as the foundation on `phase-13-part-2`; remaining work is trigger evaluation, execute-task publication, and worker-level enqueue coverage.
 
 **Responsibilities**:
 
@@ -153,7 +153,7 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - `TraceEnded` currently carries only `organizationId`, `projectId`, and `traceId`, so enqueue must reload `TraceDetail` to recover `sessionId` before scope-aware turn logic
 - `EvaluationRepository.listByProjectId({ lifecycle: "active" })` is already the canonical project-wide active scan and excludes archived/deleted rows
 - `ScoreRepository.existsByEvaluationIdAndScope()` is already the canonical persisted-state read for `turn = first`
-- `TraceRepository.matchesFiltersByTraceId()` already exposes the canonical single-filter check, but PR 2 still needs the batched one-trace/many-filter variant for performance
+- `TraceRepository.matchesFiltersByTraceId()` already exposes the canonical single-filter check, and `TraceRepository.listMatchingFilterIdsByTraceId()` now provides the batched one-trace/many-filter variant for enqueue performance
 
 **Implementation notes**:
 
@@ -180,12 +180,12 @@ Active implementation work now starts with **PR 2** on `phase-13-part-2`.
 - [x] **P13-PR2-1**: Replace the `enqueue` stub in `apps/workers/src/workers/live-evaluations.ts` by wiring a thin worker wrapper around the new enqueue use case
 - [x] **P13-PR2-2**: Load the ended trace detail with `TraceRepository.findByTraceId()` so trigger checks can use `sessionId` and current trace context
 - [x] **P13-PR2-3**: List active evaluations project-wide through `EvaluationRepository.listByProjectId({ lifecycle: "active" })` instead of manually re-implementing lifecycle filtering
+- [x] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
 - [ ] **P13-PR2-4**: Treat `sampling = 0` as paused via the shared live-evaluation eligibility helpers and skip those evaluations before publication
 - [ ] **P13-PR2-5**: Apply trigger evaluation order exactly as specified: `filter`, then `sampling`, then `turn` / `debounce`
 - [ ] **P13-PR2-6**: Publish `live-evaluations:execute` once per matching `(evaluationId, traceId)` pair, including trace-scoped or scope-scoped dedupe/debounce where required by `first` / `every` / `last`
 - [ ] **P13-PR2-7**: Add structured enqueue-path logging for active evaluations scanned, filter matches, sampling skips, turn/debounce skips, and execute tasks published
 - [ ] **P13-PR2-8**: Add worker-level tests for matching, skipping, deterministic sampling, session-vs-trace scope, turn semantics, and execute publication
-- [ ] **P13-PR2-9**: Optimize trigger filter matching for one ended trace by adding a batched `TraceRepository` read that evaluates multiple independent evaluation `FilterSet`s in one query rather than one query per evaluation
 - [ ] **P13-PR2-10**: Lock the `turn = first` plus debounce behavior with explicit tests so it delays the first eligible execution without accidentally collapsing into `last`
 
 **Exit gate**:


### PR DESCRIPTION
## Summary
- Add the `live-evaluations:enqueue` pipeline so ended traces can be turned into concrete live-evaluation execution jobs.
- Move the selection logic into domain code: load the trace, scan active evaluations, apply filter/sampling/turn rules, and publish the correct `live-evaluations:execute` jobs.
- Add the supporting repository, queue, logging, and test coverage needed to make that enqueue path reliable and reviewable.

## What this PR adds

### 1. A real enqueue path for live evaluations
The `live-evaluations` worker no longer treats `enqueue` as a stub. It now calls a dedicated domain use case that:
- reloads the ended trace from ClickHouse
- lists active evaluations for the project from Postgres
- applies trigger gates in the required order: `filter -> sampling -> turn/debounce`
- publishes one `live-evaluations:execute` job per eligible `(evaluationId, traceId)` pair

### 2. Batched trace filter matching
This PR adds a batched `TraceRepository` read for checking one trace against many evaluation filter sets in a single call, instead of issuing one filter query per evaluation.

That keeps filter semantics in the trace repository while making the enqueue scan efficient enough for project-wide evaluation checks.

### 3. Correct turn and debounce publication semantics
The enqueue path now distinguishes between:
- `every` without debounce: publish a trace-scoped execute job
- `every` with debounce: publish a scope-scoped delayed job
- `last`: publish a scope-scoped delayed job so the latest eligible trace in the scope wins
- `first`: check persisted score history before publishing
- `first` with debounce: still publish a delayed trace-scoped job, without collapsing into `last`-style scope coalescing

This PR also tightens the trigger invariant so `turn = "last"` requires `debounce > 0`.

### 4. Paused-evaluation handling
Evaluations with `sampling = 0` are now treated as paused and skipped before publication.

### 5. Structured enqueue logging
The worker now logs structured enqueue outcomes, including:
- active evaluations scanned
- filter matches
- paused skips
- sampling skips
- turn skips
- execute jobs published

### 6. Focused automated coverage
This PR adds coverage at two levels:
- domain-level tests for enqueue selection and publication semantics
- worker-level tests using in-memory Postgres and ClickHouse to exercise the real worker composition

## What is still missing for the full live-monitoring phase

This PR only implements the enqueue/selection half of the flow.

Still missing:
- `live-evaluations:execute` is still a stub
- no actual evaluation execution happens yet
- no score persistence happens yet
- no issue assignment for live evaluation results happens yet
- no execute-path logging/telemetry is implemented yet
- `live-traces:end` is still a stub, so real trace completion does not yet emit `TraceEnded`
- because of that, this flow is not yet activated automatically from live traffic
- rollout and end-to-end coverage for the sibling `TraceEnded` consumers are still pending

## Test plan
- [x] `cd packages/domain/evaluations && pnpm test src/helpers.test.ts`
- [x] `cd packages/domain/evaluations && pnpm test src/use-cases/live/enqueue-live-evaluations.test.ts`
- [x] `cd packages/domain/evaluations && pnpm typecheck`
- [x] `cd apps/workers && pnpm test src/workers/live-evaluations.test.ts`
- [x] `cd apps/workers && pnpm typecheck`