### PR TITLE
feat(observability): synthetic HTTP errors for Datadog verification

### DIFF
--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -1,4 +1,4 @@
-import { isHttpError, toHttpResponse } from "@repo/utils"
+import { isHttpError, LatitudeObservabilityTestError, toHttpResponse } from "@repo/utils"
 import type { ErrorHandler } from "hono"
 import { logger } from "../utils/logger.ts"
 
@@ -9,6 +9,10 @@ import { logger } from "../utils/logger.ts"
  * HTTP responses based on the error type.
  */
 export const honoErrorHandler: ErrorHandler = (err, c) => {
+  if (err instanceof LatitudeObservabilityTestError) {
+    return c.json({ name: err.name, message: err.message, service: err.service }, 500)
+  }
+
   // If it's an HTTP-aware error, use its status and message
   if (isHttpError(err)) {
     const { status, body } = toHttpResponse(err)

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { createRoute, type OpenAPIHono, z } from "@hono/zod-openapi"
+import { LatitudeObservabilityTestError } from "@repo/utils"
 import type { AppEnv } from "../types.ts"
 
 const HealthResponseSchema = z
@@ -24,5 +25,13 @@ const healthRoute = createRoute({
 export const registerHealthRoute = ({ app }: { app: OpenAPIHono<AppEnv> }) => {
   app.openapi(healthRoute, (c) => {
     return c.json({ service: "api" as const, status: "ok" as const }, 200)
+  })
+
+  app.get("/health/observability-test", (c) => {
+    return c.json({ service: "api" as const, observabilityTest: "armed" as const }, 200)
+  })
+
+  app.get("/health/observability-test/error", () => {
+    throw new LatitudeObservabilityTestError("api")
   })
 }

--- a/apps/ingest/src/routes/health.ts
+++ b/apps/ingest/src/routes/health.ts
@@ -1,3 +1,4 @@
+import { LatitudeObservabilityTestError } from "@repo/utils"
 import type { Hono } from "hono"
 import type { IngestEnv } from "../types.ts"
 
@@ -8,5 +9,13 @@ interface HealthRouteContext {
 export const registerHealthRoute = (context: HealthRouteContext) => {
   context.app.get("/health", (c) => {
     return c.json({ service: "ingest", status: "ok" }, 200)
+  })
+
+  context.app.get("/health/observability-test", (c) => {
+    return c.json({ service: "ingest", observabilityTest: "armed" as const }, 200)
+  })
+
+  context.app.get("/health/observability-test/error", () => {
+    throw new LatitudeObservabilityTestError("ingest")
   })
 }

--- a/apps/ingest/src/server.ts
+++ b/apps/ingest/src/server.ts
@@ -2,7 +2,7 @@ import { serve } from "@hono/node-server"
 import { httpInstrumentationMiddleware as otel } from "@hono/otel"
 import { parseEnv } from "@platform/env"
 import { createLogger, initializeObservability, shutdownObservability } from "@repo/observability"
-import { isHttpError, toHttpResponse } from "@repo/utils"
+import { isHttpError, LatitudeObservabilityTestError, toHttpResponse } from "@repo/utils"
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
 import { Hono } from "hono"
@@ -26,6 +26,10 @@ const start = async () => {
   app.use(otel())
 
   app.onError((err, c) => {
+    if (err instanceof LatitudeObservabilityTestError) {
+      return c.json({ name: err.name, message: err.message, service: err.service }, 500)
+    }
+
     if (isHttpError(err)) {
       const { status, body } = toHttpResponse(err)
       return c.json(body, status as 400 | 401 | 403 | 404 | 500)

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,7 +21,9 @@ import { Route as DesignSystemButtonRouteImport } from './routes/design-system/b
 import { Route as AuthInviteRouteImport } from './routes/auth/invite'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
+import { Route as ApiObservabilityTestIndexRouteImport } from './routes/api/observability-test/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
+import { Route as ApiObservabilityTestErrorRouteImport } from './routes/api/observability-test/error'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AuthenticatedSettingsOrganizationRouteImport } from './routes/_authenticated/settings/organization'
 import { Route as AuthenticatedSettingsMembersRouteImport } from './routes/_authenticated/settings/members'
@@ -98,11 +100,23 @@ const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const ApiObservabilityTestIndexRoute =
+  ApiObservabilityTestIndexRouteImport.update({
+    id: '/api/observability-test/',
+    path: '/api/observability-test/',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AuthenticatedSettingsIndexRoute =
   AuthenticatedSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AuthenticatedSettingsRoute,
+  } as any)
+const ApiObservabilityTestErrorRoute =
+  ApiObservabilityTestErrorRouteImport.update({
+    id: '/api/observability-test/error',
+    path: '/api/observability-test/error',
+    getParentRoute: () => rootRouteImport,
   } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
   id: '/api/auth/$',
@@ -225,7 +239,9 @@ export interface FileRoutesByFullPath {
   '/settings/members': typeof AuthenticatedSettingsMembersRoute
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/projects/$projectSlug/': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren
@@ -252,7 +268,9 @@ export interface FileRoutesByTo {
   '/settings/members': typeof AuthenticatedSettingsMembersRoute
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
+  '/api/observability-test': typeof ApiObservabilityTestIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/projects/$projectSlug/datasets/$datasetId': typeof AuthenticatedProjectsProjectSlugDatasetsDatasetIdRoute
@@ -283,7 +301,9 @@ export interface FileRoutesById {
   '/_authenticated/settings/members': typeof AuthenticatedSettingsMembersRoute
   '/_authenticated/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
+  '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/_authenticated/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/_authenticated/projects/$projectSlug/': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/_authenticated/projects/$projectSlug/annotation-queues/$queueId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren
@@ -315,7 +335,9 @@ export interface FileRouteTypes {
     | '/settings/members'
     | '/settings/organization'
     | '/api/auth/$'
+    | '/api/observability-test/error'
     | '/settings/'
+    | '/api/observability-test/'
     | '/projects/$projectSlug/settings'
     | '/projects/$projectSlug/'
     | '/projects/$projectSlug/annotation-queues/$queueId'
@@ -342,7 +364,9 @@ export interface FileRouteTypes {
     | '/settings/members'
     | '/settings/organization'
     | '/api/auth/$'
+    | '/api/observability-test/error'
     | '/settings'
+    | '/api/observability-test'
     | '/projects/$projectSlug/settings'
     | '/projects/$projectSlug'
     | '/projects/$projectSlug/datasets/$datasetId'
@@ -372,7 +396,9 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/members'
     | '/_authenticated/settings/organization'
     | '/api/auth/$'
+    | '/api/observability-test/error'
     | '/_authenticated/settings/'
+    | '/api/observability-test/'
     | '/_authenticated/projects/$projectSlug/settings'
     | '/_authenticated/projects/$projectSlug/'
     | '/_authenticated/projects/$projectSlug/annotation-queues/$queueId'
@@ -393,6 +419,8 @@ export interface RootRouteChildren {
   DownloadsExportRoute: typeof DownloadsExportRoute
   WelcomeIndexRoute: typeof WelcomeIndexRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  ApiObservabilityTestErrorRoute: typeof ApiObservabilityTestErrorRoute
+  ApiObservabilityTestIndexRoute: typeof ApiObservabilityTestIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -481,12 +509,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/api/observability-test/': {
+      id: '/api/observability-test/'
+      path: '/api/observability-test'
+      fullPath: '/api/observability-test/'
+      preLoaderRoute: typeof ApiObservabilityTestIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authenticated/settings/': {
       id: '/_authenticated/settings/'
       path: '/'
       fullPath: '/settings/'
       preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport
       parentRoute: typeof AuthenticatedSettingsRoute
+    }
+    '/api/observability-test/error': {
+      id: '/api/observability-test/error'
+      path: '/api/observability-test/error'
+      fullPath: '/api/observability-test/error'
+      preLoaderRoute: typeof ApiObservabilityTestErrorRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/auth/$': {
       id: '/api/auth/$'
@@ -719,6 +761,8 @@ const rootRouteChildren: RootRouteChildren = {
   DownloadsExportRoute: DownloadsExportRoute,
   WelcomeIndexRoute: WelcomeIndexRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  ApiObservabilityTestErrorRoute: ApiObservabilityTestErrorRoute,
+  ApiObservabilityTestIndexRoute: ApiObservabilityTestIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/api/observability-test/error.ts
+++ b/apps/web/src/routes/api/observability-test/error.ts
@@ -1,0 +1,12 @@
+import { LatitudeObservabilityTestError } from "@repo/utils"
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/api/observability-test/error")({
+  server: {
+    handlers: {
+      GET: () => {
+        throw new LatitudeObservabilityTestError("web")
+      },
+    },
+  },
+})

--- a/apps/web/src/routes/api/observability-test/index.ts
+++ b/apps/web/src/routes/api/observability-test/index.ts
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/api/observability-test/")({
+  server: {
+    handlers: {
+      GET: async () => {
+        return new Response(JSON.stringify({ service: "web", observabilityTest: "armed" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      },
+    },
+  },
+})

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -7,7 +7,14 @@ import {
   createEventsPublisher,
   loadBullMqConfig,
 } from "@platform/queue-bullmq"
-import { createLogger, initializeObservability, shutdownObservability } from "@repo/observability"
+import {
+  createLogger,
+  initializeObservability,
+  recordSpanExceptionForDatadog,
+  shutdownObservability,
+  trace,
+} from "@repo/observability"
+import { LatitudeObservabilityTestError } from "@repo/utils"
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
 import { getClickhouseClient, getPostgresClient, getWorkflowStarter } from "./clients.ts"
@@ -43,7 +50,27 @@ const bootstrap = async () => {
 
   const healthPort = Effect.runSync(parseEnv("LAT_WORKERS_HEALTH_PORT", "number", 9090))
   const healthServer = createServer((req, res) => {
-    if (req.url === "/health" && req.method === "GET") {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname
+
+    if (pathname === "/health/observability-test" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ service: "workers", observabilityTest: "armed" }))
+      return
+    }
+
+    if (pathname === "/health/observability-test/error" && req.method === "GET") {
+      const err = new LatitudeObservabilityTestError("workers")
+      logger.error(err)
+      const span = trace.getActiveSpan()
+      if (span) {
+        recordSpanExceptionForDatadog(span, err)
+      }
+      res.writeHead(500, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ name: err.name, message: err.message }))
+      return
+    }
+
+    if (pathname === "/health" && req.method === "GET") {
       const status = ready ? 200 : 503
       res.writeHead(status, { "Content-Type": "application/json" })
       res.end(JSON.stringify({ status: ready ? "ok" : "starting" }))

--- a/apps/workflows/src/server.ts
+++ b/apps/workflows/src/server.ts
@@ -4,7 +4,14 @@ import { join } from "node:path"
 import { parseEnv } from "@platform/env"
 import { loadTemporalConfig } from "@platform/workflows-temporal"
 import { runTemporalWorker } from "@platform/workflows-temporal/worker"
-import { createLogger, initializeObservability, shutdownObservability } from "@repo/observability"
+import {
+  createLogger,
+  initializeObservability,
+  recordSpanExceptionForDatadog,
+  shutdownObservability,
+  trace,
+} from "@repo/observability"
+import { LatitudeObservabilityTestError } from "@repo/utils"
 import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
 import * as activities from "./activities/index.ts"
@@ -40,7 +47,27 @@ const bootstrap = async () => {
 
   const healthPort = Effect.runSync(parseEnv("LAT_WORKFLOWS_HEALTH_PORT", "number", 9091))
   const healthServer = createServer((req, res) => {
-    if (req.url === "/health" && req.method === "GET") {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname
+
+    if (pathname === "/health/observability-test" && req.method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ service: "workflows", observabilityTest: "armed" }))
+      return
+    }
+
+    if (pathname === "/health/observability-test/error" && req.method === "GET") {
+      const err = new LatitudeObservabilityTestError("workflows")
+      logger.error(err)
+      const span = trace.getActiveSpan()
+      if (span) {
+        recordSpanExceptionForDatadog(span, err)
+      }
+      res.writeHead(500, { "Content-Type": "application/json" })
+      res.end(JSON.stringify({ name: err.name, message: err.message }))
+      return
+    }
+
+    if (pathname === "/health" && req.method === "GET") {
       const status = ready ? 200 : 503
       res.writeHead(status, { "Content-Type": "application/json" })
       res.end(JSON.stringify({ status: ready ? "ok" : "starting" }))

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,4 +13,5 @@ export {
 } from "./format.ts"
 export * from "./http-errors.ts"
 export { mapByEntityId } from "./map-by-entity-id.ts"
+export { LatitudeObservabilityTestError } from "./observability-test.ts"
 export { relativeTime } from "./relativeTime.ts"

--- a/packages/utils/src/observability-test.test.ts
+++ b/packages/utils/src/observability-test.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+import { LatitudeObservabilityTestError } from "./observability-test.ts"
+
+describe("LatitudeObservabilityTestError", () => {
+  it("uses a stable error name for log/APM filters", () => {
+    const err = new LatitudeObservabilityTestError("api")
+    expect(err.name).toBe("LatitudeObservabilityTestError")
+    expect(err.service).toBe("api")
+    expect(err.message).toContain("api")
+  })
+})

--- a/packages/utils/src/observability-test.ts
+++ b/packages/utils/src/observability-test.ts
@@ -1,0 +1,13 @@
+/**
+ * Thrown by `GET …/observability-test/error` handlers so APM/logs can filter on a
+ * stable name (`LatitudeObservabilityTestError`) per `DD_SERVICE`.
+ */
+export class LatitudeObservabilityTestError extends Error {
+  readonly service: string
+  override readonly name = "LatitudeObservabilityTestError"
+
+  constructor(service: string) {
+    super(`Synthetic observability test error (${service}) — safe to ignore in triage`)
+    this.service = service
+  }
+}


### PR DESCRIPTION
## Summary

Adds HTTP endpoints on every app so staging or production can deliberately emit errors and confirm Datadog (APM, logs, `DD_SERVICE`) wiring per process.

## Endpoints

| App | Probe (200) | Synthetic error |
|-----|-------------|-------------------|
| **api** | `GET /health/observability-test` | `GET /health/observability-test/error` |
| **ingest** | `GET /health/observability-test` | `GET /health/observability-test/error` |
| **web** | `GET /api/observability-test/` | `GET /api/observability-test/error` |
| **workers** | `GET /health/observability-test` (health port) | `GET /health/observability-test/error` → 500 JSON + log + span (process stays up) |
| **workflows** | same on workflows health port | same |

## Implementation

- Shared `LatitudeObservabilityTestError` in `@repo/utils` for stable log and APM filters (`LatitudeObservabilityTestError` / message text).
- **api** and **ingest**: route throws; global handlers return explicit JSON for this error type.
- **workers** and **workflows**: the minimal `node:http` health server returns 500 and records a span exception (no uncaught throw).

## Security / ops

These routes are **unauthenticated**. Anyone who can reach the URL can trigger a synthetic 500 and noise in APM. If that is not acceptable in production, block or restrict at the load balancer, mesh, or network layer.

## Verification

1. Run or deploy each service with observability enabled.
2. `curl` each service error URL (probe first if desired).
3. In Datadog, filter by `LatitudeObservabilityTestError` or the message substring `Synthetic observability test error` and group by `service`.

Made with [Cursor](https://cursor.com)