### PR TITLE
Table headers fix (LAT-493)

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/metric-subheader.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table/metric-subheader.tsx
@@ -9,7 +9,7 @@ const KIND_LABELS: Record<(typeof KINDS)[number], string> = {
   min: "MIN",
   max: "MAX",
   avg: "AVG",
-  median: "MEDIAN",
+  median: "MED",
   sum: "SUM",
 }
 
@@ -47,7 +47,7 @@ export function TableMetricSubheader({
 
   if (isLoading) {
     return (
-      <Text.H6 color="foregroundMuted" className="tabular-nums truncate">
+      <Text.H6 color="foregroundMuted" className="px-1 tabular-nums truncate">
         …
       </Text.H6>
     )
@@ -55,7 +55,7 @@ export function TableMetricSubheader({
 
   if (!rollup) {
     return (
-      <Text.H6 color="foregroundMuted" className="truncate">
+      <Text.H6 color="foregroundMuted" className="px-1 truncate">
         —
       </Text.H6>
     )
@@ -67,7 +67,7 @@ export function TableMetricSubheader({
     <div className="flex min-w-0 w-full items-center justify-end gap-0.5">
       <Button
         variant="ghost"
-        className="py-0"
+        className="px-1 py-0"
         onClick={(e) => {
           e.stopPropagation()
           bump(1)

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -5,7 +5,10 @@ import type { SortDirection } from "../../../utils/filtersHelpers.ts"
 import { Text } from "../../text/text.tsx"
 import { ResizableHandle } from "./resizable-handle.tsx"
 
+/** Horizontal inset for label + resize affordance (must match Tailwind padding sum). */
 const TH_HORIZONTAL_PADDING = 32
+/** Resizable `<th>`: same total width as `px-4`, shifted toward `pr` so the grab strip does not crowd the label. */
+const RESIZABLE_HEADER_PADDING = "pl-3 pr-5" as const
 
 function SortIcon({ direction }: { direction: SortDirection | null }) {
   const cls = "h-3.5 w-3.5 shrink-0"
@@ -62,7 +65,7 @@ export function HeaderCell({
 
   const headerLabel =
     typeof children === "string" ? (
-      <Text.H6 weight="medium" color="foregroundMuted">
+      <Text.H6 weight="medium" color="foregroundMuted" noWrap>
         {children}
       </Text.H6>
     ) : (
@@ -79,46 +82,55 @@ export function HeaderCell({
         ? ({ minWidth } as const)
         : undefined
 
+  const headerBody = (
+    <div className="flex min-h-0 w-full min-w-0 flex-col gap-0">
+      <div
+        className={cn(
+          "flex min-w-min items-center",
+          showSubheaderSlot ? "shrink-0" : sortable ? "h-full" : "",
+          align === "end" && "justify-end",
+          align === "end" && sortable && "w-full",
+          align === "end" && !sortable && "self-end",
+          align === "start" && !sortable && "self-start",
+        )}
+      >
+        <TextComp
+          {...textProps}
+          className={cn("flex items-center whitespace-nowrap", {
+            "w-max max-w-full": !sortable,
+            "w-full min-w-0 justify-end": align === "end" && sortable,
+            "bg-transparent border-none rounded-sm p-0 cursor-pointer select-none transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring":
+              sortable,
+          })}
+        >
+          <span ref={measureRef} className="inline-flex w-max shrink-0 items-center gap-1 whitespace-nowrap">
+            {sortable && <SortIcon direction={sortDirection ?? null} />}
+            {headerLabel}
+          </span>
+        </TextComp>
+      </div>
+      {showSubheaderSlot && (
+        <div className={cn("flex w-full min-w-0 shrink-0 items-center", align === "end" && "justify-end")}>
+          {subheader ?? <span className="block w-full shrink-0" aria-hidden />}
+        </div>
+      )}
+    </div>
+  )
+
   return (
     <th
       ref={thRef}
       className={cn(
-        "relative overflow-hidden px-4", // matches TH_HORIZONTAL_PADDING
+        "relative overflow-hidden",
+        resizable ? RESIZABLE_HEADER_PADDING : "px-4",
         showSubheaderSlot ? "py-1.5 align-top" : "h-12 align-middle",
         className,
       )}
       style={thStyle}
       aria-sort={sortable ? ariaSort(sortDirection) : undefined}
     >
-      <div className="flex min-h-0 w-full min-w-0 flex-col gap-0">
-        <div
-          className={cn(
-            "flex min-w-0 items-center",
-            showSubheaderSlot ? "shrink-0" : "h-full",
-            align === "end" && "justify-end",
-          )}
-        >
-          <TextComp
-            {...textProps}
-            className={cn("flex min-w-0 items-center truncate", {
-              "w-full justify-end": align === "end",
-              "bg-transparent border-none rounded-sm p-0 cursor-pointer select-none transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring":
-                sortable,
-            })}
-          >
-            <span ref={measureRef} className="inline-flex w-fit min-w-0 items-center gap-1">
-              {sortable && <SortIcon direction={sortDirection ?? null} />}
-              {headerLabel}
-            </span>
-          </TextComp>
-        </div>
-        {showSubheaderSlot && (
-          <div className={cn("flex w-full min-w-0 shrink-0 items-center", align === "end" && "justify-end")}>
-            {subheader ?? <span className="block w-full shrink-0" aria-hidden />}
-          </div>
-        )}
-      </div>
-      <ResizableHandle minWidth={headerMinWidth} thRef={thRef} disabled={!resizable} />
+      {headerBody}
+      {resizable ? <ResizableHandle minWidth={headerMinWidth} thRef={thRef} disabled={false} /> : null}
     </th>
   )
 }

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -55,13 +55,18 @@ export function HeaderCell({
   const textProps = sortable ? { type: "button" as const, onClick: onSortClick } : {}
   const thRef = useRef<HTMLTableCellElement>(null)
   const measureRef = useRef<HTMLSpanElement>(null)
+  const subheaderMeasureRef = useRef<HTMLDivElement>(null)
   const headerMinWidth = useRef(minWidth)
 
   useLayoutEffect(() => {
-    const el = measureRef.current
-    if (!el) return
-    headerMinWidth.current = Math.max(minWidth, el.offsetWidth + TH_HORIZONTAL_PADDING)
-  }, [minWidth, children, subheader, showSubheaderSlot])
+    const titleW = measureRef.current?.offsetWidth ?? 0
+    const subW =
+      showSubheaderSlot && subheader != null && subheaderMeasureRef.current
+        ? subheaderMeasureRef.current.offsetWidth
+        : 0
+    const contentW = Math.max(titleW, subW)
+    headerMinWidth.current = Math.max(minWidth, contentW + TH_HORIZONTAL_PADDING)
+  }, [minWidth, children, subheader, showSubheaderSlot, align])
 
   const headerLabel =
     typeof children === "string" ? (
@@ -111,7 +116,16 @@ export function HeaderCell({
       </div>
       {showSubheaderSlot && (
         <div className={cn("flex w-full min-w-0 shrink-0 items-center", align === "end" && "justify-end")}>
-          {subheader ?? <span className="block w-full shrink-0" aria-hidden />}
+          {subheader != null ? (
+            <div
+              ref={subheaderMeasureRef}
+              className={cn("max-w-full shrink-0", align === "end" ? "ml-auto w-max" : "w-max")}
+            >
+              {subheader}
+            </div>
+          ) : (
+            <span className="block w-full shrink-0" aria-hidden />
+          )}
         </div>
       )}
     </div>

--- a/packages/ui/src/components/infinite-table/headers/resizable-handle.tsx
+++ b/packages/ui/src/components/infinite-table/headers/resizable-handle.tsx
@@ -88,7 +88,10 @@ export function ResizableHandle({
       onPointerLeave={() => setHovered(false)}
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
-      className={cn("absolute right-0 top-1.5 bottom-1.5 z-10 w-2 select-none", !disabled && "cursor-col-resize")}
+      className={cn(
+        "absolute right-0 top-1.5 bottom-1.5 z-10 w-2 overflow-hidden select-none",
+        !disabled && "cursor-col-resize",
+      )}
     >
       <svg
         className={cn(

--- a/packages/ui/src/components/infinite-table/headers/resizable-handle.tsx
+++ b/packages/ui/src/components/infinite-table/headers/resizable-handle.tsx
@@ -15,11 +15,18 @@ export function ResizableHandle({
   const [hovered, setHovered] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
   const rafRef = useRef(0)
+  const draggingRef = useRef(false)
+  const previousBodyCursorRef = useRef<string | null>(null)
 
   useMountEffect(() => {
     return () => {
       abortRef.current?.abort()
       cancelAnimationFrame(rafRef.current)
+      if (draggingRef.current) {
+        document.body.style.cursor = previousBodyCursorRef.current ?? ""
+        previousBodyCursorRef.current = null
+        draggingRef.current = false
+      }
     }
   })
 
@@ -47,7 +54,11 @@ export function ResizableHandle({
       const startColWidth = th.offsetWidth
       const startTableWidth = table.offsetWidth
       const effectiveMinWidth = Math.min(startColWidth, minWidth.current)
+      draggingRef.current = true
       setDragging(true)
+
+      previousBodyCursorRef.current = document.body.style.cursor
+      document.body.style.cursor = "grabbing"
 
       const onPointerMove = (ev: PointerEvent) => {
         cancelAnimationFrame(rafRef.current)
@@ -61,7 +72,10 @@ export function ResizableHandle({
 
       const onPointerUp = () => {
         cancelAnimationFrame(rafRef.current)
+        draggingRef.current = false
         setDragging(false)
+        document.body.style.cursor = previousBodyCursorRef.current ?? ""
+        previousBodyCursorRef.current = null
         controller.abort()
         abortRef.current = null
       }
@@ -70,6 +84,9 @@ export function ResizableHandle({
         signal: controller.signal,
       })
       document.addEventListener("pointerup", onPointerUp, {
+        signal: controller.signal,
+      })
+      document.addEventListener("pointercancel", onPointerUp, {
         signal: controller.signal,
       })
     },
@@ -85,18 +102,20 @@ export function ResizableHandle({
       onPointerEnter={() => {
         if (!disabled) setHovered(true)
       }}
-      onPointerLeave={() => setHovered(false)}
+      onPointerLeave={() => {
+        if (!draggingRef.current) setHovered(false)
+      }}
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
       className={cn(
         "absolute right-0 top-1.5 bottom-1.5 z-10 w-2 overflow-hidden select-none",
-        !disabled && "cursor-col-resize",
+        !disabled && (dragging ? "cursor-grabbing" : "cursor-grab"),
       )}
     >
       <svg
         className={cn(
           "pointer-events-none absolute inset-0 size-full transition-colors duration-150",
-          lineWide ? "text-accent-foreground/40" : "text-border",
+          disabled ? "text-border" : dragging ? "text-primary" : hovered ? "text-accent-foreground/40" : "text-border",
         )}
         preserveAspectRatio="none"
         viewBox="0 0 8 100"


### PR DESCRIPTION
This PR includes a fix for the [LAT-493](https://linear.app/latitude/issue/LAT-493/fix-the-table-headers-ui) issue previously present in the tabs, where titles would become 2 lines tall if the column was shrunk too much.


**Change log:**

- Horizontal padding within headers is now visually consistent
- Grab strip interaction behavior is now more intuitive: cursor state updates to promote dragging, added focus state
- Column min width cannot be narrower than the widest element in the column header — a title or an action button

**Preview**
![ex_table](https://github.com/user-attachments/assets/c065441a-3bb9-482d-9cdc-90d06c310ec0)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `infinite-table` header sizing/resize behavior, which could affect column layout and interactions across tables, but changes are UI-only with no data/security impact.
> 
> **Overview**
> Fixes table header layout when columns are shrunk by enforcing no-wrap header titles, reworking header cell structure/padding (including resizable-specific padding), and computing resize `minWidth` from the widest of the title or subheader to avoid 2-line headers.
> 
> Improves the column resize grab strip UX by adding proper grab/grabbing cursor states (including on `document.body`), handling `pointercancel`, and preventing hover state from dropping mid-drag. Also tweaks the metric subheader label (`MEDIAN` → `MED`) and adds consistent horizontal padding to metric subheader/loading/empty states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98b2ec7ea0d98d0e579bd99f97e996f06885f10. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->