### PR TITLE
fix(web): Traces tab token count no longer grows when switching traces

### DIFF
--- a/apps/web/src/components/tracing/spans/shared/aggregateCompletionSpans.test.ts
+++ b/apps/web/src/components/tracing/spans/shared/aggregateCompletionSpans.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { AssembledSpan, SpanStatus, SpanType } from '@latitude-data/constants'
+import { aggregateCompletionEntriesByModel } from './aggregateCompletionSpans'
+
+function completionSpanStub(
+  metadata: AssembledSpan<SpanType.Completion>['metadata'],
+): AssembledSpan<SpanType.Completion> {
+  const now = new Date()
+  return {
+    id: 'span-id',
+    traceId: 'trace-id',
+    workspaceId: 1,
+    projectId: 1,
+    apiKeyId: 1,
+    name: 'completion',
+    kind: 'internal' as const,
+    type: SpanType.Completion,
+    status: SpanStatus.Ok,
+    duration: 0,
+    startedAt: now,
+    endedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    depth: 0,
+    startOffset: 0,
+    endOffset: 0,
+    children: [],
+    metadata,
+  }
+}
+
+describe('aggregateCompletionEntriesByModel', () => {
+  it('does not mutate shared token objects on the source spans', () => {
+    const sharedTokens = {
+      prompt: 100,
+      cached: 0,
+      reasoning: 0,
+      completion: 50,
+    }
+
+    const spans = [
+      completionSpanStub({
+        model: 'gpt-test',
+        provider: 'openai',
+        configuration: {},
+        input: [],
+        tokens: sharedTokens,
+        cost: 1_000,
+      }),
+      completionSpanStub({
+        model: 'gpt-test',
+        provider: 'openai',
+        configuration: {},
+        input: [],
+        tokens: sharedTokens,
+        cost: 1_000,
+      }),
+    ]
+
+    const first = aggregateCompletionEntriesByModel(spans)
+    const second = aggregateCompletionEntriesByModel(spans)
+
+    expect(sharedTokens).toEqual({
+      prompt: 100,
+      cached: 0,
+      reasoning: 0,
+      completion: 50,
+    })
+    expect(first).toEqual(second)
+    expect(first[0]?.tokens).toEqual({
+      prompt: 200,
+      cached: 0,
+      reasoning: 0,
+      completion: 100,
+    })
+  })
+})

--- a/apps/web/src/components/tracing/spans/shared/aggregateCompletionSpans.ts
+++ b/apps/web/src/components/tracing/spans/shared/aggregateCompletionSpans.ts
@@ -1,4 +1,5 @@
 import {
+  AssembledSpan,
   CompletionSpanMetadata,
   CompletionSpanTokens,
   SpanType,
@@ -20,6 +21,20 @@ import { FinishReason } from 'ai'
 import { useTrace } from '$/stores/traces'
 import { findSpanById } from '@latitude-data/core/services/tracing/spans/fetching/findSpanById'
 import { findLastSpanOfType } from '@latitude-data/core/services/tracing/spans/fetching/findLastSpanOfType'
+
+function cloneCompletionTokens(
+  tokens: CompletionSpanTokens | undefined,
+): CompletionSpanTokens {
+  if (!tokens) {
+    return { prompt: 0, cached: 0, reasoning: 0, completion: 0 }
+  }
+  return {
+    prompt: tokens.prompt,
+    cached: tokens.cached,
+    reasoning: tokens.reasoning,
+    completion: tokens.completion,
+  }
+}
 
 /**
  * Estimates the cost breakdown based on the token usage proportions.
@@ -182,6 +197,41 @@ type AggregatedEntry = {
   finishReason?: FinishReason
 }
 
+export function aggregateCompletionEntriesByModel(
+  completionSpans: AssembledSpan<SpanType.Completion>[],
+): AggregatedEntry[] {
+  if (!completionSpans.length) return []
+
+  return completionSpans.reduce<AggregatedEntry[]>((acc, span) => {
+    const model = span.metadata?.model ?? 'unknown'
+    const provider = (span.metadata?.provider ?? 'unknown') as Providers
+
+    const existing = acc.find(
+      (m) => m.model === model && m.provider === provider,
+    )
+
+    if (existing) {
+      existing.tokens.prompt += span.metadata?.tokens?.prompt ?? 0
+      existing.tokens.cached += span.metadata?.tokens?.cached ?? 0
+      existing.tokens.reasoning += span.metadata?.tokens?.reasoning ?? 0
+      existing.tokens.completion += span.metadata?.tokens?.completion ?? 0
+      existing.cost += span.metadata?.cost ?? 0
+      existing.finishReason =
+        span.metadata?.finishReason ?? existing.finishReason
+      return acc
+    }
+
+    acc.push({
+      model,
+      provider,
+      tokens: cloneCompletionTokens(span.metadata?.tokens),
+      cost: span.metadata?.cost ?? 0,
+      finishReason: span.metadata?.finishReason,
+    })
+    return acc
+  }, [])
+}
+
 export function useAggregatedCompletionSpans({
   traceId,
   spanId,
@@ -213,42 +263,7 @@ export function useAggregatedCompletionSpans({
       childSpans ?? [],
       SpanType.Completion,
     )
-
-    if (!completionSpans.length) return []
-
-    return completionSpans.reduce<AggregatedEntry[]>((acc, span) => {
-      const model = span.metadata?.model ?? 'unknown'
-      const provider = (span.metadata?.provider ?? 'unknown') as Providers
-
-      const existing = acc.find(
-        (m) => m.model === model && m.provider === provider,
-      )
-
-      if (existing) {
-        existing.tokens.prompt += span.metadata?.tokens?.prompt ?? 0
-        existing.tokens.cached += span.metadata?.tokens?.cached ?? 0
-        existing.tokens.reasoning += span.metadata?.tokens?.reasoning ?? 0
-        existing.tokens.completion += span.metadata?.tokens?.completion ?? 0
-        existing.cost += span.metadata?.cost ?? 0
-        existing.finishReason =
-          span.metadata?.finishReason ?? existing.finishReason
-        return acc
-      }
-
-      acc.push({
-        model,
-        provider,
-        tokens: span.metadata?.tokens ?? {
-          prompt: 0,
-          cached: 0,
-          reasoning: 0,
-          completion: 0,
-        },
-        cost: span.metadata?.cost ?? 0,
-        finishReason: span.metadata?.finishReason,
-      })
-      return acc
-    }, [])
+    return aggregateCompletionEntriesByModel(completionSpans)
   }, [childSpans])
 
   const totals = useMemo(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users saw the **Tokens** value in the Traces metadata panel increase every time they switched between traces (e.g. same run gaining ~83k tokens per toggle).

**Root cause:** `useAggregatedCompletionSpans` aggregated completion spans with a reducer that pushed `span.metadata.tokens` **by reference** into the accumulator, then mutated that object with `+=`. That object is the same reference held in **SWR-cached** trace data, so each aggregation pass permanently inflated the cached `tokens` on the spans. Re-selecting the trace or re-running the memo re-read those corrupted values and summed again.

**Fix:** Clone token counts when creating a new accumulator entry (`cloneCompletionTokens`). Aggregation logic is extracted to `aggregateCompletionEntriesByModel` with a regression test that runs the aggregator twice and asserts source `tokens` are unchanged and results are stable.

## Testing

- `cd apps/web && pnpm test -- src/components/tracing/spans/shared/aggregateCompletionSpans.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/D091ZVD96R0/p1774519399197319?thread_ts=1774519399.197319&cid=D091ZVD96R0)

<div><a href="https://cursor.com/agents/bc-f5cfb94d-8b21-5339-ad1c-5519bcfb3894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5cfb94d-8b21-5339-ad1c-5519bcfb3894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

