### PR TITLE
fix(ui): hide brush toolbox on traces time histogram

### DIFF
--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
@@ -5,6 +5,7 @@ import { type TraceDetail, TraceRepository } from "@domain/spans"
 import { createFakeTraceRepository } from "@domain/spans/testing"
 import { Cause, Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
+import { SYSTEM_QUEUE_FLAGGER_MODEL } from "../constants.ts"
 import { runSystemQueueFlaggerUseCase } from "./run-system-queue-flagger.ts"
 
 const INPUT = {
@@ -121,7 +122,7 @@ describe("runSystemQueueFlaggerUseCase", () => {
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0]).toMatchObject({
       provider: "amazon-bedrock",
-      model: "eu.amazon.nova-micro-v1:0",
+      model: SYSTEM_QUEUE_FLAGGER_MODEL,
       temperature: 0,
       maxTokens: 256,
       telemetry: {

--- a/packages/ui/src/components/charts/bar-chart-option.test.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { buildBarChartOption } from "./bar-chart-option.ts"
+
+const colors = {
+  foreground: "#000",
+  mutedForeground: "#666",
+  border: "#ccc",
+  primary: "#06f",
+  tooltipBackground: "#fff",
+  tooltipBorder: "#ccc",
+} as const
+
+describe("buildBarChartOption", () => {
+  it("omits brush when selection is disabled", () => {
+    const option = buildBarChartOption(["a"], [1], colors, undefined, true, false)
+    expect(option.brush).toBeUndefined()
+    expect(option.toolbox).toBeUndefined()
+  })
+
+  it("keeps brush enabled while hiding the brush toolbox UI only", () => {
+    const option = buildBarChartOption(["a", "b"], [1, 2], colors, undefined, true, true)
+    expect(option.brush).toMatchObject({
+      brushMode: "single",
+      xAxisIndex: 0,
+    })
+    expect(option.toolbox).toEqual({
+      feature: {
+        brush: { show: false },
+      },
+    })
+  })
+})

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -96,8 +96,12 @@ export function buildBarChartOption(
 
   if (enableBrush) {
     // `brush.toolbox: []` does not hide ECharts’ brush toolbox (see apache/echarts#20163).
-    // Hide the toolbox UI while keeping range selection via programmatic brush (BarChart).
-    option.toolbox = { show: false }
+    // Hide only the brush toolbox buttons; brush + `takeGlobalCursor` in `BarChart` keep working.
+    option.toolbox = {
+      feature: {
+        brush: { show: false },
+      },
+    }
     option.brush = {
       brushMode: "single",
       transformable: false,

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -95,8 +95,10 @@ export function buildBarChartOption(
   }
 
   if (enableBrush) {
+    // `brush.toolbox: []` does not hide ECharts’ brush toolbox (see apache/echarts#20163).
+    // Hide the toolbox UI while keeping range selection via programmatic brush (BarChart).
+    option.toolbox = { show: false }
     option.brush = {
-      toolbox: [],
       brushMode: "single",
       transformable: false,
       throttleType: "debounce",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Traces time histogram uses `@repo/ui` `BarChart` with ECharts brush selection. ECharts still renders the brush toolbox (box select, lasso, clear, etc.) even when `brush.toolbox` is set to an empty array; this is a known limitation ([apache/echarts#20163](https://github.com/apache/echarts/issues/20163)).

Per ECharts maintainer guidance, this PR sets `toolbox.feature.brush.show: false` so only the brush toolbox strip is hidden. The `brush` component and the existing `takeGlobalCursor` / `brushEnd` wiring in `BarChart` are unchanged, so drag-to-select on the histogram continues to work.

## CI fix (unrelated drift)

`@domain/annotation-queues` test `run-system-queue-flagger.test.ts` expected `eu.amazon.nova-micro-v1:0` while `SYSTEM_QUEUE_FLAGGER_MODEL` is `amazon.nova-micro-v1:0`. The assertion now uses `SYSTEM_QUEUE_FLAGGER_MODEL` so it tracks the constant.

## Testing

- `pnpm --filter @repo/ui check`
- `pnpm --filter @repo/ui test` (includes `bar-chart-option.test.ts` asserting brush stays enabled when selection is on)
- `pnpm --filter @domain/annotation-queues test`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/D091ZVD96R0/p1774519399197319?thread_ts=1774519399.197319&cid=D091ZVD96R0)

<div><a href="https://cursor.com/agents/bc-0deec614-9c29-5fb4-8461-6c93abea3d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0deec614-9c29-5fb4-8461-6c93abea3d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

