### PR TITLE
fix(web): optimistic annotation queue updates and sampling modal flash

### DIFF
--- a/apps/web/src/domains/annotation-queues/annotation-queues.collection.ts
+++ b/apps/web/src/domains/annotation-queues/annotation-queues.collection.ts
@@ -1,28 +1,158 @@
 import { isManualQueue, isSystemQueue } from "@domain/annotation-queues"
 import type { InfiniteTableInfiniteScroll, InfiniteTableSorting } from "@repo/ui"
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { queryCollectionOptions } from "@tanstack/query-db-collection"
+import { createCollection, useLiveQuery } from "@tanstack/react-db"
+import { useQuery } from "@tanstack/react-query"
+import { useCallback, useMemo, useState } from "react"
+import { getQueryClient } from "../../lib/data/query-client.tsx"
 import {
   type AnnotationQueueRecord,
+  deleteAnnotationQueue,
   getAnnotationQueueByProject,
   listAnnotationQueuesByProject,
+  updateAnnotationQueue,
 } from "./annotation-queues.functions.ts"
 
+const queryClient = getQueryClient()
+
 const BATCH_SIZE = 50
+const LIST_FETCH_PAGE_SIZE = 200
 
 export const annotationQueueQueryKey = (projectId: string, queueId: string) =>
   ["annotation-queue", projectId, queueId] as const
+
+export const annotationQueuesProjectQueryKey = (projectId: string) => ["annotation-queues", projectId] as const
 
 export const ANNOTATION_QUEUES_DEFAULT_SORTING: InfiniteTableSorting = {
   column: "createdAt",
   direction: "desc",
 }
 
-function mapSortColumn(column: string): "createdAt" | "name" | "completedItems" | "pendingItems" {
-  if (column === "name") return "name"
-  if (column === "completed") return "completedItems"
-  if (column === "pending") return "pendingItems"
-  return "createdAt"
+async function fetchAllAnnotationQueuesForProject(projectId: string): Promise<AnnotationQueueRecord[]> {
+  const all: AnnotationQueueRecord[] = []
+  let cursor: { sortValue: string; id: string } | undefined
+  while (true) {
+    const page = await listAnnotationQueuesByProject({
+      data: {
+        projectId,
+        limit: LIST_FETCH_PAGE_SIZE,
+        cursor,
+        sortBy: "createdAt",
+        sortDirection: "desc",
+      },
+    })
+    const queues = page?.queues ?? []
+    all.push(...queues)
+    if (!page?.hasMore || page.nextCursor === undefined) {
+      break
+    }
+    cursor = page.nextCursor
+  }
+  return all
+}
+
+function compareIds(aId: string, bId: string, direction: "asc" | "desc"): number {
+  if (aId === bId) return 0
+  const asc = aId < bId ? -1 : 1
+  return direction === "desc" ? -asc : asc
+}
+
+function compareQueues(a: AnnotationQueueRecord, b: AnnotationQueueRecord, sorting: InfiniteTableSorting): number {
+  const direction = sorting.direction
+  const primaryDir = direction === "asc" ? 1 : -1
+
+  switch (sorting.column) {
+    case "name": {
+      const c = a.name.localeCompare(b.name)
+      if (c !== 0) return c * primaryDir
+      return compareIds(a.id, b.id, direction)
+    }
+    case "completed": {
+      const c = a.completedItems - b.completedItems
+      if (c !== 0) return c * primaryDir
+      return compareIds(a.id, b.id, direction)
+    }
+    case "pending": {
+      const pa = Math.max(0, a.totalItems - a.completedItems)
+      const pb = Math.max(0, b.totalItems - b.completedItems)
+      const c = pa - pb
+      if (c !== 0) return c * primaryDir
+      return compareIds(a.id, b.id, direction)
+    }
+    default: {
+      const ta = new Date(a.createdAt).getTime()
+      const tb = new Date(b.createdAt).getTime()
+      const c = ta - tb
+      if (c !== 0) return c * primaryDir
+      return compareIds(a.id, b.id, direction)
+    }
+  }
+}
+
+const annotationQueuesCollections: Record<string, ReturnType<typeof createAnnotationQueuesCollection>> = {}
+
+function createAnnotationQueuesCollection(projectId: string) {
+  return createCollection(
+    queryCollectionOptions({
+      queryClient,
+      queryKey: annotationQueuesProjectQueryKey(projectId),
+      queryFn: async () => fetchAllAnnotationQueuesForProject(projectId),
+      getKey: (item: AnnotationQueueRecord) => item.id,
+      onUpdate: async ({ transaction }) => {
+        await Promise.all(
+          transaction.mutations.map((mutation) =>
+            updateAnnotationQueue({
+              data: {
+                projectId,
+                queueId: String(mutation.key),
+                name: mutation.modified.name,
+                description: mutation.modified.description,
+                instructions: mutation.modified.instructions,
+                assignees: [...mutation.modified.assignees],
+                ...(Object.keys(mutation.modified.settings).length > 0 ? { settings: mutation.modified.settings } : {}),
+              },
+            }),
+          ),
+        )
+      },
+      onDelete: async ({ transaction }) => {
+        await Promise.all(
+          transaction.mutations.map((mutation) =>
+            deleteAnnotationQueue({
+              data: {
+                projectId,
+                queueId: String(mutation.key),
+              },
+            }),
+          ),
+        )
+      },
+    }),
+  )
+}
+
+function getAnnotationQueuesCollection(projectId: string) {
+  if (!annotationQueuesCollections[projectId]) {
+    annotationQueuesCollections[projectId] = createAnnotationQueuesCollection(projectId)
+  }
+  return annotationQueuesCollections[projectId]
+}
+
+export function updateAnnotationQueueMutation(
+  projectId: string,
+  queueId: string,
+  updater: (draft: AnnotationQueueRecord) => void,
+) {
+  return getAnnotationQueuesCollection(projectId).update(queueId, updater)
+}
+
+export function deleteAnnotationQueueMutation(projectId: string, queueId: string) {
+  return getAnnotationQueuesCollection(projectId).delete(queueId)
+}
+
+function useAnnotationQueuesLive(projectId: string) {
+  const collection = projectId.length > 0 ? getAnnotationQueuesCollection(projectId) : null
+  return useLiveQuery((q) => (collection === null ? undefined : q.from({ queue: collection })), [projectId, collection])
 }
 
 export function useAnnotationQueuesInfiniteScroll({
@@ -32,46 +162,32 @@ export function useAnnotationQueuesInfiniteScroll({
   readonly projectId: string
   readonly sorting: InfiniteTableSorting
 }) {
-  const {
-    data: paginatedData,
-    isLoading,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useInfiniteQuery({
-    queryKey: ["annotation-queues", projectId, sorting],
-    queryFn: async ({ pageParam }) => {
-      const result = await listAnnotationQueuesByProject({
-        data: {
-          projectId,
-          limit: BATCH_SIZE,
-          cursor: pageParam,
-          sortBy: mapSortColumn(sorting.column),
-          sortDirection: sorting.direction,
-        },
-      })
-      return result ?? { queues: [], hasMore: false }
-    },
-    initialPageParam: undefined as { sortValue: string; id: string } | undefined,
-    getNextPageParam: (lastPage) => lastPage?.nextCursor,
-    enabled: projectId.length > 0,
-  })
+  const { data: rows = [], isLoading } = useAnnotationQueuesLive(projectId)
+  const [windowSize, setWindowSize] = useState(BATCH_SIZE)
+
+  const sorted = useMemo(() => {
+    if (rows.length === 0) return rows
+    return [...rows].sort((a, b) => compareQueues(a, b, sorting))
+  }, [rows, sorting])
+
+  const data = useMemo(() => sorted.slice(0, windowSize), [sorted, windowSize])
+
+  const hasMore = sorted.length > windowSize
+
+  const loadMore = useCallback(() => {
+    setWindowSize((n) => n + BATCH_SIZE)
+  }, [])
 
   const infiniteScroll: InfiniteTableInfiniteScroll = useMemo(
     () => ({
-      hasMore: hasNextPage,
-      isLoadingMore: isFetchingNextPage,
-      onLoadMore: fetchNextPage,
+      hasMore,
+      isLoadingMore: false,
+      onLoadMore: loadMore,
     }),
-    [hasNextPage, isFetchingNextPage, fetchNextPage],
+    [hasMore, loadMore],
   )
 
-  const data: readonly AnnotationQueueRecord[] = useMemo(
-    () => paginatedData?.pages.flatMap((p) => p?.queues ?? []) ?? [],
-    [paginatedData],
-  )
-
-  return { data, isLoading, infiniteScroll }
+  return { data, isLoading, infiniteScroll, resetWindow: () => setWindowSize(BATCH_SIZE) }
 }
 
 export function useAnnotationQueue({
@@ -91,29 +207,11 @@ export function useAnnotationQueue({
 }
 
 export function useAnnotationQueuesList(projectId: string) {
-  const { data: paginatedData, isLoading } = useInfiniteQuery({
-    queryKey: ["annotation-queues-list", projectId],
-    queryFn: async ({ pageParam }) => {
-      const result = await listAnnotationQueuesByProject({
-        data: {
-          projectId,
-          limit: 100,
-          cursor: pageParam,
-          sortBy: "name",
-          sortDirection: "asc",
-        },
-      })
-      return result ?? { queues: [], hasMore: false }
-    },
-    initialPageParam: undefined as { sortValue: string; id: string } | undefined,
-    getNextPageParam: (lastPage) => lastPage?.nextCursor,
-    enabled: projectId.length > 0,
-  })
+  const { data: rows = [], isLoading } = useAnnotationQueuesLive(projectId)
 
   const data = useMemo(() => {
-    const allQueues = paginatedData?.pages.flatMap((p) => p?.queues ?? []) ?? []
-    return allQueues.filter((q) => !isSystemQueue(q) && isManualQueue(q.settings))
-  }, [paginatedData])
+    return rows.filter((q) => !isSystemQueue(q) && isManualQueue(q.settings))
+  }, [rows])
 
   return { data, isLoading }
 }

--- a/apps/web/src/lib/form-server-action.ts
+++ b/apps/web/src/lib/form-server-action.ts
@@ -38,8 +38,8 @@ export function createFormSubmitHandler<TFormValues, TResult>(
 
     try {
       const result = await action(value)
-      formApi.reset()
       await options.onSuccess?.(result)
+      formApi.reset()
     } catch (error) {
       const fieldErrors = extractFieldErrors(error)
       if (fieldErrors) {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/add-to-queue-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/add-to-queue-modal.tsx
@@ -7,7 +7,10 @@ import { useCallback, useMemo, useRef, useState } from "react"
 import { QueueForm } from "../../../../../../components/annotation-queues/queue-form.tsx"
 import { queueFormValuesToSettings } from "../../../../../../components/annotation-queues/queue-form-schema.ts"
 import { addTracesToQueueFunction } from "../../../../../../domains/annotation-queue-items/annotation-queue-items.functions.ts"
-import { useAnnotationQueuesList } from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
+import {
+  annotationQueuesProjectQueryKey,
+  useAnnotationQueuesList,
+} from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
 import type { AnnotationQueueRecord } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import { getQueryClient } from "../../../../../../lib/data/query-client.tsx"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
@@ -124,8 +127,7 @@ export function AddToQueueModal({
         description: "Traces are being added in the background. Will appear in the queue shortly.",
       })
 
-      getQueryClient().invalidateQueries({ queryKey: ["annotation-queues", projectId] })
-      getQueryClient().invalidateQueries({ queryKey: ["annotation-queues-list", projectId] })
+      getQueryClient().invalidateQueries({ queryKey: annotationQueuesProjectQueryKey(projectId) })
       getQueryClient().invalidateQueries({ queryKey: ["annotation-queue-items", projectId, result.queueId] })
 
       onSuccess()

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/delete-queue-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/delete-queue-modal.tsx
@@ -1,8 +1,7 @@
 import { Alert, Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
-import { useQueryClient } from "@tanstack/react-query"
 import { useCallback, useState } from "react"
+import { deleteAnnotationQueueMutation } from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
 import type { AnnotationQueueRecord } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
-import { deleteAnnotationQueue } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 
 interface DeleteQueueModalProps {
@@ -16,27 +15,19 @@ interface DeleteQueueModalProps {
 export function DeleteQueueModal({ open, onOpenChange, projectId, queue, onSuccess }: DeleteQueueModalProps) {
   const [submitting, setSubmitting] = useState(false)
   const { toast } = useToast()
-  const queryClient = useQueryClient()
 
   const pendingItems = Math.max(0, queue.totalItems - queue.completedItems)
 
   const handleDelete = useCallback(async () => {
     setSubmitting(true)
     try {
-      await deleteAnnotationQueue({
-        data: {
-          projectId,
-          queueId: queue.id,
-        },
-      })
+      await deleteAnnotationQueueMutation(projectId, queue.id)
 
       toast({
         title: "Queue deleted",
         description: "Annotation queue has been deleted successfully.",
       })
 
-      await queryClient.invalidateQueries({ queryKey: ["annotation-queues", projectId] })
-      await queryClient.invalidateQueries({ queryKey: ["annotation-queues-list", projectId] })
       onSuccess()
       onOpenChange(false)
     } catch (error) {
@@ -48,7 +39,7 @@ export function DeleteQueueModal({ open, onOpenChange, projectId, queue, onSucce
     } finally {
       setSubmitting(false)
     }
-  }, [projectId, queue.id, toast, queryClient, onSuccess, onOpenChange])
+  }, [projectId, queue.id, toast, onSuccess, onOpenChange])
 
   return (
     <Modal

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/queue-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/queue-modal.tsx
@@ -7,11 +7,12 @@ import { useRef } from "react"
 import { QueueForm } from "../../../../../../components/annotation-queues/queue-form.tsx"
 import { queueFormValuesToSettings } from "../../../../../../components/annotation-queues/queue-form-schema.ts"
 import { UserMultiSelect } from "../../../../../../components/user-multi-select.tsx"
-import type { AnnotationQueueRecord } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import {
-  createAnnotationQueue,
-  updateAnnotationQueue,
-} from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
+  annotationQueuesProjectQueryKey,
+  updateAnnotationQueueMutation,
+} from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
+import type { AnnotationQueueRecord } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
+import { createAnnotationQueue } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { useAppForm } from "../../../../../../lib/form-hook-factory.ts"
 import { createFormSubmitHandler } from "../../../../../../lib/form-server-action.ts"
@@ -73,16 +74,15 @@ export function QueueModal({ open, onOpenChange, projectId, queue, onSuccess }: 
         const settings = isSystem ? { sampling: value.sampling } : queueFormValuesToSettings(value)
 
         if (isEdit) {
-          await updateAnnotationQueue({
-            data: {
-              projectId,
-              queueId: queue.id,
-              name: value.name.trim(),
-              description: value.description,
-              instructions: value.instructions,
-              assignees: value.assignees,
-              ...(Object.keys(settings).length > 0 ? { settings } : {}),
-            },
+          await updateAnnotationQueueMutation(projectId, queue.id, (draft) => {
+            draft.name = value.name.trim()
+            draft.description = value.description
+            draft.instructions = value.instructions
+            draft.assignees = value.assignees
+            if (Object.keys(settings).length > 0) {
+              draft.settings = { ...draft.settings, ...settings }
+            }
+            draft.updatedAt = new Date().toISOString()
           })
         } else {
           await createAnnotationQueue({
@@ -105,8 +105,9 @@ export function QueueModal({ open, onOpenChange, projectId, queue, onSuccess }: 
               ? "Annotation queue has been updated successfully."
               : "Annotation queue has been created successfully.",
           })
-          await queryClient.invalidateQueries({ queryKey: ["annotation-queues", projectId] })
-          await queryClient.invalidateQueries({ queryKey: ["annotation-queues-list", projectId] })
+          if (!isEdit) {
+            await queryClient.invalidateQueries({ queryKey: annotationQueuesProjectQueryKey(projectId) })
+          }
           onSuccess()
           onOpenChange(false)
         },

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
@@ -51,6 +51,7 @@ function AnnotationQueuesPage() {
     data: queues,
     isLoading,
     infiniteScroll,
+    resetWindow,
   } = useAnnotationQueuesInfiniteScroll({
     projectId,
     sorting,
@@ -192,7 +193,10 @@ function AnnotationQueuesPage() {
             infiniteScroll={infiniteScroll}
             sorting={sorting}
             defaultSorting={ANNOTATION_QUEUES_DEFAULT_SORTING}
-            onSortChange={setSorting}
+            onSortChange={(next) => {
+              resetWindow()
+              setSorting(next)
+            }}
             blankSlate="No annotation queues yet"
           />
         </Layout.List>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes a brief flash of stale sampling (and other controlled fields) when saving the annotation queue modal: `createFormSubmitHandler` now runs `onSuccess` before `formApi.reset()`, so the modal does not re-render from old `defaultValues` while closing.
- Replaces the annotation queues list infinite-query hook with a per-project TanStack DB `queryCollection` that loads all queues (paged server fetch under the hood), then sorts and window-rows client-side for the existing infinite table UX.
- Queue **edit** and **delete** use `collection.update` / `collection.delete` so the UI updates optimistically; the collection `onUpdate` / `onDelete` handlers persist via existing server functions. **Create** still calls `createAnnotationQueue` directly and invalidates the project collection query key (server assigns ids).
- Aligns add-to-queue cache invalidation with `annotationQueuesProjectQueryKey(projectId)` (drops the obsolete `annotation-queues-list` key).

## Test plan

- [x] `pnpm exec biome check` (scoped) and `pnpm typecheck` in `apps/web`
- [x] `pnpm test` in `apps/web`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C038XEZRDCJ/p1776181998289739?thread_ts=1776181998.289739&cid=C038XEZRDCJ)

<div><a href="https://cursor.com/agents/bc-ce6ae61d-82e5-59df-9712-85824c90cc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce6ae61d-82e5-59df-9712-85824c90cc46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

