### PR TITLE
(LAT-518) Button UI: New soft variants, fixed size grid

### DIFF
--- a/apps/web/src/routes/design-system/button.tsx
+++ b/apps/web/src/routes/design-system/button.tsx
@@ -17,7 +17,7 @@ import { useState } from "react"
 
 const VARIANTS = [
   { value: "default", label: "Default" },
-  { value: "primary-soft", label: "Primary soft" },
+  { value: "default-soft", label: "Default soft" },
   { value: "secondary", label: "Secondary" },
   { value: "secondary-soft", label: "Secondary soft" },
   { value: "outline", label: "Outline" },

--- a/apps/web/src/routes/design-system/button.tsx
+++ b/apps/web/src/routes/design-system/button.tsx
@@ -17,12 +17,17 @@ import { useState } from "react"
 
 const VARIANTS = [
   { value: "default", label: "Default" },
+  { value: "primary-soft", label: "Primary soft" },
   { value: "secondary", label: "Secondary" },
+  { value: "secondary-soft", label: "Secondary soft" },
   { value: "outline", label: "Outline" },
   { value: "ghost", label: "Ghost" },
   { value: "destructive", label: "Destructive" },
+  { value: "destructive-soft", label: "Destructive soft" },
   { value: "link", label: "Link" },
 ] as const
+
+type ButtonVariant = (typeof VARIANTS)[number]["value"]
 
 const SIZES = [
   { value: "sm", label: "Small" },
@@ -76,9 +81,7 @@ function ButtonPage() {
     }
   })
 
-  const [variant, setVariant] = useState<"default" | "secondary" | "outline" | "ghost" | "destructive" | "link">(
-    "default",
-  )
+  const [variant, setVariant] = useState<ButtonVariant>("default")
   const [size, setSize] = useState<"sm" | "default" | "lg" | "icon" | "full">("default")
   const [state, setState] = useState<"normal" | "loading" | "disabled">("normal")
   const [label, setLabel] = useState("Button")
@@ -160,9 +163,7 @@ function ButtonPage() {
                 <select
                   id="button-variant"
                   value={variant}
-                  onChange={(e) =>
-                    setVariant(e.target.value as "default" | "secondary" | "outline" | "ghost" | "destructive" | "link")
-                  }
+                  onChange={(e) => setVariant(e.target.value as ButtonVariant)}
                   className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   {VARIANTS.map((v) => (

--- a/apps/web/src/routes/design-system/colors.tsx
+++ b/apps/web/src/routes/design-system/colors.tsx
@@ -43,6 +43,8 @@ const COLOR_GROUPS: { title: string; colors: { token: string; label: string; fgT
     colors: [
       { token: "secondary", label: "secondary", fgToken: "secondary-foreground" },
       { token: "secondary-foreground", label: "secondary-foreground", fgToken: "secondary" },
+      { token: "secondary-muted", label: "secondary-muted" },
+      { token: "secondary-muted-hover", label: "secondary-muted-hover" },
     ],
   },
   {
@@ -67,6 +69,7 @@ const COLOR_GROUPS: { title: string; colors: { token: string; label: string; fgT
       { token: "destructive-foreground", label: "destructive-foreground", fgToken: "destructive" },
       { token: "destructive-muted", label: "destructive-muted" },
       { token: "destructive-muted-foreground", label: "destructive-muted-foreground", fgToken: "destructive-muted" },
+      { token: "destructive-muted-hover", label: "destructive-muted-hover" },
     ],
   },
   {

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -7,9 +7,6 @@ import { cn } from "../../utils/cn.ts"
 
 const outerElevation = "border-0 shadow-sm transition-shadow duration-200 hover:shadow-lg"
 
-const insetFaceHighlight =
-  "shadow-[var(--button-face-inset-shadow)] group-hover:shadow-[var(--button-face-inset-shadow-hover)]"
-
 const buttonContainerVariants = cva(
   cn(
     "group relative inline-flex rounded-lg transition-colors duration-200 disabled:pointer-events-none disabled:opacity-50",
@@ -43,20 +40,11 @@ const buttonVariantsConfig = cva(
   {
     variants: {
       variant: {
-        default: cn(
-          "border-0 bg-primary text-primary-foreground group-hover:bg-primary/90 disabled:cursor-default",
-          insetFaceHighlight,
-        ),
-        destructive: cn(
-          "border-0 bg-destructive text-destructive-foreground group-hover:bg-destructive/90",
-          insetFaceHighlight,
-        ),
+        default: "border-0 bg-transparent text-primary-foreground disabled:cursor-default",
+        destructive: "border-0 bg-transparent text-destructive-foreground",
         outline:
           "border border-input bg-background shadow-none group-hover:bg-secondary group-hover:text-secondary-foreground/80 group-hover:shadow-none",
-        secondary: cn(
-          "border-0 bg-secondary text-secondary-foreground [&_svg]:text-muted-foreground group-hover:bg-secondary/90",
-          insetFaceHighlight,
-        ),
+        secondary: "border-0 bg-transparent text-secondary-foreground [&_svg]:text-muted-foreground",
         ghost:
           "border-0 border-transparent bg-transparent text-muted-foreground shadow-none group-hover:bg-muted group-hover:shadow-none",
         link: "border-0 bg-transparent text-accent-foreground shadow-none underline-offset-4 group-hover:underline group-hover:shadow-none",
@@ -80,10 +68,11 @@ const buttonVariantsConfig = cva(
       {
         variant: ["default", "destructive", "secondary"],
         class: [
+          "isolate",
           "before:pointer-events-none",
           "before:absolute",
           "before:-inset-1",
-          "before:z-0",
+          "before:-z-10",
           "before:scale-95",
           "before:rounded-xl",
           "before:opacity-0",
@@ -94,11 +83,30 @@ const buttonVariantsConfig = cva(
           "group-hover:before:scale-100",
           "group-hover:before:opacity-100",
           "group-active:before:-inset-0.5",
+          "after:pointer-events-none",
+          "after:absolute",
+          "after:inset-0",
+          "after:z-0",
+          "after:rounded-[inherit]",
+          "after:content-['']",
+          "after:transition-[background-color,box-shadow]",
+          "after:duration-200",
+          "after:shadow-[var(--button-face-inset-shadow)]",
+          "group-hover:after:shadow-[var(--button-face-inset-shadow-hover)]",
         ],
       },
-      { variant: "default", class: "before:bg-primary/20" },
-      { variant: "destructive", class: "before:bg-destructive/30" },
-      { variant: "secondary", class: "before:bg-foreground/10" },
+      {
+        variant: "default",
+        class: "before:bg-primary/20 after:bg-primary group-hover:after:bg-primary/90",
+      },
+      {
+        variant: "destructive",
+        class: "before:bg-destructive/30 after:bg-destructive group-hover:after:bg-destructive/90",
+      },
+      {
+        variant: "secondary",
+        class: "before:bg-foreground/10 after:bg-secondary group-hover:after:bg-secondary/90",
+      },
     ],
     defaultVariants: {
       variant: "default",
@@ -185,7 +193,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || isLoading}
         aria-busy={isLoading ? "true" : undefined}
       >
-        <div className={cn(buttonVariantsConfig({ variant, size }), "z-[1]", className)}>
+        <div className={cn(buttonVariantsConfig({ variant, size }), "relative z-[1]", className)}>
           <div className="relative z-[1] flex max-w-full flex-row items-center gap-x-1.5">
             {isLoading && (
               <span className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -24,6 +24,9 @@ const buttonContainerVariants = cva(
         secondary: "bg-secondary hover:bg-secondary/80",
         ghost: "bg-transparent shadow-none hover:shadow-none",
         link: "bg-transparent shadow-none underline-offset-4 hover:underline hover:shadow-none",
+        "primary-soft": "bg-transparent shadow-none hover:shadow-none",
+        "destructive-soft": "bg-transparent shadow-none hover:shadow-none",
+        "secondary-soft": "bg-transparent shadow-none hover:shadow-none",
       },
     },
     defaultVariants: {
@@ -51,16 +54,22 @@ const buttonVariantsConfig = cva(
         outline:
           "border border-input bg-background shadow-none group-hover:bg-secondary group-hover:text-secondary-foreground/80 group-hover:shadow-none",
         secondary: cn(
-          "border-0 bg-secondary text-secondary-foreground group-hover:bg-secondary/90",
+          "border-0 bg-secondary text-secondary-foreground [&_svg]:text-muted-foreground group-hover:bg-secondary/90",
           insetFaceHighlight,
         ),
         ghost:
           "border-0 border-transparent bg-transparent text-muted-foreground shadow-none group-hover:bg-muted group-hover:shadow-none",
         link: "border-0 bg-transparent text-accent-foreground shadow-none underline-offset-4 group-hover:underline group-hover:shadow-none",
+        "primary-soft":
+          "border-0 bg-primary-muted text-primary shadow-none group-hover:bg-primary-muted-hover group-hover:shadow-none group-active:bg-primary-muted group-hover:group-active:bg-primary-muted [&_svg]:text-primary/70",
+        "destructive-soft":
+          "border-0 bg-destructive-muted text-destructive-muted-foreground shadow-none group-hover:bg-destructive-muted-hover group-hover:shadow-none group-active:bg-destructive-muted group-hover:group-active:bg-destructive-muted [&_svg]:text-destructive-muted-foreground/85",
+        "secondary-soft":
+          "border-0 bg-secondary-muted text-secondary-foreground shadow-none group-hover:bg-secondary-muted-hover group-hover:shadow-none group-active:bg-secondary-muted group-hover:group-active:bg-secondary-muted [&_svg]:text-muted-foreground",
       },
       size: {
         default: "min-h-8 px-3 py-buttonDefaultVertical",
-        sm: "h-8 rounded-lg px-3 text-xs",
+        sm: "h-7 rounded-lg px-2 text-xs",
         lg: "h-10 rounded-lg px-8",
         icon: "h-8 w-8 p-0",
         "icon-xs": "h-5 w-5 p-0 rounded-md",
@@ -153,19 +162,22 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || isLoading}
         aria-busy={isLoading ? "true" : undefined}
       >
-        {effectiveVariant !== "outline" && effectiveVariant !== "ghost" && effectiveVariant !== "link" && (
-          <div
-            className={cn(
-              "pointer-events-none absolute -inset-1 z-0 scale-95 rounded-xl opacity-0 transition-all duration-200 ease-out group-hover:scale-100 group-hover:opacity-100 group-active:-inset-0.5",
-              effectiveVariant === "destructive"
-                ? "bg-destructive/30"
-                : effectiveVariant === "default"
-                  ? "bg-primary/20"
-                  : "bg-foreground/10",
-            )}
-            aria-hidden
-          />
-        )}
+        {effectiveVariant !== "outline" &&
+          effectiveVariant !== "ghost" &&
+          effectiveVariant !== "link" &&
+          !effectiveVariant.endsWith("-soft") && (
+            <div
+              className={cn(
+                "pointer-events-none absolute -inset-1 z-0 scale-95 rounded-xl opacity-0 transition-all duration-200 ease-out group-hover:scale-100 group-hover:opacity-100 group-active:-inset-0.5",
+                effectiveVariant === "destructive"
+                  ? "bg-destructive/30"
+                  : effectiveVariant === "default"
+                    ? "bg-primary/20"
+                    : "bg-foreground/10",
+              )}
+              aria-hidden
+            />
+          )}
         <div className={cn(buttonVariantsConfig({ variant, size }), "relative z-[1]", className)}>
           <div className="flex max-w-full flex-row items-center gap-x-1.5">
             {isLoading && (

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -35,23 +35,6 @@ const buttonContainerVariants = cva(
   },
 )
 
-const glowBeforeBase = [
-  "before:pointer-events-none",
-  "before:absolute",
-  "before:-inset-1",
-  "before:z-0",
-  "before:scale-95",
-  "before:rounded-xl",
-  "before:opacity-0",
-  "before:transition-all",
-  "before:duration-200",
-  "before:ease-out",
-  "before:content-['']",
-  "group-hover:before:scale-100",
-  "group-hover:before:opacity-100",
-  "group-active:before:-inset-0.5",
-] as const
-
 const buttonVariantsConfig = cva(
   cn(
     "relative inline-flex w-full max-w-full cursor-pointer items-center justify-center rounded-lg font-sans font-medium transition-[color,background-color,border-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background group-disabled:pointer-events-none group-disabled:opacity-50",
@@ -96,7 +79,22 @@ const buttonVariantsConfig = cva(
     compoundVariants: [
       {
         variant: ["default", "destructive", "secondary"],
-        class: [...glowBeforeBase],
+        class: [
+          "before:pointer-events-none",
+          "before:absolute",
+          "before:-inset-1",
+          "before:z-0",
+          "before:scale-95",
+          "before:rounded-xl",
+          "before:opacity-0",
+          "before:transition-all",
+          "before:duration-200",
+          "before:ease-out",
+          "before:content-['']",
+          "group-hover:before:scale-100",
+          "group-hover:before:opacity-100",
+          "group-active:before:-inset-0.5",
+        ],
       },
       { variant: "default", class: "before:bg-primary/20" },
       { variant: "destructive", class: "before:bg-destructive/30" },

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -35,9 +35,26 @@ const buttonContainerVariants = cva(
   },
 )
 
+const glowBeforeBase = [
+  "before:pointer-events-none",
+  "before:absolute",
+  "before:-inset-1",
+  "before:z-0",
+  "before:scale-95",
+  "before:rounded-xl",
+  "before:opacity-0",
+  "before:transition-all",
+  "before:duration-200",
+  "before:ease-out",
+  "before:content-['']",
+  "group-hover:before:scale-100",
+  "group-hover:before:opacity-100",
+  "group-active:before:-inset-0.5",
+] as const
+
 const buttonVariantsConfig = cva(
   cn(
-    "inline-flex w-full max-w-full cursor-pointer items-center justify-center rounded-lg font-sans font-medium transition-[color,background-color,border-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background group-disabled:pointer-events-none group-disabled:opacity-50",
+    "relative inline-flex w-full max-w-full cursor-pointer items-center justify-center rounded-lg font-sans font-medium transition-[color,background-color,border-color,box-shadow] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background group-disabled:pointer-events-none group-disabled:opacity-50",
     font.size.h5,
   ),
   {
@@ -76,6 +93,15 @@ const buttonVariantsConfig = cva(
         full: "min-h-8 w-full px-3 py-buttonDefaultVertical",
       },
     },
+    compoundVariants: [
+      {
+        variant: ["default", "destructive", "secondary"],
+        class: [...glowBeforeBase],
+      },
+      { variant: "default", class: "before:bg-primary/20" },
+      { variant: "destructive", class: "before:bg-destructive/30" },
+      { variant: "secondary", class: "before:bg-foreground/10" },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",
@@ -135,7 +161,6 @@ function stripLeadingIconChild(children: ReactNode): ReactNode {
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, isLoading = false, children, disabled, ...props }, ref) => {
-    const effectiveVariant = variant ?? "default"
     const visibleChildren = isLoading ? stripLeadingIconChild(children) : children
 
     if (asChild) {
@@ -162,24 +187,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || isLoading}
         aria-busy={isLoading ? "true" : undefined}
       >
-        {effectiveVariant !== "outline" &&
-          effectiveVariant !== "ghost" &&
-          effectiveVariant !== "link" &&
-          !effectiveVariant.endsWith("-soft") && (
-            <div
-              className={cn(
-                "pointer-events-none absolute -inset-1 z-0 scale-95 rounded-xl opacity-0 transition-all duration-200 ease-out group-hover:scale-100 group-hover:opacity-100 group-active:-inset-0.5",
-                effectiveVariant === "destructive"
-                  ? "bg-destructive/30"
-                  : effectiveVariant === "default"
-                    ? "bg-primary/20"
-                    : "bg-foreground/10",
-              )}
-              aria-hidden
-            />
-          )}
-        <div className={cn(buttonVariantsConfig({ variant, size }), "relative z-[1]", className)}>
-          <div className="flex max-w-full flex-row items-center gap-x-1.5">
+        <div className={cn(buttonVariantsConfig({ variant, size }), "z-[1]", className)}>
+          <div className="relative z-[1] flex max-w-full flex-row items-center gap-x-1.5">
             {isLoading && (
               <span className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
             )}

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -24,7 +24,7 @@ const buttonContainerVariants = cva(
         secondary: "bg-secondary hover:bg-secondary/80",
         ghost: "bg-transparent shadow-none hover:shadow-none",
         link: "bg-transparent shadow-none underline-offset-4 hover:underline hover:shadow-none",
-        "primary-soft": "bg-transparent shadow-none hover:shadow-none",
+        "default-soft": "bg-transparent shadow-none hover:shadow-none",
         "destructive-soft": "bg-transparent shadow-none hover:shadow-none",
         "secondary-soft": "bg-transparent shadow-none hover:shadow-none",
       },
@@ -60,7 +60,7 @@ const buttonVariantsConfig = cva(
         ghost:
           "border-0 border-transparent bg-transparent text-muted-foreground shadow-none group-hover:bg-muted group-hover:shadow-none",
         link: "border-0 bg-transparent text-accent-foreground shadow-none underline-offset-4 group-hover:underline group-hover:shadow-none",
-        "primary-soft":
+        "default-soft":
           "border-0 bg-primary-muted text-primary shadow-none group-hover:bg-primary-muted-hover group-hover:shadow-none group-active:bg-primary-muted group-hover:group-active:bg-primary-muted [&_svg]:text-primary/70",
         "destructive-soft":
           "border-0 bg-destructive-muted text-destructive-muted-foreground shadow-none group-hover:bg-destructive-muted-hover group-hover:shadow-none group-active:bg-destructive-muted group-hover:group-active:bg-destructive-muted [&_svg]:text-destructive-muted-foreground/85",

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -74,6 +74,8 @@
 
   --color-secondary: hsl(var(--secondary));
   --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-secondary-muted: hsl(var(--secondary-muted));
+  --color-secondary-muted-hover: hsl(var(--secondary-muted-hover));
 
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
@@ -89,6 +91,7 @@
 
   --color-destructive-muted: hsl(var(--destructive-muted));
   --color-destructive-muted-foreground: hsl(var(--destructive-muted-foreground));
+  --color-destructive-muted-hover: hsl(var(--destructive-muted-hover));
 
   --color-warning-muted: hsl(var(--warning-muted));
   --color-warning-muted-foreground: hsl(var(--warning-muted-foreground));
@@ -204,6 +207,8 @@
   --primary-muted-hover: 210 100% 97%;
   --secondary: 210 20% 98%;
   --secondary-foreground: 221 39% 11%;
+  --secondary-muted: 210 20% 96%;
+  --secondary-muted-hover: 210 18% 93%;
   --yellow: 41 96% 91%;
   --purple: 289 51% 92%;
   --purple-foreground: 289 51% 14%;
@@ -216,6 +221,7 @@
   --destructive-foreground: 0 0% 98%;
   --destructive-muted: 0 93% 94%;
   --destructive-muted-foreground: 0 74% 42%;
+  --destructive-muted-hover: 0 90% 90%;
   --success: 142 72% 29%;
   --success-foreground: 120 87% 97%;
   --success-muted: 141 84% 93%;
@@ -255,6 +261,8 @@
   --primary-muted-hover: 210 100% 16%;
   --secondary: 0 0% 10%;
   --secondary-foreground: 0 0% 98%;
+  --secondary-muted: 0 0% 14%;
+  --secondary-muted-hover: 0 0% 18%;
   --yellow: 41 90% 14%;
   --purple: 289 51% 14%;
   --purple-foreground: 289 51% 65%;
@@ -267,6 +275,7 @@
   --destructive-foreground: 0 0% 98%;
   --destructive-muted: 0 75% 15%;
   --destructive-muted-foreground: 0 75% 56%;
+  --destructive-muted-hover: 0 72% 20%;
   --success: 142 76% 36%;
   --success-foreground: 120 87% 97%;
   --success-muted: 141 84% 10%;


### PR DESCRIPTION
This PR implements some upgrades for the button component as requested in [LAT-518](https://linear.app/latitude/issue/LAT-518/polish-ui-button-component)

Changes:
- New `default-soft` , `secondary-soft` and `destructive-soft` for elevated flexibility of the component
- `sm` size is now 28px high