### PR TITLE
fix(issue-discovery): split draft and published score events

### DIFF
--- a/apps/api/src/routes/scores.test.ts
+++ b/apps/api/src/routes/scores.test.ts
@@ -102,7 +102,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(publicationRequests).toHaveLength(1)
-    expect(publicationRequests[0]?.eventName).toBe("ScoreCreated")
+    expect(publicationRequests[0]?.eventName).toBe("ScorePublished")
     expect(publicationRequests[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,
@@ -175,7 +175,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(publicationRequests).toHaveLength(1)
-    expect(publicationRequests[0]?.eventName).toBe("ScoreCreated")
+    expect(publicationRequests[0]?.eventName).toBe("ScorePublished")
     expect(publicationRequests[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,
@@ -262,7 +262,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(outboxRows).toHaveLength(1)
-    expect(outboxRows[0]?.eventName).toBe("ScoreCreated")
+    expect(outboxRows[0]?.eventName).toBe("ScorePublished")
     expect(outboxRows[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,
@@ -314,7 +314,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(outboxRows).toHaveLength(1)
-    expect(outboxRows[0]?.eventName).toBe("ScoreCreated")
+    expect(outboxRows[0]?.eventName).toBe("ScorePublished")
     expect(outboxRows[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,
@@ -396,7 +396,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(outboxRows).toHaveLength(1)
-    expect(outboxRows[0]?.eventName).toBe("ScoreCreated")
+    expect(outboxRows[0]?.eventName).toBe("ScorePublished")
     expect(outboxRows[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,
@@ -457,7 +457,7 @@ describe("Scores Routes Integration", () => {
       .where(eq(outboxEvents.organizationId, tenant.organizationId))
 
     expect(publicationRequests).toHaveLength(1)
-    expect(publicationRequests[0]?.eventName).toBe("ScoreCreated")
+    expect(publicationRequests[0]?.eventName).toBe("ScorePublished")
     expect(publicationRequests[0]?.payload).toEqual({
       organizationId: tenant.organizationId,
       projectId,

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -308,7 +308,7 @@ describe("domain-events dispatcher", () => {
           issueId: null,
         },
         options: {
-          dedupeKey: "issues:discovery:score-3",
+          dedupeKey: `issues:discovery:score-3:${envelope.id}`,
         },
       },
       {
@@ -337,6 +337,51 @@ describe("domain-events dispatcher", () => {
           dedupeKey: "annotation-scores:mark-review-started:score-3",
         },
       },
+    ])
+  })
+
+  it("uses per-event dedupe keys for repeated ScoreCreated events on the same score", async () => {
+    const { consumer, published } = setupDispatcher()
+
+    const firstEnvelope: EventEnvelope = {
+      id: "evt-score-created-1",
+      event: {
+        name: "ScoreCreated",
+        organizationId: "org-1",
+        payload: {
+          organizationId: "org-1",
+          projectId: "proj-1",
+          scoreId: "score-3",
+          issueId: null,
+        },
+      },
+      occurredAt: new Date(),
+    }
+
+    const secondEnvelope: EventEnvelope = {
+      id: "evt-score-created-2",
+      event: {
+        name: "ScoreCreated",
+        organizationId: "org-1",
+        payload: {
+          organizationId: "org-1",
+          projectId: "proj-1",
+          scoreId: "score-3",
+          issueId: null,
+        },
+      },
+      occurredAt: new Date(),
+    }
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(firstEnvelope))
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(secondEnvelope))
+
+    const issueDiscoveryPublishes = published.filter((p) => p.queue === "issues" && p.task === "discovery")
+
+    expect(issueDiscoveryPublishes).toHaveLength(2)
+    expect(issueDiscoveryPublishes.map((p) => p.options?.dedupeKey)).toEqual([
+      "issues:discovery:score-3:evt-score-created-1",
+      "issues:discovery:score-3:evt-score-created-2",
     ])
   })
 })

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -282,10 +282,10 @@ describe("domain-events dispatcher", () => {
     expect(published.some((p) => p.queue === "posthog-analytics")).toBe(false)
   })
 
-  it("routes ScoreCreated to issues:discovery, annotation-scores publish, and markReviewStarted", async () => {
+  it("routes ScoreDraftSaved to annotation-scores publish and markReviewStarted", async () => {
     const { consumer, published } = setupDispatcher()
 
-    const envelope = makeEnvelope("ScoreCreated", {
+    const envelope = makeEnvelope("ScoreDraftSaved", {
       organizationId: "org-1",
       projectId: "proj-1",
       scoreId: "score-3",
@@ -294,23 +294,7 @@ describe("domain-events dispatcher", () => {
 
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
-    // Primary handler publishes to issues + annotation-scores; ScoreCreated is
-    // also in the PostHog whitelist so a third publish goes to posthog-analytics.
-    const primary = published.filter((p) => p.queue !== "posthog-analytics")
-    expect(primary).toEqual([
-      {
-        queue: "issues",
-        task: "discovery",
-        payload: {
-          organizationId: "org-1",
-          projectId: "proj-1",
-          scoreId: "score-3",
-          issueId: null,
-        },
-        options: {
-          dedupeKey: `issues:discovery:score-3:${envelope.id}`,
-        },
-      },
+    expect(published).toEqual([
       {
         queue: "annotation-scores",
         task: "publishHumanAnnotation",
@@ -321,6 +305,7 @@ describe("domain-events dispatcher", () => {
           issueId: null,
         },
         options: {
+          dedupeKey: "annotation-scores:publish-human:score-3",
           debounceMs: SCORE_PUBLICATION_DEBOUNCE,
         },
       },
@@ -340,48 +325,32 @@ describe("domain-events dispatcher", () => {
     ])
   })
 
-  it("uses per-event dedupe keys for repeated ScoreCreated events on the same score", async () => {
+  it("routes ScorePublished to issues:discovery", async () => {
     const { consumer, published } = setupDispatcher()
 
-    const firstEnvelope: EventEnvelope = {
-      id: "evt-score-created-1",
-      event: {
-        name: "ScoreCreated",
-        organizationId: "org-1",
+    const envelope = makeEnvelope("ScorePublished", {
+      organizationId: "org-1",
+      projectId: "proj-1",
+      scoreId: "score-3",
+      issueId: null,
+    })
+
+    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
+
+    expect(published).toEqual([
+      {
+        queue: "issues",
+        task: "discovery",
         payload: {
           organizationId: "org-1",
           projectId: "proj-1",
           scoreId: "score-3",
           issueId: null,
         },
-      },
-      occurredAt: new Date(),
-    }
-
-    const secondEnvelope: EventEnvelope = {
-      id: "evt-score-created-2",
-      event: {
-        name: "ScoreCreated",
-        organizationId: "org-1",
-        payload: {
-          organizationId: "org-1",
-          projectId: "proj-1",
-          scoreId: "score-3",
-          issueId: null,
+        options: {
+          dedupeKey: "issues:discovery:score-3",
         },
       },
-      occurredAt: new Date(),
-    }
-
-    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(firstEnvelope))
-    await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(secondEnvelope))
-
-    const issueDiscoveryPublishes = published.filter((p) => p.queue === "issues" && p.task === "discovery")
-
-    expect(issueDiscoveryPublishes).toHaveLength(2)
-    expect(issueDiscoveryPublishes.map((p) => p.options?.dedupeKey)).toEqual([
-      "issues:discovery:score-3:evt-score-created-1",
-      "issues:discovery:score-3:evt-score-created-2",
     ])
   })
 })

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -17,11 +17,18 @@ class UnhandledEventError extends Data.TaggedError("UnhandledEventError")<{
 
 const logger = createLogger("domain-events")
 
-type EventHandlerMap = {
-  [E in keyof EventPayloads]: (event: DomainEvent<E, EventPayloads[E]>) => Effect.Effect<void, unknown>
+type EventDispatchContext = {
+  readonly envelopeId: string
 }
 
-type EventHandlerFn = (e: DomainEvent) => Effect.Effect<void, unknown>
+type EventHandlerMap = {
+  [E in keyof EventPayloads]: (
+    event: DomainEvent<E, EventPayloads[E]>,
+    context: EventDispatchContext,
+  ) => Effect.Effect<void, unknown>
+}
+
+type EventHandlerFn = (e: DomainEvent, context: EventDispatchContext) => Effect.Effect<void, unknown>
 
 export const createDomainEventsWorker = ({
   consumer,
@@ -96,18 +103,20 @@ export const createDomainEventsWorker = ({
 
     TraceEnded: (event) => publishTraceEndedFanOut(event.payload),
 
-    ScoreCreated: (event) =>
-      Effect.all([
-        pub.publish("issues", "discovery", event.payload, {
-          dedupeKey: `issues:discovery:${event.payload.scoreId}`,
-        }),
-        pub.publish("annotation-scores", "publishHumanAnnotation", event.payload, {
-          debounceMs: SCORE_PUBLICATION_DEBOUNCE, // 5 minutes
-        }),
-        pub.publish("annotation-scores", "markReviewStarted", event.payload, {
-          dedupeKey: `annotation-scores:mark-review-started:${event.payload.scoreId}`,
-        }),
-      ]),
+    ScoreCreated: (event, context) =>
+      Effect.gen(function* () {
+        yield* Effect.all([
+          pub.publish("issues", "discovery", event.payload, {
+            dedupeKey: `issues:discovery:${event.payload.scoreId}:${context.envelopeId}`,
+          }),
+          pub.publish("annotation-scores", "publishHumanAnnotation", event.payload, {
+            debounceMs: SCORE_PUBLICATION_DEBOUNCE,
+          }),
+          pub.publish("annotation-scores", "markReviewStarted", event.payload, {
+            dedupeKey: `annotation-scores:mark-review-started:${event.payload.scoreId}`,
+          }),
+        ])
+      }),
 
     ScoreAssignedToIssue: (event) =>
       pub.publish("issues", "refresh", event.payload, {
@@ -167,7 +176,7 @@ export const createDomainEventsWorker = ({
       }
 
       const handler = maybeHandler as EventHandlerFn
-      const primary = handler(event)
+      const primary = handler(event, { envelopeId: envelope.id })
 
       if (!isPostHogTracked(event.name)) {
         return primary

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -17,18 +17,11 @@ class UnhandledEventError extends Data.TaggedError("UnhandledEventError")<{
 
 const logger = createLogger("domain-events")
 
-type EventDispatchContext = {
-  readonly envelopeId: string
-}
-
 type EventHandlerMap = {
-  [E in keyof EventPayloads]: (
-    event: DomainEvent<E, EventPayloads[E]>,
-    context: EventDispatchContext,
-  ) => Effect.Effect<void, unknown>
+  [E in keyof EventPayloads]: (event: DomainEvent<E, EventPayloads[E]>) => Effect.Effect<void, unknown>
 }
 
-type EventHandlerFn = (e: DomainEvent, context: EventDispatchContext) => Effect.Effect<void, unknown>
+type EventHandlerFn = (e: DomainEvent) => Effect.Effect<void, unknown>
 
 export const createDomainEventsWorker = ({
   consumer,
@@ -55,6 +48,25 @@ export const createDomainEventsWorker = ({
       ],
       { concurrency: "unbounded" },
     ).pipe(Effect.asVoid)
+
+  const publishScoreDraftSavedFanOut = (payload: EventPayloads["ScoreDraftSaved"]) =>
+    Effect.all(
+      [
+        pub.publish("annotation-scores", "publishHumanAnnotation", payload, {
+          dedupeKey: `annotation-scores:publish-human:${payload.scoreId}`,
+          debounceMs: SCORE_PUBLICATION_DEBOUNCE,
+        }),
+        pub.publish("annotation-scores", "markReviewStarted", payload, {
+          dedupeKey: `annotation-scores:mark-review-started:${payload.scoreId}`,
+        }),
+      ],
+      { concurrency: "unbounded" },
+    ).pipe(Effect.asVoid)
+
+  const publishScorePublishedFanOut = (payload: EventPayloads["ScorePublished"]) =>
+    pub.publish("issues", "discovery", payload, {
+      dedupeKey: `issues:discovery:${payload.scoreId}`,
+    })
 
   const handlers: EventHandlerMap = {
     MagicLinkEmailRequested: (event) =>
@@ -103,20 +115,8 @@ export const createDomainEventsWorker = ({
 
     TraceEnded: (event) => publishTraceEndedFanOut(event.payload),
 
-    ScoreCreated: (event, context) =>
-      Effect.gen(function* () {
-        yield* Effect.all([
-          pub.publish("issues", "discovery", event.payload, {
-            dedupeKey: `issues:discovery:${event.payload.scoreId}:${context.envelopeId}`,
-          }),
-          pub.publish("annotation-scores", "publishHumanAnnotation", event.payload, {
-            debounceMs: SCORE_PUBLICATION_DEBOUNCE,
-          }),
-          pub.publish("annotation-scores", "markReviewStarted", event.payload, {
-            dedupeKey: `annotation-scores:mark-review-started:${event.payload.scoreId}`,
-          }),
-        ])
-      }),
+    ScoreDraftSaved: (event) => publishScoreDraftSavedFanOut(event.payload),
+    ScorePublished: (event) => publishScorePublishedFanOut(event.payload),
 
     ScoreAssignedToIssue: (event) =>
       pub.publish("issues", "refresh", event.payload, {
@@ -176,7 +176,7 @@ export const createDomainEventsWorker = ({
       }
 
       const handler = maybeHandler as EventHandlerFn
-      const primary = handler(event, { envelopeId: envelope.id })
+      const primary = handler(event)
 
       if (!isPostHogTracked(event.name)) {
         return primary

--- a/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
+++ b/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
@@ -158,7 +158,7 @@ describe("persistDraftAnnotation", () => {
 
     expect(events).toEqual([
       expect.objectContaining({
-        eventName: "ScoreCreated",
+        eventName: "ScoreDraftSaved",
         payload: expect.objectContaining({
           organizationId: cuid,
           projectId: projectCuid,
@@ -244,7 +244,7 @@ describe("persistDraftAnnotation", () => {
     expect(score.metadata.rawFeedback).toBe("Issue with refund policy")
   })
 
-  it("writes ScoreCreated for draft persistence (discovery worker noops while drafted)", async () => {
+  it("writes ScoreDraftSaved for draft persistence", async () => {
     const { events, layer } = createTestLayers()
 
     await Effect.runPromise(
@@ -261,7 +261,7 @@ describe("persistDraftAnnotation", () => {
 
     expect(events).toEqual([
       expect.objectContaining({
-        eventName: "ScoreCreated",
+        eventName: "ScoreDraftSaved",
         payload: expect.objectContaining({
           organizationId: cuid,
           projectId: projectCuid,
@@ -303,7 +303,7 @@ describe("persistDraftAnnotation", () => {
     expect(updated.feedback).toBe("Updated AI feedback")
     expect(updated.metadata.rawFeedback).toBe("Updated AI feedback")
     expect(store.size).toBe(1)
-    expect(events.filter((e: unknown) => (e as { eventName: string }).eventName === "ScoreCreated")).toHaveLength(2)
+    expect(events.filter((e: unknown) => (e as { eventName: string }).eventName === "ScoreDraftSaved")).toHaveLength(2)
   })
 
   it("supports queue-backed drafts with source=annotation and queue sourceId", async () => {
@@ -325,6 +325,6 @@ describe("persistDraftAnnotation", () => {
     expect(score.sourceId).toBe(queueId)
     expect(score.draftedAt).not.toBeNull()
     expect(store.size).toBe(1)
-    expect(events.filter((e: unknown) => (e as { eventName: string }).eventName === "ScoreCreated")).toHaveLength(1)
+    expect(events.filter((e: unknown) => (e as { eventName: string }).eventName === "ScoreDraftSaved")).toHaveLength(1)
   })
 })

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -26,7 +26,13 @@ export interface EventPayloads {
     readonly projectId: string
     readonly traceId: string
   }
-  ScoreCreated: {
+  ScoreDraftSaved: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly scoreId: string
+    readonly issueId: string | null
+  }
+  ScorePublished: {
     readonly organizationId: string
     readonly projectId: string
     readonly scoreId: string

--- a/packages/domain/scores/src/use-cases/write-score.ts
+++ b/packages/domain/scores/src/use-cases/write-score.ts
@@ -88,7 +88,7 @@ const validateDraftUpdate = (existingScore: Score, input: ParsedWriteScoreInput)
   return null
 }
 
-const scoreCreatedDiscoveryPayloadIssueId = (score: Score, existingScore: Score | null): string | null => {
+const scoreDiscoveryPayloadIssueId = (score: Score, existingScore: Score | null): string | null => {
   if (
     existingScore !== null &&
     existingScore.draftedAt !== null &&
@@ -99,6 +99,9 @@ const scoreCreatedDiscoveryPayloadIssueId = (score: Score, existingScore: Score 
   }
   return null
 }
+
+const scoreEventName = (score: Score): "ScoreDraftSaved" | "ScorePublished" =>
+  score.draftedAt === null ? "ScorePublished" : "ScoreDraftSaved"
 
 const buildScore = ({
   input,
@@ -178,7 +181,7 @@ export const writeScoreUseCase = (input: WriteScoreInput) =>
         yield* scoreRepository.save(score)
 
         yield* outboxEventWriter.write({
-          eventName: "ScoreCreated",
+          eventName: scoreEventName(score),
           aggregateType: "score",
           aggregateId: score.id,
           organizationId: score.organizationId,
@@ -186,7 +189,7 @@ export const writeScoreUseCase = (input: WriteScoreInput) =>
             organizationId: score.organizationId,
             projectId: score.projectId,
             scoreId: score.id,
-            issueId: scoreCreatedDiscoveryPayloadIssueId(score, existingScore),
+            issueId: scoreDiscoveryPayloadIssueId(score, existingScore),
           },
         })
 

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -71,7 +71,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
     expect(persistedRows).toHaveLength(0)
   })
 
-  it("writes ScoreCreated for draft and published score updates (discovery worker noops when ineligible)", async () => {
+  it("writes ScoreDraftSaved for draft writes and ScorePublished for published writes", async () => {
     const organizationId = "dddddddddddddddddddddddd"
     const scoreId = "ssssssssssssssssssssssss"
 
@@ -100,7 +100,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
       )
 
     expect(draftOutboxRows).toHaveLength(1)
-    expect(draftOutboxRows[0]?.eventName).toBe("ScoreCreated")
+    expect(draftOutboxRows[0]?.eventName).toBe("ScoreDraftSaved")
 
     const publishedScore = await Effect.runPromise(
       writeScoreUseCase({
@@ -138,10 +138,10 @@ describe("ScoreRepositoryLive + score use cases", () => {
       )
 
     expect(publicationRequests).toHaveLength(2)
-    expect(publicationRequests.every((r) => r.eventName === "ScoreCreated")).toBe(true)
+    expect(publicationRequests.map((r) => r.eventName)).toEqual(["ScoreDraftSaved", "ScorePublished"])
   })
 
-  it("queues ScoreCreated for failed non-draft scores that still need issue assignment", async () => {
+  it("queues ScorePublished for failed non-draft scores that still need issue assignment", async () => {
     const organizationId = "ffffffffffffffffffffffff"
 
     const score = await Effect.runPromise(
@@ -162,7 +162,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
       .where(and(eq(outboxEvents.organizationId, organizationId), eq(outboxEvents.aggregateId, score.id as string)))
 
     expect(publicationRequests).toHaveLength(1)
-    expect(publicationRequests[0]?.eventName).toBe("ScoreCreated")
+    expect(publicationRequests[0]?.eventName).toBe("ScorePublished")
     expect(publicationRequests[0]?.payload).toEqual({
       organizationId,
       projectId: customProjectId,
@@ -171,7 +171,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
     })
   })
 
-  it("still writes ScoreCreated when the score already carries issueId (discovery worker noops)", async () => {
+  it("still writes ScorePublished when the score already carries issueId (discovery worker noops)", async () => {
     const organizationId = "rrrrrrrrrrrrrrrrrrrrrrrr"
 
     const score = await Effect.runPromise(
@@ -193,7 +193,7 @@ describe("ScoreRepositoryLive + score use cases", () => {
       .where(and(eq(outboxEvents.organizationId, organizationId), eq(outboxEvents.aggregateId, score.id as string)))
 
     expect(publicationRequests).toHaveLength(1)
-    expect(publicationRequests[0]?.eventName).toBe("ScoreCreated")
+    expect(publicationRequests[0]?.eventName).toBe("ScorePublished")
   })
 
   it("claims score issue ownership only once with assignIssueIfUnowned", async () => {


### PR DESCRIPTION
## Issue
Annotating traces from an annotation queue could publish the annotation successfully but still fail to generate an issue. In practice, the first discovery attempt happened while the score was still a draft, and the later published score never triggered an effective discovery run.

## Cause
Every time a human annotated a conversation, a Score is drafted. This emitted a `ScoreCreated` event.

When the `ScoreCreated` event is from a score draft, it does NOT trigger `issues:discovery`.

Then, after 5 minutes, the score draft is published. This emitted a new `ScoreCreated` event with the now published score. However, since the score ID is the same, the job is deduped and never executes again.

## Fix
We split the score lifecycle into two semantic events: `ScoreDraftSaved` and `ScorePublished`.

`ScoreDraftSaved` now only fans out to draft-specific work:
- debounced `annotation-scores:publishHumanAnnotation`
- `annotation-scores:markReviewStarted`

`ScorePublished` now fans out to `issues:discovery`, still deduped by `scoreId`.

This keeps dedupe where it is actually useful, while preventing draft lifecycle work from suppressing the later published-score discovery flow. The PR also updates the worker, repository, annotation, and API tests to match the new event semantics.

## Test Plan
- [x] `cd apps/workers && pnpm test src/workers/domain-events.test.ts`
- [x] `cd apps/api && pnpm test src/routes/scores.test.ts`
- [x] `cd apps/workers && pnpm typecheck`
- [x] `cd apps/api && pnpm typecheck`
- [x] `cd packages/domain/annotations && pnpm typecheck`
- [x] `cd packages/platform/db-postgres && pnpm typecheck`