### PR TITLE
feat: add trace_id filter to traces table

### DIFF
--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -47,14 +47,29 @@ export const useSpanDetail = ({ traceId, spanId }: { traceId: string; spanId: st
 
 interface TracesFilter {
   readonly traceId?: string
+  readonly status?: string
+  readonly startTimeFrom?: string
+  readonly startTimeTo?: string
 }
 
-const makeTracesCollection = ({ projectId, filter }: { projectId: string; filter?: TracesFilter }) =>
+const filterCacheKey = (filter: TracesFilter): string =>
+  [filter.traceId ?? "", filter.status ?? "", filter.startTimeFrom ?? "", filter.startTimeTo ?? ""].join("|")
+
+const makeTracesCollection = ({ projectId, filter }: { projectId: string; filter: TracesFilter }) =>
   createCollection(
     queryCollectionOptions({
       queryClient,
-      queryKey: ["traces", projectId, filter?.traceId ?? ""],
-      queryFn: () => listTracesByProject({ data: { projectId, traceId: filter?.traceId } }),
+      queryKey: ["traces", projectId, filterCacheKey(filter)],
+      queryFn: () =>
+        listTracesByProject({
+          data: {
+            projectId,
+            ...(filter.traceId ? { traceId: filter.traceId } : {}),
+            ...(filter.status ? { status: filter.status } : {}),
+            ...(filter.startTimeFrom ? { startTimeFrom: filter.startTimeFrom } : {}),
+            ...(filter.startTimeTo ? { startTimeTo: filter.startTimeTo } : {}),
+          },
+        }),
       getKey: (item: TraceRecord): string => item.traceId,
     }),
   )
@@ -63,7 +78,7 @@ type TracesCollection = ReturnType<typeof makeTracesCollection>
 const projectCollectionsCache: Record<string, TracesCollection> = {}
 
 const getTracesCollection = (projectId: string, filter: TracesFilter): TracesCollection => {
-  const cacheKey = `${projectId}:${filter.traceId ?? ""}`
+  const cacheKey = `${projectId}:${filterCacheKey(filter)}`
   if (!projectCollectionsCache[cacheKey]) {
     projectCollectionsCache[cacheKey] = makeTracesCollection({ projectId, filter })
   }

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -45,12 +45,16 @@ export const useSpanDetail = ({ traceId, spanId }: { traceId: string; spanId: st
   })
 }
 
-const makeTracesCollection = (projectId: string) =>
+export interface TracesFilter {
+  readonly traceId?: string
+}
+
+const makeTracesCollection = ({ projectId, filter }: { projectId: string; filter?: TracesFilter }) =>
   createCollection(
     queryCollectionOptions({
       queryClient,
-      queryKey: ["traces", projectId],
-      queryFn: () => listTracesByProject({ data: { projectId } }),
+      queryKey: ["traces", projectId, filter?.traceId ?? ""],
+      queryFn: () => listTracesByProject({ data: { projectId, traceId: filter?.traceId } }),
       getKey: (item: TraceRecord): string => item.traceId,
     }),
   )
@@ -58,14 +62,16 @@ const makeTracesCollection = (projectId: string) =>
 type TracesCollection = ReturnType<typeof makeTracesCollection>
 const projectCollectionsCache: Record<string, TracesCollection> = {}
 
-const getTracesCollection = (projectId: string): TracesCollection => {
-  if (!projectCollectionsCache[projectId]) {
-    projectCollectionsCache[projectId] = makeTracesCollection(projectId)
+const getTracesCollection = (projectId: string, filter: TracesFilter): TracesCollection => {
+  const cacheKey = `${projectId}:${filter.traceId ?? ""}`
+  if (!projectCollectionsCache[cacheKey]) {
+    projectCollectionsCache[cacheKey] = makeTracesCollection({ projectId, filter })
   }
-  return projectCollectionsCache[projectId]
+  return projectCollectionsCache[cacheKey]
 }
 
-export const useTracesCollection = (projectId: string) => {
-  const collection = getTracesCollection(projectId)
+export const useTracesCollection = ({ projectId, filter }: { projectId: string; filter?: TracesFilter }) => {
+  const resolved = filter ?? {}
+  const collection = getTracesCollection(projectId, resolved)
   return useLiveQuery((q) => q.from({ trace: collection }))
 }

--- a/apps/web/src/domains/spans/spans.collection.ts
+++ b/apps/web/src/domains/spans/spans.collection.ts
@@ -45,7 +45,7 @@ export const useSpanDetail = ({ traceId, spanId }: { traceId: string; spanId: st
   })
 }
 
-export interface TracesFilter {
+interface TracesFilter {
   readonly traceId?: string
 }
 

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -211,7 +211,7 @@ const serializeTrace = (trace: Trace): TraceRecord => ({
 
 export const listTracesByProject = createServerFn({ method: "GET" })
   .middleware([errorHandler])
-  .inputValidator(z.object({ projectId: z.string() }))
+  .inputValidator(z.object({ projectId: z.string(), traceId: z.string().optional() }))
   .handler(async ({ data }): Promise<TraceRecord[]> => {
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
@@ -221,7 +221,7 @@ export const listTracesByProject = createServerFn({ method: "GET" })
         return yield* repo.findByProjectId({
           organizationId: orgId,
           projectId: ProjectId(data.projectId),
-          options: { limit: 200 },
+          options: { ...(data.traceId ? { traceId: data.traceId } : {}), limit: 200 },
         })
       }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
     )

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -209,9 +209,17 @@ const serializeTrace = (trace: Trace): TraceRecord => ({
   rootSpanName: trace.rootSpanName,
 })
 
+const traceFiltersSchema = z.object({
+  projectId: z.string(),
+  traceId: z.string().optional(),
+  status: z.string().optional(),
+  startTimeFrom: z.string().optional(),
+  startTimeTo: z.string().optional(),
+})
+
 export const listTracesByProject = createServerFn({ method: "GET" })
   .middleware([errorHandler])
-  .inputValidator(z.object({ projectId: z.string(), traceId: z.string().optional() }))
+  .inputValidator(traceFiltersSchema)
   .handler(async ({ data }): Promise<TraceRecord[]> => {
     const { organizationId } = await requireSession()
     const orgId = OrganizationId(organizationId)
@@ -221,7 +229,13 @@ export const listTracesByProject = createServerFn({ method: "GET" })
         return yield* repo.findByProjectId({
           organizationId: orgId,
           projectId: ProjectId(data.projectId),
-          options: { ...(data.traceId ? { traceId: data.traceId } : {}), limit: 200 },
+          options: {
+            ...(data.traceId ? { traceId: data.traceId } : {}),
+            ...(data.status ? { status: data.status } : {}),
+            ...(data.startTimeFrom ? { startTimeFrom: new Date(data.startTimeFrom) } : {}),
+            ...(data.startTimeTo ? { startTimeTo: new Date(data.startTimeTo) } : {}),
+            limit: 200,
+          },
         })
       }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
     )

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -1,5 +1,6 @@
 import {
   Container,
+  Input,
   Table,
   TableBlankSlate,
   TableBody,
@@ -13,6 +14,7 @@ import {
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice } from "@repo/utils"
 import { createFileRoute, Link } from "@tanstack/react-router"
+import { useDeferredValue, useState } from "react"
 import { useTracesCollection } from "../../../../domains/spans/spans.collection.ts"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/")({
@@ -26,12 +28,24 @@ function StatusBadge({ status }: { status: string }) {
 
 function TracesPage() {
   const { projectId } = Route.useParams()
-  const { data: traces } = useTracesCollection(projectId)
+  const [traceIdSearch, setTraceIdSearch] = useState("")
+  const deferredTraceId = useDeferredValue(traceIdSearch)
+  const filter = deferredTraceId ? { traceId: deferredTraceId } : {}
+  const { data: traces } = useTracesCollection({ projectId, filter })
 
   return (
     <Container className="py-8">
       <TableWithHeader
         title="Traces"
+        actions={
+          <Input
+            placeholder="Filter by Trace ID..."
+            value={traceIdSearch}
+            onChange={(e) => setTraceIdSearch(e.target.value)}
+            size="sm"
+            className="w-64"
+          />
+        }
         table={
           !traces ? (
             <TableSkeleton cols={8} rows={5} />

--- a/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectId/index.tsx
@@ -1,6 +1,10 @@
 import {
+  Button,
+  Checkbox,
   Container,
+  Icon,
   Input,
+  Label,
   Table,
   TableBlankSlate,
   TableBody,
@@ -13,103 +17,291 @@ import {
   Text,
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice } from "@repo/utils"
-import { createFileRoute, Link } from "@tanstack/react-router"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { SlidersHorizontal, X } from "lucide-react"
 import { useDeferredValue, useState } from "react"
+import { z } from "zod"
 import { useTracesCollection } from "../../../../domains/spans/spans.collection.ts"
+
+const tracesSearchSchema = z.object({
+  traceId: z.string().optional(),
+  status: z.string().optional(),
+  startTimeFrom: z.string().optional(),
+  startTimeTo: z.string().optional(),
+})
+
+type TracesSearch = z.infer<typeof tracesSearchSchema>
 
 export const Route = createFileRoute("/_authenticated/projects/$projectId/")({
   component: TracesPage,
+  validateSearch: tracesSearchSchema,
 })
+
+const STATUS_OPTIONS = [
+  { value: "ok", label: "OK" },
+  { value: "error", label: "Error" },
+  { value: "unset", label: "Unset" },
+] as const
 
 function StatusBadge({ status }: { status: string }) {
   const color = status === "error" ? "destructive" : "foregroundMuted"
   return <Text.H5 color={color}>{status.toUpperCase()}</Text.H5>
 }
 
-function TracesPage() {
-  const { projectId } = Route.useParams()
-  const [traceIdSearch, setTraceIdSearch] = useState("")
-  const deferredTraceId = useDeferredValue(traceIdSearch)
-  const filter = deferredTraceId ? { traceId: deferredTraceId } : {}
-  const { data: traces } = useTracesCollection({ projectId, filter })
+function hasActiveFilters(search: TracesSearch): boolean {
+  return !!(search.traceId || search.status || search.startTimeFrom || search.startTimeTo)
+}
+
+function FiltersSidebar({
+  search,
+  onUpdate,
+}: {
+  search: TracesSearch
+  onUpdate: (patch: Partial<TracesSearch>) => void
+}) {
+  const [localTraceId, setLocalTraceId] = useState(search.traceId ?? "")
 
   return (
-    <Container className="py-8">
-      <TableWithHeader
-        title="Traces"
-        actions={
-          <Input
-            placeholder="Filter by Trace ID..."
-            value={traceIdSearch}
-            onChange={(e) => setTraceIdSearch(e.target.value)}
+    <aside className="w-[280px] shrink-0 border-r border-border flex flex-col h-full overflow-y-auto">
+      <div className="flex items-center justify-between p-4 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Icon icon={SlidersHorizontal} size="sm" color="foregroundMuted" />
+          <Text.H5 weight="bold">Filters</Text.H5>
+        </div>
+        {hasActiveFilters(search) && (
+          <Button
+            variant="ghost"
             size="sm"
-            className="w-64"
+            flat
+            onClick={() =>
+              onUpdate({ traceId: undefined, status: undefined, startTimeFrom: undefined, startTimeTo: undefined })
+            }
+          >
+            <Text.H6 color="foregroundMuted">Clear all</Text.H6>
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-6 p-4">
+        {/* Trace ID */}
+        <div className="flex flex-col gap-2">
+          <Label>
+            <Text.H6 weight="medium" color="foregroundMuted">
+              Trace ID
+            </Text.H6>
+          </Label>
+          <div className="flex flex-row gap-2">
+            <Input
+              placeholder="Search by trace ID..."
+              value={localTraceId}
+              onChange={(e) => setLocalTraceId(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  onUpdate({ traceId: localTraceId || undefined })
+                }
+              }}
+              onBlur={() => onUpdate({ traceId: localTraceId || undefined })}
+              size="sm"
+            />
+            {localTraceId && (
+              <Button
+                variant="ghost"
+                size="icon"
+                flat
+                className="h-8 w-8 shrink-0"
+                onClick={() => {
+                  setLocalTraceId("")
+                  onUpdate({ traceId: undefined })
+                }}
+              >
+                <Icon icon={X} size="sm" color="foregroundMuted" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Status */}
+        <div className="flex flex-col gap-2">
+          <Label>
+            <Text.H6 weight="medium" color="foregroundMuted">
+              Status
+            </Text.H6>
+          </Label>
+          <div className="flex flex-col gap-1">
+            {STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="flex items-center gap-2 px-1 py-1.5 rounded-md hover:bg-muted cursor-pointer text-left"
+                onClick={() => onUpdate({ status: search.status === opt.value ? undefined : opt.value })}
+              >
+                <Checkbox
+                  checked={search.status === opt.value}
+                  onCheckedChange={(checked) => {
+                    onUpdate({ status: checked ? opt.value : undefined })
+                  }}
+                />
+                <Text.H5 color={search.status === opt.value ? "foreground" : "foregroundMuted"}>{opt.label}</Text.H5>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Time range */}
+        <div className="flex flex-col gap-2">
+          <Label>
+            <Text.H6 weight="medium" color="foregroundMuted">
+              Time range
+            </Text.H6>
+          </Label>
+          <div className="flex flex-col gap-2">
+            <Input
+              type="datetime-local"
+              value={search.startTimeFrom ? toLocalDatetime(search.startTimeFrom) : ""}
+              onChange={(e) =>
+                onUpdate({ startTimeFrom: e.target.value ? new Date(e.target.value).toISOString() : undefined })
+              }
+              size="sm"
+            />
+            <Text.H6 color="foregroundMuted" className="text-center">
+              to
+            </Text.H6>
+            <Input
+              type="datetime-local"
+              value={search.startTimeTo ? toLocalDatetime(search.startTimeTo) : ""}
+              onChange={(e) =>
+                onUpdate({ startTimeTo: e.target.value ? new Date(e.target.value).toISOString() : undefined })
+              }
+              size="sm"
+            />
+          </div>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+function toLocalDatetime(iso: string): string {
+  const d = new Date(iso)
+  const offset = d.getTimezoneOffset()
+  const local = new Date(d.getTime() - offset * 60_000)
+  return local.toISOString().slice(0, 16)
+}
+
+function TracesPage() {
+  const { projectId } = Route.useParams()
+  const search = Route.useSearch()
+  const navigate = useNavigate()
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+
+  const deferredSearch = useDeferredValue(search)
+  const filter = {
+    ...(deferredSearch.traceId ? { traceId: deferredSearch.traceId } : {}),
+    ...(deferredSearch.status ? { status: deferredSearch.status } : {}),
+    ...(deferredSearch.startTimeFrom ? { startTimeFrom: deferredSearch.startTimeFrom } : {}),
+    ...(deferredSearch.startTimeTo ? { startTimeTo: deferredSearch.startTimeTo } : {}),
+  }
+  const { data: traces } = useTracesCollection({ projectId, filter })
+
+  const updateSearch = (patch: Partial<TracesSearch>) => {
+    navigate({
+      to: ".",
+      search: (prev: TracesSearch) => {
+        const next = { ...prev, ...patch }
+        return Object.fromEntries(Object.entries(next).filter(([_, v]) => v !== undefined))
+      },
+      replace: true,
+    })
+  }
+
+  const activeFilterCount = [search.traceId, search.status, search.startTimeFrom || search.startTimeTo].filter(
+    Boolean,
+  ).length
+
+  return (
+    <div className="flex h-full">
+      {sidebarOpen && <FiltersSidebar search={search} onUpdate={updateSearch} />}
+      <div className="flex-1 min-w-0 overflow-y-auto">
+        <Container className="py-8">
+          <TableWithHeader
+            title="Traces"
+            actions={
+              <Button variant={sidebarOpen ? "outline" : "ghost"} size="sm" onClick={() => setSidebarOpen((v) => !v)}>
+                <Icon icon={SlidersHorizontal} size="sm" />
+                <Text.H5>Filters</Text.H5>
+                {activeFilterCount > 0 && (
+                  <span className="inline-flex items-center justify-center rounded-full bg-accent px-1.5 text-xs text-accent-foreground">
+                    {activeFilterCount}
+                  </span>
+                )}
+              </Button>
+            }
+            table={
+              !traces ? (
+                <TableSkeleton cols={8} rows={5} />
+              ) : traces.length === 0 ? (
+                <TableBlankSlate description="No traces found for this project." />
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Spans</TableHead>
+                      <TableHead>Models</TableHead>
+                      <TableHead>Tokens (in/out)</TableHead>
+                      <TableHead>Cost</TableHead>
+                      <TableHead>Duration</TableHead>
+                      <TableHead>Start Time</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {traces.map((trace) => (
+                      <TableRow key={trace.traceId}>
+                        <TableCell>
+                          <Link
+                            to="/projects/$projectId/traces/$traceId/spans"
+                            params={{ projectId, traceId: trace.traceId }}
+                            className="underline"
+                          >
+                            <Text.H5>{trace.rootSpanName || trace.traceId.slice(0, 8)}</Text.H5>
+                          </Link>
+                        </TableCell>
+                        <TableCell>
+                          <StatusBadge status={trace.status} />
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5>
+                            {formatCount(trace.spanCount)}
+                            {trace.errorCount > 0 && <Text.H6 color="destructive"> ({trace.errorCount} err)</Text.H6>}
+                          </Text.H5>
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5>{trace.models.join(", ") || "\u2014"}</Text.H5>
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5>
+                            {formatCount(trace.tokensInput)} / {formatCount(trace.tokensOutput)}
+                          </Text.H5>
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5>{formatPrice(trace.costTotalMicrocents / 100_000_000)}</Text.H5>
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5>{formatDuration(trace.durationNs)}</Text.H5>
+                        </TableCell>
+                        <TableCell>
+                          <Text.H5 color="foregroundMuted">{new Date(trace.startTime).toLocaleString()}</Text.H5>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )
+            }
           />
-        }
-        table={
-          !traces ? (
-            <TableSkeleton cols={8} rows={5} />
-          ) : traces.length === 0 ? (
-            <TableBlankSlate description="No traces found for this project." />
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Spans</TableHead>
-                  <TableHead>Models</TableHead>
-                  <TableHead>Tokens (in/out)</TableHead>
-                  <TableHead>Cost</TableHead>
-                  <TableHead>Duration</TableHead>
-                  <TableHead>Start Time</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {traces.map((trace) => (
-                  <TableRow key={trace.traceId}>
-                    <TableCell>
-                      <Link
-                        to="/projects/$projectId/traces/$traceId/spans"
-                        params={{ projectId, traceId: trace.traceId }}
-                        className="underline"
-                      >
-                        <Text.H5>{trace.rootSpanName || trace.traceId.slice(0, 8)}</Text.H5>
-                      </Link>
-                    </TableCell>
-                    <TableCell>
-                      <StatusBadge status={trace.status} />
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>
-                        {formatCount(trace.spanCount)}
-                        {trace.errorCount > 0 && <Text.H6 color="destructive"> ({trace.errorCount} err)</Text.H6>}
-                      </Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{trace.models.join(", ") || "—"}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>
-                        {formatCount(trace.tokensInput)} / {formatCount(trace.tokensOutput)}
-                      </Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{formatPrice(trace.costTotalMicrocents / 100_000_000)}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5>{formatDuration(trace.durationNs)}</Text.H5>
-                    </TableCell>
-                    <TableCell>
-                      <Text.H5 color="foregroundMuted">{new Date(trace.startTime).toLocaleString()}</Text.H5>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )
-        }
-      />
-    </Container>
+        </Container>
+      </div>
+    </div>
   )
 }

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -23,6 +23,7 @@ export interface TraceRepositoryShape {
 }
 
 export interface TraceListOptions {
+  readonly traceId?: string
   readonly startTimeFrom?: Date
   readonly startTimeTo?: Date
   readonly limit?: number

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -24,6 +24,7 @@ export interface TraceRepositoryShape {
 
 export interface TraceListOptions {
   readonly traceId?: string
+  readonly status?: string
   readonly startTimeFrom?: Date
   readonly startTimeTo?: Date
   readonly limit?: number

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -22,6 +22,12 @@ const INT_TO_STATUS: Record<number, TraceStatus> = {
   2: "error",
 }
 
+const STATUS_TO_INT: Record<string, number> = {
+  unset: 0,
+  ok: 1,
+  error: 2,
+}
+
 const LIST_SELECT = `
   organization_id,
   project_id,
@@ -147,6 +153,7 @@ export const TraceRepositoryLive = Layer.effect(
                         AND ({hasStartFrom:Bool} = false OR min_start_time >= {startTimeFrom:DateTime64(9, 'UTC')})
                         AND ({hasStartTo:Bool} = false OR min_start_time <= {startTimeTo:DateTime64(9, 'UTC')})
                       GROUP BY organization_id, project_id, trace_id
+                      HAVING {hasStatus:Bool} = false OR overall_status = {statusValue:Int16}
                       ORDER BY start_time DESC
                       LIMIT {limit:UInt32}
                       OFFSET {offset:UInt32}`,
@@ -159,6 +166,8 @@ export const TraceRepositoryLive = Layer.effect(
                 startTimeFrom: toClickhouseDateTime(options.startTimeFrom) ?? "1970-01-01 00:00:00.000000000",
                 hasStartTo: options.startTimeTo !== undefined,
                 startTimeTo: toClickhouseDateTime(options.startTimeTo) ?? "2100-01-01 00:00:00.000000000",
+                hasStatus: options.status !== undefined && options.status !== "",
+                statusValue: STATUS_TO_INT[options.status ?? ""] ?? 0,
                 limit: options.limit ?? 50,
                 offset: options.offset ?? 0,
               },

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -143,6 +143,7 @@ export const TraceRepositoryLive = Layer.effect(
                       FROM traces
                       WHERE organization_id = {organizationId:String}
                         AND project_id = {projectId:String}
+                        AND ({hasTraceId:Bool} = false OR trace_id LIKE {traceIdPattern:String})
                         AND ({hasStartFrom:Bool} = false OR min_start_time >= {startTimeFrom:DateTime64(9, 'UTC')})
                         AND ({hasStartTo:Bool} = false OR min_start_time <= {startTimeTo:DateTime64(9, 'UTC')})
                       GROUP BY organization_id, project_id, trace_id
@@ -152,6 +153,8 @@ export const TraceRepositoryLive = Layer.effect(
               query_params: {
                 organizationId: organizationId as string,
                 projectId: projectId as string,
+                hasTraceId: options.traceId !== undefined && options.traceId !== "",
+                traceIdPattern: options.traceId ? `%${options.traceId}%` : "%",
                 hasStartFrom: options.startTimeFrom !== undefined,
                 startTimeFrom: toClickhouseDateTime(options.startTimeFrom) ?? "1970-01-01 00:00:00.000000000",
                 hasStartTo: options.startTimeTo !== undefined,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a filter sidebar to the traces table, following the same pattern as other filterable views. Users can filter traces by trace ID, status, and time range.

## Changes

**Domain layer** (`packages/domain/spans`)
- Added optional `traceId` and `status` fields to `TraceListOptions` interface

**ClickHouse query layer** (`packages/platform/db-clickhouse`)
- Added `LIKE`-based `trace_id` filter to the `findByProjectId` query (supports partial/substring matching)
- Added `HAVING` clause for status filter using `overall_status` column
- Both use the same boolean-flag pattern as existing time range filters

**Server function** (`apps/web/src/domains/spans`)
- Extended `listTracesByProject` input validator to accept `traceId`, `status`, `startTimeFrom`, `startTimeTo`
- Passes all filter params through to the repository

**Collection** (`apps/web/src/domains/spans`)
- Updated `TracesFilter` to include all filter fields (traceId, status, startTimeFrom, startTimeTo)
- Updated collection cache key to include all filter dimensions
- Spread filter params to the server function call, only including non-empty values

**UI** (`apps/web/src/routes`)
- Built a filter sidebar panel with:
  - **Trace ID** text input with search-on-enter/blur and clear button
  - **Status** checkboxes (OK, Error, Unset) — single-select toggle
  - **Time range** datetime-local inputs for start/end bounds
  - **Clear all** button in sidebar header (shows when any filter is active)
- Filters persisted in URL search params via TanStack Router `validateSearch`
- Toggle button with active filter count badge
- `useDeferredValue` for smooth UI during re-fetches

## Demo

[traces_filter_sidebar_demo.mp4](https://cursor.com/agents/bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraces_filter_sidebar_demo.mp4)

### Filter sidebar open (default state)
[Filter sidebar open](https://cursor.com/agents/bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilter_sidebar_open.webp)

### Sidebar closed — full-width table
[Filter sidebar closed](https://cursor.com/agents/bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilter_sidebar_closed.webp)

### Error status filter applied
[Error status filter applied](https://cursor.com/agents/bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffilter_error_status_applied.webp)

## Testing

- All lint checks pass (`pnpm check`)
- All type checks pass (`pnpm typecheck`)
- All tests pass (`pnpm test` — 55 tasks)
- Knip passes (no unused exports)
- Manual UI testing confirms all filter interactions work correctly

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://latitudedata.slack.com/archives/C0AJAR286FK/p1776262122015979?thread_ts=1776262122.015979&cid=C0AJAR286FK)

<div><a href="https://cursor.com/agents/bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d0fd5ab-5a5e-508e-b300-48a585f4f11c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

