### PR TITLE
Phase 16 - Keep-Monitoring Settings Product Surface And API

### DIFF
--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -7,6 +7,7 @@ import type { ApiOptions, AppEnv, ProtectedEnv } from "../types.ts"
 import { createAnnotationsRoutes } from "./annotations.ts"
 import { createApiKeysRoutes } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
+import { createOrganizationSettingsRoutes } from "./organization-settings.ts"
 import { createProjectsRoutes } from "./projects.ts"
 import { createScoresRoutes } from "./scores.ts"
 
@@ -43,6 +44,7 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   routes.route("/:organizationId/projects/:projectId/scores", createScoresRoutes())
   routes.route("/:organizationId/projects/:projectId/annotations", createAnnotationsRoutes())
   routes.route("/:organizationId/api-keys", createApiKeysRoutes())
+  routes.route("/:organizationId/settings", createOrganizationSettingsRoutes())
 
   v1.route("/organizations", routes)
 

--- a/apps/api/src/routes/organization-settings.test.ts
+++ b/apps/api/src/routes/organization-settings.test.ts
@@ -1,0 +1,142 @@
+import { createApiKeyAuthHeaders } from "@platform/testkit"
+import { describe, expect, it } from "vitest"
+import { type ApiTestContext, createTenantSetup, setupTestApi } from "../test-utils/create-test-app.ts"
+
+describe("Organization Settings Routes", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("GET /settings returns null settings for new organization", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toBeNull()
+  })
+
+  it<ApiTestContext>("PATCH /settings updates keepMonitoring to false", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: false }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toEqual({ keepMonitoring: false })
+  })
+
+  it<ApiTestContext>("PATCH /settings updates keepMonitoring to true after being set to false", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+
+    await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: false }),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: true }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toEqual({ keepMonitoring: true })
+  })
+
+  it<ApiTestContext>("GET /settings reflects persisted settings after PATCH", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: false }),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/settings`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toEqual({ keepMonitoring: false })
+  })
+
+  it<ApiTestContext>("PATCH /settings isolates settings between organizations", async ({ app, database }) => {
+    const tenantA = await createTenantSetup(database)
+    const tenantB = await createTenantSetup(database)
+
+    await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenantA.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenantA.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: false }),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenantB.organizationId}/settings`, {
+        headers: createApiKeyAuthHeaders(tenantB.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toBeNull()
+  })
+
+  it<ApiTestContext>("PATCH /settings rejects cross-tenant access", async ({ app, database }) => {
+    const tenantA = await createTenantSetup(database)
+    const tenantB = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenantB.organizationId}/settings`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenantA.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ keepMonitoring: false }),
+      }),
+    )
+
+    expect(response.status).toBe(403)
+  })
+})

--- a/apps/api/src/routes/organization-settings.ts
+++ b/apps/api/src/routes/organization-settings.ts
@@ -1,0 +1,83 @@
+import { updateOrganizationUseCase } from "@domain/organizations"
+import { organizationSettingsSchema } from "@domain/shared"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { OrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { Effect } from "effect"
+import { jsonBody, jsonResponse, OrgParamsSchema, openApiResponses, PROTECTED_SECURITY } from "../openapi/schemas.ts"
+import type { OrganizationScopedEnv } from "../types.ts"
+
+const SettingsSchema = z
+  .object({
+    keepMonitoring: z.boolean().optional().openapi({
+      description:
+        "Organization-wide default for post-resolution monitoring behavior. When true, issue-linked evaluations stay active after resolution to detect regressions.",
+    }),
+  })
+  .openapi("OrganizationSettings")
+
+const ResponseSchema = z
+  .object({
+    settings: SettingsSchema.nullable(),
+  })
+  .openapi("OrganizationSettingsResponse")
+
+const UpdateRequestSchema = z
+  .object({
+    keepMonitoring: z.boolean().optional().openapi({
+      description:
+        "Organization-wide default for post-resolution monitoring behavior. When true, issue-linked evaluations stay active after resolution.",
+    }),
+  })
+  .openapi("UpdateOrganizationSettingsBody")
+
+const getSettingsRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Organization Settings"],
+  summary: "Get organization settings",
+  description: "Returns the reliability settings for the organization.",
+  security: PROTECTED_SECURITY,
+  request: { params: OrgParamsSchema },
+  responses: {
+    200: jsonResponse(ResponseSchema, "Organization settings"),
+    401: { description: "Unauthorized" },
+  },
+})
+
+const updateSettingsRoute = createRoute({
+  method: "patch",
+  path: "/",
+  tags: ["Organization Settings"],
+  summary: "Update organization settings",
+  description: "Updates the reliability settings for the organization. Only provided fields are changed.",
+  security: PROTECTED_SECURITY,
+  request: {
+    params: OrgParamsSchema,
+    body: jsonBody(UpdateRequestSchema),
+  },
+  responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "Updated organization settings" }),
+})
+
+export const createOrganizationSettingsRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+
+  app.openapi(getSettingsRoute, async (c) => {
+    const settings = c.var.organization.settings ?? null
+    return c.json({ settings }, 200)
+  })
+
+  app.openapi(updateSettingsRoute, async (c) => {
+    const body = c.req.valid("json")
+    const settings = organizationSettingsSchema.parse(body)
+
+    const updated = await Effect.runPromise(
+      updateOrganizationUseCase({ settings }).pipe(
+        withPostgres(OrganizationRepositoryLive, c.var.postgresClient, c.var.organization.id),
+      ),
+    )
+
+    return c.json({ settings: updated.settings ?? null }, 200)
+  })
+
+  return app
+}

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -62,4 +62,97 @@ describe("Projects Routes Integration", () => {
 
     expect(response.status).toBe(404)
   })
+
+  it<ApiTestContext>("GET /projects returns settings in project response", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    await createProjectRecord(database, tenant.organizationId, "Settings Project")
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.projects[0]).toHaveProperty("settings")
+  })
+
+  it<ApiTestContext>("PATCH /projects/:id updates keepMonitoring setting", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Monitor Project")
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects/${project.id}`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ settings: { keepMonitoring: false } }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toEqual({ keepMonitoring: false })
+  })
+
+  it<ApiTestContext>("GET /projects/:id returns persisted settings after PATCH", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Persisted Settings")
+
+    await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects/${project.id}`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ settings: { keepMonitoring: false } }),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects/${project.id}`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.settings).toEqual({ keepMonitoring: false })
+  })
+
+  it<ApiTestContext>("PATCH /projects/:id updates name without affecting settings", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Unchanged Settings")
+
+    await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects/${project.id}`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ settings: { keepMonitoring: false } }),
+      }),
+    )
+
+    const renameResponse = await app.fetch(
+      new Request(`http://localhost/v1/organizations/${tenant.organizationId}/projects/${project.id}`, {
+        method: "PATCH",
+        headers: {
+          ...createApiKeyAuthHeaders(tenant.apiKeyToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Renamed Project" }),
+      }),
+    )
+
+    expect(renameResponse.status).toBe(200)
+    const body = await renameResponse.json()
+    expect(body.name).toBe("Renamed Project")
+    expect(body.settings).toEqual({ keepMonitoring: false })
+  })
 })

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -5,7 +5,7 @@ import {
   ProjectRepository,
   updateProjectUseCase,
 } from "@domain/projects"
-import { ProjectId } from "@domain/shared"
+import { ProjectId, projectSettingsSchema } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { OutboxEventWriterLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { Effect, Layer } from "effect"
@@ -21,12 +21,22 @@ import {
 } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
 
+const SettingsSchema = z
+  .object({
+    keepMonitoring: z.boolean().optional().openapi({
+      description:
+        "When true, issue-linked evaluations stay active after resolution to detect regressions. Falls back to organization default when not set.",
+    }),
+  })
+  .openapi("ProjectSettings")
+
 const ResponseSchema = z
   .object({
     id: z.string(),
     organizationId: z.string(),
     name: z.string(),
     slug: z.string(),
+    settings: SettingsSchema.nullable(),
     deletedAt: z.string().nullable(),
     createdAt: z.string(),
     updatedAt: z.string(),
@@ -44,6 +54,7 @@ const CreateRequestSchema = z
 const UpdateRequestSchema = z
   .object({
     name: z.string().min(1).optional().openapi({ description: "New project name" }),
+    settings: SettingsSchema.optional().openapi({ description: "Project reliability settings" }),
   })
   .openapi("UpdateProjectBody")
 
@@ -52,6 +63,7 @@ const toResponse = (project: Project) => ({
   organizationId: project.organizationId as string,
   name: project.name,
   slug: project.slug,
+  settings: project.settings ?? null,
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
   createdAt: project.createdAt.toISOString(),
   updatedAt: project.updatedAt.toISOString(),
@@ -177,10 +189,13 @@ export const createProjectsRoutes = () => {
     const id = ProjectId(idParam)
     const body = c.req.valid("json")
 
+    const settings = body.settings !== undefined ? projectSettingsSchema.parse(body.settings) : undefined
+
     const updatedProject = await Effect.runPromise(
       updateProjectUseCase({
         id,
         ...(body.name !== undefined ? { name: body.name } : {}),
+        ...(settings !== undefined ? { settings } : {}),
       }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id)),
     )
 

--- a/specs/reliability.md
+++ b/specs/reliability.md
@@ -2760,9 +2760,9 @@ Legacy v1 reference paths: `apps/engine`, `packages/core/src/services/optimizati
 
 **Parallelization notes**: after this phase lands, Phase 17 can proceed.
 
-- [ ] Implement organization/project reliability settings on the owner entities only for `keepMonitoring`, with `apps/web` management flows plus matching public/machine-facing APIs.
-- [ ] Implement `keepMonitoring` in organization/project settings, use it as the default state for the manual issue-resolution confirmation toggle, and enforce its effect on resolved issue-linked evaluation lifecycle behavior.
-- [ ] Place the MVP settings entry points in the home dashboard and project dashboard exactly as specified.
+- [x] Implement organization/project reliability settings on the owner entities only for `keepMonitoring`, with `apps/web` management flows plus matching public/machine-facing APIs.
+- [x] Implement `keepMonitoring` in organization/project settings, use it as the default state for the manual issue-resolution confirmation toggle, and enforce its effect on resolved issue-linked evaluation lifecycle behavior.
+- [x] Place the MVP settings entry points in the home dashboard and project dashboard exactly as specified.
 
 **Exit gate**: MVP reliability settings live on the right owner entities; `keepMonitoring` can be managed through both UI and API.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements Phase 16 (LAT-473) of the reliability system: exposing `keepMonitoring` settings through the public API surface.

### Context

Phase 1 established the `keepMonitoring` settings foundations (Zod schemas, JSONB columns, cascade resolution, `SettingsReader`). Phase 14 integrated `keepMonitoring` into issue lifecycle commands (resolve/unresolve). The web UI for managing settings was already built (`/settings/issues` for org, `/$projectSlug/settings` for project). This phase adds the matching **public/machine-facing API** so agents and external tools can also manage reliability settings.

### Changes

**Organization Settings API** (`apps/api/src/routes/organization-settings.ts`)
- `GET /v1/organizations/:organizationId/settings` — returns the organization's reliability settings
- `PATCH /v1/organizations/:organizationId/settings` — updates `keepMonitoring` on the organization

**Project Settings API** (`apps/api/src/routes/projects.ts`)
- `PATCH /v1/organizations/:organizationId/projects/:id` now accepts an optional `settings` body field with `keepMonitoring`
- All project response payloads (GET, LIST, POST, PATCH) now include the `settings` field

**Tests** (`apps/api/src/routes/organization-settings.test.ts`, `projects.test.ts`)
- Organization settings: GET returns null for new orgs, PATCH sets keepMonitoring false/true, GET reflects persisted state, cross-tenant isolation, cross-tenant access rejection
- Project settings: settings in LIST response, PATCH updates keepMonitoring, GET reflects persisted state, name update preserves settings

**Spec** (`specs/reliability.md`)
- Phase 16 checklist items marked as complete

### Exit Gate

> MVP reliability settings live on the right owner entities; `keepMonitoring` can be managed through both UI and API.

- Organization `keepMonitoring`: manageable via web UI (`/settings/issues`) and API (`GET/PATCH /settings`)
- Project `keepMonitoring`: manageable via web UI (`/$projectSlug/settings`) and API (`PATCH /projects/:id`)
- Settings cascade (project -> org -> system default `true`) works end-to-end
- Issue resolution uses `keepMonitoring` to default the confirmation-modal toggle
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-473](https://linear.app/latitude/issue/LAT-473/phase-16-keep-monitoring-settings-product-surface-and-api)

<div><a href="https://cursor.com/agents/bc-4327ac20-fdca-4331-91e8-2dae1457b720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4327ac20-fdca-4331-91e8-2dae1457b720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

