### PR TITLE
LAT-474: Annotation text selection, anchor persistence on update, and scroll-safe popover

### DIFF
--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, Icon, Text, Tooltip, useLocalStorage } from "@repo/ui"
+import { Button, cn, Icon, Text, Tooltip, useLocalStorage, useValueWithDefault } from "@repo/ui"
 import { extractLeadingEmoji } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { Link } from "@tanstack/react-router"
@@ -222,6 +222,7 @@ export function NavItem({
 function useShouldCollapseSidebar() {
   return useHasMatchStaticData((staticData) => staticData?.collapseSidebar === true)
 }
+
 export function AppSidebar({
   title,
   subtitle,
@@ -234,12 +235,21 @@ export function AppSidebar({
   footer?: (props: { collapsed: boolean }) => ReactNode
 }) {
   const autoCollapse = useShouldCollapseSidebar()
-  const { value: collapsedPreference, setValue: setCollapsedPreference } = useLocalStorage<boolean | null>({
+  const { value: storedCollapsed, setValue: setStoredCollapsed } = useLocalStorage<boolean | null>({
     key: "app-sidebar-collapsed",
     defaultValue: null,
   })
-  const collapsed = collapsedPreference ?? autoCollapse
-  const toggleCollapsed = () => setCollapsedPreference((value) => !(value ?? autoCollapse))
+
+  const defaultCollapseToken = autoCollapse ? "narrow" : storedCollapsed === true ? "narrow" : "wide"
+
+  const [collapseToken, setCollapseToken] = useValueWithDefault(defaultCollapseToken)
+  const collapsed = collapseToken === "narrow"
+
+  const toggleCollapsed = () => {
+    const nextCollapsed = !collapsed
+    setCollapseToken(nextCollapsed ? "narrow" : "wide")
+    setStoredCollapsed(nextCollapsed)
+  }
   useHotkeys([{ hotkey: "Mod+B", callback: toggleCollapsed }])
 
   return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover-content.tsx
@@ -48,7 +48,7 @@ export function AnnotationPopoverContent({
 }
 
 const ANNOTATION_POPOVER_CONTENT_CLASS =
-  "w-96 max-h-[70vh] overflow-y-auto p-1 rounded-2xl bg-secondary border-0 shadow"
+  "w-[400px] max-h-[70vh] overflow-y-auto p-1 rounded-2xl bg-secondary border-0 shadow"
 
 function handleInteractOutside(e: Event) {
   const target = e.target as HTMLElement

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-popover.tsx
@@ -1,10 +1,11 @@
 import { Popover, PopoverAnchor } from "@repo/ui"
-import { useRef } from "react"
+import { type RefObject, useRef } from "react"
 import type { AnnotationRecord } from "../../../../../../domains/annotations/annotations.functions.ts"
 import { AnnotationPopoverContent, AnnotationPopoverWrapper } from "./annotation-popover-content.tsx"
 
 export interface AnnotationPopoverProps {
   readonly position: { x: number; y: number } | null
+  readonly scrollContainerRef?: RefObject<HTMLElement | null> | undefined
   readonly projectId: string
   readonly annotations: readonly AnnotationRecord[]
   readonly showCreateForm?: boolean
@@ -12,11 +13,13 @@ export interface AnnotationPopoverProps {
   readonly isUpdateLoading?: boolean
   readonly onSave: (data: { passed: boolean; comment: string; issueId: string | null }) => void
   readonly onUpdate: (annotationId: string, data: { passed: boolean; comment: string; issueId: string | null }) => void
+  readonly onDelete?: (() => void) | undefined
   readonly onClose: () => void
 }
 
 export function AnnotationPopover({
   position,
+  scrollContainerRef,
   projectId,
   annotations,
   showCreateForm = true,
@@ -24,13 +27,32 @@ export function AnnotationPopover({
   isUpdateLoading = false,
   onSave,
   onUpdate,
+  onDelete,
   onClose,
 }: AnnotationPopoverProps) {
   const lastAnchorRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const scrollAtOpenRef = useRef(0)
+
   if (position !== null) {
     lastAnchorRef.current = position
+    scrollAtOpenRef.current = scrollContainerRef?.current?.scrollTop ?? 0
   }
   const anchorPoint = position ?? lastAnchorRef.current
+
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => DOMRect.fromRect({ width: 0, height: 0, x: anchorPoint.x, y: anchorPoint.y }),
+  })
+  virtualRef.current = {
+    getBoundingClientRect: () => {
+      const scrollDelta = (scrollContainerRef?.current?.scrollTop ?? 0) - scrollAtOpenRef.current
+      return DOMRect.fromRect({
+        width: 0,
+        height: 0,
+        x: anchorPoint.x,
+        y: anchorPoint.y - scrollDelta,
+      })
+    },
+  }
 
   function handleOpenChange(open: boolean) {
     if (!open) {
@@ -40,20 +62,9 @@ export function AnnotationPopover({
 
   return (
     <Popover open={position !== null} onOpenChange={handleOpenChange}>
-      <PopoverAnchor asChild>
-        <span
-          style={{
-            position: "fixed",
-            left: anchorPoint.x,
-            top: anchorPoint.y,
-            width: 0,
-            height: 0,
-            pointerEvents: "none",
-          }}
-        />
-      </PopoverAnchor>
+      <PopoverAnchor virtualRef={virtualRef} />
 
-      <AnnotationPopoverWrapper data-selection-popover sideOffset={8}>
+      <AnnotationPopoverWrapper data-selection-popover sideOffset={8} updatePositionStrategy="always">
         <AnnotationPopoverContent
           projectId={projectId}
           annotations={annotations}
@@ -62,7 +73,7 @@ export function AnnotationPopover({
           isUpdateLoading={isUpdateLoading}
           onSave={onSave}
           onUpdate={onUpdate}
-          onDelete={onClose}
+          onDelete={onDelete ?? onClose}
         />
       </AnnotationPopoverWrapper>
     </Popover>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.test.ts
@@ -71,7 +71,7 @@ describe("useAnnotationNavigation", () => {
     document.body.innerHTML = ""
   })
 
-  it("opens and repositions the text-selection popover before smooth scroll ends", () => {
+  it("opens the text-selection popover only after scrollend on the scroll container", () => {
     const container = document.createElement("div")
     const partRoot = document.createElement("div")
     partRoot.setAttribute("data-part-index", "0")
@@ -110,21 +110,19 @@ describe("useAnnotationNavigation", () => {
       result.current.scrollToAnnotation(annotation)
     })
 
-    expect(openExistingAnnotationPopover).toHaveBeenCalledWith(annotation, { x: 40, y: 140 })
+    expect(textElement.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" })
+    expect(openExistingAnnotationPopover).not.toHaveBeenCalled()
+    expect(updateTextSelectionPopoverPosition).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
 
     currentRect = createRect(72, 220)
     act(() => {
-      container.dispatchEvent(new Event("scroll"))
-    })
-
-    expect(updateTextSelectionPopoverPosition).toHaveBeenLastCalledWith({ x: 72, y: 220 })
-
-    act(() => {
       container.dispatchEvent(new Event("scrollend"))
     })
 
+    expect(openExistingAnnotationPopover).toHaveBeenCalledTimes(1)
+    expect(openExistingAnnotationPopover).toHaveBeenCalledWith(annotation, { x: 72, y: 220 })
+    expect(updateTextSelectionPopoverPosition).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
-    expect(updateTextSelectionPopoverPosition).toHaveBeenLastCalledWith({ x: 72, y: 220 })
   })
 })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-navigation.ts
@@ -5,6 +5,28 @@ import type { TextSelectionPopoverControls } from "./use-annotation-popover.ts"
 const HIGHLIGHT_BOX_SHADOW = "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--primary) / 0.5)"
 const HIGHLIGHT_DURATION_MS = 4000
 const POPOVER_VIEWPORT_PADDING = 24
+/**
+ * `scrollend` does not bubble — it fires only on the element whose scroll offset changed.
+ * `scrollIntoView` may scroll an ancestor of `container`, so we walk up from the target.
+ */
+function findScrollport(element: HTMLElement, root: HTMLElement): HTMLElement {
+  let node: HTMLElement | null = element
+  while (node) {
+    if (node === root) {
+      return root
+    }
+    const { overflowY } = getComputedStyle(node)
+    const canScrollY = node.scrollHeight > node.clientHeight + 1
+    if (canScrollY && (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay")) {
+      return node
+    }
+    node = node.parentElement
+    if (node && !root.contains(node)) {
+      return root
+    }
+  }
+  return root
+}
 
 export function isGlobalAnnotation(annotation: AnnotationRecord): boolean {
   return annotation.metadata.messageIndex === undefined
@@ -38,7 +60,6 @@ export function useAnnotationNavigation({
   const currentPopoverCardRef = useRef<HTMLElement | null>(null)
   const observerRef = useRef<MutationObserver | null>(null)
   const observerTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const popoverPositionSyncCleanupRef = useRef<(() => void) | null>(null)
 
   const clearObserver = useCallback(() => {
     if (observerRef.current) {
@@ -62,11 +83,6 @@ export function useAnnotationNavigation({
     }
   }, [])
 
-  const clearPopoverPositionSync = useCallback(() => {
-    popoverPositionSyncCleanupRef.current?.()
-    popoverPositionSyncCleanupRef.current = null
-  }, [])
-
   const clearHighlight = useCallback(() => {
     if (highlightTimeoutRef.current) {
       clearTimeout(highlightTimeoutRef.current)
@@ -81,9 +97,8 @@ export function useAnnotationNavigation({
   const clearAll = useCallback(() => {
     clearHighlight()
     clearPopoverCardHighlight()
-    clearPopoverPositionSync()
     clearObserver()
-  }, [clearHighlight, clearPopoverCardHighlight, clearPopoverPositionSync, clearObserver])
+  }, [clearHighlight, clearPopoverCardHighlight, clearObserver])
 
   useEffect(() => () => clearAll(), [clearAll])
 
@@ -200,69 +215,26 @@ export function useAnnotationNavigation({
     }
   }, [])
 
-  const syncTextSelectionPopoverPosition = useCallback(
-    (container: HTMLElement, element: HTMLElement, annotationId: string) => {
-      const controls = textSelectionPopoverControlsRef?.current
-      if (!controls) return
-
-      clearPopoverPositionSync()
-
-      let frameId: number | null = null
-      const updatePosition = () => {
-        controls.updateTextSelectionPopoverPosition(getTextSelectionPopoverPosition(element, annotationId))
-      }
-      const onScroll = () => {
-        if (frameId !== null) return
-        frameId = requestAnimationFrame(() => {
-          frameId = null
-          updatePosition()
-        })
-      }
-
-      container.addEventListener("scroll", onScroll, { passive: true })
-      updatePosition()
-
-      popoverPositionSyncCleanupRef.current = () => {
-        container.removeEventListener("scroll", onScroll)
-        if (frameId !== null) {
-          cancelAnimationFrame(frameId)
-        }
-      }
-    },
-    [textSelectionPopoverControlsRef, clearPopoverPositionSync, getTextSelectionPopoverPosition],
-  )
-
   const scrollToElement = useCallback(
     ({ element, clickTarget, annotation, openTextSelectionPopoverImmediately = false }: ScrollToElementOptions) => {
       const container = scrollContainerRef.current
-      clearPopoverPositionSync()
-
-      if (openTextSelectionPopoverImmediately) {
-        const controls = textSelectionPopoverControlsRef?.current
-        if (controls) {
-          controls.openExistingAnnotationPopover(annotation, getTextSelectionPopoverPosition(element, annotation.id))
-          highlightAnnotationInPopover(annotation.id)
-          if (container) {
-            syncTextSelectionPopoverPosition(container, element, annotation.id)
-          }
-        }
-      }
 
       const openAndSelectAnnotation = () => {
-        clearPopoverPositionSync()
+        if (openTextSelectionPopoverImmediately) {
+          const controls = textSelectionPopoverControlsRef?.current
+          if (controls) {
+            controls.openExistingAnnotationPopover(annotation, getTextSelectionPopoverPosition(element, annotation.id))
+            highlightAnnotationInPopover(annotation.id)
+            return
+          }
+        }
+
         applyHighlight(element)
 
         const popover = document.querySelector("[data-radix-popper-content-wrapper]")
         const cardInPopover = popover?.querySelector(`[data-annotation-card-id="${annotation.id}"]`)
 
         if (cardInPopover) {
-          highlightAnnotationInPopover(annotation.id)
-          return
-        }
-
-        const controls = textSelectionPopoverControlsRef?.current
-        if (openTextSelectionPopoverImmediately && controls) {
-          controls.updateTextSelectionPopoverPosition(getTextSelectionPopoverPosition(element, annotation.id))
           highlightAnnotationInPopover(annotation.id)
           return
         }
@@ -275,18 +247,22 @@ export function useAnnotationNavigation({
 
       if (container) {
         let handled = false
+        const scrollTarget = findScrollport(element, container)
+
+        const cleanup = () => {
+          scrollTarget.removeEventListener("scrollend", onScrollEnd)
+        }
+
         const onScrollEnd = () => {
           if (handled) return
           handled = true
-          container.removeEventListener("scrollend", onScrollEnd)
+          cleanup()
           openAndSelectAnnotation()
         }
 
-        container.addEventListener("scrollend", onScrollEnd)
-        element.scrollIntoView({ behavior: "smooth", block: "center" })
+        scrollTarget.addEventListener("scrollend", onScrollEnd, { once: true })
 
-        // Fallback: scrollend won't fire if element is already in view
-        setTimeout(onScrollEnd, 600)
+        element.scrollIntoView({ behavior: "smooth", block: "center" })
       } else {
         element.scrollIntoView({ behavior: "instant", block: "center" })
         openAndSelectAnnotation()
@@ -295,11 +271,9 @@ export function useAnnotationNavigation({
     [
       scrollContainerRef,
       textSelectionPopoverControlsRef,
-      clearPopoverPositionSync,
       applyHighlight,
       getTextSelectionPopoverPosition,
       highlightAnnotationInPopover,
-      syncTextSelectionPopoverPosition,
     ],
   )
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.test.ts
@@ -286,30 +286,39 @@ describe("useAnnotationPopover", () => {
     })
   })
 
-  describe("highlightRanges with handlers", () => {
-    it("adds onClick handlers to highlight ranges", () => {
+  describe("onAnnotationClick", () => {
+    it("returns highlight ranges without onClick handlers", () => {
       const { result } = renderHook(() =>
         useAnnotationPopover({ projectId: "proj-1", traceId: "trace-1", isActive: true }),
       )
 
       expect(result.current.highlightRanges).toHaveLength(1)
-      expect(result.current.highlightRanges[0]?.onClick).toBeDefined()
+      expect("onClick" in (result.current.highlightRanges[0] ?? {})).toBe(false)
     })
 
-    it("opens existing annotation popover when highlight is clicked", () => {
+    it("opens existing annotation popover via onAnnotationClick", () => {
       const { result } = renderHook(() =>
         useAnnotationPopover({ projectId: "proj-1", traceId: "trace-1", isActive: true }),
       )
 
-      const onClick = result.current.highlightRanges[0]?.onClick
-      expect(onClick).toBeDefined()
-
       act(() => {
-        onClick?.({ x: 150, y: 250 })
+        result.current.onAnnotationClick("ann-1", { x: 150, y: 250 })
       })
 
       expect(result.current.popoverState?.kind).toBe("existing")
       expect(result.current.popoverState?.position).toEqual({ x: 150, y: 250 })
+    })
+
+    it("does nothing for unknown annotation id", () => {
+      const { result } = renderHook(() =>
+        useAnnotationPopover({ projectId: "proj-1", traceId: "trace-1", isActive: true }),
+      )
+
+      act(() => {
+        result.current.onAnnotationClick("unknown-id", { x: 150, y: 250 })
+      })
+
+      expect(result.current.popoverState).toBeNull()
     })
   })
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/hooks/use-annotation-popover.ts
@@ -1,5 +1,5 @@
-import type { HighlightRange, TextSelectionAnchor } from "@repo/ui"
-import { useCallback, useMemo, useState } from "react"
+import type { TextSelectionAnchor } from "@repo/ui"
+import { useCallback, useState } from "react"
 import {
   type AnnotationRecord,
   isDraftAnnotation,
@@ -78,17 +78,13 @@ export function useAnnotationPopover({
     })
   }, [])
 
-  const highlightRangesWithHandlers: HighlightRange[] = useMemo(() => {
-    return highlightRanges.map((range) => {
-      const annotation = annotations.find((a) => a.id === range.id)
-      if (!annotation) return range
-
-      return {
-        ...range,
-        onClick: (position: { x: number; y: number }) => openExistingAnnotationPopover(annotation, position),
-      }
-    })
-  }, [highlightRanges, annotations, openExistingAnnotationPopover])
+  const onAnnotationClick = useCallback(
+    (annotationId: string, position: { x: number; y: number }) => {
+      const annotation = annotations.find((a) => a.id === annotationId)
+      if (annotation) openExistingAnnotationPopover(annotation, position)
+    },
+    [annotations, openExistingAnnotationPopover],
+  )
 
   const handleTextSelect = useCallback(
     (anchor: TextSelectionAnchor, position: { x: number; y: number }) => {
@@ -164,7 +160,8 @@ export function useAnnotationPopover({
   )
 
   return {
-    highlightRanges: highlightRangesWithHandlers,
+    highlightRanges,
+    onAnnotationClick,
     popoverState: openPopover,
     isPopoverLoading,
     isPopoverEditable,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/conversation-tab.tsx
@@ -33,6 +33,7 @@ function ConversationContent({
   const scrollRef = scrollContainerRef ?? internalScrollRef
   const navigatorRef = useRef<ScrollNavigatorHandle>(null)
   const navItemRefs = useRef<(HTMLDivElement | null)[]>([])
+  const clearSelectionRef = useRef<(() => void) | null>(null)
 
   const { data: spanMaps } = useConversationSpanMaps({
     projectId,
@@ -61,6 +62,7 @@ function ConversationContent({
 
   const {
     highlightRanges,
+    onAnnotationClick,
     handleTextSelect,
     openExistingAnnotationPopover,
     textSelectionPopoverPosition,
@@ -102,7 +104,7 @@ function ConversationContent({
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
-      <div ref={scrollRef} className="flex flex-col py-8 px-4 overflow-y-auto flex-1">
+      <div ref={scrollRef} className="flex flex-col py-8 px-4 custom-scrollbar overflow-y-auto flex-1">
         <Conversation
           messages={traceDetail.allMessages}
           enableNavigator
@@ -110,7 +112,10 @@ function ConversationContent({
           navigatorRef={navigatorRef}
           navItemRefsRef={navItemRefs}
           onTextSelect={handleTextSelect}
+          onSelectionDismiss={closeAnnotationPopover}
+          clearSelectionRef={clearSelectionRef}
           highlightRanges={highlightRanges}
+          onAnnotationClick={onAnnotationClick}
           messageAnnotationSlot={(messageIndex) => {
             const data = messageLevelAnnotations.get(messageIndex)
             return (
@@ -131,6 +136,7 @@ function ConversationContent({
         />
         <AnnotationPopover
           position={textSelectionPopoverPosition}
+          scrollContainerRef={scrollRef}
           projectId={projectId}
           annotations={textSelectionAnnotations}
           showCreateForm={textSelectionAnnotations.length === 0}
@@ -140,6 +146,7 @@ function ConversationContent({
           onUpdate={updateTextSelectionAnnotation}
           onClose={() => {
             closeAnnotationPopover()
+            clearSelectionRef.current?.()
             onPopoverClose?.()
           }}
         />

--- a/packages/domain/annotations/src/helpers/anchor-from-existing-annotation-score.test.ts
+++ b/packages/domain/annotations/src/helpers/anchor-from-existing-annotation-score.test.ts
@@ -1,0 +1,76 @@
+import type { AnnotationScore } from "@domain/scores"
+import { describe, expect, it } from "vitest"
+import { anchorFromExistingAnnotationScore } from "./anchor-from-existing-annotation-score.ts"
+
+/** Minimal stub — the helper only reads `metadata`. */
+function annotationScoreWithMetadata(metadata: Record<string, unknown> & { rawFeedback: string }): AnnotationScore {
+  return { source: "annotation", metadata } as AnnotationScore
+}
+
+describe("anchorFromExistingAnnotationScore", () => {
+  it("returns undefined when messageIndex is absent", () => {
+    expect(
+      anchorFromExistingAnnotationScore(annotationScoreWithMetadata({ rawFeedback: "only feedback" })),
+    ).toBeUndefined()
+  })
+
+  it("returns messageIndex-only anchor", () => {
+    expect(
+      anchorFromExistingAnnotationScore(annotationScoreWithMetadata({ rawFeedback: "x", messageIndex: 4 })),
+    ).toEqual({ messageIndex: 4 })
+  })
+
+  it("returns messageIndex and partIndex when offsets are absent", () => {
+    expect(
+      anchorFromExistingAnnotationScore(
+        annotationScoreWithMetadata({ rawFeedback: "x", messageIndex: 1, partIndex: 0 }),
+      ),
+    ).toEqual({ messageIndex: 1, partIndex: 0 })
+  })
+
+  it("returns full text-range anchor when all index fields are present", () => {
+    expect(
+      anchorFromExistingAnnotationScore(
+        annotationScoreWithMetadata({
+          rawFeedback: "x",
+          messageIndex: 2,
+          partIndex: 0,
+          startOffset: 10,
+          endOffset: 25,
+        }),
+      ),
+    ).toEqual({
+      messageIndex: 2,
+      partIndex: 0,
+      startOffset: 10,
+      endOffset: 25,
+    })
+  })
+
+  it("returns undefined when startOffset and endOffset violate schema (start > end)", () => {
+    expect(
+      anchorFromExistingAnnotationScore(
+        annotationScoreWithMetadata({
+          rawFeedback: "x",
+          messageIndex: 0,
+          partIndex: 0,
+          startOffset: 20,
+          endOffset: 5,
+        }),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("ignores a lone startOffset when endOffset is missing (keeps message + part)", () => {
+    expect(
+      anchorFromExistingAnnotationScore(
+        annotationScoreWithMetadata({
+          rawFeedback: "x",
+          messageIndex: 0,
+          partIndex: 0,
+          startOffset: 3,
+        }),
+      ),
+    ).toEqual({ messageIndex: 0, partIndex: 0 })
+  })
+})

--- a/packages/domain/annotations/src/helpers/anchor-from-existing-annotation-score.ts
+++ b/packages/domain/annotations/src/helpers/anchor-from-existing-annotation-score.ts
@@ -1,0 +1,20 @@
+import { type AnnotationAnchor, type AnnotationScore, annotationAnchorSchema } from "@domain/scores"
+
+/**
+ * Rebuilds the annotation anchor from a persisted annotation score's metadata.
+ * Used on draft updates so positioning is not taken from the HTTP payload.
+ */
+export function anchorFromExistingAnnotationScore(score: AnnotationScore): AnnotationAnchor | undefined {
+  const m = score.metadata
+  if (m.messageIndex === undefined) return undefined
+  const candidate: AnnotationAnchor = { messageIndex: m.messageIndex }
+  if (m.partIndex !== undefined) {
+    candidate.partIndex = m.partIndex
+  }
+  if (m.startOffset !== undefined && m.endOffset !== undefined) {
+    candidate.startOffset = m.startOffset
+    candidate.endOffset = m.endOffset
+  }
+  const parsedAnchor = annotationAnchorSchema.safeParse(candidate)
+  return parsedAnchor.success ? parsedAnchor.data : undefined
+}

--- a/packages/domain/annotations/src/helpers/write-annotation.test.ts
+++ b/packages/domain/annotations/src/helpers/write-annotation.test.ts
@@ -1,0 +1,104 @@
+import { Effect } from "effect"
+import type { GenAIMessage } from "rosetta-ai"
+import { describe, expect, it } from "vitest"
+import {
+  createTestLayers,
+  cuid,
+  makeTraceDetail,
+  projectCuid,
+  queueId,
+  traceIdRaw,
+} from "../testing/persist-draft-annotation-test-layers.ts"
+import { writeAnnotation } from "./write-annotation.ts"
+
+const draftedAt = new Date("2026-04-16T12:00:00.000Z")
+
+const baseInput = {
+  projectId: projectCuid,
+  sourceId: queueId,
+  traceId: traceIdRaw,
+  value: 0,
+  passed: false,
+  feedback: "Initial feedback",
+  organizationId: cuid,
+}
+
+describe("writeAnnotation", () => {
+  it("persists anchor metadata for a new annotation from flat fields", async () => {
+    const { layer } = createTestLayers()
+
+    const score = await Effect.runPromise(
+      writeAnnotation(
+        {
+          ...baseInput,
+          feedback: "Issue with refund policy",
+          messageIndex: 2,
+          partIndex: 0,
+          startOffset: 10,
+          endOffset: 25,
+        },
+        draftedAt,
+      ).pipe(Effect.provide(layer)),
+    )
+
+    expect(score.metadata.messageIndex).toBe(2)
+    expect(score.metadata.partIndex).toBe(0)
+    expect(score.metadata.startOffset).toBe(10)
+    expect(score.metadata.endOffset).toBe(25)
+    expect(score.metadata.rawFeedback).toBe("Issue with refund policy")
+  })
+
+  it("when updating by id, ignores conflicting anchor and flat fields and preserves stored anchor metadata", async () => {
+    const sliceSource = "The refund policy says no returns after 30 days."
+    const allMessages: GenAIMessage[] = [
+      { role: "user", parts: [{ type: "text", content: "hi" }] },
+      { role: "assistant", parts: [{ type: "text", content: "hello" }] },
+      { role: "assistant", parts: [{ type: "text", content: sliceSource }] },
+    ]
+    const { layer } = createTestLayers({ traceDetail: makeTraceDetail(allMessages) })
+
+    const first = await Effect.runPromise(
+      writeAnnotation(
+        {
+          ...baseInput,
+          feedback: "Issue with refund policy",
+          messageIndex: 2,
+          partIndex: 0,
+          startOffset: 10,
+          endOffset: 25,
+        },
+        draftedAt,
+      ).pipe(Effect.provide(layer)),
+    )
+
+    const updated = await Effect.runPromise(
+      writeAnnotation(
+        {
+          ...baseInput,
+          id: first.id,
+          value: 1,
+          passed: true,
+          feedback: "Updated comment only",
+          messageIndex: 0,
+          partIndex: 0,
+          startOffset: 1,
+          endOffset: 2,
+          anchor: {
+            messageIndex: 0,
+            partIndex: 0,
+            startOffset: 1,
+            endOffset: 2,
+          },
+        },
+        draftedAt,
+      ).pipe(Effect.provide(layer)),
+    )
+
+    expect(updated.metadata.messageIndex).toBe(2)
+    expect(updated.metadata.partIndex).toBe(0)
+    expect(updated.metadata.startOffset).toBe(10)
+    expect(updated.metadata.endOffset).toBe(25)
+    expect(updated.metadata.rawFeedback).toBe("Updated comment only")
+    expect(updated.passed).toBe(true)
+  })
+})

--- a/packages/domain/annotations/src/helpers/write-annotation.ts
+++ b/packages/domain/annotations/src/helpers/write-annotation.ts
@@ -1,7 +1,14 @@
-import { type AnnotationScore, writeScoreUseCase } from "@domain/scores"
+import {
+  type AnnotationAnchor,
+  type AnnotationScore,
+  type Score,
+  ScoreRepository,
+  writeScoreUseCase,
+} from "@domain/scores"
 import { OrganizationId } from "@domain/shared"
 import { Effect } from "effect"
 import type { z } from "zod"
+import { anchorFromExistingAnnotationScore } from "./anchor-from-existing-annotation-score.ts"
 import { anchorFromPersistDraftFlatFields, persistDraftAnnotationInputSchema } from "./annotation-draft-write-schema.ts"
 import { buildAnnotationScoreMetadata } from "./build-annotation-score-metadata.ts"
 import { resolveWriteAnnotationTraceContext } from "./resolve-write-annotation-trace-context.ts"
@@ -13,7 +20,18 @@ export const writeAnnotation = (
   Effect.gen(function* () {
     const parsed = persistDraftAnnotationInputSchema.parse(input)
 
-    const anchor = parsed.anchor ?? anchorFromPersistDraftFlatFields(parsed)
+    let anchor: AnnotationAnchor | undefined
+    if (parsed.id !== undefined && parsed.id !== null) {
+      const scoreRepository = yield* ScoreRepository
+      const existing: Score | null = yield* scoreRepository
+        .findById(parsed.id)
+        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+      if (existing?.source === "annotation") {
+        anchor = anchorFromExistingAnnotationScore(existing)
+      }
+    } else {
+      anchor = parsed.anchor ?? anchorFromPersistDraftFlatFields(parsed)
+    }
 
     const { sessionId, spanId } = yield* resolveWriteAnnotationTraceContext({
       organizationId: OrganizationId(input.organizationId),

--- a/packages/domain/annotations/src/testing/persist-draft-annotation-test-layers.ts
+++ b/packages/domain/annotations/src/testing/persist-draft-annotation-test-layers.ts
@@ -1,0 +1,128 @@
+import { OutboxEventWriter } from "@domain/events"
+import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository, createFakeScoreRepository } from "@domain/scores/testing"
+import {
+  ExternalUserId,
+  NotFoundError,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  SqlClient,
+  TraceId,
+} from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import type { Span, TraceDetail } from "@domain/spans"
+import { SpanRepository, TraceRepository } from "@domain/spans"
+import { createFakeSpanRepository, createFakeTraceRepository, stubListSpan } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import type { GenAIMessage } from "rosetta-ai"
+
+export const cuid = "a".repeat(24)
+export const projectCuid = "b".repeat(24)
+export const traceIdRaw = "d".repeat(32)
+const traceId = TraceId(traceIdRaw)
+export const defaultResolvedSpanId = SpanId("s".repeat(16))
+export const queueId = "q".repeat(24)
+
+function defaultCompletionSpan(): Span {
+  return stubListSpan({
+    organizationId: OrganizationId(cuid),
+    projectId: ProjectId(projectCuid),
+    traceId,
+    sessionId: SessionId("session"),
+    spanId: defaultResolvedSpanId,
+    operation: "chat",
+    startTime: new Date("2026-03-24T00:00:00.000Z"),
+    endTime: new Date("2026-03-24T00:01:00.000Z"),
+  })
+}
+
+export function makeTraceDetail(allMessages: readonly GenAIMessage[]): TraceDetail {
+  return {
+    organizationId: OrganizationId(cuid),
+    projectId: ProjectId(projectCuid),
+    traceId,
+    spanCount: 1,
+    errorCount: 0,
+    startTime: new Date("2026-03-24T00:00:00.000Z"),
+    endTime: new Date("2026-03-24T00:00:00.000Z"),
+    durationNs: 0,
+    timeToFirstTokenNs: 0,
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 0,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    sessionId: SessionId("session"),
+    userId: ExternalUserId("user"),
+    simulationId: SimulationId(""),
+    tags: [],
+    metadata: {},
+    models: [],
+    providers: [],
+    serviceNames: [],
+    rootSpanId: SpanId("r".repeat(16)),
+    rootSpanName: "root",
+    systemInstructions: [],
+    inputMessages: [],
+    outputMessages: [],
+    allMessages: [...allMessages],
+  }
+}
+
+export function createTestLayers(options?: { traceDetail?: TraceDetail | null; spansForTrace?: readonly Span[] }) {
+  const events: unknown[] = []
+  const { repository: scoreRepository, scores: store } = createFakeScoreRepository()
+  const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository()
+
+  const traceDetailForLookup =
+    options === undefined || options.traceDetail === undefined ? makeTraceDetail([]) : options.traceDetail
+
+  const { repository: traceRepository } = createFakeTraceRepository({
+    findByTraceId: () => {
+      if (traceDetailForLookup === null) {
+        return Effect.fail(new NotFoundError({ entity: "Trace", id: "" }))
+      }
+      return Effect.succeed(traceDetailForLookup)
+    },
+  })
+
+  const spans = options?.spansForTrace ?? [defaultCompletionSpan()]
+  const { repository: spanRepository } = createFakeSpanRepository({
+    listByTraceId: () => Effect.succeed([...spans]),
+  })
+
+  const ScoreRepositoryTest = Layer.succeed(ScoreRepository, scoreRepository)
+  const ScoreAnalyticsRepositoryTest = Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository)
+
+  const OutboxEventWriterTest = Layer.succeed(OutboxEventWriter, {
+    write: (event) =>
+      Effect.sync(() => {
+        events.push(event)
+      }),
+  })
+
+  const SqlClientTest = Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(cuid) }))
+
+  const TraceRepositoryTest = Layer.succeed(TraceRepository, traceRepository)
+  const SpanRepositoryTest = Layer.succeed(SpanRepository, spanRepository)
+
+  return {
+    store,
+    events,
+    layer: Layer.mergeAll(
+      ScoreRepositoryTest,
+      ScoreAnalyticsRepositoryTest,
+      OutboxEventWriterTest,
+      SqlClientTest,
+      TraceRepositoryTest,
+      SpanRepositoryTest,
+    ),
+  }
+}

--- a/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
+++ b/packages/domain/annotations/src/use-cases/write-draft-annotation.test.ts
@@ -1,133 +1,17 @@
-import { OutboxEventWriter } from "@domain/events"
-import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
-import { createFakeScoreAnalyticsRepository, createFakeScoreRepository } from "@domain/scores/testing"
-import {
-  ExternalUserId,
-  NotFoundError,
-  OrganizationId,
-  ProjectId,
-  SessionId,
-  SimulationId,
-  SpanId,
-  SqlClient,
-  TraceId,
-} from "@domain/shared"
-import { createFakeSqlClient } from "@domain/shared/testing"
-import type { Span, TraceDetail } from "@domain/spans"
-import { SpanRepository, TraceRepository } from "@domain/spans"
-import { createFakeSpanRepository, createFakeTraceRepository, stubListSpan } from "@domain/spans/testing"
-import { Effect, Layer } from "effect"
+import { SessionId, SpanId } from "@domain/shared"
+import { Effect } from "effect"
 import type { GenAIMessage } from "rosetta-ai"
 import { describe, expect, it } from "vitest"
+import {
+  createTestLayers,
+  cuid,
+  defaultResolvedSpanId,
+  makeTraceDetail,
+  projectCuid,
+  queueId,
+  traceIdRaw,
+} from "../testing/persist-draft-annotation-test-layers.ts"
 import { writeDraftAnnotationUseCase } from "./write-draft-annotation.ts"
-
-const cuid = "a".repeat(24)
-const projectCuid = "b".repeat(24)
-const traceIdRaw = "d".repeat(32)
-const traceId = TraceId(traceIdRaw)
-const defaultResolvedSpanId = SpanId("s".repeat(16))
-const queueId = "q".repeat(24)
-
-function defaultCompletionSpan(): Span {
-  return stubListSpan({
-    organizationId: OrganizationId(cuid),
-    projectId: ProjectId(projectCuid),
-    traceId,
-    sessionId: SessionId("session"),
-    spanId: defaultResolvedSpanId,
-    operation: "chat",
-    startTime: new Date("2026-03-24T00:00:00.000Z"),
-    endTime: new Date("2026-03-24T00:01:00.000Z"),
-  })
-}
-
-function makeTraceDetail(allMessages: readonly GenAIMessage[]): TraceDetail {
-  return {
-    organizationId: OrganizationId(cuid),
-    projectId: ProjectId(projectCuid),
-    traceId,
-    spanCount: 1,
-    errorCount: 0,
-    startTime: new Date("2026-03-24T00:00:00.000Z"),
-    endTime: new Date("2026-03-24T00:00:00.000Z"),
-    durationNs: 0,
-    timeToFirstTokenNs: 0,
-    tokensInput: 0,
-    tokensOutput: 0,
-    tokensCacheRead: 0,
-    tokensCacheCreate: 0,
-    tokensReasoning: 0,
-    tokensTotal: 0,
-    costInputMicrocents: 0,
-    costOutputMicrocents: 0,
-    costTotalMicrocents: 0,
-    sessionId: SessionId("session"),
-    userId: ExternalUserId("user"),
-    simulationId: SimulationId(""),
-    tags: [],
-    metadata: {},
-    models: [],
-    providers: [],
-    serviceNames: [],
-    rootSpanId: SpanId("r".repeat(16)),
-    rootSpanName: "root",
-    systemInstructions: [],
-    inputMessages: [],
-    outputMessages: [],
-    allMessages: [...allMessages],
-  }
-}
-
-function createTestLayers(options?: { traceDetail?: TraceDetail | null; spansForTrace?: readonly Span[] }) {
-  const events: unknown[] = []
-  const { repository: scoreRepository, scores: store } = createFakeScoreRepository()
-  const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository()
-
-  const traceDetailForLookup =
-    options === undefined || options.traceDetail === undefined ? makeTraceDetail([]) : options.traceDetail
-
-  const { repository: traceRepository } = createFakeTraceRepository({
-    findByTraceId: () => {
-      if (traceDetailForLookup === null) {
-        return Effect.fail(new NotFoundError({ entity: "Trace", id: "" }))
-      }
-      return Effect.succeed(traceDetailForLookup)
-    },
-  })
-
-  const spans = options?.spansForTrace ?? [defaultCompletionSpan()]
-  const { repository: spanRepository } = createFakeSpanRepository({
-    listByTraceId: () => Effect.succeed([...spans]),
-  })
-
-  const ScoreRepositoryTest = Layer.succeed(ScoreRepository, scoreRepository)
-  const ScoreAnalyticsRepositoryTest = Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository)
-
-  const OutboxEventWriterTest = Layer.succeed(OutboxEventWriter, {
-    write: (event) =>
-      Effect.sync(() => {
-        events.push(event)
-      }),
-  })
-
-  const SqlClientTest = Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(cuid) }))
-
-  const TraceRepositoryTest = Layer.succeed(TraceRepository, traceRepository)
-  const SpanRepositoryTest = Layer.succeed(SpanRepository, spanRepository)
-
-  return {
-    store,
-    events,
-    layer: Layer.mergeAll(
-      ScoreRepositoryTest,
-      ScoreAnalyticsRepositoryTest,
-      OutboxEventWriterTest,
-      SqlClientTest,
-      TraceRepositoryTest,
-      SpanRepositoryTest,
-    ),
-  }
-}
 
 describe("persistDraftAnnotation", () => {
   it("creates a draft annotation score without auto-publishing", async () => {

--- a/packages/ui/src/components/genai-conversation/conversation.tsx
+++ b/packages/ui/src/components/genai-conversation/conversation.tsx
@@ -1,11 +1,17 @@
 import { cn, Text } from "@repo/ui"
-import { type ReactNode, type Ref, type RefObject, useMemo, useRef } from "react"
+import { type ReactNode, type Ref, type RefObject, useCallback, useMemo, useRef } from "react"
 import type { GenAIMessage } from "rosetta-ai"
 import { ScrollNavigator, type ScrollNavigatorHandle } from "../scroll-navigator/scroll-navigator.tsx"
 import { Message, type ToolCallActions } from "./message.tsx"
 import type { ToolCallResult } from "./part.tsx"
 import { getKnownField } from "./parts/helpers.tsx"
-import { type HighlightRange, type TextSelectionAnchor, TextSelectionProvider } from "./text-selection.tsx"
+import { SelectionActionPopover } from "./selection-action-popover.tsx"
+import {
+  type HighlightRange,
+  SELECTION_HIGHLIGHT_CLASSES,
+  type TextSelectionAnchor,
+  TextSelectionProvider,
+} from "./text-selection.tsx"
 
 interface ToolResponsePart {
   readonly type: "tool_call_response"
@@ -77,7 +83,10 @@ export function Conversation({
   messageActions,
   toolCallActions,
   onTextSelect,
+  onSelectionDismiss,
+  clearSelectionRef,
   highlightRanges,
+  onAnnotationClick,
   messageAnnotationSlot,
 }: {
   readonly messages: readonly (GenAIMessage | null)[]
@@ -101,8 +110,14 @@ export function Conversation({
   readonly toolCallActions?: ToolCallActions
   /** Called when the user selects text within a message part. Emits the canonical anchor and popover position. */
   readonly onTextSelect?: ((anchor: TextSelectionAnchor, position: { x: number; y: number }) => void) | undefined
+  /** Called when the selection highlight is cleared (e.g. ESC, click outside). Use to close external popovers. */
+  readonly onSelectionDismiss?: (() => void) | undefined
+  /** Ref that receives a function to imperatively clear the selection highlight from outside. */
+  readonly clearSelectionRef?: RefObject<(() => void) | null> | undefined
   /** Highlight ranges to paint on text parts (e.g. from persisted annotations). */
   readonly highlightRanges?: ReadonlyArray<HighlightRange> | undefined
+  /** Called when a persisted annotation highlight is clicked. Receives the annotation id and click position. */
+  readonly onAnnotationClick?: ((annotationId: string, position: { x: number; y: number }) => void) | undefined
   /** Renders a slot below each message. Receives the original messageIndex and role. */
   readonly messageAnnotationSlot?: ((messageIndex: number, role: string) => ReactNode) | undefined
 }) {
@@ -111,6 +126,35 @@ export function Conversation({
   const navItemRefs = navItemRefsRef ?? internalNavItemRefs
   const containerRef = useRef<HTMLDivElement>(null)
   const enableTextSelection = !!onTextSelect || (highlightRanges != null && highlightRanges.length > 0)
+
+  const handleContainerClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!onAnnotationClick) return
+      const target = (e.target as HTMLElement).closest<HTMLElement>("[data-annotation-id]")
+      if (!target) return
+
+      const annotationId = target.getAttribute("data-annotation-id")
+      if (!annotationId) return
+
+      const partRoot = target.closest("[data-part-index]") ?? document.body
+      const segments = partRoot.querySelectorAll(`[data-annotation-id="${annotationId}"]`)
+      let left = e.clientX
+      let bottom = e.clientY
+      if (segments.length > 0) {
+        let minLeft = Number.POSITIVE_INFINITY
+        let maxBottom = Number.NEGATIVE_INFINITY
+        for (const seg of segments) {
+          const r = seg.getBoundingClientRect()
+          if (r.left < minLeft) minLeft = r.left
+          if (r.bottom > maxBottom) maxBottom = r.bottom
+        }
+        left = minLeft
+        bottom = maxBottom
+      }
+      onAnnotationClick(annotationId, { x: left, y: bottom })
+    },
+    [onAnnotationClick],
+  )
 
   const { resultMap, visibleMessages } = useMemo(() => {
     const { resultMap, absorbedIndexes } = buildToolResultsMap(messages)
@@ -140,7 +184,16 @@ export function Conversation({
   }
 
   const content = (
-    <div ref={containerRef} className={cn("flex min-w-0 flex-col gap-6", { "select-none": !enableTextSelection })}>
+    // biome-ignore lint/a11y/useKeyWithClickEvents: delegated click for annotation spans (keyboard handled by Escape listener)
+    // biome-ignore lint/a11y/noStaticElementInteractions: delegated event handler — actual interactive targets are annotated spans
+    <div
+      ref={containerRef}
+      onClick={handleContainerClick}
+      className={cn("flex min-w-0 flex-col gap-6", {
+        "select-none": !enableTextSelection,
+        [SELECTION_HIGHLIGHT_CLASSES]: enableTextSelection,
+      })}
+    >
       {visibleMessages.map(({ message, index }, i) => {
         const onNavigate = messageActions?.get(index)
         const isAssistant = message.role === "assistant"
@@ -205,9 +258,12 @@ export function Conversation({
         messages={messages}
         containerRef={containerRef}
         onSelect={onTextSelect}
+        onDismiss={onSelectionDismiss}
+        clearSelectionRef={clearSelectionRef}
         highlightRanges={highlightRanges}
       >
         {content}
+        <SelectionActionPopover />
       </TextSelectionProvider>
     )
   }

--- a/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.test.ts
+++ b/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import type { HighlightRange } from "../text-selection.tsx"
 import { type HastNode, sourceMappedTextPlugin } from "./source-mapped-text-plugin.ts"
 
@@ -125,7 +125,7 @@ describe("className generation", () => {
     expect(props(highlighted).className).toContain("bg-blue-100")
   })
 
-  it("adds cursor-pointer when highlight has onClick", () => {
+  it("adds cursor-pointer and hit-area when annotation has an id", () => {
     const h: HighlightRange = {
       messageIndex: 0,
       partIndex: 0,
@@ -133,15 +133,16 @@ describe("className generation", () => {
       endOffset: 5,
       type: "annotation",
       passed: true,
-      onClick: vi.fn(),
+      id: "ann-1",
     }
     const tree = rootWith(textNode("hello world", 0, 11))
     run(tree, [h])
     const highlighted = children(tree).find((n) => props(n)["data-annotated-text"])
     expect(props(highlighted).className).toContain("cursor-pointer")
+    expect(props(highlighted).className).toContain("hit-area-inline-y-2")
   })
 
-  it("does not add cursor-pointer when highlight has no onClick", () => {
+  it("does not add cursor-pointer when annotation has no id", () => {
     const h: HighlightRange = {
       messageIndex: 0,
       partIndex: 0,
@@ -173,31 +174,31 @@ describe("className generation", () => {
 })
 
 // ──────────────────────────────────────────────────────────────────────────────
-// Tag name (button vs span)
+// Tag name (always span)
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe("tagName", () => {
-  it("renders a button when highlight has onClick", () => {
+  it("always renders a span for annotation highlights", () => {
     const h: HighlightRange = {
       messageIndex: 0,
       partIndex: 0,
       startOffset: 0,
       endOffset: 5,
       type: "annotation",
-      onClick: vi.fn(),
+      id: "ann-1",
     }
     const tree = rootWith(textNode("hello world", 0, 11))
     run(tree, [h])
     const annotated = children(tree).find((n) => props(n)["data-annotated-text"])
-    expect(annotated?.tagName).toBe("button")
+    expect(annotated?.tagName).toBe("span")
   })
 
-  it("renders a span when highlight has no onClick", () => {
-    const h: HighlightRange = { messageIndex: 0, partIndex: 0, startOffset: 0, endOffset: 5, type: "annotation" }
+  it("renders a span for selection highlights", () => {
+    const h: HighlightRange = { messageIndex: 0, partIndex: 0, startOffset: 0, endOffset: 5, type: "selection" }
     const tree = rootWith(textNode("hello world", 0, 11))
     run(tree, [h])
-    const annotated = children(tree).find((n) => props(n)["data-annotated-text"])
-    expect(annotated?.tagName).toBe("span")
+    const sel = children(tree).find((n) => props(n)["data-selected-text"])
+    expect(sel?.tagName).toBe("span")
   })
 })
 

--- a/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
+++ b/packages/ui/src/components/genai-conversation/parts/source-mapped-text-plugin.ts
@@ -82,21 +82,20 @@ export function sourceMappedTextPlugin(highlights: readonly HighlightRange[]) {
             if (!segmentText) continue
 
             const activeHighlight = overlaps.find((h) => h.startOffset < segEnd && h.endOffset > segStart) ?? null
+            const isAnnotation = activeHighlight && activeHighlight.type !== "selection"
+            const isClickable = isAnnotation && !!activeHighlight.id
             const className = cn({
-              "cursor-pointer inline": !!activeHighlight?.onClick,
+              "cursor-pointer hit-area-inline-y-2": isClickable,
               "bg-yellow-100 border-b-2 border-yellow-300 dark:bg-yellow-400/20 dark:border-yellow-400/50":
                 activeHighlight?.type === "selection",
-              "bg-red-100 dark:bg-red-400/30":
-                activeHighlight?.type !== "selection" && activeHighlight?.passed === false,
-              "bg-emerald-100 dark:bg-emerald-400/30":
-                activeHighlight?.type !== "selection" && activeHighlight?.passed === true,
-              "bg-blue-100 dark:bg-blue-400/30":
-                activeHighlight?.type !== "selection" && activeHighlight?.passed === undefined && !!activeHighlight,
+              "bg-red-100 dark:bg-red-400/30": isAnnotation && activeHighlight.passed === false,
+              "bg-emerald-100 dark:bg-emerald-400/30": isAnnotation && activeHighlight.passed === true,
+              "bg-blue-100 dark:bg-blue-400/30": isAnnotation && activeHighlight.passed === undefined,
             })
 
             nextChildren.push({
               type: "element",
-              tagName: activeHighlight?.onClick ? "button" : "span",
+              tagName: "span",
               properties: {
                 "data-source-start": String(segStart),
                 "data-source-end": String(segEnd),
@@ -108,33 +107,6 @@ export function sourceMappedTextPlugin(highlights: readonly HighlightRange[]) {
                         ...(activeHighlight.id ? { "data-annotation-id": activeHighlight.id } : {}),
                       }
                     : {}),
-                ...(activeHighlight?.onClick
-                  ? {
-                      type: "button",
-                      onClick: (e: MouseEvent) => {
-                        const target = e.currentTarget as HTMLElement
-                        const annotationId = target.getAttribute("data-annotation-id")
-                        let left = e.clientX
-                        let bottom = e.clientY
-                        if (annotationId) {
-                          const partRoot = target.closest("[data-part-index]") ?? document.body
-                          const segments = partRoot.querySelectorAll(`[data-annotation-id="${annotationId}"]`)
-                          if (segments.length > 0) {
-                            let minLeft = Number.POSITIVE_INFINITY
-                            let maxBottom = Number.NEGATIVE_INFINITY
-                            for (const seg of segments) {
-                              const r = seg.getBoundingClientRect()
-                              if (r.left < minLeft) minLeft = r.left
-                              if (r.bottom > maxBottom) maxBottom = r.bottom
-                            }
-                            left = minLeft
-                            bottom = maxBottom
-                          }
-                        }
-                        activeHighlight.onClick?.({ x: left, y: bottom })
-                      },
-                    }
-                  : {}),
                 ...(className ? { className } : {}),
               },
               children: [{ type: "text", value: segmentText }],

--- a/packages/ui/src/components/genai-conversation/selection-action-popover.tsx
+++ b/packages/ui/src/components/genai-conversation/selection-action-popover.tsx
@@ -1,0 +1,88 @@
+import { ClipboardCopyIcon, MessageSquarePlusIcon } from "lucide-react"
+import { type ReactNode, use, useRef } from "react"
+import { Button } from "../button/button.tsx"
+import { Icon } from "../icons/icons.tsx"
+import { Popover, PopoverAnchor, PopoverContent } from "../popover/primitives.tsx"
+import { useToast } from "../toast/useToast.ts"
+import { TextSelectionContext } from "./text-selection.tsx"
+
+/**
+ * Thin wrapper around Radix Popover that anchors to a DOM Range via
+ * virtualRef.  Radix + Floating UI handle scroll tracking and collision
+ * avoidance automatically.
+ */
+function SelectionPopover({
+  range,
+  onDismiss,
+  children,
+}: {
+  readonly range: Range
+  readonly onDismiss: () => void
+  readonly children: ReactNode
+}) {
+  const virtualRef = useRef<{ getBoundingClientRect: () => DOMRect }>({
+    getBoundingClientRect: () => range.getBoundingClientRect(),
+  })
+  virtualRef.current = { getBoundingClientRect: () => range.getBoundingClientRect() }
+
+  return (
+    <Popover open>
+      <PopoverAnchor virtualRef={virtualRef} />
+      <PopoverContent
+        side="bottom"
+        sideOffset={6}
+        align="center"
+        updatePositionStrategy="always"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={onDismiss}
+        className="w-auto p-1"
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function SelectionActionPopover() {
+  const ctx = use(TextSelectionContext)
+  const { toast } = useToast()
+  const contentRef = useRef<HTMLDivElement>(null)
+  if (!ctx) return null
+
+  const { detected, resolveAndAnnotate, resolveAndCopy, clearSelection } = ctx
+
+  if (!detected?.isSinglePart) return null
+
+  const selectionRect = detected.range.getBoundingClientRect()
+  if (selectionRect.width === 0 && selectionRect.height === 0) return null
+
+  const handleAnnotate = () => {
+    const el = contentRef.current
+    if (el) {
+      const rect = el.getBoundingClientRect()
+      resolveAndAnnotate({ x: rect.left, y: rect.top })
+    } else {
+      resolveAndAnnotate()
+    }
+  }
+
+  const handleCopy = () => {
+    resolveAndCopy()
+    toast({ title: "Copied to clipboard" })
+  }
+
+  return (
+    <SelectionPopover range={detected.range} onDismiss={clearSelection}>
+      <div ref={contentRef} data-selection-popover className="flex items-center gap-0.5">
+        <Button variant="ghost" size="sm" onClick={handleCopy}>
+          <Icon icon={ClipboardCopyIcon} size="sm" />
+          Copy
+        </Button>
+        <Button variant="default-soft" size="sm" onClick={handleAnnotate}>
+          <Icon icon={MessageSquarePlusIcon} size="sm" />
+          Annotate
+        </Button>
+      </div>
+    </SelectionPopover>
+  )
+}

--- a/packages/ui/src/components/genai-conversation/selection-detector.ts
+++ b/packages/ui/src/components/genai-conversation/selection-detector.ts
@@ -1,0 +1,137 @@
+import type { RefObject } from "react"
+import { useCallback, useState } from "react"
+import type { GenAIMessage } from "rosetta-ai"
+import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { findIndices } from "./source-offset-resolver.ts"
+
+export interface DetectedSelection {
+  /** Cloned Range — survives focus changes and selection clearing */
+  range: Range
+  /** The visible selected text (trimmed) */
+  selectedText: string
+  /** Which message the selection starts in */
+  startMessageIndex: number
+  startPartIndex: number
+  /** Which message the selection ends in (same as start for single-part) */
+  endMessageIndex: number
+  endPartIndex: number
+  /** Whether this is a single-part selection (eligible for annotation) */
+  isSinglePart: boolean
+  /** Popover anchor position — bottom of the selection bounding rect */
+  position: { x: number; y: number }
+}
+
+export function useSelectionDetector(
+  containerRef: RefObject<HTMLElement | null>,
+  _messages: readonly (GenAIMessage | null)[],
+): { detected: DetectedSelection | null; clearDetection: () => void } {
+  const [detected, setDetected] = useState<DetectedSelection | null>(null)
+
+  const clearDetection = useCallback(() => {
+    setDetected(null)
+  }, [])
+
+  useMountEffect(() => {
+    let rafId: number | null = null
+    let timerId: ReturnType<typeof setTimeout> | null = null
+    let isSelecting = false
+
+    const cancelPending = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      if (timerId !== null) {
+        clearTimeout(timerId)
+        timerId = null
+      }
+    }
+
+    const handleSelectStart = (e: Event) => {
+      const target = e.target
+      const el = target instanceof Element ? target : (target as Node).parentElement
+      if (el && containerRef.current?.contains(el)) {
+        cancelPending()
+        isSelecting = true
+        setDetected(null)
+      }
+    }
+
+    const processSelection = () => {
+      const ws = window.getSelection()
+      if (!ws || ws.rangeCount === 0) return
+
+      const range = ws.getRangeAt(0)
+      const selectedText = range.toString().trim()
+      if (!selectedText) return
+
+      const startInside = containerRef.current?.contains(range.startContainer) ?? false
+      const endInside = containerRef.current?.contains(range.endContainer) ?? false
+
+      if (!startInside && !endInside) return
+
+      const startInfo = startInside ? findIndices(range.startContainer) : null
+      const endInfo = endInside ? findIndices(range.endContainer) : null
+
+      const insideInfo = startInfo ?? endInfo
+      if (!insideInfo) return
+
+      if (insideInfo.contentType !== "text" && insideInfo.contentType !== "reasoning") {
+        return
+      }
+
+      let isSinglePart: boolean
+      let resolvedStartInfo: { messageIndex: number; partIndex: number }
+      let resolvedEndInfo: { messageIndex: number; partIndex: number }
+
+      if (startInfo && endInfo) {
+        isSinglePart = startInfo.messageIndex === endInfo.messageIndex && startInfo.partIndex === endInfo.partIndex
+        resolvedStartInfo = startInfo
+        resolvedEndInfo = endInfo
+      } else {
+        isSinglePart = true
+        resolvedStartInfo = insideInfo
+        resolvedEndInfo = insideInfo
+      }
+
+      const clonedRange = range.cloneRange()
+      const rect = range.getBoundingClientRect()
+
+      setDetected({
+        range: clonedRange,
+        selectedText,
+        startMessageIndex: resolvedStartInfo.messageIndex,
+        startPartIndex: resolvedStartInfo.partIndex,
+        endMessageIndex: resolvedEndInfo.messageIndex,
+        endPartIndex: resolvedEndInfo.partIndex,
+        isSinglePart,
+        position: { x: rect.left, y: rect.bottom },
+      })
+    }
+
+    const handleMouseUp = () => {
+      cancelPending()
+      if (!isSelecting) return
+
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        timerId = setTimeout(() => {
+          processSelection()
+          isSelecting = false
+          timerId = null
+        }, 0)
+      })
+    }
+
+    document.addEventListener("selectstart", handleSelectStart)
+    document.addEventListener("mouseup", handleMouseUp)
+
+    return () => {
+      cancelPending()
+      document.removeEventListener("selectstart", handleSelectStart)
+      document.removeEventListener("mouseup", handleMouseUp)
+    }
+  })
+
+  return { detected, clearDetection }
+}

--- a/packages/ui/src/components/genai-conversation/source-offset-resolver.ts
+++ b/packages/ui/src/components/genai-conversation/source-offset-resolver.ts
@@ -1,0 +1,332 @@
+import type { GenAIMessage } from "rosetta-ai"
+
+export interface TextSelectionAnchor {
+  messageIndex: number
+  partIndex: number
+  startOffset: number
+  endOffset: number
+  selectedText: string
+}
+
+export function getPartText(
+  messages: readonly (GenAIMessage | null)[],
+  messageIndex: number,
+  partIndex: number,
+): string | null {
+  const msg = messages[messageIndex]
+  if (!msg) return null
+
+  let parts = msg.parts
+  if (!parts || parts.length === 0) {
+    const content = (msg as { content?: string }).content
+    if (typeof content === "string") {
+      parts = [{ type: "text" as const, content }]
+    } else {
+      return null
+    }
+  }
+
+  const part = parts[partIndex]
+  if (!part) return null
+
+  if (part.type === "text" || part.type === "reasoning") {
+    return (part as { content: string }).content ?? null
+  }
+  return null
+}
+
+export function findIndices(node: Node) {
+  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
+
+  let messageIndex: number | null = null
+  let partIndex: number | null = null
+  let contentType: string | null = null
+
+  while (el) {
+    if (messageIndex === null) {
+      const v = el.getAttribute("data-message-index")
+      if (v !== null) messageIndex = parseInt(v, 10)
+    }
+    if (partIndex === null) {
+      const v = el.getAttribute("data-part-index")
+      if (v !== null) partIndex = parseInt(v, 10)
+    }
+    if (contentType === null) {
+      const v = el.getAttribute("data-content-type")
+      if (v) contentType = v
+    }
+    if (messageIndex !== null && partIndex !== null) break
+    el = el.parentElement
+  }
+
+  if (messageIndex !== null && partIndex !== null) {
+    return { messageIndex, partIndex, contentType: contentType ?? "text" }
+  }
+  return null
+}
+
+function findPartRoot(node: Node): HTMLElement | null {
+  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
+  while (el) {
+    if (el.getAttribute("data-part-index") !== null) return el
+    el = el.parentElement
+  }
+  return null
+}
+
+function collectTextNodes(root: HTMLElement): Text[] {
+  const nodes: Text[] = []
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null)
+  let n = walker.nextNode()
+  while (n) {
+    if (n.textContent) nodes.push(n as Text)
+    n = walker.nextNode()
+  }
+  return nodes
+}
+
+function getSourceOffsetsFromNode(node: Node): { start: number; end: number } | null {
+  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
+
+  while (el && el.getAttribute("data-part-index") === null) {
+    const start = el.getAttribute("data-source-start")
+    const end = el.getAttribute("data-source-end")
+    if (start !== null && end !== null) {
+      const startNum = parseInt(start, 10)
+      const endNum = parseInt(end, 10)
+      if (!Number.isNaN(startNum) && !Number.isNaN(endNum) && endNum >= startNum) {
+        return { start: startNum, end: endNum }
+      }
+    }
+    el = el.parentElement
+  }
+  return null
+}
+
+interface MappedTextNode {
+  node: Text
+  domStart: number
+  domEnd: number
+  sourceStart: number
+  sourceEnd: number
+}
+
+function buildPositionMap(textNodes: Text[]): { map: MappedTextNode[]; totalDomLength: number } {
+  const map: MappedTextNode[] = []
+  let domOffset = 0
+  for (const node of textNodes) {
+    const len = node.textContent?.length ?? 0
+    const source = getSourceOffsetsFromNode(node)
+    if (source && len > 0) {
+      map.push({
+        node,
+        domStart: domOffset,
+        domEnd: domOffset + len,
+        sourceStart: source.start,
+        sourceEnd: source.end,
+      })
+    }
+    domOffset += len
+  }
+  return { map, totalDomLength: domOffset }
+}
+
+function resolveDomOffset(textNodes: Text[], container: Node, offset: number, side: "start" | "end"): number {
+  if (container.nodeType === Node.TEXT_NODE) {
+    let acc = 0
+    for (const tn of textNodes) {
+      if (tn === container) return acc + offset
+      acc += tn.textContent?.length ?? 0
+    }
+    return -1
+  }
+
+  const children = container.childNodes
+  if (side === "start") {
+    for (let i = offset; i < children.length; i++) {
+      const result = domOffsetOfFirstMatch(textNodes, children[i])
+      if (result >= 0) return result
+    }
+    for (let i = offset - 1; i >= 0; i--) {
+      const result = domOffsetOfLastMatch(textNodes, children[i])
+      if (result >= 0) return result
+    }
+  } else {
+    for (let i = offset - 1; i >= 0; i--) {
+      const result = domOffsetOfLastMatch(textNodes, children[i])
+      if (result >= 0) return result
+    }
+    for (let i = textNodes.length - 1; i >= 0; i--) {
+      const tn = textNodes[i]
+      if (tn && container.contains(tn)) {
+        return domOffsetOf(textNodes, tn, tn.textContent?.length ?? 0)
+      }
+    }
+  }
+  return -1
+}
+
+function domOffsetOf(textNodes: Text[], target: Text, charOffset: number): number {
+  let acc = 0
+  for (const tn of textNodes) {
+    if (tn === target) return acc + charOffset
+    acc += tn.textContent?.length ?? 0
+  }
+  return -1
+}
+
+function domOffsetOfFirstMatch(textNodes: Text[], root: Node | null | undefined): number {
+  if (!root) return -1
+  if (root.nodeType === Node.TEXT_NODE) return domOffsetOf(textNodes, root as Text, 0)
+  if (root.nodeType !== Node.ELEMENT_NODE) return -1
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null)
+  let n = walker.nextNode()
+  while (n) {
+    const result = domOffsetOf(textNodes, n as Text, 0)
+    if (result >= 0) return result
+    n = walker.nextNode()
+  }
+  return -1
+}
+
+function domOffsetOfLastMatch(textNodes: Text[], root: Node | null | undefined): number {
+  if (!root) return -1
+  if (root.nodeType === Node.TEXT_NODE) return domOffsetOf(textNodes, root as Text, root.textContent?.length ?? 0)
+  if (root.nodeType !== Node.ELEMENT_NODE) return -1
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null)
+  let last: Text | null = null
+  let n = walker.nextNode()
+  while (n) {
+    if (domOffsetOf(textNodes, n as Text, 0) >= 0) last = n as Text
+    n = walker.nextNode()
+  }
+  if (!last) return -1
+  return domOffsetOf(textNodes, last, last.textContent?.length ?? 0)
+}
+
+function domToSource(domPos: number, map: MappedTextNode[], side: "start" | "end"): number {
+  for (const entry of map) {
+    if (domPos >= entry.domStart && domPos <= entry.domEnd) {
+      const domLen = entry.domEnd - entry.domStart
+      const sourceLen = entry.sourceEnd - entry.sourceStart
+      if (domLen === 0) return entry.sourceStart
+      const ratio = (domPos - entry.domStart) / domLen
+      return Math.round(entry.sourceStart + ratio * sourceLen)
+    }
+  }
+
+  if (side === "start") {
+    for (const entry of map) {
+      if (entry.domStart >= domPos) return entry.sourceStart
+    }
+    const last = map[map.length - 1]
+    return last ? last.sourceEnd : -1
+  }
+
+  for (let i = map.length - 1; i >= 0; i--) {
+    const entry = map[i]
+    if (entry && entry.domEnd <= domPos) return entry.sourceEnd
+  }
+  const first = map[0]
+  return first ? first.sourceStart : -1
+}
+
+/**
+ * Strip markdown syntax and collapse whitespace so rendered DOM text
+ * and markdown source can be compared by length.
+ */
+function normalizeRendered(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/gm, "") // heading markers
+    .replace(/\*{1,3}|_{1,3}/g, "") // bold/italic markers
+    .replace(/`{1,3}/g, "") // inline code / code fence markers
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links → text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1") // images → alt
+    .replace(/\s+/g, " ") // collapse whitespace
+    .trim()
+}
+
+function calculateTextOffsets(
+  textNodes: Text[],
+  range: Range,
+  fullText: string,
+): { textStart: number; textEnd: number } | null {
+  const selectedText = range.toString()
+  if (!selectedText.trim()) return null
+
+  const { map } = buildPositionMap(textNodes)
+  if (map.length === 0) return null
+
+  const domStart = resolveDomOffset(textNodes, range.startContainer, range.startOffset, "start")
+  const domEnd = resolveDomOffset(textNodes, range.endContainer, range.endOffset, "end")
+  if (domStart < 0 || domEnd < 0 || domEnd <= domStart) return null
+
+  const textStart = domToSource(domStart, map, "start")
+  let textEnd = domToSource(domEnd, map, "end")
+
+  if (textStart < 0 || textEnd < 0 || textEnd <= textStart || textEnd > fullText.length) return null
+
+  // Clamp the resolved range to match what the user visually selected.
+  //
+  // When the user drags into whitespace between block elements (e.g. between
+  // a <p> and an <h2>) the DOM range end can snap to the start of the next
+  // block, causing the resolved source range to include content beyond the
+  // actual selection. The rendered DOM text (via range.toString()) is our
+  // ground truth: strip markdown syntax from both and compare.
+  const trimmedSelected = normalizeRendered(selectedText)
+  const resolvedSource = fullText.slice(textStart, textEnd)
+  const normalizedSource = normalizeRendered(resolvedSource)
+
+  if (normalizedSource.length > trimmedSelected.length && trimmedSelected.length > 0) {
+    // The resolved range overshoots. Find the last blank-line boundary
+    // (\n\n) in the source and try cutting there — block elements in
+    // markdown are separated by blank lines.
+    const sourceSlice = fullText.slice(textStart, textEnd)
+    let cutIdx = sourceSlice.lastIndexOf("\n\n")
+    while (cutIdx > 0) {
+      const candidate = sourceSlice.slice(0, cutIdx)
+      const norm = normalizeRendered(candidate)
+      if (norm.length <= trimmedSelected.length) {
+        textEnd = textStart + cutIdx
+        break
+      }
+      cutIdx = sourceSlice.lastIndexOf("\n\n", cutIdx - 1)
+    }
+    // Trim trailing whitespace/newlines
+    while (textEnd > textStart && /\s/.test(fullText[textEnd - 1])) {
+      textEnd--
+    }
+  }
+  if (textEnd <= textStart) return null
+
+  return { textStart, textEnd }
+}
+
+/**
+ * Phase 2: resolve a DOM Range to markdown source offsets.
+ * Only called when the user commits an action (Copy / Annotate).
+ */
+export function resolveSourceOffsets(
+  range: Range,
+  messages: readonly (GenAIMessage | null)[],
+  messageIndex: number,
+  partIndex: number,
+): TextSelectionAnchor | null {
+  const fullText = getPartText(messages, messageIndex, partIndex)
+  if (!fullText) return null
+
+  const partRoot = findPartRoot(range.startContainer) ?? findPartRoot(range.endContainer)
+  if (!partRoot) return null
+
+  const textNodes = collectTextNodes(partRoot)
+  const offsets = calculateTextOffsets(textNodes, range, fullText)
+  if (!offsets) return null
+
+  return {
+    messageIndex,
+    partIndex,
+    startOffset: offsets.textStart,
+    endOffset: offsets.textEnd,
+    selectedText: range.toString().trim(),
+  }
+}

--- a/packages/ui/src/components/genai-conversation/text-selection.tsx
+++ b/packages/ui/src/components/genai-conversation/text-selection.tsx
@@ -1,16 +1,13 @@
 import { createContext, type ReactNode, type RefObject, useCallback, useMemo, useRef, useState } from "react"
 import type { GenAIMessage } from "rosetta-ai"
 import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { type DetectedSelection, useSelectionDetector } from "./selection-detector.ts"
+import { getPartText, resolveSourceOffsets, type TextSelectionAnchor } from "./source-offset-resolver.ts"
 
-// --- Public types ---
+// Re-export types so external consumers keep the same import path
+export type { TextSelectionAnchor } from "./source-offset-resolver.ts"
 
-export interface TextSelectionAnchor {
-  messageIndex: number
-  partIndex: number
-  startOffset: number
-  endOffset: number
-  selectedText: string
-}
+export const SELECTION_HIGHLIGHT_CLASSES = "selection:bg-yellow-100 dark:selection:bg-yellow-400/20"
 
 export interface HighlightRange {
   messageIndex: number
@@ -20,319 +17,138 @@ export interface HighlightRange {
   type: "annotation" | "selection"
   passed?: boolean
   id?: string
-  onClick?: (position: { x: number; y: number }) => void
 }
 
-// --- Context ---
-
 interface TextSelectionContextValue {
-  selection: TextSelectionAnchor | null
+  detected: DetectedSelection | null
+  anchor: TextSelectionAnchor | null
+  resolveAndAnnotate: (clickPosition?: { x: number; y: number }) => TextSelectionAnchor | null
+  resolveAndCopy: () => void
+  clearSelection: () => void
   getHighlightsForBlock: (messageIndex: number, partIndex: number) => HighlightRange[]
 }
 
-const TextSelectionContext = createContext<TextSelectionContextValue | null>(null)
-
-export { TextSelectionContext }
-
-// --- DOM helpers ---
-
-function getPartText(
-  messages: readonly (GenAIMessage | null)[],
-  messageIndex: number,
-  partIndex: number,
-): string | null {
-  const msg = messages[messageIndex]
-  if (!msg) return null
-
-  let parts = msg.parts
-  if (!parts || parts.length === 0) {
-    const content = (msg as { content?: string }).content
-    if (typeof content === "string") {
-      parts = [{ type: "text" as const, content }]
-    } else {
-      return null
-    }
-  }
-
-  const part = parts[partIndex]
-  if (!part) return null
-
-  if (part.type === "text" || part.type === "reasoning") {
-    return (part as { content: string }).content ?? null
-  }
-  return null
-}
-
-function findIndices(node: Node) {
-  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
-
-  let messageIndex: number | null = null
-  let partIndex: number | null = null
-  let contentType: string | null = null
-
-  while (el) {
-    if (messageIndex === null) {
-      const v = el.getAttribute("data-message-index")
-      if (v !== null) messageIndex = parseInt(v, 10)
-    }
-    if (partIndex === null) {
-      const v = el.getAttribute("data-part-index")
-      if (v !== null) partIndex = parseInt(v, 10)
-    }
-    if (contentType === null) {
-      const v = el.getAttribute("data-content-type")
-      if (v) contentType = v
-    }
-    if (messageIndex !== null && partIndex !== null) break
-    el = el.parentElement
-  }
-
-  if (messageIndex !== null && partIndex !== null) {
-    return { messageIndex, partIndex, contentType: contentType ?? "text" }
-  }
-  return null
-}
-
-function findPartRoot(node: Node): HTMLElement | null {
-  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
-  while (el) {
-    if (el.getAttribute("data-part-index") !== null) return el
-    el = el.parentElement
-  }
-  return null
-}
-
-function collectTextNodes(root: HTMLElement): Text[] {
-  const nodes: Text[] = []
-  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null)
-  let n = walker.nextNode()
-  while (n) {
-    if (n.textContent) nodes.push(n as Text)
-    n = walker.nextNode()
-  }
-  return nodes
-}
-
-function getSourceOffsetsFromNode(node: Node): { start: number; end: number } | null {
-  let el: HTMLElement | null = node.nodeType === Node.TEXT_NODE ? node.parentElement : (node as HTMLElement)
-  while (el) {
-    const start = el.getAttribute("data-source-start")
-    const end = el.getAttribute("data-source-end")
-    if (start !== null && end !== null) {
-      const startNum = parseInt(start, 10)
-      const endNum = parseInt(end, 10)
-      if (!Number.isNaN(startNum) && !Number.isNaN(endNum) && endNum >= startNum) {
-        return { start: startNum, end: endNum }
-      }
-    }
-    el = el.parentElement
-  }
-  return null
-}
-
-/**
- * Computes canonical plain-text offsets from a DOM Range.
- *
- * Walks through all text nodes in the part root element and accumulates lengths
- * to find where the Range's start/end containers fall. Because the conversation
- * renders text with `white-space: pre-wrap`, the DOM text content matches the
- * canonical string 1:1 (newlines are preserved), so DOM offsets equal canonical offsets.
- */
-function calculateTextOffsets(
-  textNodes: Text[],
-  startContainer: Node,
-  endContainer: Node,
-  range: Range,
-): { textStart: number; textEnd: number } | null {
-  // Markdown render path: each text segment is wrapped with source offsets so
-  // we can map user selection back to canonical source coordinates.
-  const startSource = getSourceOffsetsFromNode(startContainer)
-  const endSource = getSourceOffsetsFromNode(endContainer)
-  if (startSource && endSource) {
-    const textStart = Math.min(startSource.end, startSource.start + range.startOffset)
-    const textEnd = Math.min(endSource.end, endSource.start + range.endOffset)
-    if (textEnd <= textStart) return null
-    return { textStart, textEnd }
-  }
-
-  let start = -1
-  let end = -1
-  let offset = 0
-
-  for (const textNode of textNodes) {
-    const len = textNode.textContent?.length ?? 0
-    if (textNode === startContainer) start = offset + range.startOffset
-    if (textNode === endContainer) end = offset + range.endOffset
-    offset += len
-    if (start >= 0 && end >= 0) break
-  }
-
-  if (start < 0 || end < 0 || end <= start) return null
-  return { textStart: start, textEnd: end }
-}
-
-// --- Selection hook ---
-
-function useTextSelectionHook(
-  messages: readonly (GenAIMessage | null)[],
-  containerRef: RefObject<HTMLElement | null>,
-  onSelect?: (anchor: TextSelectionAnchor, position: { x: number; y: number }) => void,
-) {
-  const [selection, setSelection] = useState<TextSelectionAnchor | null>(null)
-
-  const clearSelection = useCallback(() => {
-    setSelection(null)
-    // Only clear browser selection if it's within our container
-    const ws = window.getSelection()
-    if (ws?.rangeCount && containerRef.current?.contains(ws.getRangeAt(0).commonAncestorContainer)) {
-      ws.removeAllRanges()
-    }
-  }, [containerRef])
-
-  // Store callbacks in refs so the mount-only effect always calls the latest version
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
-  const onSelectRef = useRef(onSelect)
-  onSelectRef.current = onSelect
-  const selectionRef = useRef(selection)
-  selectionRef.current = selection
-
-  const processSelection = useCallback(() => {
-    const windowSelection = window.getSelection()
-    if (!windowSelection || windowSelection.rangeCount === 0) return
-
-    const range = windowSelection.getRangeAt(0)
-    const selectedText = range.toString().trim()
-    if (!selectedText) {
-      if (selectionRef.current) clearSelection()
-      return
-    }
-
-    if (
-      !containerRef.current?.contains(range.commonAncestorContainer) &&
-      !containerRef.current?.contains(range.startContainer)
-    ) {
-      clearSelection()
-      return
-    }
-
-    const startInfo = findIndices(range.startContainer)
-    const endInfo = findIndices(range.endContainer)
-
-    if (!startInfo || !endInfo) {
-      clearSelection()
-      return
-    }
-
-    // Require single-part selection within selectable textual blocks.
-    if (
-      startInfo.messageIndex !== endInfo.messageIndex ||
-      startInfo.partIndex !== endInfo.partIndex ||
-      (startInfo.contentType !== "text" && startInfo.contentType !== "reasoning")
-    ) {
-      clearSelection()
-      return
-    }
-
-    const fullText = getPartText(messagesRef.current, startInfo.messageIndex, startInfo.partIndex)
-    if (!fullText) {
-      clearSelection()
-      return
-    }
-
-    const partRoot = findPartRoot(range.startContainer)
-    if (!partRoot) {
-      clearSelection()
-      return
-    }
-
-    const textNodes = collectTextNodes(partRoot)
-    const offsets = calculateTextOffsets(textNodes, range.startContainer, range.endContainer, range)
-    if (!offsets) return
-
-    const anchor: TextSelectionAnchor = {
-      messageIndex: startInfo.messageIndex,
-      partIndex: startInfo.partIndex,
-      startOffset: offsets.textStart,
-      endOffset: offsets.textEnd,
-      selectedText,
-    }
-
-    setSelection(anchor)
-
-    const rect = range.getBoundingClientRect()
-    onSelectRef.current?.(anchor, { x: rect.left, y: rect.bottom })
-
-    // Clear browser selection so custom highlight styles are consistent
-    window.getSelection()?.removeAllRanges()
-  }, [clearSelection, containerRef])
-
-  // Register DOM event listeners once on mount; callbacks read latest state via refs.
-  useMountEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>
-    let isSelecting = false
-
-    const handleSelectStart = (e: Event) => {
-      const target = e.target
-      const el = target instanceof Element ? target : (target as Node).parentElement
-      if (el && containerRef.current?.contains(el)) isSelecting = true
-    }
-
-    const handleMouseUp = () => {
-      if (timeoutId) clearTimeout(timeoutId)
-      if (!isSelecting) return
-
-      const ws = window.getSelection()
-      if (ws?.rangeCount && containerRef.current?.contains(ws.getRangeAt(0).commonAncestorContainer)) {
-        timeoutId = setTimeout(() => {
-          processSelection()
-          isSelecting = false
-        }, 150)
-      } else {
-        isSelecting = false
-      }
-    }
-
-    const handleClickOutside = (e: MouseEvent) => {
-      const el = e.target instanceof Element ? e.target : (e.target as Node).parentElement
-      if (!el) return
-      if (el.closest("[data-selection-popover]") || el.closest('[role="dialog"]')) return
-      // Skip input elements - calling clearSelection() on input clicks interferes with
-      // the browser's text input handling, preventing users from typing in textareas/inputs.
-      const tagName = (e.target as Element)?.tagName?.toLowerCase()
-      if (tagName === "textarea" || tagName === "input") return
-      if (containerRef.current && !containerRef.current.contains(el)) clearSelection()
-    }
-
-    document.addEventListener("selectstart", handleSelectStart)
-    document.addEventListener("mouseup", handleMouseUp)
-    document.addEventListener("click", handleClickOutside, true)
-
-    return () => {
-      if (timeoutId) clearTimeout(timeoutId)
-      document.removeEventListener("selectstart", handleSelectStart)
-      document.removeEventListener("mouseup", handleMouseUp)
-      document.removeEventListener("click", handleClickOutside, true)
-    }
-  })
-
-  return { selection, clearSelection }
-}
+export const TextSelectionContext = createContext<TextSelectionContextValue | null>(null)
 
 export function TextSelectionProvider({
   messages,
   containerRef,
   onSelect,
+  onDismiss,
+  clearSelectionRef,
   highlightRanges = [],
   children,
 }: {
   readonly messages: readonly (GenAIMessage | null)[]
   readonly containerRef: RefObject<HTMLElement | null>
   readonly onSelect?: ((anchor: TextSelectionAnchor, position: { x: number; y: number }) => void) | undefined
+  readonly onDismiss?: (() => void) | undefined
+  readonly clearSelectionRef?: RefObject<(() => void) | null> | undefined
   readonly highlightRanges?: ReadonlyArray<HighlightRange> | undefined
   readonly children: ReactNode
 }) {
-  const { selection } = useTextSelectionHook(messages, containerRef, onSelect)
+  const [anchor, setAnchor] = useState<TextSelectionAnchor | null>(null)
+  const { detected, clearDetection } = useSelectionDetector(containerRef, messages)
+
+  const messagesRef = useMemo(() => ({ current: messages }), [messages])
+
+  const resolveAndAnnotate = useCallback(
+    (clickPosition?: { x: number; y: number }): TextSelectionAnchor | null => {
+      if (!detected?.isSinglePart) return null
+
+      const result = resolveSourceOffsets(
+        detected.range,
+        messagesRef.current,
+        detected.startMessageIndex,
+        detected.startPartIndex,
+      )
+      if (result) {
+        setAnchor(result)
+        onSelect?.(result, clickPosition ?? detected.position)
+      }
+      window.getSelection()?.removeAllRanges()
+      clearDetection()
+      return result
+    },
+    [detected, messagesRef, onSelect, clearDetection],
+  )
+
+  const resolveAndCopy = useCallback(() => {
+    if (!detected) return
+
+    if (detected.isSinglePart) {
+      const result = resolveSourceOffsets(
+        detected.range,
+        messagesRef.current,
+        detected.startMessageIndex,
+        detected.startPartIndex,
+      )
+      if (result) {
+        const fullText = getPartText(messagesRef.current, result.messageIndex, result.partIndex)
+        const markdown = fullText?.slice(result.startOffset, result.endOffset) ?? detected.selectedText
+        navigator.clipboard.writeText(markdown)
+      } else {
+        navigator.clipboard.writeText(detected.selectedText)
+      }
+    } else {
+      // Multi-message: map start/end messages, full markdown for middle
+      const msgs = messagesRef.current
+      const startIdx = detected.startMessageIndex
+      const endIdx = detected.endMessageIndex
+      const parts: string[] = []
+
+      for (let i = startIdx; i <= endIdx; i++) {
+        if (i === startIdx) {
+          const result = resolveSourceOffsets(detected.range, msgs, i, detected.startPartIndex)
+          if (result) {
+            const fullText = getPartText(msgs, i, detected.startPartIndex)
+            parts.push(fullText?.slice(result.startOffset) ?? "")
+          }
+        } else if (i === endIdx) {
+          const result = resolveSourceOffsets(detected.range, msgs, i, detected.endPartIndex)
+          if (result) {
+            const fullText = getPartText(msgs, i, detected.endPartIndex)
+            parts.push(fullText?.slice(0, result.endOffset) ?? "")
+          }
+        } else {
+          const fullText = getPartText(msgs, i, 0)
+          if (fullText) parts.push(fullText)
+        }
+      }
+
+      navigator.clipboard.writeText(parts.length > 0 ? parts.join("\n\n") : detected.selectedText)
+    }
+
+    window.getSelection()?.removeAllRanges()
+    clearDetection()
+  }, [detected, messagesRef, clearDetection])
+
+  const clearSelection = useCallback(() => {
+    setAnchor(null)
+    clearDetection()
+    onDismiss?.()
+    const ws = window.getSelection()
+    if (ws?.rangeCount && containerRef.current?.contains(ws.getRangeAt(0).commonAncestorContainer)) {
+      ws.removeAllRanges()
+    }
+  }, [clearDetection, containerRef, onDismiss])
+
+  const clearSelectionFnRef = useRef(clearSelection)
+  clearSelectionFnRef.current = clearSelection
+
+  if (clearSelectionRef) {
+    clearSelectionRef.current = clearSelection
+  }
+
+  useMountEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        clearSelectionFnRef.current()
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  })
 
   const rangeIndex = useMemo(() => {
     const map = new Map<string, HighlightRange[]>()
@@ -347,30 +163,30 @@ export function TextSelectionProvider({
       arr.push(r)
     }
 
-    // Add current selection as a transient highlight
-    if (selection) {
-      const key = `${selection.messageIndex}:${selection.partIndex}`
+    // After user clicks Annotate, anchor is set and browser selection cleared.
+    // Inject anchor as a highlight so the rehype plugin renders it while the
+    // annotation popover is open.
+    if (anchor) {
+      const key = `${anchor.messageIndex}:${anchor.partIndex}`
       let arr = map.get(key)
       if (!arr) {
         arr = []
         map.set(key, arr)
       }
-      const isDuplicate = arr.some(
-        (r) => r.startOffset === selection.startOffset && r.endOffset === selection.endOffset,
-      )
+      const isDuplicate = arr.some((r) => r.startOffset === anchor.startOffset && r.endOffset === anchor.endOffset)
       if (!isDuplicate) {
         arr.push({
-          messageIndex: selection.messageIndex,
-          partIndex: selection.partIndex,
-          startOffset: selection.startOffset,
-          endOffset: selection.endOffset,
+          messageIndex: anchor.messageIndex,
+          partIndex: anchor.partIndex,
+          startOffset: anchor.startOffset,
+          endOffset: anchor.endOffset,
           type: "selection",
         })
       }
     }
 
     return map
-  }, [highlightRanges, selection])
+  }, [highlightRanges, anchor])
 
   const getHighlightsForBlock = useCallback(
     (messageIndex: number, partIndex: number) => rangeIndex.get(`${messageIndex}:${partIndex}`) ?? [],
@@ -378,8 +194,15 @@ export function TextSelectionProvider({
   )
 
   const value = useMemo<TextSelectionContextValue>(
-    () => ({ selection, getHighlightsForBlock }),
-    [selection, getHighlightsForBlock],
+    () => ({
+      detected,
+      anchor,
+      resolveAndAnnotate,
+      resolveAndCopy,
+      clearSelection,
+      getHighlightsForBlock,
+    }),
+    [detected, anchor, resolveAndAnnotate, resolveAndCopy, clearSelection, getHighlightsForBlock],
   )
 
   return <TextSelectionContext.Provider value={value}>{children}</TextSelectionContext.Provider>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -87,7 +87,11 @@ export { FormWrapper } from "./components/form-wrapper/form-wrapper.tsx"
 export { Conversation } from "./components/genai-conversation/conversation.tsx"
 export { Message } from "./components/genai-conversation/message.tsx"
 export { Part, ReasoningGroup, type ToolCallResult } from "./components/genai-conversation/part.tsx"
-export type { HighlightRange, TextSelectionAnchor } from "./components/genai-conversation/text-selection.tsx"
+export {
+  type HighlightRange,
+  SELECTION_HIGHLIGHT_CLASSES,
+  type TextSelectionAnchor,
+} from "./components/genai-conversation/text-selection.tsx"
 export * from "./components/icons/custom-icons/index.tsx"
 export { Icon, type IconProps, type IconSize } from "./components/icons/icons.tsx"
 export { InfiniteTable } from "./components/infinite-table/infinite-table.tsx"

--- a/packages/ui/src/styles/plugins/hit-area.css
+++ b/packages/ui/src/styles/plugins/hit-area.css
@@ -171,3 +171,26 @@
     pointer-events: inherit;
   }
 }
+
+/*
+ * hit-area-inline-y-*  — vertical hit area for inline spans inside text.
+ * Extends vertically by the given spacing value and stretches horizontally
+ * to fill the containing block width (via -100vw/100vw insets clipped by
+ * the block ancestor's overflow).
+ */
+@utility hit-area-inline-y-* {
+  position: relative;
+  --hit-area-inline-t: --spacing(--value(number) * -1);
+  --hit-area-inline-t: calc(--value([*]) * -1);
+  --hit-area-inline-b: --spacing(--value(number) * -1);
+  --hit-area-inline-b: calc(--value([*]) * -1);
+  &::before {
+    content: "";
+    position: absolute;
+    top: var(--hit-area-inline-t, 0px);
+    bottom: var(--hit-area-inline-b, 0px);
+    left: -100vw;
+    right: -100vw;
+    pointer-events: inherit;
+  }
+}


### PR DESCRIPTION
## Summary

This branch improves **text selection and annotation UX** in annotation queues and the conversation view, fixes **anchor metadata on draft updates** in the domain layer, and tightens **sidebar collapse** behavior for narrow layouts.

## Domain (`@domain/annotations`)

- **Persisted anchor on update:** When updating an annotation score by `id`, the anchor is taken only from the existing score (not from the request), so `messageIndex` / offsets are not dropped after save.
- Extracted `anchorFromExistingAnnotationScore` and added unit tests.
- Added **`writeAnnotation` integration-style tests** with shared fake layers (`persist-draft-annotation-test-layers.ts`); trimmed duplicate setup from `write-draft-annotation.test.ts`.

## Web (`apps/web`)

- **Annotation navigation:** After `scrollIntoView` for a text-selection highlight, the popover opens on the **`scrollend`** event on the resolved scrollport (`findScrollport`), not a fixed timeout—avoids opening mid–smooth scroll.
- **Annotation popover:** Virtual anchor tracks scroll; related popover / conversation wiring updates.
- **`useAnnotationPopover`:** Adjustments aligned with selection and popover behavior (tests updated).
- **App sidebar:** Collapse state uses **`useValueWithDefault`** with a string token so entering `collapseSidebar` routes resets to a narrow nav while still allowing Mod+B to expand on the same URL; local storage only drives defaults off those routes.

## UI (`@repo/ui`)

- **Conversation text selection:** Refactor around **`source-offset-resolver`**, **`selection-detector`**, and **`selection-action-popover`**; **`text-selection`** and **`conversation`** updated so selection behavior and annotation highlights stay consistent (including source-mapped text plugin and tests).
- **`hit-area.css`** plugin for touch targets where needed.

## Testing

- Domain: new/updated Vitest coverage for anchor helper and `writeAnnotation`.
- Web/UI: updated tests for popover hook, source-mapped text plugin, and related behavior.
