### PR TITLE
Remove mock trace controls from project page

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -3,13 +3,7 @@ import { Button, Icon, type InfiniteTableSorting, type SortDirection, Tabs, Tool
 import { eq } from "@tanstack/react-db"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { createFileRoute } from "@tanstack/react-router"
-import {
-  DatabaseIcon,
-  FilterIcon,
-  LayersIcon,
-  MessagesSquareIcon,
-  TextIcon,
-} from "lucide-react"
+import { DatabaseIcon, FilterIcon, LayersIcon, MessagesSquareIcon, TextIcon } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../components/hotkey-badge.tsx"
 import { useProjectsCollection } from "../../../../domains/projects/projects.collection.ts"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -1,16 +1,13 @@
 import { type FilterSet, filterSetSchema } from "@domain/shared"
-import { Button, Icon, type InfiniteTableSorting, Input, type SortDirection, Tabs, Tooltip } from "@repo/ui"
+import { Button, Icon, type InfiniteTableSorting, type SortDirection, Tabs, Tooltip } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { createFileRoute } from "@tanstack/react-router"
 import {
-  AppWindowIcon,
-  ChevronDown,
   DatabaseIcon,
   FilterIcon,
   LayersIcon,
   MessagesSquareIcon,
-  SearchIcon,
   TextIcon,
 } from "lucide-react"
 import { useCallback, useMemo, useRef, useState } from "react"
@@ -269,11 +266,6 @@ function ProjectPage() {
       <Layout.Actions>
         <Layout.ActionsRow>
           <Layout.ActionRowItem>
-            <Button variant="outline" size="sm" disabled>
-              <AppWindowIcon className="h-4 w-4" />
-              All logs
-              <ChevronDown className="h-4 w-4" />
-            </Button>
             <TimeFilterDropdown
               {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
               {...(timeTo ? { startTimeTo: timeTo } : {})}
@@ -346,15 +338,6 @@ function ProjectPage() {
                 setActiveTab(id)
               }}
             />
-            <div className="relative">
-              <Input
-                placeholder={activeTab === "sessions" ? "Search sessions" : "Search traces"}
-                size="sm"
-                className="peer w-60 pl-8"
-                disabled
-              />
-              <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground peer-disabled:opacity-50" />
-            </div>
           </Layout.ActionRowItem>
         </Layout.ActionsRow>
       </Layout.Actions>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the disabled "All logs" button from the traces/sessions toolbar on the project page
- remove the disabled search input shown for traces/sessions since it is a noop mock
- clean up icon imports after removing those mock controls

## Testing
- `pnpm --filter @app/web check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbecd245-59fd-4b82-a337-6dd6f5a0093e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbecd245-59fd-4b82-a337-6dd6f5a0093e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

