### PR TITLE
Add confirmation modal for member removal actions

### DIFF
--- a/apps/web/src/routes/_authenticated/settings/members.tsx
+++ b/apps/web/src/routes/_authenticated/settings/members.tsx
@@ -290,6 +290,12 @@ function MembersTable({
   const [transferOpen, setTransferOpen] = useState(false)
   const [changeRoleOpen, setChangeRoleOpen] = useState(false)
   const [selectedMember, setSelectedMember] = useState<MemberRecord | null>(null)
+  const [isMutatingMember, setIsMutatingMember] = useState(false)
+  const [pendingMemberMutation, setPendingMemberMutation] = useState<
+    | { type: "remove-member"; membershipId: string; email: string; name: string | null }
+    | { type: "cancel-invite"; inviteId: string; email: string; name: string | null }
+    | null
+  >(null)
 
   const isExpired = (expiresAt: string | null | undefined) => {
     if (!expiresAt) return false
@@ -313,6 +319,32 @@ function MembersTable({
     return true
   }
 
+  const handleConfirmMemberMutation = async () => {
+    if (!pendingMemberMutation) return
+
+    setIsMutatingMember(true)
+    try {
+      const transaction =
+        pendingMemberMutation.type === "cancel-invite"
+          ? cancelMemberInviteMutation(pendingMemberMutation.inviteId)
+          : removeMemberMutation(pendingMemberMutation.membershipId)
+
+      await transaction.isPersisted.promise
+
+      toast({
+        description: pendingMemberMutation.type === "cancel-invite" ? "Invitation canceled" : "Member removed",
+      })
+      setPendingMemberMutation(null)
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setIsMutatingMember(false)
+    }
+  }
+
+  const pendingMemberDisplayName = pendingMemberMutation?.name ?? pendingMemberMutation?.email ?? "this member"
+  const isCancelInviteMutation = pendingMemberMutation?.type === "cancel-invite"
+
   return (
     <>
       <TransferOwnershipModal
@@ -327,6 +359,41 @@ function MembersTable({
         member={selectedMember}
         onRoleChange={handleRoleChange}
       />
+      <Modal.Root
+        open={pendingMemberMutation !== null}
+        onOpenChange={(open) => {
+          if (!open && !isMutatingMember) {
+            setPendingMemberMutation(null)
+          }
+        }}
+      >
+        <Modal.Content dismissible>
+          <Modal.Header
+            title={isCancelInviteMutation ? "Cancel invitation?" : "Remove member?"}
+            description={
+              isCancelInviteMutation
+                ? `Are you sure you want to cancel the pending invitation for ${pendingMemberDisplayName}?`
+                : `Are you sure you want to remove ${pendingMemberDisplayName} from this organization?`
+            }
+          />
+          <Modal.Footer>
+            <CloseTrigger />
+            <Button
+              variant="destructive"
+              onClick={() => void handleConfirmMemberMutation()}
+              disabled={pendingMemberMutation === null || isMutatingMember}
+            >
+              {isMutatingMember
+                ? isCancelInviteMutation
+                  ? "Canceling..."
+                  : "Removing..."
+                : isCancelInviteMutation
+                  ? "Cancel invitation"
+                  : "Remove member"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal.Root>
       <Table>
         <TableHeader>
           <TableRow verticalPadding>
@@ -404,20 +471,21 @@ function MembersTable({
                       <Button
                         variant="ghost"
                         onClick={() => {
-                          const transaction =
+                          setPendingMemberMutation(
                             member.status === "invited"
-                              ? cancelMemberInviteMutation(member.id)
-                              : removeMemberMutation(member.id)
-
-                          void transaction.isPersisted.promise
-                            .then(() => {
-                              toast({
-                                description: member.status === "invited" ? "Invitation canceled" : "Member removed",
-                              })
-                            })
-                            .catch((error) => {
-                              toast({ variant: "destructive", description: toUserMessage(error) })
-                            })
+                              ? {
+                                  type: "cancel-invite",
+                                  inviteId: member.id,
+                                  email: member.email,
+                                  name: member.name,
+                                }
+                              : {
+                                  type: "remove-member",
+                                  membershipId: member.id,
+                                  email: member.email,
+                                  name: member.name,
+                                },
+                          )
                         }}
                       >
                         <Icon icon={Trash2} size="sm" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a confirmation modal in `settings/members` for destructive actions triggered by the trash button
- route both active-member removal and pending-invitation cancel actions through modal confirmation before mutation execution
- keep action-specific copy and button labels so users clearly understand whether they are removing a member or canceling an invitation

## Validation
- `pnpm --filter "@app/web" check`
- `pnpm --filter "@app/web" typecheck` *(fails in this environment due to missing `@latitude-data/telemetry` type/module dependencies outside this change)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfb143ce-ad36-4d48-9c24-ca6b755b7a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb143ce-ad36-4d48-9c24-ca6b755b7a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

