### PR TITLE
Add project home tab with general overview of the project health

### DIFF
--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items-pagination.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items-pagination.ts
@@ -1,0 +1,2 @@
+/** Page size for queue item lists (infinite table + server-side focus resolution). */
+export const ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT = 50

--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items.collection.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items.collection.ts
@@ -15,8 +15,7 @@ import {
   listAnnotationQueueItemsByQueue,
   uncompleteQueueItem,
 } from "./annotation-queue-items.functions.ts"
-
-const BATCH_SIZE = 50
+import { ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT } from "./annotation-queue-items-pagination.ts"
 
 export const ANNOTATION_QUEUE_ITEMS_DEFAULT_SORTING: InfiniteTableSorting = {
   column: "status",
@@ -59,7 +58,7 @@ export function useAnnotationQueueItemsInfiniteScroll({
         data: {
           projectId,
           queueId,
-          limit: BATCH_SIZE,
+          limit: ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT,
           cursor: pageParam,
           sortBy,
           sortDirection,

--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
@@ -25,6 +25,7 @@ import { z } from "zod"
 import { queueInputSchema } from "../../components/annotation-queues/queue-form-schema.ts"
 import { requireSession } from "../../server/auth.ts"
 import { getClickhouseClient, getPostgresClient, getQueuePublisher } from "../../server/clients.ts"
+import { ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT } from "./annotation-queue-items-pagination.ts"
 
 const itemListCursorSchema = z.object({
   sortValue: z.string(),
@@ -103,7 +104,7 @@ export const listAnnotationQueueItemsByQueue = createServerFn({ method: "GET" })
 
         const c = data.cursor
         const listOptions: AnnotationQueueItemListOptions = {
-          limit: data.limit ?? 50,
+          limit: data.limit ?? ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT,
           ...(sortBy !== undefined ? { sortBy } : {}),
           ...(sortDirection !== undefined ? { sortDirection } : {}),
           ...(c

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,8 +16,10 @@ import { Route as WelcomeIndexRouteImport } from './routes/welcome/index'
 import { Route as DesignSystemIndexRouteImport } from './routes/design-system/index'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as DownloadsExportRouteImport } from './routes/downloads/export'
+import { Route as DesignSystemStatusRouteImport } from './routes/design-system/status'
 import { Route as DesignSystemColorsRouteImport } from './routes/design-system/colors'
 import { Route as DesignSystemButtonRouteImport } from './routes/design-system/button'
+import { Route as DesignSystemBadgeRouteImport } from './routes/design-system/badge'
 import { Route as AuthInviteRouteImport } from './routes/auth/invite'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
@@ -76,6 +78,11 @@ const DownloadsExportRoute = DownloadsExportRouteImport.update({
   path: '/downloads/export',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DesignSystemStatusRoute = DesignSystemStatusRouteImport.update({
+  id: '/status',
+  path: '/status',
+  getParentRoute: () => DesignSystemRouteRoute,
+} as any)
 const DesignSystemColorsRoute = DesignSystemColorsRouteImport.update({
   id: '/colors',
   path: '/colors',
@@ -84,6 +91,11 @@ const DesignSystemColorsRoute = DesignSystemColorsRouteImport.update({
 const DesignSystemButtonRoute = DesignSystemButtonRouteImport.update({
   id: '/button',
   path: '/button',
+  getParentRoute: () => DesignSystemRouteRoute,
+} as any)
+const DesignSystemBadgeRoute = DesignSystemBadgeRouteImport.update({
+  id: '/badge',
+  path: '/badge',
   getParentRoute: () => DesignSystemRouteRoute,
 } as any)
 const AuthInviteRoute = AuthInviteRouteImport.update({
@@ -234,8 +246,10 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/api/health': typeof ApiHealthRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/design-system/badge': typeof DesignSystemBadgeRoute
   '/design-system/button': typeof DesignSystemButtonRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
+  '/design-system/status': typeof DesignSystemStatusRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/design-system/': typeof DesignSystemIndexRoute
   '/welcome/': typeof WelcomeIndexRoute
@@ -264,8 +278,10 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/api/health': typeof ApiHealthRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/design-system/badge': typeof DesignSystemBadgeRoute
   '/design-system/button': typeof DesignSystemButtonRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
+  '/design-system/status': typeof DesignSystemStatusRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/': typeof AuthenticatedIndexRoute
   '/design-system': typeof DesignSystemIndexRoute
@@ -297,8 +313,10 @@ export interface FileRoutesById {
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/api/health': typeof ApiHealthRoute
   '/auth/invite': typeof AuthInviteRoute
+  '/design-system/badge': typeof DesignSystemBadgeRoute
   '/design-system/button': typeof DesignSystemButtonRoute
   '/design-system/colors': typeof DesignSystemColorsRoute
+  '/design-system/status': typeof DesignSystemStatusRoute
   '/downloads/export': typeof DownloadsExportRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
   '/design-system/': typeof DesignSystemIndexRoute
@@ -333,8 +351,10 @@ export interface FileRouteTypes {
     | '/settings'
     | '/api/health'
     | '/auth/invite'
+    | '/design-system/badge'
     | '/design-system/button'
     | '/design-system/colors'
+    | '/design-system/status'
     | '/downloads/export'
     | '/design-system/'
     | '/welcome/'
@@ -363,8 +383,10 @@ export interface FileRouteTypes {
     | '/login'
     | '/api/health'
     | '/auth/invite'
+    | '/design-system/badge'
     | '/design-system/button'
     | '/design-system/colors'
+    | '/design-system/status'
     | '/downloads/export'
     | '/'
     | '/design-system'
@@ -395,8 +417,10 @@ export interface FileRouteTypes {
     | '/_authenticated/settings'
     | '/api/health'
     | '/auth/invite'
+    | '/design-system/badge'
     | '/design-system/button'
     | '/design-system/colors'
+    | '/design-system/status'
     | '/downloads/export'
     | '/_authenticated/'
     | '/design-system/'
@@ -487,6 +511,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DownloadsExportRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/design-system/status': {
+      id: '/design-system/status'
+      path: '/status'
+      fullPath: '/design-system/status'
+      preLoaderRoute: typeof DesignSystemStatusRouteImport
+      parentRoute: typeof DesignSystemRouteRoute
+    }
     '/design-system/colors': {
       id: '/design-system/colors'
       path: '/colors'
@@ -499,6 +530,13 @@ declare module '@tanstack/react-router' {
       path: '/button'
       fullPath: '/design-system/button'
       preLoaderRoute: typeof DesignSystemButtonRouteImport
+      parentRoute: typeof DesignSystemRouteRoute
+    }
+    '/design-system/badge': {
+      id: '/design-system/badge'
+      path: '/badge'
+      fullPath: '/design-system/badge'
+      preLoaderRoute: typeof DesignSystemBadgeRouteImport
       parentRoute: typeof DesignSystemRouteRoute
     }
     '/auth/invite': {
@@ -666,14 +704,18 @@ declare module '@tanstack/react-router' {
 }
 
 interface DesignSystemRouteRouteChildren {
+  DesignSystemBadgeRoute: typeof DesignSystemBadgeRoute
   DesignSystemButtonRoute: typeof DesignSystemButtonRoute
   DesignSystemColorsRoute: typeof DesignSystemColorsRoute
+  DesignSystemStatusRoute: typeof DesignSystemStatusRoute
   DesignSystemIndexRoute: typeof DesignSystemIndexRoute
 }
 
 const DesignSystemRouteRouteChildren: DesignSystemRouteRouteChildren = {
+  DesignSystemBadgeRoute: DesignSystemBadgeRoute,
   DesignSystemButtonRoute: DesignSystemButtonRoute,
   DesignSystemColorsRoute: DesignSystemColorsRoute,
+  DesignSystemStatusRoute: DesignSystemStatusRoute,
   DesignSystemIndexRoute: DesignSystemIndexRoute,
 }
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedSettingsAccountRouteImport } from './routes/_auth
 import { Route as AuthenticatedProjectsProjectSlugRouteImport } from './routes/_authenticated/projects/$projectSlug'
 import { Route as AuthenticatedProjectsProjectSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/index'
 import { Route as AuthenticatedProjectsProjectSlugSettingsRouteImport } from './routes/_authenticated/projects/$projectSlug/settings'
+import { Route as AuthenticatedProjectsProjectSlugHomeRouteImport } from './routes/_authenticated/projects/$projectSlug/home'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/index'
 import { Route as AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/datasets/index'
 import { Route as AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/annotation-queues/index'
@@ -171,6 +172,12 @@ const AuthenticatedProjectsProjectSlugSettingsRoute =
     path: '/settings',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugHomeRoute =
+  AuthenticatedProjectsProjectSlugHomeRouteImport.update({
+    id: '/home',
+    path: '/home',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugIssuesIndexRoute =
   AuthenticatedProjectsProjectSlugIssuesIndexRouteImport.update({
     id: '/issues/',
@@ -242,6 +249,7 @@ export interface FileRoutesByFullPath {
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
+  '/projects/$projectSlug/home': typeof AuthenticatedProjectsProjectSlugHomeRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/projects/$projectSlug/': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren
@@ -271,6 +279,7 @@ export interface FileRoutesByTo {
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test': typeof ApiObservabilityTestIndexRoute
+  '/projects/$projectSlug/home': typeof AuthenticatedProjectsProjectSlugHomeRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/projects/$projectSlug': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/projects/$projectSlug/datasets/$datasetId': typeof AuthenticatedProjectsProjectSlugDatasetsDatasetIdRoute
@@ -304,6 +313,7 @@ export interface FileRoutesById {
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
+  '/_authenticated/projects/$projectSlug/home': typeof AuthenticatedProjectsProjectSlugHomeRoute
   '/_authenticated/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
   '/_authenticated/projects/$projectSlug/': typeof AuthenticatedProjectsProjectSlugIndexRoute
   '/_authenticated/projects/$projectSlug/annotation-queues/$queueId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren
@@ -338,6 +348,7 @@ export interface FileRouteTypes {
     | '/api/observability-test/error'
     | '/settings/'
     | '/api/observability-test/'
+    | '/projects/$projectSlug/home'
     | '/projects/$projectSlug/settings'
     | '/projects/$projectSlug/'
     | '/projects/$projectSlug/annotation-queues/$queueId'
@@ -367,6 +378,7 @@ export interface FileRouteTypes {
     | '/api/observability-test/error'
     | '/settings'
     | '/api/observability-test'
+    | '/projects/$projectSlug/home'
     | '/projects/$projectSlug/settings'
     | '/projects/$projectSlug'
     | '/projects/$projectSlug/datasets/$datasetId'
@@ -399,6 +411,7 @@ export interface FileRouteTypes {
     | '/api/observability-test/error'
     | '/_authenticated/settings/'
     | '/api/observability-test/'
+    | '/_authenticated/projects/$projectSlug/home'
     | '/_authenticated/projects/$projectSlug/settings'
     | '/_authenticated/projects/$projectSlug/'
     | '/_authenticated/projects/$projectSlug/annotation-queues/$queueId'
@@ -593,6 +606,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/home': {
+      id: '/_authenticated/projects/$projectSlug/home'
+      path: '/home'
+      fullPath: '/projects/$projectSlug/home'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugHomeRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/issues/': {
       id: '/_authenticated/projects/$projectSlug/issues/'
       path: '/issues'
@@ -703,6 +723,7 @@ const AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren =
   )
 
 interface AuthenticatedProjectsProjectSlugRouteChildren {
+  AuthenticatedProjectsProjectSlugHomeRoute: typeof AuthenticatedProjectsProjectSlugHomeRoute
   AuthenticatedProjectsProjectSlugSettingsRoute: typeof AuthenticatedProjectsProjectSlugSettingsRoute
   AuthenticatedProjectsProjectSlugIndexRoute: typeof AuthenticatedProjectsProjectSlugIndexRoute
   AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRoute: typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdRouteWithChildren
@@ -714,6 +735,8 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
 
 const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjectSlugRouteChildren =
   {
+    AuthenticatedProjectsProjectSlugHomeRoute:
+      AuthenticatedProjectsProjectSlugHomeRoute,
     AuthenticatedProjectsProjectSlugSettingsRoute:
       AuthenticatedProjectsProjectSlugSettingsRoute,
     AuthenticatedProjectsProjectSlugIndexRoute:

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -104,7 +104,7 @@ function ProjectLayout() {
   return (
     <div className="flex h-full">
       <ProjectSidebar project={project} projectSlug={projectSlug} />
-      <main className="flex-1 min-w-0 overflow-y-auto">
+      <main className="flex-1 min-w-0 overflow-y-auto pb-6">
         <Outlet />
       </main>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -1,6 +1,6 @@
 import { CopyableText } from "@repo/ui"
 import { createFileRoute, Outlet, redirect, useRouterState } from "@tanstack/react-router"
-import { DatabaseIcon, LayersIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
+import { DatabaseIcon, HomeIcon, LayersIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
 import { getProjectBySlug, type ProjectRecord } from "../../../domains/projects/projects.functions.ts"
 import { AppSidebar, NavItem } from "../../../layouts/AppSidebar/index.tsx"
 import { ProjectBreadcrumbSegment } from "../-components/project-breadcrumb-segment.tsx"
@@ -31,6 +31,7 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug")({
 function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; projectSlug: string }) {
   const pathname = useRouterState({ select: (state) => state.location.pathname })
 
+  const isHomeActive = pathname.startsWith(`/projects/${projectSlug}/home`)
   const isTracesActive =
     pathname === `/projects/${projectSlug}` ||
     pathname === `/projects/${projectSlug}/` ||
@@ -56,6 +57,13 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
     >
       {({ collapsed }) => (
         <>
+          <NavItem
+            icon={HomeIcon}
+            label="Home"
+            to={`/projects/${projectSlug}/home`}
+            active={isHomeActive}
+            collapsed={collapsed}
+          />
           <NavItem
             icon={TextAlignStartIcon}
             label="Traces"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -2,7 +2,7 @@ import type { FilterSet } from "@domain/shared"
 import { denseTraceTimeHistogramBuckets } from "@domain/spans"
 import { BarChart, HistogramSkeleton, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
-import { useCallback, useMemo } from "react"
+import { type ReactNode, useCallback, useMemo } from "react"
 
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
 
@@ -16,9 +16,11 @@ interface HistogramProps {
   readonly filters: FilterSet
   /** Called when user selects a time range via brush on the histogram. */
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
+  /** Replaces the default “no data” line when there are no buckets. */
+  readonly emptyContent?: ReactNode
 }
 
-export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps) {
+export function Histogram({ projectId, filters, onRangeSelect, emptyContent }: HistogramProps) {
   const {
     data: sparseBuckets,
     isLoading,
@@ -78,8 +80,12 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
 
   if (denseBuckets.length === 0) {
     return (
-      <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
-        <Text.H6 color="foregroundMuted">No traces in this time window</Text.H6>
+      <div className="w-full px-4 py-3">
+        {emptyContent ?? (
+          <div className="flex min-h-[80px] w-full items-center justify-center">
+            <Text.H6 color="foregroundMuted">No traces in this time window</Text.H6>
+          </div>
+        )}
       </div>
     )
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
@@ -1,9 +1,8 @@
-import { annotationQueueItemStatus } from "@domain/annotation-queues"
 import { Avatar, InfiniteTable, type InfiniteTableColumn, type InfiniteTableSorting, Text, Tooltip } from "@repo/ui"
 import { mapByEntityId, relativeTime } from "@repo/utils"
 import { eq } from "@tanstack/react-db"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
+import { useMemo, useState } from "react"
 import z from "zod"
 import {
   ANNOTATION_QUEUE_ITEMS_DEFAULT_SORTING,
@@ -11,12 +10,14 @@ import {
 } from "../../../../../../domains/annotation-queue-items/annotation-queue-items.collection.ts"
 import type { AnnotationQueueItemRecord } from "../../../../../../domains/annotation-queue-items/annotation-queue-items.functions.ts"
 import { useAnnotationQueue } from "../../../../../../domains/annotation-queues/annotation-queues.collection.ts"
+import { getAnnotationQueueByProject } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
 import { pickUserFromMembersMap } from "../../../../../../domains/members/pick-users-from-members.ts"
 import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
 import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
 import { QueueBadge } from "../-components/queue-badge.tsx"
 import { QueueItemStatusBadge } from "../-components/queue-item-status-badge.tsx"
+import { resolveFirstNonCompletedQueueItemId } from "./resolve-focus-queue-item.ts"
 
 const annotationQueueListSearchSchema = z
   .object({
@@ -28,12 +29,46 @@ const annotationQueueListSearchSchema = z
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/annotation-queues/$queueId/")({
   validateSearch: annotationQueueListSearchSchema,
+  loader: async ({ preload, location, params, parentMatchPromise }) => {
+    // Skip on prefetch/hover-preload; still run on `cause: "stay"` so `?focus=true` works when only search changes.
+    if (preload) return
+
+    const { focus } = annotationQueueListSearchSchema.parse(location.search)
+    if (!focus) return
+
+    const parent = await parentMatchPromise
+    const project = parent.loaderData?.project
+    if (!project) return
+
+    const { projectSlug, queueId } = params
+    const projectId = project.id
+
+    const queue = await getAnnotationQueueByProject({ data: { projectId, queueId } })
+    const queueName = queue?.name
+
+    const itemId = await resolveFirstNonCompletedQueueItemId(projectId, queueId)
+
+    if (itemId) {
+      throw redirect({
+        to: "/projects/$projectSlug/annotation-queues/$queueId/items/$itemId",
+        params: { projectSlug, queueId, itemId },
+        state: { queueName } as { queueName?: string },
+        replace: true,
+      })
+    }
+
+    throw redirect({
+      to: "/projects/$projectSlug/annotation-queues/$queueId",
+      params: { projectSlug, queueId },
+      search: {},
+      replace: true,
+    })
+  },
   component: AnnotationQueueItemsPage,
 })
 
 function AnnotationQueueItemsPage() {
   const { projectSlug, queueId } = Route.useParams()
-  const search = Route.useSearch()
   const navigate = useNavigate()
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),
@@ -58,59 +93,6 @@ function AnnotationQueueItemsPage() {
     queueId,
     sorting,
   })
-
-  const focusIntentResolvedRef = useRef(false)
-
-  // TODO(frontend-use-effect-policy): resolve `focus` search param by navigating once items are loaded,
-  // paging the infinite list until a non-completed item exists or the queue is exhausted; not mount-only.
-  useEffect(() => {
-    if (!search.focus) {
-      focusIntentResolvedRef.current = false
-      return
-    }
-    if (focusIntentResolvedRef.current) return
-    if (!projectId) return
-    if (itemsLoading && items.length === 0) return
-
-    const firstReviewItem = items.find((row) => annotationQueueItemStatus(row) !== "completed")
-
-    if (firstReviewItem) {
-      focusIntentResolvedRef.current = true
-      void navigate({
-        to: "/projects/$projectSlug/annotation-queues/$queueId/items/$itemId",
-        params: { projectSlug, queueId, itemId: firstReviewItem.id },
-        state: { queueName: queue?.name } as { queueName?: string },
-        replace: true,
-      })
-      return
-    }
-
-    if (infiniteScroll.hasMore) {
-      if (infiniteScroll.isLoadingMore) return
-      infiniteScroll.onLoadMore()
-      return
-    }
-
-    focusIntentResolvedRef.current = true
-    void navigate({
-      to: "/projects/$projectSlug/annotation-queues/$queueId",
-      params: { projectSlug, queueId },
-      search: {},
-      replace: true,
-    })
-  }, [
-    search.focus,
-    projectId,
-    projectSlug,
-    queueId,
-    queue?.name,
-    items,
-    itemsLoading,
-    navigate,
-    infiniteScroll.hasMore,
-    infiniteScroll.isLoadingMore,
-    infiniteScroll.onLoadMore,
-  ])
 
   const memberByUserId = useMemberByUserIdMap()
   const completerByItemId = useMemo(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
@@ -1,8 +1,10 @@
+import { annotationQueueItemStatus } from "@domain/annotation-queues"
 import { Avatar, InfiniteTable, type InfiniteTableColumn, type InfiniteTableSorting, Text, Tooltip } from "@repo/ui"
 import { mapByEntityId, relativeTime } from "@repo/utils"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
+import z from "zod"
 import {
   ANNOTATION_QUEUE_ITEMS_DEFAULT_SORTING,
   useAnnotationQueueItemsInfiniteScroll,
@@ -16,12 +18,22 @@ import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout
 import { QueueBadge } from "../-components/queue-badge.tsx"
 import { QueueItemStatusBadge } from "../-components/queue-item-status-badge.tsx"
 
+const annotationQueueListSearchSchema = z
+  .object({
+    focus: z.union([z.boolean(), z.string(), z.undefined()]).optional(),
+  })
+  .transform(({ focus }) => ({
+    focus: focus === true || focus === "true" || focus === "1",
+  }))
+
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/annotation-queues/$queueId/")({
+  validateSearch: annotationQueueListSearchSchema,
   component: AnnotationQueueItemsPage,
 })
 
 function AnnotationQueueItemsPage() {
   const { projectSlug, queueId } = Route.useParams()
+  const search = Route.useSearch()
   const navigate = useNavigate()
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project }) => eq(project.slug, projectSlug)).findOne(),
@@ -46,6 +58,57 @@ function AnnotationQueueItemsPage() {
     queueId,
     sorting,
   })
+
+  const focusIntentResolvedRef = useRef(false)
+
+  useEffect(() => {
+    if (!search.focus) {
+      focusIntentResolvedRef.current = false
+      return
+    }
+    if (focusIntentResolvedRef.current) return
+    if (!projectId) return
+    if (itemsLoading && items.length === 0) return
+
+    const firstReviewItem = items.find((row) => annotationQueueItemStatus(row) !== "completed")
+
+    if (firstReviewItem) {
+      focusIntentResolvedRef.current = true
+      void navigate({
+        to: "/projects/$projectSlug/annotation-queues/$queueId/items/$itemId",
+        params: { projectSlug, queueId, itemId: firstReviewItem.id },
+        state: { queueName: queue?.name } as { queueName?: string },
+        replace: true,
+      })
+      return
+    }
+
+    if (infiniteScroll.hasMore) {
+      if (infiniteScroll.isLoadingMore) return
+      infiniteScroll.onLoadMore()
+      return
+    }
+
+    focusIntentResolvedRef.current = true
+    void navigate({
+      to: "/projects/$projectSlug/annotation-queues/$queueId",
+      params: { projectSlug, queueId },
+      search: {},
+      replace: true,
+    })
+  }, [
+    search.focus,
+    projectId,
+    projectSlug,
+    queueId,
+    queue?.name,
+    items,
+    itemsLoading,
+    navigate,
+    infiniteScroll.hasMore,
+    infiniteScroll.isLoadingMore,
+    infiniteScroll.onLoadMore,
+  ])
 
   const memberByUserId = useMemberByUserIdMap()
   const completerByItemId = useMemo(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
@@ -61,6 +61,8 @@ function AnnotationQueueItemsPage() {
 
   const focusIntentResolvedRef = useRef(false)
 
+  // TODO(frontend-use-effect-policy): resolve `focus` search param by navigating once items are loaded,
+  // paging the infinite list until a non-completed item exists or the queue is exhausted; not mount-only.
   useEffect(() => {
     if (!search.focus) {
       focusIntentResolvedRef.current = false

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/resolve-focus-queue-item.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/resolve-focus-queue-item.ts
@@ -1,0 +1,34 @@
+import type { AnnotationQueueItemListCursor } from "@domain/annotation-queues"
+import { annotationQueueItemStatus } from "@domain/annotation-queues"
+import { listAnnotationQueueItemsByQueue } from "../../../../../../domains/annotation-queue-items/annotation-queue-items.functions.ts"
+import { ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT } from "../../../../../../domains/annotation-queue-items/annotation-queue-items-pagination.ts"
+
+const FOCUS_SORT_BY = "status" as const
+const FOCUS_SORT_DIRECTION = "asc" as const
+
+/**
+ * Walks queue item pages (same sort as the queue list default) until the first
+ * non-completed item is found, or the queue is exhausted.
+ */
+export async function resolveFirstNonCompletedQueueItemId(projectId: string, queueId: string): Promise<string | null> {
+  let cursor: AnnotationQueueItemListCursor | undefined
+
+  for (;;) {
+    const page = await listAnnotationQueueItemsByQueue({
+      data: {
+        projectId,
+        queueId,
+        limit: ANNOTATION_QUEUE_ITEMS_PAGE_LIMIT,
+        cursor,
+        sortBy: FOCUS_SORT_BY,
+        sortDirection: FOCUS_SORT_DIRECTION,
+      },
+    })
+
+    const first = page.items.find((row) => annotationQueueItemStatus(row) !== "completed")
+    if (first) return first.id
+
+    if (!page.hasMore || !page.nextCursor) return null
+    cursor = page.nextCursor
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
@@ -15,8 +15,8 @@ function ProjectHomePage() {
   return (
     <Layout>
       <Layout.Content>
-        <Layout.List className="pt-6 pb-8">
-          <div className="mb-6 flex min-w-0 flex-row flex-wrap items-center justify-between gap-3">
+        <Layout.List className="flex flex-col gap-6 pt-6 pb-8">
+          <div className="flex min-w-0 flex-row flex-wrap items-center justify-between gap-3">
             <div className="flex min-w-0 flex-col gap-0.5">
               <Text.H4>Overview</Text.H4>
               <Text.H6 color="foregroundMuted">Your project overview over the past 7 days</Text.H6>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
@@ -19,7 +19,7 @@ function ProjectHomePage() {
           <div className="mb-6 flex min-w-0 flex-row flex-wrap items-center justify-between gap-3">
             <div className="flex min-w-0 flex-col gap-0.5">
               <Text.H4>Overview</Text.H4>
-              <Text.H6 color="foregroundMuted">Last 7 days</Text.H6>
+              <Text.H6 color="foregroundMuted">Your project overview over the past 7 days</Text.H6>
             </div>
           </div>
           <ProjectHomeDashboard projectId={project.id} projectSlug={projectSlug} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home.tsx
@@ -1,0 +1,30 @@
+import { Text } from "@repo/ui"
+import { createFileRoute } from "@tanstack/react-router"
+import { ListingLayout as Layout } from "../../../../layouts/ListingLayout/index.tsx"
+import { useRouteProject } from "./-route-data.ts"
+import { ProjectHomeDashboard } from "./home/-components/project-home-dashboard.tsx"
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/home")({
+  component: ProjectHomePage,
+})
+
+function ProjectHomePage() {
+  const { projectSlug } = Route.useParams()
+  const project = useRouteProject()
+
+  return (
+    <Layout>
+      <Layout.Content>
+        <Layout.List className="pt-6 pb-8">
+          <div className="mb-6 flex min-w-0 flex-row flex-wrap items-center justify-between gap-3">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <Text.H4>Overview</Text.H4>
+              <Text.H6 color="foregroundMuted">Last 7 days</Text.H6>
+            </div>
+          </div>
+          <ProjectHomeDashboard projectId={project.id} projectSlug={projectSlug} />
+        </Layout.List>
+      </Layout.Content>
+    </Layout>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
@@ -1,11 +1,9 @@
 import { Text } from "@repo/ui"
-import type { ReactNode } from "react"
 
 /** Section heading styled like trace detail drawer section headers (label + dashed rule). */
-export function HomeSectionTitle({ icon, label }: { readonly icon: ReactNode; readonly label: string }) {
+export function HomeSectionTitle({ label }: { readonly label: string }) {
   return (
     <div className="flex shrink-0 flex-row items-center gap-2 text-muted-foreground">
-      <span className="flex h-4 w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4">{icon}</span>
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
       <hr className="mx-2 min-w-[12px] flex-1 border-t-2 border-dashed border-border" />
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
@@ -5,7 +5,9 @@ export function HomeSectionTitle({ label }: { readonly label: string }) {
   return (
     <div className="flex shrink-0 flex-row items-center gap-2 text-muted-foreground">
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
-      <hr className="mx-2 min-w-[12px] flex-1 border-t-2 border-dashed border-border" />
+      <div className="flex min-w-[12px] flex-1 flex-row px-2">
+        <hr className="w-full border-t-2 border-dashed border-border" />
+      </div>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-section-title.tsx
@@ -1,0 +1,13 @@
+import { Text } from "@repo/ui"
+import type { ReactNode } from "react"
+
+/** Section heading styled like trace detail drawer section headers (label + dashed rule). */
+export function HomeSectionTitle({ icon, label }: { readonly icon: ReactNode; readonly label: string }) {
+  return (
+    <div className="flex shrink-0 flex-row items-center gap-2 text-muted-foreground">
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center [&>svg]:h-4 [&>svg]:w-4">{icon}</span>
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <hr className="mx-2 min-w-[12px] flex-1 border-t-2 border-dashed border-border" />
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-seven-day-window.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/home-seven-day-window.ts
@@ -1,0 +1,31 @@
+import type { FilterCondition, FilterSet } from "@domain/shared"
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+function startTimeRange(gteMs: number, lteMs: number): FilterCondition[] {
+  return [
+    { op: "gte", value: new Date(gteMs).toISOString() },
+    { op: "lte", value: new Date(lteMs).toISOString() },
+  ]
+}
+
+/** Rolling last 7 days ending at `anchorNowMs`, plus the immediately prior 7 days for comparison. */
+export function buildHomeSevenDayWindow(anchorNowMs: number): {
+  readonly currentRange: FilterSet
+  readonly compareFilters: FilterSet
+  readonly issuesTimeRange: { readonly fromIso: string; readonly toIso: string }
+} {
+  const toMs = anchorNowMs
+  const fromMs = toMs - SEVEN_DAYS_MS
+  const prevToMs = fromMs
+  const prevFromMs = fromMs - SEVEN_DAYS_MS
+
+  const fromIso = new Date(fromMs).toISOString()
+  const toIso = new Date(toMs).toISOString()
+
+  return {
+    currentRange: { startTime: startTimeRange(fromMs, toMs) },
+    compareFilters: { startTime: startTimeRange(prevFromMs, prevToMs) },
+    issuesTimeRange: { fromIso, toIso },
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
@@ -1,18 +1,20 @@
 import { isManualQueue, isSystemQueue } from "@domain/annotation-queues"
-import { Button, Icon, Skeleton, Text } from "@repo/ui"
+import { BarChart, Button, Icon, Skeleton, Text, useChartCssTheme } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { Activity, ArrowUpRight, ChartColumn, ClipboardList } from "lucide-react"
+import { ArrowUpRight, BarChart3, CircleCheck, Layers } from "lucide-react"
 import { useMemo } from "react"
 import { listAnnotationQueuesByProject } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
 import { useIssues } from "../../../../../../domains/issues/issues.collection.ts"
 import type { IssueRecord } from "../../../../../../domains/issues/issues.functions.ts"
 import { formatPercent } from "../../issues/-components/issue-formatters.ts"
 import { IssueLifecycleStatuses } from "../../issues/-components/issue-lifecycle-statuses.tsx"
-import { IssuesAnalyticsPanel } from "../../issues/-components/issues-analytics-panel.tsx"
+import { issueOccurrenceBarColorForCategory } from "../../issues/-components/issue-status-bar-chart-colors.ts"
 import { HomeSectionTitle } from "./home-section-title.tsx"
 import { buildHomeSevenDayWindow } from "./home-seven-day-window.ts"
+import { ProjectHomeIssueTrendMiniChart } from "./project-home-issue-trend-mini-chart.tsx"
+import { ProjectHomeSectionBlankSlate } from "./project-home-section-blank-slate.tsx"
 import { ProjectHomeTracePanel } from "./project-home-trace-panel.tsx"
 
 const NEEDS_ATTENTION_STATES = new Set(["new", "escalating", "regressed"])
@@ -48,6 +50,22 @@ export function ProjectHomeDashboard({
 
   const needsAttentionRows = useMemo(() => issueRows.filter(issueNeedsAttention).slice(0, 5), [issueRows])
 
+  const chartTheme = useChartCssTheme()
+  const issuesByStatusData = useMemo(() => {
+    const rows = [
+      { category: "New", value: analytics.counts.newIssues },
+      { category: "Escalating", value: analytics.counts.escalatingIssues },
+      { category: "Regressed", value: analytics.counts.regressedIssues },
+      { category: "Resolved", value: analytics.counts.resolvedIssues },
+    ]
+    return rows
+      .filter((item) => item.value > 0)
+      .map((item) => ({
+        ...item,
+        barColor: issueOccurrenceBarColorForCategory(item.category, chartTheme),
+      }))
+  }, [analytics.counts, chartTheme])
+
   const { data: queuesResponse, isLoading: queuesLoading } = useQuery({
     queryKey: ["project-home-queues", projectId],
     queryFn: () =>
@@ -66,39 +84,61 @@ export function ProjectHomeDashboard({
   const topQueues = useMemo(() => manualQueues.slice(0, 6), [manualQueues])
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="flex flex-col gap-5 pb-6">
       <div className="flex flex-col gap-2.5">
-        <HomeSectionTitle icon={<Activity />} label="Traces" />
-        <ProjectHomeTracePanel projectId={projectId} currentRange={currentRange} compareFilters={compareFilters} />
+        <HomeSectionTitle label="Traces" />
+        <ProjectHomeTracePanel
+          projectId={projectId}
+          projectSlug={projectSlug}
+          currentRange={currentRange}
+          compareFilters={compareFilters}
+        />
       </div>
 
       <div className="flex flex-col gap-2.5">
-        <HomeSectionTitle icon={<ChartColumn />} label="Issues" />
+        <HomeSectionTitle label="Issues" />
         <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
           <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-3">
-            <div className="flex min-w-0 flex-row items-center justify-between gap-2">
-              <Text.H5M color="foreground" className="min-w-0 truncate">
-                Issue occurrences
-              </Text.H5M>
-              <Button variant="outline" size="sm" className="shrink-0 gap-1" asChild>
+            <div className="flex min-w-0 flex-row items-start justify-between gap-2">
+              <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
+                By status
+              </Text.H6>
+              <Button variant="outline" size="sm" className="shrink-0" asChild>
                 <Link to="/projects/$projectSlug/issues" params={{ projectSlug }}>
                   View issues
-                  <Icon icon={ArrowUpRight} size="sm" />
                 </Link>
               </Button>
             </div>
-            <IssuesAnalyticsPanel
-              analytics={analytics}
-              isLoading={issuesLoading}
-              showMetricsRow={false}
-              withPanelChrome={false}
-            />
+            {issuesLoading ? (
+              <Skeleton className="h-[176px] w-full" />
+            ) : issuesByStatusData.length === 0 ? (
+              <ProjectHomeSectionBlankSlate
+                icon={BarChart3}
+                title="No issues in the last 7 days"
+                description="Lifecycle counts will appear here when issues are detected in this window."
+                action={
+                  <Button variant="outline" size="sm" asChild>
+                    <Link to="/projects/$projectSlug/issues" params={{ projectSlug }}>
+                      View issues
+                    </Link>
+                  </Button>
+                }
+              />
+            ) : (
+              <BarChart
+                data={issuesByStatusData}
+                height={160}
+                showYAxis={false}
+                ariaLabel="Issues by status"
+                formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> issues`}
+              />
+            )}
           </div>
 
           <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-3">
-            <Text.H5M color="foreground" className="min-w-0 truncate">
+            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
               Needs attention
-            </Text.H5M>
+            </Text.H6>
             {issuesLoading && needsAttentionRows.length === 0 ? (
               <div className="flex flex-col gap-2">
                 <Skeleton className="h-10 w-full" />
@@ -106,7 +146,18 @@ export function ProjectHomeDashboard({
                 <Skeleton className="h-10 w-full" />
               </div>
             ) : needsAttentionRows.length === 0 ? (
-              <Text.H6 color="foregroundMuted">Nothing needs attention in the last 7 days.</Text.H6>
+              <ProjectHomeSectionBlankSlate
+                icon={CircleCheck}
+                title="Nothing needs attention"
+                description="No new, escalating, or regressing issues in the last 7 days."
+                action={
+                  <Button variant="outline" size="sm" asChild>
+                    <Link to="/projects/$projectSlug/issues" params={{ projectSlug }}>
+                      View issues
+                    </Link>
+                  </Button>
+                }
+              />
             ) : (
               <div className="flex flex-col">
                 {needsAttentionRows.map((issue) => (
@@ -125,6 +176,7 @@ export function ProjectHomeDashboard({
                     >
                       {issue.name}
                     </Link>
+                    <ProjectHomeIssueTrendMiniChart issue={issue} />
                     <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap tabular-nums">
                       {formatCount(issue.occurrences)} occ · {formatPercent(issue.affectedTracesPercent)} traces
                     </Text.H6>
@@ -137,15 +189,33 @@ export function ProjectHomeDashboard({
       </div>
 
       <div className="flex flex-col gap-2.5">
-        <HomeSectionTitle icon={<ClipboardList />} label="Annotation queues" />
+        <HomeSectionTitle label="Annotation queues" />
         <div className="flex flex-col gap-3 rounded-lg bg-secondary p-3">
-          <Text.H5M color="foreground" className="min-w-0 truncate">
-            Pending review
-          </Text.H5M>
+          <div className="flex min-w-0 flex-row items-start justify-between gap-2">
+            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
+              Pending review
+            </Text.H6>
+            <Button variant="outline" size="sm" className="shrink-0" asChild>
+              <Link to="/projects/$projectSlug/annotation-queues/" params={{ projectSlug }}>
+                View queues
+              </Link>
+            </Button>
+          </div>
           {queuesLoading ? (
             <Skeleton className="h-32 w-full" />
           ) : topQueues.length === 0 ? (
-            <Text.H6 color="foregroundMuted">No manual queues yet</Text.H6>
+            <ProjectHomeSectionBlankSlate
+              icon={Layers}
+              title="No manual queues yet"
+              description="Create a manual review queue to track annotation work for this project."
+              action={
+                <Button variant="outline" size="sm" asChild>
+                  <Link to="/projects/$projectSlug/annotation-queues/" params={{ projectSlug }}>
+                    View queues
+                  </Link>
+                </Button>
+              }
+            />
           ) : (
             <div className="flex flex-col gap-3">
               {topQueues.map((q) => {
@@ -154,10 +224,10 @@ export function ProjectHomeDashboard({
                 const total = q.totalItems
                 const doneRatioPct = total > 0 ? Math.round((completed / total) * 100) : 0
                 return (
-                  <div key={q.id} className="flex min-w-0 flex-row flex-nowrap items-center gap-2 sm:gap-3">
-                    <Text.H6 color="foreground" className="min-w-0 flex-1 truncate font-medium">
+                  <div key={q.id} className="flex min-w-0 flex-row flex-nowrap items-center gap-2 py-2 sm:gap-3">
+                    <Text.H5 color="foreground" className="min-w-0 flex-1 truncate font-medium">
                       {q.name}
-                    </Text.H6>
+                    </Text.H5>
                     <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
                       {formatCount(completed)}
                     </Text.H6>
@@ -174,6 +244,7 @@ export function ProjectHomeDashboard({
                       <Link
                         to="/projects/$projectSlug/annotation-queues/$queueId"
                         params={{ projectSlug, queueId: q.id }}
+                        search={{ focus: true }}
                       >
                         Focus
                         <Icon icon={ArrowUpRight} size="sm" />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
@@ -23,6 +23,31 @@ function issueNeedsAttention(issue: IssueRecord): boolean {
   return issue.states.some((s) => NEEDS_ATTENTION_STATES.has(s))
 }
 
+function AnnotationQueueHomeMetric({
+  label,
+  value,
+  isLoading,
+  skeletonWidthClassName = "w-16",
+}: {
+  readonly label: string
+  readonly value: string
+  readonly isLoading?: boolean
+  readonly skeletonWidthClassName?: string
+}) {
+  return (
+    <div className="flex min-w-[120px] max-w-[200px] shrink-0 basis-[148px] flex-col gap-1.5">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      {isLoading ? (
+        <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
+      ) : (
+        <Text.H5 color="foreground" className="tabular-nums">
+          {value}
+        </Text.H5>
+      )}
+    </div>
+  )
+}
+
 export function ProjectHomeDashboard({
   projectId,
   projectSlug,
@@ -82,6 +107,24 @@ export function ProjectHomeDashboard({
   }, [queuesResponse?.queues])
 
   const topQueues = useMemo(() => manualQueues.slice(0, 6), [manualQueues])
+
+  const manualQueueRollup = useMemo(() => {
+    let pending = 0
+    let completed = 0
+    let total = 0
+    for (const q of manualQueues) {
+      pending += Math.max(0, q.totalItems - q.completedItems)
+      completed += q.completedItems
+      total += q.totalItems
+    }
+    return {
+      pending,
+      completed,
+      total,
+      queueCount: manualQueues.length,
+      doneRatio: total > 0 ? completed / total : 0,
+    }
+  }, [manualQueues])
 
   return (
     <div className="flex flex-col gap-5 pb-6">
@@ -190,12 +233,35 @@ export function ProjectHomeDashboard({
 
       <div className="flex flex-col gap-2.5">
         <HomeSectionTitle label="Annotation queues" />
-        <div className="flex flex-col gap-3 rounded-lg bg-secondary p-3">
-          <div className="flex min-w-0 flex-row items-start justify-between gap-2">
-            <Text.H6 color="foregroundMuted" className="min-w-0 truncate">
-              Pending review
-            </Text.H6>
-            <Button variant="outline" size="sm" className="shrink-0" asChild>
+        <div className="flex flex-col gap-3 rounded-lg bg-secondary p-2">
+          <div className="flex min-w-0 flex-row flex-wrap items-start justify-between gap-3 p-4">
+            <div className="flex min-w-0 flex-1 flex-row flex-wrap gap-3">
+              <AnnotationQueueHomeMetric
+                label="Pending"
+                value={formatCount(manualQueueRollup.pending)}
+                isLoading={queuesLoading}
+                skeletonWidthClassName="w-14"
+              />
+              <AnnotationQueueHomeMetric
+                label="Completed"
+                value={formatCount(manualQueueRollup.completed)}
+                isLoading={queuesLoading}
+                skeletonWidthClassName="w-14"
+              />
+              <AnnotationQueueHomeMetric
+                label="Progress"
+                value={formatPercent(manualQueueRollup.doneRatio)}
+                isLoading={queuesLoading}
+                skeletonWidthClassName="w-12"
+              />
+              <AnnotationQueueHomeMetric
+                label="Queues"
+                value={formatCount(manualQueueRollup.queueCount)}
+                isLoading={queuesLoading}
+                skeletonWidthClassName="w-10"
+              />
+            </div>
+            <Button variant="outline" size="sm" className="shrink-0 self-start" asChild>
               <Link to="/projects/$projectSlug/annotation-queues/" params={{ projectSlug }}>
                 View queues
               </Link>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-dashboard.tsx
@@ -1,0 +1,191 @@
+import { isManualQueue, isSystemQueue } from "@domain/annotation-queues"
+import { Button, Icon, Skeleton, Text } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { Activity, ArrowUpRight, ChartColumn, ClipboardList } from "lucide-react"
+import { useMemo } from "react"
+import { listAnnotationQueuesByProject } from "../../../../../../domains/annotation-queues/annotation-queues.functions.ts"
+import { useIssues } from "../../../../../../domains/issues/issues.collection.ts"
+import type { IssueRecord } from "../../../../../../domains/issues/issues.functions.ts"
+import { formatPercent } from "../../issues/-components/issue-formatters.ts"
+import { IssueLifecycleStatuses } from "../../issues/-components/issue-lifecycle-statuses.tsx"
+import { IssuesAnalyticsPanel } from "../../issues/-components/issues-analytics-panel.tsx"
+import { HomeSectionTitle } from "./home-section-title.tsx"
+import { buildHomeSevenDayWindow } from "./home-seven-day-window.ts"
+import { ProjectHomeTracePanel } from "./project-home-trace-panel.tsx"
+
+const NEEDS_ATTENTION_STATES = new Set(["new", "escalating", "regressed"])
+
+function issueNeedsAttention(issue: IssueRecord): boolean {
+  return issue.states.some((s) => NEEDS_ATTENTION_STATES.has(s))
+}
+
+export function ProjectHomeDashboard({
+  projectId,
+  projectSlug,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+}) {
+  const hourBucket = Math.floor(Date.now() / (60 * 60 * 1000))
+  const { currentRange, compareFilters, issuesTimeRange } = useMemo(
+    () => buildHomeSevenDayWindow(Date.now()),
+    [hourBucket],
+  )
+
+  const {
+    data: issueRows,
+    analytics,
+    isLoading: issuesLoading,
+  } = useIssues({
+    projectId,
+    lifecycleGroup: "active",
+    sorting: { column: "occurrences", direction: "desc" },
+    timeRange: issuesTimeRange,
+    limit: 50,
+  })
+
+  const needsAttentionRows = useMemo(() => issueRows.filter(issueNeedsAttention).slice(0, 5), [issueRows])
+
+  const { data: queuesResponse, isLoading: queuesLoading } = useQuery({
+    queryKey: ["project-home-queues", projectId],
+    queryFn: () =>
+      listAnnotationQueuesByProject({
+        data: { projectId, limit: 100, sortBy: "pendingItems", sortDirection: "desc" },
+      }),
+    staleTime: 30_000,
+    enabled: projectId.length > 0,
+  })
+
+  const manualQueues = useMemo(() => {
+    const all = queuesResponse?.queues ?? []
+    return all.filter((q) => !isSystemQueue(q) && isManualQueue(q.settings))
+  }, [queuesResponse?.queues])
+
+  const topQueues = useMemo(() => manualQueues.slice(0, 6), [manualQueues])
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2.5">
+        <HomeSectionTitle icon={<Activity />} label="Traces" />
+        <ProjectHomeTracePanel projectId={projectId} currentRange={currentRange} compareFilters={compareFilters} />
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <HomeSectionTitle icon={<ChartColumn />} label="Issues" />
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-3">
+            <div className="flex min-w-0 flex-row items-center justify-between gap-2">
+              <Text.H5M color="foreground" className="min-w-0 truncate">
+                Issue occurrences
+              </Text.H5M>
+              <Button variant="outline" size="sm" className="shrink-0 gap-1" asChild>
+                <Link to="/projects/$projectSlug/issues" params={{ projectSlug }}>
+                  View issues
+                  <Icon icon={ArrowUpRight} size="sm" />
+                </Link>
+              </Button>
+            </div>
+            <IssuesAnalyticsPanel
+              analytics={analytics}
+              isLoading={issuesLoading}
+              showMetricsRow={false}
+              withPanelChrome={false}
+            />
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-3 rounded-lg bg-secondary p-3">
+            <Text.H5M color="foreground" className="min-w-0 truncate">
+              Needs attention
+            </Text.H5M>
+            {issuesLoading && needsAttentionRows.length === 0 ? (
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ) : needsAttentionRows.length === 0 ? (
+              <Text.H6 color="foregroundMuted">Nothing needs attention in the last 7 days.</Text.H6>
+            ) : (
+              <div className="flex flex-col">
+                {needsAttentionRows.map((issue) => (
+                  <div
+                    key={issue.id}
+                    className="flex flex-row items-center gap-2 border-b border-border/60 py-2.5 last:border-b-0"
+                  >
+                    <div className="min-w-0 max-w-[220px] shrink-0">
+                      <IssueLifecycleStatuses states={issue.states} wrap={false} />
+                    </div>
+                    <Link
+                      to="/projects/$projectSlug/issues"
+                      params={{ projectSlug }}
+                      search={{ issueId: issue.id }}
+                      className="min-w-0 flex-1 truncate text-left text-sm text-foreground hover:underline"
+                    >
+                      {issue.name}
+                    </Link>
+                    <Text.H6 color="foregroundMuted" className="shrink-0 whitespace-nowrap tabular-nums">
+                      {formatCount(issue.occurrences)} occ · {formatPercent(issue.affectedTracesPercent)} traces
+                    </Text.H6>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <HomeSectionTitle icon={<ClipboardList />} label="Annotation queues" />
+        <div className="flex flex-col gap-3 rounded-lg bg-secondary p-3">
+          <Text.H5M color="foreground" className="min-w-0 truncate">
+            Pending review
+          </Text.H5M>
+          {queuesLoading ? (
+            <Skeleton className="h-32 w-full" />
+          ) : topQueues.length === 0 ? (
+            <Text.H6 color="foregroundMuted">No manual queues yet</Text.H6>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {topQueues.map((q) => {
+                const completed = q.completedItems
+                const pending = Math.max(0, q.totalItems - q.completedItems)
+                const total = q.totalItems
+                const doneRatioPct = total > 0 ? Math.round((completed / total) * 100) : 0
+                return (
+                  <div key={q.id} className="flex min-w-0 flex-row flex-nowrap items-center gap-2 sm:gap-3">
+                    <Text.H6 color="foreground" className="min-w-0 flex-1 truncate font-medium">
+                      {q.name}
+                    </Text.H6>
+                    <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
+                      {formatCount(completed)}
+                    </Text.H6>
+                    <div className="h-2 w-[96px] shrink-0 overflow-hidden rounded-full bg-muted" aria-hidden>
+                      <div
+                        className="h-full rounded-full bg-primary transition-[width]"
+                        style={{ width: `${doneRatioPct}%` }}
+                      />
+                    </div>
+                    <Text.H6 color="foregroundMuted" className="shrink-0 tabular-nums">
+                      {formatCount(pending)}
+                    </Text.H6>
+                    <Button variant="secondary-soft" size="sm" className="w-fit shrink-0 gap-1 px-2.5" asChild>
+                      <Link
+                        to="/projects/$projectSlug/annotation-queues/$queueId"
+                        params={{ projectSlug, queueId: q.id }}
+                      >
+                        Focus
+                        <Icon icon={ArrowUpRight} size="sm" />
+                      </Link>
+                    </Button>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-issue-trend-mini-chart.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-issue-trend-mini-chart.tsx
@@ -1,0 +1,38 @@
+import { BarChart, Text } from "@repo/ui"
+import { formatCount } from "@repo/utils"
+import { useMemo } from "react"
+import type { IssueRecord } from "../../../../../../domains/issues/issues.functions.ts"
+import { formatDayBucketTooltipLabel } from "../../issues/-components/issue-formatters.ts"
+
+export function ProjectHomeIssueTrendMiniChart({ issue }: { readonly issue: IssueRecord }) {
+  const data = useMemo(
+    () =>
+      issue.trend.map((bucket) => ({
+        category: bucket.bucket,
+        tooltipCategory: formatDayBucketTooltipLabel(bucket.bucket),
+        value: bucket.count,
+      })),
+    [issue.trend],
+  )
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-8 w-[112px] shrink-0 items-center justify-center rounded-sm border border-dashed border-border/60 bg-background/50">
+        <Text.H7 color="foregroundMuted">—</Text.H7>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-8 w-[112px] shrink-0 overflow-hidden rounded-sm">
+      <BarChart
+        data={data}
+        height={32}
+        showYAxis={false}
+        showXAxisLabels={false}
+        ariaLabel={`Occurrences over time for ${issue.name}`}
+        formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> occurrences`}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
@@ -27,7 +27,7 @@ export function ProjectHomeSectionBlankSlate({
           {description}
         </Text.H6>
       ) : null}
-      {action ? <div className="mt-1 flex flex-row flex-wrap items-center justify-center gap-2">{action}</div> : null}
+      {action ? <div className="flex flex-row flex-wrap items-center justify-center gap-2 pt-1">{action}</div> : null}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
@@ -1,0 +1,33 @@
+import { Text } from "@repo/ui"
+import type { LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+/**
+ * In-card empty state for project home sections (Figma-aligned: gradient, icon, centered copy).
+ */
+export function ProjectHomeSectionBlankSlate({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: {
+  readonly icon: LucideIcon
+  readonly title: string
+  readonly description?: string
+  readonly action?: ReactNode
+}) {
+  return (
+    <div className="flex w-full min-h-[120px] flex-col items-center justify-center gap-2 rounded-lg bg-gradient-to-b from-muted/25 to-transparent px-4 py-10 text-center">
+      <Icon className="h-8 w-8 shrink-0 text-muted-foreground" aria-hidden />
+      <Text.H5 align="center" display="block" color="foregroundMuted" className="max-w-md">
+        {title}
+      </Text.H5>
+      {description ? (
+        <Text.H6 align="center" display="block" color="foregroundMuted" className="max-w-lg">
+          {description}
+        </Text.H6>
+      ) : null}
+      {action ? <div className="mt-1 flex flex-row flex-wrap items-center justify-center gap-2">{action}</div> : null}
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-section-blank-slate.tsx
@@ -18,7 +18,7 @@ export function ProjectHomeSectionBlankSlate({
 }) {
   return (
     <div className="flex w-full min-h-[120px] flex-col items-center justify-center gap-2 rounded-lg bg-gradient-to-b from-muted/25 to-transparent px-4 py-10 text-center">
-      <Icon className="h-8 w-8 shrink-0 text-muted-foreground" aria-hidden />
+      <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
       <Text.H5 align="center" display="block" color="foregroundMuted" className="max-w-md">
         {title}
       </Text.H5>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-trace-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-trace-panel.tsx
@@ -1,18 +1,22 @@
 import type { FilterSet } from "@domain/shared"
-import { Badge, type BadgeProps, Skeleton, Text } from "@repo/ui"
-import { formatCount, formatDuration, formatPrice } from "@repo/utils"
+import { Badge, type BadgeProps, Button, Skeleton, Text } from "@repo/ui"
+import { formatCount, formatDuration } from "@repo/utils"
 import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { Activity } from "lucide-react"
 import { useMemo } from "react"
+import { useIssues } from "../../../../../../domains/issues/issues.collection.ts"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
 import { countTracesByProject, getTraceMetricsByProject } from "../../../../../../domains/traces/traces.functions.ts"
 import { Histogram } from "../../-components/aggregations/histogram.tsx"
+import { ProjectHomeSectionBlankSlate } from "./project-home-section-blank-slate.tsx"
 
 type TrendTone = "neutral" | "positive" | "negative"
 
 function trendBadgeVariant(tone: TrendTone): BadgeProps["variant"] {
-  if (tone === "positive") return "outlineSuccessMuted"
-  if (tone === "negative") return "outlineDestructiveMuted"
-  return "outlineMuted"
+  if (tone === "positive") return "successMuted"
+  if (tone === "negative") return "destructiveMuted"
+  return "muted"
 }
 
 function countRatioTrendShortFull(
@@ -73,26 +77,28 @@ function TraceMetricWithTrend({
   readonly skeletonWidthClassName?: string
 }) {
   return (
-    <div className="flex min-w-[176px] max-w-[200px] shrink-0 basis-[176px] flex-col gap-1.5">
+    <div className="flex min-w-[176px] max-w-[220px] shrink-0 basis-[176px] flex-col gap-1.5">
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
-      {isLoading ? (
-        <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
-      ) : (
-        <Text.H5 color="foreground" className="tabular-nums">
-          {value}
-        </Text.H5>
-      )}
-      {isLoading ? (
-        <Skeleton className="h-5 w-14 rounded-md" />
-      ) : trendAwaitingCompare || !trend ? (
-        <Badge variant="outlineMuted" size="small" title={trend?.full}>
-          {trendAwaitingCompare ? "…" : "—"}
-        </Badge>
-      ) : (
-        <Badge variant={trendBadgeVariant(trendTone)} size="small" title={trend.full} className="w-fit">
-          {trend.short}
-        </Badge>
-      )}
+      <div className="flex min-w-0 flex-row items-center gap-2">
+        {isLoading ? (
+          <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
+        ) : (
+          <Text.H5 color="foreground" className="tabular-nums">
+            {value}
+          </Text.H5>
+        )}
+        {isLoading ? (
+          <Skeleton className="h-5 w-14 rounded-md" />
+        ) : trendAwaitingCompare || !trend ? (
+          <Badge variant="muted" size="small" title={trend?.full}>
+            {trendAwaitingCompare ? "…" : "—"}
+          </Badge>
+        ) : (
+          <Badge variant={trendBadgeVariant(trendTone)} size="small" title={trend.full} className="w-fit">
+            {trend.short}
+          </Badge>
+        )}
+      </div>
     </div>
   )
 }
@@ -105,12 +111,31 @@ function mergeFilters(a: FilterSet, b: FilterSet): FilterSet {
   return { ...a, ...b }
 }
 
+function timeRangeFromFilters(filters: FilterSet):
+  | {
+      readonly fromIso?: string
+      readonly toIso?: string
+    }
+  | undefined {
+  const startTime = filters.startTime
+  if (!startTime?.length) return undefined
+  const gte = startTime.find((condition) => condition.op === "gte")
+  const lte = startTime.find((condition) => condition.op === "lte")
+  if (!gte?.value && !lte?.value) return undefined
+  return {
+    ...(gte?.value ? { fromIso: String(gte.value) } : {}),
+    ...(lte?.value ? { toIso: String(lte.value) } : {}),
+  }
+}
+
 export function ProjectHomeTracePanel({
   projectId,
+  projectSlug,
   currentRange,
   compareFilters,
 }: {
   readonly projectId: string
+  readonly projectSlug: string
   readonly currentRange: FilterSet
   readonly compareFilters: FilterSet
 }) {
@@ -121,6 +146,24 @@ export function ProjectHomeTracePanel({
     projectId,
     filters: currentRange,
   })
+  const currentIssuesTimeRange = useMemo(() => timeRangeFromFilters(currentRange), [currentRange])
+  const compareIssuesTimeRange = useMemo(() => timeRangeFromFilters(compareFilters), [compareFilters])
+
+  const { totalCount: activeIssueCount, isLoading: activeIssueLoading } = useIssues({
+    projectId,
+    lifecycleGroup: "active",
+    sorting: { column: "occurrences", direction: "desc" },
+    limit: 1,
+    ...(currentIssuesTimeRange ? { timeRange: currentIssuesTimeRange } : {}),
+  })
+  const { totalCount: prevActiveIssueCount, isLoading: prevActiveIssueLoading } = useIssues({
+    projectId,
+    lifecycleGroup: "active",
+    sorting: { column: "occurrences", direction: "desc" },
+    limit: 1,
+    ...(compareIssuesTimeRange ? { timeRange: compareIssuesTimeRange } : {}),
+  })
+
   const { totalCount: traceCount, isLoading: countLoading } = useTracesCount({
     projectId,
     filters: currentRange,
@@ -152,16 +195,11 @@ export function ProjectHomeTracePanel({
   const loading = metricsLoading || countLoading
   const dash = "—"
   const traceCountStr = formatCount(traceCount)
-  const totalCostStr = traceMetrics ? formatPrice(traceMetrics.costTotalMicrocents.sum / 100_000_000) : dash
   const medianDurationStr = traceMetrics ? formatDuration(traceMetrics.durationNs.median) : dash
-  const totalTokensStr = traceMetrics ? formatCount(traceMetrics.tokensTotal.sum) : dash
-  const totalSpansStr = traceMetrics ? formatCount(traceMetrics.spanCount.sum) : dash
   const errorRate = traceCount > 0 ? (errorTraceCount / traceCount) * 100 : 0
   const prevErrorRate = prevTraceCount > 0 ? (prevErrorTraceCount / prevTraceCount) * 100 : 0
 
-  const showTtftAggregations = traceMetrics && traceMetrics.timeToFirstTokenNs.max > 0
-
-  const trendAwaitingCompare = prevTraceFetching || prevMetricsFetching || prevErrorFetching
+  const trendAwaitingCompare = prevTraceFetching || prevMetricsFetching || prevErrorFetching || prevActiveIssueLoading
 
   const tracesTrend = countRatioTrendShortFull(traceCount, prevTraceCount)
   const tracesTone: TrendTone =
@@ -169,19 +207,6 @@ export function ProjectHomeTracePanel({
       ? traceCount < prevTraceCount
         ? "positive"
         : traceCount > prevTraceCount
-          ? "negative"
-          : "neutral"
-      : "neutral"
-
-  const costTrend =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? countRatioTrendShortFull(traceMetrics.costTotalMicrocents.sum, prevTraceMetrics.costTotalMicrocents.sum)
-      : null
-  const costTone: TrendTone =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? traceMetrics.costTotalMicrocents.sum < prevTraceMetrics.costTotalMicrocents.sum
-        ? "positive"
-        : traceMetrics.costTotalMicrocents.sum > prevTraceMetrics.costTotalMicrocents.sum
           ? "negative"
           : "neutral"
       : "neutral"
@@ -199,119 +224,86 @@ export function ProjectHomeTracePanel({
           : "neutral"
       : "neutral"
 
-  const tokensTrend =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? countRatioTrendShortFull(traceMetrics.tokensTotal.sum, prevTraceMetrics.tokensTotal.sum)
-      : null
-  const tokensTone: TrendTone =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? traceMetrics.tokensTotal.sum < prevTraceMetrics.tokensTotal.sum
-        ? "positive"
-        : traceMetrics.tokensTotal.sum > prevTraceMetrics.tokensTotal.sum
-          ? "negative"
-          : "neutral"
-      : "neutral"
-
-  const spansTrend =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? countRatioTrendShortFull(traceMetrics.spanCount.sum, prevTraceMetrics.spanCount.sum)
-      : null
-  const spansTone: TrendTone =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching
-      ? traceMetrics.spanCount.sum < prevTraceMetrics.spanCount.sum
-        ? "positive"
-        : traceMetrics.spanCount.sum > prevTraceMetrics.spanCount.sum
-          ? "negative"
-          : "neutral"
-      : "neutral"
-
   const errorTrend = errorRateDeltaShortFull(errorRate, prevErrorRate)
   const errorTone: TrendTone =
     errorRate > prevErrorRate ? "negative" : errorRate < prevErrorRate ? "positive" : "neutral"
-
-  const ttftTrend =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching && showTtftAggregations
-      ? latencyDeltaShortFull(traceMetrics.timeToFirstTokenNs.median, prevTraceMetrics.timeToFirstTokenNs.median)
-      : null
-  const ttftTone: TrendTone =
-    traceMetrics && prevTraceMetrics && !prevMetricsFetching && showTtftAggregations
-      ? traceMetrics.timeToFirstTokenNs.median < prevTraceMetrics.timeToFirstTokenNs.median
+  const activeIssuesTrend = countRatioTrendShortFull(activeIssueCount, prevActiveIssueCount)
+  const activeIssuesTone: TrendTone =
+    prevActiveIssueCount > 0
+      ? activeIssueCount < prevActiveIssueCount
         ? "positive"
-        : traceMetrics.timeToFirstTokenNs.median > prevTraceMetrics.timeToFirstTokenNs.median
+        : activeIssueCount > prevActiveIssueCount
           ? "negative"
           : "neutral"
       : "neutral"
 
   return (
     <div className="flex flex-col rounded-lg bg-secondary p-2">
-      <div className="flex flex-row flex-wrap gap-3 p-4">
-        <TraceMetricWithTrend
-          label="Traces"
-          value={traceCountStr}
-          trend={tracesTrend}
-          trendTone={tracesTone}
-          isLoading={countLoading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-16"
-        />
-        <TraceMetricWithTrend
-          label="Error rate"
-          value={formatRatioPercent(errorTraceCount, traceCount)}
-          trend={errorTrend}
-          trendTone={errorTone}
-          isLoading={errorCountLoading || countLoading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-14"
-        />
-        <TraceMetricWithTrend
-          label="Total cost"
-          value={totalCostStr}
-          trend={costTrend}
-          trendTone={costTone}
-          isLoading={loading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-20"
-        />
-        <TraceMetricWithTrend
-          label="Median duration"
-          value={medianDurationStr}
-          trend={durationTrend}
-          trendTone={durationTone}
-          isLoading={loading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-20"
-        />
-        <TraceMetricWithTrend
-          label="Total tokens"
-          value={totalTokensStr}
-          trend={tokensTrend}
-          trendTone={tokensTone}
-          isLoading={loading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-20"
-        />
-        {showTtftAggregations ? (
+      <div className="flex flex-row gap-4 p-4">
+        <div className="flex min-w-0 flex-1 flex-row flex-wrap gap-3">
           <TraceMetricWithTrend
-            label="Median time to first token"
-            value={formatDuration(traceMetrics.timeToFirstTokenNs.median)}
-            trend={ttftTrend}
-            trendTone={ttftTone}
+            label="Traces"
+            value={traceCountStr}
+            trend={tracesTrend}
+            trendTone={tracesTone}
+            isLoading={countLoading}
+            trendAwaitingCompare={trendAwaitingCompare}
+            skeletonWidthClassName="w-16"
+          />
+          <TraceMetricWithTrend
+            label="Error rate"
+            value={formatRatioPercent(errorTraceCount, traceCount)}
+            trend={errorTrend}
+            trendTone={errorTone}
+            isLoading={errorCountLoading || countLoading}
+            trendAwaitingCompare={trendAwaitingCompare}
+            skeletonWidthClassName="w-14"
+          />
+          <TraceMetricWithTrend
+            label="Median latency"
+            value={medianDurationStr}
+            trend={durationTrend}
+            trendTone={durationTone}
             isLoading={loading}
             trendAwaitingCompare={trendAwaitingCompare}
-            skeletonWidthClassName="w-24"
+            skeletonWidthClassName="w-20"
           />
-        ) : null}
-        <TraceMetricWithTrend
-          label="Total spans"
-          value={totalSpansStr}
-          trend={spansTrend}
-          trendTone={spansTone}
-          isLoading={loading}
-          trendAwaitingCompare={trendAwaitingCompare}
-          skeletonWidthClassName="w-16"
-        />
+          <TraceMetricWithTrend
+            label="Active issues"
+            value={formatCount(activeIssueCount)}
+            trend={activeIssuesTrend}
+            trendTone={activeIssuesTone}
+            isLoading={activeIssueLoading}
+            trendAwaitingCompare={trendAwaitingCompare}
+            skeletonWidthClassName="w-16"
+          />
+        </div>
+        <div className="shrink-0 self-start">
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/projects/$projectSlug/" params={{ projectSlug }}>
+              View traces
+            </Link>
+          </Button>
+        </div>
       </div>
-      <Histogram projectId={projectId} filters={currentRange} />
+      <Histogram
+        projectId={projectId}
+        filters={currentRange}
+        emptyContent={
+          <ProjectHomeSectionBlankSlate
+            icon={Activity}
+            title="No traces in the last 7 days"
+            description="Once your app sends traces, volume and timing will show up here."
+            action={
+              <Button variant="outline" size="sm" asChild>
+                <Link to="/projects/$projectSlug/" params={{ projectSlug }}>
+                  View traces
+                </Link>
+              </Button>
+            }
+          />
+        }
+      />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-trace-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/home/-components/project-home-trace-panel.tsx
@@ -1,0 +1,322 @@
+import type { FilterSet } from "@domain/shared"
+import { Badge, type BadgeProps, Skeleton, Text } from "@repo/ui"
+import { formatCount, formatDuration, formatPrice } from "@repo/utils"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
+import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
+import { countTracesByProject, getTraceMetricsByProject } from "../../../../../../domains/traces/traces.functions.ts"
+import { Histogram } from "../../-components/aggregations/histogram.tsx"
+
+type TrendTone = "neutral" | "positive" | "negative"
+
+function trendBadgeVariant(tone: TrendTone): BadgeProps["variant"] {
+  if (tone === "positive") return "outlineSuccessMuted"
+  if (tone === "negative") return "outlineDestructiveMuted"
+  return "outlineMuted"
+}
+
+function countRatioTrendShortFull(
+  current: number,
+  previous: number,
+): { readonly short: string; readonly full: string } {
+  if (previous <= 0) {
+    return current > 0 ? { short: "New", full: "New vs prior 7 days" } : { short: "—", full: "No data in prior 7 days" }
+  }
+  const pct = ((current - previous) / previous) * 100
+  const sign = pct > 0 ? "+" : ""
+  const short = `${sign}${pct.toFixed(0)}%`
+  return { short, full: `${short} vs prior 7 days` }
+}
+
+function errorRateDeltaShortFull(
+  currentRate: number,
+  previousRate: number,
+): {
+  readonly short: string
+  readonly full: string
+} {
+  const d = currentRate - previousRate
+  const sign = d > 0 ? "+" : ""
+  const short = `${sign}${d.toFixed(1)}pp`
+  return { short, full: `${short} vs prior 7 days` }
+}
+
+function latencyDeltaShortFull(
+  currentNs: number,
+  previousNs: number,
+): { readonly short: string; readonly full: string } {
+  const deltaMs = (currentNs - previousNs) / 1_000_000
+  if (!Number.isFinite(deltaMs) || Math.abs(deltaMs) < 1) {
+    return { short: "Flat", full: "Flat vs prior 7 days" }
+  }
+  const sign = deltaMs > 0 ? "+" : "−"
+  const abs = formatDuration(Math.abs(deltaMs) * 1_000_000)
+  const short = `${sign}${abs}`
+  return { short, full: `${short} vs prior 7 days` }
+}
+
+function TraceMetricWithTrend({
+  label,
+  value,
+  trend,
+  trendTone,
+  isLoading,
+  trendAwaitingCompare,
+  skeletonWidthClassName = "w-16",
+}: {
+  readonly label: string
+  readonly value: string
+  readonly trend: { readonly short: string; readonly full: string } | null
+  readonly trendTone: TrendTone
+  readonly isLoading?: boolean
+  readonly trendAwaitingCompare?: boolean
+  readonly skeletonWidthClassName?: string
+}) {
+  return (
+    <div className="flex min-w-[176px] max-w-[200px] shrink-0 basis-[176px] flex-col gap-1.5">
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      {isLoading ? (
+        <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
+      ) : (
+        <Text.H5 color="foreground" className="tabular-nums">
+          {value}
+        </Text.H5>
+      )}
+      {isLoading ? (
+        <Skeleton className="h-5 w-14 rounded-md" />
+      ) : trendAwaitingCompare || !trend ? (
+        <Badge variant="outlineMuted" size="small" title={trend?.full}>
+          {trendAwaitingCompare ? "…" : "—"}
+        </Badge>
+      ) : (
+        <Badge variant={trendBadgeVariant(trendTone)} size="small" title={trend.full} className="w-fit">
+          {trend.short}
+        </Badge>
+      )}
+    </div>
+  )
+}
+
+const ERROR_STATUS_FILTER: FilterSet = {
+  status: [{ op: "in", value: ["error"] }],
+}
+
+function mergeFilters(a: FilterSet, b: FilterSet): FilterSet {
+  return { ...a, ...b }
+}
+
+export function ProjectHomeTracePanel({
+  projectId,
+  currentRange,
+  compareFilters,
+}: {
+  readonly projectId: string
+  readonly currentRange: FilterSet
+  readonly compareFilters: FilterSet
+}) {
+  const errorRange = useMemo(() => mergeFilters(currentRange, ERROR_STATUS_FILTER), [currentRange])
+  const previousErrorRange = useMemo(() => mergeFilters(compareFilters, ERROR_STATUS_FILTER), [compareFilters])
+
+  const { data: traceMetrics, isLoading: metricsLoading } = useTraceMetrics({
+    projectId,
+    filters: currentRange,
+  })
+  const { totalCount: traceCount, isLoading: countLoading } = useTracesCount({
+    projectId,
+    filters: currentRange,
+  })
+  const { totalCount: errorTraceCount, isLoading: errorCountLoading } = useTracesCount({
+    projectId,
+    filters: errorRange,
+  })
+
+  const { data: prevTraceCount = 0, isFetching: prevTraceFetching } = useQuery({
+    queryKey: ["traces-count", projectId, compareFilters],
+    queryFn: () => countTracesByProject({ data: { projectId, filters: compareFilters } }),
+    staleTime: 30_000,
+    enabled: projectId.length > 0,
+  })
+  const { data: prevErrorTraceCount = 0, isFetching: prevErrorFetching } = useQuery({
+    queryKey: ["traces-count-error", projectId, previousErrorRange],
+    queryFn: () => countTracesByProject({ data: { projectId, filters: previousErrorRange } }),
+    staleTime: 30_000,
+    enabled: projectId.length > 0,
+  })
+  const { data: prevTraceMetrics, isFetching: prevMetricsFetching } = useQuery({
+    queryKey: ["traces-metrics", projectId, compareFilters],
+    queryFn: () => getTraceMetricsByProject({ data: { projectId, filters: compareFilters } }),
+    staleTime: 30_000,
+    enabled: projectId.length > 0,
+  })
+
+  const loading = metricsLoading || countLoading
+  const dash = "—"
+  const traceCountStr = formatCount(traceCount)
+  const totalCostStr = traceMetrics ? formatPrice(traceMetrics.costTotalMicrocents.sum / 100_000_000) : dash
+  const medianDurationStr = traceMetrics ? formatDuration(traceMetrics.durationNs.median) : dash
+  const totalTokensStr = traceMetrics ? formatCount(traceMetrics.tokensTotal.sum) : dash
+  const totalSpansStr = traceMetrics ? formatCount(traceMetrics.spanCount.sum) : dash
+  const errorRate = traceCount > 0 ? (errorTraceCount / traceCount) * 100 : 0
+  const prevErrorRate = prevTraceCount > 0 ? (prevErrorTraceCount / prevTraceCount) * 100 : 0
+
+  const showTtftAggregations = traceMetrics && traceMetrics.timeToFirstTokenNs.max > 0
+
+  const trendAwaitingCompare = prevTraceFetching || prevMetricsFetching || prevErrorFetching
+
+  const tracesTrend = countRatioTrendShortFull(traceCount, prevTraceCount)
+  const tracesTone: TrendTone =
+    prevTraceCount > 0
+      ? traceCount < prevTraceCount
+        ? "positive"
+        : traceCount > prevTraceCount
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  const costTrend =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? countRatioTrendShortFull(traceMetrics.costTotalMicrocents.sum, prevTraceMetrics.costTotalMicrocents.sum)
+      : null
+  const costTone: TrendTone =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? traceMetrics.costTotalMicrocents.sum < prevTraceMetrics.costTotalMicrocents.sum
+        ? "positive"
+        : traceMetrics.costTotalMicrocents.sum > prevTraceMetrics.costTotalMicrocents.sum
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  const durationTrend =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? latencyDeltaShortFull(traceMetrics.durationNs.median, prevTraceMetrics.durationNs.median)
+      : null
+  const durationTone: TrendTone =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? traceMetrics.durationNs.median < prevTraceMetrics.durationNs.median
+        ? "positive"
+        : traceMetrics.durationNs.median > prevTraceMetrics.durationNs.median
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  const tokensTrend =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? countRatioTrendShortFull(traceMetrics.tokensTotal.sum, prevTraceMetrics.tokensTotal.sum)
+      : null
+  const tokensTone: TrendTone =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? traceMetrics.tokensTotal.sum < prevTraceMetrics.tokensTotal.sum
+        ? "positive"
+        : traceMetrics.tokensTotal.sum > prevTraceMetrics.tokensTotal.sum
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  const spansTrend =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? countRatioTrendShortFull(traceMetrics.spanCount.sum, prevTraceMetrics.spanCount.sum)
+      : null
+  const spansTone: TrendTone =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching
+      ? traceMetrics.spanCount.sum < prevTraceMetrics.spanCount.sum
+        ? "positive"
+        : traceMetrics.spanCount.sum > prevTraceMetrics.spanCount.sum
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  const errorTrend = errorRateDeltaShortFull(errorRate, prevErrorRate)
+  const errorTone: TrendTone =
+    errorRate > prevErrorRate ? "negative" : errorRate < prevErrorRate ? "positive" : "neutral"
+
+  const ttftTrend =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching && showTtftAggregations
+      ? latencyDeltaShortFull(traceMetrics.timeToFirstTokenNs.median, prevTraceMetrics.timeToFirstTokenNs.median)
+      : null
+  const ttftTone: TrendTone =
+    traceMetrics && prevTraceMetrics && !prevMetricsFetching && showTtftAggregations
+      ? traceMetrics.timeToFirstTokenNs.median < prevTraceMetrics.timeToFirstTokenNs.median
+        ? "positive"
+        : traceMetrics.timeToFirstTokenNs.median > prevTraceMetrics.timeToFirstTokenNs.median
+          ? "negative"
+          : "neutral"
+      : "neutral"
+
+  return (
+    <div className="flex flex-col rounded-lg bg-secondary p-2">
+      <div className="flex flex-row flex-wrap gap-3 p-4">
+        <TraceMetricWithTrend
+          label="Traces"
+          value={traceCountStr}
+          trend={tracesTrend}
+          trendTone={tracesTone}
+          isLoading={countLoading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-16"
+        />
+        <TraceMetricWithTrend
+          label="Error rate"
+          value={formatRatioPercent(errorTraceCount, traceCount)}
+          trend={errorTrend}
+          trendTone={errorTone}
+          isLoading={errorCountLoading || countLoading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-14"
+        />
+        <TraceMetricWithTrend
+          label="Total cost"
+          value={totalCostStr}
+          trend={costTrend}
+          trendTone={costTone}
+          isLoading={loading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-20"
+        />
+        <TraceMetricWithTrend
+          label="Median duration"
+          value={medianDurationStr}
+          trend={durationTrend}
+          trendTone={durationTone}
+          isLoading={loading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-20"
+        />
+        <TraceMetricWithTrend
+          label="Total tokens"
+          value={totalTokensStr}
+          trend={tokensTrend}
+          trendTone={tokensTone}
+          isLoading={loading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-20"
+        />
+        {showTtftAggregations ? (
+          <TraceMetricWithTrend
+            label="Median time to first token"
+            value={formatDuration(traceMetrics.timeToFirstTokenNs.median)}
+            trend={ttftTrend}
+            trendTone={ttftTone}
+            isLoading={loading}
+            trendAwaitingCompare={trendAwaitingCompare}
+            skeletonWidthClassName="w-24"
+          />
+        ) : null}
+        <TraceMetricWithTrend
+          label="Total spans"
+          value={totalSpansStr}
+          trend={spansTrend}
+          trendTone={spansTone}
+          isLoading={loading}
+          trendAwaitingCompare={trendAwaitingCompare}
+          skeletonWidthClassName="w-16"
+        />
+      </div>
+      <Histogram projectId={projectId} filters={currentRange} />
+    </div>
+  )
+}
+
+function formatRatioPercent(numerator: number, denominator: number): string {
+  if (denominator <= 0) return "0%"
+  return `${((numerator / denominator) * 100).toFixed(1)}%`
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-lifecycle-badges.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-lifecycle-badges.tsx
@@ -10,6 +10,10 @@ const STATE_VARIANTS = {
   ignored: "outlineMuted",
 } as const
 
+export function issueLifecycleBadgeVariantForState(state: string): ComponentProps<typeof Badge>["variant"] {
+  return STATE_VARIANTS[state as keyof typeof STATE_VARIANTS] ?? "outline"
+}
+
 interface IssueExtraBadge {
   readonly key: string
   readonly label: string

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-status-bar-chart-colors.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-status-bar-chart-colors.ts
@@ -8,7 +8,7 @@ export function issueOccurrenceBarColorForCategory(category: string, theme: Char
   if (theme.isDark) {
     switch (category) {
       case "New":
-        return "rgb(96 165 250)"
+        return theme.primary
       case "Escalating":
         return "rgb(251 191 36)"
       case "Regressed":
@@ -21,7 +21,7 @@ export function issueOccurrenceBarColorForCategory(category: string, theme: Char
   }
   switch (category) {
     case "New":
-      return "rgb(37 99 235)"
+      return theme.primary
     case "Escalating":
       return "rgb(217 119 6)"
     case "Regressed":

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-status-bar-chart-colors.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-status-bar-chart-colors.ts
@@ -1,0 +1,34 @@
+import type { ChartCssThemeColors } from "@repo/ui"
+
+/**
+ * Bar fills aligned with `Status` / `IssueLifecycleStatuses` lifecycle colors
+ * (`status.tsx` dot tones: info=blue, warning=amber, destructive=rose, neutral=muted).
+ */
+export function issueOccurrenceBarColorForCategory(category: string, theme: ChartCssThemeColors): string {
+  if (theme.isDark) {
+    switch (category) {
+      case "New":
+        return "rgb(96 165 250)"
+      case "Escalating":
+        return "rgb(251 191 36)"
+      case "Regressed":
+        return "rgb(251 113 133)"
+      case "Resolved":
+        return theme.mutedForeground
+      default:
+        return theme.primary
+    }
+  }
+  switch (category) {
+    case "New":
+      return "rgb(37 99 235)"
+    case "Escalating":
+      return "rgb(217 119 6)"
+    case "Regressed":
+      return "rgb(225 29 72)"
+    case "Resolved":
+      return theme.mutedForeground
+    default:
+      return theme.primary
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -42,10 +42,16 @@ export function IssuesAnalyticsPanel({
   analytics,
   isLoading,
   onRangeSelect,
+  showMetricsRow = true,
+  withPanelChrome = true,
 }: {
   readonly analytics: IssuesListResultRecord["analytics"]
   readonly isLoading: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
+  /** When false, only the occurrence histogram is shown (e.g. project home). */
+  readonly showMetricsRow?: boolean
+  /** When false, omit outer `rounded-lg bg-secondary` wrapper — parent supplies chrome. */
+  readonly withPanelChrome?: boolean
 }) {
   const handleSelect = useCallback(
     (range: { startIndex: number; endIndex: number } | null) => {
@@ -68,45 +74,70 @@ export function IssuesAnalyticsPanel({
     [analytics.histogram, onRangeSelect],
   )
 
+  const chartBlock = isLoading ? (
+    <div className="px-2 py-2">
+      <HistogramSkeleton height={160} />
+    </div>
+  ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
+    <div className="flex min-h-[80px] w-full items-center justify-center px-2 py-2">
+      <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
+    </div>
+  ) : (
+    <div className="px-2 py-2">
+      <BarChart
+        data={analytics.histogram.map((bucket) => ({
+          category: formatDayBucketLabel(bucket.bucket).replaceAll(" ", "\u00A0"),
+          tooltipCategory: formatDayBucketTooltipLabel(bucket.bucket),
+          value: bucket.count,
+        }))}
+        height={160}
+        showYAxis={false}
+        xAxisLabelFontSize={10}
+        ariaLabel="Issue occurrences by day"
+        formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> occurrences`}
+        onSelect={onRangeSelect ? handleSelect : undefined}
+      />
+    </div>
+  )
+
+  if (!withPanelChrome) {
+    return (
+      <div className="flex flex-col">
+        {showMetricsRow ? (
+          <div className="flex flex-row flex-wrap gap-3 p-4">
+            {COUNT_CARDS.map((card) => (
+              <AggregationItem
+                key={card.key}
+                label={card.label}
+                value={formatCount(analytics.counts[card.key])}
+                isLoading={isLoading}
+                skeletonWidthClassName={card.key === "seenOccurrences" ? "w-20" : "w-16"}
+              />
+            ))}
+          </div>
+        ) : null}
+        {chartBlock}
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col rounded-lg bg-secondary p-2">
-      <div className="flex flex-row flex-wrap gap-3 p-4">
-        {COUNT_CARDS.map((card) => (
-          <AggregationItem
-            key={card.key}
-            label={card.label}
-            value={formatCount(analytics.counts[card.key])}
-            isLoading={isLoading}
-            skeletonWidthClassName={card.key === "seenOccurrences" ? "w-20" : "w-16"}
-          />
-        ))}
-      </div>
+      {showMetricsRow ? (
+        <div className="flex flex-row flex-wrap gap-3 p-4">
+          {COUNT_CARDS.map((card) => (
+            <AggregationItem
+              key={card.key}
+              label={card.label}
+              value={formatCount(analytics.counts[card.key])}
+              isLoading={isLoading}
+              skeletonWidthClassName={card.key === "seenOccurrences" ? "w-20" : "w-16"}
+            />
+          ))}
+        </div>
+      ) : null}
 
-      {isLoading ? (
-        <div className="px-4 py-3">
-          <HistogramSkeleton height={160} />
-        </div>
-      ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
-        <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
-          <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
-        </div>
-      ) : (
-        <div className="px-4 py-3">
-          <BarChart
-            data={analytics.histogram.map((bucket) => ({
-              category: formatDayBucketLabel(bucket.bucket).replaceAll(" ", "\u00A0"),
-              tooltipCategory: formatDayBucketTooltipLabel(bucket.bucket),
-              value: bucket.count,
-            }))}
-            height={160}
-            showYAxis={false}
-            xAxisLabelFontSize={10}
-            ariaLabel="Issue occurrences by day"
-            formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> occurrences`}
-            onSelect={onRangeSelect ? handleSelect : undefined}
-          />
-        </div>
-      )}
+      {chartBlock}
     </div>
   )
 }

--- a/apps/web/src/routes/design-system/badge.tsx
+++ b/apps/web/src/routes/design-system/badge.tsx
@@ -1,0 +1,262 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Icon,
+  Text,
+  useMountEffect,
+} from "@repo/ui"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Check, Moon, Star, Sun } from "lucide-react"
+import { useState } from "react"
+
+const BADGE_VARIANTS = [
+  "default",
+  "secondary",
+  "yellow",
+  "purple",
+  "accent",
+  "success",
+  "successMuted",
+  "destructive",
+  "destructiveMuted",
+  "warningMuted",
+  "muted",
+  "outline",
+  "outlineMuted",
+  "outlineAccent",
+  "outlinePurple",
+  "outlineSuccessMuted",
+  "outlineDestructiveMuted",
+  "outlineWarningMuted",
+  "noBorderMuted",
+  "noBorderDestructiveMuted",
+  "white",
+] as const
+
+const BADGE_SIZES = ["small", "normal", "large"] as const
+
+const BADGE_SHAPES = ["default", "rounded"] as const
+
+export const Route = createFileRoute("/design-system/badge")({
+  component: BadgePage,
+})
+
+function BadgePage() {
+  const [theme, setTheme] = useState<"light" | "dark">("light")
+  const pageSurfaceClass = theme === "dark" ? "bg-black" : "bg-white"
+
+  const applyTheme = (nextTheme: "light" | "dark") => {
+    const root = document.documentElement
+    root.classList.toggle("dark", nextTheme === "dark")
+    root.style.colorScheme = nextTheme
+  }
+
+  const restoreHostTheme = () => {
+    const root = document.documentElement
+    const hostTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    root.classList.toggle("dark", hostTheme === "dark")
+    root.style.colorScheme = hostTheme
+  }
+
+  useMountEffect(() => {
+    applyTheme(theme)
+    return () => {
+      restoreHostTheme()
+    }
+  })
+
+  return (
+    <main className={`flex min-h-screen flex-col gap-6 p-4 text-foreground sm:p-6 lg:p-8 ${pageSurfaceClass}`}>
+      <div className="flex w-full max-w-4xl flex-col gap-6 self-center">
+        <header
+          className={`flex flex-col gap-4 rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${pageSurfaceClass}`}
+        >
+          <Link
+            to="/design-system"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            <span aria-hidden="true">←</span>
+            Design system
+          </Link>
+          <div className="flex flex-col gap-2">
+            <Text.H6 color="accentForeground" weight="semibold">
+              Reference
+            </Text.H6>
+            <Text.H2 className="text-balance">Badge</Text.H2>
+          </div>
+          <Text.H6 color="foregroundMuted">
+            Every color variant, size, shape, and common modifier states. Toggle theme to validate light and dark
+            styles.
+          </Text.H6>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTheme((currentTheme) => {
+                  const nextTheme = currentTheme === "light" ? "dark" : "light"
+                  applyTheme(nextTheme)
+                  return nextTheme
+                })
+              }}
+            >
+              <Icon icon={theme === "light" ? Moon : Sun} size="sm" />
+              {theme === "light" ? "Switch to Dark" : "Switch to Light"}
+            </Button>
+            <div className={`flex items-center gap-2 rounded-lg border border-border/60 p-2 ${pageSurfaceClass}`}>
+              <Text.H6 color="foregroundMuted">Theme</Text.H6>
+              <Text.Mono>{theme}</Text.Mono>
+            </div>
+          </div>
+        </header>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Variants</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">All `variant` values at default size and shape.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {BADGE_VARIANTS.map((variant) => (
+              <div
+                key={variant}
+                className="grid grid-cols-1 items-center gap-3 border-b border-border/40 pb-3 last:border-b-0 last:pb-0 sm:grid-cols-[minmax(0,14rem)_1fr]"
+              >
+                <div className="min-w-0 truncate">
+                  <Text.Mono size="h6" color="foregroundMuted" display="block">
+                    {variant}
+                  </Text.Mono>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={variant} noWrap>
+                    Label
+                  </Badge>
+                  <Badge variant={variant} uppercase noWrap>
+                    status
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Sizes</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">`small`, `normal`, and `large` on the default variant.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-end gap-4">
+            {BADGE_SIZES.map((size) => (
+              <div key={size} className="flex flex-col gap-2">
+                <Text.Mono size="h6" color="foregroundMuted">
+                  {size}
+                </Text.Mono>
+                <Badge size={size} noWrap>
+                  {size === "large" ? "Large" : "Text"}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Shapes</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">`default` vs pill `rounded`.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-4">
+            {BADGE_SHAPES.map((shape) => (
+              <div key={shape} className="flex flex-col gap-2">
+                <Text.Mono size="h6" color="foregroundMuted">
+                  {shape}
+                </Text.Mono>
+                <Badge shape={shape} variant="secondary" noWrap>
+                  Shape
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>States & composition</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">Disabled, leading dot, icons, truncation, and alignment.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <Text.H6 weight="semibold">Disabled</Text.H6>
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge disabled>Muted off</Badge>
+                <Badge variant="success" disabled>
+                  Success off
+                </Badge>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Text.H6 weight="semibold">Leading dot (`indicatorProps`)</Text.H6>
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge variant="outline" indicatorProps={{ variant: "default" }} noWrap>
+                  Default dot
+                </Badge>
+                <Badge variant="outline" indicatorProps={{ variant: "success", size: "md" }} noWrap>
+                  Success dot
+                </Badge>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Text.H6 weight="semibold">Icons (`iconProps`)</Text.H6>
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge variant="secondary" iconProps={{ icon: Check, placement: "start" }} noWrap>
+                  Start icon
+                </Badge>
+                <Badge variant="secondary" iconProps={{ icon: Star, placement: "end" }} noWrap>
+                  End icon
+                </Badge>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Text.H6 weight="semibold">Ellipsis in narrow layout</Text.H6>
+              <div className="max-w-48">
+                <Badge variant="muted" ellipsis className="w-full max-w-full">
+                  This label is intentionally long and should truncate with an ellipsis
+                </Badge>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Text.H6 weight="semibold">Centered</Text.H6>
+              <div className="w-full max-w-xs rounded-lg border border-dashed border-border/60 p-3">
+                <Badge variant="outline" centered className="w-full" noWrap>
+                  Centered in container
+                </Badge>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/routes/design-system/index.tsx
+++ b/apps/web/src/routes/design-system/index.tsx
@@ -32,8 +32,38 @@ import {
   useMountEffect,
 } from "@repo/ui"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { Check, Moon, Palette, Sparkles, Sun } from "lucide-react"
+import { Check, Loader2, Moon, Palette, Sparkles, Star, Sun } from "lucide-react"
 import { useState } from "react"
+
+const DESIGN_SYSTEM_BADGE_VARIANTS = [
+  "default",
+  "secondary",
+  "yellow",
+  "purple",
+  "accent",
+  "success",
+  "successMuted",
+  "destructive",
+  "destructiveMuted",
+  "warningMuted",
+  "muted",
+  "outline",
+  "outlineMuted",
+  "outlineAccent",
+  "outlinePurple",
+  "outlineSuccessMuted",
+  "outlineDestructiveMuted",
+  "outlineWarningMuted",
+  "noBorderMuted",
+  "noBorderDestructiveMuted",
+  "white",
+] as const
+
+const DESIGN_SYSTEM_BADGE_SIZES = ["small", "normal", "large"] as const
+
+const DESIGN_SYSTEM_BADGE_SHAPES = ["default", "rounded"] as const
+
+const DESIGN_SYSTEM_STATUS_VARIANTS = ["neutral", "info", "success", "warning", "destructive"] as const
 
 export const Route = createFileRoute("/design-system/")({
   component: DesignSystemPage,
@@ -132,11 +162,107 @@ function DesignSystemShowcase({ theme }: { theme: "light" | "dark" }) {
               ]}
             />
           </div>
+        </div>
+      </ShowcaseSection>
+
+      <ShowcaseSection
+        theme={theme}
+        title="Badge"
+        description="Label chips: color variants, sizes, shapes, disabled, dot, icons, and truncation."
+      >
+        <div className="flex flex-col gap-6">
+          <Link
+            to="/design-system/badge"
+            className="inline-flex w-fit items-center gap-1 text-sm text-accent-foreground underline-offset-4 hover:underline"
+          >
+            Full badge reference (light/dark playground) →
+          </Link>
+
           <div className="flex flex-col gap-2">
-            <Text.H6 weight="semibold">Badge uppercase</Text.H6>
+            <Text.H6 weight="semibold">Variants</Text.H6>
+            <div className="flex flex-col gap-2">
+              {DESIGN_SYSTEM_BADGE_VARIANTS.map((variant) => (
+                <div
+                  key={variant}
+                  className="grid grid-cols-1 items-center gap-2 border-b border-border/40 pb-2 last:border-b-0 last:pb-0 sm:grid-cols-[minmax(0,12rem)_1fr]"
+                >
+                  <div className="min-w-0 truncate">
+                    <Text.Mono size="h6" color="foregroundMuted" display="block">
+                      {variant}
+                    </Text.Mono>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant={variant} noWrap>
+                      Label
+                    </Badge>
+                    <Badge variant={variant} uppercase noWrap>
+                      status
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Sizes</Text.H6>
+            <div className="flex flex-wrap items-end gap-4">
+              {DESIGN_SYSTEM_BADGE_SIZES.map((size) => (
+                <div key={size} className="flex flex-col gap-2">
+                  <Text.Mono size="h6" color="foregroundMuted">
+                    {size}
+                  </Text.Mono>
+                  <Badge size={size} noWrap>
+                    {size === "large" ? "Large" : "Text"}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Shapes</Text.H6>
+            <div className="flex flex-wrap items-center gap-4">
+              {DESIGN_SYSTEM_BADGE_SHAPES.map((shape) => (
+                <div key={shape} className="flex flex-col gap-2">
+                  <Text.Mono size="h6" color="foregroundMuted">
+                    {shape}
+                  </Text.Mono>
+                  <Badge shape={shape} variant="secondary" noWrap>
+                    Shape
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Disabled, dot, icons</Text.H6>
             <div className="flex flex-wrap items-center gap-3">
-              <Badge variant="outline" size="small" uppercase noWrap>
-                live
+              <Badge disabled>Muted off</Badge>
+              <Badge variant="success" disabled>
+                Success off
+              </Badge>
+              <Badge variant="outline" indicatorProps={{ variant: "default" }} noWrap>
+                Dot
+              </Badge>
+              <Badge variant="outline" indicatorProps={{ variant: "success", size: "md" }} noWrap>
+                Live
+              </Badge>
+              <Badge variant="secondary" iconProps={{ icon: Check, placement: "start" }} noWrap>
+                Start
+              </Badge>
+              <Badge variant="secondary" iconProps={{ icon: Sparkles, placement: "end" }} noWrap>
+                End
+              </Badge>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Ellipsis</Text.H6>
+            <div className="max-w-48">
+              <Badge variant="muted" ellipsis className="w-full max-w-full">
+                This label is intentionally long and should truncate with an ellipsis
               </Badge>
             </div>
           </div>
@@ -264,23 +390,64 @@ function DesignSystemShowcase({ theme }: { theme: "light" | "dark" }) {
       <ShowcaseSection
         theme={theme}
         title="Status"
-        description="Compact pill statuses with semantic variants and a leading dot."
+        description="Compact pill statuses: semantic variants, optional dot, custom indicators, truncation."
       >
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-3">
-            <Status label="Neutral" variant="neutral" />
-            <Status label="Info" variant="info" />
-            <Status label="Success" variant="success" />
-            <Status label="Warning" variant="warning" />
-            <Status label="Destructive" variant="destructive" />
+        <div className="flex flex-col gap-6">
+          <Link
+            to="/design-system/status"
+            className="inline-flex w-fit items-center gap-1 text-sm text-accent-foreground underline-offset-4 hover:underline"
+          >
+            Full status reference (light/dark playground) →
+          </Link>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Variants (default dot)</Text.H6>
+            <div className="flex flex-col gap-2">
+              {DESIGN_SYSTEM_STATUS_VARIANTS.map((variant) => (
+                <div
+                  key={variant}
+                  className="grid grid-cols-1 items-center gap-2 border-b border-border/40 pb-2 last:border-b-0 last:pb-0 sm:grid-cols-[minmax(0,10rem)_1fr]"
+                >
+                  <Text.Mono size="h6" color="foregroundMuted">
+                    {variant}
+                  </Text.Mono>
+                  <Status variant={variant} label={variant.charAt(0).toUpperCase() + variant.slice(1)} />
+                </div>
+              ))}
+            </div>
           </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">No dot</Text.H6>
+            <div className="flex flex-wrap items-center gap-3">
+              {DESIGN_SYSTEM_STATUS_VARIANTS.map((variant) => (
+                <Status key={variant} variant={variant} indicator={false} label="Text only" />
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Text.H6 weight="semibold">Custom indicator</Text.H6>
+            <div className="flex flex-wrap items-center gap-3">
+              <Status
+                variant="info"
+                label="Loading"
+                indicator={<Icon icon={Loader2} size="xs" className="animate-spin" aria-hidden />}
+              />
+              <Status variant="success" label="Star" indicator={<Icon icon={Star} size="xs" aria-hidden />} />
+            </div>
+          </div>
+
           <div className="flex flex-col gap-2">
             <Text.H6 weight="semibold">Truncation</Text.H6>
-            <div className="max-w-64">
-              <Status
-                label="This is a longer status label that truncates cleanly in constrained layouts"
-                variant="info"
-              />
+            <div className="max-w-sm flex flex-col gap-2">
+              {DESIGN_SYSTEM_STATUS_VARIANTS.map((variant) => (
+                <Status
+                  key={variant}
+                  variant={variant}
+                  label="This status line is long and should ellipsize instead of wrapping the layout"
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -622,6 +789,18 @@ function DesignSystemPage() {
                 className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
               >
                 Colors
+              </Link>
+              <Link
+                to="/design-system/badge"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Badge
+              </Link>
+              <Link
+                to="/design-system/status"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                Status
               </Link>
             </div>
 

--- a/apps/web/src/routes/design-system/status.tsx
+++ b/apps/web/src/routes/design-system/status.tsx
@@ -1,0 +1,172 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Icon,
+  Status,
+  Text,
+  useMountEffect,
+} from "@repo/ui"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { Loader2, Moon, Star, Sun } from "lucide-react"
+import { useState } from "react"
+
+const STATUS_VARIANTS = ["neutral", "info", "success", "warning", "destructive"] as const
+
+export const Route = createFileRoute("/design-system/status")({
+  component: StatusPage,
+})
+
+function StatusPage() {
+  const [theme, setTheme] = useState<"light" | "dark">("light")
+  const pageSurfaceClass = theme === "dark" ? "bg-black" : "bg-white"
+
+  const applyTheme = (nextTheme: "light" | "dark") => {
+    const root = document.documentElement
+    root.classList.toggle("dark", nextTheme === "dark")
+    root.style.colorScheme = nextTheme
+  }
+
+  const restoreHostTheme = () => {
+    const root = document.documentElement
+    const hostTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+    root.classList.toggle("dark", hostTheme === "dark")
+    root.style.colorScheme = hostTheme
+  }
+
+  useMountEffect(() => {
+    applyTheme(theme)
+    return () => {
+      restoreHostTheme()
+    }
+  })
+
+  return (
+    <main className={`flex min-h-screen flex-col gap-6 p-4 text-foreground sm:p-6 lg:p-8 ${pageSurfaceClass}`}>
+      <div className="flex w-full max-w-4xl flex-col gap-6 self-center">
+        <header
+          className={`flex flex-col gap-4 rounded-2xl border border-border/70 p-5 shadow-xl sm:p-6 ${pageSurfaceClass}`}
+        >
+          <Link
+            to="/design-system"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            <span aria-hidden="true">←</span>
+            Design system
+          </Link>
+          <div className="flex flex-col gap-2">
+            <Text.H6 color="accentForeground" weight="semibold">
+              Reference
+            </Text.H6>
+            <Text.H2 className="text-balance">Status</Text.H2>
+          </div>
+          <Text.H6 color="foregroundMuted">
+            Semantic variants with the default dot, text-only mode, truncation, and a custom leading indicator. Toggle
+            theme for light and dark checks.
+          </Text.H6>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setTheme((currentTheme) => {
+                  const nextTheme = currentTheme === "light" ? "dark" : "light"
+                  applyTheme(nextTheme)
+                  return nextTheme
+                })
+              }}
+            >
+              <Icon icon={theme === "light" ? Moon : Sun} size="sm" />
+              {theme === "light" ? "Switch to Dark" : "Switch to Light"}
+            </Button>
+            <div className={`flex items-center gap-2 rounded-lg border border-border/60 p-2 ${pageSurfaceClass}`}>
+              <Text.H6 color="foregroundMuted">Theme</Text.H6>
+              <Text.Mono>{theme}</Text.Mono>
+            </div>
+          </div>
+        </header>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Variants</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">All `variant` values with the default leading dot.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            {STATUS_VARIANTS.map((variant) => (
+              <div
+                key={variant}
+                className="grid grid-cols-1 items-center gap-3 border-b border-border/40 pb-3 last:border-b-0 last:pb-0 sm:grid-cols-[minmax(0,10rem)_1fr]"
+              >
+                <Text.Mono size="h6" color="foregroundMuted">
+                  {variant}
+                </Text.Mono>
+                <Status variant={variant} label={variant.charAt(0).toUpperCase() + variant.slice(1)} />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>No dot</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">`indicator={false}` removes the leading marker.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-3">
+            {STATUS_VARIANTS.map((variant) => (
+              <Status key={variant} variant={variant} indicator={false} label="Text only" />
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Custom indicator</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">Pass any `ReactNode` as `indicator`.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-3">
+            <Status
+              variant="info"
+              label="Loading"
+              indicator={<Icon icon={Loader2} size="xs" className="animate-spin" aria-hidden />}
+            />
+            <Status variant="success" label="Star" indicator={<Icon icon={Star} size="xs" aria-hidden />} />
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/70 shadow-xl">
+          <CardHeader>
+            <CardTitle>
+              <Text.H4>Truncation</Text.H4>
+            </CardTitle>
+            <CardDescription>
+              <Text.H6 color="foregroundMuted">Long labels truncate inside constrained widths.</Text.H6>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex max-w-sm flex-col gap-4">
+            {STATUS_VARIANTS.map((variant) => (
+              <Status
+                key={variant}
+                variant={variant}
+                label="This status line is long and should ellipsize instead of wrapping the layout"
+              />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  )
+}

--- a/packages/ui/src/components/badge/index.tsx
+++ b/packages/ui/src/components/badge/index.tsx
@@ -7,36 +7,33 @@ import { DotIndicator, type DotIndicatorProps } from "../dot-indicator/dot-indic
 import { Icon, type IconProps } from "../icons/icons.tsx"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-md font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-primary-foreground/10 bg-primary text-primary-foreground hover:bg-primary/80",
-        secondary: "border-secondary-foreground/10 bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        yellow: "border-transparent bg-yellow text-foreground hover:bg-yellow/80",
-        purple: "border-purple-foreground/10 bg-purple text-purple-foreground hover:bg-purple/80",
-        accent: "border-accent-foreground/10 bg-accent text-accent-foreground hover:bg-accent/80",
-        success: "border-transparent bg-green-500 text-success-foreground hover:bg-green-500/80",
-        successMuted:
-          "border-success-muted-foreground/10 bg-success-muted text-success-muted-foreground hover:bg-success-muted/80",
-        destructive:
-          "border-destructive-foreground/10 bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        default: "border-none bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary: "border-none bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        yellow: "border-none bg-yellow text-foreground hover:bg-yellow/80",
+        purple: "border-none bg-purple text-purple-foreground hover:bg-purple/80",
+        accent: "border-none bg-accent text-accent-foreground hover:bg-accent/80",
+        success: "border-none bg-green-500 text-success-foreground hover:bg-green-500/80",
+        successMuted: "border-none bg-success-muted text-success-muted-foreground hover:bg-success-muted/80",
+        destructive: "border-none bg-destructive text-destructive-foreground hover:bg-destructive/80",
         destructiveMuted:
-          "border-destructive-muted-foreground/10 bg-destructive-muted text-destructive-muted-foreground hover:bg-destructive-muted/80",
-        warningMuted:
-          "border-warning-muted-foreground/10 bg-warning-muted text-warning-muted-foreground hover:bg-warning-muted/80",
-        muted: "border-muted-foreground/10 bg-muted text-muted-foreground hover:bg-muted/80",
-        outline: "text-foreground",
-        outlineMuted: "border-muted-foreground/30 text-muted-foreground",
-        outlineAccent: "border-accent-foreground/30 text-accent-foreground",
-        outlinePurple: "border-purple-foreground/30 text-purple-foreground",
-        outlineSuccessMuted: "border-success-muted-foreground/30 text-success-muted-foreground",
-        outlineDestructiveMuted: "border-destructive-muted-foreground/30 text-destructive-muted-foreground",
-        outlineWarningMuted: "border-warning-muted-foreground/30 text-warning-muted-foreground",
-        noBorderMuted: "bg-muted border-none text-muted-foreground hover:bg-muted/80",
+          "border-none bg-destructive-muted text-destructive-muted-foreground hover:bg-destructive-muted/80",
+        warningMuted: "border-none bg-warning-muted text-warning-muted-foreground hover:bg-warning-muted/80",
+        muted: "border-none bg-muted text-muted-foreground hover:bg-muted/80",
+        outline: "border border-border text-foreground",
+        outlineMuted: "border border-muted-foreground/30 text-muted-foreground",
+        outlineAccent: "border border-accent-foreground/30 text-accent-foreground",
+        outlinePurple: "border border-purple-foreground/30 text-purple-foreground",
+        outlineSuccessMuted: "border border-success-muted-foreground/30 text-success-muted-foreground",
+        outlineDestructiveMuted: "border border-destructive-muted-foreground/30 text-destructive-muted-foreground",
+        outlineWarningMuted: "border border-warning-muted-foreground/30 text-warning-muted-foreground",
+        noBorderMuted: "border-none bg-muted text-muted-foreground hover:bg-muted/80",
         noBorderDestructiveMuted:
-          "bg-destructive-muted border-none text-destructive-muted-foreground hover:bg-destructive-muted/80",
-        white: "bg-white text-primary hover:bg-white/80",
+          "border-none bg-destructive-muted text-destructive-muted-foreground hover:bg-destructive-muted/80",
+        white: "border-none bg-white text-primary hover:bg-white/80",
       },
       shape: {
         default: "max-h-5",

--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -1,6 +1,14 @@
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
-import { type ButtonHTMLAttributes, Children, forwardRef, isValidElement, type ReactNode } from "react"
+import {
+  type ButtonHTMLAttributes,
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 
 import { font } from "../../tokens/font.ts"
 import { cn } from "../../utils/cn.ts"
@@ -170,18 +178,38 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const visibleChildren = isLoading ? stripLeadingIconChild(children) : children
 
     if (asChild) {
+      const onlyChild = Children.only(visibleChildren)
+      if (!isValidElement(onlyChild)) {
+        throw new Error("Button asChild requires a single React element child.")
+      }
+      const childProps = onlyChild.props as {
+        readonly className?: string
+        readonly children?: ReactNode
+      }
       return (
-        <Slot
-          ref={ref}
-          className={cn(
-            buttonContainerVariants({ variant }),
-            buttonVariantsConfig({ variant, size }),
-            className,
-            isLoading && "animate-pulse",
-          )}
-          {...props}
-        >
-          {visibleChildren}
+        <Slot {...props}>
+          {cloneElement(onlyChild as ReactElement<Record<string, unknown>>, {
+            ref,
+            className: cn(childProps.className, buttonContainerVariants({ variant }), isLoading && "animate-pulse"),
+            children: (
+              <span
+                className={cn(
+                  buttonVariantsConfig({ variant, size }),
+                  "relative z-[1] flex max-w-full flex-row items-center gap-x-1.5",
+                  className,
+                )}
+              >
+                {isLoading ? (
+                  <>
+                    <span className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    {stripLeadingIconChild(childProps.children)}
+                  </>
+                ) : (
+                  childProps.children
+                )}
+              </span>
+            ),
+          })}
         </Slot>
       )
     }

--- a/packages/ui/src/components/charts/bar-chart-option.ts
+++ b/packages/ui/src/components/charts/bar-chart-option.ts
@@ -19,6 +19,10 @@ export function buildBarChartOption(
   showYAxis = true,
   enableBrush = false,
   xAxisLabelFontSize = 11,
+  /** Per-bar fill; index aligns with `values`. Omitted entries use `colors.primary`. */
+  itemColors?: readonly (string | undefined)[],
+  /** When false, hides category labels, ticks, and axis line (sparkline-style). */
+  showXAxisLabels = true,
 ): EChartsCoreOption {
   const categoryLabelInterval =
     categories.length <= maxCategoryAxisLabels
@@ -27,13 +31,16 @@ export function buildBarChartOption(
   const capBarWidth = categories.length > barMaxWidthCategoryThreshold
   const splitLineColor = colors.isDark ? colors.mutedForeground : colors.border
   const splitLineOpacity = colors.isDark ? 0.3 : 0.6
+  const gridBottom = showXAxisLabels ? gridVerticalInsetPx : 4
+  const gridTop = showXAxisLabels ? gridVerticalInsetPx : 4
+
   const option: EChartsCoreOption = {
     backgroundColor: "transparent",
     grid: {
-      left: showYAxis ? 48 : 8,
-      right: 16,
-      top: gridVerticalInsetPx,
-      bottom: gridVerticalInsetPx,
+      left: showYAxis ? 48 : 4,
+      right: showXAxisLabels ? 16 : 4,
+      top: gridTop,
+      bottom: gridBottom,
       containLabel: false,
     },
     tooltip: {
@@ -62,20 +69,24 @@ export function buildBarChartOption(
     xAxis: {
       type: "category",
       data: [...categories],
-      axisLine: { lineStyle: { color: colors.border } },
-      axisLabel: {
-        color: colors.mutedForeground,
-        fontSize: xAxisLabelFontSize,
-        rotate: 0,
-        interval: categoryLabelInterval,
-        hideOverlap: true,
-      },
-      axisTick: { alignWithLabel: true, lineStyle: { color: colors.border } },
+      axisLine: showXAxisLabels ? { lineStyle: { color: colors.border } } : { show: false },
+      axisLabel: showXAxisLabels
+        ? {
+            color: colors.mutedForeground,
+            fontSize: xAxisLabelFontSize,
+            rotate: 0,
+            interval: categoryLabelInterval,
+            hideOverlap: true,
+          }
+        : { show: false },
+      axisTick: showXAxisLabels ? { alignWithLabel: true, lineStyle: { color: colors.border } } : { show: false },
     },
     yAxis: {
       type: "value",
       minInterval: 1,
-      splitLine: { lineStyle: { color: splitLineColor, type: "dashed", opacity: splitLineOpacity } },
+      splitLine: showXAxisLabels
+        ? { lineStyle: { color: splitLineColor, type: "dashed", opacity: splitLineOpacity } }
+        : { show: false },
       axisLine: { show: false },
       ...(showYAxis ? {} : { axisTick: { show: false } }),
       axisLabel: showYAxis ? { color: colors.mutedForeground, fontSize: 11 } : { show: false },
@@ -83,7 +94,17 @@ export function buildBarChartOption(
     series: [
       {
         type: "bar",
-        data: [...values],
+        data: values.map((v, i) => {
+          const c = itemColors?.[i]
+          if (!c) return v
+          return {
+            value: v,
+            itemStyle: { color: c, borderRadius: [4, 4, 0, 0] },
+            emphasis: {
+              itemStyle: { color: c, borderRadius: [4, 4, 0, 0] },
+            },
+          }
+        }),
         ...(capBarWidth ? { barMaxWidth: barMaxWidthPx } : {}),
         barCategoryGap: "18%",
         cursor: "default",

--- a/packages/ui/src/components/charts/bar-chart.tsx
+++ b/packages/ui/src/components/charts/bar-chart.tsx
@@ -15,6 +15,8 @@ export type BarChartDataPoint = {
   readonly category: string
   readonly tooltipCategory?: string
   readonly value: number
+  /** When set, this bar uses this fill instead of the theme primary (e.g. status-colored bars). */
+  readonly barColor?: string
 }
 
 export type BarChartProps = Omit<HTMLAttributes<HTMLDivElement>, "children" | "onSelect"> & {
@@ -33,6 +35,8 @@ export type BarChartProps = Omit<HTMLAttributes<HTMLDivElement>, "children" | "o
   readonly showYAxis?: boolean
   /** Optional x-axis label font size override in pixels. */
   readonly xAxisLabelFontSize?: number
+  /** When false, hides x-axis labels and ticks (mini / sparkline charts). */
+  readonly showXAxisLabels?: boolean
   /**
    * Called when user selects a range via brush (e.g., drag on the histogram).
    * Receives the selected data range [startIndex, endIndex] or null if cleared.
@@ -65,6 +69,7 @@ function BarChart({
   formatTooltip,
   showYAxis = true,
   xAxisLabelFontSize,
+  showXAxisLabels = true,
   onSelect,
   className,
   ...rest
@@ -85,6 +90,7 @@ function BarChart({
   const categories = useMemo(() => data.map((d) => d.category), [data])
   const tooltipCategories = useMemo(() => data.map((d) => d.tooltipCategory ?? d.category), [data])
   const values = useMemo(() => data.map((d) => d.value), [data])
+  const itemColors = useMemo(() => data.map((d) => d.barColor), [data])
 
   const option = useMemo(
     () =>
@@ -97,8 +103,21 @@ function BarChart({
         showYAxis,
         hasBrush,
         xAxisLabelFontSize,
+        itemColors.some((c) => c !== undefined) ? itemColors : undefined,
+        showXAxisLabels,
       ),
-    [categories, values, tooltipCategories, colors, formatTooltip, showYAxis, hasBrush, xAxisLabelFontSize],
+    [
+      categories,
+      values,
+      tooltipCategories,
+      colors,
+      formatTooltip,
+      showYAxis,
+      hasBrush,
+      xAxisLabelFontSize,
+      itemColors,
+      showXAxisLabels,
+    ],
   )
 
   // Stable event handlers that read the latest onSelect from a ref.

--- a/packages/ui/src/components/charts/lazy-pie-chart.tsx
+++ b/packages/ui/src/components/charts/lazy-pie-chart.tsx
@@ -1,0 +1,16 @@
+import { type ComponentProps, lazy, Suspense } from "react"
+
+import { HistogramSkeleton } from "./histogram-skeleton.tsx"
+
+const PieChartLazy = lazy(() => import("./pie-chart.tsx").then((m) => ({ default: m.PieChart })))
+
+/**
+ * Lazy-loaded PieChart that defers the echarts bundle until the component is rendered.
+ */
+export function LazyPieChart(props: ComponentProps<typeof PieChartLazy>) {
+  return (
+    <Suspense fallback={<HistogramSkeleton height={props.height ?? 220} />}>
+      <PieChartLazy {...props} />
+    </Suspense>
+  )
+}

--- a/packages/ui/src/components/charts/pie-chart-option.ts
+++ b/packages/ui/src/components/charts/pie-chart-option.ts
@@ -1,0 +1,70 @@
+/// <reference path="../../echarts-subpaths.d.ts" />
+import type { EChartsCoreOption } from "echarts/core"
+
+import type { ChartCssThemeColors } from "./chart-css-theme.ts"
+
+export type PieChartDataPoint = {
+  readonly name: string
+  readonly value: number
+}
+
+export function buildPieChartOption(
+  data: readonly PieChartDataPoint[],
+  segmentColors: readonly string[],
+  colors: ChartCssThemeColors,
+  formatTooltip?: (name: string, value: number, percent: number) => string,
+): EChartsCoreOption {
+  const total = data.reduce((sum, d) => sum + d.value, 0)
+  const seriesData = data.map((d, index) => ({
+    name: d.name,
+    value: d.value,
+    itemStyle: {
+      color: segmentColors[index % segmentColors.length] ?? colors.primary,
+    },
+  }))
+
+  return {
+    backgroundColor: "transparent",
+    tooltip: {
+      trigger: "item",
+      backgroundColor: colors.tooltipBackground,
+      borderColor: colors.tooltipBorder,
+      textStyle: { color: colors.foreground, fontSize: 12 },
+      formatter: (params: unknown) => {
+        const p = params as { name?: string; value?: number; percent?: number } | undefined
+        const name = p?.name ?? ""
+        const value = typeof p?.value === "number" ? p.value : Number(p?.value ?? 0)
+        const percent = typeof p?.percent === "number" ? p.percent : total > 0 ? (value / total) * 100 : 0
+        return formatTooltip
+          ? formatTooltip(name, value, percent)
+          : `${name}<br/><b>${value}</b> (${percent.toFixed(1)}%)`
+      },
+    },
+    legend: {
+      orient: "vertical",
+      right: 8,
+      top: "middle",
+      textStyle: { color: colors.mutedForeground, fontSize: 11 },
+      itemWidth: 8,
+      itemHeight: 8,
+    },
+    series: [
+      {
+        type: "pie",
+        radius: ["42%", "68%"],
+        center: ["38%", "50%"],
+        avoidLabelOverlap: true,
+        itemStyle: {
+          borderRadius: 4,
+          borderColor: colors.tooltipBackground,
+          borderWidth: 2,
+        },
+        label: { show: false },
+        emphasis: {
+          label: { show: true, color: colors.foreground, fontSize: 12 },
+        },
+        data: seriesData,
+      },
+    ],
+  }
+}

--- a/packages/ui/src/components/charts/pie-chart.tsx
+++ b/packages/ui/src/components/charts/pie-chart.tsx
@@ -1,0 +1,119 @@
+/// <reference path="../../echarts-subpaths.d.ts" />
+import type { EChartsCoreOption } from "echarts/core"
+import EChartsReact from "echarts-for-react/lib/core"
+import type { ComponentType, CSSProperties, HTMLAttributes } from "react"
+import { useMemo, useState } from "react"
+
+import { useMountEffect } from "../../hooks/use-mount-effect.ts"
+import { cn } from "../../utils/cn.ts"
+import { chartThemeFallback } from "./chart-css-theme.ts"
+import { buildPieChartOption, type PieChartDataPoint } from "./pie-chart-option.ts"
+import { echarts } from "./register-echarts.ts"
+import { useChartCssTheme } from "./use-chart-css-theme.ts"
+
+export type { PieChartDataPoint } from "./pie-chart-option.ts"
+
+export type PieChartProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
+  readonly data: readonly PieChartDataPoint[]
+  /** Pixel height of the chart area (default 220). */
+  readonly height?: number
+  readonly ariaLabel?: string
+  readonly colorScheme?: "light" | "dark"
+  readonly formatTooltip?: (name: string, value: number, percent: number) => string
+}
+
+type EChartsReactBridgeProps = {
+  readonly echarts: typeof echarts
+  readonly option: EChartsCoreOption
+  readonly style?: CSSProperties
+  readonly opts?: { readonly renderer?: "canvas" | "svg" }
+  readonly notMerge?: boolean
+  readonly lazyUpdate?: boolean
+}
+
+const EChartsView = ((EChartsReact as unknown as { default?: unknown }).default ??
+  EChartsReact) as unknown as ComponentType<EChartsReactBridgeProps>
+
+const FALLBACK_SEGMENT_LIGHT = [
+  "hsl(12 76% 61%)",
+  "hsl(173 58% 39%)",
+  "hsl(197 37% 24%)",
+  "hsl(43 74% 66%)",
+  "hsl(27 87% 67%)",
+]
+
+const FALLBACK_SEGMENT_DARK = [
+  "hsl(220 70% 50%)",
+  "hsl(160 60% 45%)",
+  "hsl(30 80% 55%)",
+  "hsl(280 65% 60%)",
+  "hsl(340 75% 55%)",
+]
+
+function readPieSegmentColors(isDark: boolean): readonly string[] {
+  if (typeof document === "undefined") {
+    return isDark ? FALLBACK_SEGMENT_DARK : FALLBACK_SEGMENT_LIGHT
+  }
+  const style = getComputedStyle(document.documentElement)
+  const out: string[] = []
+  for (let i = 1; i <= 5; i += 1) {
+    const raw = style.getPropertyValue(`--chart-${i}`).trim()
+    out.push(
+      raw ? `hsl(${raw})` : ((isDark ? FALLBACK_SEGMENT_DARK : FALLBACK_SEGMENT_LIGHT)[i - 1] ?? "hsl(211 94% 43%)"),
+    )
+  }
+  return out
+}
+
+function PieChart({
+  data,
+  height = 220,
+  ariaLabel = "Pie chart",
+  colorScheme,
+  formatTooltip,
+  className,
+  ...rest
+}: PieChartProps) {
+  const [mounted, setMounted] = useState(false)
+
+  useMountEffect(() => {
+    setMounted(true)
+  })
+
+  const cssTheme = useChartCssTheme()
+  const colors = colorScheme ? chartThemeFallback(colorScheme === "dark") : cssTheme
+  const segmentColors = useMemo(() => readPieSegmentColors(colors.isDark), [colors.isDark])
+
+  const option = useMemo(
+    () => buildPieChartOption(data, segmentColors, colors, formatTooltip),
+    [data, segmentColors, colors, formatTooltip],
+  )
+
+  if (!mounted) {
+    return (
+      <div
+        {...rest}
+        role="img"
+        className={cn("w-full shrink-0", className)}
+        style={{ height, ...rest.style }}
+        aria-label={ariaLabel}
+        aria-busy
+      />
+    )
+  }
+
+  return (
+    <div {...rest} role="img" className={cn("w-full shrink-0", className)} aria-label={ariaLabel}>
+      <EChartsView
+        echarts={echarts}
+        option={option}
+        style={{ height, width: "100%" }}
+        opts={{ renderer: "canvas" }}
+        notMerge
+        lazyUpdate
+      />
+    </div>
+  )
+}
+
+export { PieChart }

--- a/packages/ui/src/components/charts/register-echarts.ts
+++ b/packages/ui/src/components/charts/register-echarts.ts
@@ -1,9 +1,18 @@
 /// <reference path="../../echarts-subpaths.d.ts" />
-import { BarChart } from "echarts/charts"
-import { BrushComponent, GridComponent, ToolboxComponent, TooltipComponent } from "echarts/components"
+import { BarChart, PieChart } from "echarts/charts"
+import { BrushComponent, GridComponent, LegendComponent, ToolboxComponent, TooltipComponent } from "echarts/components"
 import * as echarts from "echarts/core"
 import { CanvasRenderer } from "echarts/renderers"
 
-echarts.use([BarChart, GridComponent, TooltipComponent, ToolboxComponent, BrushComponent, CanvasRenderer])
+echarts.use([
+  BarChart,
+  PieChart,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent,
+  ToolboxComponent,
+  BrushComponent,
+  CanvasRenderer,
+])
 
 export { echarts }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,6 +31,8 @@ export {
 export { ChartSkeleton, type ChartSkeletonProps } from "./components/charts/chart-skeleton.tsx"
 export { HistogramSkeleton, type HistogramSkeletonProps } from "./components/charts/histogram-skeleton.tsx"
 export { LazyBarChart as BarChart } from "./components/charts/lazy-bar-chart.tsx"
+export { LazyPieChart as PieChart } from "./components/charts/lazy-pie-chart.tsx"
+export type { PieChartDataPoint, PieChartProps } from "./components/charts/pie-chart.tsx"
 export { Checkbox, type CheckedState } from "./components/checkbox/checkbox.tsx"
 export { CheckboxInput, type CheckboxInputProps } from "./components/checkbox/checkbox-input.tsx"
 export { CodeBlock, type CodeBlockProps } from "./components/code-block/code-block.tsx"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -33,6 +33,7 @@ export { HistogramSkeleton, type HistogramSkeletonProps } from "./components/cha
 export { LazyBarChart as BarChart } from "./components/charts/lazy-bar-chart.tsx"
 export { LazyPieChart as PieChart } from "./components/charts/lazy-pie-chart.tsx"
 export type { PieChartDataPoint, PieChartProps } from "./components/charts/pie-chart.tsx"
+export { useChartCssTheme } from "./components/charts/use-chart-css-theme.ts"
 export { Checkbox, type CheckedState } from "./components/checkbox/checkbox.tsx"
 export { CheckboxInput, type CheckboxInputProps } from "./components/checkbox/checkbox-input.tsx"
 export { CodeBlock, type CodeBlockProps } from "./components/code-block/code-block.tsx"


### PR DESCRIPTION
This PR includes implementing a base for the project home page along with general charts providing an overview of the project health.

The home tab roadmap:

- [ ] Implement customisable charts so that users can build a personalized observation space and monitor the most important metrics
- [ ] Polish UI so that it matches Figma mocks fully