### PR TITLE
feat(workflows): add Datadog activity interceptor to Temporal worker

### DIFF
--- a/packages/platform/workflows-temporal/package.json
+++ b/packages/platform/workflows-temporal/package.json
@@ -18,8 +18,10 @@
   },
   "dependencies": {
     "@domain/queue": "workspace:*",
+    "@opentelemetry/api": "catalog:",
     "@platform/env": "workspace:*",
     "@repo/observability": "workspace:*",
+    "@temporalio/activity": "catalog:",
     "@temporalio/client": "catalog:",
     "@temporalio/worker": "catalog:",
     "effect": "catalog:"

--- a/packages/platform/workflows-temporal/src/worker.ts
+++ b/packages/platform/workflows-temporal/src/worker.ts
@@ -1,6 +1,55 @@
-import { createLogger } from "@repo/observability"
+import { SpanStatusCode, trace } from "@opentelemetry/api"
+import { createLogger, recordSpanExceptionForDatadog } from "@repo/observability"
+import { Context as ActivityContext } from "@temporalio/activity"
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  ActivityInterceptorsFactory,
+  Next,
+} from "@temporalio/worker"
 import { NativeConnection, Worker } from "@temporalio/worker"
 import type { TemporalConfig } from "./config.ts"
+
+const tracer = trace.getTracer("temporal-worker")
+
+const datadogActivityInterceptor: ActivityInterceptorsFactory = (_ctx: ActivityContext) => ({
+  inbound: {
+    async execute(
+      input: ActivityExecuteInput,
+      next: Next<ActivityInboundCallsInterceptor, "execute">,
+    ): Promise<unknown> {
+      const info = ActivityContext.current().info
+      const spanName = `temporal.activity.${info.activityType}`
+
+      return tracer.startActiveSpan(
+        spanName,
+        {
+          attributes: {
+            "temporal.activity.type": info.activityType,
+            "temporal.workflow.type": info.workflowType,
+            "temporal.workflow.namespace": info.workflowNamespace,
+            "temporal.task_queue": info.taskQueue,
+            "temporal.activity.id": info.activityId,
+            "temporal.attempt": info.attempt,
+          },
+        },
+        async (span) => {
+          try {
+            const result = await next(input)
+            span.setStatus({ code: SpanStatusCode.OK })
+            return result
+          } catch (error) {
+            const err = recordSpanExceptionForDatadog(span, error)
+            span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+            throw err
+          } finally {
+            span.end()
+          }
+        },
+      )
+    },
+  },
+})
 
 const logger = createLogger("workflows-temporal-worker")
 
@@ -33,6 +82,9 @@ export async function runTemporalWorker(input: RunTemporalWorkerInput) {
     taskQueue: config.taskQueue,
     workflowsPath,
     activities,
+    interceptors: {
+      activity: [datadogActivityInterceptor],
+    },
   })
 
   const runPromise = worker.run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@paralleldrive/cuid2':
       specifier: 3.3.0
       version: 3.3.0
+    '@temporalio/activity':
+      specifier: 1.16.0
+      version: 1.16.0
     '@temporalio/client':
       specifier: 1.16.0
       version: 1.16.0
@@ -1589,12 +1592,18 @@ importers:
       '@domain/queue':
         specifier: workspace:*
         version: link:../../domain/queue
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
       '@platform/env':
         specifier: workspace:*
         version: link:../env
       '@repo/observability':
         specifier: workspace:*
         version: link:../../observability
+      '@temporalio/activity':
+        specifier: 'catalog:'
+        version: 1.16.0
       '@temporalio/client':
         specifier: 'catalog:'
         version: 1.16.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   '@hono/node-server': 1.19.13
   '@opentelemetry/api': ^1.9.0
   '@paralleldrive/cuid2': 3.3.0
+  '@temporalio/activity': 1.16.0
   '@temporalio/client': 1.16.0
   '@temporalio/worker': 1.16.0
   '@temporalio/workflow': 1.16.0


### PR DESCRIPTION
## Summary
- Add an OTel activity interceptor to the Temporal worker that wraps each activity execution with a span and records exceptions via `recordSpanExceptionForDatadog()`
- Activity errors inside Temporal's retry loop were invisible to Datadog — this closes that observability gap without interfering with retry semantics
- Adds `@opentelemetry/api` and `@temporalio/activity` dependencies to `@platform/workflows-temporal`

## Test plan
- [x] `biome check` passes
- [x] Typecheck passes (no new errors)
- [x] `@app/workflows` builds successfully with interceptor bundled
- [x] App starts and loads without import/runtime errors (fails only at Temporal connection as expected without server)
- [ ] Deploy to staging and verify activity spans appear in Datadog APM
- [ ] Trigger an activity failure and confirm error is recorded as span exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)