### PR TITLE
Fix spanId query cleanup when closing trace drawer

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -123,6 +123,7 @@ function ProjectPage() {
   })
   const [filtersOpen, setFiltersOpen] = useParamState("filtersOpen", false)
   const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
+  const [, setSelectedSpanId] = useParamState("spanId", "")
   const [rawFilters, setRawFilters] = useParamState("filters", "")
   const [sortBy, setSortBy] = useParamState("sortBy", DEFAULT_TRACE_SORTING.column)
   const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_TRACE_SORTING.direction, {
@@ -205,12 +206,21 @@ function ProjectPage() {
     setRawFilters("")
   }
 
+  const closeTraceDrawer = useCallback(() => {
+    setActiveTraceId("")
+    setSelectedSpanId("")
+  }, [setActiveTraceId, setSelectedSpanId])
+
   const onActiveTraceChange = (traceId: string | undefined) => {
-    setActiveTraceId(traceId ?? "")
+    if (!traceId) {
+      closeTraceDrawer()
+      return
+    }
+    setActiveTraceId(traceId)
   }
 
   const onActiveSessionChange = (_sessionId: string | undefined) => {
-    setActiveTraceId("")
+    closeTraceDrawer()
   }
 
   const clearSelections = () => setSelectionState(EMPTY_SELECTION)
@@ -241,7 +251,7 @@ function ProjectPage() {
     { hotkey: "2", callback: () => setActiveTab("sessions"), options: { enabled: !activeTraceId } },
     {
       hotkey: "Escape",
-      callback: () => setActiveTraceId(""),
+      callback: closeTraceDrawer,
       options: { enabled: !!activeTraceId, ignoreInputs: true },
     },
   ])
@@ -391,7 +401,7 @@ function ProjectPage() {
             baselines={cohortSummary?.baselines}
             filters={filters}
             onFiltersChange={onFiltersChange}
-            onClose={() => setActiveTraceId("")}
+            onClose={closeTraceDrawer}
             onNextTrace={onNextTrace}
             onPrevTrace={onPrevTrace}
             canNavigateNext={canNavigateNext}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared trace drawer close handler in the project route
- clear both `traceId` and `spanId` search params when closing/deselecting the trace drawer
- wire the shared handler into drawer close, Escape hotkey close, and session-switch close paths

## Testing
- `pnpm --filter @app/web check`
- `pnpm --filter @app/web typecheck` *(fails in this environment due to missing `@latitude-data/telemetry` type resolution in other packages, unrelated to this change)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f86672b-3532-4563-b893-cf0f4341933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f86672b-3532-4563-b893-cf0f4341933e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

