### PR TITLE
Preserve repository error stacks in production traces

### DIFF
--- a/packages/domain/shared/src/errors.test.ts
+++ b/packages/domain/shared/src/errors.test.ts
@@ -19,6 +19,19 @@ describe("static httpStatus and httpMessage", () => {
     expect(err.cause).toBe("timeout")
     expect(err.operation).toBe("findById")
   })
+
+  it("reuses the wrapped error stack when cause is an Error", () => {
+    const cause = new Error("query failed")
+
+    cause.stack = [
+      "Error: query failed",
+      "at query (file:///app/packages/platform/db-clickhouse/src/ch-sql-client.ts:12:9)",
+    ].join("\n")
+
+    const err = new RepositoryError({ cause, operation: "findById" })
+
+    expect(err.stack).toBe(cause.stack)
+  })
 })
 
 describe("dynamic httpMessage", () => {

--- a/packages/domain/shared/src/errors.ts
+++ b/packages/domain/shared/src/errors.ts
@@ -4,6 +4,14 @@ export class RepositoryError extends Data.TaggedError("RepositoryError")<{
   readonly cause: unknown
   readonly operation: string
 }> {
+  constructor(args: { readonly cause: unknown; readonly operation: string }) {
+    super(args)
+
+    if (args.cause instanceof Error && args.cause.stack) {
+      this.stack = args.cause.stack
+    }
+  }
+
   readonly httpStatus = 500
   readonly httpMessage = "Internal server error"
 }


### PR DESCRIPTION
## Summary
- preserve the original stack when wrapping repository failures in `RepositoryError`
- keep Datadog production traces anchored on the underlying repository/client failure instead of `toRepositoryError`
- add a unit test covering stack reuse and verify with `pnpm --filter @domain/shared test -- src/errors.test.ts` and `pnpm --filter @domain/shared typecheck`