### PR TITLE
feat(observability): instrument Effect business logic with native OTel tracing

### DIFF
--- a/.agents/skills/architecture-boundaries/SKILL.md
+++ b/.agents/skills/architecture-boundaries/SKILL.md
@@ -23,6 +23,7 @@ No business logic in handlers, controllers, or jobs.
 - **Clients**: Initialize integrations in `apps/*/clients.ts` and import from boundaries — avoid scattering raw clients.
 - **Routes**: Use `apps/*/routes/` with a `registerRoutes()` (or equivalent) pattern so the HTTP surface stays modular.
 - **Logging**: Use `createLogger()` from `@repo/observability` with a stable service name per app.
+- **Tracing**: Every `Effect.runPromise` call site must include `withTracing` from `@repo/observability` in the pipe chain to connect Effect spans to the OTel pipeline. See [effect-and-errors](../effect-and-errors/SKILL.md) for the full tracing rules.
 - **Configuration values**: Read env through `parseEnv` / `parseEnvOptional` — see [env-configuration](../env-configuration/SKILL.md).
 
 ## Web vs public API (`apps/web` and `apps/api`)

--- a/.agents/skills/async-jobs-and-events/SKILL.md
+++ b/.agents/skills/async-jobs-and-events/SKILL.md
@@ -61,6 +61,7 @@ ScoreCreated: (event) =>
 - Put **IDs** or opaque storage keys in job payloads — not full mutable entities.
 - **Re-fetch** authoritative state inside the worker before acting.
 - Make **stale or deleted** entities an explicit outcome (skip, dead-letter, or record failure) instead of assuming rows still exist.
+- Worker handler effects must include `withTracing` from `@repo/observability` in their pipe chain so that Effect spans flow into the OTel pipeline. See [effect-and-errors](../effect-and-errors/SKILL.md) for tracing rules.
 - For **transactional domain events**, write through the **`OutboxEventWriter`** service (or a plain `OutboxEventWriterShape` from `createOutboxWriter` in `@platform/db-postgres`) instead of inserting outbox rows directly.
 - For **high-volume or otherwise non-transactional producers** whose upstream write is already durable, publish directly through **`createEventsPublisher(queuePublisher)`** into `domain-events` instead of persisting an outbox row only to forward it.
 - Domain-event consumers should act as **dispatchers**: publish downstream topic tasks or start workflows, but do not run synchronous business logic inline inside the event handler.

--- a/.agents/skills/effect-and-errors/SKILL.md
+++ b/.agents/skills/effect-and-errors/SKILL.md
@@ -33,6 +33,54 @@ details when the documentation isn't enough.
 - Use `Effect.repeat` with `Schedule` for polling/recurring tasks
 - Use `Fiber` for lifecycle management of long-running effects
 
+## Tracing and observability
+
+Effect programs are instrumented with Effect's native OpenTelemetry support via `@effect/opentelemetry`. This bridges Effect spans into the existing OTel pipeline (Datadog, etc.) so business logic is visible alongside HTTP request spans.
+
+### Use case instrumentation (required for all new use cases)
+
+Every use case function that returns an Effect **must** be wrapped with `Effect.withSpan` and annotated with key business IDs:
+
+```typescript
+export const writeScoreUseCase = (input: WriteScoreInput) =>
+  Effect.gen(function* () {
+    const parsedInput = yield* parseOrBadRequest(writeScoreInputSchema, input, "Invalid score write input")
+    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+    yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
+    // ... business logic
+  }).pipe(Effect.withSpan("scores.writeScore"))
+```
+
+**Rules:**
+
+1. **Span naming:** `{domain}.{functionName}` in camelCase — e.g. `scores.writeScore`, `issues.discoverIssue`, `evaluations.runLiveEvaluation`.
+2. **Attribute annotation:** Call `yield* Effect.annotateCurrentSpan("key", value)` early in the function (after input parsing, before business logic) for key IDs (`projectId`, `scoreId`, `issueId`, etc.) and discriminating attributes (`source`, `status`). Only annotate when the value is present (guard nullables).
+3. **No type signature changes:** `Effect.withSpan` is transparent — it does not alter the Effect's success, error, or requirements channels.
+4. **No extra imports:** `Effect` is already imported in every use case file. `withSpan` and `annotateCurrentSpan` are methods on `Effect`.
+
+### Edge call sites (required for all new Effect.runPromise sites)
+
+Every `Effect.runPromise` call site **must** include `withTracing` in the pipe chain to provide the OTel tracer layer:
+
+```typescript
+import { withTracing } from "@repo/observability"
+
+const result = await Effect.runPromise(
+  myEffect.pipe(
+    withPostgres(Layer.mergeAll(RepoLive, ...), client, organizationId),
+    withClickHouse(AnalyticsRepoLive, chClient, organizationId),
+    withTracing,
+  ),
+)
+```
+
+**Rules:**
+
+1. `withTracing` is a pipe combinator exported from `@repo/observability`. It provides `EffectOtelTracerLive` — the bridge between Effect's Tracer and the global OTel TracerProvider.
+2. Place `withTracing` alongside (not inside) infrastructure providers like `withPostgres` / `withClickHouse`. Tracing is decoupled from DB layers.
+3. Without `withTracing`, `Effect.withSpan` calls are no-ops (Effect's default tracer discards spans). In tests this is fine — tests don't initialize OTel.
+4. Active OTel spans from HTTP middleware (Hono `@hono/otel`) are automatically picked up as parents, so Effect spans nest correctly under request traces.
+
 ## Error handling
 
 - Always use typed errors (`Data.TaggedError`) instead of raw `Error` at domain/platform boundaries

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { OrganizationId, UnauthorizedError, UserId } from "@domain/shared"
 import { validateApiKey } from "@platform/api-key-auth"
 import type { PostgresClient } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import type { Context, MiddlewareHandler, Next } from "hono"
 import { getAdminPostgresClient } from "../clients.ts"
@@ -79,7 +80,7 @@ interface AuthMiddlewareOptions {
 
 export const createAuthMiddleware = (options: AuthMiddlewareOptions): MiddlewareHandler => {
   return async (c: Context, next: Next) => {
-    const authContext = await Effect.runPromise(authenticate(c, options))
+    const authContext = await Effect.runPromise(authenticate(c, options).pipe(withTracing))
     c.set("auth", authContext)
     await next()
   }

--- a/apps/api/src/middleware/organization-context.ts
+++ b/apps/api/src/middleware/organization-context.ts
@@ -1,6 +1,7 @@
 import { OrganizationRepository } from "@domain/organizations"
 import { BadRequestError, OrganizationId, PermissionError } from "@domain/shared"
 import { OrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import type { Context, MiddlewareHandler, Next } from "hono"
 
@@ -24,7 +25,7 @@ export const createOrganizationContextMiddleware = (): MiddlewareHandler => {
       Effect.gen(function* () {
         const repo = yield* OrganizationRepository
         return yield* repo.findById(organizationId)
-      }).pipe(withPostgres(OrganizationRepositoryLive, c.var.postgresClient, organizationId)),
+      }).pipe(withPostgres(OrganizationRepositoryLive, c.var.postgresClient, organizationId), withTracing),
     )
 
     c.set("organization", organization)

--- a/apps/api/src/middleware/touch-buffer.ts
+++ b/apps/api/src/middleware/touch-buffer.ts
@@ -2,7 +2,7 @@ import { ApiKeyRepository } from "@domain/api-keys"
 import { ApiKeyId } from "@domain/shared"
 import type { PostgresClient } from "@platform/db-postgres"
 import { ApiKeyRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 
 const logger = createLogger("touch-buffer")
@@ -113,7 +113,7 @@ class TouchBuffer {
         Effect.gen(function* () {
           const repo = yield* ApiKeyRepository
           return yield* repo.touchBatch(keyIds)
-        }).pipe(withPostgres(ApiKeyRepositoryLive, this.client)),
+        }).pipe(withPostgres(ApiKeyRepositoryLive, this.client), withTracing),
       )
 
       this.log({

--- a/apps/api/src/routes/annotations.ts
+++ b/apps/api/src/routes/annotations.ts
@@ -11,6 +11,7 @@ import {
 } from "@platform/db-clickhouse"
 import { OutboxEventWriterLive, ProjectRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { QueuePublisherLive } from "@platform/queue-bullmq"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { jsonBody, OrgAndProjectParamsSchema, openApiResponses, PROTECTED_SECURITY } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
@@ -106,6 +107,7 @@ export const createAnnotationsRoutes = () => {
           organizationId,
         ),
         Effect.provide(QueuePublisherLive(c.var.queuePublisher)),
+        withTracing,
       ),
     )
 

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -9,6 +9,7 @@ import { ApiKeyId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { RedisClient } from "@platform/cache-redis"
 import { ApiKeyRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import {
   errorResponse,
@@ -142,6 +143,7 @@ export const createApiKeysRoutes = () => {
           c.var.postgresClient,
           c.var.organization.id,
         ),
+        withTracing,
       ),
     )
     return c.json(toResponse(apiKey), 201)
@@ -152,7 +154,7 @@ export const createApiKeysRoutes = () => {
       Effect.gen(function* () {
         const repo = yield* ApiKeyRepository
         return yield* repo.list()
-      }).pipe(withPostgres(ApiKeyRepositoryLive, c.var.postgresClient, c.var.organization.id)),
+      }).pipe(withPostgres(ApiKeyRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
     return c.json({ apiKeys: apiKeys.map(toListItemResponse) }, 200)
   })
@@ -164,6 +166,7 @@ export const createApiKeysRoutes = () => {
       revokeApiKeyUseCase({ id: ApiKeyId(idParam) }).pipe(
         Effect.provideService(ApiKeyCacheInvalidator, createApiKeyCacheInvalidator(c.var.redis)),
         withPostgres(ApiKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
       ),
     )
     return c.body(null, 204)

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -8,6 +8,7 @@ import {
 import { ProjectId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { OutboxEventWriterLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import {
   errorResponse,
@@ -142,6 +143,7 @@ export const createProjectsRoutes = () => {
           c.var.postgresClient,
           c.var.organization.id,
         ),
+        withTracing,
       ),
     )
     return c.json(toResponse(project), 201)
@@ -152,7 +154,7 @@ export const createProjectsRoutes = () => {
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.list()
-      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id)),
+      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
 
     return c.json({ projects: projects.map(toResponse) }, 200)
@@ -166,7 +168,7 @@ export const createProjectsRoutes = () => {
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.findById(id)
-      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id)),
+      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
 
     return c.json(toResponse(project), 200)
@@ -181,7 +183,7 @@ export const createProjectsRoutes = () => {
       updateProjectUseCase({
         id,
         ...(body.name !== undefined ? { name: body.name } : {}),
-      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id)),
+      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
 
     return c.json(toResponse(updatedProject), 200)
@@ -195,7 +197,7 @@ export const createProjectsRoutes = () => {
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.softDelete(id)
-      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id)),
+      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
     return c.body(null, 204)
   })

--- a/apps/api/src/routes/scores.ts
+++ b/apps/api/src/routes/scores.ts
@@ -12,6 +12,7 @@ import { cuidSchema, ProjectId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { ScoreAnalyticsRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { OutboxEventWriterLive, ProjectRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { jsonBody, OrgAndProjectParamsSchema, openApiResponses, PROTECTED_SECURITY } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
@@ -184,6 +185,7 @@ export const createScoresRoutes = () => {
           organizationId,
         ),
         withClickHouse(ScoreAnalyticsRepositoryLive, c.var.clickhouse, organizationId),
+        withTracing,
       ),
     )
 

--- a/apps/ingest/src/middleware/project.ts
+++ b/apps/ingest/src/middleware/project.ts
@@ -1,6 +1,7 @@
 import { ProjectRepository } from "@domain/projects"
 import { isNotFoundError, OrganizationId } from "@domain/shared"
 import { ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import type { MiddlewareHandler } from "hono"
 import { getPostgresClient } from "../clients.ts"
@@ -24,7 +25,7 @@ export const projectMiddleware: MiddlewareHandler<IngestEnv> = async (c, next) =
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.findBySlug(projectSlug)
-      }).pipe(withPostgres(ProjectRepositoryLive, client, OrganizationId(organizationId))),
+      }).pipe(withPostgres(ProjectRepositoryLive, client, OrganizationId(organizationId)), withTracing),
     )
 
     c.set("projectId", project.id as string)

--- a/apps/ingest/src/middleware/touch-buffer.ts
+++ b/apps/ingest/src/middleware/touch-buffer.ts
@@ -2,7 +2,7 @@ import { ApiKeyRepository } from "@domain/api-keys"
 import { ApiKeyId } from "@domain/shared"
 import type { PostgresClient } from "@platform/db-postgres"
 import { ApiKeyRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 
 const logger = createLogger("touch-buffer")
@@ -113,7 +113,7 @@ class TouchBuffer {
         Effect.gen(function* () {
           const repo = yield* ApiKeyRepository
           return yield* repo.touchBatch(keyIds)
-        }).pipe(withPostgres(ApiKeyRepositoryLive, this.client)),
+        }).pipe(withPostgres(ApiKeyRepositoryLive, this.client), withTracing),
       )
 
       this.log({

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -2,6 +2,7 @@ import { OrganizationId, ProjectId } from "@domain/shared"
 import { ingestSpansUseCase } from "@domain/spans"
 import { QueuePublisherLive } from "@platform/queue-bullmq"
 import { StorageDiskLive } from "@platform/storage-object"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import type { Hono } from "hono"
 import { getQueuePublisher, getRedisClient, getStorageDisk } from "../clients.ts"
@@ -54,7 +55,7 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
         apiKeyId: c.get("apiKeyId"),
         payload: new Uint8Array(body),
         contentType,
-      }).pipe(Effect.provide(Layer.merge(StorageDiskLive(disk), QueuePublisherLive(publisher)))),
+      }).pipe(Effect.provide(Layer.merge(StorageDiskLive(disk), QueuePublisherLive(publisher))), withTracing),
     )
 
     return c.json({}, 202)

--- a/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
+++ b/apps/web/src/domains/annotation-queue-items/annotation-queue-items.functions.ts
@@ -19,6 +19,7 @@ import {
   SqlClientLive,
 } from "@platform/db-postgres"
 import { QueuePublisherLive } from "@platform/queue-bullmq"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -157,7 +158,7 @@ export const listAnnotationQueueItemsByQueue = createServerFn({ method: "GET" })
           hasMore: listPage.hasMore,
           nextCursor: listPage.nextCursor,
         }
-      }).pipe(Effect.provide(itemsLayer)),
+      }).pipe(Effect.provide(itemsLayer), withTracing),
     )
 
     return page
@@ -211,7 +212,7 @@ export const addTracesToQueueFunction = createServerFn({ method: "POST" })
       ? { projectId, queueId: AnnotationQueueId(data.queueId), selection }
       : { projectId, newQueue: data.newQueue as NewQueueInput, selection }
 
-    const result = await Effect.runPromise(requestBulkQueueItems(input).pipe(Effect.provide(layer)))
+    const result = await Effect.runPromise(requestBulkQueueItems(input).pipe(Effect.provide(layer), withTracing))
     return { queueId: result.queueId as string }
   })
 
@@ -262,7 +263,7 @@ export const getAnnotationQueueItemDetail = createServerFn({ method: "GET" })
           ...toItemRecord(item),
           traceDisplayName,
         }
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(layer), withTracing),
     )
   })
 
@@ -312,7 +313,7 @@ export const getQueueItemNavigation = createServerFn({ method: "GET" })
           currentIndex: position.currentIndex,
           totalItems: position.totalItems,
         }
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(layer), withTracing),
     )
   })
 
@@ -354,7 +355,7 @@ export const completeQueueItem = createServerFn({ method: "POST" })
         })
 
         return { nextItemId }
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(layer), withTracing),
     )
   })
 
@@ -381,6 +382,6 @@ export const uncompleteQueueItem = createServerFn({ method: "POST" })
         projectId,
         queueId: data.queueId,
         itemId: data.itemId,
-      }).pipe(Effect.provide(layer)),
+      }).pipe(Effect.provide(layer), withTracing),
     )
   })

--- a/apps/web/src/domains/annotation-queues/annotation-queues.functions.ts
+++ b/apps/web/src/domains/annotation-queues/annotation-queues.functions.ts
@@ -8,6 +8,7 @@ import {
 } from "@domain/annotation-queues"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { AnnotationQueueRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -89,7 +90,7 @@ export const listAnnotationQueuesByProject = createServerFn({ method: "GET" })
             ...(data.sortDirection !== undefined ? { sortDirection: data.sortDirection } : {}),
           },
         })
-      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId)),
+      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId), withTracing),
     )
 
     const queues = page.items.map((q) => toAnnotationQueueRecord(q))
@@ -121,7 +122,7 @@ export const getAnnotationQueueByProject = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* AnnotationQueueRepository
         return yield* repo.findByIdInProject({ projectId, queueId: data.queueId })
-      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId)),
+      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId), withTracing),
     )
 
     if (!queue) {
@@ -151,7 +152,7 @@ export const createAnnotationQueue = createServerFn({ method: "POST" })
         instructions: data.instructions,
         assignees: data.assignees ?? [],
         ...(data.settings !== undefined ? { settings: data.settings } : {}),
-      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId)),
+      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId), withTracing),
     )
 
     return toAnnotationQueueRecord(result.queue)
@@ -178,7 +179,7 @@ export const updateAnnotationQueue = createServerFn({ method: "POST" })
         instructions: data.instructions,
         assignees: data.assignees ?? [],
         ...(data.settings !== undefined ? { settings: data.settings } : {}),
-      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId)),
+      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId), withTracing),
     )
 
     return toAnnotationQueueRecord(result.queue)
@@ -200,6 +201,6 @@ export const deleteAnnotationQueue = createServerFn({ method: "POST" })
       deleteQueueUseCase({
         projectId: ProjectId(data.projectId),
         queueId: data.queueId,
-      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId)),
+      }).pipe(withPostgres(AnnotationQueueRepositoryLive, client, orgId), withTracing),
     )
   })

--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -16,6 +16,7 @@ import {
 } from "@platform/db-clickhouse"
 import { OutboxEventWriterLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { QueuePublisherLive } from "@platform/queue-bullmq"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -109,6 +110,7 @@ export const createAnnotation = createServerFn({ method: "POST" })
           chClient,
           organizationId,
         ),
+        withTracing,
       ),
     )
 
@@ -154,6 +156,7 @@ export const updateAnnotation = createServerFn({ method: "POST" })
           chClient,
           organizationId,
         ),
+        withTracing,
       ),
     )
 
@@ -171,6 +174,7 @@ export const deleteAnnotation = createServerFn({ method: "POST" })
     await Effect.runPromise(
       deleteAnnotationUseCase({ scoreId: ScoreId(data.scoreId) }).pipe(
         withPostgres(postgresLayer, pgClient, organizationId),
+        withTracing,
       ),
     )
   })
@@ -196,7 +200,7 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
         limit: data.limit,
         offset: data.offset,
         draftMode: data.draftMode ?? "include", // draft-aware by default for trace-scoped reads
-      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
     )
 
     return toListResult(result)
@@ -213,6 +217,7 @@ export const approveSystemAnnotation = createServerFn({ method: "POST" })
       approveSystemAnnotationUseCase({ scoreId: ScoreId(data.scoreId) }).pipe(
         Effect.provide(Layer.succeed(WorkflowStarter, workflowStarter)),
         withPostgres(ScoreRepositoryLive, client, organizationId),
+        withTracing,
       ),
     )
 
@@ -230,6 +235,7 @@ export const rejectSystemAnnotation = createServerFn({ method: "POST" })
     await Effect.runPromise(
       deleteAnnotationUseCase({ scoreId: ScoreId(data.scoreId) }).pipe(
         withPostgres(postgresLayer, pgClient, organizationId),
+        withTracing,
       ),
     )
 

--- a/apps/web/src/domains/api-keys/api-keys.functions.ts
+++ b/apps/web/src/domains/api-keys/api-keys.functions.ts
@@ -1,6 +1,7 @@
 import { type ApiKey, ApiKeyRepository, generateApiKeyUseCase, updateApiKeyUseCase } from "@domain/api-keys"
 import { ApiKeyId, isValidId } from "@domain/shared"
 import { ApiKeyRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -35,7 +36,7 @@ export const listApiKeys = createServerFn({ method: "GET" }).handler(async (): P
     Effect.gen(function* () {
       const repo = yield* ApiKeyRepository
       return yield* repo.list()
-    }).pipe(withPostgres(ApiKeyRepositoryLive, client, organizationId)),
+    }).pipe(withPostgres(ApiKeyRepositoryLive, client, organizationId), withTracing),
   )
 
   return apiKeys.map(toRecord)
@@ -62,7 +63,10 @@ export const createApiKey = createServerFn({ method: "POST" })
         ...(data.id ? { id: ApiKeyId(data.id) } : {}),
         name: data.name,
         actorUserId: userId,
-      }).pipe(withPostgres(Layer.mergeAll(ApiKeyRepositoryLive, OutboxEventWriterLive), client, organizationId)),
+      }).pipe(
+        withPostgres(Layer.mergeAll(ApiKeyRepositoryLive, OutboxEventWriterLive), client, organizationId),
+        withTracing,
+      ),
     )
 
     return toRecord(apiKey)
@@ -77,6 +81,7 @@ export const updateApiKey = createServerFn({ method: "POST" })
     const apiKey = await Effect.runPromise(
       updateApiKeyUseCase({ id: ApiKeyId(data.id), name: data.name }).pipe(
         withPostgres(ApiKeyRepositoryLive, client, organizationId),
+        withTracing,
       ),
     )
 
@@ -93,6 +98,6 @@ export const deleteApiKey = createServerFn({ method: "POST" })
       Effect.gen(function* () {
         const repo = yield* ApiKeyRepository
         yield* repo.delete(ApiKeyId(data.id))
-      }).pipe(withPostgres(ApiKeyRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(ApiKeyRepositoryLive, client, organizationId), withTracing),
     )
   })

--- a/apps/web/src/domains/auth/auth.functions.ts
+++ b/apps/web/src/domains/auth/auth.functions.ts
@@ -1,5 +1,6 @@
 import { InvitationRepository } from "@domain/organizations"
 import { InvitationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
@@ -54,6 +55,6 @@ export const getInvitationPreview = createServerFn({ method: "GET" })
         return yield* repo
           .findPublicPendingPreviewById(data.invitationId)
           .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-      }).pipe(withPostgres(InvitationRepositoryLive, client)),
+      }).pipe(withPostgres(InvitationRepositoryLive, client), withTracing),
     )
   })

--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -34,6 +34,7 @@ import {
 } from "@domain/shared"
 import { DatasetRowRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { DatasetRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -164,7 +165,7 @@ export const listDatasetsByProject = createServerFn({ method: "GET" })
           ...(data.sortBy ? { sortBy: data.sortBy } : {}),
           ...(data.sortDirection ? { sortDirection: data.sortDirection } : {}),
         },
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId)),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     const datasets = page.datasets.map(toDatasetRecord)
@@ -188,6 +189,7 @@ export const getDatasetQuery = createServerFn({ method: "GET" })
       }).pipe(
         Effect.catchTag("DatasetNotFoundError", () => Effect.succeed(null)),
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
+        withTracing,
       ),
     )
   })
@@ -245,6 +247,7 @@ export const listRowsQuery = createServerFn({ method: "GET" })
         }).pipe(
           withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
           withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+          withTracing,
         ),
       )
 
@@ -278,6 +281,7 @@ export const getRowQuery = createServerFn({ method: "GET" })
         Effect.catchTag("RowNotFoundError", () => Effect.succeed(null)),
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
   })
@@ -299,7 +303,7 @@ export const updateDataset = createServerFn({ method: "POST" })
         datasetId: DatasetId(data.datasetId),
         name: data.name,
         description: data.description ?? null,
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId)),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     return toDatasetRecord(dataset)
@@ -314,7 +318,7 @@ export const deleteDatasetFunction = createServerFn({ method: "POST" })
     await Effect.runPromise(
       deleteDataset({
         datasetId: DatasetId(data.datasetId),
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId)),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
   })
 
@@ -342,13 +346,14 @@ export const getDatasetDownload = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* DatasetRepository
         return yield* repo.findById(datasetId)
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId)),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     const total = await Effect.runPromise(
       countRows({ datasetId }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -377,6 +382,7 @@ export const getDatasetDownload = createServerFn({ method: "GET" })
       listRows({ datasetId, limit: total, offset: 0 }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -420,6 +426,7 @@ export const createDatasetFunction = createServerFn({ method: "POST" })
       }).pipe(
         withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -459,7 +466,7 @@ export const saveDatasetCsv = createServerFn({ method: "POST" })
           id: DatasetId(datasetId),
           fileKey,
         })
-      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId)),
+      }).pipe(withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId), withTracing),
     )
 
     const { rows } = parseDatasetCsv(content)
@@ -477,6 +484,7 @@ export const saveDatasetCsv = createServerFn({ method: "POST" })
       }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -511,6 +519,7 @@ export const insertDatasetRow = createServerFn({ method: "POST" })
         }).pipe(
           withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
           withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+          withTracing,
         ),
       )
 
@@ -551,6 +560,7 @@ export const updateDatasetRow = createServerFn({ method: "POST" })
       }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -583,6 +593,7 @@ export const deleteDatasetRows = createServerFn({ method: "POST" })
       }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, getClickhouseClient(), orgId),
+        withTracing,
       ),
     )
 
@@ -616,6 +627,7 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
         withClickHouse(TraceRepositoryLive, chClient, orgId),
+        withTracing,
       ),
     )
 
@@ -666,6 +678,7 @@ export const createDatasetFromTracesFunction = createServerFn({
           withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), pgClient, orgId),
           withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
           withClickHouse(TraceRepositoryLive, chClient, orgId),
+          withTracing,
         ),
       )
 

--- a/apps/web/src/domains/evaluations/evaluation-alignment.functions.ts
+++ b/apps/web/src/domains/evaluations/evaluation-alignment.functions.ts
@@ -26,6 +26,7 @@ import {
   ProjectId,
 } from "@domain/shared"
 import { EvaluationRepositoryLive, IssueRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -142,7 +143,7 @@ export const startEvaluationAlignment = createServerFn({ method: "POST" })
             message: `Issue ${issue.id} does not belong to project ${projectId}`,
           })
         }
-      }).pipe(withPostgres(IssueRepositoryLive, client, OrganizationId(organizationId))),
+      }).pipe(withPostgres(IssueRepositoryLive, client, OrganizationId(organizationId)), withTracing),
     )
 
     const pendingStatus = await writeJobStatus({
@@ -239,7 +240,7 @@ export const triggerManualEvaluationRealignment = createServerFn({ method: "POST
             message: `Evaluation ${evaluation.id} does not match the requested issue or project`,
           })
         }
-      }).pipe(withPostgres(EvaluationRepositoryLive, client, OrganizationId(organizationId))),
+      }).pipe(withPostgres(EvaluationRepositoryLive, client, OrganizationId(organizationId)), withTracing),
     )
 
     const pendingStatus = await writeJobStatus({
@@ -307,6 +308,6 @@ export const softDeleteIssueEvaluation = createServerFn({ method: "POST" })
         yield* repository.save(deletedEvaluation)
 
         return toEvaluationSummaryRecord(deletedEvaluation)
-      }).pipe(withPostgres(EvaluationRepositoryLive, client, OrganizationId(organizationId))),
+      }).pipe(withPostgres(EvaluationRepositoryLive, client, OrganizationId(organizationId)), withTracing),
     )
   })

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -24,6 +24,7 @@ import { AIEmbedLive } from "@platform/ai-voyage"
 import { ScoreAnalyticsRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { EvaluationRepositoryLive, IssueRepositoryLive, SettingsReaderLive, withPostgres } from "@platform/db-postgres"
 import { IssueProjectionRepositoryLive, withWeaviate } from "@platform/db-weaviate"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -291,6 +292,7 @@ export const listIssues = createServerFn({ method: "GET" })
         withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive), chClient, orgId),
         provideIssueProjection,
         withAi(AIEmbedLive, redisClient),
+        withTracing,
       ),
     )
 
@@ -316,7 +318,7 @@ export const getIssue = createServerFn({ method: "GET" })
         const issue = issues[0]
 
         return issue ? toIssueSummaryRecord(issue) : null
-      }).pipe(withPostgres(IssueRepositoryLive, pgClient, orgId)),
+      }).pipe(withPostgres(IssueRepositoryLive, pgClient, orgId), withTracing),
     )
   })
 
@@ -404,6 +406,7 @@ export const getIssueDetail = createServerFn({ method: "GET" })
           orgId,
         ),
         withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
+        withTracing,
       ),
     )
   })
@@ -464,7 +467,10 @@ export const listIssueTraces = createServerFn({ method: "GET" })
           limit: tracePage.limit,
           offset: tracePage.offset,
         })
-      }).pipe(withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive), chClient, orgId)),
+      }).pipe(
+        withClickHouse(Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive), chClient, orgId),
+        withTracing,
+      ),
     )
   })
 
@@ -487,6 +493,7 @@ export const applyIssueLifecycleAction = createServerFn({ method: "POST" })
           pgClient,
           orgId,
         ),
+        withTracing,
       ),
     )
 

--- a/apps/web/src/domains/members/members.functions.ts
+++ b/apps/web/src/domains/members/members.functions.ts
@@ -6,6 +6,7 @@ import {
 } from "@domain/organizations"
 import { MembershipId, UserId } from "@domain/shared"
 import { MembershipRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
@@ -37,7 +38,7 @@ export const listMembers = createServerFn({ method: "GET" }).handler(async (): P
     Effect.gen(function* () {
       const membershipRepo = yield* MembershipRepository
       return yield* membershipRepo.listMembersWithUser(organizationId)
-    }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId)),
+    }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId), withTracing),
   )
 
   const invitationResult = await getBetterAuth().api.listInvitations({
@@ -88,7 +89,7 @@ export const removeMember = createServerFn({ method: "POST" })
       removeMemberUseCase({
         membershipId: MembershipId(data.membershipId),
         requestingUserId: UserId(userId),
-      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId), withTracing),
     )
   })
 
@@ -138,7 +139,7 @@ export const transferOwnership = createServerFn({ method: "POST" })
         organizationId,
         currentOwnerUserId: userId,
         newOwnerUserId: UserId(data.newOwnerUserId),
-      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId), withTracing),
     )
   })
 
@@ -154,6 +155,6 @@ export const updateMemberRole = createServerFn({ method: "POST" })
         requestingUserId: userId,
         targetUserId: UserId(data.targetUserId),
         newRole: data.newRole,
-      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(MembershipRepositoryLive, client, organizationId), withTracing),
     )
   })

--- a/apps/web/src/domains/organizations/organizations.functions.ts
+++ b/apps/web/src/domains/organizations/organizations.functions.ts
@@ -5,6 +5,7 @@ import {
 } from "@domain/organizations"
 import { OrganizationId, UserId } from "@domain/shared"
 import { MembershipRepositoryLive, OrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect, Layer } from "effect"
@@ -20,7 +21,7 @@ export const listOrganizations = createServerFn({ method: "GET" }).handler(async
     Effect.gen(function* () {
       const repo = yield* OrganizationRepository
       return yield* repo.listByUserId(UserId(userId))
-    }).pipe(withPostgres(repoLayer, client)),
+    }).pipe(withPostgres(repoLayer, client), withTracing),
   )
 })
 
@@ -32,6 +33,7 @@ export const createOrganization = createServerFn({ method: "POST" })
     const slug = await Effect.runPromise(
       generateUniqueOrganizationSlugUseCase({ name: data.name }).pipe(
         withPostgres(OrganizationRepositoryLive, adminClient),
+        withTracing,
       ),
     )
 
@@ -82,6 +84,7 @@ export const updateOrganization = createServerFn({ method: "POST" })
     return await Effect.runPromise(
       updateOrganizationUseCase({ name: data.name, settings: data.settings }).pipe(
         withPostgres(OrganizationRepositoryLive, client, organizationId),
+        withTracing,
       ),
     )
   })

--- a/apps/web/src/domains/projects/projects.functions.ts
+++ b/apps/web/src/domains/projects/projects.functions.ts
@@ -13,7 +13,7 @@ import {
   ProjectRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -45,7 +45,7 @@ export const listProjects = createServerFn({ method: "GET" }).handler(async (): 
     Effect.gen(function* () {
       const repo = yield* ProjectRepository
       return yield* repo.list()
-    }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId)),
+    }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId), withTracing),
   )
 
   return projects.map(toRecord)
@@ -61,7 +61,7 @@ export const getProjectBySlug = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.findBySlug(data.slug)
-      }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId), withTracing),
     )
 
     return toRecord(project)
@@ -88,7 +88,10 @@ export const createProject = createServerFn({ method: "POST" })
         ...(data.id ? { id: ProjectId(data.id) } : {}),
         name: data.name,
         actorUserId: userId,
-      }).pipe(withPostgres(Layer.mergeAll(ProjectRepositoryLive, OutboxEventWriterLive), client, organizationId)),
+      }).pipe(
+        withPostgres(Layer.mergeAll(ProjectRepositoryLive, OutboxEventWriterLive), client, organizationId),
+        withTracing,
+      ),
     )
 
     return toRecord(project)
@@ -113,6 +116,7 @@ export const updateProject = createServerFn({ method: "POST" })
     const project = await Effect.runPromise(
       updateProjectUseCase({ id: ProjectId(data.id), name: data.name, settings: data.settings }).pipe(
         withPostgres(ProjectRepositoryLive, client, organizationId),
+        withTracing,
       ),
     )
 
@@ -129,7 +133,7 @@ export const deleteProject = createServerFn({ method: "POST" })
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         return yield* repo.softDelete(ProjectId(data.id))
-      }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId)),
+      }).pipe(withPostgres(ProjectRepositoryLive, client, organizationId), withTracing),
     )
 
     const outboxWriter = getOutboxWriter()
@@ -172,6 +176,7 @@ export const getProjectStats = createServerFn({ method: "GET" })
       return result.datasets.length
     }).pipe(
       withPostgres(DatasetRepositoryLive, pgClient, orgId),
+      withTracing,
       Effect.tapError((error) => Effect.sync(() => logger.error({ error, operation: "countDatasets" }))),
       Effect.orElseSucceed(() => 0),
     )
@@ -184,6 +189,7 @@ export const getProjectStats = createServerFn({ method: "GET" })
       })
     }).pipe(
       withClickHouse(TraceRepositoryLive, chClient, orgId),
+      withTracing,
       Effect.tapError((error) => Effect.sync(() => logger.error({ error, operation: "countTraces" }))),
       Effect.orElseSucceed(() => 0),
     )
@@ -208,6 +214,7 @@ export const getProjectStats = createServerFn({ method: "GET" })
           hybridSearch: () => Effect.succeed([]),
         }),
       ),
+      withTracing,
       Effect.tapError((error) => Effect.sync(() => logger.error({ error, operation: "countActiveIssues" }))),
       Effect.orElseSucceed(() => 0),
     )

--- a/apps/web/src/domains/sessions/session.functions.ts
+++ b/apps/web/src/domains/sessions/session.functions.ts
@@ -1,4 +1,5 @@
 import { generateId, UnauthorizedError } from "@domain/shared"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
@@ -58,18 +59,20 @@ export const deleteCurrentUser = createServerFn({ method: "POST" }).handler(asyn
 
   // Write a domain event for background deletion
   await Effect.runPromise(
-    outboxWriter.write({
-      id: generateId(),
-      eventName: "UserDeletionRequested",
-      aggregateType: "user",
-      aggregateId: userId,
-      organizationId: "system",
-      payload: {
-        organizationId: session.session.activeOrganizationId ?? "system",
-        userId,
-      },
-      occurredAt: new Date(),
-    }),
+    outboxWriter
+      .write({
+        id: generateId(),
+        eventName: "UserDeletionRequested",
+        aggregateType: "user",
+        aggregateId: userId,
+        organizationId: "system",
+        payload: {
+          organizationId: session.session.activeOrganizationId ?? "system",
+          userId,
+        },
+        occurredAt: new Date(),
+      })
+      .pipe(withTracing),
   )
 
   // Revoke the session so the user is logged out

--- a/apps/web/src/domains/sessions/sessions.functions.ts
+++ b/apps/web/src/domains/sessions/sessions.functions.ts
@@ -2,6 +2,7 @@ import { filterSetSchema, OrganizationId, ProjectId } from "@domain/shared"
 import type { Session, SessionDistinctColumn, SessionMetrics } from "@domain/spans"
 import { SessionRepository } from "@domain/spans"
 import { SessionRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -79,7 +80,7 @@ export const listSessionsByProject = createServerFn({ method: "GET" })
             ...(data.filters ? { filters: data.filters } : {}),
           },
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
 
     if (!page.nextCursor) {
@@ -106,7 +107,7 @@ export const getSessionMetricsByProject = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           ...(data.filters ? { filters: data.filters } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -135,6 +136,6 @@ export const getSessionDistinctValues = createServerFn({ method: "GET" })
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
           ...(data.search ? { search: data.search } : {}),
         })
-      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(SessionRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -2,6 +2,7 @@ import { OrganizationId, ProjectId, SpanId, TraceId } from "@domain/shared"
 import type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode } from "@domain/spans"
 import { buildConversationSpanMaps, SpanRepository, TraceRepository } from "@domain/spans"
 import { SpanRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect, Layer } from "effect"
 import { z } from "zod"
@@ -144,7 +145,7 @@ export const listSpansByTrace = createServerFn({ method: "GET" })
       Effect.gen(function* () {
         const repo = yield* SpanRepository
         return yield* repo.listByTraceId({ organizationId: orgId, traceId: TraceId(data.traceId) })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return spans.map(serializeSpan)
   })
@@ -176,7 +177,10 @@ export const mapConversationToSpans = createServerFn({ method: "GET" })
           if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
 
           return buildConversationSpanMaps(traceDetail.allMessages, spans)
-        }).pipe(withClickHouse(Layer.merge(TraceRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId)),
+        }).pipe(
+          withClickHouse(Layer.merge(TraceRepositoryLive, SpanRepositoryLive), getClickhouseClient(), orgId),
+          withTracing,
+        ),
       )
     },
   )
@@ -194,7 +198,7 @@ export const getSpanDetail = createServerFn({ method: "GET" })
           traceId: TraceId(data.traceId),
           spanId: SpanId(data.spanId),
         })
-      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(SpanRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
     return serializeSpanDetail(span)
   })

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -14,6 +14,7 @@ import {
   TraceRepository,
 } from "@domain/spans"
 import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import type { GenAIMessage, GenAISystem } from "rosetta-ai"
@@ -138,7 +139,7 @@ export const listTracesByProject = createServerFn({ method: "GET" })
             ...(data.filters ? { filters: data.filters } : {}),
           },
         })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
 
     if (!page.nextCursor) {
@@ -165,7 +166,7 @@ export const countTracesByProject = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           ...(data.filters ? { filters: data.filters } : {}),
         })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -183,7 +184,7 @@ export const getTraceMetricsByProject = createServerFn({ method: "GET" })
           projectId: ProjectId(data.projectId),
           ...(data.filters ? { filters: data.filters } : {}),
         })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -205,7 +206,7 @@ export const getTraceCohortSummaryByProject = createServerFn({ method: "GET" })
         filters: effectiveFilters,
         effectiveRangeStartIso,
         effectiveRangeEndIso,
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -244,7 +245,7 @@ export const getTraceTimeHistogramByProject = createServerFn({ method: "GET" })
           filters: mergedFilters,
           bucketSeconds: data.bucketSeconds,
         })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })
 
@@ -265,7 +266,7 @@ export const getTraceDetail = createServerFn({ method: "GET" })
           })
           .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
         return detail ? serializeTraceDetail(detail) : null
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
 
     // rosetta-ai GenAI types use [x: string]: unknown index signatures, but
@@ -301,6 +302,6 @@ export const getTraceDistinctValues = createServerFn({ method: "GET" })
           ...(data.limit !== undefined ? { limit: data.limit } : {}),
           ...(data.search ? { search: data.search } : {}),
         })
-      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId)),
+      }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), orgId), withTracing),
     )
   })

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -8,6 +8,7 @@ import { parseEnv, parseEnvOptional } from "@platform/env"
 import { createBullMqQueuePublisher, loadBullMqConfig } from "@platform/queue-bullmq"
 import { createStorageDisk } from "@platform/storage-object"
 import { createTemporalClient, createWorkflowStarter, loadTemporalConfig } from "@platform/workflows-temporal"
+import { withTracing } from "@repo/observability"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
 import { Effect } from "effect"
 
@@ -143,46 +144,52 @@ export const getBetterAuth = () => {
       extraPlugins: [tanstackStartCookies()],
       onUserCreated: async (user) => {
         await Effect.runPromise(
-          outboxWriter.write({
-            eventName: "UserSignedUp",
-            aggregateType: "user",
-            aggregateId: user.id,
-            organizationId: "system",
-            payload: { userId: user.id, email: user.email },
-          }),
+          outboxWriter
+            .write({
+              eventName: "UserSignedUp",
+              aggregateType: "user",
+              aggregateId: user.id,
+              organizationId: "system",
+              payload: { userId: user.id, email: user.email },
+            })
+            .pipe(withTracing),
         )
       },
       onMemberCreated: async (member) => {
         await Effect.runPromise(
-          outboxWriter.write({
-            eventName: "MemberJoined",
-            aggregateType: "member",
-            aggregateId: member.userId,
-            organizationId: member.organizationId,
-            payload: {
+          outboxWriter
+            .write({
+              eventName: "MemberJoined",
+              aggregateType: "member",
+              aggregateId: member.userId,
               organizationId: member.organizationId,
-              userId: member.userId,
-              role: member.role,
-            },
-          }),
+              payload: {
+                organizationId: member.organizationId,
+                userId: member.userId,
+                role: member.role,
+              },
+            })
+            .pipe(withTracing),
         )
       },
       sendMagicLink: async ({ email, url }) => {
         const emailFlow = getEmailFlowFromMagicLinkUrl({ magicLinkUrl: url, webUrl })
 
         await Effect.runPromise(
-          outboxWriter.write({
-            eventName: "MagicLinkEmailRequested",
-            aggregateType: "email_request",
-            aggregateId: generateId(),
-            organizationId: "system",
-            payload: {
-              email,
-              magicLinkUrl: url,
+          outboxWriter
+            .write({
+              eventName: "MagicLinkEmailRequested",
+              aggregateType: "email_request",
+              aggregateId: generateId(),
               organizationId: "system",
-              emailFlow,
-            },
-          }),
+              payload: {
+                email,
+                magicLinkUrl: url,
+                organizationId: "system",
+                emailFlow,
+              },
+            })
+            .pipe(withTracing),
         )
       },
       sendInvitationEmail: async (data) => {
@@ -191,34 +198,38 @@ export const getBetterAuth = () => {
             ? data.inviter.user.name.trim()
             : "A teammate"
         await Effect.runPromise(
-          outboxWriter.write({
-            eventName: "InvitationEmailRequested",
-            aggregateType: "invitation",
-            aggregateId: data.id,
-            organizationId: "system",
-            payload: {
-              email: data.email,
-              invitationUrl: `${webUrl}/auth/invite?invitationId=${encodeURIComponent(data.id)}`,
+          outboxWriter
+            .write({
+              eventName: "InvitationEmailRequested",
+              aggregateType: "invitation",
+              aggregateId: data.id,
               organizationId: "system",
-              organizationName: data.organization.name,
-              inviterName,
-            },
-            occurredAt: new Date(),
-          }),
+              payload: {
+                email: data.email,
+                invitationUrl: `${webUrl}/auth/invite?invitationId=${encodeURIComponent(data.id)}`,
+                organizationId: "system",
+                organizationName: data.organization.name,
+                inviterName,
+              },
+              occurredAt: new Date(),
+            })
+            .pipe(withTracing),
         )
         await Effect.runPromise(
-          outboxWriter.write({
-            eventName: "MemberInvited",
-            aggregateType: "invitation",
-            aggregateId: data.id,
-            organizationId: "system",
-            payload: {
+          outboxWriter
+            .write({
+              eventName: "MemberInvited",
+              aggregateType: "invitation",
+              aggregateId: data.id,
               organizationId: "system",
-              actorUserId: data.inviter.user.id,
-              email: data.email,
-              role: data.role,
-            },
-          }),
+              payload: {
+                organizationId: "system",
+                actorUserId: data.inviter.user.id,
+                email: data.email,
+                role: data.role,
+              },
+            })
+            .pipe(withTracing),
         )
       },
     })

--- a/apps/workers/src/services/provisioning.ts
+++ b/apps/workers/src/services/provisioning.ts
@@ -2,7 +2,7 @@ import { provisionSystemQueuesUseCase } from "@domain/annotation-queues"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
 import { AnnotationQueueRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import { getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -17,6 +17,7 @@ export const provisionSystemQueues = async (input: { readonly organizationId: st
       projectId: ProjectId(input.projectId),
     }).pipe(
       withPostgres(AnnotationQueueRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
+      withTracing,
       Effect.provide(RedisCacheStoreLive(getRedisClient())),
     ),
   )

--- a/apps/workers/src/workers/annotation-queues.ts
+++ b/apps/workers/src/workers/annotation-queues.ts
@@ -3,7 +3,7 @@ import type { QueueConsumer } from "@domain/queue"
 import { AnnotationQueueId, type FilterSet, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { AnnotationQueueItemRepositoryLive, AnnotationQueueRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
@@ -58,6 +58,7 @@ export const createAnnotationQueuesWorker = ({ consumer }: AnnotationQueuesDeps)
           organizationId,
         ),
         withClickHouse(TraceRepositoryLive, chClient, organizationId),
+        withTracing,
         Effect.tap((result) =>
           Effect.sync(() =>
             logger.info("Bulk import completed", {

--- a/apps/workers/src/workers/annotation-scores.ts
+++ b/apps/workers/src/workers/annotation-scores.ts
@@ -6,7 +6,7 @@ import { ScoreRepository } from "@domain/scores"
 import { OrganizationId, type ScoreId } from "@domain/shared"
 import type { PostgresClient } from "@platform/db-postgres"
 import { AnnotationQueueItemRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getPostgresClient } from "../clients.ts"
 
@@ -25,6 +25,7 @@ export const createAnnotationScoresWorker = ({ consumer, workflowStarter, postgr
     publishHumanAnnotation: (payload) =>
       publishHumanAnnotationUseCase({ scoreId: payload.scoreId as ScoreId }).pipe(
         withPostgres(ScoreRepositoryLive, pgClient, OrganizationId(payload.organizationId)),
+        withTracing,
         Effect.provide(Layer.succeed(WorkflowStarter, workflowStarter)),
         Effect.tap((result) =>
           Effect.sync(() => {
@@ -59,6 +60,7 @@ export const createAnnotationScoresWorker = ({ consumer, workflowStarter, postgr
           pgClient,
           OrganizationId(payload.organizationId),
         ),
+        withTracing,
         Effect.catchTag("NotFoundError", () =>
           Effect.sync(() => logger.warn(`Score ${payload.scoreId} not found, skipping markReviewStarted`)),
         ),

--- a/apps/workers/src/workers/api-keys.ts
+++ b/apps/workers/src/workers/api-keys.ts
@@ -2,7 +2,7 @@ import { generateApiKeyUseCase } from "@domain/api-keys"
 import type { QueueConsumer } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import { ApiKeyRepositoryLive, OutboxEventWriterLive, type PostgresClient, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getPostgresClient } from "../clients.ts"
 
@@ -25,6 +25,7 @@ export const createApiKeysWorker = ({
           pgClient,
           OrganizationId(payload.organizationId),
         ),
+        withTracing,
         Effect.tap(() => Effect.sync(() => logger.info(`API key created for organization ${payload.organizationId}`))),
         Effect.tapError((error) =>
           Effect.sync(() => logger.error(`Failed to create API key for organization ${payload.organizationId}`, error)),

--- a/apps/workers/src/workers/dataset-export.ts
+++ b/apps/workers/src/workers/dataset-export.ts
@@ -7,7 +7,7 @@ import { DatasetRowRepositoryLive, withClickHouse } from "@platform/db-clickhous
 import { DatasetRepositoryLive, type PostgresClient, withPostgres } from "@platform/db-postgres"
 import { createEmailTransportSender } from "@platform/email-transport"
 import { createStorageDisk } from "@platform/storage-object"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Data, Effect } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
@@ -110,6 +110,7 @@ export const createDatasetExportWorker = ({
         ),
         withPostgres(DatasetRepositoryLive, pgClient, organizationId),
         withClickHouse(DatasetRowRepositoryLive, chClient, organizationId),
+        withTracing,
       )
     },
   })

--- a/apps/workers/src/workers/domain-events/user-deletion.ts
+++ b/apps/workers/src/workers/domain-events/user-deletion.ts
@@ -6,7 +6,7 @@ import {
   UserRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getAdminPostgresClient } from "../../clients.ts"
 
@@ -24,6 +24,7 @@ export const createUserDeletionWorker = ({ consumer }: UserDeletionDeps) => {
 
       return deleteUserUseCase({ userId: payload.userId }).pipe(
         withPostgres(repoLayer, pgClient),
+        withTracing,
         Effect.tap(() => Effect.sync(() => logger.info(`User ${payload.userId} permanently deleted`))),
         Effect.tapError((error) =>
           Effect.sync(() => logger.error(`User deletion failed for ${payload.userId}`, error)),

--- a/apps/workers/src/workers/issues.ts
+++ b/apps/workers/src/workers/issues.ts
@@ -23,7 +23,7 @@ import {
   withPostgres,
 } from "@platform/db-postgres"
 import { IssueProjectionRepositoryLive, type WeaviateClient, withWeaviate } from "@platform/db-weaviate"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient, getWeaviateClient } from "../clients.ts"
 
@@ -74,6 +74,7 @@ export const createIssuesWorker = async ({
         withClickHouse(ScoreAnalyticsRepositoryLive, chClient, OrganizationId(payload.organizationId)),
         withWeaviate(IssueProjectionRepositoryLive, wvClient, OrganizationId(payload.organizationId)),
         withAi(AIEmbedLive, rdClient),
+        withTracing,
         Effect.provide(Layer.succeed(WorkflowStarter, workflowStarter)),
         Effect.asVoid,
       ),
@@ -86,6 +87,7 @@ export const createIssuesWorker = async ({
         ),
         withWeaviate(IssueProjectionRepositoryLive, wvClient, OrganizationId(payload.organizationId)),
         withAi(AIGenerateLive, rdClient),
+        withTracing,
         Effect.provide(Layer.succeed(QueuePublisher, publisher)),
         Effect.tap(() =>
           Effect.sync(() =>
@@ -110,6 +112,7 @@ export const createIssuesWorker = async ({
         withPostgres(IssueRepositoryLive, pgClient, OrganizationId(payload.organizationId)),
         withWeaviate(IssueProjectionRepositoryLive, wvClient, OrganizationId(payload.organizationId)),
         withAi(AIEmbedLive, rdClient),
+        withTracing,
         Effect.tap((result) =>
           Effect.sync(() => {
             if (result.action === "removed") {

--- a/apps/workers/src/workers/live-annotation-queues.ts
+++ b/apps/workers/src/workers/live-annotation-queues.ts
@@ -16,7 +16,7 @@ import {
   type PostgresClient,
   withPostgres,
 } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient } from "../clients.ts"
 
@@ -67,6 +67,7 @@ export const createCurateHandler =
         OrganizationId(payload.organizationId),
       ),
       withClickHouse(TraceRepositoryLive, clickhouseClient, OrganizationId(payload.organizationId)),
+      withTracing,
       Effect.tap((result) =>
         Effect.sync(() => {
           if (result.action === "skipped") {

--- a/apps/workers/src/workers/live-evaluations.ts
+++ b/apps/workers/src/workers/live-evaluations.ts
@@ -26,7 +26,7 @@ import {
   ScoreRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -173,6 +173,7 @@ export const createLiveEvaluationsWorker = ({
           OrganizationId(payload.organizationId),
         ),
         withClickHouse(TraceRepositoryLive, chClient, OrganizationId(payload.organizationId)),
+        withTracing,
         Effect.provide(Layer.succeed(LiveEvaluationQueuePublisher, liveEvaluationQueuePublisher)),
         Effect.tap((result) =>
           Effect.sync(() => {
@@ -222,6 +223,7 @@ export const createLiveEvaluationsWorker = ({
           OrganizationId(payload.organizationId),
         ),
         withDefaultAi,
+        withTracing,
         Effect.tap((result) =>
           Effect.sync(() => {
             if (result.action === "skipped") {

--- a/apps/workers/src/workers/projects.ts
+++ b/apps/workers/src/workers/projects.ts
@@ -3,7 +3,7 @@ import { ProjectRepository } from "@domain/projects"
 import type { QueueConsumer } from "@domain/queue"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { OutboxEventWriterLive, type PostgresClient, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Data, Effect, Layer } from "effect"
 import { getPostgresClient } from "../clients.ts"
 import { provisionSystemQueues } from "../services/provisioning.ts"
@@ -41,7 +41,7 @@ export const createProjectsWorker = ({ consumer, postgresClient }: ProjectsDeps)
           queuesProvisioned: results.length,
           results: results.map((r) => r.queueSlug),
         })
-      }),
+      }).pipe(withTracing),
 
     checkFirstTrace: (payload) =>
       Effect.gen(function* () {
@@ -89,6 +89,7 @@ export const createProjectsWorker = ({ consumer, postgresClient }: ProjectsDeps)
           pgClient,
           OrganizationId(payload.organizationId),
         ),
+        withTracing,
         Effect.ignore,
       ),
   })

--- a/apps/workers/src/workers/scores.ts
+++ b/apps/workers/src/workers/scores.ts
@@ -3,7 +3,7 @@ import { deleteScoreAnalyticsUseCase } from "@domain/scores"
 import { OrganizationId, ScoreId } from "@domain/shared"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { ScoreAnalyticsRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import { getClickhouseClient } from "../clients.ts"
 
@@ -21,6 +21,7 @@ export const createScoresWorker = ({ consumer, clickhouseClient }: ScoresWorkerD
     "delete-analytics": (payload) =>
       deleteScoreAnalyticsUseCase({ scoreId: ScoreId(payload.scoreId) }).pipe(
         withClickHouse(ScoreAnalyticsRepositoryLive, chClient, OrganizationId(payload.organizationId)),
+        withTracing,
         Effect.tap((result) =>
           Effect.sync(() => {
             if (result.action === "deleted") {

--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -5,7 +5,7 @@ import { processIngestedSpansUseCase } from "@domain/spans"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
 import { SpanRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { StorageDiskLive } from "@platform/storage-object"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import { getClickhouseClient, getStorageDisk } from "../clients.ts"
 
@@ -53,6 +53,7 @@ export const createSpanIngestionWorker = ({
           ),
           Effect.tapError((error) => Effect.sync(() => logger.error("Span ingestion failed", error))),
           withClickHouse(SpanRepositoryLive, chClient, OrganizationId(organizationId)),
+          withTracing,
           Effect.provide(StorageDiskLive(disk)),
         )
       },

--- a/apps/workers/src/workers/system-annotation-queues.ts
+++ b/apps/workers/src/workers/system-annotation-queues.ts
@@ -3,7 +3,7 @@ import type { QueueConsumer, WorkflowStarterShape } from "@domain/queue"
 import { deterministicSampling, OrganizationId, ProjectId } from "@domain/shared"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
 import { AnnotationQueueRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import { getPostgresClient, getRedisClient } from "../clients.ts"
 import { createIterationProgress } from "../services/iteration-progress.ts"
@@ -122,7 +122,7 @@ const handleFanOut = (deps: SystemAnnotationQueuesDeps) => {
           startedWorkflows,
         }),
       )
-    })
+    }).pipe(withTracing)
   }
 }
 

--- a/apps/workflows/src/activities/annotation-publication-activities.ts
+++ b/apps/workflows/src/activities/annotation-publication-activities.ts
@@ -13,6 +13,7 @@ import {
   withClickHouse,
 } from "@platform/db-clickhouse"
 import { OutboxEventWriterLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -30,6 +31,7 @@ export const enrichAnnotationForPublication = async (input: {
         OrganizationId(input.organizationId),
       ),
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
     ),
   )
 
@@ -73,5 +75,6 @@ export const writePublishedAnnotationScore = async (input: {
         OrganizationId(input.organizationId),
       ),
       withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )

--- a/apps/workflows/src/activities/evaluation-alignment-activities.ts
+++ b/apps/workflows/src/activities/evaluation-alignment-activities.ts
@@ -40,6 +40,7 @@ import {
   GEPA_DETAILS_GENERATOR_SYSTEM_PROMPT,
   gepaDetailsOutputSchema,
 } from "@platform/op-gepa"
+import { withTracing } from "@repo/observability"
 import { Data, Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -125,6 +126,7 @@ export const loadEvaluationAlignmentState = (input: {
   Effect.runPromise(
     loadAlignmentStateUseCase(input).pipe(
       withPostgres(evaluationAlignmentRepositoriesLive, getPostgresClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )
 
@@ -139,6 +141,7 @@ export const collectEvaluationAlignmentExamples = (input: {
     collectAlignmentExamplesUseCase(input).pipe(
       withPostgres(evaluationAlignmentRepositoriesLive, getPostgresClient(), OrganizationId(input.organizationId)),
       withClickHouse(TraceRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )
 
@@ -174,6 +177,7 @@ export const evaluateBaselineEvaluationDraft = (input: {
       script: input.draft.script,
     }).pipe(
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.mapError(
         (cause) =>
           new EvaluationAlignmentActivityError({
@@ -195,6 +199,7 @@ export const evaluateIncrementalEvaluationDraft = (input: {
   Effect.runPromise(
     evaluateIncrementalDraftUseCase(input).pipe(
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.mapError(
         (cause) =>
           new EvaluationAlignmentActivityError({
@@ -230,6 +235,7 @@ export const generateEvaluationDetails = (input: {
       }
     }).pipe(
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.mapError(
         (cause) =>
           new EvaluationAlignmentActivityError({
@@ -246,5 +252,6 @@ export const persistEvaluationAlignmentResult = (
   Effect.runPromise(
     persistAlignmentResultUseCase(input).pipe(
       withPostgres(EvaluationRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )

--- a/apps/workflows/src/activities/evaluation-optimization-activities.ts
+++ b/apps/workflows/src/activities/evaluation-optimization-activities.ts
@@ -27,6 +27,7 @@ import {
   GepaOptimizerLive,
   gepaProposalOutputSchema,
 } from "@platform/op-gepa"
+import { withTracing } from "@repo/observability"
 import { Data, Effect } from "effect"
 import { getRedisClient } from "../clients.ts"
 
@@ -92,6 +93,7 @@ const proposeOptimizationCandidate = (input: {
       } satisfies OptimizationCandidate
     }).pipe(
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.mapError(
         (cause) =>
           new EvaluationOptimizationActivityError({
@@ -151,6 +153,7 @@ export const optimizeEvaluationDraft = (input: {
               issueDescription: input.issueDescription,
             }).pipe(
               withAi(AIGenerateLive, getRedisClient()),
+              withTracing,
               Effect.mapError(
                 (cause) =>
                   new EvaluationOptimizationActivityError({

--- a/apps/workflows/src/activities/flagger-activities.ts
+++ b/apps/workflows/src/activities/flagger-activities.ts
@@ -22,7 +22,7 @@ import {
   ScoreRepositoryLive,
   withPostgres,
 } from "@platform/db-postgres"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient } from "../clients.ts"
 
@@ -39,6 +39,7 @@ export const runFlagger = async (input: {
     runSystemQueueFlaggerUseCase(input).pipe(
       withClickHouse(TraceRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId)),
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.tap(() =>
         Effect.sync(() =>
           logger.info("Ran system queue flagger", {
@@ -78,6 +79,7 @@ export const draftAnnotate = async (input: {
         OrganizationId(input.organizationId),
       ),
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
       Effect.tapError((error) =>
         Effect.sync(() => {
           systemQueueLogger.error("System queue draft annotate activity failed", {
@@ -118,6 +120,7 @@ export const persistAnnotation = async (input: {
         getClickhouseClient(),
         OrganizationId(input.organizationId),
       ),
+      withTracing,
       Effect.tapError((error) =>
         Effect.sync(() => {
           systemQueueLogger.error("System queue persist annotation activity failed", {

--- a/apps/workflows/src/activities/issue-discovery-activities.ts
+++ b/apps/workflows/src/activities/issue-discovery-activities.ts
@@ -25,7 +25,7 @@ import { AIEmbedLive, AIRerankLive } from "@platform/ai-voyage"
 import { ScoreAnalyticsRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { IssueRepositoryLive, OutboxEventWriterLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { IssueProjectionRepositoryLive, withWeaviate } from "@platform/db-weaviate"
-import { createLogger } from "@repo/observability"
+import { createLogger, withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { getClickhouseClient, getPostgresClient, getRedisClient, getWeaviateClient } from "../clients.ts"
 
@@ -36,6 +36,7 @@ export const checkEligibility = async (input: CheckEligibilityInput) => {
     await Effect.runPromise(
       checkEligibilityUseCase(input).pipe(
         withPostgres(ScoreRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
+        withTracing,
       ),
     )
 
@@ -63,6 +64,7 @@ export const embedScoreFeedback = async (input: EmbedScoreFeedbackInput) =>
     embedScoreFeedbackUseCase(input).pipe(
       withPostgres(ScoreRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
       withAi(AIEmbedLive, getRedisClient()),
+      withTracing,
     ),
   )
 
@@ -70,16 +72,18 @@ export const hybridSearchIssues = async (input: HybridSearchIssuesInput) =>
   Effect.runPromise(
     hybridSearchIssuesUseCase(input).pipe(
       withWeaviate(IssueProjectionRepositoryLive, await getWeaviateClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )
 
 export const rerankIssueCandidates = async (input: RerankIssueCandidatesInput) =>
-  Effect.runPromise(rerankIssueCandidatesUseCase(input).pipe(withAi(AIRerankLive, getRedisClient())))
+  Effect.runPromise(rerankIssueCandidatesUseCase(input).pipe(withAi(AIRerankLive, getRedisClient()), withTracing))
 
 export const resolveMatchedIssue = async (input: ResolveMatchedIssueInput) =>
   Effect.runPromise(
     resolveMatchedIssueUseCase(input).pipe(
       withPostgres(IssueRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )
 
@@ -92,6 +96,7 @@ export const createIssueFromScore = async (input: CreateIssueFromScoreInput) =>
         OrganizationId(input.organizationId),
       ),
       withAi(AIGenerateLive, getRedisClient()),
+      withTracing,
     ),
   )
 
@@ -103,6 +108,7 @@ export const assignScoreToIssue = async (input: AssignScoreToIssueInput) =>
         getPostgresClient(),
         OrganizationId(input.organizationId),
       ),
+      withTracing,
     ),
   )
 
@@ -111,6 +117,7 @@ export const syncScoreAnalytics = async (input: SyncScoreAnalyticsInput) =>
     syncScoreAnalyticsUseCase(input).pipe(
       withPostgres(ScoreRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
       withClickHouse(ScoreAnalyticsRepositoryLive, getClickhouseClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )
 
@@ -119,5 +126,6 @@ export const syncIssueProjections = async (input: SyncIssueProjectionsInput) =>
     syncIssueProjectionsUseCase(input).pipe(
       withPostgres(IssueRepositoryLive, getPostgresClient(), OrganizationId(input.organizationId)),
       withWeaviate(IssueProjectionRepositoryLive, await getWeaviateClient(), OrganizationId(input.organizationId)),
+      withTracing,
     ),
   )

--- a/packages/domain/annotation-queues/src/use-cases/add-traces-to-queue.ts
+++ b/packages/domain/annotation-queues/src/use-cases/add-traces-to-queue.ts
@@ -25,6 +25,9 @@ export function addTracesToQueue(args: {
   SqlClient | ChSqlClient | TraceRepository | AnnotationQueueItemRepository | AnnotationQueueRepository
 > {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", args.queueId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", args.projectId)
+
     const items = yield* resolveQueueItems({
       projectId: args.projectId,
       selection: args.selection,
@@ -57,5 +60,5 @@ export function addTracesToQueue(args: {
         return { insertedCount }
       }),
     )
-  })
+  }).pipe(Effect.withSpan("annotationQueues.addTracesToQueue"))
 }

--- a/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
@@ -16,6 +16,10 @@ export type CompleteQueueItemError = RepositoryError | QueueItemNotFoundError | 
 
 export const completeQueueItemUseCase = (input: CompleteQueueItemInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
+
     const sqlClient = yield* SqlClient
     const itemRepo = yield* AnnotationQueueItemRepository
     const queueRepo = yield* AnnotationQueueRepository
@@ -68,4 +72,4 @@ export const completeQueueItemUseCase = (input: CompleteQueueItemInput) =>
         return updated
       }),
     )
-  })
+  }).pipe(Effect.withSpan("annotationQueues.completeQueueItem"))

--- a/packages/domain/annotation-queues/src/use-cases/create-queue.ts
+++ b/packages/domain/annotation-queues/src/use-cases/create-queue.ts
@@ -28,6 +28,9 @@ export const createQueueUseCase = (
   input: CreateQueueInput,
 ): Effect.Effect<CreateQueueResult, CreateQueueError, AnnotationQueueRepository> =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+
     const repo = yield* AnnotationQueueRepository
 
     const now = new Date()
@@ -64,4 +67,4 @@ export const createQueueUseCase = (
     const queue = yield* repo.save(queueData)
 
     return { queue }
-  })
+  }).pipe(Effect.withSpan("annotationQueues.createQueue"))

--- a/packages/domain/annotation-queues/src/use-cases/curate-live-annotation-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/curate-live-annotation-queues.ts
@@ -55,6 +55,10 @@ const shouldSampleLiveQueue = async (input: {
 
 export const curateLiveAnnotationQueuesUseCase = (input: CurateLiveAnnotationQueuesInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+
     const traceRepository = yield* TraceRepository
     const queueRepository = yield* AnnotationQueueRepository
     const queueItemRepository = yield* AnnotationQueueItemRepository
@@ -164,7 +168,7 @@ export const curateLiveAnnotationQueuesUseCase = (input: CurateLiveAnnotationQue
         insertedItemCount,
       },
     } satisfies CurateLiveAnnotationQueuesResult
-  }) as Effect.Effect<
+  }).pipe(Effect.withSpan("annotationQueues.curateLiveAnnotationQueues")) as Effect.Effect<
     CurateLiveAnnotationQueuesResult,
     CurateLiveAnnotationQueuesError,
     SqlClient | TraceRepository | AnnotationQueueRepository | AnnotationQueueItemRepository

--- a/packages/domain/annotation-queues/src/use-cases/delete-queue.ts
+++ b/packages/domain/annotation-queues/src/use-cases/delete-queue.ts
@@ -36,6 +36,9 @@ export const deleteQueueUseCase = (
   input: DeleteQueueInput,
 ): Effect.Effect<DeleteQueueResult, DeleteQueueError, AnnotationQueueRepository> =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+
     const repo = yield* AnnotationQueueRepository
 
     const existing = yield* repo.findByIdInProject({
@@ -62,4 +65,4 @@ export const deleteQueueUseCase = (
     const saved = yield* repo.save(deleted)
 
     return { queue: saved }
-  })
+  }).pipe(Effect.withSpan("annotationQueues.deleteQueue"))

--- a/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
@@ -44,6 +44,11 @@ export type DraftSystemQueueAnnotationError = BadRequestError | RepositoryError 
  */
 export const draftSystemQueueAnnotationUseCase = (input: DraftSystemQueueAnnotationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+
     const parsedInput = yield* parseOrBadRequest(
       systemQueueAnnotateInputSchema,
       input,
@@ -80,4 +85,4 @@ export const draftSystemQueueAnnotationUseCase = (input: DraftSystemQueueAnnotat
       feedback: annotatorResult.feedback,
       traceCreatedAt: annotatorResult.traceCreatedAt,
     } as DraftSystemQueueAnnotationOutput
-  })
+  }).pipe(Effect.withSpan("annotationQueues.draftSystemQueueAnnotation"))

--- a/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
@@ -48,6 +48,9 @@ export interface EvictProjectSystemQueuesInput {
 
 export const getProjectSystemQueuesUseCase = (input: GetProjectSystemQueuesInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+
     const cache = yield* CacheStore
     const cacheKey = buildProjectSystemQueuesCacheKey(input.organizationId, input.projectId)
 
@@ -69,7 +72,7 @@ export const getProjectSystemQueuesUseCase = (input: GetProjectSystemQueuesInput
       .pipe(Effect.catchTag("CacheError", () => Effect.void))
 
     return entries
-  })
+  }).pipe(Effect.withSpan("annotationQueues.getProjectSystemQueues"))
 
 export const evictProjectSystemQueuesUseCase = (input: EvictProjectSystemQueuesInput) =>
   Effect.serviceOption(CacheStore).pipe(
@@ -82,4 +85,5 @@ export const evictProjectSystemQueuesUseCase = (input: EvictProjectSystemQueuesI
         },
       }),
     ),
+    Effect.withSpan("annotationQueues.evictProjectSystemQueues"),
   )

--- a/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
+++ b/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
@@ -19,6 +19,9 @@ export interface MarkReviewStartedInput {
  */
 export const markReviewStartedUseCase = (input: MarkReviewStartedInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("score.id", input.score.id)
+    yield* Effect.annotateCurrentSpan("score.projectId", input.score.projectId)
+
     const { score } = input
 
     if (score.source !== "annotation") return 0
@@ -66,4 +69,4 @@ export const markReviewStartedUseCase = (input: MarkReviewStartedInput) =>
     )
 
     return pendingItems.length
-  })
+  }).pipe(Effect.withSpan("annotationQueues.markReviewStarted"))

--- a/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
@@ -46,6 +46,9 @@ export type PersistSystemQueueAnnotationError = BadRequestError | RepositoryErro
  */
 export const persistSystemQueueAnnotationUseCase = (input: PersistSystemQueueAnnotationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+
     const parsedInput = yield* parseOrBadRequest(
       systemQueueAnnotateInputSchema,
       input,
@@ -146,4 +149,4 @@ export const persistSystemQueueAnnotationUseCase = (input: PersistSystemQueueAnn
       draftAnnotationId: result.draftAnnotationId,
       wasCreated: result.wasCreated,
     }) as SystemQueueAnnotateOutput
-  })
+  }).pipe(Effect.withSpan("annotationQueues.persistSystemQueueAnnotation"))

--- a/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
@@ -48,6 +48,9 @@ const createSystemQueue = (
  */
 export const provisionSystemQueuesUseCase = (input: ProvisionSystemQueuesInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+
     const sqlClient = yield* SqlClient
     const { organizationId, projectId } = input
 
@@ -82,4 +85,4 @@ export const provisionSystemQueuesUseCase = (input: ProvisionSystemQueuesInput) 
         return results
       }),
     )
-  })
+  }).pipe(Effect.withSpan("annotationQueues.provisionSystemQueues"))

--- a/packages/domain/annotation-queues/src/use-cases/request-bulk-queue-items.ts
+++ b/packages/domain/annotation-queues/src/use-cases/request-bulk-queue-items.ts
@@ -59,6 +59,11 @@ export function requestBulkQueueItems(
   ChSqlClient | QueuePublisher | AnnotationQueueRepository
 > {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.projectId", args.projectId)
+    if ("queueId" in args) {
+      yield* Effect.annotateCurrentSpan("queue.id", args.queueId)
+    }
+
     const chSqlClient = yield* ChSqlClient
     const queueRepository = yield* AnnotationQueueRepository
     const queuePublisher = yield* QueuePublisher
@@ -99,5 +104,5 @@ export function requestBulkQueueItems(
     })
 
     return { queueId }
-  })
+  }).pipe(Effect.withSpan("annotationQueues.requestBulkQueueItems"))
 }

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -114,6 +114,11 @@ const loadTraceDetail = (input: RunSystemQueueAnnotatorInput) =>
 
 export const runSystemQueueAnnotatorUseCase = (input: RunSystemQueueAnnotatorInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+
     const ai = yield* AI
 
     const trace = yield* loadTraceDetail(input)
@@ -151,4 +156,4 @@ export const runSystemQueueAnnotatorUseCase = (input: RunSystemQueueAnnotatorInp
       feedback: result.object.feedback,
       traceCreatedAt: trace.startTime.toISOString(),
     }
-  })
+  }).pipe(Effect.withSpan("annotationQueues.runSystemQueueAnnotator"))

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -287,6 +287,11 @@ export function getSystemQueueMatcherBySlug(queueSlug: string): SystemQueueMatch
 
 export const runSystemQueueFlaggerUseCase = (input: RunSystemQueueFlaggerInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+
     const deterministicMatcher = getSystemQueueMatcherBySlug(input.queueSlug)
 
     if (deterministicMatcher) {
@@ -303,4 +308,4 @@ export const runSystemQueueFlaggerUseCase = (input: RunSystemQueueFlaggerInput) 
     return {
       matched: decisions.matched,
     } satisfies RunSystemQueueFlaggerResult
-  })
+  }).pipe(Effect.withSpan("annotationQueues.runSystemQueueFlagger"))

--- a/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
@@ -14,6 +14,10 @@ export type UncompleteQueueItemError = RepositoryError | QueueItemNotFoundError 
 
 export const uncompleteQueueItemUseCase = (input: UncompleteQueueItemInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
+
     const sqlClient = yield* SqlClient
     const itemRepo = yield* AnnotationQueueItemRepository
     const queueRepo = yield* AnnotationQueueRepository
@@ -51,4 +55,4 @@ export const uncompleteQueueItemUseCase = (input: UncompleteQueueItemInput) =>
         return updated
       }),
     )
-  })
+  }).pipe(Effect.withSpan("annotationQueues.uncompleteQueueItem"))

--- a/packages/domain/annotation-queues/src/use-cases/update-queue.ts
+++ b/packages/domain/annotation-queues/src/use-cases/update-queue.ts
@@ -36,6 +36,9 @@ export const updateQueueUseCase = (
   input: UpdateQueueInput,
 ): Effect.Effect<UpdateQueueResult, UpdateQueueError, AnnotationQueueRepository> =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+
     const repo = yield* AnnotationQueueRepository
 
     const existing = yield* repo.findByIdInProject({
@@ -83,4 +86,4 @@ export const updateQueueUseCase = (
     const saved = yield* repo.save(updated)
 
     return { queue: saved }
-  })
+  }).pipe(Effect.withSpan("annotationQueues.updateQueue"))

--- a/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
@@ -37,6 +37,7 @@ const startPublishAnnotationWorkflow = (
 
 export const approveSystemAnnotationUseCase = (input: ApproveSystemAnnotationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const workflowStarter = yield* WorkflowStarter
     const scoreRepository = yield* ScoreRepository
     const score = yield* scoreRepository
@@ -77,4 +78,4 @@ export const approveSystemAnnotationUseCase = (input: ApproveSystemAnnotationInp
     })
 
     return { action: "approved", scoreId: score.id } satisfies ApproveSystemAnnotationResult
-  })
+  }).pipe(Effect.withSpan("annotations.approveSystemAnnotation"))

--- a/packages/domain/annotations/src/use-cases/delete-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/delete-annotation.ts
@@ -11,6 +11,7 @@ export type DeleteAnnotationError = RepositoryError | BadRequestError
 
 export const deleteAnnotationUseCase = (input: DeleteAnnotationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const sqlClient = yield* SqlClient
     const scoreRepository = yield* ScoreRepository
     const outboxEventWriter = yield* OutboxEventWriter
@@ -51,4 +52,4 @@ export const deleteAnnotationUseCase = (input: DeleteAnnotationInput) =>
         yield* scoreRepository.delete(input.scoreId)
       }),
     )
-  })
+  }).pipe(Effect.withSpan("annotations.deleteAnnotation"))

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -113,6 +113,7 @@ export type EnrichAnnotationForPublicationError = RepositoryError | BadRequestEr
 
 export const enrichAnnotationForPublicationUseCase = (input: EnrichAnnotationForPublicationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const ai = yield* AI
 
     const loaded = yield* loadAnnotationScoreForPublicationMutation(input.scoreId)
@@ -186,4 +187,4 @@ export const enrichAnnotationForPublicationUseCase = (input: EnrichAnnotationFor
       resolvedSessionId: resolvedSessionId === null ? null : String(resolvedSessionId),
       resolvedSpanId: resolvedSpanId === null ? null : String(resolvedSpanId),
     }
-  })
+  }).pipe(Effect.withSpan("annotations.enrichAnnotationForPublication"))

--- a/packages/domain/annotations/src/use-cases/list-annotations.ts
+++ b/packages/domain/annotations/src/use-cases/list-annotations.ts
@@ -33,6 +33,8 @@ export const listTraceAnnotationsUseCase = (input: ListTraceAnnotationsInput) =>
       input,
       "Invalid list trace annotations input",
     )
+    yield* Effect.annotateCurrentSpan("annotation.projectId", parsed.projectId)
+    yield* Effect.annotateCurrentSpan("annotation.traceId", parsed.traceId)
 
     const scoreRepository = yield* ScoreRepository
 
@@ -46,4 +48,4 @@ export const listTraceAnnotationsUseCase = (input: ListTraceAnnotationsInput) =>
         draftMode: parsed.draftMode,
       },
     })
-  })
+  }).pipe(Effect.withSpan("annotations.listTraceAnnotations"))

--- a/packages/domain/annotations/src/use-cases/publish-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/publish-annotation.ts
@@ -32,6 +32,7 @@ const startPublishAnnotationWorkflow = (
 
 export const publishHumanAnnotationUseCase = (input: PublishAnnotationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const workflowStarter = yield* WorkflowStarter
     const scoreRepository = yield* ScoreRepository
     const score = yield* scoreRepository
@@ -72,4 +73,4 @@ export const publishHumanAnnotationUseCase = (input: PublishAnnotationInput) =>
       action: "workflow-started",
       scoreId: score.id,
     } satisfies PublishAnnotationResult
-  })
+  }).pipe(Effect.withSpan("annotations.publishHumanAnnotation"))

--- a/packages/domain/annotations/src/use-cases/write-draft-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/write-draft-annotation.ts
@@ -1,5 +1,6 @@
 import type { ScoreDraftClosedError, ScoreDraftUpdateConflictError } from "@domain/scores"
 import type { BadRequestError, RepositoryError } from "@domain/shared"
+import { Effect } from "effect"
 import type { z } from "zod"
 import { persistDraftAnnotationInputSchema } from "../helpers/annotation-draft-write-schema.ts"
 import { writeAnnotation } from "../helpers/write-annotation.ts"
@@ -15,4 +16,4 @@ export type PersistDraftAnnotationError =
 
 /** Thin primitive: persist or update a **draft** annotation score (`draftedAt` set). */
 export const writeDraftAnnotationUseCase = (input: WriteDraftAnnotationInput & { organizationId: string }) =>
-  writeAnnotation(input, new Date())
+  writeAnnotation(input, new Date()).pipe(Effect.withSpan("annotations.writeDraftAnnotation"))

--- a/packages/domain/api-keys/src/use-cases/generate-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/generate-api-key.ts
@@ -17,6 +17,9 @@ export type GenerateApiKeyError = RepositoryError | ValidationError | InvalidApi
 export const generateApiKeyUseCase = (input: GenerateApiKeyInput) =>
   Effect.gen(function* () {
     const { organizationId } = yield* SqlClient
+    if (input.id) {
+      yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
+    }
 
     if (!input.name || input.name.trim().length === 0) {
       return yield* new InvalidApiKeyNameError({ name: input.name, reason: "Name cannot be empty" })
@@ -54,4 +57,4 @@ export const generateApiKeyUseCase = (input: GenerateApiKeyInput) =>
     })
 
     return apiKey
-  })
+  }).pipe(Effect.withSpan("apiKeys.generateApiKey"))

--- a/packages/domain/api-keys/src/use-cases/revoke-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/revoke-api-key.ts
@@ -20,6 +20,7 @@ export class ApiKeyCacheInvalidator extends ServiceMap.Service<
 
 export const revokeApiKeyUseCase = (input: RevokeApiKeyInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
     const sqlClient = yield* SqlClient
     const cacheInvalidator = yield* ApiKeyCacheInvalidator
 
@@ -38,4 +39,4 @@ export const revokeApiKeyUseCase = (input: RevokeApiKeyInput) =>
         return revokedApiKey
       }),
     )
-  })
+  }).pipe(Effect.withSpan("apiKeys.revokeApiKey"))

--- a/packages/domain/api-keys/src/use-cases/update-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/update-api-key.ts
@@ -13,6 +13,7 @@ export type UpdateApiKeyError = RepositoryError | ApiKeyNotFoundError
 
 export const updateApiKeyUseCase = (input: UpdateApiKeyInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
     const repo = yield* ApiKeyRepository
     const apiKey = yield* repo
       .findById(input.id)
@@ -22,4 +23,4 @@ export const updateApiKeyUseCase = (input: UpdateApiKeyInput) =>
     yield* repo.save(updated)
 
     return updated
-  })
+  }).pipe(Effect.withSpan("apiKeys.updateApiKey"))

--- a/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
@@ -100,6 +100,9 @@ export function addTracesToDataset(args: {
   readonly selection: TraceSelection
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
     const chSqlClient = yield* ChSqlClient
     const rowRepo = yield* DatasetRowRepository
 
@@ -134,7 +137,7 @@ export function addTracesToDataset(args: {
       rows,
       source: "traces",
     })
-  })
+  }).pipe(Effect.withSpan("datasets.addTracesToDataset"))
 }
 
 export function createDatasetFromTraces(args: {
@@ -143,6 +146,8 @@ export function createDatasetFromTraces(args: {
   readonly selection: TraceSelection
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
     const chSqlClient = yield* ChSqlClient
     const datasetRepo = yield* DatasetRepository
 
@@ -184,5 +189,5 @@ export function createDatasetFromTraces(args: {
     })
 
     return yield* populateDataset.pipe(Effect.tapError(() => datasetRepo.softDelete(dataset.id)))
-  })
+  }).pipe(Effect.withSpan("datasets.createDatasetFromTraces"))
 }

--- a/packages/domain/datasets/src/use-cases/count-rows.ts
+++ b/packages/domain/datasets/src/use-cases/count-rows.ts
@@ -9,6 +9,8 @@ export function countRows(args: {
   readonly search?: string
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const rowRepo = yield* DatasetRowRepository
 
     let version: number | undefined
@@ -25,5 +27,5 @@ export function countRows(args: {
       ...(version !== undefined ? { version } : {}),
       ...(args.search ? { search: args.search } : {}),
     })
-  })
+  }).pipe(Effect.withSpan("datasets.countRows"))
 }

--- a/packages/domain/datasets/src/use-cases/create-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/create-dataset.ts
@@ -13,6 +13,8 @@ export function createDataset(args: {
   readonly actorUserId?: string
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
     const repo = yield* DatasetRepository
     const name = yield* validateDatasetNameInProject({
       projectId: args.projectId,
@@ -36,5 +38,5 @@ export function createDataset(args: {
     })
 
     return dataset
-  })
+  }).pipe(Effect.withSpan("datasets.createDataset"))
 }

--- a/packages/domain/datasets/src/use-cases/delete-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/delete-dataset.ts
@@ -4,8 +4,10 @@ import { DatasetRepository } from "../ports/dataset-repository.ts"
 
 export function deleteDataset(args: { readonly datasetId: DatasetId }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const repo = yield* DatasetRepository
     yield* repo.findById(args.datasetId)
     yield* repo.softDelete(args.datasetId)
-  })
+  }).pipe(Effect.withSpan("datasets.deleteDataset"))
 }

--- a/packages/domain/datasets/src/use-cases/delete-rows.ts
+++ b/packages/domain/datasets/src/use-cases/delete-rows.ts
@@ -12,6 +12,8 @@ export type DeleteRowsSelection =
 // See update-row.ts for details on the last-write-wins behavior.
 export function deleteRows(args: { readonly datasetId: DatasetId; readonly selection: DeleteRowsSelection }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     if (args.selection.mode === "selected" && args.selection.rowIds.length === 0) {
       return { versionId: null, version: 0 }
     }
@@ -54,5 +56,5 @@ export function deleteRows(args: { readonly datasetId: DatasetId; readonly selec
       .pipe(Effect.tapError(() => datasetRepo.decrementVersion({ id: args.datasetId, versionId: version.id })))
 
     return { versionId: version.id, version: version.version, deletedCount }
-  })
+  }).pipe(Effect.withSpan("datasets.deleteRows"))
 }

--- a/packages/domain/datasets/src/use-cases/get-row-detail.ts
+++ b/packages/domain/datasets/src/use-cases/get-row-detail.ts
@@ -9,6 +9,9 @@ export function getRowDetail(args: {
   readonly versionId?: DatasetVersionId
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+    yield* Effect.annotateCurrentSpan("rowId", args.rowId)
+
     const rowRepo = yield* DatasetRowRepository
 
     let version: number | undefined
@@ -25,5 +28,5 @@ export function getRowDetail(args: {
       rowId: args.rowId,
       ...(version !== undefined ? { version } : {}),
     })
-  })
+  }).pipe(Effect.withSpan("datasets.getRowDetail"))
 }

--- a/packages/domain/datasets/src/use-cases/insert-rows.ts
+++ b/packages/domain/datasets/src/use-cases/insert-rows.ts
@@ -16,6 +16,8 @@ export function insertRows(args: {
   readonly source?: string
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const resolvedRows = yield* Effect.forEach(args.rows, (row) =>
       buildValidRowId(row.id).pipe(Effect.map((id) => ({ ...row, id }))),
     )
@@ -45,5 +47,5 @@ export function insertRows(args: {
       )
 
     return { versionId: version.id, version: version.version, rowIds }
-  })
+  }).pipe(Effect.withSpan("datasets.insertRows"))
 }

--- a/packages/domain/datasets/src/use-cases/list-datasets.ts
+++ b/packages/domain/datasets/src/use-cases/list-datasets.ts
@@ -5,9 +5,11 @@ import { DatasetRepository } from "../ports/dataset-repository.ts"
 
 export function listDatasets(args: { readonly projectId: ProjectId; readonly options?: DatasetListOptions }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
     const repo = yield* DatasetRepository
     return yield* repo.listByProject(
       args.options !== undefined ? { projectId: args.projectId, options: args.options } : { projectId: args.projectId },
     )
-  })
+  }).pipe(Effect.withSpan("datasets.listDatasets"))
 }

--- a/packages/domain/datasets/src/use-cases/list-rows.ts
+++ b/packages/domain/datasets/src/use-cases/list-rows.ts
@@ -13,6 +13,8 @@ export function listRows(args: {
   readonly cursor?: { readonly createdAt: string; readonly rowId: DatasetRowId }
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const rowRepo = yield* DatasetRowRepository
 
     let version: number | undefined
@@ -33,5 +35,5 @@ export function listRows(args: {
       ...(args.offset !== undefined ? { offset: args.offset } : {}),
       ...(args.cursor ? { cursor: args.cursor } : {}),
     })
-  })
+  }).pipe(Effect.withSpan("datasets.listRows"))
 }

--- a/packages/domain/datasets/src/use-cases/rename-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/rename-dataset.ts
@@ -5,6 +5,8 @@ import { validateDatasetNameInProject } from "./validate-dataset-name.ts"
 
 export function renameDataset(args: { readonly datasetId: DatasetId; readonly name: string }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const repo = yield* DatasetRepository
     const dataset = yield* repo.findById(args.datasetId)
     const trimmed = args.name.trim()
@@ -17,5 +19,5 @@ export function renameDataset(args: { readonly datasetId: DatasetId; readonly na
     })
 
     return yield* repo.updateName({ id: args.datasetId, name })
-  })
+  }).pipe(Effect.withSpan("datasets.renameDataset"))
 }

--- a/packages/domain/datasets/src/use-cases/update-dataset-details.ts
+++ b/packages/domain/datasets/src/use-cases/update-dataset-details.ts
@@ -16,6 +16,8 @@ export function updateDatasetDetails(args: {
   readonly description: string | null | undefined
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+
     const repo = yield* DatasetRepository
     const dataset = yield* repo.findById(args.datasetId)
     const trimmedName = args.name.trim()
@@ -39,5 +41,5 @@ export function updateDatasetDetails(args: {
       name,
       description: normalizedDesc,
     })
-  })
+  }).pipe(Effect.withSpan("datasets.updateDatasetDetails"))
 }

--- a/packages/domain/datasets/src/use-cases/update-row.ts
+++ b/packages/domain/datasets/src/use-cases/update-row.ts
@@ -15,6 +15,9 @@ export function updateRow(args: {
   readonly metadata: RowFieldValue
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+    yield* Effect.annotateCurrentSpan("rowId", args.rowId)
+
     const datasetRepo = yield* DatasetRepository
     const rowRepo = yield* DatasetRowRepository
 
@@ -48,5 +51,5 @@ export function updateRow(args: {
       )
 
     return { versionId: version.id, version: version.version }
-  })
+  }).pipe(Effect.withSpan("datasets.updateRow"))
 }

--- a/packages/domain/datasets/src/use-cases/validate-dataset-name.ts
+++ b/packages/domain/datasets/src/use-cases/validate-dataset-name.ts
@@ -14,6 +14,8 @@ export function validateDatasetNameInProject(args: {
   readonly excludeDatasetId?: DatasetId
 }) {
   return Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
     const repo = yield* DatasetRepository
     const trimmed = args.name.trim()
     if (!trimmed) {
@@ -28,5 +30,5 @@ export function validateDatasetNameInProject(args: {
       return yield* new DuplicateDatasetNameError({ projectId: args.projectId, name: trimmed })
     }
     return trimmed
-  })
+  }).pipe(Effect.withSpan("datasets.validateDatasetName"))
 }

--- a/packages/domain/email/src/use-cases/send-email.ts
+++ b/packages/domain/email/src/use-cases/send-email.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect"
+import { Effect } from "effect"
 import type { EmailContent } from "../entities/email.ts"
 import type { EmailSendError } from "../errors.ts"
 import type { EmailSender } from "../ports/email-sender.ts"
@@ -12,12 +12,14 @@ import type { EmailSender } from "../ports/email-sender.ts"
 
 export const sendEmail = ({ emailSender }: { readonly emailSender: EmailSender }) => {
   return (email: EmailContent): Effect.Effect<void, EmailSendError> => {
-    return emailSender.send({
-      to: email.to,
-      subject: email.subject,
-      html: email.html,
-      ...(email.text && { text: email.text }),
-    })
+    return emailSender
+      .send({
+        to: email.to,
+        subject: email.subject,
+        html: email.html,
+        ...(email.text && { text: email.text }),
+      })
+      .pipe(Effect.withSpan("email.sendEmail"))
   }
 }
 

--- a/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
@@ -19,6 +19,10 @@ export const collectAlignmentExamplesUseCase = (input: {
   readonly requirePositiveExamples?: boolean
 }) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+
     const issueRepository = yield* EvaluationIssueRepository
     const exampleRepository = yield* EvaluationAlignmentExamplesRepository
     const traceRepository = yield* TraceRepository
@@ -96,4 +100,4 @@ export const collectAlignmentExamplesUseCase = (input: {
       positiveExamples: positiveExamples.map(hydrateExample),
       negativeExamples: negativeExamples.map(hydrateExample),
     } satisfies CollectedEvaluationAlignmentExamples
-  })
+  }).pipe(Effect.withSpan("evaluations.collectAlignmentExamples"))

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-baseline-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-baseline-draft.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect"
 import type { HydratedEvaluationAlignmentExample } from "../../alignment/types.ts"
 import { evaluateDraftAgainstExamplesUseCase } from "./evaluate-draft-against-examples.ts"
 
@@ -14,4 +15,4 @@ export const evaluateBaselineDraftUseCase = (input: {
     script: input.script,
     positiveExamples: input.positiveExamples,
     negativeExamples: input.negativeExamples,
-  })
+  }).pipe(Effect.withSpan("evaluations.evaluateBaselineDraft"))

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
@@ -52,4 +52,4 @@ export const evaluateDraftAgainstExamplesUseCase = (input: {
       metrics: deriveEvaluationAlignmentMetrics(confusionMatrix),
       exampleResults,
     } satisfies BaselineEvaluationResult
-  })
+  }).pipe(Effect.withSpan("evaluations.evaluateDraftAgainstExamples"))

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
@@ -69,4 +69,4 @@ export const evaluateIncrementalDraftUseCase = (input: {
       matthewsCorrelationCoefficientDrop: decision.matthewsCorrelationCoefficientDrop,
       confusionMatrix: incremental.confusionMatrix,
     } satisfies IncrementalEvaluationRefreshResult
-  })
+  }).pipe(Effect.withSpan("evaluations.evaluateIncrementalDraft"))

--- a/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
@@ -20,4 +20,4 @@ export const generateBaselineDraftUseCase = (input: {
       evaluationHash: yield* Effect.tryPromise(() => hashOptimizationCandidateText(script)),
       trigger: defaultEvaluationTrigger(),
     } satisfies GeneratedEvaluationDraft
-  })
+  }).pipe(Effect.withSpan("evaluations.generateBaselineDraft"))

--- a/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
@@ -12,6 +12,10 @@ export const loadAlignmentStateUseCase = (input: {
   readonly evaluationId: string
 }) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+
     const evaluationRepository = yield* EvaluationRepository
     const issueRepository = yield* EvaluationIssueRepository
     const evaluation = yield* evaluationRepository
@@ -53,4 +57,4 @@ export const loadAlignmentStateUseCase = (input: {
       },
       confusionMatrix: evaluation.alignment.confusionMatrix,
     } satisfies LoadedEvaluationAlignmentState
-  })
+  }).pipe(Effect.withSpan("evaluations.loadAlignmentState"))

--- a/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
@@ -18,6 +18,12 @@ export const persistAlignmentResultUseCase = (input: {
   readonly description: string
 }) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+    if (input.evaluationId) {
+      yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+    }
+
     const evaluationRepository = yield* EvaluationRepository
     const projectId = ProjectId(input.projectId)
     const issueId = IssueId(input.issueId)
@@ -69,4 +75,4 @@ export const persistAlignmentResultUseCase = (input: {
     yield* evaluationRepository.save(evaluation)
 
     return { evaluationId: evaluation.id } satisfies PersistEvaluationAlignmentResult
-  })
+  }).pipe(Effect.withSpan("evaluations.persistAlignmentResult"))

--- a/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/enqueue-live-evaluations.ts
@@ -148,6 +148,10 @@ const buildExecutePublication = (input: {
 
 export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("evaluation.traceId", input.traceId)
+
     const scoreRepository = yield* ScoreRepository
     const liveEvaluationQueuePublisher = yield* LiveEvaluationQueuePublisher
     const traceRepository = yield* TraceRepository
@@ -277,7 +281,7 @@ export const enqueueLiveEvaluationsUseCase = (input: EnqueueLiveEvaluationsInput
         publishedExecuteCount,
       },
     } satisfies EnqueueLiveEvaluationsResult
-  }) as Effect.Effect<
+  }).pipe(Effect.withSpan("evaluations.enqueueLiveEvaluations")) as Effect.Effect<
     EnqueueLiveEvaluationsResult,
     EnqueueLiveEvaluationsError,
     TraceRepository | EvaluationRepository | LiveEvaluationQueuePublisher | ScoreRepository

--- a/packages/domain/evaluations/src/use-cases/live/execute-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/execute-live-evaluation.ts
@@ -63,6 +63,8 @@ const toGenerateTelemetryCapture = (
 
 export const executeLiveEvaluationUseCase = (input: LiveEvaluationExecutionInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+
     if (!validateEvaluationScript(input.script)) {
       return yield* new LiveEvaluationExecutionError({
         evaluationId: input.evaluationId,
@@ -99,4 +101,8 @@ export const executeLiveEvaluationUseCase = (input: LiveEvaluationExecutionInput
           cause: error,
         }),
     })
-  }) as Effect.Effect<LiveEvaluationExecutionResult, ExecuteLiveEvaluationError, AI>
+  }).pipe(Effect.withSpan("evaluations.executeLiveEvaluation")) as Effect.Effect<
+    LiveEvaluationExecutionResult,
+    ExecuteLiveEvaluationError,
+    AI
+  >

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -125,6 +125,11 @@ const buildLiveEvaluationExecutionTelemetry = (input: RunLiveEvaluationInput): G
 
 export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+    yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("evaluation.traceId", input.traceId)
+
     const evaluationRepository = yield* EvaluationRepository
     const scoreRepository = yield* ScoreRepository
     const projectId = ProjectId(input.projectId)
@@ -304,7 +309,7 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
         score,
       },
     } satisfies RunLiveEvaluationResult
-  }) as Effect.Effect<
+  }).pipe(Effect.withSpan("evaluations.runLiveEvaluation")) as Effect.Effect<
     RunLiveEvaluationResult,
     RunLiveEvaluationError,
     | AI

--- a/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
+++ b/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
@@ -12,6 +12,9 @@ export const evaluateOptimizationCandidate = (input: {
   readonly issueDescription: string
 }) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("evaluation.candidateHash", input.candidate.hash)
+    yield* Effect.annotateCurrentSpan("evaluation.exampleTraceId", input.example.traceId)
+
     const execution = yield* executeEvaluationScriptWithAI({
       script: input.candidate.text,
       conversation: input.example.conversation,
@@ -38,4 +41,4 @@ export const evaluateOptimizationCandidate = (input: {
         totalTokens: execution.totalTokens,
       } satisfies OptimizationTrajectory,
     }
-  })
+  }).pipe(Effect.withSpan("evaluations.evaluateOptimizationCandidate"))

--- a/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.ts
+++ b/packages/domain/issues/src/use-cases/apply-issue-lifecycle-command.ts
@@ -154,6 +154,8 @@ export const applyIssueLifecycleCommandUseCase = (
 > =>
   Effect.gen(function* () {
     const parsed = applyIssueLifecycleCommandInputSchema.parse(input)
+    yield* Effect.annotateCurrentSpan("projectId", String(parsed.projectId))
+    yield* Effect.annotateCurrentSpan("command", parsed.command)
     const sqlClient = yield* SqlClient
     const keepMonitoring =
       parsed.command === "resolve"
@@ -207,4 +209,4 @@ export const applyIssueLifecycleCommandUseCase = (
         } satisfies ApplyIssueLifecycleCommandResult
       }),
     )
-  })
+  }).pipe(Effect.withSpan("issues.applyIssueLifecycleCommand"))

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
@@ -100,6 +100,9 @@ const buildIssueWithAssignedScore = ({
 
 export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const sqlClient = yield* SqlClient
     const scoreResult = yield* loadEligibleScoreOrCurrentOwner(input)
 
@@ -176,4 +179,7 @@ export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
         } satisfies AssignScoreToIssueResult
       }),
     )
-  }) as Effect.Effect<AssignScoreToIssueResult, AssignScoreToIssueError>
+  }).pipe(Effect.withSpan("issues.assignScoreToIssue")) as Effect.Effect<
+    AssignScoreToIssueResult,
+    AssignScoreToIssueError
+  >

--- a/packages/domain/issues/src/use-cases/check-eligibility.ts
+++ b/packages/domain/issues/src/use-cases/check-eligibility.ts
@@ -22,6 +22,8 @@ export interface CheckEligibilityInput {
 
 export const checkEligibilityUseCase = (input: CheckEligibilityInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const scoreRepository = yield* ScoreRepository
 
     const score = yield* scoreRepository
@@ -61,4 +63,4 @@ export const checkEligibilityUseCase = (input: CheckEligibilityInput) =>
     }
 
     return score
-  }) as Effect.Effect<Score, CheckEligibilityError | RepositoryError>
+  }).pipe(Effect.withSpan("issues.checkEligibility")) as Effect.Effect<Score, CheckEligibilityError | RepositoryError>

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.ts
@@ -107,6 +107,8 @@ const buildNewIssueFromScore = ({
 
 export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const initialScoreResult = yield* loadEligibleScoreOrCurrentOwner(input)
     if (initialScoreResult.action === "already-assigned") {
       return {
@@ -178,4 +180,7 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
         } satisfies CreateIssueFromScoreResult
       }),
     )
-  }) as Effect.Effect<CreateIssueFromScoreResult, CreateIssueFromScoreError>
+  }).pipe(Effect.withSpan("issues.createIssueFromScore")) as Effect.Effect<
+    CreateIssueFromScoreResult,
+    CreateIssueFromScoreError
+  >

--- a/packages/domain/issues/src/use-cases/discover-issue.ts
+++ b/packages/domain/issues/src/use-cases/discover-issue.ts
@@ -129,6 +129,11 @@ const asSkipped = (reason: DiscoverIssueSkipReason) =>
 
 export const discoverIssueUseCase = (input: DiscoverIssueInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    if (input.issueId !== null) {
+      yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    }
     const workflowStarter = yield* WorkflowStarter
 
     const eligibilityResult = yield* checkEligibilityUseCase(input).pipe(
@@ -197,4 +202,4 @@ export const discoverIssueUseCase = (input: DiscoverIssueInput) =>
       workflow: "assignScoreToKnownIssueWorkflow",
       scoreId: score.id,
     } satisfies DiscoverIssueResult
-  })
+  }).pipe(Effect.withSpan("issues.discoverIssue"))

--- a/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
+++ b/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
@@ -20,6 +20,7 @@ export interface EmbedIssueSearchQueryResult {
 export const embedIssueSearchQueryUseCase = (input: EmbedIssueSearchQueryInput) =>
   Effect.gen(function* () {
     const parsed = embedIssueSearchQueryInputSchema.parse(input)
+    yield* Effect.annotateCurrentSpan("projectId", parsed.projectId)
     const ai = yield* AI
 
     const result = yield* ai.embed({
@@ -41,4 +42,4 @@ export const embedIssueSearchQueryUseCase = (input: EmbedIssueSearchQueryInput) 
       query: parsed.query,
       normalizedEmbedding,
     } satisfies EmbedIssueSearchQueryResult
-  })
+  }).pipe(Effect.withSpan("issues.embedIssueSearchQuery"))

--- a/packages/domain/issues/src/use-cases/embed-score-feedback.ts
+++ b/packages/domain/issues/src/use-cases/embed-score-feedback.ts
@@ -20,6 +20,8 @@ export interface EmbeddedScoreFeedback {
 
 export const embedScoreFeedbackUseCase = (input: EmbedScoreFeedbackInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const scoreRepository = yield* ScoreRepository
     const ai = yield* AI
 
@@ -51,4 +53,4 @@ export const embedScoreFeedbackUseCase = (input: EmbedScoreFeedbackInput) =>
       feedback: score.feedback,
       normalizedEmbedding: normalizeEmbedding(embedding.embedding),
     } satisfies EmbeddedScoreFeedback
-  })
+  }).pipe(Effect.withSpan("issues.embedScoreFeedback"))

--- a/packages/domain/issues/src/use-cases/generate-issue-details.ts
+++ b/packages/domain/issues/src/use-cases/generate-issue-details.ts
@@ -103,6 +103,10 @@ You must:
 
 export const generateIssueDetailsUseCase = (input: GenerateIssueDetailsInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    if (input.issueId) {
+      yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    }
     const ai = yield* AI
 
     let previousName: string | null = null
@@ -184,4 +188,7 @@ export const generateIssueDetailsUseCase = (input: GenerateIssueDetailsInput) =>
       name: truncateIssueName(result.object.name),
       description: collapseWhitespace(result.object.description),
     } satisfies GeneratedIssueDetails
-  }) as Effect.Effect<GeneratedIssueDetails, GenerateIssueDetailsError>
+  }).pipe(Effect.withSpan("issues.generateIssueDetails")) as Effect.Effect<
+    GeneratedIssueDetails,
+    GenerateIssueDetailsError
+  >

--- a/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
+++ b/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
@@ -14,6 +14,7 @@ export interface HybridSearchIssuesResult {
 
 export const hybridSearchIssuesUseCase = (input: HybridSearchIssuesInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const issueProjectionRepository = yield* IssueProjectionRepository
 
     const candidates = yield* issueProjectionRepository.hybridSearch({
@@ -25,4 +26,4 @@ export const hybridSearchIssuesUseCase = (input: HybridSearchIssuesInput) =>
     return {
       candidates,
     } satisfies HybridSearchIssuesResult
-  })
+  }).pipe(Effect.withSpan("issues.hybridSearchIssues"))

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -311,6 +311,7 @@ export const listIssuesUseCase = (
 > =>
   Effect.gen(function* () {
     const parsed = listIssuesInputSchema.parse(input)
+    yield* Effect.annotateCurrentSpan("projectId", String(parsed.projectId))
     const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
     const issueRepository = yield* IssueRepository
     const evaluationRepository = yield* EvaluationRepository
@@ -520,4 +521,4 @@ export const listIssuesUseCase = (
       offset: parsed.offset,
       occurrencesSum,
     } satisfies ListIssuesResult
-  })
+  }).pipe(Effect.withSpan("issues.listIssues"))

--- a/packages/domain/issues/src/use-cases/refresh-issue-details.ts
+++ b/packages/domain/issues/src/use-cases/refresh-issue-details.ts
@@ -62,6 +62,8 @@ const enqueueLinkedEvaluationAlignments = (input: RefreshIssueDetailsInput) =>
 
 export const refreshIssueDetailsUseCase = (input: RefreshIssueDetailsInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const generatedDetailsResult = yield* generateIssueDetailsUseCase({
       projectId: input.projectId,
       issueId: input.issueId,
@@ -132,4 +134,7 @@ export const refreshIssueDetailsUseCase = (input: RefreshIssueDetailsInput) =>
     }
 
     return result
-  }) as Effect.Effect<RefreshIssueDetailsResult, RefreshIssueDetailsError>
+  }).pipe(Effect.withSpan("issues.refreshIssueDetails")) as Effect.Effect<
+    RefreshIssueDetailsResult,
+    RefreshIssueDetailsError
+  >

--- a/packages/domain/issues/src/use-cases/remove-score-from-issue.ts
+++ b/packages/domain/issues/src/use-cases/remove-score-from-issue.ts
@@ -26,6 +26,10 @@ export type RemoveScoreFromIssueError = RepositoryError
 
 export const removeScoreFromIssueUseCase = (input: RemoveScoreFromIssueInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    if (input.issueId !== null) {
+      yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    }
     if (input.draftedAt !== null) {
       return { action: "skipped", reason: "draft" } satisfies RemoveScoreFromIssueResult
     }
@@ -102,4 +106,7 @@ export const removeScoreFromIssueUseCase = (input: RemoveScoreFromIssueInput) =>
     }
 
     return result
-  }) as Effect.Effect<RemoveScoreFromIssueResult, RemoveScoreFromIssueError>
+  }).pipe(Effect.withSpan("issues.removeScoreFromIssue")) as Effect.Effect<
+    RemoveScoreFromIssueResult,
+    RemoveScoreFromIssueError
+  >

--- a/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
+++ b/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
@@ -24,6 +24,7 @@ export interface RetrievalResult {
 
 export const rerankIssueCandidatesUseCase = (input: RerankIssueCandidatesInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("candidateCount", input.candidates.length)
     const limitedCandidates = [...input.candidates]
       .sort((left, right) => right.score - left.score)
       .slice(0, ISSUE_DISCOVERY_RERANK_CANDIDATES)
@@ -72,4 +73,4 @@ export const rerankIssueCandidatesUseCase = (input: RerankIssueCandidatesInput) 
       matchedIssueUuid: matchedIssue.uuid,
       similarityScore: best.relevanceScore,
     } satisfies RetrievalResult
-  })
+  }).pipe(Effect.withSpan("issues.rerankIssueCandidates"))

--- a/packages/domain/issues/src/use-cases/resolve-matched-issue.ts
+++ b/packages/domain/issues/src/use-cases/resolve-matched-issue.ts
@@ -14,6 +14,10 @@ export interface ResolvedIssueMatch {
 
 export const resolveMatchedIssueUseCase = (input: ResolveMatchedIssueInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    if (input.matchedIssueUuid !== null) {
+      yield* Effect.annotateCurrentSpan("matchedIssueUuid", input.matchedIssueUuid)
+    }
     if (input.matchedIssueUuid === null) {
       return {
         issueId: null,
@@ -31,4 +35,4 @@ export const resolveMatchedIssueUseCase = (input: ResolveMatchedIssueInput) =>
     return {
       issueId: issue?.id ?? null,
     } satisfies ResolvedIssueMatch
-  }) as Effect.Effect<ResolvedIssueMatch, RepositoryError>
+  }).pipe(Effect.withSpan("issues.resolveMatchedIssue")) as Effect.Effect<ResolvedIssueMatch, RepositoryError>

--- a/packages/domain/issues/src/use-cases/sync-projections.ts
+++ b/packages/domain/issues/src/use-cases/sync-projections.ts
@@ -11,6 +11,7 @@ export interface SyncIssueProjectionsInput {
 
 export const syncIssueProjectionsUseCase = (input: SyncIssueProjectionsInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
     const issueProjectionRepository = yield* IssueProjectionRepository
     const issueRepository = yield* IssueRepository
 
@@ -37,4 +38,4 @@ export const syncIssueProjectionsUseCase = (input: SyncIssueProjectionsInput) =>
       description: issue.description,
       vector,
     })
-  })
+  }).pipe(Effect.withSpan("issues.syncProjections"))

--- a/packages/domain/organizations/src/use-cases/cleanup-user-memberships.ts
+++ b/packages/domain/organizations/src/use-cases/cleanup-user-memberships.ts
@@ -12,6 +12,8 @@ export const cleanupUserMembershipsUseCase = (
   input: CleanupUserMembershipsInput,
 ): Effect.Effect<void, RepositoryError, MembershipRepository | OrganizationRepository> =>
   E.gen(function* () {
+    yield* E.annotateCurrentSpan("userId", input.userId)
+
     const membershipRepo = yield* MembershipRepository
     const orgRepo = yield* OrganizationRepository
 
@@ -27,4 +29,4 @@ export const cleanupUserMembershipsUseCase = (
         yield* membershipRepo.delete(membership.id)
       }
     }
-  })
+  }).pipe(E.withSpan("organizations.cleanupUserMemberships"))

--- a/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
+++ b/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
@@ -28,4 +28,4 @@ export const generateUniqueOrganizationSlugUseCase = (input: { name: string }) =
     return yield* new SlugGenerationError({
       message: `Could not generate a unique slug after ${MAX_SLUG_ATTEMPTS} attempts`,
     })
-  })
+  }).pipe(Effect.withSpan("organizations.generateUniqueOrganizationSlug"))

--- a/packages/domain/organizations/src/use-cases/remove-member.ts
+++ b/packages/domain/organizations/src/use-cases/remove-member.ts
@@ -10,6 +10,8 @@ export interface RemoveMemberInput {
 
 export const removeMemberUseCase = (input: RemoveMemberInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("membershipId", input.membershipId)
+
     const repository = yield* MembershipRepository
 
     const membership = yield* repository
@@ -25,4 +27,4 @@ export const removeMemberUseCase = (input: RemoveMemberInput) =>
     }
 
     yield* repository.delete(input.membershipId)
-  })
+  }).pipe(Effect.withSpan("organizations.removeMember"))

--- a/packages/domain/organizations/src/use-cases/transfer-ownership.ts
+++ b/packages/domain/organizations/src/use-cases/transfer-ownership.ts
@@ -17,6 +17,9 @@ export interface TransferOwnershipInput {
 
 export const transferOwnershipUseCase = (input: TransferOwnershipInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("newOwnerUserId", input.newOwnerUserId)
+
     const repository = yield* MembershipRepository
 
     // Check if current owner is actually the owner
@@ -62,4 +65,4 @@ export const transferOwnershipUseCase = (input: TransferOwnershipInput) =>
     yield* repository.save(updatedNewOwnerMembership)
 
     return { success: true }
-  })
+  }).pipe(Effect.withSpan("organizations.transferOwnership"))

--- a/packages/domain/organizations/src/use-cases/update-member-role.ts
+++ b/packages/domain/organizations/src/use-cases/update-member-role.ts
@@ -18,6 +18,10 @@ export interface UpdateMemberRoleInput {
 
 export const updateMemberRoleUseCase = (input: UpdateMemberRoleInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("targetUserId", input.targetUserId)
+    yield* Effect.annotateCurrentSpan("newRole", input.newRole)
+
     const repository = yield* MembershipRepository
 
     // Check if requesting user is an admin
@@ -54,4 +58,4 @@ export const updateMemberRoleUseCase = (input: UpdateMemberRoleInput) =>
     yield* repository.save(updatedMembership)
 
     return { success: true }
-  })
+  }).pipe(Effect.withSpan("organizations.updateMemberRole"))

--- a/packages/domain/organizations/src/use-cases/update-organization.ts
+++ b/packages/domain/organizations/src/use-cases/update-organization.ts
@@ -26,4 +26,4 @@ export const updateOrganizationUseCase = (input: UpdateOrganizationInput) =>
     yield* repo.save(updated)
 
     return updated
-  })
+  }).pipe(Effect.withSpan("organizations.updateOrganization"))

--- a/packages/domain/projects/src/use-cases/create-project.ts
+++ b/packages/domain/projects/src/use-cases/create-project.ts
@@ -23,6 +23,9 @@ export type CreateProjectError = RepositoryError | ValidationError | ConflictErr
 
 export const createProjectUseCase = (input: CreateProjectInput) =>
   Effect.gen(function* () {
+    if (input.id) {
+      yield* Effect.annotateCurrentSpan("project.id", input.id)
+    }
     const trimmedName = input.name.trim()
     const sqlClient = yield* SqlClient
     const { organizationId } = sqlClient
@@ -109,4 +112,4 @@ export const createProjectUseCase = (input: CreateProjectInput) =>
         return project
       }),
     )
-  })
+  }).pipe(Effect.withSpan("projects.createProject"))

--- a/packages/domain/projects/src/use-cases/list-projects.ts
+++ b/packages/domain/projects/src/use-cases/list-projects.ts
@@ -12,8 +12,9 @@ export const listAllProjectsUseCase = (
   input: ListAllProjectsInput,
 ): Effect.Effect<readonly Project[], RepositoryError, ProjectRepository> =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("project.organizationId", input.organizationId)
     const repo = yield* ProjectRepository
     if (input.includeDeleted) return yield* repo.listIncludingDeleted()
 
     return yield* repo.list()
-  })
+  }).pipe(Effect.withSpan("projects.listAllProjects"))

--- a/packages/domain/projects/src/use-cases/update-project.ts
+++ b/packages/domain/projects/src/use-cases/update-project.ts
@@ -28,6 +28,7 @@ export type UpdateProjectError =
 
 export const updateProjectUseCase = (input: UpdateProjectInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("project.id", input.id)
     const sqlClient = yield* SqlClient
     const { organizationId } = sqlClient
 
@@ -88,4 +89,4 @@ export const updateProjectUseCase = (input: UpdateProjectInput) =>
         return updatedProject
       }),
     )
-  })
+  }).pipe(Effect.withSpan("projects.updateProject"))

--- a/packages/domain/scores/src/use-cases/delete-score-analytics.ts
+++ b/packages/domain/scores/src/use-cases/delete-score-analytics.ts
@@ -6,6 +6,7 @@ type DeleteScoreAnalyticsResult = { readonly action: "deleted" } | { readonly ac
 
 export const deleteScoreAnalyticsUseCase = (input: { scoreId: ScoreId }) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("score.scoreId", input.scoreId)
     const analyticsRepository = yield* ScoreAnalyticsRepository
 
     const exists = yield* analyticsRepository.existsById(input.scoreId)
@@ -15,4 +16,4 @@ export const deleteScoreAnalyticsUseCase = (input: { scoreId: ScoreId }) =>
 
     yield* analyticsRepository.delete(input.scoreId)
     return { action: "deleted" } satisfies DeleteScoreAnalyticsResult
-  }) as Effect.Effect<DeleteScoreAnalyticsResult, RepositoryError>
+  }).pipe(Effect.withSpan("scores.deleteScoreAnalytics")) as Effect.Effect<DeleteScoreAnalyticsResult, RepositoryError>

--- a/packages/domain/scores/src/use-cases/list-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-scores.ts
@@ -37,6 +37,7 @@ export type ListScoresError = RepositoryError | BadRequestError
 export const listProjectScoresUseCase = (input: ListProjectScoresInput) =>
   Effect.gen(function* () {
     const parsedInput = yield* parseOrBadRequest(listProjectScoresInputSchema, input, "Invalid project score query")
+    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
     const repository = yield* ScoreRepository
 
     return yield* repository.listByProjectId({
@@ -47,11 +48,14 @@ export const listProjectScoresUseCase = (input: ListProjectScoresInput) =>
         draftMode: parsedInput.draftMode,
       },
     })
-  })
+  }).pipe(Effect.withSpan("scores.listProjectScores"))
 
 export const listSourceScoresUseCase = (input: ListSourceScoresInput) =>
   Effect.gen(function* () {
     const parsedInput = yield* parseOrBadRequest(listSourceScoresInputSchema, input, "Invalid source query")
+    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+    yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
+    yield* Effect.annotateCurrentSpan("score.sourceId", parsedInput.sourceId)
     const repository = yield* ScoreRepository
 
     return yield* repository.listBySourceId({
@@ -64,4 +68,4 @@ export const listSourceScoresUseCase = (input: ListSourceScoresInput) =>
         draftMode: parsedInput.draftMode,
       },
     })
-  })
+  }).pipe(Effect.withSpan("scores.listSourceScores"))

--- a/packages/domain/scores/src/use-cases/save-score-analytics.ts
+++ b/packages/domain/scores/src/use-cases/save-score-analytics.ts
@@ -11,6 +11,7 @@ export interface SyncScoreAnalyticsInput {
 
 export const syncScoreAnalyticsUseCase = (input: SyncScoreAnalyticsInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("score.scoreId", input.scoreId)
     const scoreRepository = yield* ScoreRepository
     const analyticsRepository = yield* ScoreAnalyticsRepository
 
@@ -27,4 +28,4 @@ export const syncScoreAnalyticsUseCase = (input: SyncScoreAnalyticsInput) =>
     }
 
     yield* analyticsRepository.insert(score)
-  })
+  }).pipe(Effect.withSpan("scores.syncScoreAnalytics"))

--- a/packages/domain/scores/src/use-cases/write-score.ts
+++ b/packages/domain/scores/src/use-cases/write-score.ts
@@ -145,6 +145,8 @@ const buildScore = ({
 export const writeScoreUseCase = (input: WriteScoreInput) =>
   Effect.gen(function* () {
     const parsedInput = yield* parseOrBadRequest(writeScoreInputSchema, input, "Invalid score write input")
+    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+    yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
     const sqlClient = yield* SqlClient
 
     const score = yield* sqlClient.transaction(
@@ -203,4 +205,4 @@ export const writeScoreUseCase = (input: WriteScoreInput) =>
     }
 
     return score
-  })
+  }).pipe(Effect.withSpan("scores.writeScore"))

--- a/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
@@ -15,6 +15,9 @@ export type BuildTraceCohortListingSpecError = TraceCohortUnavailableError | Rep
 
 export const buildTraceCohortListingSpecUseCase = (input: BuildTraceCohortListingSpecInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("cohort", input.cohort)
+
     const traceRepository = yield* TraceRepository
     const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
       organizationId: input.organizationId,
@@ -31,4 +34,4 @@ export const buildTraceCohortListingSpecUseCase = (input: BuildTraceCohortListin
     }
 
     return spec
-  })
+  }).pipe(Effect.withSpan("spans.buildTraceCohortListingSpec"))

--- a/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
+++ b/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
@@ -15,6 +15,9 @@ export type EvaluateTraceResourceOutliersError = NotFoundError | RepositoryError
 
 export const evaluateTraceResourceOutliersUseCase = (input: EvaluateTraceResourceOutliersInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+    yield* Effect.annotateCurrentSpan("traceId", input.traceId)
+
     const traceRepository = yield* TraceRepository
     const trace = yield* traceRepository.findByTraceId({
       organizationId: input.organizationId,
@@ -30,4 +33,4 @@ export const evaluateTraceResourceOutliersUseCase = (input: EvaluateTraceResourc
     })
 
     return evaluateTraceResourceOutliers(trace, buildTraceMetricBaselines(baselineData))
-  })
+  }).pipe(Effect.withSpan("spans.evaluateTraceResourceOutliers"))

--- a/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
@@ -13,6 +13,8 @@ export interface GetTraceCohortSummaryInput {
 
 export const getTraceCohortSummaryUseCase = (input: GetTraceCohortSummaryInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
     const traceRepository = yield* TraceRepository
     const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
       organizationId: input.organizationId,
@@ -27,4 +29,4 @@ export const getTraceCohortSummaryUseCase = (input: GetTraceCohortSummaryInput) 
       traceCount: baselineData.traceCount,
       baselines,
     } satisfies TraceCohortSummary
-  })
+  }).pipe(Effect.withSpan("spans.getTraceCohortSummary"))

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -18,6 +18,9 @@ export const ingestSpansUseCase = (
   input: IngestSpansInput,
 ): Effect.Effect<void, StorageError | QueuePublishError, StorageDisk | QueuePublisher> =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
     const publisher = yield* QueuePublisher
 
     let fileKey: string | null = null
@@ -45,4 +48,4 @@ export const ingestSpansUseCase = (
       apiKeyId: input.apiKeyId,
       ingestedAt: new Date().toISOString(),
     })
-  })
+  }).pipe(Effect.withSpan("spans.ingestSpans"))

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -91,6 +91,9 @@ export const processIngestedSpansUseCase =
     SpanRepository | StorageDisk
   > =>
     Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+      yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
       const payload = yield* resolvePayload(input)
       const spans = yield* decodeAndTransform(payload, input)
 
@@ -112,4 +115,4 @@ export const processIngestedSpansUseCase =
         ),
         { concurrency: "unbounded" },
       )
-    })
+    }).pipe(Effect.withSpan("spans.processIngestedSpans"))

--- a/packages/domain/users/src/use-cases/delete-user.ts
+++ b/packages/domain/users/src/use-cases/delete-user.ts
@@ -8,10 +8,12 @@ export interface DeleteUserInput {
 
 export const deleteUserUseCase = (input: DeleteUserInput) =>
   Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("userId", input.userId)
+
     // Clean up memberships and sole-member organizations
     yield* cleanupUserMembershipsUseCase({ userId: input.userId })
 
     // Delete the user record (cascades to sessions, accounts)
     const userRepo = yield* UserRepository
     yield* userRepo.delete(input.userId)
-  })
+  }).pipe(Effect.withSpan("users.deleteUser"))

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -25,9 +25,12 @@
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
     "@opentelemetry/resources": "catalog:",
+    "@opentelemetry/sdk-logs": "catalog:",
+    "@opentelemetry/sdk-metrics": "catalog:",
     "@opentelemetry/sdk-node": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.6.0",
     "@opentelemetry/sdk-trace-node": "catalog:",
+    "@opentelemetry/sdk-trace-web": "catalog:",
     "@opentelemetry/semantic-conventions": "catalog:",
     "@platform/env": "workspace:*",
     "effect": "catalog:"

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -19,12 +19,16 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@effect/opentelemetry": "catalog:",
     "@latitude-data/telemetry": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
+    "@opentelemetry/resources": "catalog:",
     "@opentelemetry/sdk-node": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.6.0",
+    "@opentelemetry/sdk-trace-node": "catalog:",
+    "@opentelemetry/semantic-conventions": "catalog:",
     "@platform/env": "workspace:*",
     "effect": "catalog:"
   }

--- a/packages/observability/src/effect-tracer.ts
+++ b/packages/observability/src/effect-tracer.ts
@@ -1,0 +1,28 @@
+import { Resource, Tracer } from "@effect/opentelemetry"
+import { Effect, Layer } from "effect"
+
+/**
+ * Bridges Effect's Tracer to the already-running OTel TracerProvider.
+ *
+ * Tracer.layerGlobal reads the global OTel TracerProvider (set by NodeSDK.start())
+ * and picks up active OTel spans as parents (e.g. HTTP request spans from Hono middleware).
+ *
+ * Resource.layerFromEnv reads OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES,
+ * both already set by startTracing() in otel.ts.
+ */
+export const EffectOtelTracerLive = Tracer.layerGlobal.pipe(Layer.provide(Resource.layerFromEnv()))
+
+/**
+ * Pipe combinator to provide the OTel tracer layer to any effect.
+ *
+ * @example
+ * ```ts
+ * const result = await Effect.runPromise(
+ *   myEffect.pipe(
+ *     withPostgres(...),
+ *     withTracing,
+ *   ),
+ * )
+ * ```
+ */
+export const withTracing = <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.provide(effect, EffectOtelTracerLive)

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -9,6 +9,7 @@ import { startTracing } from "./otel.ts"
 import { getObservabilityState } from "./state.ts"
 import type { InitializeObservabilityOptions } from "./types.ts"
 
+export { EffectOtelTracerLive, withTracing } from "./effect-tracer.ts"
 export { recordSpanExceptionForDatadog } from "./record-span-exception.ts"
 export { trace, SpanStatusCode }
 export const createLogger = (scope: string) => createLoggerWithState(getObservabilityState(), scope)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,17 @@ catalogs:
     '@opentelemetry/resources':
       specifier: ^2.6.1
       version: 2.6.1
+    '@opentelemetry/sdk-logs':
+      specifier: ^0.213.0
+      version: 0.213.0
+    '@opentelemetry/sdk-metrics':
+      specifier: ^2.6.0
+      version: 2.6.0
     '@opentelemetry/sdk-trace-node':
       specifier: ^2.6.1
+      version: 2.6.1
+    '@opentelemetry/sdk-trace-web':
+      specifier: ^2.6.0
       version: 2.6.1
     '@opentelemetry/semantic-conventions':
       specifier: ^1.40.0
@@ -1111,7 +1120,7 @@ importers:
     dependencies:
       '@effect/opentelemetry':
         specifier: 'catalog:'
-        version: 4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)
+        version: 4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)
       '@latitude-data/telemetry':
         specifier: workspace:*
         version: link:../telemetry/typescript
@@ -1127,6 +1136,12 @@ importers:
       '@opentelemetry/resources':
         specifier: 'catalog:'
         version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: 'catalog:'
+        version: 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: 'catalog:'
+        version: 2.6.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.213.0
         version: 0.213.0(@opentelemetry/api@1.9.1)
@@ -1134,6 +1149,9 @@ importers:
         specifier: ^2.6.0
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node':
+        specifier: 'catalog:'
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web':
         specifier: 'catalog:'
         version: 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions':
@@ -4628,6 +4646,12 @@ packages:
 
   '@opentelemetry/sdk-trace-node@2.6.1':
     resolution: {integrity: sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/sdk-trace-web@2.6.1':
+    resolution: {integrity: sha512-JQevIjBlWGcKBfuwe7tdxGR/75RERsf1OOIvUzPKq86J8qhzkyjnLTTuPNPLRQF1xxEe65W5aI1Uwl6yWUGPQQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': 1.9.1
@@ -12799,7 +12823,7 @@ snapshots:
 
   '@effect/language-service@0.84.3': {}
 
-  '@effect/opentelemetry@4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)':
+  '@effect/opentelemetry@4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-web@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.40.0
       effect: 4.0.0-beta.4
@@ -12810,6 +12834,7 @@ snapshots:
       '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-node': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-web': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@electric-sql/pglite@0.3.15': {}
 
@@ -14664,6 +14689,12 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-web@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,21 @@ catalogs:
     '@clickhouse/client':
       specifier: 1.18.2
       version: 1.18.2
+    '@effect/opentelemetry':
+      specifier: 4.0.0-beta.4
+      version: 4.0.0-beta.4
     '@hono/node-server':
       specifier: 1.19.13
       version: 1.19.13
+    '@opentelemetry/resources':
+      specifier: ^2.6.1
+      version: 2.6.1
+    '@opentelemetry/sdk-trace-node':
+      specifier: ^2.6.1
+      version: 2.6.1
+    '@opentelemetry/semantic-conventions':
+      specifier: ^1.40.0
+      version: 1.40.0
     '@paralleldrive/cuid2':
       specifier: 3.3.0
       version: 3.3.0
@@ -1097,6 +1109,9 @@ importers:
 
   packages/observability:
     dependencies:
+      '@effect/opentelemetry':
+        specifier: 'catalog:'
+        version: 4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)
       '@latitude-data/telemetry':
         specifier: workspace:*
         version: link:../telemetry/typescript
@@ -1109,12 +1124,21 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.213.0
         version: 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: 'catalog:'
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.213.0
         version: 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.6.0
         version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node':
+        specifier: 'catalog:'
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: 'catalog:'
+        version: 1.40.0
       '@platform/env':
         specifier: workspace:*
         version: link:../platform/env
@@ -2732,6 +2756,35 @@ packages:
   '@effect/language-service@0.84.3':
     resolution: {integrity: sha512-zpxi6rLCwst/cBQd7ElwDvt36Y6Jvz8v6bCLnNiOL6OXvdLmqjOFWyzWZdMh92vvBQA/aVKhfIAAOP3o4wKt0A==}
     hasBin: true
+
+  '@effect/opentelemetry@4.0.0-beta.4':
+    resolution: {integrity: sha512-G+u2cB4Vge/18cbsh0Cd9iuvm+RwGoerhaxlWiWGTFkpNYhEKRGhQaprJZ/g/F6gq34y7kMap6MnM5fnxCh07Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': ^2.0.0
+      '@opentelemetry/sdk-logs': '>=0.203.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': ^2.0.0
+      '@opentelemetry/sdk-trace-base': ^2.0.0
+      '@opentelemetry/sdk-trace-node': ^2.0.0
+      '@opentelemetry/sdk-trace-web': ^2.0.0
+      '@opentelemetry/semantic-conventions': ^1.33.0
+      effect: ^4.0.0-beta.4
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-logs':
+        optional: true
+      '@opentelemetry/sdk-metrics':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/sdk-trace-node':
+        optional: true
+      '@opentelemetry/sdk-trace-web':
+        optional: true
 
   '@electric-sql/pglite@0.3.15':
     resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
@@ -12745,6 +12798,18 @@ snapshots:
   '@drizzle-team/brocli@0.11.0': {}
 
   '@effect/language-service@0.84.3': {}
+
+  '@effect/opentelemetry@4.0.0-beta.4(@opentelemetry/api@1.9.1)(@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)(effect@4.0.0-beta.4)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.40.0
+      effect: 4.0.0-beta.4
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@electric-sql/pglite@0.3.15': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,9 @@ catalog:
   '@clickhouse/client': 1.18.2
   '@hono/node-server': 1.19.13
   '@opentelemetry/api': ^1.9.0
+  '@opentelemetry/resources': ^2.6.1
+  '@opentelemetry/sdk-trace-node': ^2.6.1
+  '@opentelemetry/semantic-conventions': ^1.40.0
   '@paralleldrive/cuid2': 3.3.0
   '@temporalio/client': 1.16.0
   '@temporalio/worker': 1.16.0
@@ -27,6 +30,7 @@ catalog:
   drizzle-kit: 1.0.0-beta.15-859cf75
   drizzle-orm: 1.0.0-beta.21-af6b4cb
   fast-json-stable-stringify: 2.1.0
+  '@effect/opentelemetry': 4.0.0-beta.4
   effect: 4.0.0-beta.4
   hono: 4.12.14
   ioredis: 5.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,10 @@ catalog:
   '@hono/node-server': 1.19.13
   '@opentelemetry/api': ^1.9.0
   '@opentelemetry/resources': ^2.6.1
+  '@opentelemetry/sdk-logs': ^0.213.0
+  '@opentelemetry/sdk-metrics': ^2.6.0
   '@opentelemetry/sdk-trace-node': ^2.6.1
+  '@opentelemetry/sdk-trace-web': ^2.6.0
   '@opentelemetry/semantic-conventions': ^1.40.0
   '@paralleldrive/cuid2': 3.3.0
   '@temporalio/client': 1.16.0


### PR DESCRIPTION
## Summary

- Bridges Effect's built-in tracing (`Effect.withSpan`, `Effect.annotateCurrentSpan`) to the existing OTel pipeline via `@effect/opentelemetry`, so Effect spans flow into Datadog alongside existing HTTP spans
- Adds a `withTracing` pipe combinator to every `Effect.runPromise` edge (API routes, workers, workflows, web server functions, ingest middleware) — decoupled from DB layers
- Instruments ~80 use case functions across all 11 domains with named spans and business-context attributes (projectId, scoreId, issueId, etc.)

## How it works

`EffectOtelTracerLive` reads the global OTel `TracerProvider` (already started by `NodeSDK`) and registers it as Effect's `Tracer`. Active OTel spans (e.g. HTTP request spans from Hono middleware) are automatically picked up as parents, so Effect spans nest correctly under request traces.

**Span naming convention:** `{domain}.{functionName}` — e.g. `scores.writeScore`, `issues.discoverIssue`, `evaluations.runLiveEvaluation`

## Test plan

- [x] Full monorepo typecheck passes (48/48 tasks)
- [x] All domain unit tests pass (pre-existing failure in `vercel.test.ts` unrelated to this change)
- [x] Biome lint/format passes
- [x] Pre-commit hooks (format + knip) pass
- [ ] Deploy to staging and verify spans appear in Datadog with correct parent-child relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)