### PR TITLE
Lots of QA fixes

### DIFF
--- a/apps/web/src/layouts/AppSidebar/index.tsx
+++ b/apps/web/src/layouts/AppSidebar/index.tsx
@@ -251,7 +251,7 @@ export function AppSidebar({
     >
       <div className="flex min-h-0 flex-1 flex-col">
         <div
-          className={cn("flex shrink-0 flex-col gap-2 border-b border-border p-4", {
+          className={cn("flex shrink-0 flex-col gap-0.5 border-b border-border p-4", {
             "items-center": collapsed,
           })}
         >

--- a/apps/web/src/layouts/ListingLayout/index.tsx
+++ b/apps/web/src/layouts/ListingLayout/index.tsx
@@ -135,4 +135,13 @@ ListingLayout.Body = Body
 ListingLayout.Sidebar = Sidebar
 ListingLayout.List = List
 
+/**
+ * Use with `InfiniteTable` / `ProjectTracesTable` inside `ListingLayout.List` so the scroll area
+ * height follows the table (horizontal scrollbar sits under the last row when the list is short).
+ */
+export const listingLayoutIntrinsicScroll = {
+  infiniteTable: { scrollAreaLayout: "intrinsic" as const, className: "max-h-full" },
+  projectTracesTable: { scrollAreaLayout: "intrinsic" as const, scrollContainerClassName: "max-h-full" },
+}
+
 export { ListingLayout }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -60,6 +60,11 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
     [denseBuckets, bucketSeconds, onRangeSelect],
   )
 
+  const formatTooltip = useCallback(
+    (category: string, value: number) => `${category}<br/><b>${formatCount(value)}</b> traces`,
+    [],
+  )
+
   if (isLoading) {
     return (
       <div className="px-4 py-3">
@@ -91,7 +96,7 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
         height={160}
         showYAxis={false}
         ariaLabel="Trace count by time bucket"
-        formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> traces`}
+        formatTooltip={formatTooltip}
         onSelect={onRangeSelect ? handleSelect : undefined}
       />
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-card.tsx
@@ -18,9 +18,8 @@ import { useNavigate, useParams } from "@tanstack/react-router"
 import {
   EllipsisIcon,
   GlobeIcon,
-  HashIcon,
   InfoIcon,
-  PencilIcon,
+  ShieldAlertIcon,
   SparklesIcon,
   ThumbsDownIcon,
   ThumbsUpIcon,
@@ -69,7 +68,7 @@ function AnnotationApprovalButtons({ annotationId, onAction }: AnnotationApprova
           </span>
         }
       >
-        This annotation was created by our AI agent and requires review. Approve to keep it or reject to delete it.
+        This annotation was automatically created with AI and requires review
       </Tooltip>
       <Button
         variant="destructive-soft"
@@ -123,6 +122,7 @@ export function AnnotationCard({
   })
 
   const linkedIssueName = linkedIssue?.name ?? null
+  const linkedIssueDescription = linkedIssue?.description?.trim()
   const provenance = getAnnotationProvenance(annotation)
   const isEditable = canUpdateAnnotation(annotation)
   const isDraft = annotation.draftedAt !== null
@@ -188,7 +188,9 @@ export function AnnotationCard({
   const rawFeedback = (annotation.metadata as { rawFeedback?: string })?.rawFeedback?.trim()
   const humanFeedback = annotation.feedback?.trim()
   const showRawFeedback =
-    rawFeedback && (provenance === "agent" || ((provenance === "human" || provenance === "api") && isPublished))
+    rawFeedback &&
+    (provenance === "agent" || ((provenance === "human" || provenance === "api") && isPublished)) &&
+    rawFeedback !== humanFeedback
 
   return (
     <div
@@ -204,40 +206,20 @@ export function AnnotationCard({
           </>
         )}
         {provenance === "agent" && (
-          <Tooltip
-            asChild
-            trigger={
-              <div className="flex items-center gap-1.5">
-                <LatitudeLogo className="h-4 w-4" />
-                <Text.H6 weight="bold">Latitude</Text.H6>
-                <Badge variant="secondary" size="small">
-                  Agent
-                </Badge>
-              </div>
-            }
-          >
-            Created automatically by a Latitude system queue
-          </Tooltip>
+          <div className="flex items-center gap-1.5">
+            <LatitudeLogo className="h-4 w-4" />
+            <Text.H6 weight="bold">Latitude</Text.H6>
+            <Badge variant="secondary" size="small">
+              Agent
+            </Badge>
+          </div>
         )}
         {provenance === "api" && (
-          <Tooltip
-            asChild
-            trigger={
-              <Badge variant="outline" size="small">
-                API
-              </Badge>
-            }
-          >
-            Created via the public API
-          </Tooltip>
+          <Badge variant="outline" size="small">
+            API
+          </Badge>
         )}
         <Text.H6 color="foregroundMuted">{relativeTime(new Date(annotation.createdAt))}</Text.H6>
-        {isDraft && (
-          <Tooltip asChild trigger={<Icon icon={PencilIcon} size="xs" color="foregroundMuted" />}>
-            Draft annotation. It will be published automatically, or you can edit it while in draft.
-          </Tooltip>
-        )}
-
         <div className="ml-auto flex items-center gap-x-1">
           {isGlobal && (
             <Tooltip
@@ -262,7 +244,7 @@ export function AnnotationCard({
                 <PopoverContent side="bottom" align="end" className="max-w-md">
                   <div className="flex flex-col gap-0.5">
                     <Text.H6 color="foregroundMuted" className="mb-1">
-                      Original feedback
+                      This feedback has been enriched with AI
                     </Text.H6>
                     <Text.H6 className="whitespace-pre-wrap">{rawFeedback}</Text.H6>
                   </div>
@@ -296,31 +278,42 @@ export function AnnotationCard({
 
       {(linkedIssueName || isAgentDraft) && (
         <div className="flex items-center gap-2 pt-1">
-          {linkedIssueName && (
-            <Badge
-              data-no-navigate
-              variant="outline"
-              size="small"
-              ellipsis
-              role="button"
-              tabIndex={0}
-              aria-label={`Open issue ${linkedIssueName}`}
-              className="cursor-pointer hover:bg-muted"
-              iconProps={{
-                icon: HashIcon,
-                color: "foregroundMuted",
-                placement: "start",
-              }}
-              onClick={openLinkedIssue}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                  openLinkedIssue(event)
-                }
-              }}
-            >
-              {linkedIssueName}
-            </Badge>
-          )}
+          {linkedIssueName &&
+            (() => {
+              const issueLinkBadge = (
+                <Badge
+                  data-no-navigate
+                  variant="outline"
+                  size="small"
+                  ellipsis
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Open issue ${linkedIssueName}`}
+                  className="cursor-pointer hover:bg-muted"
+                  iconProps={{
+                    icon: ShieldAlertIcon,
+                    color: "foregroundMuted",
+                    placement: "start",
+                    className: "stroke-[2.5]",
+                  }}
+                  onClick={openLinkedIssue}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      openLinkedIssue(event)
+                    }
+                  }}
+                >
+                  {linkedIssueName}
+                </Badge>
+              )
+              return linkedIssueDescription ? (
+                <Tooltip asChild trigger={issueLinkBadge}>
+                  <span className="block max-w-xs whitespace-pre-wrap text-left">{linkedIssueDescription}</span>
+                </Tooltip>
+              ) : (
+                issueLinkBadge
+              )
+            })()}
           {isAgentDraft && (
             <div className="ml-auto">
               <AnnotationApprovalButtons annotationId={annotation.id} onAction={onDelete} />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
@@ -133,7 +133,7 @@ export function AnnotationInput({
   return (
     <div
       className={cn(
-        "flex flex-col rounded-2xl border bg-background transition-colors",
+        "flex flex-col rounded-2xl border border-2 bg-background transition-colors",
         "border-input focus-within:border-ring",
       )}
     >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
@@ -17,12 +17,15 @@ export function TraceAnnotationsList({
   queueId,
   selectedAnnotationId,
   onAnnotationClick,
+  hideAnnotationIntro = false,
 }: {
   readonly projectId: string
   readonly traceId: string
   readonly queueId?: string | undefined
   readonly selectedAnnotationId?: string | undefined
   readonly onAnnotationClick?: ((annotation: AnnotationRecord) => void) | undefined
+  /** When true, omit the Annotations title, count, and helper line (e.g. trace detail tab already shows the label). */
+  readonly hideAnnotationIntro?: boolean | undefined
 }) {
   const {
     data: annotationsData,
@@ -105,16 +108,22 @@ export function TraceAnnotationsList({
           <hr className="border border-border border-dashed" />
         </>
       )}
-      <div className="flex flex-col">
-        <div className="flex items-center gap-1">
-          <Text.H5M>Annotations</Text.H5M>
-          <Text.H5M color="foregroundMuted">{annotationsError ? "–" : annotations.length}</Text.H5M>
-        </div>
+      {!hideAnnotationIntro && (
+        <div className="flex flex-col">
+          <div className="flex items-center gap-1">
+            <Text.H5M>Annotations</Text.H5M>
+            {annotationsError ? (
+              <Text.H5M color="foregroundMuted">–</Text.H5M>
+            ) : annotationsLoading ? null : annotations.length > 0 ? (
+              <Text.H5M color="foregroundMuted">{annotations.length}</Text.H5M>
+            ) : null}
+          </div>
 
-        <Text.H5 color="foregroundMuted">
-          Select text, a message or annotate the entire conversation in this section
-        </Text.H5>
-      </div>
+          <Text.H5 color="foregroundMuted">
+            Select text, a message or annotate the entire conversation in this section
+          </Text.H5>
+        </div>
+      )}
 
       {/* Input and list */}
       <div className="flex flex-col gap-4">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -81,6 +81,8 @@ interface ProjectTracesTableProps {
   readonly traceMetrics?: TraceMetrics | null | undefined
   readonly metricsLoading?: boolean | undefined
   readonly baselines?: Baselines | undefined
+  readonly scrollAreaLayout?: "fill" | "intrinsic"
+  readonly scrollContainerClassName?: string
 }
 
 export function ProjectTracesTable({
@@ -101,6 +103,8 @@ export function ProjectTracesTable({
   traceMetrics,
   metricsLoading,
   baselines,
+  scrollAreaLayout,
+  scrollContainerClassName,
 }: ProjectTracesTableProps) {
   const showMetricSubheaders = traceMetrics !== undefined || metricsLoading !== undefined
 
@@ -313,6 +317,8 @@ export function ProjectTracesTable({
     <InfiniteTable
       data={data}
       {...(isLoading !== undefined ? { isLoading } : {})}
+      {...(scrollAreaLayout !== undefined ? { scrollAreaLayout } : {})}
+      {...(scrollContainerClassName !== undefined ? { className: scrollContainerClassName } : {})}
       columns={columns}
       getRowKey={(trace) => trace.traceId}
       {...(onTraceClick

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -18,7 +18,7 @@ import { type RefObject, useCallback, useMemo, useState } from "react"
 import { useSessionMetrics, useSessionsInfiniteScroll } from "../../../../../domains/sessions/sessions.collection.ts"
 import type { SessionRecord } from "../../../../../domains/sessions/sessions.functions.ts"
 import { listTracesByProject, type TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
-import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { FiltersSidebar } from "./filters-sidebar.tsx"
 import { TableMetricSubheader } from "./table/metric-subheader.tsx"
@@ -446,6 +446,7 @@ export function SessionsView({
       )}
       <Layout.List>
         <InfiniteTable
+          {...listingLayoutIntrinsicScroll.infiniteTable}
           data={tableData}
           isLoading={isLoading}
           columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   Text,
   Tooltip,
-  useMountEffect,
 } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import {
@@ -22,8 +21,9 @@ import {
   MessageSquareIcon,
   MessagesSquareIcon,
 } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../components/hotkey-badge.tsx"
+import { useAnnotationsByTrace } from "../../../../../domains/annotations/annotations.collection.ts"
 import type { AnnotationRecord } from "../../../../../domains/annotations/annotations.functions.ts"
 import { useTraceDetail } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
@@ -59,6 +59,34 @@ const TABS: TabOption<TabId>[] = [
   },
 ]
 
+function isTraceDetailTab(v: string): v is TabId {
+  return v === "trace" || v === "conversation" || v === "spans" || v === "annotations"
+}
+
+const annotationTabCountPillClass =
+  "inline-flex min-h-5 min-w-[1.125rem] shrink-0 items-center justify-center rounded-full bg-muted px-1.5 text-[0.6875rem] font-medium leading-none text-muted-foreground"
+
+function getAnnotationTabSuffix({
+  annotationsByTraceError,
+  annotationsByTraceLoading,
+  annotationCount,
+}: {
+  readonly annotationsByTraceError: boolean
+  readonly annotationsByTraceLoading: boolean
+  readonly annotationCount: number
+}): ReactNode {
+  if (annotationsByTraceError) {
+    return <span className={annotationTabCountPillClass}>–</span>
+  }
+  if (annotationsByTraceLoading) {
+    return null
+  }
+  if (annotationCount === 0) {
+    return null
+  }
+  return <span className={cn(annotationTabCountPillClass, "tabular-nums")}>{annotationCount}</span>
+}
+
 export function TraceDetailDrawer({
   traceId,
   trace,
@@ -71,7 +99,6 @@ export function TraceDetailDrawer({
   onPrevTrace,
   canNavigateNext,
   canNavigatePrev,
-  onTabChange,
 }: {
   readonly traceId: string
   readonly trace?: TraceRecord | undefined
@@ -84,16 +111,40 @@ export function TraceDetailDrawer({
   readonly onPrevTrace?: () => void
   readonly canNavigateNext: boolean
   readonly canNavigatePrev: boolean
-  readonly onTabChange?: (tab: TabId) => void
 }) {
   const { data: traceDetail, isLoading: isDetailLoading } = useTraceDetail({
     projectId,
     traceId,
   })
+  const {
+    data: annotationsByTraceData,
+    isLoading: annotationsByTraceLoading,
+    isError: annotationsByTraceError,
+  } = useAnnotationsByTrace({
+    projectId,
+    traceId,
+    draftMode: "include",
+  })
+  const annotationCount = annotationsByTraceData?.items?.length ?? 0
+  const annotationTabSuffix = useMemo(
+    () =>
+      getAnnotationTabSuffix({
+        annotationsByTraceError,
+        annotationsByTraceLoading,
+        annotationCount,
+      }),
+    [annotationsByTraceError, annotationsByTraceLoading, annotationCount],
+  )
+  const tabsWithAnnotationCount = useMemo<TabOption<TabId>[]>(
+    () => TABS.map((tab) => (tab.id === "annotations" ? { ...tab, suffix: annotationTabSuffix } : tab)),
+    [annotationTabSuffix],
+  )
   const isRecordLoading = !trace && !traceDetail
   const traceRecord: TraceRecord | undefined = traceDetail ?? trace
-  const [activeTab, setActiveTab] = useState<TabId>("trace")
-  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(() => new Set(["trace"]))
+  const [activeTab, setActiveTab] = useParamState("traceDetailTab", "trace", {
+    validate: isTraceDetailTab,
+  })
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(() => new Set([activeTab]))
   const [selectedSpanId, setSelectedSpanId] = useParamState("spanId", "")
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const textSelectionPopoverControlsRef = useRef<TextSelectionPopoverControls | null>(null)
@@ -105,14 +156,13 @@ export function TraceDetailDrawer({
     textSelectionPopoverControlsRef,
   })
 
-  useMountEffect(() => {
-    onTabChange?.("trace")
-  })
+  useEffect(() => {
+    setVisitedTabs((prev) => new Set([...prev, activeTab]))
+  }, [activeTab])
 
   function handleSetActiveTab(tab: TabId) {
     setActiveTab(tab)
     setVisitedTabs((prev) => new Set([...prev, tab]))
-    onTabChange?.(tab)
   }
 
   function handleAnnotationClick(annotation: AnnotationRecord) {
@@ -242,7 +292,7 @@ export function TraceDetailDrawer({
             <CopyableText value={traceId} displayValue={traceId.slice(0, 7)} size="sm" tooltip="Copy trace ID" />
           </div>
 
-          <Tabs options={TABS} active={activeTab} onSelect={handleSetActiveTab} />
+          <Tabs options={tabsWithAnnotationCount} active={activeTab} onSelect={handleSetActiveTab} />
         </>
       }
     >
@@ -285,7 +335,12 @@ export function TraceDetailDrawer({
       </div>
       <div className={cn("flex flex-col flex-1 overflow-hidden", { hidden: activeTab !== "annotations" })}>
         {visitedTabs.has("annotations") && (
-          <TraceAnnotationsList projectId={projectId} traceId={traceId} onAnnotationClick={handleAnnotationClick} />
+          <TraceAnnotationsList
+            projectId={projectId}
+            traceId={traceId}
+            hideAnnotationIntro
+            onAnnotationClick={handleAnnotationClick}
+          />
         )}
       </div>
     </DetailDrawer>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -138,10 +138,10 @@ function UsageRow({
       </Tooltip>
 
       <div className="flex items-center gap-2 self-center">
+        {badges}
         <Text.H5 color="foreground" noWrap>
           {formattedTotal}
         </Text.H5>
-        {badges}
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/helpers.ts
@@ -1,3 +1,6 @@
+/** Horizontal inset for waterfall bars & time labels so bars don’t touch column edges (matches `px-3`). */
+export const WATERFALL_H_INSET_PX = 12
+
 export const ROW_HEIGHT = 32
 export const INDENT_PX = 16
 export const MIN_TREE_WIDTH = 180

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/index.tsx
@@ -4,7 +4,13 @@ import { ChevronsDownUpIcon, ChevronsUpDownIcon, MaximizeIcon, MinimizeIcon } fr
 import { useCallback, useMemo, useRef, useState } from "react"
 import { HotkeyBadge } from "../../../../../../../../../components/hotkey-badge.tsx"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { MIN_TREE_WIDTH, MIN_WATERFALL_WIDTH, MINIMIZED_MAX_HEIGHT, ROW_HEIGHT } from "./helpers.ts"
+import {
+  MIN_TREE_WIDTH,
+  MIN_WATERFALL_WIDTH,
+  MINIMIZED_MAX_HEIGHT,
+  ROW_HEIGHT,
+  WATERFALL_H_INSET_PX,
+} from "./helpers.ts"
 import { TreeRow } from "./tree-row.tsx"
 import { buildSpanTree, flattenTree, formatDuration, getTraceTimeRange } from "./tree-utils.ts"
 import { useResizablePanel } from "./use-resizable-panel.ts"
@@ -155,7 +161,10 @@ export function SpanTree({
           )}
         </div>
         <div className="shrink-0 w-px self-stretch bg-border" />
-        <div className="flex-1 flex flex-row items-center justify-between px-2">
+        <div
+          className="flex-1 flex flex-row items-center justify-between min-w-0"
+          style={{ paddingLeft: WATERFALL_H_INSET_PX, paddingRight: WATERFALL_H_INSET_PX }}
+        >
           <Text.H6 color="foregroundMuted">0ms</Text.H6>
           <Text.H6 color="foregroundMuted">{formatDuration(timeRange.totalDuration)}</Text.H6>
         </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/tree-row.tsx
@@ -1,7 +1,7 @@
 import { cn, Text } from "@repo/ui"
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
 import { memo } from "react"
-import { INDENT_PX, ROW_HEIGHT, statusTextColor } from "./helpers.ts"
+import { INDENT_PX, ROW_HEIGHT, statusTextColor, WATERFALL_H_INSET_PX } from "./helpers.ts"
 import { SpanIcon } from "./span-icon.tsx"
 import type { FlattenedNode, TraceTimeRange } from "./tree-utils.ts"
 import { formatDuration } from "./tree-utils.ts"
@@ -110,7 +110,9 @@ export const TreeRow = memo(function TreeRow({
       </div>
 
       <div className="flex-1 relative h-full min-w-0">
-        <WaterfallBar span={node.span} timeRange={timeRange} />
+        <div className="absolute inset-y-0 min-w-0" style={{ left: WATERFALL_H_INSET_PX, right: WATERFALL_H_INSET_PX }}>
+          <WaterfallBar span={node.span} timeRange={timeRange} />
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-tree/waterfall.tsx
@@ -1,7 +1,7 @@
 import { cn, Text } from "@repo/ui"
 import { useCallback, useMemo, useState } from "react"
 import type { SpanRecord } from "../../../../../../../../../domains/spans/spans.functions.ts"
-import { statusBarColor } from "./helpers.ts"
+import { statusBarColor, WATERFALL_H_INSET_PX } from "./helpers.ts"
 import type { TraceTimeRange } from "./tree-utils.ts"
 import { formatDuration } from "./tree-utils.ts"
 
@@ -44,8 +44,16 @@ export function useWaterfallCursor({
       const rect = containerRef.current.getBoundingClientRect()
       const x = e.clientX - rect.left
       const waterfallStart = treeWidth + 1
-      if (x >= waterfallStart) {
-        setCursorX(x - waterfallStart)
+      const relX = x - waterfallStart
+      const waterfallWidth = containerRef.current.offsetWidth - treeWidth - 1
+      const g = WATERFALL_H_INSET_PX
+      const trackWidth = waterfallWidth - 2 * g
+      if (relX < 0 || waterfallWidth <= 0 || trackWidth <= 0) {
+        setCursorX(null)
+        return
+      }
+      if (relX >= g && relX <= waterfallWidth - g) {
+        setCursorX(relX)
       } else {
         setCursorX(null)
       }
@@ -58,8 +66,10 @@ export function useWaterfallCursor({
   const cursorTimeLabel = useMemo(() => {
     if (cursorX === null || !containerRef.current || timeRange.totalDuration === 0) return null
     const waterfallWidth = containerRef.current.offsetWidth - treeWidth - 1
-    if (waterfallWidth <= 0) return null
-    const fraction = cursorX / waterfallWidth
+    const g = WATERFALL_H_INSET_PX
+    const trackWidth = waterfallWidth - 2 * g
+    if (waterfallWidth <= 0 || trackWidth <= 0) return null
+    const fraction = (cursorX - g) / trackWidth
     return formatDuration(fraction * timeRange.totalDuration)
   }, [cursorX, containerRef, treeWidth, timeRange])
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -170,7 +170,6 @@ export function TraceTab({
 
   const durationValue = traceRecord ? (
     <span className="flex items-center gap-1">
-      {traceRecord.durationNs > 0 ? formatDuration(traceRecord.durationNs) : "-"}
       {durationBadge ? (
         <PercentileStatus
           level={durationBadge}
@@ -186,12 +185,12 @@ export function TraceTab({
           }
         />
       ) : null}
+      {traceRecord.durationNs > 0 ? formatDuration(traceRecord.durationNs) : "-"}
     </span>
   ) : undefined
 
   const ttftValue = traceRecord ? (
     <span className="flex items-center gap-1">
-      {traceRecord.timeToFirstTokenNs > 0 ? formatDuration(traceRecord.timeToFirstTokenNs) : "-"}
       {ttftBadge ? (
         <PercentileStatus
           level={ttftBadge}
@@ -207,6 +206,7 @@ export function TraceTab({
           }
         />
       ) : null}
+      {traceRecord.timeToFirstTokenNs > 0 ? formatDuration(traceRecord.timeToFirstTokenNs) : "-"}
     </span>
   ) : undefined
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -5,7 +5,7 @@ import { useHotkeys } from "@tanstack/react-hotkeys"
 import { type RefObject, useCallback, useMemo } from "react"
 import { useTraceMetrics, useTracesInfiniteScroll } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
-import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { FiltersSidebar } from "./filters-sidebar.tsx"
 import { DEFAULT_TRACE_TABLE_SORTING, ProjectTracesTable, type TraceColumnId } from "./project-traces-table.tsx"
@@ -128,6 +128,7 @@ export function TracesView({
       )}
       <Layout.List>
         <ProjectTracesTable
+          {...listingLayoutIntrinsicScroll.projectTracesTable}
           data={traces}
           isLoading={isLoading}
           visibleColumnIds={visibleColumnIds}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/$queueId/index.tsx
@@ -12,7 +12,10 @@ import { useAnnotationQueue } from "../../../../../../domains/annotation-queues/
 import { useMemberByUserIdMap } from "../../../../../../domains/members/members.collection.ts"
 import { pickUserFromMembersMap } from "../../../../../../domains/members/pick-users-from-members.ts"
 import { useProjectsCollection } from "../../../../../../domains/projects/projects.collection.ts"
-import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import {
+  ListingLayout as Layout,
+  listingLayoutIntrinsicScroll,
+} from "../../../../../../layouts/ListingLayout/index.tsx"
 import { QueueBadge } from "../-components/queue-badge.tsx"
 import { QueueItemStatusBadge } from "../-components/queue-item-status-badge.tsx"
 
@@ -131,6 +134,7 @@ function AnnotationQueueItemsPage() {
       <Layout.Body>
         <Layout.List>
           <InfiniteTable
+            {...listingLayoutIntrinsicScroll.infiniteTable}
             data={items}
             isLoading={itemsLoading}
             columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
@@ -22,7 +22,7 @@ import type { AnnotationQueueRecord } from "../../../../../domains/annotation-qu
 import { useMemberByUserIdMap } from "../../../../../domains/members/members.collection.ts"
 import { pickUsersFromMembersMap } from "../../../../../domains/members/pick-users-from-members.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
-import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { AqListBreadcrumb } from "./-components/aq-list-breadcrumb.tsx"
 import { DeleteQueueModal } from "./-components/delete-queue-modal.tsx"
 import { QueueBadge } from "./-components/queue-badge.tsx"
@@ -187,6 +187,7 @@ function AnnotationQueuesPage() {
       <Layout.Body>
         <Layout.List>
           <InfiniteTable
+            {...listingLayoutIntrinsicScroll.infiniteTable}
             data={queues}
             isLoading={isLoading}
             columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/$datasetId.tsx
@@ -30,7 +30,7 @@ import {
   saveDatasetCsv,
   updateDatasetRow,
 } from "../../../../../domains/datasets/datasets.functions.ts"
-import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { type BulkSelection, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
@@ -623,6 +623,7 @@ function DatasetRowsView({
           </Layout.Actions>
           <Layout.List>
             <InfiniteTable<DatasetRowRecord>
+              {...listingLayoutIntrinsicScroll.infiniteTable}
               data={displayRows}
               isLoading={isLoading}
               columns={rowColumns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -16,7 +16,7 @@ import { useCallback, useState } from "react"
 import { useDatasetsInfiniteScroll } from "../../../../../domains/datasets/datasets.collection.ts"
 import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
 import { createDatasetMutation } from "../../../../../domains/datasets/datasets.mutations.ts"
-import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { useRouteProject } from "../-route-data.ts"
@@ -127,6 +127,7 @@ function DatasetsPage() {
         </Layout.Actions>
         <Layout.List>
           <InfiniteTable
+            {...listingLayoutIntrinsicScroll.infiniteTable}
             data={datasets}
             isLoading={isLoading}
             columns={columns}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -125,8 +125,10 @@ function ProjectPage() {
     serializeTraceColumnIds(DEFAULT_TRACE_COLUMNS),
   )
 
-  // Tracks which drawer tab is active so J/K knows when to defer to span navigation
-  const [activeDrawerTab, setActiveDrawerTab] = useState<string>("trace")
+  const [traceDetailTab, setTraceDetailTab] = useParamState("traceDetailTab", "trace", {
+    validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
+      v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
+  })
 
   // Ref to the ordered list of trace IDs from the currently loaded table page
   const traceIdsRef = useRef<string[]>([])
@@ -200,7 +202,8 @@ function ProjectPage() {
   const closeTraceDrawer = useCallback(() => {
     setActiveTraceId("")
     setSelectedSpanId("")
-  }, [setActiveTraceId, setSelectedSpanId])
+    setTraceDetailTab("trace")
+  }, [setActiveTraceId, setSelectedSpanId, setTraceDetailTab])
 
   const onActiveTraceChange = (traceId: string | undefined) => {
     if (!traceId) {
@@ -252,7 +255,7 @@ function ProjectPage() {
     filters,
     filtersOpen,
     activeTraceId: activeTraceId || undefined,
-    activeDrawerTab,
+    activeDrawerTab: traceDetailTab,
     baselines: cohortSummary?.baselines,
     sorting,
     onSortingChange,
@@ -383,7 +386,6 @@ function ProjectPage() {
             onPrevTrace={onPrevTrace}
             canNavigateNext={canNavigateNext}
             canNavigatePrev={canNavigatePrev}
-            onTabChange={setActiveDrawerTab}
           />
         </Layout.Aside>
       ) : null}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -40,13 +40,13 @@ import {
   type TraceColumnId,
 } from "../../-components/project-traces-table.tsx"
 import { IssueDrawerEvaluations } from "./issue-drawer-evaluations.tsx"
-import { formatSeenAgeParts } from "./issue-formatters.ts"
+import { formatIssueAgeAgoLabel, formatSeenAgeParts } from "./issue-formatters.ts"
 import { IssueLifecycleStatuses } from "./issue-lifecycle-statuses.tsx"
 import { IssueTrendBar } from "./issue-trend-bar.tsx"
 
 function SummaryField({ label, value }: { readonly label: string; readonly value: ReactNode }) {
   return (
-    <div className="flex shrink-0 flex-col gap-0.5">
+    <div className="flex min-w-0 max-w-full flex-col gap-0.5">
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
       {value}
     </div>
@@ -63,18 +63,39 @@ function SeenAtSummaryValue({
   const { lastSeenLabel, firstSeenLabel } = formatSeenAgeParts(lastSeenAtIso, firstSeenAtIso)
 
   return (
-    <Text.H5 color="foreground" className="flex min-w-0 items-center gap-1 whitespace-nowrap">
-      <Tooltip asChild trigger={<span className="truncate">{lastSeenLabel}</span>}>
+    <Text.H5 color="foreground" className="flex min-w-0 flex-wrap items-center gap-x-1 gap-y-0.5">
+      <Tooltip asChild trigger={<span className="break-words">{lastSeenLabel}</span>}>
         <div className="flex flex-col gap-0.5">
           <Text.H6 color="foregroundMuted">Last seen at</Text.H6>
           <Text.H6B>{new Date(lastSeenAtIso).toLocaleString()}</Text.H6B>
         </div>
       </Tooltip>
-      <span className="text-muted-foreground">/</span>
-      <Tooltip asChild trigger={<span className="truncate">{firstSeenLabel}</span>}>
+      <span className="shrink-0 text-muted-foreground">/</span>
+      <Tooltip asChild trigger={<span className="break-words">{firstSeenLabel}</span>}>
         <div className="flex flex-col gap-0.5">
           <Text.H6 color="foregroundMuted">First seen at</Text.H6>
           <Text.H6B>{new Date(firstSeenAtIso).toLocaleString()}</Text.H6B>
+        </div>
+      </Tooltip>
+    </Text.H5>
+  )
+}
+
+function IssueLifecycleTimestampSummaryValue({
+  tooltipHeading,
+  iso,
+}: {
+  readonly tooltipHeading: string
+  readonly iso: string
+}) {
+  const label = formatIssueAgeAgoLabel(iso)
+
+  return (
+    <Text.H5 color="foreground" className="flex min-w-0 flex-wrap items-center gap-1">
+      <Tooltip asChild trigger={<span className="break-words">{label}</span>}>
+        <div className="flex flex-col gap-0.5">
+          <Text.H6 color="foregroundMuted">{tooltipHeading}</Text.H6>
+          <Text.H6B>{new Date(iso).toLocaleString()}</Text.H6B>
         </div>
       </Tooltip>
     </Text.H5>
@@ -90,7 +111,8 @@ function getLifecycleConfirmation(action: LifecycleConfirmationAction) {
     case "ignore":
       return {
         title: "Ignore issue",
-        description: "Mark this issue as ignored. We won't alert you about new ocurrences of this issue anymore",
+        description:
+          "Mark this issue as ignored. We won't monitor or alert you about new occurrences of this issue anymore",
         confirmLabel: "Ignore",
         confirmIcon: PauseIcon,
         confirmVariant: "destructive" as const,
@@ -160,13 +182,14 @@ export function IssueDetailDrawer({
       search: {
         tab: "traces",
         traceId,
+        traceDetailTab: "annotations",
       },
     })
   }
 
   const getTraceRowAriaLabel = (input: { readonly traceId: string; readonly rootSpanName: string }) => {
     const shortName = input.rootSpanName || input.traceId.slice(0, 8)
-    return `Open trace ${shortName} in traces dashboard`
+    return `Open trace ${shortName} with annotations tab in traces dashboard`
   }
 
   const runLifecycleCommand = async (command: "resolve" | "unresolve" | "ignore" | "unignore", override?: boolean) => {
@@ -310,11 +333,11 @@ export function IssueDetailDrawer({
       >
         <div className="flex flex-col flex-1 overflow-y-auto p-6 gap-6">
           <div className="flex flex-col gap-4">
-            <div className="flex flex-row items-start gap-8">
+            <div className="flex flex-row flex-wrap content-start items-start gap-x-8 gap-y-4">
               {isLoading ? (
                 <SummaryField label="Status" value={<Skeleton className="h-5 w-24" />} />
               ) : issue && issue.states.length > 0 ? (
-                <SummaryField label="Status" value={<IssueLifecycleStatuses states={issue.states} wrap={false} />} />
+                <SummaryField label="Status" value={<IssueLifecycleStatuses states={issue.states} wrap />} />
               ) : null}
               <SummaryField
                 label="Seen at"
@@ -328,6 +351,18 @@ export function IssueDetailDrawer({
                   )
                 }
               />
+              {!isLoading && issue?.resolvedAt ? (
+                <SummaryField
+                  label="Resolved at"
+                  value={<IssueLifecycleTimestampSummaryValue tooltipHeading="Resolved at" iso={issue.resolvedAt} />}
+                />
+              ) : null}
+              {!isLoading && issue?.ignoredAt ? (
+                <SummaryField
+                  label="Ignored at"
+                  value={<IssueLifecycleTimestampSummaryValue tooltipHeading="Ignored at" iso={issue.ignoredAt} />}
+                />
+              ) : null}
               <SummaryField
                 label="Occurrences"
                 value={
@@ -387,21 +422,21 @@ export function IssueDetailDrawer({
             icon={<Icon icon={TextAlignStartIcon} size="sm" />}
             label="Traces"
             defaultOpen
-            contentClassName="pl-0 max-h-none overflow-visible"
+            contentClassName="pl-0 max-h-none overflow-hidden flex flex-col"
           >
-            <div className="flex min-h-72 flex-col">
-              <ProjectTracesTable
-                data={traces}
-                isLoading={tracesLoading}
-                visibleColumnIds={ISSUE_TRACE_COLUMN_IDS}
-                defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
-                onTraceClick={(trace) => handleTraceClick(trace.traceId)}
-                getTraceRowAriaLabel={getTraceRowAriaLabel}
-                rowInteractionRole="link"
-                infiniteScroll={infiniteScroll}
-                blankSlate="This issue has not been seen on any traces yet."
-              />
-            </div>
+            <ProjectTracesTable
+              data={traces}
+              isLoading={tracesLoading}
+              visibleColumnIds={ISSUE_TRACE_COLUMN_IDS}
+              defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
+              onTraceClick={(trace) => handleTraceClick(trace.traceId)}
+              getTraceRowAriaLabel={getTraceRowAriaLabel}
+              rowInteractionRole="link"
+              infiniteScroll={infiniteScroll}
+              blankSlate="This issue has not been seen on any traces yet."
+              scrollAreaLayout="intrinsic"
+              scrollContainerClassName="max-h-[min(28rem,50vh)]"
+            />
           </DetailSection>
         </div>
       </DetailDrawer>
@@ -410,7 +445,7 @@ export function IssueDetailDrawer({
         <Modal.Content dismissible>
           <Modal.Header
             title="Resolve issue"
-            description="Mark this issue as resolved. If this issue starts occurring again we will promote it as regressed"
+            description="Mark this issue as resolved. If this issue starts occurring again we will alert you and promote it as regressed"
           />
           {hasActiveLinkedEvaluations ? (
             <Modal.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-formatters.ts
@@ -37,6 +37,13 @@ export function formatSeenAgeParts(lastSeenAtIso: string, firstSeenAtIso: string
   }
 }
 
+/** Same wording as the “last seen” half of {@link formatSeenAgeParts} (e.g. `3h ago`). */
+export function formatIssueAgeAgoLabel(iso: string): string {
+  const now = Date.now()
+  const t = new Date(iso).getTime()
+  return `${formatCompactElapsed(Math.max(0, now - t))} ago`
+}
+
 export function formatPercent(value: number): string {
   const percent = Math.max(0, value) * 100
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -1,6 +1,6 @@
 import { BarChart, HistogramSkeleton, Skeleton, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
 import type { IssuesListResultRecord } from "../../../../../../domains/issues/issues.functions.ts"
 import { formatDayBucketLabel, formatDayBucketTooltipLabel } from "./issue-formatters.ts"
 
@@ -47,6 +47,21 @@ export function IssuesAnalyticsPanel({
   readonly isLoading: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }) {
+  const histogramBarChartData = useMemo(
+    () =>
+      analytics.histogram.map((bucket) => ({
+        category: formatDayBucketLabel(bucket.bucket).replaceAll(" ", "\u00A0"),
+        tooltipCategory: formatDayBucketTooltipLabel(bucket.bucket),
+        value: bucket.count,
+      })),
+    [analytics.histogram],
+  )
+
+  const formatHistogramTooltip = useCallback(
+    (category: string, value: number) => `${category}<br/><b>${formatCount(value)}</b> occurrences`,
+    [],
+  )
+
   const handleSelect = useCallback(
     (range: { startIndex: number; endIndex: number } | null) => {
       if (!onRangeSelect) return
@@ -93,16 +108,12 @@ export function IssuesAnalyticsPanel({
       ) : (
         <div className="px-4 py-3">
           <BarChart
-            data={analytics.histogram.map((bucket) => ({
-              category: formatDayBucketLabel(bucket.bucket).replaceAll(" ", "\u00A0"),
-              tooltipCategory: formatDayBucketTooltipLabel(bucket.bucket),
-              value: bucket.count,
-            }))}
+            data={histogramBarChartData}
             height={160}
             showYAxis={false}
             xAxisLabelFontSize={10}
             ariaLabel="Issue occurrences by day"
-            formatTooltip={(category, value) => `${category}<br/><b>${formatCount(value)}</b> occurrences`}
+            formatTooltip={formatHistogramTooltip}
             onSelect={onRangeSelect ? handleSelect : undefined}
           />
         </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -3,7 +3,10 @@ import { formatCount } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import type { RefObject } from "react"
 import type { IssueRecord } from "../../../../../../domains/issues/issues.functions.ts"
-import { ListingLayout as Layout } from "../../../../../../layouts/ListingLayout/index.tsx"
+import {
+  ListingLayout as Layout,
+  listingLayoutIntrinsicScroll,
+} from "../../../../../../layouts/ListingLayout/index.tsx"
 import { formatPercent, formatSeenAgeParts } from "./issue-formatters.ts"
 import { IssueLifecycleStatuses } from "./issue-lifecycle-statuses.tsx"
 import { IssueTrendBar } from "./issue-trend-bar.tsx"
@@ -211,6 +214,7 @@ export function IssuesView({
     <Layout.Body>
       <Layout.List>
         <InfiniteTable
+          {...listingLayoutIntrinsicScroll.infiniteTable}
           data={issues}
           isLoading={isLoading}
           columns={columns}

--- a/apps/web/src/routes/design-system/index.tsx
+++ b/apps/web/src/routes/design-system/index.tsx
@@ -34,6 +34,7 @@ import {
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { Check, Moon, Palette, Sparkles, Sun } from "lucide-react"
 import { useState } from "react"
+import { listingLayoutIntrinsicScroll } from "../../layouts/ListingLayout/index.tsx"
 
 export const Route = createFileRoute("/design-system/")({
   component: DesignSystemPage,
@@ -421,6 +422,7 @@ function InfiniteTableSubheaderDemo() {
   return (
     <div className="h-[200px] min-h-0 flex flex-col rounded-lg border border-border/60">
       <InfiniteTable
+        {...listingLayoutIntrinsicScroll.infiniteTable}
         data={data}
         columns={demoTableColumns}
         getRowKey={(r) => r.id}

--- a/packages/ui/src/components/charts/bar-chart.tsx
+++ b/packages/ui/src/components/charts/bar-chart.tsx
@@ -2,7 +2,7 @@
 import type { ECharts, EChartsCoreOption } from "echarts/core"
 import EChartsReact from "echarts-for-react/lib/core"
 import type { ComponentType, CSSProperties, HTMLAttributes } from "react"
-import { useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import { useMountEffect } from "../../hooks/use-mount-effect.ts"
 import { cn } from "../../utils/cn.ts"
@@ -103,6 +103,17 @@ function BarChart({
 
   // Stable event handlers that read the latest onSelect from a ref.
   // This prevents echarts-for-react from rebinding events on every render.
+  const reapplyBrushCursor = useCallback(() => {
+    chartRef.current?.dispatchAction({
+      type: "takeGlobalCursor",
+      key: "brush",
+      brushOption: {
+        brushType: "lineX",
+        brushMode: "single",
+      },
+    })
+  }, [])
+
   const onEvents = useMemo(() => {
     if (!hasBrush) return undefined
     return {
@@ -121,24 +132,23 @@ function BarChart({
         }
         onSelectRef.current?.(null)
       },
+      /**
+       * `notMerge` replaces the full option; brush interaction mode is reset and must be
+       * re-established. `onChartReady` only runs once, so we reapply after each render cycle.
+       */
+      finished: () => {
+        reapplyBrushCursor()
+      },
     }
-  }, [hasBrush])
+  }, [hasBrush, reapplyBrushCursor])
 
   const onChartReady = useMemo(() => {
     if (!hasBrush) return undefined
     return (instance: ECharts) => {
       chartRef.current = instance
-      // Activate brush cursor on every chart init/re-init
-      instance.dispatchAction({
-        type: "takeGlobalCursor",
-        key: "brush",
-        brushOption: {
-          brushType: "lineX",
-          brushMode: "single",
-        },
-      })
+      reapplyBrushCursor()
     }
-  }, [hasBrush])
+  }, [hasBrush, reapplyBrushCursor])
 
   if (!mounted) {
     return (

--- a/packages/ui/src/components/copyable-text/index.tsx
+++ b/packages/ui/src/components/copyable-text/index.tsx
@@ -1,4 +1,4 @@
-import { Check, Clipboard } from "lucide-react"
+import { Check, Copy } from "lucide-react"
 import { useCallback, useRef, useState } from "react"
 import { useMountEffect } from "../../hooks/use-mount-effect.ts"
 import { cn } from "../../utils/cn.ts"
@@ -9,13 +9,14 @@ import { Tooltip } from "../tooltip/tooltip.tsx"
 
 type CopyableTextSize = "sm" | "default"
 
-const SIZE_CONFIG: Record<CopyableTextSize, { buttonClass: string; iconSize: IconSize }> = {
+/** Badge `muted`-like pill; size maps to padding + icon scale. */
+const SIZE_CONFIG: Record<CopyableTextSize, { paddingClass: string; iconSize: IconSize }> = {
   sm: {
-    buttonClass: "gap-1 px-1.5 py-0.5 -mx-1.5",
+    paddingClass: "gap-1 px-1.5 py-0.5",
     iconSize: "xs",
   },
   default: {
-    buttonClass: "gap-2 px-2.5 py-1.5 -mx-2.5",
+    paddingClass: "gap-2 px-2.5 py-1.5",
     iconSize: "sm",
   },
 }
@@ -66,15 +67,17 @@ export function CopyableText({
       type="button"
       onClick={handleCopy}
       className={cn(
-        "flex items-center min-w-0 rounded-md cursor-pointer hover:bg-muted transition-colors",
-        config.buttonClass,
+        "inline-flex w-fit max-w-full shrink-0 items-center self-start rounded-md cursor-pointer transition-colors",
+        "border border-muted-foreground/10 bg-muted text-muted-foreground hover:bg-muted/80",
+        config.paddingClass,
+        ellipsis && "min-w-0",
       )}
     >
       <Label color="foregroundMuted" ellipsis={ellipsis}>
         {displayValue ?? value}
       </Label>
       <Icon
-        icon={copied ? Check : Clipboard}
+        icon={copied ? Check : Copy}
         size={config.iconSize}
         color={copied ? "success" : "foregroundMuted"}
         className="shrink-0"

--- a/packages/ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/ui/src/components/date-range-picker/date-range-picker.tsx
@@ -268,11 +268,11 @@ export function DateRangePicker({
       <PopoverTrigger asChild>
         <Button type="button" variant="outline" size="sm" disabled={disabled} className="w-auto justify-start gap-2">
           <span className="flex items-center gap-2">
-            <Icon icon={CalendarIcon} size="sm" color={selection.selected ? "accentForeground" : "foregroundMuted"} />
+            <Icon icon={CalendarIcon} size="sm" color={selection.selected ? "accentForeground" : "foreground"} />
             <span
               className={cn("whitespace-nowrap", {
-                "text-foreground": selection.selected,
-                "text-muted-foreground": !selection.selected,
+                "text-accent-foreground": selection.selected,
+                "text-foreground": !selection.selected,
               })}
             >
               {selection.label}

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -36,6 +36,7 @@ export function InfiniteTable<T>({
   defaultSorting,
   onSortChange,
   blankSlate,
+  scrollAreaLayout = "fill",
   className,
   expandedRowKeys,
   getExpandedRows,
@@ -139,14 +140,18 @@ export function InfiniteTable<T>({
       )
     ) : null
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className={cn("flex flex-col min-h-0", scrollAreaLayout === "fill" ? "flex-1" : "w-full max-w-full")}>
       {blankSlateContent ? (
         blankSlateContent
       ) : (
         <div
           ref={scrollContainerRef}
           onScroll={handleScroll}
-          className={cn("flex-1 min-h-0 overflow-auto custom-scrollbar", className)}
+          className={cn(
+            scrollAreaLayout === "fill" ? "min-h-0 flex-1" : "min-h-0 w-full max-w-full",
+            "overflow-auto custom-scrollbar",
+            className,
+          )}
         >
           <table
             ref={tableRef}

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -65,6 +65,8 @@ export interface InfiniteTableSharedProps<T> {
   defaultSorting?: InfiniteTableSorting
   onSortChange?: (sorting: InfiniteTableSorting) => void
   blankSlate?: ReactNode | string
+  /** `fill` (default) stretches in a fixed parent; `intrinsic` sizes to content up to scroll `className` max-height. */
+  scrollAreaLayout?: "fill" | "intrinsic"
   className?: string
   expandedRowKeys?: ReadonlySet<string>
   getExpandedRows?: (row: T) => ExpandedRows<T>

--- a/packages/ui/src/components/tabs/tabs.tsx
+++ b/packages/ui/src/components/tabs/tabs.tsx
@@ -122,6 +122,8 @@ export type TabOption<T extends string = string> = {
   readonly id: T
   readonly label: string
   readonly icon?: ReactNode
+  /** Renders after the label (e.g. a count pill). */
+  readonly suffix?: ReactNode
   /** Extra content appended to the tab's tooltip (e.g. a HotkeyBadge). When hideLabels is true the label is automatically prepended. */
   readonly tooltip?: ReactNode
 }
@@ -334,6 +336,7 @@ export function Tabs<T extends string>({
               <>
                 {option.icon}
                 <Text.H5 color={isActive ? "foreground" : "foregroundMuted"}>{option.label}</Text.H5>
+                {option.suffix}
               </>
             )}
           </button>


### PR DESCRIPTION
### Layout & listing tables (intrinsic scroll)

- **`ListingLayout`**: Exported **`listingLayoutIntrinsicScroll`** — preset props for **`InfiniteTable`** and **`ProjectTracesTable`** so scroll height follows table content (`scrollAreaLayout: "intrinsic"`, `max-h-full` / `scrollContainerClassName`), keeping the horizontal scrollbar under the last row when the list is short.
- **`InfiniteTable`**: New optional **`scrollAreaLayout`** (`"fill"` default vs `"intrinsic"`). Intrinsic mode avoids always stretching to fill the parent; documents behavior in **`types.ts`**.
- **`ProjectTracesTable`**: Forwards **`scrollAreaLayout`** and **`scrollContainerClassName`** to **`InfiniteTable`**.
- **Wired `listingLayoutIntrinsicScroll`** on: **Traces**, **Sessions**, **Issues** table, **Annotation queues** (list + queue items), **Datasets** (list + rows), and **Design system** infinite-table demo.
- **`AppSidebar`**: Tighter header spacing (`gap-2` → **`gap-0.5`**).

### Trace detail drawer & project page

- **Active tab in URL**: Trace drawer tab state moved from local React state + `onTabChange` to **`useParamState("traceDetailTab", …)`** with validation; **`ProjectPage`** uses the same search param for hotkeys and **resets `traceDetailTab` to `"trace"`** when closing the drawer.
- **Removed** **`onTabChange`** from **`TraceDetailDrawer`**; **`useMountEffect`** that forced `"trace"` on mount removed; **`visitedTabs`** still tracks lazy-loaded panels; effect syncs visited tabs when **`activeTab`** changes.
- **Annotations tab**:
  - Loads annotation count via **`useAnnotationsByTrace`** (shared query with the list).
  - **`Tabs`**: optional **`suffix`** on **`TabOption`** — **Annotations** shows a **muted rounded pill** with count, **`–`** on error, **nothing** while loading or when count is **0**.
- **`TraceAnnotationsList`**: New **`hideAnnotationIntro`** — hides title, inline count, and helper copy when used in the trace drawer (queue flows unchanged). Count rules: **`–`** on error; **no count** while loading or when **0**.

### Annotations UI (`annotation-card`, `annotation-input`)

- **Linked issue badge**: **`HashIcon` → `ShieldAlertIcon`**, slightly bolder stroke; optional **tooltip** with **issue description** when present.
- **Copy / tooltips**: Shorter agent review copy; **raw vs human feedback** popover only when **`rawFeedback !== humanFeedback`**; popover title **“This feedback has been enriched with AI”**; removed extra tooltips around Latitude/API/draft pencil; **API** badge no longer wrapped in tooltip.
- **`AnnotationInput`**: **Thicker border** (`border` + **`border-2`**).

### Span tree & waterfall

- **`WATERFALL_H_INSET_PX` (12)** in **`helpers.ts`** — horizontal inset for bars/labels (aligned with `px-3`).
- **Span tree header** (`0ms` / total duration): **`min-w-0`** + inset padding instead of bare `px-2`.
- **`TreeRow`**: Waterfall bar inset via absolutely positioned wrapper.
- **`useWaterfallCursor`**: Cursor math uses **inset track width** so time-under-cursor matches the inset bars.

### Trace tab metrics (`trace-tab` / `usage-summary`)

- **Duration & TTFT**: **Percentile badges moved before** the numeric duration (layout order).

### Issues

- **`issue-formatters`**: **`formatIssueAgeAgoLabel`** — same compact **“X ago”** style as “last seen”.
- **`IssueDetailDrawer` — summary row**:
  - **`flex-wrap`** + **`gap-x-8 gap-y-4`**; **`SummaryField`** uses **`min-w-0 max-w-full`**.
  - **Seen at**: **`flex-wrap`**, **`break-words`** instead of nowrap/truncate; **`/`** is **`shrink-0`**.
  - **Resolved at** / **Ignored at** when set: relative label + tooltip with absolute time (**`formatIssueAgeAgoLabel`**).
  - **Status**: **`IssueLifecycleStatuses`** with **`wrap`** enabled.
  - **Ignore modal** copy updated (monitor/alert + spelling **“occurrences”**).
- **Traces section**: **`ProjectTracesTable`** with **`scrollAreaLayout="intrinsic"`** and **`max-h-[min(28rem,50vh)]`**; section **`overflow-hidden flex flex-col`**; removed extra **`min-h-72`** wrapper.
- **Open trace from issue**: **`traceDetailTab: "annotations"`**; **ARIA** label mentions **annotations tab**.
- **Resolve modal**: Copy mentions **alert** when issue regresses.
- **`IssuesAnalyticsPanel`**: **`useMemo`** for histogram **`BarChart` data**; **`useCallback`** for tooltip formatter (stable props for charts).

### Charts (`BarChart`)

- **`takeGlobalCursor`** for brush extracted to **`reapplyBrushCursor`**.
- **`finished`** handler re-applies brush after each render — fixes brush/cursor lost when **`notMerge`** replaces options (e.g. after data refresh).
- **`onChartReady`** calls **`reapplyBrushCursor`** instead of inlining dispatch.

### Copyable text (`CopyableText`)

- Single visual style: **muted pill** (`border`, **`bg-muted`**, **`hover:bg-muted/80`**), **`inline-flex w-fit self-start`** (no full-width stretch), **`Copy`** icon instead of **Clipboard**, **`paddingClass`** instead of negative margins.

### Date range picker

- Trigger: calendar icon and label colors adjusted (**`foreground` / `accent-foreground`** vs previous muted pairing).

### Traces analytics histogram

- **`formatTooltip`** stabilized with **`useCallback`** so **`BarChart`** options do not churn every render.

### Design system

- Infinite table demo uses **`listingLayoutIntrinsicScroll.infiniteTable`**.

---

### Testing / review notes

- **32 files** across **`apps/web`**, **`packages/ui`**; touches routing/search params, annotations, issues, tables, and ECharts brush behavior.
- Manually verify: **trace drawer tabs + URL**, **histogram brush** after filter changes, **issue summary** wrapping and new timestamps, **listing tables** scroll height on short lists.