### PR TITLE
Trace all LLM generation with Latitude Telemetry

### DIFF
--- a/apps/workflows/src/activities/evaluation-alignment-activities.test.ts
+++ b/apps/workflows/src/activities/evaluation-alignment-activities.test.ts
@@ -79,6 +79,14 @@ const organizationId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
 const issueId = IssueId("i".repeat(24))
 
+const alignmentActivityScope = {
+  organizationId: String(organizationId),
+  projectId: String(projectId),
+  issueId: String(issueId),
+  evaluationId: "e".repeat(24) as string | null,
+  jobId: "job-alignment-test",
+}
+
 const insertIssue = async () => {
   await pg.db.insert(issuesTable).values({
     id: issueId,
@@ -319,6 +327,8 @@ describe("evaluation-alignment activities", () => {
     )
 
     const result = await generateEvaluationDetails({
+      ...alignmentActivityScope,
+      evaluationHash: "eh-details-1",
       issueName: "Fabricated refund guarantees in support answers",
       issueDescription: "The agent invents refund or cancellation guarantees not confirmed in the conversation.",
       script,
@@ -351,6 +361,8 @@ describe("evaluation-alignment activities", () => {
     )
 
     const result = await generateEvaluationDetails({
+      ...alignmentActivityScope,
+      evaluationHash: "eh-details-2",
       issueName: "Test issue",
       issueDescription: "Test description",
       script: wrapPromptAsEvaluationScript("Test prompt"),
@@ -374,6 +386,7 @@ describe("evaluation-alignment activities", () => {
     })
 
     const result = await evaluateBaselineEvaluationDraft({
+      ...alignmentActivityScope,
       issueName: "Tool output leakage",
       issueDescription: "Secrets are exposed in assistant tool output.",
       draft: {
@@ -482,6 +495,7 @@ describe("evaluation-alignment activities", () => {
 
   it("returns a no-op incremental refresh when no new examples are available", async () => {
     const result = await evaluateIncrementalEvaluationDraft({
+      ...alignmentActivityScope,
       issueName: "Tool output leakage",
       issueDescription: "Secrets are exposed in assistant tool output.",
       draft: {
@@ -535,6 +549,7 @@ describe("evaluation-alignment activities", () => {
     })
 
     const result = await evaluateIncrementalEvaluationDraft({
+      ...alignmentActivityScope,
       issueName: "Tool output leakage",
       issueDescription: "Secrets are exposed in assistant tool output.",
       draft: {
@@ -601,6 +616,7 @@ describe("evaluation-alignment activities", () => {
     )
 
     const result = await evaluateIncrementalEvaluationDraft({
+      ...alignmentActivityScope,
       issueName: "Tool output leakage",
       issueDescription: "Secrets are exposed in assistant tool output.",
       draft: {
@@ -785,6 +801,11 @@ describe("evaluation-alignment activities", () => {
     )
 
     const result = await optimizeEvaluationDraft({
+      organizationId: String(organizationId),
+      projectId: String(projectId),
+      issueId: String(issueId),
+      evaluationId: null,
+      jobId: "job-opt-test",
       draft: {
         script: baselineScript,
         evaluationHash: "hash-baseline",

--- a/apps/workflows/src/activities/evaluation-alignment-activities.ts
+++ b/apps/workflows/src/activities/evaluation-alignment-activities.ts
@@ -3,6 +3,7 @@ import {
   ALIGNMENT_MANUAL_REALIGNMENT_RATE_LIMIT_MS,
   type BaselineEvaluationResult,
   buildEvaluationAlignmentJobStatus,
+  buildEvaluationGepaSummaryTelemetryCapture,
   type CollectedEvaluationAlignmentExamples,
   collectAlignmentExamplesUseCase,
   EVALUATION_JOB_STATUS_TTL_SECONDS,
@@ -165,6 +166,11 @@ export const generateBaselineEvaluationDraft = (input: {
   )
 
 export const evaluateBaselineEvaluationDraft = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId: string
   readonly issueName: string
   readonly issueDescription: string
   readonly draft: GeneratedEvaluationDraft
@@ -173,8 +179,18 @@ export const evaluateBaselineEvaluationDraft = (input: {
 }): Promise<BaselineEvaluationResult> =>
   Effect.runPromise(
     evaluateBaselineDraftUseCase({
-      ...input,
+      issueName: input.issueName,
+      issueDescription: input.issueDescription,
       script: input.draft.script,
+      positiveExamples: input.positiveExamples,
+      negativeExamples: input.negativeExamples,
+      judgeTelemetry: {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        issueId: input.issueId,
+        evaluationId: input.evaluationId,
+        jobId: input.jobId,
+      },
     }).pipe(
       withAi(AIGenerateLive, getRedisClient()),
       withTracing,
@@ -189,6 +205,11 @@ export const evaluateBaselineEvaluationDraft = (input: {
   )
 
 export const evaluateIncrementalEvaluationDraft = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId?: string | null
   readonly issueName: string
   readonly issueDescription: string
   readonly draft: GeneratedEvaluationDraft
@@ -197,7 +218,21 @@ export const evaluateIncrementalEvaluationDraft = (input: {
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
 }): Promise<IncrementalEvaluationRefreshResult> =>
   Effect.runPromise(
-    evaluateIncrementalDraftUseCase(input).pipe(
+    evaluateIncrementalDraftUseCase({
+      issueName: input.issueName,
+      issueDescription: input.issueDescription,
+      draft: input.draft,
+      previousConfusionMatrix: input.previousConfusionMatrix,
+      positiveExamples: input.positiveExamples,
+      negativeExamples: input.negativeExamples,
+      judgeTelemetry: {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        issueId: input.issueId,
+        evaluationId: input.evaluationId,
+        ...(input.jobId !== undefined ? { jobId: input.jobId } : {}),
+      },
+    }).pipe(
       withAi(AIGenerateLive, getRedisClient()),
       withTracing,
       Effect.mapError(
@@ -211,6 +246,12 @@ export const evaluateIncrementalEvaluationDraft = (input: {
   )
 
 export const generateEvaluationDetails = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId: string
+  readonly evaluationHash: string
   readonly issueName: string
   readonly issueDescription: string
   readonly script: string
@@ -220,6 +261,14 @@ export const generateEvaluationDetails = (input: {
       const ai = yield* AI
       const result = yield* ai.generate({
         ...GEPA_DETAILS_GENERATOR_MODEL,
+        telemetry: buildEvaluationGepaSummaryTelemetryCapture({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          issueId: input.issueId,
+          evaluationId: input.evaluationId,
+          jobId: input.jobId,
+          evaluationHash: input.evaluationHash,
+        }),
         system: GEPA_DETAILS_GENERATOR_SYSTEM_PROMPT,
         prompt: buildGepaDetailsPrompt({
           issueName: input.issueName,

--- a/apps/workflows/src/activities/evaluation-optimization-activities.ts
+++ b/apps/workflows/src/activities/evaluation-optimization-activities.ts
@@ -3,6 +3,7 @@ import {
   ALIGNMENT_DEFAULT_SEED,
   ALIGNMENT_TRAIN_SPLIT,
   ALIGNMENT_VALIDATION_SPLIT,
+  buildEvaluationGepaProposeTelemetryCapture,
   evaluateOptimizationCandidate,
   type GeneratedEvaluationDraft,
   type HydratedEvaluationAlignmentExample,
@@ -43,6 +44,12 @@ class EvaluationOptimizationActivityError extends Data.TaggedError("EvaluationAl
 }
 
 const proposeOptimizationCandidate = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId: string
+  readonly draftEvaluationHash: string
   readonly candidate: OptimizationCandidate
   readonly issueName: string
   readonly issueDescription: string
@@ -60,6 +67,15 @@ const proposeOptimizationCandidate = (input: {
       const ai = yield* AI
       const result = yield* ai.generate({
         ...GEPA_PROPOSER_MODEL,
+        telemetry: buildEvaluationGepaProposeTelemetryCapture({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          issueId: input.issueId,
+          evaluationId: input.evaluationId,
+          jobId: input.jobId,
+          evaluationHash: input.draftEvaluationHash,
+          candidateHash: input.candidate.hash,
+        }),
         system: GEPA_PROPOSER_SYSTEM_PROMPT,
         prompt: buildGepaProposalPrompt({
           issueName: input.issueName,
@@ -105,6 +121,11 @@ const proposeOptimizationCandidate = (input: {
   )
 
 export const optimizeEvaluationDraft = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId: string
   readonly draft: GeneratedEvaluationDraft
   readonly issueName: string
   readonly issueDescription: string
@@ -151,6 +172,13 @@ export const optimizeEvaluationDraft = (input: {
               example: hydratedExample,
               issueName: input.issueName,
               issueDescription: input.issueDescription,
+              judgeTelemetry: {
+                organizationId: input.organizationId,
+                projectId: input.projectId,
+                issueId: input.issueId,
+                evaluationId: input.evaluationId,
+                jobId: input.jobId,
+              },
             }).pipe(
               withAi(AIGenerateLive, getRedisClient()),
               withTracing,
@@ -166,6 +194,12 @@ export const optimizeEvaluationDraft = (input: {
         },
         propose: ({ candidate, context }: OptimizeProposalInput) =>
           proposeOptimizationCandidate({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            issueId: input.issueId,
+            evaluationId: input.evaluationId,
+            jobId: input.jobId,
+            draftEvaluationHash: input.draft.evaluationHash,
             candidate,
             issueName: input.issueName,
             issueDescription: input.issueDescription,

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
@@ -329,6 +329,12 @@ describe("evaluationAlignmentWorkflow", () => {
     ])
 
     expect(mockActivities.generateEvaluationDetails).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      projectId: "proj-1",
+      issueId: "issue-1",
+      evaluationId: null,
+      jobId: "job-1",
+      evaluationHash: "hash-1",
       issueName: "Tool output leakage",
       issueDescription: "Secrets are exposed in assistant tool output.",
       script: wrapPromptAsEvaluationScript("Placeholder evaluation prompt."),

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
@@ -115,6 +115,11 @@ const runFullAlignment = async (
     })
 
     const optimizedDraft = await optimizeEvaluationDraft({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      issueId: input.issueId,
+      evaluationId: input.evaluationId ?? null,
+      jobId: input.jobId,
       draft: baselineDraft,
       issueName: collected.issueName,
       issueDescription: collected.issueDescription,
@@ -123,6 +128,11 @@ const runFullAlignment = async (
     })
 
     const baselineEvaluation = await evaluateBaselineEvaluationDraft({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      issueId: input.issueId,
+      evaluationId: input.evaluationId ?? null,
+      jobId: input.jobId,
       issueName: collected.issueName,
       issueDescription: collected.issueDescription,
       draft: optimizedDraft,
@@ -136,6 +146,12 @@ const runFullAlignment = async (
           description: existingState.description,
         }
       : await generateEvaluationDetails({
+          organizationId: input.organizationId,
+          projectId: input.projectId,
+          issueId: input.issueId,
+          evaluationId: input.evaluationId ?? null,
+          jobId: input.jobId,
+          evaluationHash: optimizedDraft.evaluationHash,
           issueName: collected.issueName,
           issueDescription: collected.issueDescription,
           script: optimizedDraft.script,
@@ -193,6 +209,7 @@ const runIncrementalMetricRefresh = async (input: {
   readonly projectId: string
   readonly issueId: string
   readonly evaluationId: string
+  readonly jobId: string
 }): Promise<{
   readonly strategy: "no-op" | "metric-only" | "full-reoptimization"
   readonly evaluationId: string
@@ -212,6 +229,11 @@ const runIncrementalMetricRefresh = async (input: {
     requirePositiveExamples: false,
   })
   const refresh = await evaluateIncrementalEvaluationDraft({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    issueId: input.issueId,
+    evaluationId: state.evaluationId,
+    jobId: input.jobId,
     issueName: state.issueName,
     issueDescription: state.issueDescription,
     draft: state.draft,
@@ -337,6 +359,7 @@ export const evaluationAlignmentWorkflow = async (input: EvaluationAlignmentWork
           projectId: input.projectId,
           issueId: input.issueId,
           evaluationId: input.evaluationId,
+          jobId: input.jobId,
         })
 
         if (result.strategy === "full-reoptimization") {

--- a/packages/domain/ai/src/ai-generate-telemetry.ts
+++ b/packages/domain/ai/src/ai-generate-telemetry.ts
@@ -3,15 +3,15 @@
  * Use with `GenerateInput.telemetry` / `GenerateTelemetryCapture`.
  */
 export const AI_GENERATE_TELEMETRY_TAGS = {
-  issueDetails: ["issue", "details"],
-  annotationEnrichPublication: ["annotation", "enrich", "publication"],
-  queueSystemClassify: ["queue", "system", "classify"],
-  queueSystemDraft: ["queue", "system", "draft"],
-  evaluationJudgeLive: ["evaluation", "judge", "live"],
-  evaluationJudgeAlignment: ["evaluation", "judge", "alignment"],
-  evaluationJudgeOptimization: ["evaluation", "judge", "optimization"],
-  evaluationSummaryOptimization: ["evaluation", "summary", "optimization"],
-  evaluationProposeOptimization: ["evaluation", "propose", "optimization"],
+  issueDetails: ["issue:details", "details"],
+  annotationEnrichPublication: ["annotation:enrichment"],
+  queueSystemClassify: ["system-queue:classify"],
+  queueSystemDraft: ["system-queue:draft"],
+  evaluationJudgeLive: ["eval:execute", "live"],
+  evaluationJudgeAlignment: ["eval:execute", "alignment"],
+  evaluationJudgeOptimization: ["eval:execute", "optimization"],
+  evaluationSummaryOptimization: ["gepa:summary"],
+  evaluationProposeOptimization: ["gepa:propose"],
 } as const satisfies Record<string, readonly string[]>
 
 export const AI_GENERATE_TELEMETRY_SPAN_NAMES = {

--- a/packages/domain/ai/src/ai-generate-telemetry.ts
+++ b/packages/domain/ai/src/ai-generate-telemetry.ts
@@ -1,0 +1,51 @@
+/**
+ * Stable tag tuples and span names for Latitude `capture` on structured `AI.generate` calls.
+ * Use with `GenerateInput.telemetry` / `GenerateTelemetryCapture`.
+ */
+export const AI_GENERATE_TELEMETRY_TAGS = {
+  issueDetails: ["issue", "details"],
+  annotationEnrichPublication: ["annotation", "enrich", "publication"],
+  queueSystemClassify: ["queue", "system", "classify"],
+  queueSystemDraft: ["queue", "system", "draft"],
+  evaluationJudgeLive: ["evaluation", "judge", "live"],
+  evaluationJudgeAlignment: ["evaluation", "judge", "alignment"],
+  evaluationJudgeOptimization: ["evaluation", "judge", "optimization"],
+  evaluationSummaryOptimization: ["evaluation", "summary", "optimization"],
+  evaluationProposeOptimization: ["evaluation", "propose", "optimization"],
+} as const satisfies Record<string, readonly string[]>
+
+export const AI_GENERATE_TELEMETRY_SPAN_NAMES = {
+  issueDetails: "issue.details",
+  annotationEnrichPublication: "annotation.enrich.publication",
+  queueSystemClassify: "queue.system.classify",
+  queueSystemDraft: "queue.system.draft",
+  evaluationJudgeLive: "evaluation.judge.live",
+  evaluationJudgeAlignment: "evaluation.judge.alignment",
+  evaluationJudgeOptimization: "evaluation.judge.optimization",
+  evaluationSummaryOptimization: "evaluation.summary.optimization",
+  evaluationProposeOptimization: "evaluation.propose.optimization",
+} as const satisfies Record<string, string>
+
+export type ProjectScopedAiIds = {
+  readonly organizationId: string
+  readonly projectId: string
+}
+
+/**
+ * Metadata for AI generate telemetry: always includes org + project, then subject fields with `undefined` omitted.
+ */
+export const buildProjectScopedAiMetadata = (
+  scope: ProjectScopedAiIds,
+  subject: Record<string, string | number | boolean | null | undefined>,
+): Record<string, unknown> => {
+  const metadata: Record<string, unknown> = {
+    organizationId: scope.organizationId,
+    projectId: scope.projectId,
+  }
+  for (const [key, value] of Object.entries(subject)) {
+    if (value !== undefined) {
+      metadata[key] = value
+    }
+  }
+  return metadata
+}

--- a/packages/domain/ai/src/index.ts
+++ b/packages/domain/ai/src/index.ts
@@ -3,6 +3,12 @@ import { type Effect, ServiceMap } from "effect"
 import type { z } from "zod"
 import type { AICredentialError, AIError } from "./errors.ts"
 
+export {
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  buildProjectScopedAiMetadata,
+  type ProjectScopedAiIds,
+} from "./ai-generate-telemetry.ts"
 export { AICredentialError, AIError } from "./errors.ts"
 export {
   formatGenAIConversation,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
@@ -1,4 +1,4 @@
-import { AIError } from "@domain/ai"
+import { AI_GENERATE_TELEMETRY_TAGS, AIError } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import { type TraceDetail, TraceRepository } from "@domain/spans"
@@ -101,7 +101,7 @@ describe("runSystemQueueAnnotatorUseCase", () => {
     expect(generateCall.system).toContain("Jailbreaking")
     expect(generateCall.telemetry).toMatchObject({
       spanName: "queue.system.draft",
-      tags: ["queue", "system", "draft"],
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
       metadata: {
         organizationId: INPUT.organizationId,
         projectId: INPUT.projectId,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
@@ -100,8 +100,8 @@ describe("runSystemQueueAnnotatorUseCase", () => {
     expect(generateCall.provider).toBe("amazon-bedrock")
     expect(generateCall.system).toContain("Jailbreaking")
     expect(generateCall.telemetry).toMatchObject({
-      spanName: "system-queue-annotator",
-      tags: ["annotation-queue", "system-annotator"],
+      spanName: "queue.system.draft",
+      tags: ["queue", "system", "draft"],
       metadata: {
         organizationId: INPUT.organizationId,
         projectId: INPUT.projectId,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -1,4 +1,12 @@
-import { AI, type AICredentialError, type AIError, formatGenAIMessage } from "@domain/ai"
+import {
+  AI,
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  type AICredentialError,
+  type AIError,
+  buildProjectScopedAiMetadata,
+  formatGenAIMessage,
+} from "@domain/ai"
 import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
 import type { TraceResourceOutlierReason } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
@@ -141,14 +149,12 @@ export const runSystemQueueAnnotatorUseCase = (input: RunSystemQueueAnnotatorInp
       prompt,
       schema: systemQueueAnnotatorOutputSchema,
       telemetry: {
-        spanName: "system-queue-annotator",
-        tags: ["annotation-queue", "system-annotator"],
-        metadata: {
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          traceId: input.traceId,
-          queueSlug: input.queueSlug,
-        },
+        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.queueSystemDraft,
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
+        metadata: buildProjectScopedAiMetadata(
+          { organizationId: input.organizationId, projectId: input.projectId },
+          { traceId: input.traceId, queueSlug: input.queueSlug },
+        ),
       },
     })
 

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
@@ -124,8 +124,8 @@ describe("runSystemQueueFlaggerUseCase", () => {
       ...SYSTEM_QUEUE_FLAGGER_MODEL,
       maxTokens: 256,
       telemetry: {
-        spanName: "system-queue-flagger",
-        tags: ["annotation-queue", "system-flagger"],
+        spanName: "queue.system.classify",
+        tags: ["queue", "system", "classify"],
         metadata: {
           organizationId: INPUT.organizationId,
           projectId: INPUT.projectId,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
@@ -1,4 +1,4 @@
-import { AIError } from "@domain/ai"
+import { AI_GENERATE_TELEMETRY_TAGS, AIError } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, SpanId, TraceId } from "@domain/shared"
 import { type TraceDetail, TraceRepository } from "@domain/spans"
@@ -125,7 +125,7 @@ describe("runSystemQueueFlaggerUseCase", () => {
       maxTokens: 256,
       telemetry: {
         spanName: "queue.system.classify",
-        tags: ["queue", "system", "classify"],
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemClassify],
         metadata: {
           organizationId: INPUT.organizationId,
           projectId: INPUT.projectId,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -1,4 +1,13 @@
-import { AI, type AICredentialError, type AIError, formatGenAIConversation, formatGenAIMessage } from "@domain/ai"
+import {
+  AI,
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  type AICredentialError,
+  type AIError,
+  buildProjectScopedAiMetadata,
+  formatGenAIConversation,
+  formatGenAIMessage,
+} from "@domain/ai"
 import { type NotFoundError, OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
 import {
   evaluateTraceResourceOutliersUseCase,
@@ -267,14 +276,12 @@ const runLlmFlagger = (
       prompt: buildFlaggerPrompt(trace),
       schema: systemQueueFlaggerOutputSchema,
       telemetry: {
-        spanName: "system-queue-flagger",
-        tags: ["annotation-queue", "system-flagger"],
-        metadata: {
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          traceId: input.traceId,
-          queueSlug: input.queueSlug,
-        },
+        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.queueSystemClassify,
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemClassify],
+        metadata: buildProjectScopedAiMetadata(
+          { organizationId: input.organizationId, projectId: input.projectId },
+          { traceId: input.traceId, queueSlug: input.queueSlug },
+        ),
       },
     })
 

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -1,4 +1,12 @@
-import { AI, type AICredentialError, type AIError, formatGenAIMessage } from "@domain/ai"
+import {
+  AI,
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  type AICredentialError,
+  type AIError,
+  buildProjectScopedAiMetadata,
+  formatGenAIMessage,
+} from "@domain/ai"
 import type { AnnotationScoreMetadata } from "@domain/scores"
 import {
   type BadRequestError,
@@ -164,14 +172,18 @@ export const enrichAnnotationForPublicationUseCase = (input: EnrichAnnotationFor
     const result = yield* ai.generate({
       ...ANNOTATION_ENRICHMENT_MODEL,
       telemetry: {
-        spanName: "annotation-publication-enrichment",
-        tags: ["annotation", "publish-enrichment"],
-        metadata: {
-          scoreId: input.scoreId,
-          organizationId: annotationScore.organizationId,
-          projectId: annotationScore.projectId,
-          ...(annotationScore.traceId !== null ? { traceId: annotationScore.traceId } : {}),
-        },
+        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.annotationEnrichPublication,
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.annotationEnrichPublication],
+        metadata: buildProjectScopedAiMetadata(
+          {
+            organizationId: annotationScore.organizationId,
+            projectId: annotationScore.projectId,
+          },
+          {
+            scoreId: input.scoreId,
+            ...(annotationScore.traceId !== null ? { traceId: annotationScore.traceId } : {}),
+          },
+        ),
         ...(resolvedSessionId !== null ? { sessionId: resolvedSessionId } : {}),
       },
       system: ENRICHMENT_SYSTEM_PROMPT,

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -125,6 +125,15 @@ export {
   type PublishLiveEvaluationExecuteInput,
 } from "./ports/live-evaluation-queue-publisher.ts"
 export {
+  buildEvaluationAlignmentJudgeTelemetryCapture,
+  buildEvaluationGepaProposeTelemetryCapture,
+  buildEvaluationGepaSummaryTelemetryCapture,
+  buildEvaluationJudgeLiveTelemetryCapture,
+  buildEvaluationOptimizationJudgeTelemetryCapture,
+  type EvaluationAlignmentJudgeTelemetryScope,
+  type EvaluationOptimizationJudgeTelemetryScope,
+} from "./runtime/ai-telemetry.ts"
+export {
   EVALUATION_CONVERSATION_PLACEHOLDER,
   EVALUATION_SCRIPT_RUNTIME_MODEL,
   EVALUATION_SCRIPT_RUNTIME_SYSTEM_PROMPT,

--- a/packages/domain/evaluations/src/live-execution.test.ts
+++ b/packages/domain/evaluations/src/live-execution.test.ts
@@ -132,11 +132,13 @@ describe("executeLiveEvaluationUseCase", () => {
   it("executes the MVP script bridge through the shared AI service", async () => {
     const telemetry = liveEvaluationExecutionInputSchema.pick({ telemetry: true }).parse({
       telemetry: {
-        spanName: "evaluation.live.execute",
-        tags: ["evaluations", "live"],
+        spanName: "evaluation.judge.live",
+        tags: ["evaluation", "judge", "live"],
         metadata: {
-          evaluationId,
+          organizationId: "o".repeat(24),
           projectId: "p".repeat(24),
+          evaluationId,
+          issueId: "i".repeat(24),
           traceId: "t".repeat(32),
         },
       },

--- a/packages/domain/evaluations/src/live-execution.test.ts
+++ b/packages/domain/evaluations/src/live-execution.test.ts
@@ -1,4 +1,4 @@
-import { AIError, type GenerateInput, type GenerateResult } from "@domain/ai"
+import { AI_GENERATE_TELEMETRY_TAGS, AIError, type GenerateInput, type GenerateResult } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
@@ -133,7 +133,7 @@ describe("executeLiveEvaluationUseCase", () => {
     const telemetry = liveEvaluationExecutionInputSchema.pick({ telemetry: true }).parse({
       telemetry: {
         spanName: "evaluation.judge.live",
-        tags: ["evaluation", "judge", "live"],
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationJudgeLive],
         metadata: {
           organizationId: "o".repeat(24),
           projectId: "p".repeat(24),

--- a/packages/domain/evaluations/src/runtime/ai-telemetry.ts
+++ b/packages/domain/evaluations/src/runtime/ai-telemetry.ts
@@ -1,0 +1,124 @@
+import {
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  buildProjectScopedAiMetadata,
+  type GenerateTelemetryCapture,
+  type ProjectScopedAiIds,
+} from "@domain/ai"
+
+/** Org/project + issue/evaluation context shared by alignment, optimization, and GEPA activities. */
+export type EvaluationAlignmentJudgeTelemetryScope = ProjectScopedAiIds & {
+  readonly issueId: string
+  readonly evaluationId: string | null
+  readonly jobId?: string | null
+}
+
+export type EvaluationOptimizationJudgeTelemetryScope = EvaluationAlignmentJudgeTelemetryScope
+
+const optionalJobIdMetadata = (jobId: string | null | undefined): Record<string, string> =>
+  jobId !== undefined && jobId !== null && jobId.length > 0 ? { jobId } : {}
+
+export const buildEvaluationAlignmentJudgeTelemetryCapture = (input: {
+  readonly scope: EvaluationAlignmentJudgeTelemetryScope
+  readonly traceId: string
+  readonly exampleLabel: "positive" | "negative"
+}): GenerateTelemetryCapture => {
+  const { organizationId, projectId, issueId, evaluationId, jobId } = input.scope
+  return {
+    spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.evaluationJudgeAlignment,
+    tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationJudgeAlignment],
+    metadata: buildProjectScopedAiMetadata(
+      { organizationId, projectId },
+      {
+        issueId,
+        evaluationId,
+        traceId: input.traceId,
+        exampleLabel: input.exampleLabel,
+        ...optionalJobIdMetadata(jobId),
+      },
+    ),
+  }
+}
+
+export const buildEvaluationOptimizationJudgeTelemetryCapture = (input: {
+  readonly scope: EvaluationOptimizationJudgeTelemetryScope
+  readonly candidateHash: string
+  readonly exampleTraceId: string
+}): GenerateTelemetryCapture => {
+  const { organizationId, projectId, issueId, evaluationId, jobId } = input.scope
+  return {
+    spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.evaluationJudgeOptimization,
+    tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationJudgeOptimization],
+    metadata: buildProjectScopedAiMetadata(
+      { organizationId, projectId },
+      {
+        issueId,
+        evaluationId,
+        candidateHash: input.candidateHash,
+        exampleTraceId: input.exampleTraceId,
+        ...optionalJobIdMetadata(jobId),
+      },
+    ),
+  }
+}
+
+export const buildEvaluationJudgeLiveTelemetryCapture = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly evaluationId: string
+  readonly issueId: string
+  readonly traceId: string
+}): GenerateTelemetryCapture => ({
+  spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.evaluationJudgeLive,
+  tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationJudgeLive],
+  metadata: buildProjectScopedAiMetadata(
+    { organizationId: input.organizationId, projectId: input.projectId },
+    {
+      evaluationId: input.evaluationId,
+      issueId: input.issueId,
+      traceId: input.traceId,
+    },
+  ),
+})
+
+export const buildEvaluationGepaSummaryTelemetryCapture = (
+  scope: EvaluationAlignmentJudgeTelemetryScope & { readonly evaluationHash: string },
+): GenerateTelemetryCapture => {
+  const { organizationId, projectId, issueId, evaluationId, jobId, evaluationHash } = scope
+  return {
+    spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.evaluationSummaryOptimization,
+    tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationSummaryOptimization],
+    metadata: buildProjectScopedAiMetadata(
+      { organizationId, projectId },
+      {
+        issueId,
+        evaluationId,
+        evaluationHash,
+        ...optionalJobIdMetadata(jobId),
+      },
+    ),
+  }
+}
+
+export const buildEvaluationGepaProposeTelemetryCapture = (
+  scope: EvaluationAlignmentJudgeTelemetryScope & {
+    readonly evaluationHash: string
+    readonly candidateHash: string
+  },
+): GenerateTelemetryCapture => {
+  const { organizationId, projectId, issueId, evaluationId, jobId, evaluationHash, candidateHash } = scope
+  return {
+    spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.evaluationProposeOptimization,
+    tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationProposeOptimization],
+    metadata: buildProjectScopedAiMetadata(
+      { organizationId, projectId },
+      {
+        issueId,
+        evaluationId,
+        evaluationHash,
+        candidateHash,
+        ...optionalJobIdMetadata(jobId),
+      },
+    ),
+  }
+}

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-baseline-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-baseline-draft.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect"
 import type { HydratedEvaluationAlignmentExample } from "../../alignment/types.ts"
+import type { EvaluationAlignmentJudgeTelemetryScope } from "../../runtime/ai-telemetry.ts"
 import { evaluateDraftAgainstExamplesUseCase } from "./evaluate-draft-against-examples.ts"
 
 export const evaluateBaselineDraftUseCase = (input: {
@@ -8,6 +9,7 @@ export const evaluateBaselineDraftUseCase = (input: {
   readonly script: string
   readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
+  readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
 }) =>
   evaluateDraftAgainstExamplesUseCase({
     issueName: input.issueName,
@@ -15,4 +17,5 @@ export const evaluateBaselineDraftUseCase = (input: {
     script: input.script,
     positiveExamples: input.positiveExamples,
     negativeExamples: input.negativeExamples,
+    judgeTelemetry: input.judgeTelemetry,
   }).pipe(Effect.withSpan("evaluations.evaluateBaselineDraft"))

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
@@ -5,6 +5,10 @@ import type {
   HydratedEvaluationAlignmentExample,
 } from "../../alignment/types.ts"
 import { addConfusionMatrixObservation, deriveEvaluationAlignmentMetrics, emptyConfusionMatrix } from "../../helpers.ts"
+import {
+  buildEvaluationAlignmentJudgeTelemetryCapture,
+  type EvaluationAlignmentJudgeTelemetryScope,
+} from "../../runtime/ai-telemetry.ts"
 import { executeEvaluationScriptWithAI } from "../../runtime/evaluation-execution.ts"
 
 // TODO(eval-sandbox): when sandbox is available, executeEvaluationScript will run arbitrary JS;
@@ -15,6 +19,7 @@ export const evaluateDraftAgainstExamplesUseCase = (input: {
   readonly script: string
   readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
+  readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
 }) =>
   Effect.gen(function* () {
     const examples = [...input.positiveExamples, ...input.negativeExamples]
@@ -29,6 +34,11 @@ export const evaluateDraftAgainstExamplesUseCase = (input: {
           name: input.issueName,
           description: input.issueDescription,
         },
+        telemetry: buildEvaluationAlignmentJudgeTelemetryCapture({
+          scope: input.judgeTelemetry,
+          traceId: String(example.traceId),
+          exampleLabel: example.label,
+        }),
       })
 
       const expectedPositive = example.label === "positive"

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
@@ -11,6 +11,7 @@ import {
   deriveEvaluationAlignmentMetrics,
   emptyConfusionMatrix,
 } from "../../helpers.ts"
+import type { EvaluationAlignmentJudgeTelemetryScope } from "../../runtime/ai-telemetry.ts"
 import { evaluateDraftAgainstExamplesUseCase } from "./evaluate-draft-against-examples.ts"
 
 export const evaluateIncrementalDraftUseCase = (input: {
@@ -20,6 +21,7 @@ export const evaluateIncrementalDraftUseCase = (input: {
   readonly previousConfusionMatrix: ConfusionMatrix
   readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
+  readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
 }) =>
   Effect.gen(function* () {
     const newExampleCount = input.positiveExamples.length + input.negativeExamples.length
@@ -48,6 +50,7 @@ export const evaluateIncrementalDraftUseCase = (input: {
       script: input.draft.script,
       positiveExamples: input.positiveExamples,
       negativeExamples: input.negativeExamples,
+      judgeTelemetry: input.judgeTelemetry,
     })
 
     const decision = decideAlignmentRefreshStrategy({

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -1,4 +1,4 @@
-import { type AI, AIError, type GenerateInput, type GenerateResult } from "@domain/ai"
+import { type AI, AI_GENERATE_TELEMETRY_TAGS, AIError, type GenerateInput, type GenerateResult } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
 import { OutboxEventWriter, type OutboxEventWriterShape } from "@domain/events"
 import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
@@ -830,7 +830,7 @@ describe("runLiveEvaluationUseCase", () => {
     expectImmutableAnalyticsSyncOrder(operations)
     expect(calls.generate[0]?.telemetry).toMatchObject({
       spanName: "evaluation.judge.live",
-      tags: ["evaluation", "judge", "live"],
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.evaluationJudgeLive],
       metadata: {
         organizationId: INPUT.organizationId,
         projectId: INPUT.projectId,

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.test.ts
@@ -829,12 +829,13 @@ describe("runLiveEvaluationUseCase", () => {
     expect(calls.generate).toHaveLength(1)
     expectImmutableAnalyticsSyncOrder(operations)
     expect(calls.generate[0]?.telemetry).toMatchObject({
-      spanName: "evaluation.live.execute",
-      tags: ["evaluations", "live"],
+      spanName: "evaluation.judge.live",
+      tags: ["evaluation", "judge", "live"],
       metadata: {
         organizationId: INPUT.organizationId,
         projectId: INPUT.projectId,
         evaluationId: INPUT.evaluationId,
+        issueId: "i".repeat(24),
         traceId: INPUT.traceId,
       },
     })

--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -1,4 +1,4 @@
-import type { AI, GenerateTelemetryCapture } from "@domain/ai"
+import type { AI } from "@domain/ai"
 import type { OutboxEventWriter } from "@domain/events"
 import {
   type EvaluationScore,
@@ -22,6 +22,7 @@ import type { Evaluation } from "../../entities/evaluation.ts"
 import { getLiveEvaluationEligibility } from "../../helpers.ts"
 import { EvaluationIssueRepository } from "../../ports/evaluation-issue-repository.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
+import { buildEvaluationJudgeLiveTelemetryCapture } from "../../runtime/ai-telemetry.ts"
 import {
   executeLiveEvaluationUseCase,
   type LiveEvaluationExecutionResult,
@@ -112,17 +113,6 @@ const toErroredExecution = (message: string, startedAtMs: number): RunLiveEvalua
   tokens: 0,
   cost: 0,
 })
-const buildLiveEvaluationExecutionTelemetry = (input: RunLiveEvaluationInput): GenerateTelemetryCapture => ({
-  spanName: "evaluation.live.execute",
-  tags: ["evaluations", "live"],
-  metadata: {
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    evaluationId: input.evaluationId,
-    traceId: input.traceId,
-  },
-})
-
 export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
@@ -218,7 +208,13 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
       script: evaluation.script,
       issue: issueContext,
       conversation: traceDetail.allMessages,
-      telemetry: buildLiveEvaluationExecutionTelemetry(input),
+      telemetry: buildEvaluationJudgeLiveTelemetryCapture({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        evaluationId: evaluation.id,
+        issueId: String(evaluation.issueId),
+        traceId: input.traceId,
+      }),
     }).pipe(
       Effect.map(
         (result) =>

--- a/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
+++ b/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
@@ -1,6 +1,10 @@
 import type { OptimizationCandidate, OptimizationTrajectory } from "@domain/optimizations"
 import { Effect } from "effect"
 import type { HydratedEvaluationAlignmentExample } from "../../alignment/types.ts"
+import {
+  buildEvaluationOptimizationJudgeTelemetryCapture,
+  type EvaluationOptimizationJudgeTelemetryScope,
+} from "../../runtime/ai-telemetry.ts"
 import { executeEvaluationScriptWithAI } from "../../runtime/evaluation-execution.ts"
 
 // TODO(eval-sandbox): when sandbox is available, executeEvaluationScript will run arbitrary JS
@@ -10,6 +14,7 @@ export const evaluateOptimizationCandidate = (input: {
   readonly example: HydratedEvaluationAlignmentExample
   readonly issueName: string
   readonly issueDescription: string
+  readonly judgeTelemetry: EvaluationOptimizationJudgeTelemetryScope
 }) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("evaluation.candidateHash", input.candidate.hash)
@@ -22,6 +27,11 @@ export const evaluateOptimizationCandidate = (input: {
         name: input.issueName,
         description: input.issueDescription,
       },
+      telemetry: buildEvaluationOptimizationJudgeTelemetryCapture({
+        scope: input.judgeTelemetry,
+        candidateHash: input.candidate.hash,
+        exampleTraceId: String(input.example.traceId),
+      }),
     })
 
     const expectedPositive = input.example.label === "positive"

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.ts
@@ -118,6 +118,7 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
     }
 
     const issueDetails = yield* generateIssueDetailsUseCase({
+      organizationId: input.organizationId,
       projectId: input.projectId,
       occurrences: [
         {

--- a/packages/domain/issues/src/use-cases/generate-issue-details.test.ts
+++ b/packages/domain/issues/src/use-cases/generate-issue-details.test.ts
@@ -86,6 +86,7 @@ describe("generateIssueDetailsUseCase", () => {
 
     const result = await Effect.runPromise(
       generateIssueDetailsUseCase({
+        organizationId,
         projectId,
         occurrences: [
           {
@@ -131,6 +132,7 @@ describe("generateIssueDetailsUseCase", () => {
 
     const result = await Effect.runPromise(
       generateIssueDetailsUseCase({
+        organizationId,
         projectId,
         issueId: existingIssue.id,
       }).pipe(
@@ -174,6 +176,7 @@ describe("generateIssueDetailsUseCase", () => {
 
     const result = await Effect.runPromise(
       generateIssueDetailsUseCase({
+        organizationId,
         projectId,
         issueId: existingIssue.id,
       }).pipe(

--- a/packages/domain/issues/src/use-cases/generate-issue-details.ts
+++ b/packages/domain/issues/src/use-cases/generate-issue-details.ts
@@ -1,4 +1,11 @@
-import { AI, type AICredentialError, type AIError } from "@domain/ai"
+import {
+  AI,
+  AI_GENERATE_TELEMETRY_SPAN_NAMES,
+  AI_GENERATE_TELEMETRY_TAGS,
+  type AICredentialError,
+  type AIError,
+  buildProjectScopedAiMetadata,
+} from "@domain/ai"
 import { ScoreRepository, type ScoreSource } from "@domain/scores"
 import { IssueId, ProjectId, type RepositoryError } from "@domain/shared"
 import { Effect } from "effect"
@@ -41,6 +48,7 @@ export interface GeneratedIssueDetails {
 }
 
 export interface GenerateIssueDetailsInput {
+  readonly organizationId: string
   readonly projectId: string
   readonly issueId?: string | null
   readonly occurrences?: readonly IssueOccurrenceInput[]
@@ -167,13 +175,15 @@ export const generateIssueDetailsUseCase = (input: GenerateIssueDetailsInput) =>
     const result = yield* ai.generate({
       ...ISSUE_DETAILS_GENERATION_MODEL,
       telemetry: {
-        spanName: "issue-details-generation",
-        tags: ["issues", "llm"],
-        metadata: {
-          projectId: input.projectId,
-          ...(input.issueId ? { issueId: input.issueId } : {}),
-          occurrenceCount: occurrences.length,
-        },
+        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.issueDetails,
+        tags: [...AI_GENERATE_TELEMETRY_TAGS.issueDetails],
+        metadata: buildProjectScopedAiMetadata(
+          { organizationId: input.organizationId, projectId: input.projectId },
+          {
+            ...(input.issueId ? { issueId: input.issueId } : {}),
+            occurrenceCount: occurrences.length,
+          },
+        ),
       },
       system: ISSUE_DETAILS_SYSTEM_PROMPT,
       prompt: buildPrompt({

--- a/packages/domain/issues/src/use-cases/refresh-issue-details.ts
+++ b/packages/domain/issues/src/use-cases/refresh-issue-details.ts
@@ -65,6 +65,7 @@ export const refreshIssueDetailsUseCase = (input: RefreshIssueDetailsInput) =>
     yield* Effect.annotateCurrentSpan("issueId", input.issueId)
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const generatedDetailsResult = yield* generateIssueDetailsUseCase({
+      organizationId: input.organizationId,
       projectId: input.projectId,
       issueId: input.issueId,
     }).pipe(


### PR DESCRIPTION
## Telemetry coverage

### Features that already had `AI.generate` telemetry

- **Issue details** (`generate-issue-details`)
- **Annotation publication enrichment** (`enrich-annotation-for-publication`)
- **System annotation queues — LLM flagger** (`run-system-queue-flagger`)
- **System annotation queues — LLM annotator (draft)** (`run-system-queue-annotator`)
- **Live evaluation script execution** (`run-live-evaluation` → `execute-live-evaluation`, i.e. the structured `AI.generate` used to run the live eval script)

### Features that did not have telemetry and are included in this PR

- **Alignment / draft judging** — `executeEvaluationScriptWithAI` in draft-vs-examples alignment (`evaluate-draft-against-examples` and its baseline / incremental callers)
- **Optimization candidate judging** (`evaluate-optimization-candidate`)
- **GEPA optimization — summary `AI.generate`** (evaluation alignment activities)
- **GEPA optimization — propose `AI.generate`** (evaluation optimization activities)

---

## Tags and metadata by feature

### Issue details (`generate-issue-details`)

Regenerates or proposes issue title/description from recent score feedback (optionally anchored to an existing issue).

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | `issues`, `llm` | `issue:details`, `details` |
| **Metadata** | `projectId`, `issueId`*, `occurrenceCount` | `organizationId`, `projectId`, `issueId`*, `occurrenceCount` |

### Annotation publication enrichment (`enrich-annotation-for-publication`)

Distills raw human feedback into a single clusterable sentence before publication.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | `annotation`, `publish-enrichment` | `annotation:enrichment` |
| **Metadata** | `scoreId`, `organizationId`, `projectId`, `traceId`* | `scoreId`, `organizationId`, `projectId`, `traceId`* |

### System queue LLM flagger (`run-system-queue-flagger`)

LLM triage for behavioral system queues (jailbreak, refusal, etc.) over a trace excerpt.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | `annotation-queue`, `system-flagger` | `system-queue:classify` |
| **Metadata** | `organizationId`, `projectId`, `traceId`, `queueSlug` | `organizationId`, `projectId`, `traceId`, `queueSlug` |

### System queue LLM annotator (`run-system-queue-annotator`)

Drafts human-review feedback for a trace once it matched a system queue.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | `annotation-queue`, `system-annotator` | `system-queue:draft` |
| **Metadata** | `organizationId`, `projectId`, `traceId`, `queueSlug` | `organizationId`, `projectId`, `traceId`, `queueSlug` |

### Live evaluation judge (`run-live-evaluation` → `execute-live-evaluation`)

Runs the persisted evaluation script (LLM-as-judge) against a single live trace.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | `evaluations`, `live` | `eval:execute`, `live` |
| **Metadata** | `organizationId`, `projectId`, `evaluationId`, `traceId` | `organizationId`, `projectId`, `evaluationId`, `traceId` |

### Alignment judge (`executeEvaluationScriptWithAI` in `evaluate-draft-against-examples`)

Scores each alignment example (positive/negative) against a draft script.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | *(no `AI.generate` capture)* | `eval:execute`, `alignment` |
| **Metadata** | *(none)* | `organizationId`, `projectId`, `issueId`, `evaluationId`* (nullable), `traceId` (example), `exampleLabel` (`positive` / `negative`), optional `jobId` |

### Optimization judge (`evaluate-optimization-candidate`)

Scores one optimization candidate against one hydrated example trajectory.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | *(no `AI.generate` capture)* | `eval:execute`, `optimization` |
| **Metadata** | *(none)* | `organizationId`, `projectId`, `issueId`, `evaluationId` (nullable), `candidateHash`, `exampleTraceId`, optional `jobId` |

### GEPA — evaluation details summary (`generateEvaluationDetails` activity)

LLM summarizes name/description for the draft evaluation (GEPA “details” step).

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | *(no `AI.generate` capture)* | `gepa:summary` |
| **Metadata** | *(none)* | `organizationId`, `projectId`, `issueId`, `evaluationId` (nullable), `evaluationHash`, `jobId` |

### GEPA — proposal (`optimizeEvaluationDraft` activity)

LLM proposes an updated candidate script from trajectories and current candidate.

| | **Before** | **Now** |
| --- | --- | --- |
| **Tags** | *(no `AI.generate` capture)* | `gepa:propose` |
| **Metadata** | *(none)* | `organizationId`, `projectId`, `issueId`, `evaluationId` (nullable), `evaluationHash`, `candidateHash`, `jobId` |

---

### Flat list (for dashboards / migrations)

**Distinct tag tokens used before (surfaces that already had telemetry):**  
`annotation`, `annotation-queue`, `evaluations`, `issues`, `llm`, `live`, `publish-enrichment`, `system-annotator`, `system-flagger`

**Distinct tag tokens used now (`AI_GENERATE_TELEMETRY_TAGS`):**  
`alignment`, `annotation:enrichment`, `details`, `eval:execute`, `gepa:propose`, `gepa:summary`, `issue:details`, `live`, `optimization`, `system-queue:classify`, `system-queue:draft`