### PR TITLE
fix(web): make trace names in issue detail drawer real links

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -12,6 +12,7 @@ import {
   Tooltip,
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import { type ReactNode, useCallback, useMemo } from "react"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { TableMetricSubheader } from "./table/metric-subheader.tsx"
@@ -78,6 +79,8 @@ interface ProjectTracesTableProps {
   readonly onTraceClick?: (trace: TraceRecord) => void
   readonly getTraceRowAriaLabel?: (trace: TraceRecord) => string
   readonly rowInteractionRole?: "button" | "link"
+  /** When provided, renders the name column as a real link for accessibility (e.g., open in new tab). */
+  readonly getTraceHref?: (trace: TraceRecord) => string
   readonly traceMetrics?: TraceMetrics | null | undefined
   readonly metricsLoading?: boolean | undefined
   readonly baselines?: Baselines | undefined
@@ -100,6 +103,7 @@ export function ProjectTracesTable({
   onTraceClick,
   getTraceRowAriaLabel,
   rowInteractionRole,
+  getTraceHref,
   traceMetrics,
   metricsLoading,
   baselines,
@@ -125,7 +129,21 @@ export function ProjectTracesTable({
         key: "name",
         header: "Name",
         width: 180,
-        render: (trace) => trace.rootSpanName || trace.traceId.slice(0, 8),
+        render: (trace) => {
+          const displayName = trace.rootSpanName || trace.traceId.slice(0, 8)
+          if (getTraceHref) {
+            return (
+              <Link
+                to={getTraceHref(trace)}
+                onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                className="hover:underline"
+              >
+                {displayName}
+              </Link>
+            )
+          }
+          return displayName
+        },
       },
       {
         key: "tags",
@@ -289,7 +307,7 @@ export function ProjectTracesTable({
           : {}),
       },
     ]
-  }, [showMetricSubheaders, traceMetrics, metricsLoading, baselines])
+  }, [showMetricSubheaders, traceMetrics, metricsLoading, baselines, getTraceHref])
 
   const columns = useMemo(
     () => allColumns.filter((column) => visibleColumnIds.includes(column.key as TraceColumnId)),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -187,6 +187,10 @@ export function IssueDetailDrawer({
     })
   }
 
+  const getTraceHref = (trace: { readonly traceId: string }) => {
+    return `/projects/${projectSlug}?tab=traces&traceId=${trace.traceId}&traceDetailTab=annotations`
+  }
+
   const getTraceRowAriaLabel = (input: { readonly traceId: string; readonly rootSpanName: string }) => {
     const shortName = input.rootSpanName || input.traceId.slice(0, 8)
     return `Open trace ${shortName} with annotations tab in traces dashboard`
@@ -431,6 +435,7 @@ export function IssueDetailDrawer({
               defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
               onTraceClick={(trace) => handleTraceClick(trace.traceId)}
               getTraceRowAriaLabel={getTraceRowAriaLabel}
+              getTraceHref={getTraceHref}
               rowInteractionRole="link"
               infiniteScroll={infiniteScroll}
               blankSlate="This issue has not been seen on any traces yet."


### PR DESCRIPTION
Allows users to right-click and open traces in a new tab by rendering the name column as an actual <Link> element when getTraceHref is provided. The row click handler is preserved for convenience clicking.

https://claude.ai/code/session_01R2ZXhk5GdkQEz2Xh33h2dZ