### PR TITLE
Try fix web build with temporal client dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+public-hoist-pattern[]=@temporalio/*
+public-hoist-pattern[]=@grpc/*
+public-hoist-pattern[]=protobufjs
+public-hoist-pattern[]=@protobufjs/*
+public-hoist-pattern[]=long
+
+confirm-modules-purge=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # ---------------------------------------------------------------------------
 FROM base AS deps
 
-COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 
 # Populate pnpm store from lockfile only for better cache reuse
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -36,9 +36,12 @@ FROM deps AS source
 
 COPY . .
 
-# Skip postinstall scripts (chdb and other dev-only native deps)
+# Skip postinstall scripts (chdb and other dev-only native deps).
+# CI=true tells pnpm to auto-confirm operations like purging node_modules
+# after `.npmrc` public-hoist-pattern changes, which is required in non-TTY
+# Docker builds.
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
-  pnpm install --frozen-lockfile --ignore-scripts --offline
+  CI=true pnpm install --frozen-lockfile --ignore-scripts --offline
 
 # ---------------------------------------------------------------------------
 # Build api — compile api app (turbo builds dependencies automatically)
@@ -133,6 +136,7 @@ COPY --from=build-api /app/apps/api/package.json ./apps/api/package.json
 COPY --from=build-api /app/package.json ./package.json
 COPY --from=build-api /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-api /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-api /app/.npmrc ./.npmrc
 COPY --from=build-api /app/packages ./packages
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -155,6 +159,7 @@ COPY --from=build-ingest /app/apps/ingest/package.json ./apps/ingest/package.jso
 COPY --from=build-ingest /app/package.json ./package.json
 COPY --from=build-ingest /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-ingest /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-ingest /app/.npmrc ./.npmrc
 COPY --from=build-ingest /app/packages ./packages
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -176,6 +181,7 @@ COPY --from=build-workers /app/apps/workers/package.json ./apps/workers/package.
 COPY --from=build-workers /app/package.json ./package.json
 COPY --from=build-workers /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-workers /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-workers /app/.npmrc ./.npmrc
 COPY --from=build-workers /app/packages ./packages
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -205,6 +211,7 @@ COPY --from=build-workflows /app/apps/workflows/src/activities ./apps/workflows/
 COPY --from=build-workflows /app/package.json ./package.json
 COPY --from=build-workflows /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-workflows /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-workflows /app/.npmrc ./.npmrc
 COPY --from=build-workflows /app/packages ./packages
 
 # Install GEPA Python dependencies into a venv via uv
@@ -239,6 +246,7 @@ COPY --from=build-web /app/apps/web/package.json ./apps/web/package.json
 COPY --from=build-web /app/package.json ./package.json
 COPY --from=build-web /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-web /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-web /app/.npmrc ./.npmrc
 COPY --from=build-web /app/packages ./packages
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
@@ -279,6 +287,7 @@ COPY --from=build-migrations /app/apps/workflows ./apps/workflows
 COPY --from=build-migrations /app/package.json ./package.json
 COPY --from=build-migrations /app/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=build-migrations /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build-migrations /app/.npmrc ./.npmrc
 
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
   pnpm install --frozen-lockfile --ignore-scripts

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.168.10",
     "@tanstack/react-start": "1.167.16",
+    "@temporalio/client": "catalog:",
     "better-auth": "catalog:",
     "effect": "catalog:",
     "lucide-react": "^1.8.0",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,9 +20,35 @@ if (existsSync(envFilePath)) {
 const webPortNumber = Effect.runSync(parseEnv("LAT_WEB_PORT", "number", 3000))
 const bundleAnalyze = Effect.runSync(parseEnv("LAT_WEB_BUNDLE_ANALYZE", "boolean", false))
 
+// @temporalio/client ships protobufjs runtime codegen and @grpc/grpc-js. The two
+// packages hold references to each other's module instances, so partial bundling
+// (protobufjs bundled, grpc-js external) breaks gRPC status deserialization and
+// produces "undefined undefined: undefined" errors at connect time.
+// Externalize the entire Temporal dep tree so Node loads one coherent copy at
+// runtime. See `.npmrc` public-hoist-pattern for the matching pnpm hoisting.
+const temporalExternal: (string | RegExp)[] = [
+  /^@temporalio\//,
+  /^@grpc\//,
+  /^protobufjs(\/.*)?$/,
+  /^@protobufjs\//,
+  "long",
+]
+
 export default defineConfig({
   // Nitro server bundle uses its own sourcemap flag (Vite `build.sourcemap` is client-only).
-  plugins: [tanstackStart(), nitro({ sourcemap: true }), tailwindcss(), react()],
+  plugins: [
+    tanstackStart(),
+    nitro({
+      sourcemap: true,
+      rollupConfig: { external: temporalExternal },
+      rolldownConfig: { external: temporalExternal },
+    }),
+    tailwindcss(),
+    react(),
+  ],
+  ssr: {
+    external: ["@temporalio/client", "@temporalio/proto", "@grpc/grpc-js", "protobufjs", "long"],
+  },
   resolve: {
     alias: {
       // tslib's CJS UMD sets __esModule: true without providing a default

--- a/knip.json
+++ b/knip.json
@@ -20,7 +20,7 @@
     "apps/web": {
       "entry": ["src/router.tsx", "src/start.ts", "src/routes/**/*.tsx"],
       "project": ["src/**/*.ts", "src/**/*.tsx"],
-      "ignoreDependencies": []
+      "ignoreDependencies": ["@temporalio/client"]
     },
     "infra": {
       "entry": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.167.16
         version: 1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
+      '@temporalio/client':
+        specifier: 'catalog:'
+        version: 1.16.0
       better-auth:
         specifier: 'catalog:'
         version: 1.5.6(81b6a556f219e9ebb364b9d22b62cec9)


### PR DESCRIPTION
## What

Staging web was failing to connect to Temporal Cloud with an opaque gRPC error:
\`\`\`
TemporalConnectionError: Failed to connect to Temporal at ZONE.aws.api.temporal.io:7233
  (namespace latitude-llm-staging.SOMETHING): Error
  -- rawError: Error: undefined undefined: undefined
  -- code: undefined, details: undefined
\`\`\`

## Why

\`@temporalio/client\` pulls in \`@grpc/grpc-js\` and \`protobufjs\`. Nitro was **partially** bundling the tree — \`protobufjs\` got bundled into an SSR chunk (\`_ssr/protobufjs-*.mjs\`) while \`@grpc/grpc-js\` resolved from \`node_modules\` at runtime. protobufjs uses \`new Function()\` to codegen encoders/decoders at load time, and those generated functions close over whichever protobufjs module instance was active at codegen time. When \`@temporalio/proto\` (bundled) and \`@grpc/grpc-js\` (external) disagree on that instance, gRPC status deserialization silently drops every field → \`undefined undefined: undefined\`.

## Fix

Force the entire Temporal dep tree to live on one side of the bundler boundary: all external, all resolved at runtime from the same pnpm store entry.

- **\`apps/web/vite.config.ts\`** — Nitro \`rollupConfig.external\` + \`rolldownConfig.external\` + \`ssr.external\` all include \`@temporalio/*\`, \`@grpc/*\`, \`protobufjs\`, \`@protobufjs/*\`, \`long\`.
- **\`.npmrc\`** — \`public-hoist-pattern\` for those same packages so Node's upward resolution from \`.output/server/index.mjs\` finds them at \`/app/node_modules/\` in the Docker image. Without this, the externalized requires would fail because the packages only exist nested under \`packages/platform/workflows-temporal/node_modules/\`.
- **\`apps/web/package.json\`** — \`@temporalio/client\` added as a direct dep. Not imported by web source, but declared so the runtime dependency is explicit at the web boundary (knip ignored accordingly).
- **\`Dockerfile\`** — \`.npmrc\` copied into the \`deps\` stage so \`pnpm fetch\` sees the same hoist rules; \`CI=true\` on the install step to auto-confirm the modules-dir purge when hoist patterns change.

## Why not move Temporal calls to workers?

Considered. Rejected: Redis and Postgres clients work fine from web, so "web can't talk to infra" isn't the right principle. The actual issue was bundler-specific to gRPC + protobufjs codegen. With this fix, adding more Temporal use cases in web server functions keeps working.