### PR TITLE
Claude code observability

### DIFF
--- a/.github/workflows/publish-claude-code-telemetry.yml
+++ b/.github/workflows/publish-claude-code-telemetry.yml
@@ -1,0 +1,101 @@
+name: Publish Claude Code Telemetry
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/telemetry/claude-code/**
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Get package version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./packages/telemetry/claude-code/package.json').version")
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version on npm
+        id: check_version
+        run: |
+          NPM_VERSION=$(npm view @latitude-data/claude-code-telemetry version 2>/dev/null || echo "0.0.0")
+          if [ "${{ steps.get_version.outputs.version }}" != "$NPM_VERSION" ]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/claude-code-telemetry build
+
+      - name: Typecheck
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/claude-code-telemetry typecheck
+
+      - name: Lint
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/claude-code-telemetry check
+
+      - name: Test
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/claude-code-telemetry test
+
+      - name: Publish to npm
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm publish --access public --filter @latitude-data/claude-code-telemetry --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract changelog
+        if: steps.check_version.outputs.should_publish == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if [ -f packages/telemetry/claude-code/CHANGELOG.md ]; then
+            awk -v ver="$VERSION" '
+              /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) { found=1; next } }
+              found { print }
+            ' packages/telemetry/claude-code/CHANGELOG.md > release_notes.md
+          fi
+          if [ ! -s release_notes.md ]; then
+            echo "Package updates and improvements" > release_notes.md
+          fi
+          {
+            echo "body<<EOF"
+            cat release_notes.md
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: claude-code-telemetry-${{ steps.get_version.outputs.version }}
+          name: Claude Code Telemetry v${{ steps.get_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: ${{ contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'rc') }}

--- a/docs/claude-code-telemetry.md
+++ b/docs/claude-code-telemetry.md
@@ -1,0 +1,183 @@
+# Claude Code telemetry
+
+Latitude ingests Claude Code sessions via a `Stop` hook that ships the full session transcript as OTLP traces. This page covers the user-facing integration. For the architectural rationale (hooks vs. native OTEL), see [`prd/claude-code-telemetry.md`](../prd/claude-code-telemetry.md).
+
+## User setup
+
+Paste into `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_PROJECT": "my-project-slug",
+    "LATITUDE_BASE_URL": "https://ingest.latitude.so"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook runs on every assistant-turn completion. It reads **new** lines from the session transcript since the last run (state is tracked at `~/.claude/state/latitude/state.json`), converts them into OTLP spans, and POSTs to `${LATITUDE_BASE_URL}/v1/traces` with `Authorization: Bearer ${LATITUDE_API_KEY}` and `X-Latitude-Project: ${LATITUDE_PROJECT}`. The project must already exist under the organization that owns the API key.
+
+## Ingestion shape
+
+Each turn produces three kinds of spans, all routed through the existing `apps/ingest` OTLP endpoint:
+
+| `span.type` | Maps to `Operation` | Carries |
+| --- | --- | --- |
+| `interaction` | `prompt` | Root of the turn. `user_prompt`, `session.id`, `interaction.duration_ms`. |
+| `llm_request` | `chat` | Child of interaction. `model`, token counts (input/output/cache_read/cache_creation), `gen_ai.input.messages`, `gen_ai.output.messages` (full conversation as JSON). |
+| `tool_execution` | `execute_tool` | Child of llm_request, one per tool call. `tool.name`, `tool.id`, `tool.input`, `tool.output`. |
+
+Server-side routing lives in `packages/domain/spans/src/otlp/resolvers/operation.ts` (`CLAUDE_CODE_OPERATION` map) and `packages/domain/spans/src/otlp/content/claude-code.ts`. The `gen_ai.input.messages` / `gen_ai.output.messages` attributes are parsed by the generic `parseGenAICurrent` parser, which takes precedence over `parseClaudeCode`.
+
+## Supported surfaces
+
+| Surface | Works | Why |
+| --- | --- | --- |
+| CLI | ✅ | Reads `~/.claude/settings.json`, spawns the local hook. |
+| Desktop app (Mac/Windows) | ✅ | Shares the same settings file and hook lifecycle. |
+| IDE extensions (VS Code, JetBrains) | ✅ | Invoke Claude Code locally under the hood. |
+| Web app (`claude.ai/code`) | ❌ | Runs in Anthropic's cloud — no filesystem, no local process. |
+
+## Self-hosted
+
+Point the CLI at your own ingest URL:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_BASE_URL": "http://localhost:8787"
+  }
+}
+```
+
+## Local development setup
+
+For testing the hook against your local Latitude stack without publishing to npm.
+
+### 1. Build the CLI
+
+```bash
+pnpm --filter @latitude-data/claude-code-telemetry build
+```
+
+Produces `packages/telemetry/claude-code/dist/index.js`. The dist is pre-built, not live-compiled — rebuild after any source change in `packages/telemetry/claude-code/src/`.
+
+### 2. Point the hook at the local build
+
+In `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_seed_default_api_key_token",
+    "LATITUDE_PROJECT": "default-project",
+    "LATITUDE_BASE_URL": "http://localhost:3002",
+    "LATITUDE_DEBUG": "1"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/ABSOLUTE/PATH/TO/node /Users/<you>/code/latitude/data-llm/packages/telemetry/claude-code/dist/index.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Notes on the config:
+
+- `lat_seed_default_api_key_token` + `default-project` are the seed values from `packages/domain/shared/src/seeds.ts`. Run `pnpm seed` first so they exist.
+- `LATITUDE_BASE_URL` points at the local `apps/ingest` dev server (port 3002 by default).
+- `LATITUDE_DEBUG=1` logs each hook step to stderr.
+- **Do not** use `npx -y @latitude-data/claude-code-telemetry` in local dev — that pulls the published package and ignores your local changes.
+- Omit `"async": true` while debugging. With the default (synchronous), Claude Code waits for the hook and its stderr lands in the same terminal right after the assistant's response — you'll see the `[latitude-claude-code]` debug lines without hunting through log files. Flip `async` on once the setup works; the CLI logs only on failure in that mode.
+
+### 3. Absolute node path (especially for the Desktop app)
+
+GUI-launched apps on macOS get a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and don't see `mise` / `nvm` / `volta` / `homebrew`-installed node binaries. The hook command must use an **absolute path** to node:
+
+```bash
+which node
+# e.g. /Users/<you>/.local/share/mise/installs/node/25.7.0/bin/node
+```
+
+Paste that full path into the `command` field. The version-specific path breaks on node upgrades; two alternatives:
+
+- **Shim** — if your node manager provides one (e.g. `~/.local/share/mise/shims/node`), use it; it re-resolves on every call.
+- **Login shell wrapper** — `"command": "/bin/bash -lc 'node /path/to/dist/index.js'"`. The `-l` flag sources your profile, which activates mise/nvm. Slightly slower per invocation.
+
+### 4. Verify the hook fired
+
+After any prompt in Claude Code:
+
+```bash
+stat -f "%Sm %N" ~/.claude/state/latitude/state.json
+cat ~/.claude/state/latitude/state.json
+```
+
+A recent `updated` timestamp on the entry for your current session = hook ran. If the file doesn't exist at all, the hook never executed — almost always a wrong node path or missing env var. The CLI exits early without writing state if `LATITUDE_API_KEY` or `LATITUDE_PROJECT` is empty.
+
+### 5. Smoke test without Claude Code
+
+Validate the CLI end-to-end against a synthetic transcript:
+
+```bash
+mkdir -p /tmp/latitude-hook-smoke
+cat > /tmp/latitude-hook-smoke/transcript.jsonl <<'EOF'
+{"type":"user","timestamp":"2026-04-17T12:00:00Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","timestamp":"2026-04-17T12:00:02Z","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":5,"output_tokens":2}}}
+EOF
+
+rm -f ~/.claude/state/latitude/state.json
+echo '{"session_id":"smoke","transcript_path":"/tmp/latitude-hook-smoke/transcript.jsonl"}' \
+  | LATITUDE_API_KEY=lat_seed_default_api_key_token \
+    LATITUDE_PROJECT=default-project \
+    LATITUDE_BASE_URL=http://localhost:3002 \
+    LATITUDE_DEBUG=1 \
+    node packages/telemetry/claude-code/dist/index.js
+```
+
+`HTTP 202` = ingest accepted the payload. The trace appears in the web UI after `apps/workers` processes the queue.
+
+### Debugging table
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| No state file after a session | Hook never ran (PATH issue or async swallowing output) | Absolute node path; remove `async: true` |
+| State file updates but never a `2xx` line | `LATITUDE_API_KEY` or `LATITUDE_PROJECT` missing | Both must be in settings.json `env` — hooks don't inherit shell env |
+| HTTP 400 "X-Latitude-Project header is required" | `LATITUDE_PROJECT` unset | Add it to settings.json |
+| HTTP 404 "Project not found" | Slug mismatch or project not in this org | Run `pnpm seed` to create `default-project`; verify org via API key |
+| HTTP 401 "Invalid API key" | Wrong token | Seed token is `lat_seed_default_api_key_token` |
+| Traces visible but `assistantText` empty | `transcript.ts` regression | Run smoke test + `pnpm --filter @latitude-data/claude-code-telemetry test` |
+
+## Privacy
+
+The hook sends the **full conversation** (prompts, assistant responses, tool I/O) to Latitude on every turn. There is no per-attribute opt-in. Users who need to pause telemetry mid-session can set `LATITUDE_CLAUDE_CODE_ENABLED=0` in their shell.
+
+## Package layout
+
+Source lives at `packages/telemetry/claude-code/`. It is published to npm as `@latitude-data/claude-code-telemetry`. The CLI is invoked via `npx -y @latitude-data/claude-code-telemetry`.
+
+Tests: `pnpm --filter @latitude-data/claude-code-telemetry test`.
+
+Server-side Claude Code span tests: `pnpm --filter @domain/spans test src/otlp/tests/claude-code.test.ts`.

--- a/packages/domain/spans/src/otlp/resolvers/operation.ts
+++ b/packages/domain/spans/src/otlp/resolvers/operation.ts
@@ -41,6 +41,7 @@ const VERCEL_OPERATION: Record<string, Operation> = {
 const CLAUDE_CODE_OPERATION: Record<string, string> = {
   llm_request: "chat",
   interaction: "prompt",
+  tool_execution: "execute_tool",
 }
 
 export const operationCandidates = [

--- a/packages/domain/spans/src/otlp/tests/claude-code.test.ts
+++ b/packages/domain/spans/src/otlp/tests/claude-code.test.ts
@@ -67,6 +67,34 @@ describe("Claude Code OTLP span expansion", () => {
     expect(parts?.[0]).toMatchObject({ type: "text", content: "hi claudio" })
   })
 
+  it("maps tool_execution spans to execute_tool operation", () => {
+    const span: OtlpSpan = {
+      traceId: TRACE_ID,
+      spanId: "cccccccccccccccc",
+      parentSpanId: "bbbbbbbbbbbbbbbb",
+      name: "tool:Bash",
+      kind: 1,
+      startTimeUnixNano: "1710590402100000000",
+      endTimeUnixNano: "1710590402200000000",
+      attributes: [
+        str("span.type", "tool_execution"),
+        str("session.id", SESSION),
+        str("user.id", USER_ID),
+        str("tool.name", "Bash"),
+        str("tool.id", "toolu_01ABC"),
+        str("tool.input", '{"command":"ls"}'),
+        str("tool.output", "file1\nfile2"),
+        str("success", "true"),
+      ],
+      status: { code: 1 },
+    }
+
+    const d = runTransform(span)
+
+    expect(d.sessionId).toBe(SESSION)
+    expect(d.operation).toBe("execute_tool")
+  })
+
   it("maps llm_request spans: model, tokens, cache, TTFT, provider", () => {
     const span: OtlpSpan = {
       traceId: TRACE_ID,

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -1,0 +1,81 @@
+# @latitude-data/claude-code-telemetry
+
+Claude Code `Stop` hook that streams session transcripts to [Latitude](https://latitude.so) as OTLP traces. Full conversation fidelity — user prompts, assistant responses, and tool I/O — without the truncation and flag combinatorics of Claude Code's native OpenTelemetry path.
+
+## Setup
+
+Add this to your `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_PROJECT": "my-project-slug",
+    "LATITUDE_BASE_URL": "https://ingest.latitude.so"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+That's it. The hook fires after every assistant turn, reads new lines from the session transcript, converts them into OTLP traces, and POSTs them to `${LATITUDE_BASE_URL}/v1/traces`.
+
+`LATITUDE_PROJECT` is the slug of the Latitude project you want traces to land in — same value you'd pass in the `X-Latitude-Project` header when using the ingest API directly. The project must already exist under the organization that owns your API key.
+
+`async: true` means Claude Code doesn't wait for the HTTP request — your terminal stays snappy.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
+| `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
+| `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override for self-hosted deploys. |
+| `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to turn the hook off without removing it from `settings.json`. |
+| `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
+
+## What gets sent
+
+For each turn, the hook emits:
+
+- One `interaction` span — the user prompt.
+- One `llm_request` span — model, token usage (input/output/cache), and the full assistant response.
+- One `tool_execution` span per tool call — tool name, input, output.
+
+All spans carry `session.id` so they group into a single session in the Latitude UI. State lives in `~/.claude/state/latitude/state.json` so each invocation only processes new transcript lines.
+
+## Privacy
+
+This hook reads your session transcript from disk and sends the **full content** to Latitude — prompts, assistant responses, and tool I/O (including file contents returned by `Read`, `Bash` output, etc.). There is no per-flag opt-in: the moment the hook is installed, everything gets shipped.
+
+If that's not what you want, either:
+- Don't install the hook.
+- Set `LATITUDE_CLAUDE_CODE_ENABLED=0` in your shell before starting a sensitive session.
+
+## Supported surfaces
+
+| Surface | Works |
+| --- | --- |
+| CLI (`claude` in terminal) | ✅ |
+| Desktop app (Mac/Windows) | ✅ |
+| IDE extensions (VS Code, JetBrains) | ✅ |
+| Web app (`claude.ai/code`) | ❌ — runs in Anthropic's cloud; no local hooks. |
+
+## How it fails
+
+The hook is fail-open by design. If the API is unreachable, your key is wrong, or the transcript is malformed, the hook logs to stderr (when `LATITUDE_DEBUG=1`) and exits `0`. It never blocks Claude from finishing a turn.
+
+## License
+
+MIT

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@latitude-data/claude-code-telemetry",
+  "version": "0.0.1",
+  "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
+  "author": "Latitude Data SL <hello@latitude.so>",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "telemetry",
+    "otlp",
+    "opentelemetry",
+    "latitude"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/claude-code"
+  },
+  "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/claude-code#readme",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "latitude-claude-code": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --pool=forks --passWithNoTests --dir src"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "tsup": "^8.0.0",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/packages/telemetry/claude-code/src/client.ts
+++ b/packages/telemetry/claude-code/src/client.ts
@@ -1,0 +1,47 @@
+import type { Logger } from "./logger.ts"
+import type { OtlpExportRequest } from "./types.ts"
+
+export async function postTraces({
+  baseUrl,
+  apiKey,
+  project,
+  payload,
+  logger,
+  timeoutMs = 10_000,
+}: {
+  baseUrl: string
+  apiKey: string
+  project: string
+  payload: OtlpExportRequest
+  logger: Logger
+  timeoutMs?: number
+}): Promise<void> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/traces`
+  const bodyText = JSON.stringify(payload)
+  logger.debug(`POST ${url} (project=${project}, ${bodyText.length} bytes)`)
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "X-Latitude-Project": project,
+      },
+      body: bodyText,
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      logger.warn(`ingest HTTP ${res.status}: ${text.slice(0, 500)}`)
+    } else {
+      logger.debug(`ingest HTTP ${res.status}`)
+    }
+  } catch (err) {
+    logger.warn(`ingest failed: ${String(err)}`)
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/telemetry/claude-code/src/config.ts
+++ b/packages/telemetry/claude-code/src/config.ts
@@ -1,0 +1,16 @@
+interface Config {
+  apiKey: string
+  baseUrl: string
+  project: string
+  enabled: boolean
+  debug: boolean
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const apiKey = env.LATITUDE_API_KEY ?? ""
+  const baseUrl = env.LATITUDE_BASE_URL ?? "https://ingest.latitude.so"
+  const project = env.LATITUDE_PROJECT ?? ""
+  const enabled = (env.LATITUDE_CLAUDE_CODE_ENABLED ?? "1") !== "0" && apiKey !== "" && project !== ""
+  const debug = env.LATITUDE_DEBUG === "1"
+  return { apiKey, baseUrl, project, enabled, debug }
+}

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -1,0 +1,209 @@
+import { postTraces } from "./client.ts"
+import { loadConfig } from "./config.ts"
+import type { Logger } from "./logger.ts"
+import { createLogger } from "./logger.ts"
+import { buildOtlpRequest } from "./otlp.ts"
+import { load, save, stateKey, withLock } from "./state.ts"
+import { buildTurns, discoverSubagentFiles, firstPromptIdOf, readIncremental, readSubagentMeta } from "./transcript.ts"
+import type { HookPayload, SubagentFile, ToolCall, TranscriptRow, Turn } from "./types.ts"
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return ""
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer)
+  }
+  return Buffer.concat(chunks).toString("utf-8")
+}
+
+function parsePayload(raw: string): HookPayload {
+  const trimmed = raw.trim()
+  if (!trimmed) return {}
+  try {
+    return JSON.parse(trimmed) as HookPayload
+  } catch {
+    return {}
+  }
+}
+
+function pickSession(p: HookPayload): { sessionId?: string | undefined; transcriptPath?: string | undefined } {
+  return {
+    sessionId: p.session_id ?? p.sessionId,
+    transcriptPath: p.transcript_path ?? p.transcriptPath,
+  }
+}
+
+async function main(): Promise<void> {
+  const config = loadConfig()
+  const logger = createLogger(config.debug)
+
+  if (!config.enabled) {
+    if (config.apiKey === "") logger.debug("disabled: LATITUDE_API_KEY is empty")
+    if (config.project === "") logger.debug("disabled: LATITUDE_PROJECT is empty")
+    return
+  }
+  logger.debug(`enabled: project=${config.project} base=${config.baseUrl}`)
+
+  const raw = await readStdin()
+  const payload = parsePayload(raw)
+  const { sessionId, transcriptPath } = pickSession(payload)
+  if (!sessionId || !transcriptPath) {
+    logger.debug(`missing session_id or transcript_path in hook payload (stdin was ${raw.length} bytes)`)
+    return
+  }
+  logger.debug(`session=${sessionId} transcript=${transcriptPath}`)
+
+  await withLock(() => {
+    const key = stateKey(sessionId, transcriptPath)
+    const prior = load(key)
+    logger.debug(`prior offset=${prior.offset} turnCount=${prior.turnCount}`)
+
+    const { rows, newOffset, newBuffer } = readIncremental(transcriptPath, prior.offset, prior.buffer)
+    logger.debug(`read ${rows.length} rows; newOffset=${newOffset}`)
+
+    if (rows.length === 0) {
+      save(key, { ...prior, offset: newOffset, buffer: newBuffer })
+      return
+    }
+
+    const turns = buildTurns(rows)
+    logger.debug(`assembled ${turns.length} turn(s)`)
+    if (turns.length === 0) {
+      save(key, { ...prior, offset: newOffset, buffer: newBuffer })
+      return
+    }
+
+    const subagentStates = stitchSubagents({
+      sessionId,
+      mainTranscriptPath: transcriptPath,
+      turns,
+      logger,
+    })
+
+    const otlpRequest = buildOtlpRequest({
+      sessionId,
+      turnStartNumber: prior.turnCount + 1,
+      turns,
+    })
+
+    return postTraces({
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
+      project: config.project,
+      payload: otlpRequest,
+      logger,
+    }).then(() => {
+      save(key, {
+        offset: newOffset,
+        buffer: newBuffer,
+        turnCount: prior.turnCount + turns.length,
+      })
+      for (const s of subagentStates) {
+        save(s.key, { offset: s.newOffset, buffer: s.newBuffer, turnCount: s.turnCount })
+      }
+    })
+  })
+}
+
+interface SubagentReadResult {
+  key: string
+  newOffset: number
+  newBuffer: string
+  turnCount: number
+}
+
+function stitchSubagents(args: {
+  sessionId: string
+  mainTranscriptPath: string
+  turns: Turn[]
+  logger: Logger
+}): SubagentReadResult[] {
+  const { sessionId, mainTranscriptPath, turns, logger } = args
+  const files = discoverSubagentFiles(mainTranscriptPath)
+  if (files.length === 0) return []
+
+  const agentCallsByPromptId = indexAgentCallsByPromptId(turns)
+  if (agentCallsByPromptId.size === 0) {
+    logger.debug(`found ${files.length} subagent file(s) but no Agent tool calls in new turns`)
+    return []
+  }
+
+  const results: SubagentReadResult[] = []
+  for (const file of files) {
+    const key = stateKey(sessionId, file.filePath)
+    const prior = load(key)
+    const { rows, newOffset, newBuffer } = readIncremental(file.filePath, prior.offset, prior.buffer)
+    if (rows.length === 0) continue
+
+    const subTurns = buildTurns(rows, { includeSidechain: true })
+    if (subTurns.length === 0) {
+      results.push({ key, newOffset, newBuffer, turnCount: prior.turnCount })
+      continue
+    }
+
+    attachSubagentTurns({
+      file,
+      rows,
+      subTurns,
+      agentCallsByPromptId,
+      logger,
+    })
+
+    results.push({
+      key,
+      newOffset,
+      newBuffer,
+      turnCount: prior.turnCount + subTurns.length,
+    })
+  }
+  return results
+}
+
+function indexAgentCallsByPromptId(turns: Turn[]): Map<string, ToolCall> {
+  const map = new Map<string, ToolCall>()
+  for (const turn of turns) {
+    for (const call of turn.toolCalls) {
+      if (call.name !== "Agent") continue
+      if (!call.promptId) continue
+      map.set(call.promptId, call)
+    }
+  }
+  return map
+}
+
+function attachSubagentTurns(args: {
+  file: SubagentFile
+  rows: TranscriptRow[]
+  subTurns: Turn[]
+  agentCallsByPromptId: Map<string, ToolCall>
+  logger: Logger
+}): void {
+  const { file, rows, subTurns, agentCallsByPromptId, logger } = args
+  const promptId = firstPromptIdOf(rows)
+  if (!promptId) {
+    logger.debug(`subagent ${file.agentId}: no promptId in rows; skipping stitch`)
+    return
+  }
+  const call = agentCallsByPromptId.get(promptId)
+  if (!call) {
+    logger.debug(`subagent ${file.agentId}: no matching Agent tool call for promptId=${promptId}`)
+    return
+  }
+  const meta = readSubagentMeta(file.metaPath)
+  call.subagent = {
+    agentId: file.agentId,
+    agentType: meta?.agentType ?? "unknown",
+    description: meta?.description ?? "",
+    turns: subTurns,
+  }
+  logger.debug(
+    `subagent ${file.agentId}: attached ${subTurns.length} turn(s) to Agent call ${call.id} (${meta?.agentType ?? "unknown"})`,
+  )
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    process.stderr.write(`[latitude-claude-code] unexpected: ${String(err)}\n`)
+    process.exit(0)
+  })

--- a/packages/telemetry/claude-code/src/logger.ts
+++ b/packages/telemetry/claude-code/src/logger.ts
@@ -1,0 +1,13 @@
+const PREFIX = "[latitude-claude-code]"
+
+export interface Logger {
+  debug: (msg: string) => void
+  warn: (msg: string) => void
+}
+
+export function createLogger(debugEnabled: boolean): Logger {
+  return {
+    debug: debugEnabled ? (msg) => process.stderr.write(`${PREFIX} ${msg}\n`) : () => {},
+    warn: (msg) => process.stderr.write(`${PREFIX} ${msg}\n`),
+  }
+}

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest"
+import { buildOtlpRequest } from "./otlp.ts"
+import type { OtlpKeyValue, Turn } from "./types.ts"
+
+function unwrap<T>(value: T | undefined | null): T {
+  expect(value).toBeDefined()
+  if (value === undefined || value === null) {
+    throw new Error("expected defined value")
+  }
+  return value
+}
+
+function otlpSpans(req: ReturnType<typeof buildOtlpRequest>) {
+  const rs = unwrap(req.resourceSpans[0])
+  const ss = unwrap(rs.scopeSpans[0])
+  return ss.spans
+}
+
+function getAttr(attrs: OtlpKeyValue[], key: string): string | undefined {
+  const a = attrs.find((x) => x.key === key)
+  return a?.value?.stringValue ?? a?.value?.intValue
+}
+
+function baseTurn(overrides: Partial<Turn> = {}): Turn {
+  return {
+    userText: "hello",
+    assistantText: "hi there",
+    model: "claude-sonnet-4-6",
+    tokens: { input_tokens: 10, output_tokens: 5 },
+    toolCalls: [],
+    startMs: 1_000,
+    endMs: 2_000,
+    ...overrides,
+  }
+}
+
+describe("buildOtlpRequest", () => {
+  it("emits one interaction + one llm_request span per turn", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [baseTurn()],
+    })
+
+    const spans = otlpSpans(req)
+    expect(spans).toHaveLength(2)
+    expect(getAttr(unwrap(spans[0]).attributes, "span.type")).toBe("interaction")
+    expect(getAttr(unwrap(spans[1]).attributes, "span.type")).toBe("llm_request")
+  })
+
+  it("sets service.name=claude-code on the resource", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [baseTurn()],
+    })
+
+    const resAttrs = unwrap(req.resourceSpans[0]).resource.attributes
+    expect(getAttr(resAttrs, "service.name")).toBe("claude-code")
+  })
+
+  it("puts user prompt on interaction span and messages on llm_request", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [baseTurn({ userText: "run it", assistantText: "done" })],
+    })
+
+    const [interaction, llm] = otlpSpans(req)
+
+    expect(getAttr(interaction.attributes, "user_prompt")).toBe("run it")
+    expect(getAttr(interaction.attributes, "user_prompt_length")).toBe("6")
+
+    const inputMsgs = getAttr(llm.attributes, "gen_ai.input.messages")
+    const outputMsgs = getAttr(llm.attributes, "gen_ai.output.messages")
+    expect(JSON.parse(unwrap(inputMsgs))).toEqual([{ role: "user", parts: [{ type: "text", content: "run it" }] }])
+    expect(JSON.parse(unwrap(outputMsgs))).toEqual([{ role: "assistant", parts: [{ type: "text", content: "done" }] }])
+  })
+
+  it("includes tokens and model on the llm_request span", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          model: "claude-opus-4-6",
+          tokens: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 30,
+            cache_creation_input_tokens: 20,
+          },
+        }),
+      ],
+    })
+
+    const llm = unwrap(otlpSpans(req)[1])
+
+    expect(getAttr(llm.attributes, "model")).toBe("claude-opus-4-6")
+    expect(getAttr(llm.attributes, "input_tokens")).toBe("100")
+    expect(getAttr(llm.attributes, "output_tokens")).toBe("50")
+    expect(getAttr(llm.attributes, "cache_read_tokens")).toBe("30")
+    expect(getAttr(llm.attributes, "cache_creation_tokens")).toBe("20")
+  })
+
+  it("emits tool_execution spans parented to the llm_request span", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          toolCalls: [{ id: "tu_1", name: "Bash", input: { command: "ls" }, output: "ok" }],
+        }),
+      ],
+    })
+
+    const spans = otlpSpans(req)
+    expect(spans).toHaveLength(3)
+    const tool = unwrap(spans[2])
+
+    expect(getAttr(tool.attributes, "span.type")).toBe("tool_execution")
+    expect(getAttr(tool.attributes, "tool.name")).toBe("Bash")
+    expect(getAttr(tool.attributes, "tool.id")).toBe("tu_1")
+    expect(tool.parentSpanId).toBe(unwrap(spans[1]).spanId)
+    expect(tool.traceId).toBe(unwrap(spans[0]).traceId)
+  })
+
+  it("uses deterministic IDs so retries over the same (session, turn) collapse", () => {
+    const a = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 3,
+      turns: [baseTurn()],
+    })
+    const b = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 3,
+      turns: [baseTurn()],
+    })
+
+    const aSpans = otlpSpans(a)
+    const bSpans = otlpSpans(b)
+    expect(unwrap(aSpans[0]).traceId).toBe(unwrap(bSpans[0]).traceId)
+    expect(unwrap(aSpans[0]).spanId).toBe(unwrap(bSpans[0]).spanId)
+  })
+
+  it("nests subagent interaction+llm_request+tool spans under the parent Agent tool span", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          model: "claude-opus-4-7",
+          tokens: { input_tokens: 200, output_tokens: 30 },
+          toolCalls: [
+            {
+              id: "toolu_agent_1",
+              name: "Agent",
+              input: { subagent_type: "Explore", description: "find X" },
+              output: "found X",
+              subagent: {
+                agentId: "a4dabb47",
+                agentType: "Explore",
+                description: "find X",
+                turns: [
+                  {
+                    userText: "find X in repo",
+                    assistantText: "X is at foo.ts",
+                    model: "claude-haiku-4-5",
+                    tokens: { input_tokens: 500, output_tokens: 40 },
+                    toolCalls: [{ id: "toolu_grep_1", name: "Grep", input: { pattern: "X" }, output: "match" }],
+                    startMs: 1_100,
+                    endMs: 1_900,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ],
+    })
+
+    const spans = otlpSpans(req)
+
+    // Expected shape:
+    // 0 main interaction
+    // 1 main llm_request
+    // 2 Agent tool_execution (with subagent meta)
+    // 3 subagent_interaction (parent = Agent tool)
+    // 4 subagent llm_request
+    // 5 subagent Grep tool_execution
+    expect(spans).toHaveLength(6)
+
+    const mainInteraction = unwrap(spans[0])
+    const mainLlm = unwrap(spans[1])
+    const agentTool = unwrap(spans[2])
+    const subInteraction = unwrap(spans[3])
+    const subLlm = unwrap(spans[4])
+    const subTool = unwrap(spans[5])
+
+    expect(getAttr(agentTool.attributes, "span.type")).toBe("tool_execution")
+    expect(getAttr(agentTool.attributes, "tool.name")).toBe("Agent")
+    expect(getAttr(agentTool.attributes, "subagent.type")).toBe("Explore")
+    expect(getAttr(agentTool.attributes, "subagent.turn_count")).toBe("1")
+    expect(agentTool.parentSpanId).toBe(mainLlm.spanId)
+
+    expect(getAttr(subInteraction.attributes, "span.type")).toBe("interaction")
+    expect(getAttr(subInteraction.attributes, "interaction.kind")).toBe("subagent")
+    expect(getAttr(subInteraction.attributes, "subagent.id")).toBe("Explore:a4dabb47")
+    expect(subInteraction.parentSpanId).toBe(agentTool.spanId)
+    expect(subInteraction.traceId).toBe(mainInteraction.traceId)
+
+    expect(getAttr(subLlm.attributes, "span.type")).toBe("llm_request")
+    expect(getAttr(subLlm.attributes, "model")).toBe("claude-haiku-4-5")
+    expect(getAttr(subLlm.attributes, "input_tokens")).toBe("500")
+    expect(subLlm.parentSpanId).toBe(subInteraction.spanId)
+
+    expect(getAttr(subTool.attributes, "span.type")).toBe("tool_execution")
+    expect(getAttr(subTool.attributes, "tool.name")).toBe("Grep")
+    expect(subTool.parentSpanId).toBe(subLlm.spanId)
+  })
+})

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -1,0 +1,249 @@
+import { createHash } from "node:crypto"
+import { arch, hostname, platform, release } from "node:os"
+import type {
+  OtlpExportRequest,
+  OtlpKeyValue,
+  OtlpResourceSpans,
+  OtlpSpan,
+  SubagentInvocation,
+  ToolCall,
+  Turn,
+} from "./types.ts"
+
+const SCOPE_NAME = "@latitude-data/claude-code-telemetry"
+const SCOPE_VERSION = "0.0.1"
+
+export function buildOtlpRequest(opts: {
+  sessionId: string
+  userId?: string | undefined
+  turnStartNumber: number
+  turns: Turn[]
+}): OtlpExportRequest {
+  const spans: OtlpSpan[] = []
+  opts.turns.forEach((turn, i) => {
+    const turnNum = opts.turnStartNumber + i
+    spans.push(...buildTurnSpans(opts.sessionId, opts.userId, turnNum, turn))
+  })
+
+  const rs: OtlpResourceSpans = {
+    resource: { attributes: resourceAttrs() },
+    scopeSpans: [
+      {
+        scope: { name: SCOPE_NAME, version: SCOPE_VERSION },
+        spans,
+      },
+    ],
+  }
+
+  return { resourceSpans: [rs] }
+}
+
+function buildTurnSpans(sessionId: string, userId: string | undefined, turnNum: number, turn: Turn): OtlpSpan[] {
+  const traceId = hashHex(`${sessionId}:${turnNum}`, 32)
+  const turnSpanId = hashHex(`${traceId}:turn`, 16)
+  const out: OtlpSpan[] = []
+  buildInteractionTree(out, {
+    traceId,
+    turnSpanId,
+    parentSpanId: "",
+    sessionId,
+    userId,
+    turn,
+    isSubagent: false,
+    subagentLabel: undefined,
+    turnNum,
+    interactionIdSalt: "turn",
+    genIdSalt: "gen",
+  })
+  return out
+}
+
+interface TreeCtx {
+  traceId: string
+  turnSpanId: string
+  parentSpanId: string
+  sessionId: string
+  userId: string | undefined
+  turn: Turn
+  isSubagent: boolean
+  subagentLabel: string | undefined
+  turnNum: number | undefined
+  interactionIdSalt: string
+  genIdSalt: string
+}
+
+function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
+  const { traceId, sessionId, userId, turn, isSubagent, subagentLabel, turnNum } = ctx
+  const startNs = msToNs(turn.startMs)
+  const endNs = msToNs(turn.endMs)
+  const durationMs = Math.max(0, turn.endMs - turn.startMs)
+
+  const interactionSpan: OtlpSpan = {
+    traceId,
+    spanId: ctx.turnSpanId,
+    parentSpanId: ctx.parentSpanId,
+    name: "interaction",
+    kind: 1,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "interaction"),
+      str("interaction.kind", isSubagent ? "subagent" : "user"),
+      str("session.id", sessionId),
+      userId ? str("user.id", userId) : undefined,
+      str("user_prompt", turn.userText),
+      int("user_prompt_length", turn.userText.length),
+      int("interaction.duration_ms", durationMs),
+      turnNum !== undefined ? int("turn.number", turnNum) : undefined,
+      isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
+      str("gen_ai.input.messages", JSON.stringify([messagePart("user", turn.userText)])),
+    ]),
+    status: { code: 1 },
+  }
+  out.push(interactionSpan)
+
+  const genSpanId = hashHex(`${traceId}:${ctx.genIdSalt}`, 16)
+  const genSpan: OtlpSpan = {
+    traceId,
+    spanId: genSpanId,
+    parentSpanId: ctx.turnSpanId,
+    name: "llm_request",
+    kind: 3,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "llm_request"),
+      str("session.id", sessionId),
+      userId ? str("user.id", userId) : undefined,
+      str("llm_request.context", isSubagent ? "subagent_interaction" : "interaction"),
+      str("model", turn.model),
+      turn.tokens.input_tokens !== undefined ? int("input_tokens", turn.tokens.input_tokens) : undefined,
+      turn.tokens.output_tokens !== undefined ? int("output_tokens", turn.tokens.output_tokens) : undefined,
+      turn.tokens.cache_read_input_tokens !== undefined
+        ? int("cache_read_tokens", turn.tokens.cache_read_input_tokens)
+        : undefined,
+      turn.tokens.cache_creation_input_tokens !== undefined
+        ? int("cache_creation_tokens", turn.tokens.cache_creation_input_tokens)
+        : undefined,
+      str("success", "true"),
+      isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
+      str("gen_ai.input.messages", JSON.stringify([messagePart("user", turn.userText)])),
+      str("gen_ai.output.messages", JSON.stringify([messagePart("assistant", turn.assistantText)])),
+    ]),
+    status: { code: 1 },
+  }
+  out.push(genSpan)
+
+  turn.toolCalls.forEach((call, idx) => {
+    const toolSpanId = hashHex(`${traceId}:${ctx.genIdSalt}:tool:${idx}:${call.id}`, 16)
+    out.push(buildToolSpan(traceId, genSpanId, toolSpanId, sessionId, userId, startNs, endNs, call))
+
+    const subagent = call.subagent
+    if (!subagent) return
+    subagent.turns.forEach((subTurn, subIdx) => {
+      const subSalt = `sub:${subagent.agentId}:${subIdx}`
+      buildInteractionTree(out, {
+        traceId,
+        turnSpanId: hashHex(`${traceId}:${subSalt}:turn`, 16),
+        parentSpanId: toolSpanId,
+        sessionId,
+        userId,
+        turn: subTurn,
+        isSubagent: true,
+        subagentLabel: subagentAttr(subagent),
+        turnNum: undefined,
+        interactionIdSalt: `${subSalt}:turn`,
+        genIdSalt: `${subSalt}:gen`,
+      })
+    })
+  })
+}
+
+function subagentAttr(sub: SubagentInvocation): string {
+  return `${sub.agentType}:${sub.agentId}`
+}
+
+function buildToolSpan(
+  traceId: string,
+  parentSpanId: string,
+  spanId: string,
+  sessionId: string,
+  userId: string | undefined,
+  startNs: string,
+  endNs: string,
+  call: ToolCall,
+): OtlpSpan {
+  return {
+    traceId,
+    spanId,
+    parentSpanId,
+    name: `tool:${call.name}`,
+    kind: 1,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "tool_execution"),
+      str("session.id", sessionId),
+      userId ? str("user.id", userId) : undefined,
+      str("tool.name", call.name),
+      str("tool.id", call.id),
+      str("tool.input", safeJson(call.input)),
+      call.output !== undefined ? str("tool.output", safeJson(call.output)) : undefined,
+      bool("tool.is_error", call.isError === true),
+      str("success", call.isError ? "false" : "true"),
+      call.subagent ? str("subagent.id", subagentAttr(call.subagent)) : undefined,
+      call.subagent ? str("subagent.type", call.subagent.agentType) : undefined,
+      call.subagent ? int("subagent.turn_count", call.subagent.turns.length) : undefined,
+    ]),
+    status: { code: call.isError ? 2 : 1 },
+  }
+}
+
+function messagePart(role: "user" | "assistant", content: string) {
+  return { role, parts: [{ type: "text", content }] }
+}
+
+function resourceAttrs(): OtlpKeyValue[] {
+  return [
+    str("service.name", "claude-code"),
+    str("service.version", SCOPE_VERSION),
+    str("host.name", hostname()),
+    str("host.arch", arch()),
+    str("os.type", platform()),
+    str("os.version", release()),
+  ]
+}
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+
+function int(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(Math.trunc(value)) } }
+}
+
+function bool(key: string, value: boolean): OtlpKeyValue {
+  return { key, value: { boolValue: value } }
+}
+
+function stripUndef(items: Array<OtlpKeyValue | undefined>): OtlpKeyValue[] {
+  return items.filter((x): x is OtlpKeyValue => x !== undefined)
+}
+
+function hashHex(input: string, length: number): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, length)
+}
+
+function msToNs(ms: number): string {
+  // BigInt to keep precision beyond 2^53
+  return (BigInt(Math.trunc(ms)) * 1_000_000n).toString()
+}
+
+function safeJson(value: unknown): string {
+  try {
+    if (typeof value === "string") return value
+    return JSON.stringify(value)
+  } catch {
+    return ""
+  }
+}

--- a/packages/telemetry/claude-code/src/state.ts
+++ b/packages/telemetry/claude-code/src/state.ts
@@ -1,0 +1,114 @@
+import { createHash } from "node:crypto"
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const STATE_DIR = join(homedir(), ".claude", "state", "latitude")
+const STATE_FILE = join(STATE_DIR, "state.json")
+const LOCK_FILE = join(STATE_DIR, "state.lock")
+const LOCK_TIMEOUT_MS = 2_000
+
+interface SessionState {
+  offset: number
+  buffer: string
+  turnCount: number
+  traceId?: string | undefined
+  updated?: string | undefined
+}
+
+type StateMap = Record<string, SessionState>
+
+export function stateKey(sessionId: string, transcriptPath: string): string {
+  return createHash("sha256").update(`${sessionId}::${transcriptPath}`).digest("hex")
+}
+
+export function load(key: string): SessionState {
+  try {
+    if (!existsSync(STATE_FILE)) return empty()
+    const raw = readFileSync(STATE_FILE, "utf-8")
+    const all = JSON.parse(raw) as StateMap
+    const entry = all[key]
+    if (!entry) return empty()
+    return {
+      offset: Number(entry.offset) || 0,
+      buffer: typeof entry.buffer === "string" ? entry.buffer : "",
+      turnCount: Number(entry.turnCount) || 0,
+      traceId: typeof entry.traceId === "string" ? entry.traceId : undefined,
+    }
+  } catch {
+    return empty()
+  }
+}
+
+export function save(key: string, state: SessionState): void {
+  try {
+    ensureDir()
+    const all = readAll()
+    all[key] = { ...state, updated: new Date().toISOString() }
+    const tmp = `${STATE_FILE}.tmp`
+    writeFileSync(tmp, JSON.stringify(all, null, 2), "utf-8")
+    renameSync(tmp, STATE_FILE)
+  } catch {
+    // fail-open
+  }
+}
+
+export async function withLock<T>(fn: () => Promise<T> | T): Promise<T | undefined> {
+  ensureDir()
+  const deadline = Date.now() + LOCK_TIMEOUT_MS
+  let fd: number | undefined
+  while (Date.now() < deadline) {
+    try {
+      fd = openSync(LOCK_FILE, "wx")
+      break
+    } catch {
+      await sleep(50)
+    }
+  }
+  try {
+    return await fn()
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      unlinkSync(LOCK_FILE)
+    } catch {
+      // lock was never acquired or already gone
+    }
+  }
+}
+
+function readAll(): StateMap {
+  try {
+    if (!existsSync(STATE_FILE)) return {}
+    return JSON.parse(readFileSync(STATE_FILE, "utf-8")) as StateMap
+  } catch {
+    return {}
+  }
+}
+
+function ensureDir(): void {
+  if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true })
+}
+
+function empty(): SessionState {
+  return { offset: 0, buffer: "", turnCount: 0 }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}

--- a/packages/telemetry/claude-code/src/transcript.test.ts
+++ b/packages/telemetry/claude-code/src/transcript.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest"
+import { buildTurns } from "./transcript.ts"
+import type { TranscriptRow } from "./types.ts"
+
+describe("buildTurns", () => {
+  it("groups a user prompt + assistant response into a single turn", () => {
+    const rows: TranscriptRow[] = [
+      {
+        type: "user",
+        timestamp: "2026-04-10T12:00:00.000Z",
+        message: { role: "user", content: "hello claude" },
+      },
+      {
+        type: "assistant",
+        timestamp: "2026-04-10T12:00:02.000Z",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "hi there" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.userText).toBe("hello claude")
+    expect(turns[0]?.assistantText).toBe("hi there")
+    expect(turns[0]?.model).toBe("claude-sonnet-4-6")
+    expect(turns[0]?.tokens.input_tokens).toBe(10)
+    expect(turns[0]?.tokens.output_tokens).toBe(5)
+    expect(turns[0]?.toolCalls).toHaveLength(0)
+  })
+
+  it("merges content across rows that share a message.id (one-block-per-row format)", () => {
+    // Real Claude Code writes each content block as its own JSONL row,
+    // all sharing the same message.id. We must aggregate — not dedupe.
+    const rows: TranscriptRow[] = [
+      { type: "user", message: { role: "user", content: "hi" } },
+      {
+        type: "assistant",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "thinking", thinking: "..." }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "text", text: "here is my answer" }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu_1", name: "Bash", input: { command: "ls" } }],
+          usage: { input_tokens: 10, output_tokens: 200 },
+        },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.assistantText).toBe("here is my answer")
+    expect(turns[0]?.toolCalls).toHaveLength(1)
+    expect(turns[0]?.toolCalls[0]?.name).toBe("Bash")
+    // Usage is dedup'd per message.id (latest wins per id), then summed across ids.
+    // All 3 rows share msg_1, so only the last row's usage counts.
+    expect(turns[0]?.tokens.input_tokens).toBe(10)
+    expect(turns[0]?.tokens.output_tokens).toBe(200)
+  })
+
+  it("skips isMeta, isSidechain, and system/summary/file-history rows by default", () => {
+    const rows: TranscriptRow[] = [
+      { type: "file-history-snapshot" },
+      { type: "system", subtype: "turn_duration" },
+      { type: "user", isMeta: true, message: { role: "user", content: "<local-command-caveat>..." } },
+      { type: "user", message: { role: "user", content: "real prompt" } },
+      {
+        type: "assistant",
+        isSidechain: true,
+        message: { id: "sub", role: "assistant", content: [{ type: "text", text: "from subagent" }] },
+      },
+      {
+        type: "assistant",
+        message: { id: "main", role: "assistant", content: [{ type: "text", text: "main response" }] },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.userText).toBe("real prompt")
+    expect(turns[0]?.assistantText).toBe("main response")
+  })
+
+  it("includes sidechain rows when includeSidechain=true (used on subagent files)", () => {
+    // This mirrors a real subagent transcript: every row has isSidechain:true,
+    // the first is the synthetic user prompt injected by Claude Code.
+    const rows: TranscriptRow[] = [
+      {
+        type: "user",
+        isSidechain: true,
+        promptId: "p-sub-1",
+        message: { role: "user", content: "Explore the repo" },
+      },
+      {
+        type: "assistant",
+        isSidechain: true,
+        message: {
+          id: "sub_1",
+          role: "assistant",
+          model: "claude-haiku-4-5",
+          content: [{ type: "text", text: "I'll look" }],
+          usage: { input_tokens: 3, output_tokens: 5 },
+        },
+      },
+    ]
+
+    const turns = buildTurns(rows, { includeSidechain: true })
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.userText).toBe("Explore the repo")
+    expect(turns[0]?.assistantText).toBe("I'll look")
+    expect(turns[0]?.model).toBe("claude-haiku-4-5")
+  })
+
+  it("captures promptId on a tool call from its tool_result row", () => {
+    // In real transcripts, the promptId we need to stitch subagents lives on the tool_result
+    // row (a user-role row), not on the tool_use row. Assert we lift it onto the ToolCall.
+    const rows: TranscriptRow[] = [
+      { type: "user", message: { role: "user", content: "launch subagent" } },
+      {
+        type: "assistant",
+        message: {
+          id: "a1",
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_agent_1",
+              name: "Agent",
+              input: { subagent_type: "Explore", description: "find X", prompt: "go look" },
+            },
+          ],
+        },
+      },
+      {
+        type: "user",
+        promptId: "prompt-abc",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_agent_1", content: "found X" }],
+        },
+      },
+      {
+        type: "assistant",
+        message: { id: "a2", role: "assistant", content: [{ type: "text", text: "ok" }] },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.toolCalls).toHaveLength(1)
+    expect(turns[0]?.toolCalls[0]?.name).toBe("Agent")
+    expect(turns[0]?.toolCalls[0]?.promptId).toBe("prompt-abc")
+  })
+
+  it("matches tool_use to tool_result by tool_use_id", () => {
+    const rows: TranscriptRow[] = [
+      { type: "user", message: { role: "user", content: "run ls" } },
+      {
+        type: "assistant",
+        message: {
+          id: "msg_1",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu_1", name: "Bash", input: { command: "ls" } }],
+        },
+      },
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu_1", content: "file1\nfile2" }],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          id: "msg_2",
+          role: "assistant",
+          content: [{ type: "text", text: "Done." }],
+        },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.assistantText).toBe("Done.")
+    expect(turns[0]?.toolCalls).toHaveLength(1)
+    expect(turns[0]?.toolCalls[0]).toMatchObject({
+      id: "tu_1",
+      name: "Bash",
+      input: { command: "ls" },
+      output: "file1\nfile2",
+      isError: false,
+    })
+  })
+
+  it("starts a new turn when a non-tool-result user message appears", () => {
+    const rows: TranscriptRow[] = [
+      { type: "user", message: { role: "user", content: "first prompt" } },
+      {
+        type: "assistant",
+        message: { id: "a1", role: "assistant", content: [{ type: "text", text: "reply 1" }] },
+      },
+      { type: "user", message: { role: "user", content: "second prompt" } },
+      {
+        type: "assistant",
+        message: { id: "a2", role: "assistant", content: [{ type: "text", text: "reply 2" }] },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns).toHaveLength(2)
+    expect(turns[0]?.userText).toBe("first prompt")
+    expect(turns[0]?.assistantText).toBe("reply 1")
+    expect(turns[1]?.userText).toBe("second prompt")
+    expect(turns[1]?.assistantText).toBe("reply 2")
+  })
+
+  it("aggregates usage across multiple assistant messages in the same turn", () => {
+    const rows: TranscriptRow[] = [
+      { type: "user", message: { role: "user", content: "do it" } },
+      {
+        type: "assistant",
+        message: {
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "text", text: "step 1" }],
+          usage: { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 50 },
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          id: "a2",
+          role: "assistant",
+          content: [{ type: "text", text: "step 2" }],
+          usage: { input_tokens: 120, output_tokens: 15 },
+        },
+      },
+    ]
+
+    const turns = buildTurns(rows)
+
+    expect(turns[0]?.tokens.input_tokens).toBe(220)
+    expect(turns[0]?.tokens.output_tokens).toBe(25)
+    expect(turns[0]?.tokens.cache_read_input_tokens).toBe(50)
+  })
+})

--- a/packages/telemetry/claude-code/src/transcript.ts
+++ b/packages/telemetry/claude-code/src/transcript.ts
@@ -1,0 +1,290 @@
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs"
+import { basename, dirname, extname, join } from "node:path"
+import type {
+  ContentBlock,
+  SubagentFile,
+  ToolCall,
+  ToolResultBlock,
+  ToolUseBlock,
+  TranscriptRow,
+  Turn,
+  Usage,
+} from "./types.ts"
+
+interface ReadResult {
+  rows: TranscriptRow[]
+  newOffset: number
+  newBuffer: string
+}
+
+export function readIncremental(path: string, offset: number, buffer: string): ReadResult {
+  if (!existsSync(path)) return { rows: [], newOffset: offset, newBuffer: buffer }
+
+  const { size } = statSync(path)
+  if (size < offset) {
+    // file was truncated or rotated; restart from beginning
+    offset = 0
+    buffer = ""
+  }
+  if (size === offset) return { rows: [], newOffset: offset, newBuffer: buffer }
+
+  const fd = openSync(path, "r")
+  try {
+    const length = size - offset
+    const chunk = Buffer.alloc(length)
+    readSync(fd, chunk, 0, length, offset)
+    const text = buffer + chunk.toString("utf-8")
+    const parts = text.split("\n")
+    const tail = parts.pop() ?? ""
+    const rows: TranscriptRow[] = []
+    for (const line of parts) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try {
+        rows.push(JSON.parse(trimmed) as TranscriptRow)
+      } catch {
+        // skip malformed line
+      }
+    }
+    return { rows, newOffset: size, newBuffer: tail }
+  } finally {
+    closeSync(fd)
+  }
+}
+
+export function buildTurns(
+  rows: TranscriptRow[],
+  opts: {
+    includeSidechain?: boolean
+  } = {},
+): Turn[] {
+  const allowSidechain = opts.includeSidechain === true
+  const turns: Turn[] = []
+  let userRow: TranscriptRow | undefined
+  let assistantRows: TranscriptRow[] = []
+  let toolResults = new Map<string, ToolResultBlock>()
+  let toolPromptIds = new Map<string, string>()
+
+  const flush = () => {
+    if (!userRow) return
+    if (assistantRows.length === 0) return
+    turns.push(buildTurn(userRow, assistantRows, toolResults, toolPromptIds))
+  }
+
+  for (const row of rows) {
+    if (!allowSidechain && row.isSidechain) continue
+    if (row.isMeta) continue
+    if (row.type === "file-history-snapshot") continue
+    if (row.type === "system") continue
+    if (row.type === "summary") continue
+
+    if (isToolResultRow(row)) {
+      for (const block of iterToolResults(row)) {
+        if (!block.tool_use_id) continue
+        toolResults.set(block.tool_use_id, block)
+        if (row.promptId) toolPromptIds.set(block.tool_use_id, row.promptId)
+      }
+      continue
+    }
+
+    const role = roleOf(row)
+    if (role === "user") {
+      flush()
+      userRow = row
+      assistantRows = []
+      toolResults = new Map()
+      toolPromptIds = new Map()
+      continue
+    }
+
+    if (role === "assistant") {
+      if (!userRow) continue
+      // Claude Code writes each content block as its own JSONL row with the same message.id.
+      // We keep every row and aggregate text/tool_uses across them; usage is deduped per
+      // message.id (latest wins) in aggregateUsage.
+      assistantRows.push(row)
+    }
+  }
+
+  flush()
+  return turns
+}
+
+function buildTurn(
+  userRow: TranscriptRow,
+  assistantRows: TranscriptRow[],
+  toolResults: Map<string, ToolResultBlock>,
+  toolPromptIds: Map<string, string>,
+): Turn {
+  const userText = extractText(contentOf(userRow))
+  const assistantText = assistantRows
+    .map((r) => extractText(contentOf(r)))
+    .filter((t) => t.length > 0)
+    .join("\n\n")
+  const modelRow = assistantRows.find((r) => r.message?.model && r.message.model !== "<synthetic>")
+  const model = modelRow?.message?.model ?? "claude"
+  const lastAssistant = assistantRows[assistantRows.length - 1]
+
+  const tokens = aggregateUsage(assistantRows)
+  const toolCalls = collectToolCalls(assistantRows, toolResults, toolPromptIds)
+
+  const startMs = parseTs(userRow.timestamp) ?? Date.now()
+  const endMs = parseTs(lastAssistant?.timestamp) ?? startMs
+
+  return { userText, assistantText, model, tokens, toolCalls, startMs, endMs }
+}
+
+function aggregateUsage(rows: TranscriptRow[]): Usage {
+  // Each assistant content block is its own row but shares message.id with its siblings,
+  // and usage is updated on each row (later rows supersede earlier ones for the same id).
+  // We keep only the last usage per message.id, then sum across distinct messages.
+  const perMessage = new Map<string, Usage>()
+  rows.forEach((r, idx) => {
+    const u = r.message?.usage
+    if (!u) return
+    const id = r.message?.id ?? `noid:${idx}`
+    perMessage.set(id, u)
+  })
+  const out: Usage = {}
+  for (const u of perMessage.values()) {
+    if (u.input_tokens !== undefined) out.input_tokens = (out.input_tokens ?? 0) + u.input_tokens
+    if (u.output_tokens !== undefined) out.output_tokens = (out.output_tokens ?? 0) + u.output_tokens
+    if (u.cache_read_input_tokens !== undefined)
+      out.cache_read_input_tokens = (out.cache_read_input_tokens ?? 0) + u.cache_read_input_tokens
+    if (u.cache_creation_input_tokens !== undefined)
+      out.cache_creation_input_tokens = (out.cache_creation_input_tokens ?? 0) + u.cache_creation_input_tokens
+  }
+  return out
+}
+
+function collectToolCalls(
+  assistantRows: TranscriptRow[],
+  toolResults: Map<string, ToolResultBlock>,
+  toolPromptIds: Map<string, string>,
+): ToolCall[] {
+  const seen = new Set<string>()
+  const calls: ToolCall[] = []
+  for (const row of assistantRows) {
+    for (const block of iterToolUses(row)) {
+      if (seen.has(block.id)) continue
+      seen.add(block.id)
+      const result = toolResults.get(block.id)
+      const promptId = toolPromptIds.get(block.id)
+      const call: ToolCall = {
+        id: block.id,
+        name: block.name,
+        input: block.input,
+        output: result?.content,
+        isError: result?.is_error === true,
+      }
+      if (promptId) call.promptId = promptId
+      calls.push(call)
+    }
+  }
+  return calls
+}
+
+function isToolResultRow(row: TranscriptRow): boolean {
+  if (roleOf(row) !== "user") return false
+  const c = contentOf(row)
+  if (!Array.isArray(c)) return false
+  return c.some((b) => isBlock(b) && b.type === "tool_result")
+}
+
+function iterToolResults(row: TranscriptRow): ToolResultBlock[] {
+  const c = contentOf(row)
+  if (!Array.isArray(c)) return []
+  return c.filter((b): b is ToolResultBlock => isBlock(b) && b.type === "tool_result")
+}
+
+function iterToolUses(row: TranscriptRow): ToolUseBlock[] {
+  const c = contentOf(row)
+  if (!Array.isArray(c)) return []
+  return c.filter((b): b is ToolUseBlock => isBlock(b) && b.type === "tool_use")
+}
+
+function isBlock(b: unknown): b is ContentBlock {
+  return typeof b === "object" && b !== null && "type" in b
+}
+
+function contentOf(row: TranscriptRow): string | ContentBlock[] | undefined {
+  if (row.message && "content" in row.message) return row.message.content
+  return row.content
+}
+
+function roleOf(row: TranscriptRow): "user" | "assistant" | undefined {
+  if (row.type === "user" || row.type === "assistant") return row.type
+  const r = row.message?.role
+  if (r === "user" || r === "assistant") return r
+  return undefined
+}
+
+function extractText(content: string | ContentBlock[] | undefined): string {
+  if (content === undefined) return ""
+  if (typeof content === "string") return content
+  const parts: string[] = []
+  for (const b of content) {
+    if (!isBlock(b)) continue
+    if (b.type === "text" && typeof (b as { text?: string }).text === "string") {
+      parts.push((b as { text: string }).text)
+    }
+  }
+  return parts.join("\n")
+}
+
+function parseTs(ts: string | undefined): number | undefined {
+  if (!ts) return undefined
+  const ms = Date.parse(ts)
+  return Number.isFinite(ms) ? ms : undefined
+}
+
+function subagentDir(mainTranscriptPath: string): string {
+  const dir = dirname(mainTranscriptPath)
+  const sessionId = basename(mainTranscriptPath, extname(mainTranscriptPath))
+  return join(dir, sessionId, "subagents")
+}
+
+export function discoverSubagentFiles(mainTranscriptPath: string): SubagentFile[] {
+  const sub = subagentDir(mainTranscriptPath)
+  if (!existsSync(sub)) return []
+  const entries = readdirSync(sub)
+  const files: SubagentFile[] = []
+  for (const entry of entries) {
+    if (!entry.endsWith(".jsonl")) continue
+    const agentId = entry.replace(/^agent-/, "").replace(/\.jsonl$/, "")
+    if (!agentId) continue
+    files.push({
+      agentId,
+      filePath: join(sub, entry),
+      metaPath: join(sub, entry.replace(/\.jsonl$/, ".meta.json")),
+    })
+  }
+  return files
+}
+
+interface SubagentMeta {
+  agentType: string
+  description: string
+}
+
+export function readSubagentMeta(metaPath: string): SubagentMeta | undefined {
+  try {
+    if (!existsSync(metaPath)) return undefined
+    const raw = readFileSync(metaPath, "utf-8")
+    const obj = JSON.parse(raw) as Partial<SubagentMeta>
+    if (typeof obj.agentType !== "string") return undefined
+    return {
+      agentType: obj.agentType,
+      description: typeof obj.description === "string" ? obj.description : "",
+    }
+  } catch {
+    return undefined
+  }
+}
+
+export function firstPromptIdOf(rows: TranscriptRow[]): string | undefined {
+  for (const row of rows) {
+    if (row.promptId && roleOf(row) === "user") return row.promptId
+  }
+  return undefined
+}

--- a/packages/telemetry/claude-code/src/types.ts
+++ b/packages/telemetry/claude-code/src/types.ts
@@ -1,0 +1,136 @@
+export interface HookPayload {
+  session_id?: string
+  sessionId?: string
+  transcript_path?: string
+  transcriptPath?: string
+  cwd?: string
+}
+
+export interface TextBlock {
+  type: "text"
+  text: string
+}
+
+export interface ToolUseBlock {
+  type: "tool_use"
+  id: string
+  name: string
+  input: unknown
+}
+
+export interface ToolResultBlock {
+  type: "tool_result"
+  tool_use_id: string
+  content: unknown
+  is_error?: boolean
+}
+
+export interface ThinkingBlock {
+  type: "thinking"
+  thinking: string
+}
+
+export type ContentBlock =
+  | TextBlock
+  | ToolUseBlock
+  | ToolResultBlock
+  | ThinkingBlock
+  | { type: string; [key: string]: unknown }
+
+export interface Usage {
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+export interface InnerMessage {
+  id?: string
+  role?: "user" | "assistant"
+  model?: string
+  content?: string | ContentBlock[]
+  usage?: Usage
+}
+
+export interface TranscriptRow {
+  type?: "user" | "assistant" | "summary" | "system" | "file-history-snapshot"
+  subtype?: string
+  message?: InnerMessage
+  content?: string | ContentBlock[]
+  uuid?: string
+  timestamp?: string
+  parentUuid?: string | null
+  isMeta?: boolean
+  isSidechain?: boolean
+  promptId?: string
+}
+
+export interface ToolCall {
+  id: string
+  name: string
+  input: unknown
+  output?: unknown
+  isError?: boolean
+  promptId?: string
+  subagent?: SubagentInvocation
+}
+
+export interface SubagentInvocation {
+  agentId: string
+  agentType: string
+  description: string
+  turns: Turn[]
+}
+
+export interface Turn {
+  userText: string
+  assistantText: string
+  model: string
+  tokens: Usage
+  toolCalls: ToolCall[]
+  startMs: number
+  endMs: number
+}
+
+export interface SubagentFile {
+  agentId: string
+  filePath: string
+  metaPath: string
+}
+
+export interface OtlpAnyValue {
+  stringValue?: string
+  intValue?: string
+  boolValue?: boolean
+  doubleValue?: number
+  arrayValue?: { values: OtlpAnyValue[] }
+}
+
+export interface OtlpKeyValue {
+  key: string
+  value: OtlpAnyValue
+}
+
+export interface OtlpSpan {
+  traceId: string
+  spanId: string
+  parentSpanId: string
+  name: string
+  kind: number
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  attributes: OtlpKeyValue[]
+  status: { code: number }
+}
+
+export interface OtlpResourceSpans {
+  resource: { attributes: OtlpKeyValue[] }
+  scopeSpans: Array<{
+    scope: { name: string; version: string }
+    spans: OtlpSpan[]
+  }>
+}
+
+export interface OtlpExportRequest {
+  resourceSpans: OtlpResourceSpans[]
+}

--- a/packages/telemetry/claude-code/tsconfig.json
+++ b/packages/telemetry/claude-code/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "incremental": false,
+    "composite": false
+  }
+}

--- a/packages/telemetry/claude-code/tsup.config.ts
+++ b/packages/telemetry/claude-code/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "node20",
+  banner: { js: "#!/usr/bin/env node" },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1354,10 +1354,10 @@ importers:
     dependencies:
       '@better-auth/core':
         specifier: ^1.5.6
-        version: 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
+        version: 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/stripe':
         specifier: ^1.5.6
-        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(better-auth@1.5.6(1e6bfea094c23e4e3dfa90a7d91b502d))(better-call@1.1.8(zod@4.3.6))(stripe@22.0.1(@types/node@24.12.2))
+        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(better-auth@1.5.6(1e6bfea094c23e4e3dfa90a7d91b502d))(better-call@1.3.2(zod@4.3.6))(stripe@22.0.1(@types/node@24.12.2))
       '@domain/annotation-queues':
         specifier: workspace:*
         version: link:../../domain/annotation-queues
@@ -1427,7 +1427,7 @@ importers:
     devDependencies:
       '@better-auth/cli':
         specifier: ^1.4.22
-        version: 1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.2.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.3.2(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.2.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))
       '@electric-sql/pglite':
         specifier: 0.3.15
         version: 0.3.15
@@ -1656,6 +1656,24 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/telemetry/claude-code:
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.4.6
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.1
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.26)(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/typescript:
     dependencies:
@@ -12450,13 +12468,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/cli@1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.2.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@better-auth/cli@1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.3.2(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.2.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
-      '@better-auth/telemetry': 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))
+      '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
+      '@better-auth/telemetry': 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.0
       '@clack/prompts': 0.11.0
       '@mrleebo/prisma-ast': 0.13.1
@@ -12545,6 +12563,17 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
+  '@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.2(zod@4.3.6)
+      jose: 6.2.2
+      kysely: 0.28.16
+      nanostores: 1.2.0
+      zod: 4.3.6
+
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.3.1
@@ -12558,14 +12587,14 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.2.2
       kysely: 0.28.16
       nanostores: 1.2.0
@@ -12609,18 +12638,18 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 5.22.0
 
-  '@better-auth/stripe@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(better-auth@1.5.6(1e6bfea094c23e4e3dfa90a7d91b502d))(better-call@1.1.8(zod@4.3.6))(stripe@22.0.1(@types/node@24.12.2))':
+  '@better-auth/stripe@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(better-auth@1.5.6(1e6bfea094c23e4e3dfa90a7d91b502d))(better-call@1.3.2(zod@4.3.6))(stripe@22.0.1(@types/node@24.12.2))':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       better-auth: 1.5.6(1e6bfea094c23e4e3dfa90a7d91b502d)
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.7
       stripe: 22.0.1(@types/node@24.12.2)
       zod: 4.3.6
 
-  '@better-auth/telemetry@1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))':
+  '@better-auth/telemetry@1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))':
     dependencies:
-      '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
+      '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
 
@@ -17241,7 +17270,7 @@ snapshots:
   better-auth@1.4.22(1f4266b1fd234697df9603cfcdb6cbbe):
     dependencies:
       '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0)
-      '@better-auth/telemetry': 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))
+      '@better-auth/telemetry': 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0

--- a/prd/claude-code-telemetry.md
+++ b/prd/claude-code-telemetry.md
@@ -1,0 +1,185 @@
+# Claude Code telemetry in Latitude
+
+## Goal
+
+Let a Claude Code user point their CLI at Latitude and see each session in the
+Latitude dashboard, with **full, untruncated conversation content** including
+user prompts, assistant responses, and tool I/O — matching what Langfuse ships
+at `langfuse.com/integrations/other/claude-code`.
+
+## Supported surfaces
+
+Claude Code runs in four places. The hook approach covers the three that
+execute locally:
+
+| Surface | Covered | Why |
+| --- | --- | --- |
+| CLI (`claude` in terminal) | ✅ | Reads `~/.claude/settings.json`, spawns local command hooks. |
+| Desktop app (Mac / Windows) | ✅ | Shares the same settings file and hook lifecycle as the CLI. Worth smoke-testing before GA. |
+| IDE extensions (VS Code, JetBrains) | ✅ | Invoke Claude Code locally under the hood. |
+| Web app (claude.ai/code) | ❌ | Runs in Anthropic's cloud — no filesystem, no local process, no way to execute a command hook. |
+
+Web-app users are out of scope. If that becomes a real segment we'd need an
+Anthropic-side integration we can't build ourselves.
+
+## Why hooks, not native OTEL
+
+Claude Code has native OpenTelemetry export, but it's a poor fit for a
+conversation-inspection product:
+
+1. **Full conversation gated behind `OTEL_LOG_RAW_API_BODIES=1`**, and only
+   emitted as log events (`claude_code.api_request_body` /
+   `api_response_body`), not as traces. Latitude's `/v1/traces` endpoint would
+   never see them.
+2. **60 KB truncation** per API body — real sessions blow past it. A long
+   session's conversation history is silently lost.
+3. **Extended-thinking is always redacted** from API bodies, regardless of
+   flags.
+4. **Four separate opt-in flags** (`OTEL_LOG_USER_PROMPTS`,
+   `OTEL_LOG_TOOL_DETAILS`, `OTEL_LOG_TOOL_CONTENT`, `OTEL_LOG_RAW_API_BODIES`)
+   before users get anything useful.
+
+The `Stop` hook reads the **session transcript JSONL** directly off disk. No
+truncation, no redaction, no flag combinatorics — it's the exact file Claude
+Code uses to reconstruct context. That's why Langfuse went this route, and
+it's why we should too.
+
+Trade-off we accept: the hook loses native OTEL metrics
+(`claude_code.cost.usage`, `claude_code.token.usage`, session/commit/PR
+counters). We can reconstruct all of these from transcript data — it contains
+`message.usage` per assistant turn with input/output/cache tokens and enough
+metadata to compute cost.
+
+## How the integration works
+
+### Claude Code side
+
+User adds two things to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_BASE_URL": "https://ingest.latitude.so"
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "npx -y @latitude-data/claude-code" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+That's it. The `Stop` hook fires after every assistant turn. Claude Code
+passes `session_id`, `transcript_path`, `cwd` as JSON on stdin. Our script
+does the rest.
+
+### Our hook script (`@latitude-data/claude-code`)
+
+A small Node CLI published as an npm package. Node is already a Claude Code
+dependency, so no new runtime. On each invocation:
+
+1. Read hook payload (JSON on stdin) → extract `session_id`,
+   `transcript_path`.
+2. Look up `~/.claude/state/latitude/<session_id>.json` for the last processed
+   byte offset (Langfuse-style incremental reader — never re-read the full
+   transcript).
+3. Tail the transcript JSONL from that offset; parse new lines.
+4. Group new messages into OTLP spans:
+   - **Session span** (root) — one per `session_id`, created on first
+     invocation.
+   - **Turn span** — one per user prompt → assistant response cycle, child of
+     session.
+   - **Generation span** — wraps the assistant response, carries
+     `model`, `input_tokens`, `output_tokens`, `cache_read_tokens`,
+     `cost_usd` from `message.usage`.
+   - **Tool span** — one per `tool_use` block, with `tool_name`,
+     `tool_input`, and the matching `tool_result` from the next user message.
+5. POST the OTLP payload (JSON or protobuf) to
+   `${LATITUDE_BASE_URL}/v1/traces` with
+   `Authorization: Bearer ${LATITUDE_API_KEY}`.
+6. Persist the new offset + dedup state atomically (`fcntl` lock on Unix).
+7. Exit `0` on success. **Always exit `0` on failure** — a non-zero exit from
+   a `Stop` hook would block Claude from finishing its turn.
+
+Configure the hook with `async: true` so the user doesn't wait for our POST.
+
+### Latitude side
+
+Most of the backend is already in place:
+
+- `POST /v1/traces` accepts OTLP (`apps/ingest/src/routes/traces.ts:19`).
+- Bearer-token auth (`packages/platform/api-key-auth`).
+- A `parseClaudeCode` content parser lives at
+  `packages/domain/spans/src/otlp/content/claude-code.ts`, keyed off
+  `service.name=claude-code` resource attribute.
+- Identity resolvers already pick up `session.id`, `user.email` from resource
+  attributes.
+
+What we need to change:
+
+1. Extend `parseClaudeCode` to handle the three new span shapes our hook
+   emits (`turn`, `generation`, `tool`) — today it only parses a single
+   `interaction` span with `user_prompt`.
+2. Extend the operation resolver
+   (`packages/domain/spans/src/otlp/resolvers/operation.ts`) to classify turn
+   vs generation vs tool vs session spans so the trace UI renders them
+   correctly.
+3. Add a test fixture in
+   `packages/domain/spans/src/otlp/tests/claude-code.test.ts` using a real
+   transcript captured from a `claude` session.
+
+No new endpoints. No new ClickHouse columns. Traces table already has
+`session_id`, `tokens_input/output`, `cost_*`, `input_messages`,
+`output_messages`.
+
+## Deliverables
+
+1. **`packages/integrations/claude-code/`** (new package) — the hook CLI.
+   - `src/index.ts` — entrypoint that reads stdin, routes to handler.
+   - `src/transcript.ts` — incremental JSONL reader + state file.
+   - `src/otlp.ts` — transcript → OTLP spans transform.
+   - `src/client.ts` — POST to `/v1/traces`.
+   - Published to npm as `@latitude-data/claude-code`.
+2. **Server-side parser updates** — three items listed above under "Latitude
+   side".
+3. **Docs page** `docs/integrations/claude-code.md` — the four-line setup
+   block + a privacy note.
+4. **Rate-limit sanity check** — default Claude Code session fires `Stop`
+   roughly once every 10–60s, so we're well inside
+   `apps/ingest/src/rate-limit/trace-ingestion.ts` defaults. Worth confirming
+   with a multi-hour session.
+
+## What we deliberately don't ship
+
+- A dedicated Claude Code dashboard. The existing trace UI covers it.
+- Metrics ingestion (`/v1/metrics`). Tokens + cost are on the generation
+  span; everything else (LoC, commits, PRs) is lower-value and
+  reconstructable from git.
+- Log ingestion (`/v1/logs`). The hook gives us fuller data than OTEL logs
+  would.
+- `otelHeadersHelper` / dynamic-token refresh. Static bearer token is fine;
+  enterprise users can wrap the command.
+- Native OTEL as an alternative entry point. Supporting two ingestion paths
+  doubles the parser surface area. Pick hooks, document it as the only way.
+
+## Open questions
+
+- **Package scope.** Publish as `@latitude-data/claude-code` under the
+  existing npm org, or as a standalone package? I'd lean toward the org —
+  names the provenance clearly.
+- **Public ingest hostname.** Confirm `https://ingest.latitude.so` is the
+  canonical URL to put in docs.
+- **Privacy posture.** Unlike the OTEL path, this captures the full
+  conversation the moment the hook is installed. The docs need a clear
+  "this sends your prompts, assistant responses, and tool I/O to Latitude"
+  banner. No surprise data collection.
+- **Subagent transcripts.** `SubagentStop` fires with its own
+  `agent_transcript_path`. Do we surface subagents as nested spans under the
+  parent turn, or as separate traces? Affects trace-tree readability.
+- **Self-hosted.** Docs should include a `LATITUDE_BASE_URL` override
+  example for self-hosted installs.


### PR DESCRIPTION
## Summary

Adds Claude Code session observability to Latitude via a `Stop`-hook that streams full transcripts as OTLP traces.

- New `@latitude-data/claude-code-telemetry` package — a CLI hook that reads incremental lines from `~/.claude/projects/**/*.jsonl`, converts each turn into `interaction` / `llm_request` / `tool_execution` spans, and POSTs them to `${LATITUDE_BASE_URL}/v1/traces`. State at `~/.claude/state/latitude/state.json` makes runs incremental.
- Server-side routing in `packages/domain/spans/src/otlp/resolvers/operation.ts` maps the new span types to existing `Operation` kinds; parsing reuses the generic `parseGenAICurrent` path.
- GitHub Actions workflow (`publish-claude-code-telemetry.yml`) publishes the package to npm on merges to `main` when the version bumps, mirroring the typescript telemetry workflow.
- Docs in `docs/claude-code-telemetry.md` (user-facing setup) and `prd/claude-code-telemetry.md` (rationale — why a Stop hook instead of Claude Code's native OTEL path: full transcript fidelity, no truncation, no flag combinatorics).

Install path for end users:

\`\`\`json
{
  "env": { "LATITUDE_API_KEY": "lat_xxx", "LATITUDE_PROJECT": "my-project" },
  "hooks": { "Stop": [{ "hooks": [{ "type": "command", "command": "npx -y @latitude-data/claude-code-telemetry", "async": true }] }] }
}
\`\`\`

Works for CLI, desktop, and IDE integrations; the web app at `claude.ai/code` is unsupported (no local filesystem).

## Test plan

- [x] Unit tests pass: \`pnpm --filter @latitude-data/claude-code-telemetry test\` (covers transcript parsing and OTLP conversion)
- [x] New server-side test \`packages/domain/spans/src/otlp/tests/claude-code.test.ts\` passes
- [x] \`pnpm knip\` is clean
- [x] End-to-end smoke: install the hook locally, run a Claude Code session, confirm spans appear in the Latitude UI grouped by \`session.id\`
- [x] Verify the publish workflow is gated to version bumps and won't re-publish on unrelated pushes