### PR TITLE
fix(workflows): stop evaluation alignment workflow hanging in progress

### DIFF
--- a/apps/workflows/src/workflows/annotation-publication-workflow.ts
+++ b/apps/workflows/src/workflows/annotation-publication-workflow.ts
@@ -1,8 +1,13 @@
 import { proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 const { enrichAnnotationForPublication, writePublishedAnnotationScore } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
+  retry: {
+    ...defaultActivityRetryPolicy,
+    nonRetryableErrorTypes: ["BadRequestError"],
+  },
 })
 
 export const publishAnnotationWorkflow = async (input: {

--- a/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.ts
+++ b/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.ts
@@ -1,9 +1,13 @@
 import { proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 const { embedScoreFeedback, assignScoreToIssue, syncIssueProjections, syncScoreAnalytics } = proxyActivities<
   typeof activities
->({ startToCloseTimeout: "5 minutes" })
+>({
+  startToCloseTimeout: "5 minutes",
+  retry: defaultActivityRetryPolicy,
+})
 
 export const assignScoreToKnownIssueWorkflow = async (input: {
   readonly organizationId: string

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
@@ -408,23 +408,17 @@ describe("evaluationAlignmentWorkflow", () => {
   })
 
   it("coalesces repeated metric-refresh signals into one incremental pass", async () => {
-    let waitForSignal = true
     workflowRuntime.setConditionImpl(async (_predicate, timeout) => {
-      if (timeout === undefined && waitForSignal) {
-        waitForSignal = false
-        workflowRuntime.signalHandler?.({
-          reason: "debounced-metric-refresh",
-          jobId: "auto-refresh:eval-existing",
-        })
-        workflowRuntime.signalHandler?.({
-          reason: "debounced-metric-refresh",
-          jobId: "auto-refresh:eval-existing",
-        })
-        return true
-      }
-
       if (timeout !== undefined) {
         workflowRuntime.nowMs += timeout
+        workflowRuntime.signalHandler?.({
+          reason: "debounced-metric-refresh",
+          jobId: "auto-refresh:eval-existing",
+        })
+        workflowRuntime.signalHandler?.({
+          reason: "debounced-metric-refresh",
+          jobId: "auto-refresh:eval-existing",
+        })
         workflowRuntime.setConditionImpl(async () => {
           throw workflowRuntime.stopRefreshLoop
         })
@@ -439,10 +433,10 @@ describe("evaluationAlignmentWorkflow", () => {
         organizationId: "org-1",
         projectId: "proj-1",
         issueId: "issue-1",
-        jobId: "refresh-loop",
+        jobId: "auto-refresh:eval-existing",
         evaluationId: "eval-existing",
         refreshLoop: true,
-        reason: "initial-generation",
+        reason: "debounced-metric-refresh",
       }),
     ).rejects.toThrow("stop refresh loop")
 
@@ -508,9 +502,6 @@ describe("evaluationAlignmentWorkflow", () => {
     workflowRuntime.setConditionImpl(async (_predicate, timeout) => {
       if (timeout !== undefined) {
         workflowRuntime.nowMs += timeout
-        workflowRuntime.setConditionImpl(async () => {
-          throw workflowRuntime.stopRefreshLoop
-        })
         return false
       }
 
@@ -527,7 +518,7 @@ describe("evaluationAlignmentWorkflow", () => {
         refreshLoop: true,
         reason: "debounced-metric-refresh",
       }),
-    ).rejects.toThrow("stop refresh loop")
+    ).resolves.toBeUndefined()
 
     expect(callOrder).toEqual([
       "loadEvaluationAlignmentState",
@@ -543,18 +534,12 @@ describe("evaluationAlignmentWorkflow", () => {
   })
 
   it("runs a manual signal through the full realignment path inside the refresh loop", async () => {
-    let waitForSignal = true
     workflowRuntime.setConditionImpl(async () => {
-      if (waitForSignal) {
-        waitForSignal = false
-        workflowRuntime.signalHandler?.({
-          reason: "manual-realignment",
-          jobId: "manual-job-1",
-        })
-        return true
-      }
-
-      throw workflowRuntime.stopRefreshLoop
+      workflowRuntime.signalHandler?.({
+        reason: "manual-realignment",
+        jobId: "manual-job-1",
+      })
+      return true
     })
 
     await expect(
@@ -562,12 +547,12 @@ describe("evaluationAlignmentWorkflow", () => {
         organizationId: "org-1",
         projectId: "proj-1",
         issueId: "issue-1",
-        jobId: "refresh-loop",
+        jobId: "auto-refresh:eval-existing",
         evaluationId: "eval-existing",
         refreshLoop: true,
-        reason: "initial-generation",
+        reason: "debounced-metric-refresh",
       }),
-    ).rejects.toThrow("stop refresh loop")
+    ).resolves.toBeUndefined()
 
     expect(callOrder).toEqual([
       "status:running",

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
@@ -38,7 +38,16 @@ const {
   optimizeEvaluationDraft,
   persistEvaluationAlignmentResult,
   writeEvaluationAlignmentJobStatus,
-} = proxyActivities<typeof activities>({ startToCloseTimeout: "5 minutes" })
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    initialInterval: "1 second",
+    backoffCoefficient: 2,
+    maximumInterval: "1 minute",
+    maximumAttempts: 5,
+    nonRetryableErrorTypes: ["EvaluationManualRealignmentRateLimitedError"],
+  },
+})
 
 const toFailurePayload = (error: unknown) => {
   const maybeTag = (error as { _tag?: string } | null)?._tag

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
@@ -382,8 +382,7 @@ export const evaluationAlignmentWorkflow = async (input: EvaluationAlignmentWork
     const currentRevision = scheduleRevision
 
     if (nextDueAtMs === null) {
-      await condition(() => scheduleRevision !== currentRevision || pendingManualJobId !== null)
-      continue
+      return
     }
 
     await condition(

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.ts
@@ -5,6 +5,7 @@ import {
 import { EVALUATION_ALIGNMENT_REFRESH_SIGNAL } from "@domain/queue/workflow-registry"
 import { condition, defineSignal, proxyActivities, setHandler } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 type EvaluationAlignmentWorkflowInput = {
   readonly organizationId: string
@@ -41,10 +42,7 @@ const {
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
   retry: {
-    initialInterval: "1 second",
-    backoffCoefficient: 2,
-    maximumInterval: "1 minute",
-    maximumAttempts: 5,
+    ...defaultActivityRetryPolicy,
     nonRetryableErrorTypes: ["EvaluationManualRealignmentRateLimitedError"],
   },
 })

--- a/apps/workflows/src/workflows/issue-discovery-workflow.ts
+++ b/apps/workflows/src/workflows/issue-discovery-workflow.ts
@@ -1,5 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 const {
   checkEligibility,
@@ -11,7 +12,10 @@ const {
   assignScoreToIssue,
   syncIssueProjections,
   syncScoreAnalytics,
-} = proxyActivities<typeof activities>({ startToCloseTimeout: "5 minutes" })
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: defaultActivityRetryPolicy,
+})
 
 export const issueDiscoveryWorkflow = async (input: {
   readonly organizationId: string

--- a/apps/workflows/src/workflows/retry-policy.ts
+++ b/apps/workflows/src/workflows/retry-policy.ts
@@ -1,0 +1,20 @@
+import type { ActivityOptions } from "@temporalio/workflow"
+
+/**
+ * Default retry policy for activities in this app.
+ *
+ * Temporal's built-in default is unlimited retries with 100s-capped backoff,
+ * which lets a failing activity keep a workflow "in progress" forever. This
+ * policy caps attempts at 5 with backoff up to 1 minute between tries.
+ *
+ * Workflows that throw deterministic domain errors (validation failures,
+ * rate limits, not-found conditions that won't resolve with time) should
+ * spread this and extend `nonRetryableErrorTypes` so those errors fail fast
+ * instead of burning attempts.
+ */
+export const defaultActivityRetryPolicy: NonNullable<ActivityOptions["retry"]> = {
+  initialInterval: "1 second",
+  backoffCoefficient: 2,
+  maximumInterval: "1 minute",
+  maximumAttempts: 5,
+}

--- a/apps/workflows/src/workflows/system-queue-flagger-workflow.ts
+++ b/apps/workflows/src/workflows/system-queue-flagger-workflow.ts
@@ -1,8 +1,10 @@
 import { log, proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 const { runFlagger, draftAnnotate, persistAnnotation } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 seconds",
+  retry: defaultActivityRetryPolicy,
 })
 
 /**


### PR DESCRIPTION
## The problem

Evaluation alignment workflows would show as **in progress** in Temporal indefinitely, even after every activity had finished. Two independent causes, both reproducible on any run of the refresh-loop variant:

1. **Idle loop never exits.** When the refresh-loop drained its pending work, it parked on an untimed `condition()` waiting for a signal that might never come.
2. **Activities retry forever on failure.** `proxyActivities` was called without a retry policy, so activities inherited Temporal's default — unlimited attempts with exponential backoff capped at 100s. A single failing activity kept the workflow alive forever.

Either one alone is enough to leave a workflow "in progress" with no apparent cause. Together, they made the state essentially unrecoverable without manual termination.

The retry issue turned out to affect **every** workflow in `apps/workflows/src/workflows/`, not just evaluation alignment, so this PR also applies the same bounded retry policy to the other four.

---

## Fix 1 — Exit the refresh loop when idle

**File:** [`apps/workflows/src/workflows/evaluation-alignment-workflow.ts`](apps/workflows/src/workflows/evaluation-alignment-workflow.ts)

The refresh-loop branch ran `for (;;)` and, after processing any pending refresh, called:

```typescript
// Before
if (nextDueAtMs === null) {
  await condition(() => scheduleRevision !== currentRevision || pendingManualJobId !== null)
  continue
}
```

With no timeout, this awaited indefinitely. For one-shot invocations (manual realignment via `signalWithStart`), no further signal ever arrived.

```typescript
// After
if (nextDueAtMs === null) {
  return
}
```

### Why returning is safe

- **Every caller uses `signalWithStart`** ([`apps/workers/src/workers/evaluations.ts:21`](apps/workers/src/workers/evaluations.ts#L21), [`apps/web/src/domains/evaluations/evaluation-alignment.functions.ts:253`](apps/web/src/domains/evaluations/evaluation-alignment.functions.ts#L253)). If a signal arrives after the workflow closes, Temporal starts a fresh workflow to handle it. No plain `signal()` calls exist for this workflow.
- **Signals received during activity calls aren't lost.** Handlers run at `await` boundaries and mutate the `pending*` state that the loop re-checks before deciding to return. So any signal arriving *before* the workflow closes is processed.
- The workflow now has a clear invariant: **run while there is scheduled or pending work; exit when the queue empties.**

### Test changes

Two tests used `reason: "initial-generation"` + `refreshLoop: true` as an "idle-start" fixture. That combo never occurs in production (initial generation goes through the non-loop branch) and is incompatible with the new exit-on-idle invariant. Switched them to start with a realistic reason (`debounced-metric-refresh`) and inject signals during the timed wait. Two tests now assert `.resolves.toBeUndefined()` instead of throwing a sentinel to break out of the loop.

---

## Fix 2 — Bound activity retries (all five workflows)

**New file:** [`apps/workflows/src/workflows/retry-policy.ts`](apps/workflows/src/workflows/retry-policy.ts) — a shared `defaultActivityRetryPolicy`.

**Updated:** every workflow in [`apps/workflows/src/workflows/`](apps/workflows/src/workflows/).

Each workflow proxied activities without a retry policy:

```typescript
// Before
proxyActivities<typeof activities>({ startToCloseTimeout: "5 minutes" })
```

Temporal's default retry policy is unlimited attempts (`maximumAttempts: 0`). That means:

- Any transient activity failure retried forever at up to 100s intervals.
- Permanent failures (bugs, bad data) also retried forever.
- Workflow-level `try/catch` around activity calls never fired, because Temporal never gave up on the activity to give control back.

The shared policy:

```typescript
// retry-policy.ts
export const defaultActivityRetryPolicy = {
  initialInterval: "1 second",
  backoffCoefficient: 2,
  maximumInterval: "1 minute",
  maximumAttempts: 5,
}
```

Applied as:

```typescript
// After (generic)
proxyActivities<typeof activities>({
  startToCloseTimeout: "5 minutes",
  retry: defaultActivityRetryPolicy,
})
```

Two workflows extend the policy with deterministic, non-retryable domain errors:

| Workflow | Non-retryable error | Rationale |
| --- | --- | --- |
| `evaluation-alignment` | `EvaluationManualRealignmentRateLimitedError` | User hit the rate limit. Retrying just burns attempts until the Redis TTL expires. |
| `annotation-publication` | `BadRequestError` | Validation failures (missing score, wrong source) are deterministic — retrying can't fix them. |

The other three (`issue-discovery`, `assign-score-to-known-issue`, `system-queue-flagger`) use the base policy unchanged.

### Why 5 attempts

- Enough to absorb transient infra blips (DB reconnects, ClickHouse throttling, brief network issues).
- Small enough to surface bugs quickly instead of letting them compound into long-running failing workflows.
- With the 1s → 2s → 4s → 8s → 16s (capped at 60s) backoff, the last attempt lands within ~30s — fast feedback while still giving retries room.

---

## Test plan

- [x] `pnpm --filter @app/workflows test` — 51 tests pass
- [x] `pnpm --filter @app/workflows typecheck` — clean
- [ ] Verify on staging Temporal UI that a manual realignment workflow closes after completion
- [ ] Verify on staging Temporal UI that a workflow with a failing activity closes after 5 attempts rather than retrying indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)