### PR TITLE
fix(telemetry): restore capture root traces

### DIFF
--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0a2] - 2026-04-17
+
+### Fixed
+
+- `capture()` now starts a new Latitude root trace when called under an active non-Latitude span, so wrapper spans such as workflow-level capture names are preserved instead of being absorbed into foreign traces.
+- Nested Latitude `capture()` calls still reuse the existing Latitude-owned trace and merge context as before.
+
 ## [3.0.0a1] - 2026-04-01
 
 ### Breaking Changes

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a1"
+version = "3.0.0a2"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
@@ -58,11 +58,14 @@ def get_latitude_context(ctx: Context) -> _LatitudeContextData | None:
     return data if isinstance(data, _LatitudeContextData) else None
 
 
-def _set_capture_context(name: str, options: ContextOptions | None = None) -> Context:
+def _should_reuse_active_latitude_trace(current_context: Context) -> bool:
+    return get_latitude_context(current_context) is not None
+
+
+def _set_capture_context(name: str, base_context: Context, options: ContextOptions | None = None) -> Context:
     """Set up the capture context and return the new OTel context."""
     opts = options or {}
-    current_context = otel_context.get_current()
-    existing_data = get_latitude_context(current_context)
+    existing_data = get_latitude_context(base_context)
 
     # Merge logic matching TypeScript SDK:
     # - name: options.name takes precedence over capture name
@@ -81,22 +84,23 @@ def _set_capture_context(name: str, options: ContextOptions | None = None) -> Co
         user_id=opts.get("user_id") or (existing_data.user_id if existing_data else None),
     )
 
-    return otel_context.set_value(LATITUDE_CONTEXT_KEY, merged_data, current_context)
+    return otel_context.set_value(LATITUDE_CONTEXT_KEY, merged_data, base_context)
 
 
 def _execute_with_context(name: str, fn: Callable[[], T], options: ContextOptions | None = None) -> T:
-    """Execute a function within the capture context, creating a parent span if no trace exists."""
+    """Execute within capture context, reusing only Latitude-owned active traces."""
     current_context = otel_context.get_current()
-    new_context = _set_capture_context(name, options)
+    should_reuse_trace = _should_reuse_active_latitude_trace(current_context)
+    base_context = (
+        current_context if should_reuse_trace else trace.set_span_in_context(trace.INVALID_SPAN, current_context)
+    )
+    new_context = _set_capture_context(name, base_context, options)
 
-    # Check if there's already an active span in the current context
     existing_span = trace.get_current_span(current_context)
 
-    if existing_span and existing_span.is_recording():
-        # There's already a trace ongoing - just propagate context without creating a new parent
+    if existing_span and existing_span.is_recording() and should_reuse_trace:
         return _execute_with_existing_context(fn, new_context)
 
-    # No active span - create a parent span to establish trace continuity
     return _execute_with_new_parent_span(name, fn, new_context)
 
 
@@ -203,8 +207,9 @@ def capture(
     The context includes tags, metadata, session_id, and user_id which are
     stamped onto all spans via the LatitudeSpanProcessor.on_start() method.
 
-    If no active trace exists, capture() creates a parent span to establish
-    trace continuity. If a trace already exists, it participates in that trace.
+    If no active Latitude trace exists, capture() creates a parent span to
+    establish trace continuity. Nested Latitude capture() calls reuse the
+    existing Latitude trace instead of creating another root span.
 
     Args:
         name: Name for the capture context (stored as latitude.capture.name attribute)
@@ -270,20 +275,21 @@ async def _execute_with_context_async(
 ) -> object:
     """Execute async function with capture context."""
     current_context = otel_context.get_current()
-    new_context = _set_capture_context(name, options)
+    should_reuse_trace = _should_reuse_active_latitude_trace(current_context)
+    base_context = (
+        current_context if should_reuse_trace else trace.set_span_in_context(trace.INVALID_SPAN, current_context)
+    )
+    new_context = _set_capture_context(name, base_context, options)
 
-    # Check if there's already an active span in the current context
     existing_span = trace.get_current_span(current_context)
 
-    if existing_span and existing_span.is_recording():
-        # There's already a trace ongoing - just propagate context without creating a new parent
+    if existing_span and existing_span.is_recording() and should_reuse_trace:
         token = otel_context.attach(new_context)
         try:
             return await fn(*args, **kwargs)
         finally:
             otel_context.detach(token)
 
-    # No active span - create a parent span to establish trace continuity
     tracer = trace.get_tracer(CAPTURE_TRACER_NAME)
     token = otel_context.attach(new_context)
     try:
@@ -309,20 +315,21 @@ def _execute_with_context_sync(
 ) -> object:
     """Execute sync function with capture context."""
     current_context = otel_context.get_current()
-    new_context = _set_capture_context(name, options)
+    should_reuse_trace = _should_reuse_active_latitude_trace(current_context)
+    base_context = (
+        current_context if should_reuse_trace else trace.set_span_in_context(trace.INVALID_SPAN, current_context)
+    )
+    new_context = _set_capture_context(name, base_context, options)
 
-    # Check if there's already an active span in the current context
     existing_span = trace.get_current_span(current_context)
 
-    if existing_span and existing_span.is_recording():
-        # There's already a trace ongoing - just propagate context without creating a new parent
+    if existing_span and existing_span.is_recording() and should_reuse_trace:
         token = otel_context.attach(new_context)
         try:
             return fn(*args, **kwargs)
         finally:
             otel_context.detach(token)
 
-    # No active span - create a parent span to establish trace continuity
     tracer = trace.get_tracer(CAPTURE_TRACER_NAME)
     token = otel_context.attach(new_context)
     try:

--- a/packages/telemetry/python/tests/telemetry/trace_continuity_test.py
+++ b/packages/telemetry/python/tests/telemetry/trace_continuity_test.py
@@ -6,6 +6,7 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
 from latitude_telemetry import capture, get_latitude_context
+from latitude_telemetry.sdk.context import LATITUDE_CONTEXT_KEY, _LatitudeContextData
 
 
 class TestTraceContinuity:
@@ -53,11 +54,10 @@ class TestTraceContinuity:
         # First span should be the capture parent span (recording)
         assert spans[0]["is_recording"] is True
 
-    def test_capture_reuses_existing_trace(self):
-        """Test that capture() joins existing trace when one exists."""
+    def test_capture_creates_new_root_trace_when_only_external_trace_exists(self):
+        """Test that capture() starts a new root trace when the active trace is not Latitude-owned."""
         tracer = trace.get_tracer("test.tracer")
 
-        # First, create an outer span manually
         with tracer.start_as_current_span("outer-manual-span") as outer:
             outer_trace_id = outer.get_span_context().trace_id
 
@@ -70,7 +70,33 @@ class TestTraceContinuity:
 
             capture("nested-capture", my_function)
 
-            # The captured span should be in the same trace
+            assert captured_trace_id[0] != outer_trace_id
+
+    def test_capture_reuses_existing_latitude_trace(self):
+        """Test that nested Latitude capture() calls stay inside the existing Latitude trace."""
+        tracer = trace.get_tracer("test.tracer")
+
+        with tracer.start_as_current_span("outer-manual-span") as outer:
+            outer_trace_id = outer.get_span_context().trace_id
+            latitude_context = otel_context.set_value(
+                LATITUDE_CONTEXT_KEY,
+                _LatitudeContextData(name="outer-capture", tags=["outer"], metadata={"foo": "bar"}),
+                otel_context.get_current(),
+            )
+
+            captured_trace_id = []
+
+            def my_function():
+                current_span = trace.get_current_span()
+                captured_trace_id.append(current_span.get_span_context().trace_id)
+                return "done"
+
+            token = otel_context.attach(latitude_context)
+            try:
+                capture("nested-capture", my_function, {"tags": ["inner"]})
+            finally:
+                otel_context.detach(token)
+
             assert captured_trace_id[0] == outer_trace_id
 
     def test_child_spans_share_trace_id(self):

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.5] - 2026-04-17
+
+### Fixed
+
+- `capture()` now starts a new Latitude root trace when called under an active non-Latitude span, so wrapper spans such as workflow-level capture names are preserved instead of being absorbed into foreign traces.
+- Nested Latitude `capture()` calls still reuse the existing Latitude-owned trace and merge context as before.
+
 ## [3.0.0-alpha.4] - 2026-04-14
 
 ### Fixed

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.4",
+  "version": "3.0.0-alpha.5",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/sdk/capture-continuity.test.ts
+++ b/packages/telemetry/typescript/src/sdk/capture-continuity.test.ts
@@ -1,10 +1,12 @@
-import { context, type TracerProvider, trace } from "@opentelemetry/api"
+import { context, createContextKey, type TracerProvider, trace } from "@opentelemetry/api"
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
 import type { ReadableSpan, Span } from "@opentelemetry/sdk-trace-node"
 import { beforeAll, describe, expect, it, vi } from "vitest"
-import { capture, LATITUDE_CONTEXT_KEY } from "./context.ts"
+import { capture, getLatitudeContext, LATITUDE_CONTEXT_KEY } from "./context.ts"
 import { LatitudeSpanProcessor } from "./processor.ts"
 import { isDefaultExportSpan } from "./span-filter.ts"
+
+const TEST_CONTEXT_KEY = createContextKey("test-context-key")
 
 describe("capture trace continuity", () => {
   beforeAll(() => {
@@ -54,7 +56,7 @@ describe("capture trace continuity", () => {
       trace.setGlobalTracerProvider(originalGetTracerProvider)
     })
 
-    it("should propagate context when trace exists", async () => {
+    it("should create a new root capture span when only an external trace exists", async () => {
       const mockExistingSpan = {
         spanContext: () => ({
           traceId: "existing-trace-id",
@@ -63,22 +65,90 @@ describe("capture trace continuity", () => {
         }),
       }
 
-      const originalGetSpan = trace.getSpan
-      vi.spyOn(trace, "getSpan").mockReturnValue(mockExistingSpan as unknown as Span)
+      const getSpanSpy = vi.spyOn(trace, "getSpan").mockReturnValue(mockExistingSpan as unknown as Span)
+
+      const mockTracer = {
+        startActiveSpan: vi.fn((name: string, options: unknown, ctx: unknown, callback: (span: Span) => unknown) => {
+          const mockSpan = {
+            name,
+            attributes: (options as { attributes?: Record<string, unknown> }).attributes || {},
+            spanContext: () => ({
+              traceId: "new-root-trace-id",
+              spanId: "new-root-span-id",
+              traceFlags: 1,
+            }),
+            end: vi.fn(),
+            recordException: vi.fn(),
+          } as unknown as Span
+
+          expect(getLatitudeContext(ctx as Parameters<typeof getLatitudeContext>[0])?.name).toBe("nested-capture")
+          expect((ctx as Parameters<typeof getLatitudeContext>[0]).getValue(TEST_CONTEXT_KEY)).toBe("test-value")
+          return callback(mockSpan)
+        }),
+      }
+      const getTracerSpy = vi.spyOn(trace, "getTracer").mockReturnValue(mockTracer as never)
 
       let contextWasPropagated = false
 
-      await capture(
-        "nested-capture",
-        async () => {
-          contextWasPropagated = true
-          return "done"
-        },
-        { tags: ["nested"] },
+      await context.with(context.active().setValue(TEST_CONTEXT_KEY, "test-value"), () =>
+        capture(
+          "nested-capture",
+          async () => {
+            contextWasPropagated = true
+            return "done"
+          },
+          { tags: ["nested"] },
+        ),
       )
 
       expect(contextWasPropagated).toBe(true)
-      trace.getSpan = originalGetSpan
+      expect(mockTracer.startActiveSpan).toHaveBeenCalledTimes(1)
+      expect(mockTracer.startActiveSpan.mock.calls[0]?.[0]).toBe("nested-capture")
+      expect(mockTracer.startActiveSpan.mock.calls[0]?.[1]).toEqual({ attributes: { "latitude.capture.root": true } })
+      getTracerSpy.mockRestore()
+      getSpanSpy.mockRestore()
+    })
+
+    it("should reuse the current trace when Latitude capture context already exists", async () => {
+      const mockExistingSpan = {
+        spanContext: () => ({
+          traceId: "existing-latitude-trace-id",
+          spanId: "existing-latitude-span-id",
+          traceFlags: 1,
+        }),
+      }
+
+      const getSpanSpy = vi.spyOn(trace, "getSpan").mockReturnValue(mockExistingSpan as unknown as Span)
+      const mockStartActiveSpan = vi.fn()
+      const getTracerSpy = vi
+        .spyOn(trace, "getTracer")
+        .mockReturnValue({ startActiveSpan: mockStartActiveSpan } as never)
+
+      let contextWasPropagated = false
+
+      await context.with(
+        context.active().setValue(LATITUDE_CONTEXT_KEY, {
+          name: "outer-capture",
+          tags: ["outer"],
+          metadata: { foo: "bar" },
+          sessionId: undefined,
+          userId: undefined,
+        }),
+        async () => {
+          await capture(
+            "nested-latitude-capture",
+            async () => {
+              contextWasPropagated = true
+            },
+            { tags: ["inner"] },
+          )
+        },
+      )
+
+      expect(contextWasPropagated).toBe(true)
+      expect(mockStartActiveSpan).not.toHaveBeenCalled()
+      getTracerSpy.mockRestore()
+      getSpanSpy.mockRestore()
     })
   })
 

--- a/packages/telemetry/typescript/src/sdk/context.ts
+++ b/packages/telemetry/typescript/src/sdk/context.ts
@@ -33,9 +33,15 @@ function mergeArrays<T>(a: T[] | undefined, b: T[] | undefined): T[] | undefined
   return [...new Set([...a, ...b])]
 }
 
+function shouldReuseActiveLatitudeTrace(currentContext: Context): boolean {
+  return getLatitudeContext(currentContext) !== undefined
+}
+
 export function capture<T>(name: string, fn: () => T | Promise<T>, options: ContextOptions = {}): T | Promise<T> {
   const currentContext = context.active()
   const existingData = getLatitudeContext(currentContext)
+  const shouldReuseTrace = shouldReuseActiveLatitudeTrace(currentContext)
+  const parentContext = shouldReuseTrace ? currentContext : trace.deleteSpan(currentContext)
 
   const mergedData: LatitudeContextData = {
     name: options.name ?? name,
@@ -45,10 +51,10 @@ export function capture<T>(name: string, fn: () => T | Promise<T>, options: Cont
     userId: options.userId ?? existingData?.userId,
   }
 
-  const newContext = currentContext.setValue(LATITUDE_CONTEXT_KEY, mergedData)
+  const newContext = parentContext.setValue(LATITUDE_CONTEXT_KEY, mergedData)
   const existingSpan = trace.getSpan(currentContext)
 
-  if (existingSpan) {
+  if (existingSpan && shouldReuseTrace) {
     return context.with(newContext, fn)
   }
 


### PR DESCRIPTION
## Summary
- restore `capture()` root span behavior by reusing the active trace only when it already belongs to Latitude capture context
- start a fresh Latitude root trace under non-Latitude active spans while preserving unrelated context values, and add continuity regressions in both SDKs
- bump the telemetry package versions and changelogs to document the fix (`@latitude-data/telemetry` `3.0.0-alpha.5`, `latitude-telemetry` `3.0.0a2`)

## Testing
- `pnpm --filter @latitude-data/telemetry test -- src/sdk/context.test.ts src/sdk/capture-continuity.test.ts`
- `pnpm --filter @latitude-data/telemetry typecheck`
- `./.venv/bin/pytest tests/telemetry/capture_test.py tests/telemetry/trace_continuity_test.py`
- `./.venv/bin/ruff format src/latitude_telemetry/sdk/context.py tests/telemetry/trace_continuity_test.py tests/telemetry/capture_test.py && ./.venv/bin/ruff check src/latitude_telemetry/sdk/context.py tests/telemetry/trace_continuity_test.py tests/telemetry/capture_test.py`

## Notes
- `./.venv/bin/pyright` in `packages/telemetry/python` still reports existing missing-import / unknown-type issues for OpenTelemetry and pytest in this environment, so I did not include it as a passing check.