### PR TITLE
refactor(domain): adopt Effect.fn pattern for use cases

### DIFF
--- a/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
@@ -14,8 +14,7 @@ export interface CompleteQueueItemInput {
 
 export type CompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemAlreadyCompletedError
 
-export const completeQueueItemUseCase = (input: CompleteQueueItemInput) =>
-  Effect.gen(function* () {
+export const completeQueueItemUseCase = Effect.fn("annotationQueues.completeQueueItem")(function* (input: CompleteQueueItemInput) {
     yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
@@ -72,4 +71,4 @@ export const completeQueueItemUseCase = (input: CompleteQueueItemInput) =>
         return updated
       }),
     )
-  }).pipe(Effect.withSpan("annotationQueues.completeQueueItem"))
+  })

--- a/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/complete-queue-item.ts
@@ -14,61 +14,63 @@ export interface CompleteQueueItemInput {
 
 export type CompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemAlreadyCompletedError
 
-export const completeQueueItemUseCase = Effect.fn("annotationQueues.completeQueueItem")(function* (input: CompleteQueueItemInput) {
-    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
+export const completeQueueItemUseCase = Effect.fn("annotationQueues.completeQueueItem")(function* (
+  input: CompleteQueueItemInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
 
-    const sqlClient = yield* SqlClient
-    const itemRepo = yield* AnnotationQueueItemRepository
-    const queueRepo = yield* AnnotationQueueRepository
+  const sqlClient = yield* SqlClient
+  const itemRepo = yield* AnnotationQueueItemRepository
+  const queueRepo = yield* AnnotationQueueRepository
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const item = yield* itemRepo.findById({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          itemId: input.itemId,
-        })
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const item = yield* itemRepo.findById({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        itemId: input.itemId,
+      })
 
-        if (!item) {
-          return yield* new QueueItemNotFoundError({ itemId: input.itemId })
-        }
+      if (!item) {
+        return yield* new QueueItemNotFoundError({ itemId: input.itemId })
+      }
 
-        if (item.completedAt) {
-          return yield* new QueueItemAlreadyCompletedError({ itemId: input.itemId })
-        }
+      if (item.completedAt) {
+        return yield* new QueueItemAlreadyCompletedError({ itemId: input.itemId })
+      }
 
-        const updated = yield* itemRepo.update({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          itemId: input.itemId,
-          completedAt: new Date(),
-          completedBy: input.userId,
-        })
+      const updated = yield* itemRepo.update({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        itemId: input.itemId,
+        completedAt: new Date(),
+        completedBy: input.userId,
+      })
 
-        yield* queueRepo.incrementCompletedItems({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          delta: 1,
-        })
+      yield* queueRepo.incrementCompletedItems({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        delta: 1,
+      })
 
-        const outboxEventWriter = yield* OutboxEventWriter
-        yield* outboxEventWriter.write({
-          eventName: "AnnotationQueueItemCompleted",
-          aggregateType: "annotation_queue_item",
-          aggregateId: input.itemId,
+      const outboxEventWriter = yield* OutboxEventWriter
+      yield* outboxEventWriter.write({
+        eventName: "AnnotationQueueItemCompleted",
+        aggregateType: "annotation_queue_item",
+        aggregateId: input.itemId,
+        organizationId: sqlClient.organizationId,
+        payload: {
           organizationId: sqlClient.organizationId,
-          payload: {
-            organizationId: sqlClient.organizationId,
-            actorUserId: input.userId,
-            projectId: input.projectId,
-            queueId: input.queueId,
-            itemId: input.itemId,
-          },
-        })
+          actorUserId: input.userId,
+          projectId: input.projectId,
+          queueId: input.queueId,
+          itemId: input.itemId,
+        },
+      })
 
-        return updated
-      }),
-    )
-  })
+      return updated
+    }),
+  )
+})

--- a/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
@@ -42,8 +42,7 @@ export type DraftSystemQueueAnnotationError = BadRequestError | RepositoryError 
  * This use case is idempotent - retrying with the same (queueId, traceId) will
  * regenerate the same feedback (or similar, since LLM output may vary slightly).
  */
-export const draftSystemQueueAnnotationUseCase = (input: DraftSystemQueueAnnotationInput) =>
-  Effect.gen(function* () {
+export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.draftSystemQueueAnnotation")(function* (input: DraftSystemQueueAnnotationInput) {
     yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
@@ -84,5 +83,5 @@ export const draftSystemQueueAnnotationUseCase = (input: DraftSystemQueueAnnotat
       traceId: parsedInput.traceId,
       feedback: annotatorResult.feedback,
       traceCreatedAt: annotatorResult.traceCreatedAt,
-    } as DraftSystemQueueAnnotationOutput
-  }).pipe(Effect.withSpan("annotationQueues.draftSystemQueueAnnotation"))
+  } as DraftSystemQueueAnnotationOutput
+})

--- a/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
@@ -42,46 +42,48 @@ export type DraftSystemQueueAnnotationError = BadRequestError | RepositoryError 
  * This use case is idempotent - retrying with the same (queueId, traceId) will
  * regenerate the same feedback (or similar, since LLM output may vary slightly).
  */
-export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.draftSystemQueueAnnotation")(function* (input: DraftSystemQueueAnnotationInput) {
-    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
-    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.draftSystemQueueAnnotation")(function* (
+  input: DraftSystemQueueAnnotationInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
 
-    const parsedInput = yield* parseOrBadRequest(
-      systemQueueAnnotateInputSchema,
-      input,
-      "Invalid system queue annotate input",
-    )
+  const parsedInput = yield* parseOrBadRequest(
+    systemQueueAnnotateInputSchema,
+    input,
+    "Invalid system queue annotate input",
+  )
 
-    const projectId = ProjectId(parsedInput.projectId)
+  const projectId = ProjectId(parsedInput.projectId)
 
-    const queueRepository = yield* AnnotationQueueRepository
-    const queue = yield* queueRepository.findSystemQueueBySlugInProject({
-      projectId,
-      queueSlug: parsedInput.queueSlug,
+  const queueRepository = yield* AnnotationQueueRepository
+  const queue = yield* queueRepository.findSystemQueueBySlugInProject({
+    projectId,
+    queueSlug: parsedInput.queueSlug,
+  })
+
+  if (!queue) {
+    return yield* new BadRequestError({
+      message: `System queue not found for slug: ${parsedInput.queueSlug}`,
     })
+  }
 
-    if (!queue) {
-      return yield* new BadRequestError({
-        message: `System queue not found for slug: ${parsedInput.queueSlug}`,
-      })
-    }
+  const queueId = queue.id
 
-    const queueId = queue.id
+  const annotatorResult = yield* runSystemQueueAnnotatorUseCase({
+    organizationId: parsedInput.organizationId,
+    projectId: parsedInput.projectId,
+    queueSlug: parsedInput.queueSlug,
+    traceId: parsedInput.traceId,
+    ...(input.matchReasons ? { matchReasons: input.matchReasons } : {}),
+  })
 
-    const annotatorResult = yield* runSystemQueueAnnotatorUseCase({
-      organizationId: parsedInput.organizationId,
-      projectId: parsedInput.projectId,
-      queueSlug: parsedInput.queueSlug,
-      traceId: parsedInput.traceId,
-      ...(input.matchReasons ? { matchReasons: input.matchReasons } : {}),
-    })
-
-    return {
-      queueId,
-      traceId: parsedInput.traceId,
-      feedback: annotatorResult.feedback,
-      traceCreatedAt: annotatorResult.traceCreatedAt,
+  return {
+    queueId,
+    traceId: parsedInput.traceId,
+    feedback: annotatorResult.feedback,
+    traceCreatedAt: annotatorResult.traceCreatedAt,
   } as DraftSystemQueueAnnotationOutput
 })

--- a/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
@@ -46,31 +46,33 @@ export interface EvictProjectSystemQueuesInput {
   readonly projectId: ProjectId
 }
 
-export const getProjectSystemQueuesUseCase = Effect.fn("annotationQueues.getProjectSystemQueues")(function* (input: GetProjectSystemQueuesInput) {
-    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+export const getProjectSystemQueuesUseCase = Effect.fn("annotationQueues.getProjectSystemQueues")(function* (
+  input: GetProjectSystemQueuesInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
 
-    const cache = yield* CacheStore
-    const cacheKey = buildProjectSystemQueuesCacheKey(input.organizationId, input.projectId)
+  const cache = yield* CacheStore
+  const cacheKey = buildProjectSystemQueuesCacheKey(input.organizationId, input.projectId)
 
-    const cachedResult = yield* cache.get(cacheKey).pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
+  const cachedResult = yield* cache.get(cacheKey).pipe(Effect.catchTag("CacheError", () => Effect.succeed(null)))
 
-    if (cachedResult !== null) {
-      const parsed = parseCacheEntries(cachedResult)
-      if (parsed !== null) {
-        return parsed
-      }
+  if (cachedResult !== null) {
+    const parsed = parseCacheEntries(cachedResult)
+    if (parsed !== null) {
+      return parsed
     }
+  }
 
-    const repo = yield* AnnotationQueueRepository
-    const queues = yield* repo.listSystemQueuesByProject({ projectId: input.projectId })
-    const entries = queues.map(toCacheEntry)
+  const repo = yield* AnnotationQueueRepository
+  const queues = yield* repo.listSystemQueuesByProject({ projectId: input.projectId })
+  const entries = queues.map(toCacheEntry)
 
-    yield* cache
-      .set(cacheKey, encodeCacheEntries(entries), { ttlSeconds: CACHE_TTL_SECONDS })
-      .pipe(Effect.catchTag("CacheError", () => Effect.void))
+  yield* cache
+    .set(cacheKey, encodeCacheEntries(entries), { ttlSeconds: CACHE_TTL_SECONDS })
+    .pipe(Effect.catchTag("CacheError", () => Effect.void))
 
-    return entries
+  return entries
 })
 
 export const evictProjectSystemQueuesUseCase = (input: EvictProjectSystemQueuesInput) =>

--- a/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/get-project-system-queues.ts
@@ -46,8 +46,7 @@ export interface EvictProjectSystemQueuesInput {
   readonly projectId: ProjectId
 }
 
-export const getProjectSystemQueuesUseCase = (input: GetProjectSystemQueuesInput) =>
-  Effect.gen(function* () {
+export const getProjectSystemQueuesUseCase = Effect.fn("annotationQueues.getProjectSystemQueues")(function* (input: GetProjectSystemQueuesInput) {
     yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
 
@@ -72,7 +71,7 @@ export const getProjectSystemQueuesUseCase = (input: GetProjectSystemQueuesInput
       .pipe(Effect.catchTag("CacheError", () => Effect.void))
 
     return entries
-  }).pipe(Effect.withSpan("annotationQueues.getProjectSystemQueues"))
+})
 
 export const evictProjectSystemQueuesUseCase = (input: EvictProjectSystemQueuesInput) =>
   Effect.serviceOption(CacheStore).pipe(

--- a/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
+++ b/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
@@ -17,55 +17,57 @@ export interface MarkReviewStartedInput {
  *
  * Skips if the score is not an annotation or has no traceId.
  */
-export const markReviewStartedUseCase = Effect.fn("annotationQueues.markReviewStarted")(function* (input: MarkReviewStartedInput) {
-    yield* Effect.annotateCurrentSpan("score.id", input.score.id)
-    yield* Effect.annotateCurrentSpan("score.projectId", input.score.projectId)
+export const markReviewStartedUseCase = Effect.fn("annotationQueues.markReviewStarted")(function* (
+  input: MarkReviewStartedInput,
+) {
+  yield* Effect.annotateCurrentSpan("score.id", input.score.id)
+  yield* Effect.annotateCurrentSpan("score.projectId", input.score.projectId)
 
-    const { score } = input
+  const { score } = input
 
-    if (score.source !== "annotation") return 0
-    if (!score.traceId) return 0
+  if (score.source !== "annotation") return 0
+  if (!score.traceId) return 0
 
-    const projectId = ProjectId(score.projectId)
-    const traceId = score.traceId
+  const projectId = ProjectId(score.projectId)
+  const traceId = score.traceId
 
-    const existingAnnotations = yield* listTraceAnnotationsUseCase({
-      projectId: projectId as unknown as string,
-      traceId,
-      limit: 2,
-      draftMode: "include",
-    })
+  const existingAnnotations = yield* listTraceAnnotationsUseCase({
+    projectId: projectId as unknown as string,
+    traceId,
+    limit: 2,
+    draftMode: "include",
+  })
 
-    if (existingAnnotations.items.length > 1) {
-      return 0
-    }
+  if (existingAnnotations.items.length > 1) {
+    return 0
+  }
 
-    const itemRepo = yield* AnnotationQueueItemRepository
+  const itemRepo = yield* AnnotationQueueItemRepository
 
-    const items = yield* itemRepo.listByTraceId({
-      projectId,
-      traceId,
-    })
+  const items = yield* itemRepo.listByTraceId({
+    projectId,
+    traceId,
+  })
 
-    const pendingItems = items.filter((item) => item.completedAt === null && item.reviewStartedAt === null)
+  const pendingItems = items.filter((item) => item.completedAt === null && item.reviewStartedAt === null)
 
-    if (pendingItems.length === 0) {
-      return 0
-    }
+  if (pendingItems.length === 0) {
+    return 0
+  }
 
-    const now = new Date()
+  const now = new Date()
 
-    yield* Effect.forEach(
-      pendingItems,
-      (item) =>
-        itemRepo.update({
-          projectId,
-          queueId: item.queueId,
-          itemId: item.id,
-          reviewStartedAt: now,
-        }),
-      { concurrency: "unbounded" },
-    )
+  yield* Effect.forEach(
+    pendingItems,
+    (item) =>
+      itemRepo.update({
+        projectId,
+        queueId: item.queueId,
+        itemId: item.id,
+        reviewStartedAt: now,
+      }),
+    { concurrency: "unbounded" },
+  )
 
   return pendingItems.length
 })

--- a/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
+++ b/packages/domain/annotation-queues/src/use-cases/mark-review-started.ts
@@ -17,8 +17,7 @@ export interface MarkReviewStartedInput {
  *
  * Skips if the score is not an annotation or has no traceId.
  */
-export const markReviewStartedUseCase = (input: MarkReviewStartedInput) =>
-  Effect.gen(function* () {
+export const markReviewStartedUseCase = Effect.fn("annotationQueues.markReviewStarted")(function* (input: MarkReviewStartedInput) {
     yield* Effect.annotateCurrentSpan("score.id", input.score.id)
     yield* Effect.annotateCurrentSpan("score.projectId", input.score.projectId)
 
@@ -68,5 +67,5 @@ export const markReviewStartedUseCase = (input: MarkReviewStartedInput) =>
       { concurrency: "unbounded" },
     )
 
-    return pendingItems.length
-  }).pipe(Effect.withSpan("annotationQueues.markReviewStarted"))
+  return pendingItems.length
+})

--- a/packages/domain/annotation-queues/src/use-cases/materialize-live-queue-items.ts
+++ b/packages/domain/annotation-queues/src/use-cases/materialize-live-queue-items.ts
@@ -17,8 +17,7 @@ export interface MaterializeLiveQueueItemsResult {
 
 export type MaterializeLiveQueueItemsError = RepositoryError
 
-export const materializeLiveQueueItemsUseCase = (input: MaterializeLiveQueueItemsInput) =>
-  Effect.gen(function* () {
+export const materializeLiveQueueItemsUseCase = Effect.fn("annotationQueues.materializeLiveQueueItems")(function* (input: MaterializeLiveQueueItemsInput) {
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("traceId", input.traceId)
     yield* Effect.annotateCurrentSpan("annotationQueues.queueCount", input.queueIds.length)
@@ -53,5 +52,5 @@ export const materializeLiveQueueItemsUseCase = (input: MaterializeLiveQueueItem
 
     return {
       insertedItemCount,
-    } satisfies MaterializeLiveQueueItemsResult
-  }).pipe(Effect.withSpan("annotationQueues.materializeLiveQueueItems"))
+  } satisfies MaterializeLiveQueueItemsResult
+})

--- a/packages/domain/annotation-queues/src/use-cases/materialize-live-queue-items.ts
+++ b/packages/domain/annotation-queues/src/use-cases/materialize-live-queue-items.ts
@@ -17,40 +17,42 @@ export interface MaterializeLiveQueueItemsResult {
 
 export type MaterializeLiveQueueItemsError = RepositoryError
 
-export const materializeLiveQueueItemsUseCase = Effect.fn("annotationQueues.materializeLiveQueueItems")(function* (input: MaterializeLiveQueueItemsInput) {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("traceId", input.traceId)
-    yield* Effect.annotateCurrentSpan("annotationQueues.queueCount", input.queueIds.length)
+export const materializeLiveQueueItemsUseCase = Effect.fn("annotationQueues.materializeLiveQueueItems")(function* (
+  input: MaterializeLiveQueueItemsInput,
+) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("annotationQueues.queueCount", input.queueIds.length)
 
-    if (input.queueIds.length === 0) {
-      return {
-        insertedItemCount: 0,
-      } satisfies MaterializeLiveQueueItemsResult
-    }
-
-    const sqlClient = yield* SqlClient
-    const queueRepository = yield* AnnotationQueueRepository
-    const queueItemRepository = yield* AnnotationQueueItemRepository
-
-    const insertedItemCount = yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const { insertedQueueIds } = yield* queueItemRepository.insertManyAcrossQueues({
-          projectId: ProjectId(input.projectId),
-          traceId: TraceId(input.traceId),
-          traceCreatedAt: input.traceCreatedAt,
-          queueIds: input.queueIds,
-        })
-
-        yield* queueRepository.incrementTotalItemsMany({
-          projectId: ProjectId(input.projectId),
-          queueIds: insertedQueueIds,
-        })
-
-        return insertedQueueIds.length
-      }),
-    )
-
+  if (input.queueIds.length === 0) {
     return {
-      insertedItemCount,
+      insertedItemCount: 0,
+    } satisfies MaterializeLiveQueueItemsResult
+  }
+
+  const sqlClient = yield* SqlClient
+  const queueRepository = yield* AnnotationQueueRepository
+  const queueItemRepository = yield* AnnotationQueueItemRepository
+
+  const insertedItemCount = yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const { insertedQueueIds } = yield* queueItemRepository.insertManyAcrossQueues({
+        projectId: ProjectId(input.projectId),
+        traceId: TraceId(input.traceId),
+        traceCreatedAt: input.traceCreatedAt,
+        queueIds: input.queueIds,
+      })
+
+      yield* queueRepository.incrementTotalItemsMany({
+        projectId: ProjectId(input.projectId),
+        queueIds: insertedQueueIds,
+      })
+
+      return insertedQueueIds.length
+    }),
+  )
+
+  return {
+    insertedItemCount,
   } satisfies MaterializeLiveQueueItemsResult
 })

--- a/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
@@ -44,8 +44,7 @@ export type PersistSystemQueueAnnotationError = BadRequestError | RepositoryErro
  * - Default to `passed = false`, `value = 0`, no anchor (conversation-level)
  * - Do NOT auto-publish (no `annotation-scores:publish` event)
  */
-export const persistSystemQueueAnnotationUseCase = (input: PersistSystemQueueAnnotationInput) =>
-  Effect.gen(function* () {
+export const persistSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.persistSystemQueueAnnotation")(function* (input: PersistSystemQueueAnnotationInput) {
     yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
     yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
 
@@ -148,5 +147,5 @@ export const persistSystemQueueAnnotationUseCase = (input: PersistSystemQueueAnn
       traceId: parsedInput.traceId,
       draftAnnotationId: result.draftAnnotationId,
       wasCreated: result.wasCreated,
-    }) as SystemQueueAnnotateOutput
-  }).pipe(Effect.withSpan("annotationQueues.persistSystemQueueAnnotation"))
+  }) as SystemQueueAnnotateOutput
+})

--- a/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
@@ -44,7 +44,8 @@ export type PersistSystemQueueAnnotationError = BadRequestError | RepositoryErro
  * - Default to `passed = false`, `value = 0`, no anchor (conversation-level)
  * - Do NOT auto-publish (no `annotation-scores:publish` event)
  */
-export const persistSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.persistSystemQueueAnnotation")(function* (input: PersistSystemQueueAnnotationInput) {
+export const persistSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.persistSystemQueueAnnotation")(
+  function* (input: PersistSystemQueueAnnotationInput) {
     yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
     yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
 
@@ -147,5 +148,6 @@ export const persistSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.p
       traceId: parsedInput.traceId,
       draftAnnotationId: result.draftAnnotationId,
       wasCreated: result.wasCreated,
-  }) as SystemQueueAnnotateOutput
-})
+    }) as SystemQueueAnnotateOutput
+  },
+)

--- a/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
@@ -46,42 +46,44 @@ const createSystemQueue = (
  * - All system queues use the same slug generation from their canonical name
  * - Safe for concurrent calls: insertIfNotExists handles race conditions gracefully
  */
-export const provisionSystemQueuesUseCase = Effect.fn("annotationQueues.provisionSystemQueues")(function* (input: ProvisionSystemQueuesInput) {
-    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+export const provisionSystemQueuesUseCase = Effect.fn("annotationQueues.provisionSystemQueues")(function* (
+  input: ProvisionSystemQueuesInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
 
-    const sqlClient = yield* SqlClient
-    const { organizationId, projectId } = input
+  const sqlClient = yield* SqlClient
+  const { organizationId, projectId } = input
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const queueRepository = yield* AnnotationQueueRepository
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const queueRepository = yield* AnnotationQueueRepository
 
-        const results: Array<{ queueSlug: string; action: "created" | "skipped" | "exists" }> = []
+      const results: Array<{ queueSlug: string; action: "created" | "skipped" | "exists" }> = []
 
-        for (const definition of SYSTEM_QUEUE_DEFINITIONS) {
-          const slug = toSlug(definition.name)
+      for (const definition of SYSTEM_QUEUE_DEFINITIONS) {
+        const slug = toSlug(definition.name)
 
-          const existing = yield* queueRepository.findSystemQueueBySlugInProject({
-            projectId,
-            queueSlug: slug,
-          })
+        const existing = yield* queueRepository.findSystemQueueBySlugInProject({
+          projectId,
+          queueSlug: slug,
+        })
 
-          if (existing) {
-            if (existing.deletedAt !== null) {
-              results.push({ queueSlug: slug, action: "skipped" })
-            } else {
-              results.push({ queueSlug: slug, action: "exists" })
-            }
-            continue
+        if (existing) {
+          if (existing.deletedAt !== null) {
+            results.push({ queueSlug: slug, action: "skipped" })
+          } else {
+            results.push({ queueSlug: slug, action: "exists" })
           }
-
-          const queue = createSystemQueue(projectId, organizationId, definition)
-          const wasInserted = yield* queueRepository.insertIfNotExists(queue)
-          results.push({ queueSlug: slug, action: wasInserted ? "created" : "exists" })
+          continue
         }
 
-        return results
+        const queue = createSystemQueue(projectId, organizationId, definition)
+        const wasInserted = yield* queueRepository.insertIfNotExists(queue)
+        results.push({ queueSlug: slug, action: wasInserted ? "created" : "exists" })
+      }
+
+      return results
     }),
   )
 })

--- a/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
+++ b/packages/domain/annotation-queues/src/use-cases/provision-system-queues.ts
@@ -46,8 +46,7 @@ const createSystemQueue = (
  * - All system queues use the same slug generation from their canonical name
  * - Safe for concurrent calls: insertIfNotExists handles race conditions gracefully
  */
-export const provisionSystemQueuesUseCase = (input: ProvisionSystemQueuesInput) =>
-  Effect.gen(function* () {
+export const provisionSystemQueuesUseCase = Effect.fn("annotationQueues.provisionSystemQueues")(function* (input: ProvisionSystemQueuesInput) {
     yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
 
@@ -83,6 +82,6 @@ export const provisionSystemQueuesUseCase = (input: ProvisionSystemQueuesInput) 
         }
 
         return results
-      }),
-    )
-  }).pipe(Effect.withSpan("annotationQueues.provisionSystemQueues"))
+    }),
+  )
+})

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -120,44 +120,46 @@ const loadTraceDetail = (input: RunSystemQueueAnnotatorInput) =>
     })
   })
 
-export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (input: RunSystemQueueAnnotatorInput) {
-    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
-    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (
+  input: RunSystemQueueAnnotatorInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
 
-    const ai = yield* AI
+  const ai = yield* AI
 
-    const trace = yield* loadTraceDetail(input)
+  const trace = yield* loadTraceDetail(input)
 
-    const systemPrompt = buildAnnotatorSystemPrompt(input.queueSlug)
+  const systemPrompt = buildAnnotatorSystemPrompt(input.queueSlug)
 
-    const conversationText =
-      trace.allMessages.length > 0
-        ? formatConversationForAnnotator(trace.allMessages)
-        : "<no conversation messages available>"
+  const conversationText =
+    trace.allMessages.length > 0
+      ? formatConversationForAnnotator(trace.allMessages)
+      : "<no conversation messages available>"
 
-    const matchReasonText = formatMatchReasonsForAnnotator(input.matchReasons)
+  const matchReasonText = formatMatchReasonsForAnnotator(input.matchReasons)
 
-    const prompt = `Deterministic match context:\n\n${matchReasonText}\n\nFull conversation context:\n\n${conversationText}\n\nProvide your feedback analysis per the schema.`
+  const prompt = `Deterministic match context:\n\n${matchReasonText}\n\nFull conversation context:\n\n${conversationText}\n\nProvide your feedback analysis per the schema.`
 
-    const result = yield* ai.generate({
-      ...SYSTEM_QUEUE_ANNOTATOR_MODEL,
-      maxTokens: SYSTEM_QUEUE_ANNOTATOR_MAX_TOKENS,
-      system: systemPrompt,
-      prompt,
-      schema: systemQueueAnnotatorOutputSchema,
-      telemetry: {
-        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.queueSystemDraft,
-        tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
-        metadata: buildProjectScopedAiMetadata(
-          { organizationId: input.organizationId, projectId: input.projectId },
-          { traceId: input.traceId, queueSlug: input.queueSlug },
-        ),
-      },
-    })
+  const result = yield* ai.generate({
+    ...SYSTEM_QUEUE_ANNOTATOR_MODEL,
+    maxTokens: SYSTEM_QUEUE_ANNOTATOR_MAX_TOKENS,
+    system: systemPrompt,
+    prompt,
+    schema: systemQueueAnnotatorOutputSchema,
+    telemetry: {
+      spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.queueSystemDraft,
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
+      metadata: buildProjectScopedAiMetadata(
+        { organizationId: input.organizationId, projectId: input.projectId },
+        { traceId: input.traceId, queueSlug: input.queueSlug },
+      ),
+    },
+  })
 
-    return {
+  return {
     feedback: result.object.feedback,
     traceCreatedAt: trace.startTime.toISOString(),
   }

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -120,8 +120,7 @@ const loadTraceDetail = (input: RunSystemQueueAnnotatorInput) =>
     })
   })
 
-export const runSystemQueueAnnotatorUseCase = (input: RunSystemQueueAnnotatorInput) =>
-  Effect.gen(function* () {
+export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (input: RunSystemQueueAnnotatorInput) {
     yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
@@ -159,7 +158,7 @@ export const runSystemQueueAnnotatorUseCase = (input: RunSystemQueueAnnotatorInp
     })
 
     return {
-      feedback: result.object.feedback,
-      traceCreatedAt: trace.startTime.toISOString(),
-    }
-  }).pipe(Effect.withSpan("annotationQueues.runSystemQueueAnnotator"))
+    feedback: result.object.feedback,
+    traceCreatedAt: trace.startTime.toISOString(),
+  }
+})

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -292,31 +292,33 @@ export function getSystemQueueMatcherBySlug(queueSlug: string): SystemQueueMatch
   return isDeterministicQueueSlug(queueSlug) ? deterministicQueueMatchers[queueSlug] : undefined
 }
 
-export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSystemQueueFlagger")(function* (input: RunSystemQueueFlaggerInput) {
-    yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
-    yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSystemQueueFlagger")(function* (
+  input: RunSystemQueueFlaggerInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
 
-    const deterministicMatcher = getSystemQueueMatcherBySlug(input.queueSlug)
+  const deterministicMatcher = getSystemQueueMatcherBySlug(input.queueSlug)
 
-    if (deterministicMatcher) {
-      return yield* deterministicMatcher(input)
-    }
+  if (deterministicMatcher) {
+    return yield* deterministicMatcher(input)
+  }
 
-    if (!isLlmQueueSlug(input.queueSlug)) {
-      return { matched: false }
-    }
+  if (!isLlmQueueSlug(input.queueSlug)) {
+    return { matched: false }
+  }
 
-    const trace = yield* loadTraceDetail(input)
+  const trace = yield* loadTraceDetail(input)
 
-    if (trace.allMessages.length === 0) {
-      return { matched: false }
-    }
+  if (trace.allMessages.length === 0) {
+    return { matched: false }
+  }
 
-    const decisions = yield* runLlmFlagger({ ...input, queueSlug: input.queueSlug }, trace)
+  const decisions = yield* runLlmFlagger({ ...input, queueSlug: input.queueSlug }, trace)
 
-    return {
+  return {
     matched: decisions.matched,
   } satisfies RunSystemQueueFlaggerResult
 })

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -292,8 +292,7 @@ export function getSystemQueueMatcherBySlug(queueSlug: string): SystemQueueMatch
   return isDeterministicQueueSlug(queueSlug) ? deterministicQueueMatchers[queueSlug] : undefined
 }
 
-export const runSystemQueueFlaggerUseCase = (input: RunSystemQueueFlaggerInput) =>
-  Effect.gen(function* () {
+export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSystemQueueFlagger")(function* (input: RunSystemQueueFlaggerInput) {
     yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
@@ -318,6 +317,6 @@ export const runSystemQueueFlaggerUseCase = (input: RunSystemQueueFlaggerInput) 
     const decisions = yield* runLlmFlagger({ ...input, queueSlug: input.queueSlug }, trace)
 
     return {
-      matched: decisions.matched,
-    } satisfies RunSystemQueueFlaggerResult
-  }).pipe(Effect.withSpan("annotationQueues.runSystemQueueFlagger"))
+    matched: decisions.matched,
+  } satisfies RunSystemQueueFlaggerResult
+})

--- a/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
@@ -12,46 +12,48 @@ export interface UncompleteQueueItemInput {
 
 export type UncompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemNotCompletedError
 
-export const uncompleteQueueItemUseCase = Effect.fn("annotationQueues.uncompleteQueueItem")(function* (input: UncompleteQueueItemInput) {
-    yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
-    yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
+export const uncompleteQueueItemUseCase = Effect.fn("annotationQueues.uncompleteQueueItem")(function* (
+  input: UncompleteQueueItemInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
 
-    const sqlClient = yield* SqlClient
-    const itemRepo = yield* AnnotationQueueItemRepository
-    const queueRepo = yield* AnnotationQueueRepository
+  const sqlClient = yield* SqlClient
+  const itemRepo = yield* AnnotationQueueItemRepository
+  const queueRepo = yield* AnnotationQueueRepository
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const item = yield* itemRepo.findById({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          itemId: input.itemId,
-        })
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const item = yield* itemRepo.findById({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        itemId: input.itemId,
+      })
 
-        if (!item) {
-          return yield* new QueueItemNotFoundError({ itemId: input.itemId })
-        }
+      if (!item) {
+        return yield* new QueueItemNotFoundError({ itemId: input.itemId })
+      }
 
-        if (!item.completedAt) {
-          return yield* new QueueItemNotCompletedError({ itemId: input.itemId })
-        }
+      if (!item.completedAt) {
+        return yield* new QueueItemNotCompletedError({ itemId: input.itemId })
+      }
 
-        const updated = yield* itemRepo.update({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          itemId: input.itemId,
-          completedAt: null,
-          completedBy: null,
-        })
+      const updated = yield* itemRepo.update({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        itemId: input.itemId,
+        completedAt: null,
+        completedBy: null,
+      })
 
-        yield* queueRepo.incrementCompletedItems({
-          projectId: input.projectId,
-          queueId: input.queueId,
-          delta: -1,
-        })
+      yield* queueRepo.incrementCompletedItems({
+        projectId: input.projectId,
+        queueId: input.queueId,
+        delta: -1,
+      })
 
-        return updated
-      }),
-    )
-  })
+      return updated
+    }),
+  )
+})

--- a/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
+++ b/packages/domain/annotation-queues/src/use-cases/uncomplete-queue-item.ts
@@ -12,8 +12,7 @@ export interface UncompleteQueueItemInput {
 
 export type UncompleteQueueItemError = RepositoryError | QueueItemNotFoundError | QueueItemNotCompletedError
 
-export const uncompleteQueueItemUseCase = (input: UncompleteQueueItemInput) =>
-  Effect.gen(function* () {
+export const uncompleteQueueItemUseCase = Effect.fn("annotationQueues.uncompleteQueueItem")(function* (input: UncompleteQueueItemInput) {
     yield* Effect.annotateCurrentSpan("queue.id", input.queueId)
     yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("queue.itemId", input.itemId)
@@ -55,4 +54,4 @@ export const uncompleteQueueItemUseCase = (input: UncompleteQueueItemInput) =>
         return updated
       }),
     )
-  }).pipe(Effect.withSpan("annotationQueues.uncompleteQueueItem"))
+  })

--- a/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
@@ -35,8 +35,8 @@ const startPublishAnnotationWorkflow = (
     },
   )
 
-export const approveSystemAnnotationUseCase = (input: ApproveSystemAnnotationInput) =>
-  Effect.gen(function* () {
+export const approveSystemAnnotationUseCase = Effect.fn("annotations.approveSystemAnnotation")(
+  function* (input: ApproveSystemAnnotationInput) {
     yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const workflowStarter = yield* WorkflowStarter
     const scoreRepository = yield* ScoreRepository
@@ -78,4 +78,5 @@ export const approveSystemAnnotationUseCase = (input: ApproveSystemAnnotationInp
     })
 
     return { action: "approved", scoreId: score.id } satisfies ApproveSystemAnnotationResult
-  }).pipe(Effect.withSpan("annotations.approveSystemAnnotation"))
+  },
+)

--- a/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/approve-system-annotation.ts
@@ -35,48 +35,48 @@ const startPublishAnnotationWorkflow = (
     },
   )
 
-export const approveSystemAnnotationUseCase = Effect.fn("annotations.approveSystemAnnotation")(
-  function* (input: ApproveSystemAnnotationInput) {
-    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
-    const workflowStarter = yield* WorkflowStarter
-    const scoreRepository = yield* ScoreRepository
-    const score = yield* scoreRepository
-      .findById(input.scoreId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new BadRequestError({ message: `Annotation ${input.scoreId} not found` })),
-        ),
-      )
+export const approveSystemAnnotationUseCase = Effect.fn("annotations.approveSystemAnnotation")(function* (
+  input: ApproveSystemAnnotationInput,
+) {
+  yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
+  const workflowStarter = yield* WorkflowStarter
+  const scoreRepository = yield* ScoreRepository
+  const score = yield* scoreRepository
+    .findById(input.scoreId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new BadRequestError({ message: `Annotation ${input.scoreId} not found` })),
+      ),
+    )
 
-    if (score.draftedAt === null) {
-      return { action: "already-published" } satisfies ApproveSystemAnnotationResult
-    }
+  if (score.draftedAt === null) {
+    return { action: "already-published" } satisfies ApproveSystemAnnotationResult
+  }
 
-    if (score.source !== "annotation") {
-      return yield* new BadRequestError({
-        message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
-      })
-    }
-
-    if (score.annotatorId !== null) {
-      return yield* new BadRequestError({
-        message: "Only system-created annotations can be approved via this flow",
-      })
-    }
-
-    if (!isValidId(score.sourceId)) {
-      return yield* new BadRequestError({
-        message: `Annotation ${input.scoreId} was not created by a system queue (sourceId: ${score.sourceId})`,
-      })
-    }
-
-    yield* startPublishAnnotationWorkflow(workflowStarter, {
-      organizationId: score.organizationId,
-      projectId: score.projectId,
-      scoreId: score.id,
-      preEnrichedFeedback: score.feedback,
+  if (score.source !== "annotation") {
+    return yield* new BadRequestError({
+      message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
     })
+  }
 
-    return { action: "approved", scoreId: score.id } satisfies ApproveSystemAnnotationResult
-  },
-)
+  if (score.annotatorId !== null) {
+    return yield* new BadRequestError({
+      message: "Only system-created annotations can be approved via this flow",
+    })
+  }
+
+  if (!isValidId(score.sourceId)) {
+    return yield* new BadRequestError({
+      message: `Annotation ${input.scoreId} was not created by a system queue (sourceId: ${score.sourceId})`,
+    })
+  }
+
+  yield* startPublishAnnotationWorkflow(workflowStarter, {
+    organizationId: score.organizationId,
+    projectId: score.projectId,
+    scoreId: score.id,
+    preEnrichedFeedback: score.feedback,
+  })
+
+  return { action: "approved", scoreId: score.id } satisfies ApproveSystemAnnotationResult
+})

--- a/packages/domain/annotations/src/use-cases/delete-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/delete-annotation.ts
@@ -9,48 +9,48 @@ export interface DeleteAnnotationInput {
 
 export type DeleteAnnotationError = RepositoryError | BadRequestError
 
-export const deleteAnnotationUseCase = Effect.fn("annotations.deleteAnnotation")(
-  function* (input: DeleteAnnotationInput) {
-    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
-    const sqlClient = yield* SqlClient
-    const scoreRepository = yield* ScoreRepository
-    const outboxEventWriter = yield* OutboxEventWriter
+export const deleteAnnotationUseCase = Effect.fn("annotations.deleteAnnotation")(function* (
+  input: DeleteAnnotationInput,
+) {
+  yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
+  const sqlClient = yield* SqlClient
+  const scoreRepository = yield* ScoreRepository
+  const outboxEventWriter = yield* OutboxEventWriter
 
-    const score = yield* scoreRepository
-      .findById(input.scoreId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new BadRequestError({ message: `Score ${input.scoreId} not found` })),
-        ),
-      )
-
-    if (score.source !== "annotation") {
-      return yield* new BadRequestError({
-        message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
-      })
-    }
-
-    yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        yield* outboxEventWriter.write({
-          eventName: "AnnotationDeleted",
-          aggregateType: "score",
-          aggregateId: score.id,
-          organizationId: score.organizationId,
-          payload: {
-            organizationId: score.organizationId,
-            projectId: score.projectId,
-            scoreId: score.id,
-            issueId: score.issueId,
-            draftedAt: score.draftedAt?.toISOString() ?? null,
-            feedback: score.feedback,
-            source: score.source,
-            createdAt: score.createdAt.toISOString(),
-          },
-        })
-
-        yield* scoreRepository.delete(input.scoreId)
-      }),
+  const score = yield* scoreRepository
+    .findById(input.scoreId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new BadRequestError({ message: `Score ${input.scoreId} not found` })),
+      ),
     )
-  },
-)
+
+  if (score.source !== "annotation") {
+    return yield* new BadRequestError({
+      message: `Score ${input.scoreId} is not an annotation (source: ${score.source})`,
+    })
+  }
+
+  yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      yield* outboxEventWriter.write({
+        eventName: "AnnotationDeleted",
+        aggregateType: "score",
+        aggregateId: score.id,
+        organizationId: score.organizationId,
+        payload: {
+          organizationId: score.organizationId,
+          projectId: score.projectId,
+          scoreId: score.id,
+          issueId: score.issueId,
+          draftedAt: score.draftedAt?.toISOString() ?? null,
+          feedback: score.feedback,
+          source: score.source,
+          createdAt: score.createdAt.toISOString(),
+        },
+      })
+
+      yield* scoreRepository.delete(input.scoreId)
+    }),
+  )
+})

--- a/packages/domain/annotations/src/use-cases/delete-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/delete-annotation.ts
@@ -9,8 +9,8 @@ export interface DeleteAnnotationInput {
 
 export type DeleteAnnotationError = RepositoryError | BadRequestError
 
-export const deleteAnnotationUseCase = (input: DeleteAnnotationInput) =>
-  Effect.gen(function* () {
+export const deleteAnnotationUseCase = Effect.fn("annotations.deleteAnnotation")(
+  function* (input: DeleteAnnotationInput) {
     yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const sqlClient = yield* SqlClient
     const scoreRepository = yield* ScoreRepository
@@ -52,4 +52,5 @@ export const deleteAnnotationUseCase = (input: DeleteAnnotationInput) =>
         yield* scoreRepository.delete(input.scoreId)
       }),
     )
-  }).pipe(Effect.withSpan("annotations.deleteAnnotation"))
+  },
+)

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -119,8 +119,8 @@ export type EnrichAnnotationForPublicationResult =
 
 export type EnrichAnnotationForPublicationError = RepositoryError | BadRequestError | AIError | AICredentialError
 
-export const enrichAnnotationForPublicationUseCase = (input: EnrichAnnotationForPublicationInput) =>
-  Effect.gen(function* () {
+export const enrichAnnotationForPublicationUseCase = Effect.fn("annotations.enrichAnnotationForPublication")(
+  function* (input: EnrichAnnotationForPublicationInput) {
     yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
     const ai = yield* AI
 
@@ -199,4 +199,5 @@ export const enrichAnnotationForPublicationUseCase = (input: EnrichAnnotationFor
       resolvedSessionId: resolvedSessionId === null ? null : String(resolvedSessionId),
       resolvedSpanId: resolvedSpanId === null ? null : String(resolvedSpanId),
     }
-  }).pipe(Effect.withSpan("annotations.enrichAnnotationForPublication"))
+  },
+)

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -119,85 +119,85 @@ export type EnrichAnnotationForPublicationResult =
 
 export type EnrichAnnotationForPublicationError = RepositoryError | BadRequestError | AIError | AICredentialError
 
-export const enrichAnnotationForPublicationUseCase = Effect.fn("annotations.enrichAnnotationForPublication")(
-  function* (input: EnrichAnnotationForPublicationInput) {
-    yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
-    const ai = yield* AI
+export const enrichAnnotationForPublicationUseCase = Effect.fn("annotations.enrichAnnotationForPublication")(function* (
+  input: EnrichAnnotationForPublicationInput,
+) {
+  yield* Effect.annotateCurrentSpan("annotation.scoreId", input.scoreId)
+  const ai = yield* AI
 
-    const loaded = yield* loadAnnotationScoreForPublicationMutation(input.scoreId)
+  const loaded = yield* loadAnnotationScoreForPublicationMutation(input.scoreId)
 
-    if (loaded.kind === "already-published") {
-      return { status: "already-published" as const }
-    }
+  if (loaded.kind === "already-published") {
+    return { status: "already-published" as const }
+  }
 
-    const annotationScore = loaded.score
-    const metadata = annotationScore.metadata as AnnotationScoreMetadata
+  const annotationScore = loaded.score
+  const metadata = annotationScore.metadata as AnnotationScoreMetadata
 
-    let fullConversationText: string | undefined
-    let highlightedExcerpt: string | undefined
-    let resolvedSessionId = annotationScore.sessionId
-    let resolvedSpanId = annotationScore.spanId
+  let fullConversationText: string | undefined
+  let highlightedExcerpt: string | undefined
+  let resolvedSessionId = annotationScore.sessionId
+  let resolvedSpanId = annotationScore.spanId
 
-    if (annotationScore.traceId !== null) {
-      const traceRepository = yield* TraceRepository
-      const detail = yield* traceRepository
-        .findByTraceId({
+  if (annotationScore.traceId !== null) {
+    const traceRepository = yield* TraceRepository
+    const detail = yield* traceRepository
+      .findByTraceId({
+        organizationId: OrganizationId(annotationScore.organizationId),
+        projectId: ProjectId(annotationScore.projectId),
+        traceId: TraceId(annotationScore.traceId),
+      })
+      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    if (detail) {
+      if (resolvedSessionId === null) {
+        resolvedSessionId = detail.sessionId
+      }
+      if (resolvedSpanId === null) {
+        const spanRepository = yield* SpanRepository
+        const spans = yield* spanRepository.listByTraceId({
           organizationId: OrganizationId(annotationScore.organizationId),
-          projectId: ProjectId(annotationScore.projectId),
           traceId: TraceId(annotationScore.traceId),
         })
-        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-      if (detail) {
-        if (resolvedSessionId === null) {
-          resolvedSessionId = detail.sessionId
-        }
-        if (resolvedSpanId === null) {
-          const spanRepository = yield* SpanRepository
-          const spans = yield* spanRepository.listByTraceId({
-            organizationId: OrganizationId(annotationScore.organizationId),
-            traceId: TraceId(annotationScore.traceId),
-          })
-          resolvedSpanId = resolveLastLlmCompletionSpanId(spans) ?? null
-        }
+        resolvedSpanId = resolveLastLlmCompletionSpanId(spans) ?? null
+      }
 
-        if (detail.allMessages.length > 0) {
-          fullConversationText = formatGenAIMessagesForEnrichmentPrompt(detail.allMessages)
-          if (metadata.messageIndex !== undefined) {
-            highlightedExcerpt = resolveAnnotationAnchorText(detail.allMessages, metadata)
-          }
+      if (detail.allMessages.length > 0) {
+        fullConversationText = formatGenAIMessagesForEnrichmentPrompt(detail.allMessages)
+        if (metadata.messageIndex !== undefined) {
+          highlightedExcerpt = resolveAnnotationAnchorText(detail.allMessages, metadata)
         }
       }
     }
+  }
 
-    const result = yield* ai.generate({
-      ...ANNOTATION_ENRICHMENT_MODEL,
-      telemetry: {
-        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.annotationEnrichPublication,
-        tags: [...AI_GENERATE_TELEMETRY_TAGS.annotationEnrichPublication],
-        metadata: buildProjectScopedAiMetadata(
-          {
-            organizationId: annotationScore.organizationId,
-            projectId: annotationScore.projectId,
-          },
-          {
-            scoreId: input.scoreId,
-            ...(annotationScore.traceId !== null ? { traceId: annotationScore.traceId } : {}),
-          },
-        ),
-        ...(resolvedSessionId !== null ? { sessionId: resolvedSessionId } : {}),
-      },
-      system: ENRICHMENT_SYSTEM_PROMPT,
-      prompt: buildEnrichmentPrompt(metadata, { fullConversationText, highlightedExcerpt }),
-      schema: annotationPublicationEnrichmentSchema,
-    })
+  const result = yield* ai.generate({
+    ...ANNOTATION_ENRICHMENT_MODEL,
+    telemetry: {
+      spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.annotationEnrichPublication,
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.annotationEnrichPublication],
+      metadata: buildProjectScopedAiMetadata(
+        {
+          organizationId: annotationScore.organizationId,
+          projectId: annotationScore.projectId,
+        },
+        {
+          scoreId: input.scoreId,
+          ...(annotationScore.traceId !== null ? { traceId: annotationScore.traceId } : {}),
+        },
+      ),
+      ...(resolvedSessionId !== null ? { sessionId: resolvedSessionId } : {}),
+    },
+    system: ENRICHMENT_SYSTEM_PROMPT,
+    prompt: buildEnrichmentPrompt(metadata, { fullConversationText, highlightedExcerpt }),
+    schema: annotationPublicationEnrichmentSchema,
+  })
 
-    const enrichedFeedback = result.object.enrichedFeedback.trim() || metadata.rawFeedback
+  const enrichedFeedback = result.object.enrichedFeedback.trim() || metadata.rawFeedback
 
-    return {
-      status: "enriched" as const,
-      enrichedFeedback,
-      resolvedSessionId: resolvedSessionId === null ? null : String(resolvedSessionId),
-      resolvedSpanId: resolvedSpanId === null ? null : String(resolvedSpanId),
-    }
-  },
-)
+  return {
+    status: "enriched" as const,
+    enrichedFeedback,
+    resolvedSessionId: resolvedSessionId === null ? null : String(resolvedSessionId),
+    resolvedSpanId: resolvedSpanId === null ? null : String(resolvedSpanId),
+  }
+})

--- a/packages/domain/annotations/src/use-cases/list-annotations.ts
+++ b/packages/domain/annotations/src/use-cases/list-annotations.ts
@@ -26,8 +26,8 @@ export type ListTraceAnnotationsInput = z.input<typeof listTraceAnnotationsInput
 
 export type ListAnnotationsError = RepositoryError | BadRequestError
 
-export const listTraceAnnotationsUseCase = (input: ListTraceAnnotationsInput) =>
-  Effect.gen(function* () {
+export const listTraceAnnotationsUseCase = Effect.fn("annotations.listTraceAnnotations")(
+  function* (input: ListTraceAnnotationsInput) {
     const parsed = yield* parseOrBadRequest(
       listTraceAnnotationsInputSchema,
       input,
@@ -48,4 +48,5 @@ export const listTraceAnnotationsUseCase = (input: ListTraceAnnotationsInput) =>
         draftMode: parsed.draftMode,
       },
     })
-  }).pipe(Effect.withSpan("annotations.listTraceAnnotations"))
+  },
+)

--- a/packages/domain/annotations/src/use-cases/list-annotations.ts
+++ b/packages/domain/annotations/src/use-cases/list-annotations.ts
@@ -26,27 +26,27 @@ export type ListTraceAnnotationsInput = z.input<typeof listTraceAnnotationsInput
 
 export type ListAnnotationsError = RepositoryError | BadRequestError
 
-export const listTraceAnnotationsUseCase = Effect.fn("annotations.listTraceAnnotations")(
-  function* (input: ListTraceAnnotationsInput) {
-    const parsed = yield* parseOrBadRequest(
-      listTraceAnnotationsInputSchema,
-      input,
-      "Invalid list trace annotations input",
-    )
-    yield* Effect.annotateCurrentSpan("annotation.projectId", parsed.projectId)
-    yield* Effect.annotateCurrentSpan("annotation.traceId", parsed.traceId)
+export const listTraceAnnotationsUseCase = Effect.fn("annotations.listTraceAnnotations")(function* (
+  input: ListTraceAnnotationsInput,
+) {
+  const parsed = yield* parseOrBadRequest(
+    listTraceAnnotationsInputSchema,
+    input,
+    "Invalid list trace annotations input",
+  )
+  yield* Effect.annotateCurrentSpan("annotation.projectId", parsed.projectId)
+  yield* Effect.annotateCurrentSpan("annotation.traceId", parsed.traceId)
 
-    const scoreRepository = yield* ScoreRepository
+  const scoreRepository = yield* ScoreRepository
 
-    return yield* scoreRepository.listByTraceId({
-      projectId: parsed.projectId,
-      traceId: parsed.traceId,
-      source: "annotation",
-      options: {
-        limit: parsed.limit,
-        offset: parsed.offset,
-        draftMode: parsed.draftMode,
-      },
-    })
-  },
-)
+  return yield* scoreRepository.listByTraceId({
+    projectId: parsed.projectId,
+    traceId: parsed.traceId,
+    source: "annotation",
+    options: {
+      limit: parsed.limit,
+      offset: parsed.offset,
+      draftMode: parsed.draftMode,
+    },
+  })
+})

--- a/packages/domain/api-keys/src/use-cases/generate-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/generate-api-key.ts
@@ -14,47 +14,46 @@ export interface GenerateApiKeyInput {
 
 export type GenerateApiKeyError = RepositoryError | ValidationError | InvalidApiKeyNameError | CryptoError
 
-export const generateApiKeyUseCase = (input: GenerateApiKeyInput) =>
-  Effect.gen(function* () {
-    const { organizationId } = yield* SqlClient
-    if (input.id) {
-      yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
-    }
+export const generateApiKeyUseCase = Effect.fn("apiKeys.generateApiKey")(function* (input: GenerateApiKeyInput) {
+  const { organizationId } = yield* SqlClient
+  if (input.id) {
+    yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
+  }
 
-    if (!input.name || input.name.trim().length === 0) {
-      return yield* new InvalidApiKeyNameError({ name: input.name, reason: "Name cannot be empty" })
-    }
+  if (!input.name || input.name.trim().length === 0) {
+    return yield* new InvalidApiKeyNameError({ name: input.name, reason: "Name cannot be empty" })
+  }
 
-    if (input.name.length > 256) {
-      return yield* new InvalidApiKeyNameError({ name: input.name, reason: "Name exceeds 256 characters" })
-    }
+  if (input.name.length > 256) {
+    return yield* new InvalidApiKeyNameError({ name: input.name, reason: "Name exceeds 256 characters" })
+  }
 
-    const token = generateApiKeyToken()
-    const tokenHash = yield* hash(token)
-    const apiKey = createApiKey({
-      id: input.id,
+  const token = generateApiKeyToken()
+  const tokenHash = yield* hash(token)
+  const apiKey = createApiKey({
+    id: input.id,
+    organizationId,
+    token,
+    tokenHash,
+    name: input.name.trim(),
+  })
+
+  const repo = yield* ApiKeyRepository
+  yield* repo.save(apiKey)
+
+  const outboxEventWriter = yield* OutboxEventWriter
+  yield* outboxEventWriter.write({
+    eventName: "ApiKeyCreated",
+    aggregateType: "api_key",
+    aggregateId: apiKey.id,
+    organizationId,
+    payload: {
       organizationId,
-      token,
-      tokenHash,
-      name: input.name.trim(),
-    })
+      actorUserId: input.actorUserId ?? "",
+      apiKeyId: apiKey.id,
+      name: apiKey.name,
+    },
+  })
 
-    const repo = yield* ApiKeyRepository
-    yield* repo.save(apiKey)
-
-    const outboxEventWriter = yield* OutboxEventWriter
-    yield* outboxEventWriter.write({
-      eventName: "ApiKeyCreated",
-      aggregateType: "api_key",
-      aggregateId: apiKey.id,
-      organizationId,
-      payload: {
-        organizationId,
-        actorUserId: input.actorUserId ?? "",
-        apiKeyId: apiKey.id,
-        name: apiKey.name,
-      },
-    })
-
-    return apiKey
-  }).pipe(Effect.withSpan("apiKeys.generateApiKey"))
+  return apiKey
+})

--- a/packages/domain/api-keys/src/use-cases/revoke-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/revoke-api-key.ts
@@ -18,25 +18,24 @@ export class ApiKeyCacheInvalidator extends ServiceMap.Service<
   }
 >()("@domain/api-keys/ApiKeyCacheInvalidator") {}
 
-export const revokeApiKeyUseCase = (input: RevokeApiKeyInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
-    const sqlClient = yield* SqlClient
-    const cacheInvalidator = yield* ApiKeyCacheInvalidator
+export const revokeApiKeyUseCase = Effect.fn("apiKeys.revokeApiKey")(function* (input: RevokeApiKeyInput) {
+  yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
+  const sqlClient = yield* SqlClient
+  const cacheInvalidator = yield* ApiKeyCacheInvalidator
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const repo = yield* ApiKeyRepository
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* ApiKeyRepository
 
-        const apiKey = yield* repo.findById(input.id)
-        if (apiKey.deletedAt !== null) return yield* new ApiKeyAlreadyRevokedError({ id: input.id })
+      const apiKey = yield* repo.findById(input.id)
+      if (apiKey.deletedAt !== null) return yield* new ApiKeyAlreadyRevokedError({ id: input.id })
 
-        const revokedApiKey = revoke(apiKey)
-        yield* repo.save(revokedApiKey)
+      const revokedApiKey = revoke(apiKey)
+      yield* repo.save(revokedApiKey)
 
-        yield* cacheInvalidator.delete(revokedApiKey.tokenHash)
+      yield* cacheInvalidator.delete(revokedApiKey.tokenHash)
 
-        return revokedApiKey
-      }),
-    )
-  }).pipe(Effect.withSpan("apiKeys.revokeApiKey"))
+      return revokedApiKey
+    }),
+  )
+})

--- a/packages/domain/api-keys/src/use-cases/update-api-key.ts
+++ b/packages/domain/api-keys/src/use-cases/update-api-key.ts
@@ -11,16 +11,15 @@ export interface UpdateApiKeyInput {
 
 export type UpdateApiKeyError = RepositoryError | ApiKeyNotFoundError
 
-export const updateApiKeyUseCase = (input: UpdateApiKeyInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
-    const repo = yield* ApiKeyRepository
-    const apiKey = yield* repo
-      .findById(input.id)
-      .pipe(Effect.catchTag("NotFoundError", () => Effect.fail(new ApiKeyNotFoundError({ id: input.id }))))
+export const updateApiKeyUseCase = Effect.fn("apiKeys.updateApiKey")(function* (input: UpdateApiKeyInput) {
+  yield* Effect.annotateCurrentSpan("apiKey.id", input.id)
+  const repo = yield* ApiKeyRepository
+  const apiKey = yield* repo
+    .findById(input.id)
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.fail(new ApiKeyNotFoundError({ id: input.id }))))
 
-    const updated: ApiKey = { ...apiKey, name: input.name, updatedAt: new Date() }
-    yield* repo.save(updated)
+  const updated: ApiKey = { ...apiKey, name: input.name, updatedAt: new Date() }
+  yield* repo.save(updated)
 
-    return updated
-  }).pipe(Effect.withSpan("apiKeys.updateApiKey"))
+  return updated
+})

--- a/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
@@ -94,100 +94,96 @@ function fetchTraces(args: {
 
 const EMPTY_RESULT = { versionId: "" as const, version: 0, rowIds: [] as string[] }
 
-export function addTracesToDataset(args: {
+export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(function* (args: {
   readonly projectId: ProjectId
   readonly datasetId: DatasetId
   readonly selection: TraceSelection
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
-    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("projectId", args.projectId)
 
-    const chSqlClient = yield* ChSqlClient
-    const rowRepo = yield* DatasetRowRepository
+  const chSqlClient = yield* ChSqlClient
+  const rowRepo = yield* DatasetRowRepository
 
+  const traceIds = yield* resolveTraceIds({
+    organizationId: chSqlClient.organizationId,
+    projectId: args.projectId,
+    selection: args.selection,
+  })
+  if (traceIds.length === 0) return EMPTY_RESULT
+  if (traceIds.length > MAX_TRACES_PER_DATASET_IMPORT) {
+    return yield* new TooManyTracesError({ count: traceIds.length, limit: MAX_TRACES_PER_DATASET_IMPORT })
+  }
+
+  const existingTraceIds = yield* rowRepo.findExistingTraceIds({
+    datasetId: args.datasetId,
+    traceIds,
+  })
+
+  const newTraceIds = traceIds.filter((id) => !existingTraceIds.has(id))
+  if (newTraceIds.length === 0) return EMPTY_RESULT
+
+  const traces = yield* fetchTraces({
+    organizationId: chSqlClient.organizationId,
+    projectId: args.projectId,
+    traceIds: newTraceIds,
+  })
+  const rows = traces.map(mapTraceToRow)
+  if (rows.length === 0) return EMPTY_RESULT
+
+  return yield* insertRows({
+    datasetId: args.datasetId,
+    rows,
+    source: "traces",
+  })
+})
+
+export const createDatasetFromTraces = Effect.fn("datasets.createDatasetFromTraces")(function* (args: {
+  readonly projectId: ProjectId
+  readonly name: string
+  readonly selection: TraceSelection
+}) {
+  yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+
+  const chSqlClient = yield* ChSqlClient
+  const datasetRepo = yield* DatasetRepository
+
+  const dataset = yield* createDataset({
+    projectId: args.projectId,
+    name: args.name,
+  })
+
+  const populateDataset = Effect.gen(function* () {
     const traceIds = yield* resolveTraceIds({
       organizationId: chSqlClient.organizationId,
       projectId: args.projectId,
       selection: args.selection,
     })
-    if (traceIds.length === 0) return EMPTY_RESULT
+    if (traceIds.length === 0) {
+      return { datasetId: dataset.id, ...EMPTY_RESULT }
+    }
     if (traceIds.length > MAX_TRACES_PER_DATASET_IMPORT) {
       return yield* new TooManyTracesError({ count: traceIds.length, limit: MAX_TRACES_PER_DATASET_IMPORT })
     }
 
-    const existingTraceIds = yield* rowRepo.findExistingTraceIds({
-      datasetId: args.datasetId,
-      traceIds,
-    })
-
-    const newTraceIds = traceIds.filter((id) => !existingTraceIds.has(id))
-    if (newTraceIds.length === 0) return EMPTY_RESULT
-
     const traces = yield* fetchTraces({
       organizationId: chSqlClient.organizationId,
       projectId: args.projectId,
-      traceIds: newTraceIds,
+      traceIds,
     })
     const rows = traces.map(mapTraceToRow)
-    if (rows.length === 0) return EMPTY_RESULT
+    if (rows.length === 0) {
+      return { datasetId: dataset.id, ...EMPTY_RESULT }
+    }
 
-    return yield* insertRows({
-      datasetId: args.datasetId,
+    const result = yield* insertRows({
+      datasetId: dataset.id,
       rows,
       source: "traces",
     })
-  }).pipe(Effect.withSpan("datasets.addTracesToDataset"))
-}
 
-export function createDatasetFromTraces(args: {
-  readonly projectId: ProjectId
-  readonly name: string
-  readonly selection: TraceSelection
-}) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+    return { datasetId: dataset.id, ...result }
+  })
 
-    const chSqlClient = yield* ChSqlClient
-    const datasetRepo = yield* DatasetRepository
-
-    const dataset = yield* createDataset({
-      projectId: args.projectId,
-      name: args.name,
-    })
-
-    const populateDataset = Effect.gen(function* () {
-      const traceIds = yield* resolveTraceIds({
-        organizationId: chSqlClient.organizationId,
-        projectId: args.projectId,
-        selection: args.selection,
-      })
-      if (traceIds.length === 0) {
-        return { datasetId: dataset.id, ...EMPTY_RESULT }
-      }
-      if (traceIds.length > MAX_TRACES_PER_DATASET_IMPORT) {
-        return yield* new TooManyTracesError({ count: traceIds.length, limit: MAX_TRACES_PER_DATASET_IMPORT })
-      }
-
-      const traces = yield* fetchTraces({
-        organizationId: chSqlClient.organizationId,
-        projectId: args.projectId,
-        traceIds,
-      })
-      const rows = traces.map(mapTraceToRow)
-      if (rows.length === 0) {
-        return { datasetId: dataset.id, ...EMPTY_RESULT }
-      }
-
-      const result = yield* insertRows({
-        datasetId: dataset.id,
-        rows,
-        source: "traces",
-      })
-
-      return { datasetId: dataset.id, ...result }
-    })
-
-    return yield* populateDataset.pipe(Effect.tapError(() => datasetRepo.softDelete(dataset.id)))
-  }).pipe(Effect.withSpan("datasets.createDatasetFromTraces"))
-}
+  return yield* populateDataset.pipe(Effect.tapError(() => datasetRepo.softDelete(dataset.id)))
+})

--- a/packages/domain/datasets/src/use-cases/count-rows.ts
+++ b/packages/domain/datasets/src/use-cases/count-rows.ts
@@ -3,29 +3,27 @@ import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
 
-export function countRows(args: {
+export const countRows = Effect.fn("datasets.countRows")(function* (args: {
   readonly datasetId: DatasetId
   readonly versionId?: DatasetVersionId
   readonly search?: string
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const rowRepo = yield* DatasetRowRepository
+  const rowRepo = yield* DatasetRowRepository
 
-    let version: number | undefined
-    if (args.versionId) {
-      const datasetRepo = yield* DatasetRepository
-      version = yield* datasetRepo.resolveVersion({
-        datasetId: args.datasetId,
-        versionId: args.versionId,
-      })
-    }
-
-    return yield* rowRepo.count({
+  let version: number | undefined
+  if (args.versionId) {
+    const datasetRepo = yield* DatasetRepository
+    version = yield* datasetRepo.resolveVersion({
       datasetId: args.datasetId,
-      ...(version !== undefined ? { version } : {}),
-      ...(args.search ? { search: args.search } : {}),
+      versionId: args.versionId,
     })
-  }).pipe(Effect.withSpan("datasets.countRows"))
-}
+  }
+
+  return yield* rowRepo.count({
+    datasetId: args.datasetId,
+    ...(version !== undefined ? { version } : {}),
+    ...(args.search ? { search: args.search } : {}),
+  })
+})

--- a/packages/domain/datasets/src/use-cases/create-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/create-dataset.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { validateDatasetNameInProject } from "./validate-dataset-name.ts"
 
-export function createDataset(args: {
+export const createDataset = Effect.fn("datasets.createDataset")(function* (args: {
   readonly id?: DatasetId
   readonly projectId: ProjectId
   readonly name: string
@@ -12,31 +12,29 @@ export function createDataset(args: {
   readonly fileKey?: string
   readonly actorUserId?: string
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+  yield* Effect.annotateCurrentSpan("projectId", args.projectId)
 
-    const repo = yield* DatasetRepository
-    const name = yield* validateDatasetNameInProject({
-      projectId: args.projectId,
-      name: args.name,
-    })
-    const dataset = yield* repo.create({ ...args, name })
+  const repo = yield* DatasetRepository
+  const name = yield* validateDatasetNameInProject({
+    projectId: args.projectId,
+    name: args.name,
+  })
+  const dataset = yield* repo.create({ ...args, name })
 
-    const outboxEventWriter = yield* OutboxEventWriter
-    yield* outboxEventWriter.write({
-      eventName: "DatasetCreated",
-      aggregateType: "dataset",
-      aggregateId: dataset.id,
+  const outboxEventWriter = yield* OutboxEventWriter
+  yield* outboxEventWriter.write({
+    eventName: "DatasetCreated",
+    aggregateType: "dataset",
+    aggregateId: dataset.id,
+    organizationId: dataset.organizationId,
+    payload: {
       organizationId: dataset.organizationId,
-      payload: {
-        organizationId: dataset.organizationId,
-        actorUserId: args.actorUserId ?? "",
-        projectId: dataset.projectId,
-        datasetId: dataset.id,
-        name: dataset.name,
-      },
-    })
+      actorUserId: args.actorUserId ?? "",
+      projectId: dataset.projectId,
+      datasetId: dataset.id,
+      name: dataset.name,
+    },
+  })
 
-    return dataset
-  }).pipe(Effect.withSpan("datasets.createDataset"))
-}
+  return dataset
+})

--- a/packages/domain/datasets/src/use-cases/delete-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/delete-dataset.ts
@@ -2,12 +2,10 @@ import type { DatasetId } from "@domain/shared"
 import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 
-export function deleteDataset(args: { readonly datasetId: DatasetId }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+export const deleteDataset = Effect.fn("datasets.deleteDataset")(function* (args: { readonly datasetId: DatasetId }) {
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const repo = yield* DatasetRepository
-    yield* repo.findById(args.datasetId)
-    yield* repo.softDelete(args.datasetId)
-  }).pipe(Effect.withSpan("datasets.deleteDataset"))
-}
+  const repo = yield* DatasetRepository
+  yield* repo.findById(args.datasetId)
+  yield* repo.softDelete(args.datasetId)
+})

--- a/packages/domain/datasets/src/use-cases/delete-rows.ts
+++ b/packages/domain/datasets/src/use-cases/delete-rows.ts
@@ -10,51 +10,52 @@ export type DeleteRowsSelection =
 
 // Known limitation: concurrent deletes/updates race on version number.
 // See update-row.ts for details on the last-write-wins behavior.
-export function deleteRows(args: { readonly datasetId: DatasetId; readonly selection: DeleteRowsSelection }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+export const deleteRows = Effect.fn("datasets.deleteRows")(function* (args: {
+  readonly datasetId: DatasetId
+  readonly selection: DeleteRowsSelection
+}) {
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    if (args.selection.mode === "selected" && args.selection.rowIds.length === 0) {
-      return { versionId: null, version: 0 }
-    }
+  if (args.selection.mode === "selected" && args.selection.rowIds.length === 0) {
+    return { versionId: null, version: 0 }
+  }
 
-    const datasetRepo = yield* DatasetRepository
-    const rowRepo = yield* DatasetRowRepository
+  const datasetRepo = yield* DatasetRepository
+  const rowRepo = yield* DatasetRowRepository
 
-    if (args.selection.mode === "selected") {
-      yield* Effect.all(args.selection.rowIds.map((rowId) => rowRepo.findById({ datasetId: args.datasetId, rowId })))
-
-      const version = yield* datasetRepo.incrementVersion({
-        id: args.datasetId,
-        rowsDeleted: args.selection.rowIds.length,
-        source: "web",
-      })
-
-      yield* rowRepo
-        .deleteBatch({
-          datasetId: args.datasetId,
-          rowIds: args.selection.rowIds,
-          version: version.version,
-        })
-        .pipe(Effect.tapError(() => datasetRepo.decrementVersion({ id: args.datasetId, versionId: version.id })))
-
-      return { versionId: version.id, version: version.version }
-    }
+  if (args.selection.mode === "selected") {
+    yield* Effect.all(args.selection.rowIds.map((rowId) => rowRepo.findById({ datasetId: args.datasetId, rowId })))
 
     const version = yield* datasetRepo.incrementVersion({
       id: args.datasetId,
+      rowsDeleted: args.selection.rowIds.length,
       source: "web",
     })
 
-    const deleteAllArgs =
-      args.selection.mode === "allExcept"
-        ? { datasetId: args.datasetId, version: version.version, excludedRowIds: args.selection.rowIds }
-        : { datasetId: args.datasetId, version: version.version }
-
-    const deletedCount = yield* rowRepo
-      .deleteAll(deleteAllArgs)
+    yield* rowRepo
+      .deleteBatch({
+        datasetId: args.datasetId,
+        rowIds: args.selection.rowIds,
+        version: version.version,
+      })
       .pipe(Effect.tapError(() => datasetRepo.decrementVersion({ id: args.datasetId, versionId: version.id })))
 
-    return { versionId: version.id, version: version.version, deletedCount }
-  }).pipe(Effect.withSpan("datasets.deleteRows"))
-}
+    return { versionId: version.id, version: version.version }
+  }
+
+  const version = yield* datasetRepo.incrementVersion({
+    id: args.datasetId,
+    source: "web",
+  })
+
+  const deleteAllArgs =
+    args.selection.mode === "allExcept"
+      ? { datasetId: args.datasetId, version: version.version, excludedRowIds: args.selection.rowIds }
+      : { datasetId: args.datasetId, version: version.version }
+
+  const deletedCount = yield* rowRepo
+    .deleteAll(deleteAllArgs)
+    .pipe(Effect.tapError(() => datasetRepo.decrementVersion({ id: args.datasetId, versionId: version.id })))
+
+  return { versionId: version.id, version: version.version, deletedCount }
+})

--- a/packages/domain/datasets/src/use-cases/get-row-detail.ts
+++ b/packages/domain/datasets/src/use-cases/get-row-detail.ts
@@ -3,30 +3,28 @@ import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
 
-export function getRowDetail(args: {
+export const getRowDetail = Effect.fn("datasets.getRowDetail")(function* (args: {
   readonly datasetId: DatasetId
   readonly rowId: DatasetRowId
   readonly versionId?: DatasetVersionId
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
-    yield* Effect.annotateCurrentSpan("rowId", args.rowId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("rowId", args.rowId)
 
-    const rowRepo = yield* DatasetRowRepository
+  const rowRepo = yield* DatasetRowRepository
 
-    let version: number | undefined
-    if (args.versionId) {
-      const datasetRepo = yield* DatasetRepository
-      version = yield* datasetRepo.resolveVersion({
-        datasetId: args.datasetId,
-        versionId: args.versionId,
-      })
-    }
-
-    return yield* rowRepo.findById({
+  let version: number | undefined
+  if (args.versionId) {
+    const datasetRepo = yield* DatasetRepository
+    version = yield* datasetRepo.resolveVersion({
       datasetId: args.datasetId,
-      rowId: args.rowId,
-      ...(version !== undefined ? { version } : {}),
+      versionId: args.versionId,
     })
-  }).pipe(Effect.withSpan("datasets.getRowDetail"))
-}
+  }
+
+  return yield* rowRepo.findById({
+    datasetId: args.datasetId,
+    rowId: args.rowId,
+    ...(version !== undefined ? { version } : {}),
+  })
+})

--- a/packages/domain/datasets/src/use-cases/insert-rows.ts
+++ b/packages/domain/datasets/src/use-cases/insert-rows.ts
@@ -5,7 +5,7 @@ import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
 import { buildValidRowId } from "../validate-row-id.ts"
 
-export function insertRows(args: {
+export const insertRows = Effect.fn("datasets.insertRows")(function* (args: {
   readonly datasetId: DatasetId
   readonly rows: readonly {
     readonly id?: DatasetRowId
@@ -15,37 +15,35 @@ export function insertRows(args: {
   }[]
   readonly source?: string
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const resolvedRows = yield* Effect.forEach(args.rows, (row) =>
-      buildValidRowId(row.id).pipe(Effect.map((id) => ({ ...row, id }))),
+  const resolvedRows = yield* Effect.forEach(args.rows, (row) =>
+    buildValidRowId(row.id).pipe(Effect.map((id) => ({ ...row, id }))),
+  )
+
+  const datasetRepo = yield* DatasetRepository
+  const rowRepo = yield* DatasetRowRepository
+
+  const version = yield* datasetRepo.incrementVersion({
+    id: args.datasetId,
+    rowsInserted: resolvedRows.length,
+    source: args.source ?? "api",
+  })
+
+  const rowIds = yield* rowRepo
+    .insertBatch({
+      datasetId: args.datasetId,
+      version: version.version,
+      rows: resolvedRows,
+    })
+    .pipe(
+      Effect.tapError(() =>
+        datasetRepo.decrementVersion({
+          id: args.datasetId,
+          versionId: version.id,
+        }),
+      ),
     )
 
-    const datasetRepo = yield* DatasetRepository
-    const rowRepo = yield* DatasetRowRepository
-
-    const version = yield* datasetRepo.incrementVersion({
-      id: args.datasetId,
-      rowsInserted: resolvedRows.length,
-      source: args.source ?? "api",
-    })
-
-    const rowIds = yield* rowRepo
-      .insertBatch({
-        datasetId: args.datasetId,
-        version: version.version,
-        rows: resolvedRows,
-      })
-      .pipe(
-        Effect.tapError(() =>
-          datasetRepo.decrementVersion({
-            id: args.datasetId,
-            versionId: version.id,
-          }),
-        ),
-      )
-
-    return { versionId: version.id, version: version.version, rowIds }
-  }).pipe(Effect.withSpan("datasets.insertRows"))
-}
+  return { versionId: version.id, version: version.version, rowIds }
+})

--- a/packages/domain/datasets/src/use-cases/list-datasets.ts
+++ b/packages/domain/datasets/src/use-cases/list-datasets.ts
@@ -3,13 +3,14 @@ import { Effect } from "effect"
 import type { DatasetListOptions } from "../ports/dataset-repository.ts"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 
-export function listDatasets(args: { readonly projectId: ProjectId; readonly options?: DatasetListOptions }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+export const listDatasets = Effect.fn("datasets.listDatasets")(function* (args: {
+  readonly projectId: ProjectId
+  readonly options?: DatasetListOptions
+}) {
+  yield* Effect.annotateCurrentSpan("projectId", args.projectId)
 
-    const repo = yield* DatasetRepository
-    return yield* repo.listByProject(
-      args.options !== undefined ? { projectId: args.projectId, options: args.options } : { projectId: args.projectId },
-    )
-  }).pipe(Effect.withSpan("datasets.listDatasets"))
-}
+  const repo = yield* DatasetRepository
+  return yield* repo.listByProject(
+    args.options !== undefined ? { projectId: args.projectId, options: args.options } : { projectId: args.projectId },
+  )
+})

--- a/packages/domain/datasets/src/use-cases/list-rows.ts
+++ b/packages/domain/datasets/src/use-cases/list-rows.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
 
-export function listRows(args: {
+export const listRows = Effect.fn("datasets.listRows")(function* (args: {
   readonly datasetId: DatasetId
   readonly versionId?: DatasetVersionId
   readonly search?: string
@@ -12,28 +12,26 @@ export function listRows(args: {
   readonly offset?: number
   readonly cursor?: { readonly createdAt: string; readonly rowId: DatasetRowId }
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const rowRepo = yield* DatasetRowRepository
+  const rowRepo = yield* DatasetRowRepository
 
-    let version: number | undefined
-    if (args.versionId) {
-      const datasetRepo = yield* DatasetRepository
-      version = yield* datasetRepo.resolveVersion({
-        datasetId: args.datasetId,
-        versionId: args.versionId,
-      })
-    }
-
-    return yield* rowRepo.list({
+  let version: number | undefined
+  if (args.versionId) {
+    const datasetRepo = yield* DatasetRepository
+    version = yield* datasetRepo.resolveVersion({
       datasetId: args.datasetId,
-      ...(version !== undefined ? { version } : {}),
-      ...(args.search ? { search: args.search } : {}),
-      ...(args.sortDirection !== undefined ? { sortDirection: args.sortDirection } : {}),
-      ...(args.limit !== undefined ? { limit: args.limit } : {}),
-      ...(args.offset !== undefined ? { offset: args.offset } : {}),
-      ...(args.cursor ? { cursor: args.cursor } : {}),
+      versionId: args.versionId,
     })
-  }).pipe(Effect.withSpan("datasets.listRows"))
-}
+  }
+
+  return yield* rowRepo.list({
+    datasetId: args.datasetId,
+    ...(version !== undefined ? { version } : {}),
+    ...(args.search ? { search: args.search } : {}),
+    ...(args.sortDirection !== undefined ? { sortDirection: args.sortDirection } : {}),
+    ...(args.limit !== undefined ? { limit: args.limit } : {}),
+    ...(args.offset !== undefined ? { offset: args.offset } : {}),
+    ...(args.cursor ? { cursor: args.cursor } : {}),
+  })
+})

--- a/packages/domain/datasets/src/use-cases/rename-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/rename-dataset.ts
@@ -3,21 +3,22 @@ import { Effect } from "effect"
 import { DatasetRepository } from "../ports/dataset-repository.ts"
 import { validateDatasetNameInProject } from "./validate-dataset-name.ts"
 
-export function renameDataset(args: { readonly datasetId: DatasetId; readonly name: string }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+export const renameDataset = Effect.fn("datasets.renameDataset")(function* (args: {
+  readonly datasetId: DatasetId
+  readonly name: string
+}) {
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const repo = yield* DatasetRepository
-    const dataset = yield* repo.findById(args.datasetId)
-    const trimmed = args.name.trim()
-    if (dataset.name === trimmed) return dataset
+  const repo = yield* DatasetRepository
+  const dataset = yield* repo.findById(args.datasetId)
+  const trimmed = args.name.trim()
+  if (dataset.name === trimmed) return dataset
 
-    const name = yield* validateDatasetNameInProject({
-      projectId: dataset.projectId,
-      name: args.name,
-      excludeDatasetId: args.datasetId,
-    })
+  const name = yield* validateDatasetNameInProject({
+    projectId: dataset.projectId,
+    name: args.name,
+    excludeDatasetId: args.datasetId,
+  })
 
-    return yield* repo.updateName({ id: args.datasetId, name })
-  }).pipe(Effect.withSpan("datasets.renameDataset"))
-}
+  return yield* repo.updateName({ id: args.datasetId, name })
+})

--- a/packages/domain/datasets/src/use-cases/update-dataset-details.ts
+++ b/packages/domain/datasets/src/use-cases/update-dataset-details.ts
@@ -10,36 +10,34 @@ function normalizeDescription(description: string | null | undefined): string | 
   return t === "" ? null : t
 }
 
-export function updateDatasetDetails(args: {
+export const updateDatasetDetails = Effect.fn("datasets.updateDatasetDetails")(function* (args: {
   readonly datasetId: DatasetId
   readonly name: string
   readonly description: string | null | undefined
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
 
-    const repo = yield* DatasetRepository
-    const dataset = yield* repo.findById(args.datasetId)
-    const trimmedName = args.name.trim()
-    if (trimmedName === "") {
-      return yield* new ValidationError({ field: "name", message: "Name cannot be empty" })
-    }
-    const normalizedDesc = normalizeDescription(args.description)
+  const repo = yield* DatasetRepository
+  const dataset = yield* repo.findById(args.datasetId)
+  const trimmedName = args.name.trim()
+  if (trimmedName === "") {
+    return yield* new ValidationError({ field: "name", message: "Name cannot be empty" })
+  }
+  const normalizedDesc = normalizeDescription(args.description)
 
-    if (dataset.name === trimmedName && dataset.description === normalizedDesc) {
-      return dataset
-    }
+  if (dataset.name === trimmedName && dataset.description === normalizedDesc) {
+    return dataset
+  }
 
-    const name = yield* validateDatasetNameInProject({
-      projectId: dataset.projectId,
-      name: args.name,
-      excludeDatasetId: args.datasetId,
-    })
+  const name = yield* validateDatasetNameInProject({
+    projectId: dataset.projectId,
+    name: args.name,
+    excludeDatasetId: args.datasetId,
+  })
 
-    return yield* repo.updateDetails({
-      id: args.datasetId,
-      name,
-      description: normalizedDesc,
-    })
-  }).pipe(Effect.withSpan("datasets.updateDatasetDetails"))
-}
+  return yield* repo.updateDetails({
+    id: args.datasetId,
+    name,
+    description: normalizedDesc,
+  })
+})

--- a/packages/domain/datasets/src/use-cases/update-row.ts
+++ b/packages/domain/datasets/src/use-cases/update-row.ts
@@ -7,49 +7,47 @@ import { DatasetRowRepository } from "../ports/dataset-row-repository.ts"
 // Known limitation: concurrent updates to the same row are last-write-wins.
 // Both callers get version N+1 and ClickHouse's argMax picks non-deterministically.
 // Optimistic locking (expectedVersion) should be added if this becomes a real concern.
-export function updateRow(args: {
+export const updateRow = Effect.fn("datasets.updateRow")(function* (args: {
   readonly datasetId: DatasetId
   readonly rowId: DatasetRowId
   readonly input: RowFieldValue
   readonly output: RowFieldValue
   readonly metadata: RowFieldValue
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
-    yield* Effect.annotateCurrentSpan("rowId", args.rowId)
+  yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
+  yield* Effect.annotateCurrentSpan("rowId", args.rowId)
 
-    const datasetRepo = yield* DatasetRepository
-    const rowRepo = yield* DatasetRowRepository
+  const datasetRepo = yield* DatasetRepository
+  const rowRepo = yield* DatasetRowRepository
 
-    yield* rowRepo.findById({
+  yield* rowRepo.findById({
+    datasetId: args.datasetId,
+    rowId: args.rowId,
+  })
+
+  const version = yield* datasetRepo.incrementVersion({
+    id: args.datasetId,
+    rowsUpdated: 1,
+    source: "web",
+  })
+
+  yield* rowRepo
+    .updateRow({
       datasetId: args.datasetId,
       rowId: args.rowId,
+      version: version.version,
+      input: args.input,
+      output: args.output,
+      metadata: args.metadata,
     })
+    .pipe(
+      Effect.tapError(() =>
+        datasetRepo.decrementVersion({
+          id: args.datasetId,
+          versionId: version.id,
+        }),
+      ),
+    )
 
-    const version = yield* datasetRepo.incrementVersion({
-      id: args.datasetId,
-      rowsUpdated: 1,
-      source: "web",
-    })
-
-    yield* rowRepo
-      .updateRow({
-        datasetId: args.datasetId,
-        rowId: args.rowId,
-        version: version.version,
-        input: args.input,
-        output: args.output,
-        metadata: args.metadata,
-      })
-      .pipe(
-        Effect.tapError(() =>
-          datasetRepo.decrementVersion({
-            id: args.datasetId,
-            versionId: version.id,
-          }),
-        ),
-      )
-
-    return { versionId: version.id, version: version.version }
-  }).pipe(Effect.withSpan("datasets.updateRow"))
-}
+  return { versionId: version.id, version: version.version }
+})

--- a/packages/domain/datasets/src/use-cases/validate-dataset-name.ts
+++ b/packages/domain/datasets/src/use-cases/validate-dataset-name.ts
@@ -8,27 +8,25 @@ import { DatasetRepository } from "../ports/dataset-repository.ts"
  * Validates a dataset name for a project: trims, rejects empty, rejects duplicate.
  * Returns the trimmed name on success.
  */
-export function validateDatasetNameInProject(args: {
+export const validateDatasetNameInProject = Effect.fn("datasets.validateDatasetName")(function* (args: {
   readonly projectId: ProjectId
   readonly name: string
   readonly excludeDatasetId?: DatasetId
 }) {
-  return Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", args.projectId)
+  yield* Effect.annotateCurrentSpan("projectId", args.projectId)
 
-    const repo = yield* DatasetRepository
-    const trimmed = args.name.trim()
-    if (!trimmed) {
-      return yield* new ValidationError({ field: "name", message: "Name cannot be empty" })
-    }
-    const exists = yield* repo.existsByNameInProject({
-      projectId: args.projectId,
-      name: trimmed,
-      ...(args.excludeDatasetId !== undefined ? { excludeDatasetId: args.excludeDatasetId } : {}),
-    })
-    if (exists) {
-      return yield* new DuplicateDatasetNameError({ projectId: args.projectId, name: trimmed })
-    }
-    return trimmed
-  }).pipe(Effect.withSpan("datasets.validateDatasetName"))
-}
+  const repo = yield* DatasetRepository
+  const trimmed = args.name.trim()
+  if (!trimmed) {
+    return yield* new ValidationError({ field: "name", message: "Name cannot be empty" })
+  }
+  const exists = yield* repo.existsByNameInProject({
+    projectId: args.projectId,
+    name: trimmed,
+    ...(args.excludeDatasetId !== undefined ? { excludeDatasetId: args.excludeDatasetId } : {}),
+  })
+  if (exists) {
+    return yield* new DuplicateDatasetNameError({ projectId: args.projectId, name: trimmed })
+  }
+  return trimmed
+})

--- a/packages/domain/evaluations/package.json
+++ b/packages/domain/evaluations/package.json
@@ -6,7 +6,10 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "browser": "./src/browser.ts",
+      "default": "./src/index.ts"
+    },
     "./constants": "./src/constants.ts"
   },
   "scripts": {

--- a/packages/domain/evaluations/src/browser.ts
+++ b/packages/domain/evaluations/src/browser.ts
@@ -1,0 +1,14 @@
+export { EVALUATION_JOB_STATUS_TTL_SECONDS } from "./constants.ts"
+export type { Evaluation, EvaluationAlignmentJobStatus } from "./entities/evaluation.ts"
+export { EvaluationNotFoundError } from "./errors.ts"
+export {
+  buildEvaluationAlignmentJobStatus,
+  deriveEvaluationAlignmentMetrics,
+  evaluationAlignmentJobStatusKey,
+  parseStoredEvaluationAlignmentJobStatus,
+  softDeleteEvaluation,
+} from "./helpers.ts"
+export {
+  EvaluationRepository,
+  type EvaluationRepositoryShape,
+} from "./ports/evaluation-repository.ts"

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.ts
@@ -194,39 +194,39 @@ export const executeEvaluationScriptWithAI = Effect.fn("evaluations.executeEvalu
   readonly issue: EvaluationIssueContext
   readonly telemetry?: GenerateTelemetryCapture
 }) {
-    yield* Effect.annotateCurrentSpan("evaluation.conversationMessageCount", input.conversation.length)
+  yield* Effect.annotateCurrentSpan("evaluation.conversationMessageCount", input.conversation.length)
 
-    const ai = yield* AI
-    const services = yield* Effect.services<never>()
+  const ai = yield* AI
+  const services = yield* Effect.services<never>()
 
-    return yield* Effect.tryPromise({
-      try: () =>
-        executeEvaluationScript({
-          script: input.script,
-          conversation: input.conversation,
-          issue: input.issue,
-          generateStructuredObject: <T>(llmInput: {
-            readonly prompt: string
-            readonly schema: EvaluationScriptSchema<T>
-          }): Promise<GenerateResult<T>> =>
-            Effect.runPromiseWith(services)(
-              ai.generate({
-                ...EVALUATION_SCRIPT_RUNTIME_MODEL,
-                system: EVALUATION_SCRIPT_RUNTIME_SYSTEM_PROMPT,
-                prompt: llmInput.prompt,
-                schema: llmInput.schema,
-                ...(input.telemetry ? { telemetry: input.telemetry } : {}),
-              }),
-            ),
-        }),
-      catch: (error) => {
-        if (error instanceof AIError || error instanceof AICredentialError) {
-          return error
-        }
+  return yield* Effect.tryPromise({
+    try: () =>
+      executeEvaluationScript({
+        script: input.script,
+        conversation: input.conversation,
+        issue: input.issue,
+        generateStructuredObject: <T>(llmInput: {
+          readonly prompt: string
+          readonly schema: EvaluationScriptSchema<T>
+        }): Promise<GenerateResult<T>> =>
+          Effect.runPromiseWith(services)(
+            ai.generate({
+              ...EVALUATION_SCRIPT_RUNTIME_MODEL,
+              system: EVALUATION_SCRIPT_RUNTIME_SYSTEM_PROMPT,
+              prompt: llmInput.prompt,
+              schema: llmInput.schema,
+              ...(input.telemetry ? { telemetry: input.telemetry } : {}),
+            }),
+          ),
+      }),
+    catch: (error) => {
+      if (error instanceof AIError || error instanceof AICredentialError) {
+        return error
+      }
 
-        return new EvaluationExecutionError({
-          message: error instanceof Error ? error.message : "Evaluation execution failed",
-        })
-      },
-    })
+      return new EvaluationExecutionError({
+        message: error instanceof Error ? error.message : "Evaluation execution failed",
+      })
+    },
   })
+})

--- a/packages/domain/evaluations/src/runtime/evaluation-execution.ts
+++ b/packages/domain/evaluations/src/runtime/evaluation-execution.ts
@@ -188,13 +188,12 @@ export const executeEvaluationScript = async (input: {
   }
 }
 
-export const executeEvaluationScriptWithAI = (input: {
+export const executeEvaluationScriptWithAI = Effect.fn("evaluations.executeEvaluationScriptWithAi")(function* (input: {
   readonly script: string
   readonly conversation: readonly EvaluationConversationMessage[]
   readonly issue: EvaluationIssueContext
   readonly telemetry?: GenerateTelemetryCapture
-}) =>
-  Effect.gen(function* () {
+}) {
     yield* Effect.annotateCurrentSpan("evaluation.conversationMessageCount", input.conversation.length)
 
     const ai = yield* AI
@@ -227,8 +226,7 @@ export const executeEvaluationScriptWithAI = (input: {
 
         return new EvaluationExecutionError({
           message: error instanceof Error ? error.message : "Evaluation execution failed",
-          cause: error,
         })
       },
     })
-  }).pipe(Effect.withSpan("evaluations.executeEvaluationScriptWithAi"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
@@ -11,14 +11,13 @@ import {
   toEvaluationConversationMessages,
 } from "../../runtime/evaluation-execution.ts"
 
-export const collectAlignmentExamplesUseCase = (input: {
+export const collectAlignmentExamplesUseCase = Effect.fn("evaluations.collectAlignmentExamples")(function* (input: {
   readonly organizationId: string
   readonly projectId: string
   readonly issueId: string
   readonly createdAfter?: string | null
   readonly requirePositiveExamples?: boolean
-}) =>
-  Effect.gen(function* () {
+}) {
     yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
     yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
@@ -100,4 +99,4 @@ export const collectAlignmentExamplesUseCase = (input: {
       positiveExamples: positiveExamples.map(hydrateExample),
       negativeExamples: negativeExamples.map(hydrateExample),
     } satisfies CollectedEvaluationAlignmentExamples
-  }).pipe(Effect.withSpan("evaluations.collectAlignmentExamples"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.ts
@@ -18,85 +18,83 @@ export const collectAlignmentExamplesUseCase = Effect.fn("evaluations.collectAli
   readonly createdAfter?: string | null
   readonly requirePositiveExamples?: boolean
 }) {
-    yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+  yield* Effect.annotateCurrentSpan("evaluation.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
 
-    const issueRepository = yield* EvaluationIssueRepository
-    const exampleRepository = yield* EvaluationAlignmentExamplesRepository
-    const traceRepository = yield* TraceRepository
-    const issueId = IssueId(input.issueId)
-    const projectId = ProjectId(input.projectId)
-    const issue = yield* issueRepository.findById(issueId)
+  const issueRepository = yield* EvaluationIssueRepository
+  const exampleRepository = yield* EvaluationAlignmentExamplesRepository
+  const traceRepository = yield* TraceRepository
+  const issueId = IssueId(input.issueId)
+  const projectId = ProjectId(input.projectId)
+  const issue = yield* issueRepository.findById(issueId)
 
-    if (issue.projectId !== projectId) {
-      return yield* new BadRequestError({
-        message: `Issue ${input.issueId} does not belong to project ${input.projectId}`,
-      })
-    }
-
-    const positiveExamples = yield* exampleRepository.listPositiveExamples({
-      projectId,
-      issueId,
-      ...(input.createdAfter ? { createdAfter: new Date(input.createdAfter) } : {}),
+  if (issue.projectId !== projectId) {
+    return yield* new BadRequestError({
+      message: `Issue ${input.issueId} does not belong to project ${input.projectId}`,
     })
+  }
 
-    if (positiveExamples.length === 0 && input.requirePositiveExamples !== false) {
-      return yield* new BadRequestError({
-        message: `Issue ${input.issueId} has no positive alignment examples yet`,
-      })
-    }
+  const positiveExamples = yield* exampleRepository.listPositiveExamples({
+    projectId,
+    issueId,
+    ...(input.createdAfter ? { createdAfter: new Date(input.createdAfter) } : {}),
+  })
 
-    const negativeExamples = yield* exampleRepository.listNegativeExamples({
-      projectId,
-      issueId,
-      excludeTraceIds: positiveExamples.map((example) => example.traceId),
-      ...(input.createdAfter ? { createdAfter: new Date(input.createdAfter) } : {}),
+  if (positiveExamples.length === 0 && input.requirePositiveExamples !== false) {
+    return yield* new BadRequestError({
+      message: `Issue ${input.issueId} has no positive alignment examples yet`,
     })
+  }
 
-    if (positiveExamples.length === 0 && negativeExamples.length === 0) {
-      return {
-        issueId: issue.id,
-        issueName: issue.name,
-        issueDescription: issue.description,
-        positiveExamples: [],
-        negativeExamples: [],
-      } satisfies CollectedEvaluationAlignmentExamples
-    }
+  const negativeExamples = yield* exampleRepository.listNegativeExamples({
+    projectId,
+    issueId,
+    excludeTraceIds: positiveExamples.map((example) => example.traceId),
+    ...(input.createdAfter ? { createdAfter: new Date(input.createdAfter) } : {}),
+  })
 
-    const traceDetails = yield* traceRepository.listByTraceIds({
-      organizationId: OrganizationId(input.organizationId),
-      projectId,
-      traceIds: [...new Set([...positiveExamples, ...negativeExamples].map((example) => example.traceId))],
-    })
-
-    const traceDetailsById = new Map(traceDetails.map((detail) => [detail.traceId as string, detail]))
-
-    const hydrateExample = (example: EvaluationAlignmentExample): HydratedEvaluationAlignmentExample => {
-      const detail = traceDetailsById.get(example.traceId as string)
-
-      if (!detail) {
-        throw new BadRequestError({
-          message: `Trace ${example.traceId} was not found for alignment example hydration`,
-        })
-      }
-
-      const conversation: readonly EvaluationConversationMessage[] = toEvaluationConversationMessages(
-        detail.allMessages,
-      )
-
-      return {
-        ...example,
-        conversation,
-        conversationText: formatGenAIConversation(detail.allMessages),
-      }
-    }
-
+  if (positiveExamples.length === 0 && negativeExamples.length === 0) {
     return {
       issueId: issue.id,
       issueName: issue.name,
       issueDescription: issue.description,
-      positiveExamples: positiveExamples.map(hydrateExample),
-      negativeExamples: negativeExamples.map(hydrateExample),
+      positiveExamples: [],
+      negativeExamples: [],
     } satisfies CollectedEvaluationAlignmentExamples
+  }
+
+  const traceDetails = yield* traceRepository.listByTraceIds({
+    organizationId: OrganizationId(input.organizationId),
+    projectId,
+    traceIds: [...new Set([...positiveExamples, ...negativeExamples].map((example) => example.traceId))],
   })
+
+  const traceDetailsById = new Map(traceDetails.map((detail) => [detail.traceId as string, detail]))
+
+  const hydrateExample = (example: EvaluationAlignmentExample): HydratedEvaluationAlignmentExample => {
+    const detail = traceDetailsById.get(example.traceId as string)
+
+    if (!detail) {
+      throw new BadRequestError({
+        message: `Trace ${example.traceId} was not found for alignment example hydration`,
+      })
+    }
+
+    const conversation: readonly EvaluationConversationMessage[] = toEvaluationConversationMessages(detail.allMessages)
+
+    return {
+      ...example,
+      conversation,
+      conversationText: formatGenAIConversation(detail.allMessages),
+    }
+  }
+
+  return {
+    issueId: issue.id,
+    issueName: issue.name,
+    issueDescription: issue.description,
+    positiveExamples: positiveExamples.map(hydrateExample),
+    negativeExamples: negativeExamples.map(hydrateExample),
+  } satisfies CollectedEvaluationAlignmentExamples
+})

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
@@ -13,14 +13,15 @@ import { executeEvaluationScriptWithAI } from "../../runtime/evaluation-executio
 
 // TODO(eval-sandbox): when sandbox is available, executeEvaluationScript will run arbitrary JS;
 // this function delegates to it and its structure won't change.
-export const evaluateDraftAgainstExamplesUseCase = Effect.fn("evaluations.evaluateDraftAgainstExamples")(function* (input: {
-  readonly issueName: string
-  readonly issueDescription: string
-  readonly script: string
-  readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
-  readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
-  readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
-}) {
+export const evaluateDraftAgainstExamplesUseCase = Effect.fn("evaluations.evaluateDraftAgainstExamples")(
+  function* (input: {
+    readonly issueName: string
+    readonly issueDescription: string
+    readonly script: string
+    readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
+    readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
+    readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
+  }) {
     const examples = [...input.positiveExamples, ...input.negativeExamples]
     let confusionMatrix = emptyConfusionMatrix()
     const exampleResults: BaselineEvaluationExampleResult[] = []
@@ -61,4 +62,5 @@ export const evaluateDraftAgainstExamplesUseCase = Effect.fn("evaluations.evalua
       metrics: deriveEvaluationAlignmentMetrics(confusionMatrix),
       exampleResults,
     } satisfies BaselineEvaluationResult
-  })
+  },
+)

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-draft-against-examples.ts
@@ -13,15 +13,14 @@ import { executeEvaluationScriptWithAI } from "../../runtime/evaluation-executio
 
 // TODO(eval-sandbox): when sandbox is available, executeEvaluationScript will run arbitrary JS;
 // this function delegates to it and its structure won't change.
-export const evaluateDraftAgainstExamplesUseCase = (input: {
+export const evaluateDraftAgainstExamplesUseCase = Effect.fn("evaluations.evaluateDraftAgainstExamples")(function* (input: {
   readonly issueName: string
   readonly issueDescription: string
   readonly script: string
   readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
-}) =>
-  Effect.gen(function* () {
+}) {
     const examples = [...input.positiveExamples, ...input.negativeExamples]
     let confusionMatrix = emptyConfusionMatrix()
     const exampleResults: BaselineEvaluationExampleResult[] = []
@@ -62,4 +61,4 @@ export const evaluateDraftAgainstExamplesUseCase = (input: {
       metrics: deriveEvaluationAlignmentMetrics(confusionMatrix),
       exampleResults,
     } satisfies BaselineEvaluationResult
-  }).pipe(Effect.withSpan("evaluations.evaluateDraftAgainstExamples"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
@@ -23,52 +23,52 @@ export const evaluateIncrementalDraftUseCase = Effect.fn("evaluations.evaluateIn
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
 }) {
-    const newExampleCount = input.positiveExamples.length + input.negativeExamples.length
-    const previousMetrics = deriveEvaluationAlignmentMetrics(input.previousConfusionMatrix)
+  const newExampleCount = input.positiveExamples.length + input.negativeExamples.length
+  const previousMetrics = deriveEvaluationAlignmentMetrics(input.previousConfusionMatrix)
 
-    if (newExampleCount === 0) {
-      return {
-        strategy: "no-op",
-        previousConfusionMatrix: input.previousConfusionMatrix,
-        incrementalConfusionMatrix: emptyConfusionMatrix(),
-        nextConfusionMatrix: input.previousConfusionMatrix,
-        metrics: previousMetrics,
-        exampleResults: [],
-        newExampleCount,
-        previousMetrics,
-        previousMatthewsCorrelationCoefficient: previousMetrics.matthewsCorrelationCoefficient,
-        nextMatthewsCorrelationCoefficient: previousMetrics.matthewsCorrelationCoefficient,
-        matthewsCorrelationCoefficientDrop: 0,
-        confusionMatrix: emptyConfusionMatrix(),
-      } satisfies IncrementalEvaluationRefreshResult
-    }
-
-    const incremental: BaselineEvaluationResult = yield* evaluateDraftAgainstExamplesUseCase({
-      issueName: input.issueName,
-      issueDescription: input.issueDescription,
-      script: input.draft.script,
-      positiveExamples: input.positiveExamples,
-      negativeExamples: input.negativeExamples,
-      judgeTelemetry: input.judgeTelemetry,
-    })
-
-    const decision = decideAlignmentRefreshStrategy({
-      previousConfusionMatrix: input.previousConfusionMatrix,
-      incrementalConfusionMatrix: incremental.confusionMatrix,
-    })
-
+  if (newExampleCount === 0) {
     return {
-      strategy: decision.strategy,
+      strategy: "no-op",
       previousConfusionMatrix: input.previousConfusionMatrix,
-      incrementalConfusionMatrix: incremental.confusionMatrix,
-      nextConfusionMatrix: decision.nextConfusionMatrix,
-      metrics: deriveEvaluationAlignmentMetrics(decision.nextConfusionMatrix),
-      exampleResults: incremental.exampleResults,
+      incrementalConfusionMatrix: emptyConfusionMatrix(),
+      nextConfusionMatrix: input.previousConfusionMatrix,
+      metrics: previousMetrics,
+      exampleResults: [],
       newExampleCount,
       previousMetrics,
-      previousMatthewsCorrelationCoefficient: decision.previousMatthewsCorrelationCoefficient,
-      nextMatthewsCorrelationCoefficient: decision.nextMatthewsCorrelationCoefficient,
-      matthewsCorrelationCoefficientDrop: decision.matthewsCorrelationCoefficientDrop,
-      confusionMatrix: incremental.confusionMatrix,
+      previousMatthewsCorrelationCoefficient: previousMetrics.matthewsCorrelationCoefficient,
+      nextMatthewsCorrelationCoefficient: previousMetrics.matthewsCorrelationCoefficient,
+      matthewsCorrelationCoefficientDrop: 0,
+      confusionMatrix: emptyConfusionMatrix(),
     } satisfies IncrementalEvaluationRefreshResult
+  }
+
+  const incremental: BaselineEvaluationResult = yield* evaluateDraftAgainstExamplesUseCase({
+    issueName: input.issueName,
+    issueDescription: input.issueDescription,
+    script: input.draft.script,
+    positiveExamples: input.positiveExamples,
+    negativeExamples: input.negativeExamples,
+    judgeTelemetry: input.judgeTelemetry,
   })
+
+  const decision = decideAlignmentRefreshStrategy({
+    previousConfusionMatrix: input.previousConfusionMatrix,
+    incrementalConfusionMatrix: incremental.confusionMatrix,
+  })
+
+  return {
+    strategy: decision.strategy,
+    previousConfusionMatrix: input.previousConfusionMatrix,
+    incrementalConfusionMatrix: incremental.confusionMatrix,
+    nextConfusionMatrix: decision.nextConfusionMatrix,
+    metrics: deriveEvaluationAlignmentMetrics(decision.nextConfusionMatrix),
+    exampleResults: incremental.exampleResults,
+    newExampleCount,
+    previousMetrics,
+    previousMatthewsCorrelationCoefficient: decision.previousMatthewsCorrelationCoefficient,
+    nextMatthewsCorrelationCoefficient: decision.nextMatthewsCorrelationCoefficient,
+    matthewsCorrelationCoefficientDrop: decision.matthewsCorrelationCoefficientDrop,
+    confusionMatrix: incremental.confusionMatrix,
+  } satisfies IncrementalEvaluationRefreshResult
+})

--- a/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/evaluate-incremental-draft.ts
@@ -14,7 +14,7 @@ import {
 import type { EvaluationAlignmentJudgeTelemetryScope } from "../../runtime/ai-telemetry.ts"
 import { evaluateDraftAgainstExamplesUseCase } from "./evaluate-draft-against-examples.ts"
 
-export const evaluateIncrementalDraftUseCase = (input: {
+export const evaluateIncrementalDraftUseCase = Effect.fn("evaluations.evaluateIncrementalDraft")(function* (input: {
   readonly issueName: string
   readonly issueDescription: string
   readonly draft: GeneratedEvaluationDraft
@@ -22,8 +22,7 @@ export const evaluateIncrementalDraftUseCase = (input: {
   readonly positiveExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly negativeExamples: readonly HydratedEvaluationAlignmentExample[]
   readonly judgeTelemetry: EvaluationAlignmentJudgeTelemetryScope
-}) =>
-  Effect.gen(function* () {
+}) {
     const newExampleCount = input.positiveExamples.length + input.negativeExamples.length
     const previousMetrics = deriveEvaluationAlignmentMetrics(input.previousConfusionMatrix)
 
@@ -72,4 +71,4 @@ export const evaluateIncrementalDraftUseCase = (input: {
       matthewsCorrelationCoefficientDrop: decision.matthewsCorrelationCoefficientDrop,
       confusionMatrix: incremental.confusionMatrix,
     } satisfies IncrementalEvaluationRefreshResult
-  }).pipe(Effect.withSpan("evaluations.evaluateIncrementalDraft"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
@@ -11,12 +11,12 @@ export const generateBaselineDraftUseCase = Effect.fn("evaluations.generateBasel
   readonly issueName: string
   readonly issueDescription: string
 }) {
-    const promptText = generateBaselinePromptText(input.issueName, input.issueDescription)
-    const script = wrapPromptAsEvaluationScript(promptText)
+  const promptText = generateBaselinePromptText(input.issueName, input.issueDescription)
+  const script = wrapPromptAsEvaluationScript(promptText)
 
-    return {
-      script,
-      evaluationHash: yield* Effect.tryPromise(() => hashOptimizationCandidateText(script)),
-      trigger: defaultEvaluationTrigger(),
-    } satisfies GeneratedEvaluationDraft
-  })
+  return {
+    script,
+    evaluationHash: yield* Effect.tryPromise(() => hashOptimizationCandidateText(script)),
+    trigger: defaultEvaluationTrigger(),
+  } satisfies GeneratedEvaluationDraft
+})

--- a/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/generate-baseline-draft.ts
@@ -7,11 +7,10 @@ import { wrapPromptAsEvaluationScript } from "../../runtime/evaluation-execution
 
 // TODO(eval-sandbox): restore LLM-based baseline generation for arbitrary scripts when sandbox
 // is available.
-export const generateBaselineDraftUseCase = (input: {
+export const generateBaselineDraftUseCase = Effect.fn("evaluations.generateBaselineDraft")(function* (input: {
   readonly issueName: string
   readonly issueDescription: string
-}) =>
-  Effect.gen(function* () {
+}) {
     const promptText = generateBaselinePromptText(input.issueName, input.issueDescription)
     const script = wrapPromptAsEvaluationScript(promptText)
 
@@ -20,4 +19,4 @@ export const generateBaselineDraftUseCase = (input: {
       evaluationHash: yield* Effect.tryPromise(() => hashOptimizationCandidateText(script)),
       trigger: defaultEvaluationTrigger(),
     } satisfies GeneratedEvaluationDraft
-  }).pipe(Effect.withSpan("evaluations.generateBaselineDraft"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
@@ -5,13 +5,12 @@ import { isDeletedEvaluation } from "../../helpers.ts"
 import { EvaluationIssueRepository } from "../../ports/evaluation-issue-repository.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 
-export const loadAlignmentStateUseCase = (input: {
+export const loadAlignmentStateUseCase = Effect.fn("evaluations.loadAlignmentState")(function* (input: {
   readonly organizationId: string
   readonly projectId: string
   readonly issueId: string
   readonly evaluationId: string
-}) =>
-  Effect.gen(function* () {
+}) {
     yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
     yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
@@ -57,4 +56,4 @@ export const loadAlignmentStateUseCase = (input: {
       },
       confusionMatrix: evaluation.alignment.confusionMatrix,
     } satisfies LoadedEvaluationAlignmentState
-  }).pipe(Effect.withSpan("evaluations.loadAlignmentState"))
+  })

--- a/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/load-alignment-state.ts
@@ -11,49 +11,49 @@ export const loadAlignmentStateUseCase = Effect.fn("evaluations.loadAlignmentSta
   readonly issueId: string
   readonly evaluationId: string
 }) {
-    yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
-    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+  yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+  yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
 
-    const evaluationRepository = yield* EvaluationRepository
-    const issueRepository = yield* EvaluationIssueRepository
-    const evaluation = yield* evaluationRepository
-      .findById(EvaluationId(input.evaluationId))
-      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  const evaluationRepository = yield* EvaluationRepository
+  const issueRepository = yield* EvaluationIssueRepository
+  const evaluation = yield* evaluationRepository
+    .findById(EvaluationId(input.evaluationId))
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
 
-    if (evaluation === null) {
-      return yield* new BadRequestError({
-        message: `Evaluation ${input.evaluationId} was not found for alignment`,
-      })
-    }
+  if (evaluation === null) {
+    return yield* new BadRequestError({
+      message: `Evaluation ${input.evaluationId} was not found for alignment`,
+    })
+  }
 
-    if (isDeletedEvaluation(evaluation)) {
-      return yield* new BadRequestError({
-        message: `Deleted evaluation ${evaluation.id} cannot be realigned`,
-      })
-    }
+  if (isDeletedEvaluation(evaluation)) {
+    return yield* new BadRequestError({
+      message: `Deleted evaluation ${evaluation.id} cannot be realigned`,
+    })
+  }
 
-    if (evaluation.projectId !== ProjectId(input.projectId) || evaluation.issueId !== IssueId(input.issueId)) {
-      return yield* new BadRequestError({
-        message: `Evaluation ${evaluation.id} does not match the requested issue or project`,
-      })
-    }
+  if (evaluation.projectId !== ProjectId(input.projectId) || evaluation.issueId !== IssueId(input.issueId)) {
+    return yield* new BadRequestError({
+      message: `Evaluation ${evaluation.id} does not match the requested issue or project`,
+    })
+  }
 
-    const issue = yield* issueRepository.findById(IssueId(input.issueId))
+  const issue = yield* issueRepository.findById(IssueId(input.issueId))
 
-    return {
-      evaluationId: evaluation.id,
-      issueId: evaluation.issueId,
-      issueName: issue.name,
-      issueDescription: issue.description,
-      name: evaluation.name,
-      description: evaluation.description,
-      alignedAt: evaluation.alignedAt.toISOString(),
-      draft: {
-        script: evaluation.script,
-        evaluationHash: evaluation.alignment.evaluationHash,
-        trigger: evaluation.trigger,
-      },
-      confusionMatrix: evaluation.alignment.confusionMatrix,
-    } satisfies LoadedEvaluationAlignmentState
-  })
+  return {
+    evaluationId: evaluation.id,
+    issueId: evaluation.issueId,
+    issueName: issue.name,
+    issueDescription: issue.description,
+    name: evaluation.name,
+    description: evaluation.description,
+    alignedAt: evaluation.alignedAt.toISOString(),
+    draft: {
+      script: evaluation.script,
+      evaluationHash: evaluation.alignment.evaluationHash,
+      trigger: evaluation.trigger,
+    },
+    confusionMatrix: evaluation.alignment.confusionMatrix,
+  } satisfies LoadedEvaluationAlignmentState
+})

--- a/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
@@ -17,61 +17,61 @@ export const persistAlignmentResultUseCase = Effect.fn("evaluations.persistAlign
   readonly name: string
   readonly description: string
 }) {
-    yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
-    if (input.evaluationId) {
-      yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
-    }
+  yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
+  if (input.evaluationId) {
+    yield* Effect.annotateCurrentSpan("evaluation.id", input.evaluationId)
+  }
 
-    const evaluationRepository = yield* EvaluationRepository
-    const projectId = ProjectId(input.projectId)
-    const issueId = IssueId(input.issueId)
-    const existingEvaluation = input.evaluationId
-      ? yield* evaluationRepository
-          .findById(EvaluationId(input.evaluationId))
-          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-      : null
+  const evaluationRepository = yield* EvaluationRepository
+  const projectId = ProjectId(input.projectId)
+  const issueId = IssueId(input.issueId)
+  const existingEvaluation = input.evaluationId
+    ? yield* evaluationRepository
+        .findById(EvaluationId(input.evaluationId))
+        .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+    : null
 
-    if (input.evaluationId && existingEvaluation === null) {
-      return yield* new BadRequestError({
-        message: `Evaluation ${input.evaluationId} was not found for alignment`,
-      })
-    }
-
-    if (existingEvaluation && isDeletedEvaluation(existingEvaluation)) {
-      return yield* new BadRequestError({
-        message: `Deleted evaluation ${existingEvaluation.id} cannot be realigned`,
-      })
-    }
-
-    if (existingEvaluation && (existingEvaluation.projectId !== projectId || existingEvaluation.issueId !== issueId)) {
-      return yield* new BadRequestError({
-        message: `Evaluation ${existingEvaluation.id} does not match the requested issue or project`,
-      })
-    }
-
-    const now = new Date()
-    const evaluation = evaluationSchema.parse({
-      id: existingEvaluation?.id ?? input.evaluationId ?? generateId(),
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      issueId: input.issueId,
-      name: existingEvaluation?.name ?? input.name,
-      description: existingEvaluation?.description ?? input.description,
-      script: input.script,
-      trigger: input.trigger,
-      alignment: {
-        evaluationHash: input.evaluationHash,
-        confusionMatrix: input.confusionMatrix,
-      },
-      alignedAt: now,
-      archivedAt: existingEvaluation?.archivedAt ?? null,
-      deletedAt: existingEvaluation?.deletedAt ?? null,
-      createdAt: existingEvaluation?.createdAt ?? now,
-      updatedAt: now,
+  if (input.evaluationId && existingEvaluation === null) {
+    return yield* new BadRequestError({
+      message: `Evaluation ${input.evaluationId} was not found for alignment`,
     })
+  }
 
-    yield* evaluationRepository.save(evaluation)
+  if (existingEvaluation && isDeletedEvaluation(existingEvaluation)) {
+    return yield* new BadRequestError({
+      message: `Deleted evaluation ${existingEvaluation.id} cannot be realigned`,
+    })
+  }
 
-    return { evaluationId: evaluation.id } satisfies PersistEvaluationAlignmentResult
+  if (existingEvaluation && (existingEvaluation.projectId !== projectId || existingEvaluation.issueId !== issueId)) {
+    return yield* new BadRequestError({
+      message: `Evaluation ${existingEvaluation.id} does not match the requested issue or project`,
+    })
+  }
+
+  const now = new Date()
+  const evaluation = evaluationSchema.parse({
+    id: existingEvaluation?.id ?? input.evaluationId ?? generateId(),
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    issueId: input.issueId,
+    name: existingEvaluation?.name ?? input.name,
+    description: existingEvaluation?.description ?? input.description,
+    script: input.script,
+    trigger: input.trigger,
+    alignment: {
+      evaluationHash: input.evaluationHash,
+      confusionMatrix: input.confusionMatrix,
+    },
+    alignedAt: now,
+    archivedAt: existingEvaluation?.archivedAt ?? null,
+    deletedAt: existingEvaluation?.deletedAt ?? null,
+    createdAt: existingEvaluation?.createdAt ?? now,
+    updatedAt: now,
   })
+
+  yield* evaluationRepository.save(evaluation)
+
+  return { evaluationId: evaluation.id } satisfies PersistEvaluationAlignmentResult
+})

--- a/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/persist-alignment-result.ts
@@ -5,7 +5,7 @@ import { type ConfusionMatrix, type EvaluationTrigger, evaluationSchema } from "
 import { isDeletedEvaluation } from "../../helpers.ts"
 import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 
-export const persistAlignmentResultUseCase = (input: {
+export const persistAlignmentResultUseCase = Effect.fn("evaluations.persistAlignmentResult")(function* (input: {
   readonly organizationId: string
   readonly projectId: string
   readonly issueId: string
@@ -16,8 +16,7 @@ export const persistAlignmentResultUseCase = (input: {
   readonly trigger: EvaluationTrigger
   readonly name: string
   readonly description: string
-}) =>
-  Effect.gen(function* () {
+}) {
     yield* Effect.annotateCurrentSpan("evaluation.projectId", input.projectId)
     yield* Effect.annotateCurrentSpan("evaluation.issueId", input.issueId)
     if (input.evaluationId) {
@@ -75,4 +74,4 @@ export const persistAlignmentResultUseCase = (input: {
     yield* evaluationRepository.save(evaluation)
 
     return { evaluationId: evaluation.id } satisfies PersistEvaluationAlignmentResult
-  }).pipe(Effect.withSpan("evaluations.persistAlignmentResult"))
+  })

--- a/packages/domain/evaluations/src/use-cases/live/list-all-active-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/list-all-active-evaluations.ts
@@ -6,8 +6,10 @@ import { EvaluationRepository } from "../../ports/evaluation-repository.ts"
 
 const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
 
-export const listAllActiveEvaluations = ({ projectId }: { readonly projectId: ProjectId }) =>
-  Effect.gen(function* () {
+export const listAllActiveEvaluations = Effect.fn("evaluations.listAllActiveEvaluations")(function* (_: {
+  readonly projectId: ProjectId
+}) {
+    const projectId = _.projectId
     yield* Effect.annotateCurrentSpan("projectId", projectId)
 
     const evaluationRepository = yield* EvaluationRepository
@@ -32,4 +34,4 @@ export const listAllActiveEvaluations = ({ projectId }: { readonly projectId: Pr
 
       offset += page.limit
     }
-  }).pipe(Effect.withSpan("evaluations.listAllActiveEvaluations"))
+  })

--- a/packages/domain/evaluations/src/use-cases/live/list-all-active-evaluations.ts
+++ b/packages/domain/evaluations/src/use-cases/live/list-all-active-evaluations.ts
@@ -9,29 +9,29 @@ const ACTIVE_EVALUATION_SCAN_PAGE_SIZE = 100
 export const listAllActiveEvaluations = Effect.fn("evaluations.listAllActiveEvaluations")(function* (_: {
   readonly projectId: ProjectId
 }) {
-    const projectId = _.projectId
-    yield* Effect.annotateCurrentSpan("projectId", projectId)
+  const projectId = _.projectId
+  yield* Effect.annotateCurrentSpan("projectId", projectId)
 
-    const evaluationRepository = yield* EvaluationRepository
-    const evaluations: Evaluation[] = []
-    let offset = 0
+  const evaluationRepository = yield* EvaluationRepository
+  const evaluations: Evaluation[] = []
+  let offset = 0
 
-    while (true) {
-      const page = yield* evaluationRepository.listByProjectId({
-        projectId,
-        options: {
-          lifecycle: "active",
-          limit: ACTIVE_EVALUATION_SCAN_PAGE_SIZE,
-          offset,
-        },
-      })
+  while (true) {
+    const page = yield* evaluationRepository.listByProjectId({
+      projectId,
+      options: {
+        lifecycle: "active",
+        limit: ACTIVE_EVALUATION_SCAN_PAGE_SIZE,
+        offset,
+      },
+    })
 
-      evaluations.push(...page.items)
+    evaluations.push(...page.items)
 
-      if (!page.hasMore) {
-        return evaluations
-      }
-
-      offset += page.limit
+    if (!page.hasMore) {
+      return evaluations
     }
-  })
+
+    offset += page.limit
+  }
+})

--- a/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
+++ b/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
@@ -16,37 +16,37 @@ export const evaluateOptimizationCandidate = Effect.fn("evaluations.evaluateOpti
   readonly issueDescription: string
   readonly judgeTelemetry: EvaluationOptimizationJudgeTelemetryScope
 }) {
-    yield* Effect.annotateCurrentSpan("evaluation.candidateHash", input.candidate.hash)
-    yield* Effect.annotateCurrentSpan("evaluation.exampleTraceId", input.example.traceId)
+  yield* Effect.annotateCurrentSpan("evaluation.candidateHash", input.candidate.hash)
+  yield* Effect.annotateCurrentSpan("evaluation.exampleTraceId", input.example.traceId)
 
-    const execution = yield* executeEvaluationScriptWithAI({
-      script: input.candidate.text,
-      conversation: input.example.conversation,
-      issue: {
-        name: input.issueName,
-        description: input.issueDescription,
-      },
-      telemetry: buildEvaluationOptimizationJudgeTelemetryCapture({
-        scope: input.judgeTelemetry,
-        candidateHash: input.candidate.hash,
-        exampleTraceId: String(input.example.traceId),
-      }),
-    })
+  const execution = yield* executeEvaluationScriptWithAI({
+    script: input.candidate.text,
+    conversation: input.example.conversation,
+    issue: {
+      name: input.issueName,
+      description: input.issueDescription,
+    },
+    telemetry: buildEvaluationOptimizationJudgeTelemetryCapture({
+      scope: input.judgeTelemetry,
+      candidateHash: input.candidate.hash,
+      exampleTraceId: String(input.example.traceId),
+    }),
+  })
 
-    const expectedPositive = input.example.label === "positive"
-    const predictedPositive = execution.result.passed === false
-    const score = expectedPositive === predictedPositive ? 1 : 0
+  const expectedPositive = input.example.label === "positive"
+  const predictedPositive = execution.result.passed === false
+  const score = expectedPositive === predictedPositive ? 1 : 0
 
-    return {
-      trajectory: {
-        id: input.example.traceId,
-        conversationText: input.example.conversationText,
-        feedback: execution.result.feedback,
-        ...(input.example.annotationFeedback ? { annotationContext: input.example.annotationFeedback } : {}),
-        expectedPositive,
-        predictedPositive,
-        passed: execution.result.passed,
-        score,
+  return {
+    trajectory: {
+      id: input.example.traceId,
+      conversationText: input.example.conversationText,
+      feedback: execution.result.feedback,
+      ...(input.example.annotationFeedback ? { annotationContext: input.example.annotationFeedback } : {}),
+      expectedPositive,
+      predictedPositive,
+      passed: execution.result.passed,
+      score,
       totalTokens: execution.totalTokens,
     } satisfies OptimizationTrajectory,
   }

--- a/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
+++ b/packages/domain/evaluations/src/use-cases/optimization/evaluate-optimization-candidate.ts
@@ -9,14 +9,13 @@ import { executeEvaluationScriptWithAI } from "../../runtime/evaluation-executio
 
 // TODO(eval-sandbox): when sandbox is available, executeEvaluationScript will run arbitrary JS
 // and this function's structure will remain the same — it just calls executeEvaluationScript.
-export const evaluateOptimizationCandidate = (input: {
+export const evaluateOptimizationCandidate = Effect.fn("evaluations.evaluateOptimizationCandidate")(function* (input: {
   readonly candidate: OptimizationCandidate
   readonly example: HydratedEvaluationAlignmentExample
   readonly issueName: string
   readonly issueDescription: string
   readonly judgeTelemetry: EvaluationOptimizationJudgeTelemetryScope
-}) =>
-  Effect.gen(function* () {
+}) {
     yield* Effect.annotateCurrentSpan("evaluation.candidateHash", input.candidate.hash)
     yield* Effect.annotateCurrentSpan("evaluation.exampleTraceId", input.example.traceId)
 
@@ -48,7 +47,7 @@ export const evaluateOptimizationCandidate = (input: {
         predictedPositive,
         passed: execution.result.passed,
         score,
-        totalTokens: execution.totalTokens,
-      } satisfies OptimizationTrajectory,
-    }
-  }).pipe(Effect.withSpan("evaluations.evaluateOptimizationCandidate"))
+      totalTokens: execution.totalTokens,
+    } satisfies OptimizationTrajectory,
+  }
+})

--- a/packages/domain/issues/src/use-cases/discover-issue.ts
+++ b/packages/domain/issues/src/use-cases/discover-issue.ts
@@ -127,8 +127,7 @@ const asSkipped = (reason: DiscoverIssueSkipReason) =>
     reason,
   } as const)
 
-export const discoverIssueUseCase = (input: DiscoverIssueInput) =>
-  Effect.gen(function* () {
+export const discoverIssueUseCase = Effect.fn("issues.discoverIssue")(function* (input: DiscoverIssueInput) {
     yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     if (input.issueId !== null) {
@@ -202,4 +201,4 @@ export const discoverIssueUseCase = (input: DiscoverIssueInput) =>
       workflow: "assignScoreToKnownIssueWorkflow",
       scoreId: score.id,
     } satisfies DiscoverIssueResult
-  }).pipe(Effect.withSpan("issues.discoverIssue"))
+  })

--- a/packages/domain/issues/src/use-cases/discover-issue.ts
+++ b/packages/domain/issues/src/use-cases/discover-issue.ts
@@ -128,77 +128,75 @@ const asSkipped = (reason: DiscoverIssueSkipReason) =>
   } as const)
 
 export const discoverIssueUseCase = Effect.fn("issues.discoverIssue")(function* (input: DiscoverIssueInput) {
-    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    if (input.issueId !== null) {
-      yield* Effect.annotateCurrentSpan("issueId", input.issueId)
-    }
-    const workflowStarter = yield* WorkflowStarter
+  yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  if (input.issueId !== null) {
+    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+  }
+  const workflowStarter = yield* WorkflowStarter
 
-    const eligibilityResult = yield* checkEligibilityUseCase(input).pipe(
-      Effect.map((score) => ({ action: "ready", score }) as const),
-      Effect.catchTag("ScoreAlreadyOwnedByIssueError", () => loadAssignedScoreOrSkip(input.scoreId)),
-      Effect.catchTag("ScoreNotFoundForDiscoveryError", () => asSkipped("ScoreNotFoundForDiscoveryError")),
-      Effect.catchTag("ScoreDiscoveryOrganizationMismatchError", () =>
-        asSkipped("ScoreDiscoveryOrganizationMismatchError"),
-      ),
-      Effect.catchTag("ScoreDiscoveryProjectMismatchError", () => asSkipped("ScoreDiscoveryProjectMismatchError")),
-      Effect.catchTag("DraftScoreNotEligibleForDiscoveryError", () =>
-        asSkipped("DraftScoreNotEligibleForDiscoveryError"),
-      ),
-      Effect.catchTag("ErroredScoreNotEligibleForDiscoveryError", () =>
-        asSkipped("ErroredScoreNotEligibleForDiscoveryError"),
-      ),
-      Effect.catchTag("MissingScoreFeedbackForDiscoveryError", () =>
-        asSkipped("MissingScoreFeedbackForDiscoveryError"),
-      ),
-      Effect.catchTag("PassedScoreNotEligibleForDiscoveryError", () =>
-        asSkipped("PassedScoreNotEligibleForDiscoveryError"),
-      ),
-    )
+  const eligibilityResult = yield* checkEligibilityUseCase(input).pipe(
+    Effect.map((score) => ({ action: "ready", score }) as const),
+    Effect.catchTag("ScoreAlreadyOwnedByIssueError", () => loadAssignedScoreOrSkip(input.scoreId)),
+    Effect.catchTag("ScoreNotFoundForDiscoveryError", () => asSkipped("ScoreNotFoundForDiscoveryError")),
+    Effect.catchTag("ScoreDiscoveryOrganizationMismatchError", () =>
+      asSkipped("ScoreDiscoveryOrganizationMismatchError"),
+    ),
+    Effect.catchTag("ScoreDiscoveryProjectMismatchError", () => asSkipped("ScoreDiscoveryProjectMismatchError")),
+    Effect.catchTag("DraftScoreNotEligibleForDiscoveryError", () =>
+      asSkipped("DraftScoreNotEligibleForDiscoveryError"),
+    ),
+    Effect.catchTag("ErroredScoreNotEligibleForDiscoveryError", () =>
+      asSkipped("ErroredScoreNotEligibleForDiscoveryError"),
+    ),
+    Effect.catchTag("MissingScoreFeedbackForDiscoveryError", () => asSkipped("MissingScoreFeedbackForDiscoveryError")),
+    Effect.catchTag("PassedScoreNotEligibleForDiscoveryError", () =>
+      asSkipped("PassedScoreNotEligibleForDiscoveryError"),
+    ),
+  )
 
-    if (eligibilityResult.action === "skipped") {
-      return eligibilityResult satisfies DiscoverIssueResult
-    }
+  if (eligibilityResult.action === "skipped") {
+    return eligibilityResult satisfies DiscoverIssueResult
+  }
 
-    if (eligibilityResult.action === "already-assigned") {
-      yield* syncIssueProjectionsUseCase({
-        organizationId: input.organizationId,
-        issueId: eligibilityResult.issueId,
-      })
-      yield* syncScoreAnalyticsUseCase({
-        organizationId: input.organizationId,
-        scoreId: input.scoreId,
-      })
+  if (eligibilityResult.action === "already-assigned") {
+    yield* syncIssueProjectionsUseCase({
+      organizationId: input.organizationId,
+      issueId: eligibilityResult.issueId,
+    })
+    yield* syncScoreAnalyticsUseCase({
+      organizationId: input.organizationId,
+      scoreId: input.scoreId,
+    })
 
-      return {
-        action: "already-assigned",
-        issueId: eligibilityResult.issueId,
-      } satisfies DiscoverIssueResult
-    }
+    return {
+      action: "already-assigned",
+      issueId: eligibilityResult.issueId,
+    } satisfies DiscoverIssueResult
+  }
 
-    const score = eligibilityResult.score
-    const selectedIssueId =
-      input.issueId === null
-        ? yield* resolveLinkedIssueId(score)
-        : yield* resolveKnownIssueId({
-            issueId: input.issueId,
-            projectId: score.projectId,
-          })
+  const score = eligibilityResult.score
+  const selectedIssueId =
+    input.issueId === null
+      ? yield* resolveLinkedIssueId(score)
+      : yield* resolveKnownIssueId({
+          issueId: input.issueId,
+          projectId: score.projectId,
+        })
 
-    if (selectedIssueId === null) {
-      yield* startDiscoveryWorkflow(workflowStarter, input)
-      return {
-        action: "workflow-started",
-        workflow: "issueDiscoveryWorkflow",
-        scoreId: score.id,
-      } satisfies DiscoverIssueResult
-    }
-
-    yield* startAssignScoreToKnownIssueWorkflow(workflowStarter, input, selectedIssueId)
+  if (selectedIssueId === null) {
+    yield* startDiscoveryWorkflow(workflowStarter, input)
     return {
       action: "workflow-started",
-      workflow: "assignScoreToKnownIssueWorkflow",
+      workflow: "issueDiscoveryWorkflow",
       scoreId: score.id,
     } satisfies DiscoverIssueResult
-  })
+  }
+
+  yield* startAssignScoreToKnownIssueWorkflow(workflowStarter, input, selectedIssueId)
+  return {
+    action: "workflow-started",
+    workflow: "assignScoreToKnownIssueWorkflow",
+    scoreId: score.id,
+  } satisfies DiscoverIssueResult
+})

--- a/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
+++ b/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
@@ -17,8 +17,7 @@ export interface EmbedIssueSearchQueryResult {
   readonly normalizedEmbedding: number[]
 }
 
-export const embedIssueSearchQueryUseCase = (input: EmbedIssueSearchQueryInput) =>
-  Effect.gen(function* () {
+export const embedIssueSearchQueryUseCase = Effect.fn("issues.embedIssueSearchQuery")(function* (input: EmbedIssueSearchQueryInput) {
     const parsed = embedIssueSearchQueryInputSchema.parse(input)
     yield* Effect.annotateCurrentSpan("projectId", parsed.projectId)
     const ai = yield* AI
@@ -42,4 +41,4 @@ export const embedIssueSearchQueryUseCase = (input: EmbedIssueSearchQueryInput) 
       query: parsed.query,
       normalizedEmbedding,
     } satisfies EmbedIssueSearchQueryResult
-  }).pipe(Effect.withSpan("issues.embedIssueSearchQuery"))
+  })

--- a/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
+++ b/packages/domain/issues/src/use-cases/embed-issue-search-query.ts
@@ -17,28 +17,30 @@ export interface EmbedIssueSearchQueryResult {
   readonly normalizedEmbedding: number[]
 }
 
-export const embedIssueSearchQueryUseCase = Effect.fn("issues.embedIssueSearchQuery")(function* (input: EmbedIssueSearchQueryInput) {
-    const parsed = embedIssueSearchQueryInputSchema.parse(input)
-    yield* Effect.annotateCurrentSpan("projectId", parsed.projectId)
-    const ai = yield* AI
+export const embedIssueSearchQueryUseCase = Effect.fn("issues.embedIssueSearchQuery")(function* (
+  input: EmbedIssueSearchQueryInput,
+) {
+  const parsed = embedIssueSearchQueryInputSchema.parse(input)
+  yield* Effect.annotateCurrentSpan("projectId", parsed.projectId)
+  const ai = yield* AI
 
-    const result = yield* ai.embed({
-      text: parsed.query,
-      model: CENTROID_EMBEDDING_MODEL,
-      dimensions: CENTROID_EMBEDDING_DIMENSIONS,
-      telemetry: {
-        spanName: "embed-issue-search-query",
-        tags: ["issues", "embedding", "search"],
-        metadata: {
-          organizationId: parsed.organizationId,
-          projectId: parsed.projectId,
-        },
+  const result = yield* ai.embed({
+    text: parsed.query,
+    model: CENTROID_EMBEDDING_MODEL,
+    dimensions: CENTROID_EMBEDDING_DIMENSIONS,
+    telemetry: {
+      spanName: "embed-issue-search-query",
+      tags: ["issues", "embedding", "search"],
+      metadata: {
+        organizationId: parsed.organizationId,
+        projectId: parsed.projectId,
       },
-    })
-    const normalizedEmbedding = normalizeEmbedding(result.embedding)
-
-    return {
-      query: parsed.query,
-      normalizedEmbedding,
-    } satisfies EmbedIssueSearchQueryResult
+    },
   })
+  const normalizedEmbedding = normalizeEmbedding(result.embedding)
+
+  return {
+    query: parsed.query,
+    normalizedEmbedding,
+  } satisfies EmbedIssueSearchQueryResult
+})

--- a/packages/domain/issues/src/use-cases/embed-score-feedback.ts
+++ b/packages/domain/issues/src/use-cases/embed-score-feedback.ts
@@ -18,38 +18,40 @@ export interface EmbeddedScoreFeedback {
   readonly normalizedEmbedding: number[]
 }
 
-export const embedScoreFeedbackUseCase = Effect.fn("issues.embedScoreFeedback")(function* (input: EmbedScoreFeedbackInput) {
-    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    const scoreRepository = yield* ScoreRepository
-    const ai = yield* AI
+export const embedScoreFeedbackUseCase = Effect.fn("issues.embedScoreFeedback")(function* (
+  input: EmbedScoreFeedbackInput,
+) {
+  yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  const scoreRepository = yield* ScoreRepository
+  const ai = yield* AI
 
-    const score = yield* scoreRepository
-      .findById(ScoreId(input.scoreId))
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new ScoreNotFoundForDiscoveryError({ scoreId: input.scoreId })),
-        ),
-      )
+  const score = yield* scoreRepository
+    .findById(ScoreId(input.scoreId))
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new ScoreNotFoundForDiscoveryError({ scoreId: input.scoreId })),
+      ),
+    )
 
-    const embedding = yield* ai.embed({
-      text: score.feedback,
-      model: CENTROID_EMBEDDING_MODEL,
-      dimensions: CENTROID_EMBEDDING_DIMENSIONS,
-      telemetry: {
-        spanName: "embed-score-feedback",
-        tags: ["issues", "embedding"],
-        metadata: {
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          scoreId: input.scoreId,
-        },
+  const embedding = yield* ai.embed({
+    text: score.feedback,
+    model: CENTROID_EMBEDDING_MODEL,
+    dimensions: CENTROID_EMBEDDING_DIMENSIONS,
+    telemetry: {
+      spanName: "embed-score-feedback",
+      tags: ["issues", "embedding"],
+      metadata: {
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        scoreId: input.scoreId,
       },
-    })
-
-    return {
-      scoreId: score.id,
-      feedback: score.feedback,
-      normalizedEmbedding: normalizeEmbedding(embedding.embedding),
-    } satisfies EmbeddedScoreFeedback
+    },
   })
+
+  return {
+    scoreId: score.id,
+    feedback: score.feedback,
+    normalizedEmbedding: normalizeEmbedding(embedding.embedding),
+  } satisfies EmbeddedScoreFeedback
+})

--- a/packages/domain/issues/src/use-cases/embed-score-feedback.ts
+++ b/packages/domain/issues/src/use-cases/embed-score-feedback.ts
@@ -18,8 +18,7 @@ export interface EmbeddedScoreFeedback {
   readonly normalizedEmbedding: number[]
 }
 
-export const embedScoreFeedbackUseCase = (input: EmbedScoreFeedbackInput) =>
-  Effect.gen(function* () {
+export const embedScoreFeedbackUseCase = Effect.fn("issues.embedScoreFeedback")(function* (input: EmbedScoreFeedbackInput) {
     yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const scoreRepository = yield* ScoreRepository
@@ -53,4 +52,4 @@ export const embedScoreFeedbackUseCase = (input: EmbedScoreFeedbackInput) =>
       feedback: score.feedback,
       normalizedEmbedding: normalizeEmbedding(embedding.embedding),
     } satisfies EmbeddedScoreFeedback
-  }).pipe(Effect.withSpan("issues.embedScoreFeedback"))
+  })

--- a/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
+++ b/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
@@ -12,17 +12,19 @@ export interface HybridSearchIssuesResult {
   readonly candidates: readonly IssueProjectionCandidate[]
 }
 
-export const hybridSearchIssuesUseCase = Effect.fn("issues.hybridSearchIssues")(function* (input: HybridSearchIssuesInput) {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    const issueProjectionRepository = yield* IssueProjectionRepository
+export const hybridSearchIssuesUseCase = Effect.fn("issues.hybridSearchIssues")(function* (
+  input: HybridSearchIssuesInput,
+) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  const issueProjectionRepository = yield* IssueProjectionRepository
 
-    const candidates = yield* issueProjectionRepository.hybridSearch({
-      projectId: input.projectId,
-      query: input.query,
-      vector: input.normalizedEmbedding,
-    })
-
-    return {
-      candidates,
-    } satisfies HybridSearchIssuesResult
+  const candidates = yield* issueProjectionRepository.hybridSearch({
+    projectId: input.projectId,
+    query: input.query,
+    vector: input.normalizedEmbedding,
   })
+
+  return {
+    candidates,
+  } satisfies HybridSearchIssuesResult
+})

--- a/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
+++ b/packages/domain/issues/src/use-cases/hybrid-search-issues.ts
@@ -12,8 +12,7 @@ export interface HybridSearchIssuesResult {
   readonly candidates: readonly IssueProjectionCandidate[]
 }
 
-export const hybridSearchIssuesUseCase = (input: HybridSearchIssuesInput) =>
-  Effect.gen(function* () {
+export const hybridSearchIssuesUseCase = Effect.fn("issues.hybridSearchIssues")(function* (input: HybridSearchIssuesInput) {
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const issueProjectionRepository = yield* IssueProjectionRepository
 
@@ -26,4 +25,4 @@ export const hybridSearchIssuesUseCase = (input: HybridSearchIssuesInput) =>
     return {
       candidates,
     } satisfies HybridSearchIssuesResult
-  }).pipe(Effect.withSpan("issues.hybridSearchIssues"))
+  })

--- a/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
+++ b/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
@@ -22,54 +22,56 @@ export interface RetrievalResult {
   readonly similarityScore: number
 }
 
-export const rerankIssueCandidatesUseCase = Effect.fn("issues.rerankIssueCandidates")(function* (input: RerankIssueCandidatesInput) {
-    yield* Effect.annotateCurrentSpan("candidateCount", input.candidates.length)
-    const limitedCandidates = [...input.candidates]
-      .sort((left, right) => right.score - left.score)
-      .slice(0, ISSUE_DISCOVERY_RERANK_CANDIDATES)
+export const rerankIssueCandidatesUseCase = Effect.fn("issues.rerankIssueCandidates")(function* (
+  input: RerankIssueCandidatesInput,
+) {
+  yield* Effect.annotateCurrentSpan("candidateCount", input.candidates.length)
+  const limitedCandidates = [...input.candidates]
+    .sort((left, right) => right.score - left.score)
+    .slice(0, ISSUE_DISCOVERY_RERANK_CANDIDATES)
 
-    if (limitedCandidates.length === 0) {
-      return {
-        matchedIssueUuid: null,
-        similarityScore: 0,
-      } satisfies RetrievalResult
-    }
-
-    const ai = yield* AI
-    const reranked = yield* ai.rerank({
-      query: input.query,
-      documents: limitedCandidates.map(buildRerankDocument),
-      model: ISSUE_DISCOVERY_RERANK_MODEL,
-      telemetry: {
-        spanName: "rerank-issue-candidates",
-        tags: ["issues", "rerank"],
-        metadata: {
-          candidateCount: limitedCandidates.length,
-        },
-      },
-    })
-
-    const best = reranked
-      .filter((item) => item.relevanceScore >= ISSUE_DISCOVERY_MIN_RELEVANCE)
-      .sort((left, right) => right.relevanceScore - left.relevanceScore)[0]
-
-    if (!best) {
-      return {
-        matchedIssueUuid: null,
-        similarityScore: 0,
-      } satisfies RetrievalResult
-    }
-
-    const matchedIssue = limitedCandidates[best.index]
-    if (!matchedIssue) {
-      return {
-        matchedIssueUuid: null,
-        similarityScore: 0,
-      } satisfies RetrievalResult
-    }
-
+  if (limitedCandidates.length === 0) {
     return {
-      matchedIssueUuid: matchedIssue.uuid,
-      similarityScore: best.relevanceScore,
+      matchedIssueUuid: null,
+      similarityScore: 0,
     } satisfies RetrievalResult
+  }
+
+  const ai = yield* AI
+  const reranked = yield* ai.rerank({
+    query: input.query,
+    documents: limitedCandidates.map(buildRerankDocument),
+    model: ISSUE_DISCOVERY_RERANK_MODEL,
+    telemetry: {
+      spanName: "rerank-issue-candidates",
+      tags: ["issues", "rerank"],
+      metadata: {
+        candidateCount: limitedCandidates.length,
+      },
+    },
   })
+
+  const best = reranked
+    .filter((item) => item.relevanceScore >= ISSUE_DISCOVERY_MIN_RELEVANCE)
+    .sort((left, right) => right.relevanceScore - left.relevanceScore)[0]
+
+  if (!best) {
+    return {
+      matchedIssueUuid: null,
+      similarityScore: 0,
+    } satisfies RetrievalResult
+  }
+
+  const matchedIssue = limitedCandidates[best.index]
+  if (!matchedIssue) {
+    return {
+      matchedIssueUuid: null,
+      similarityScore: 0,
+    } satisfies RetrievalResult
+  }
+
+  return {
+    matchedIssueUuid: matchedIssue.uuid,
+    similarityScore: best.relevanceScore,
+  } satisfies RetrievalResult
+})

--- a/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
+++ b/packages/domain/issues/src/use-cases/rerank-issue-candidates.ts
@@ -22,8 +22,7 @@ export interface RetrievalResult {
   readonly similarityScore: number
 }
 
-export const rerankIssueCandidatesUseCase = (input: RerankIssueCandidatesInput) =>
-  Effect.gen(function* () {
+export const rerankIssueCandidatesUseCase = Effect.fn("issues.rerankIssueCandidates")(function* (input: RerankIssueCandidatesInput) {
     yield* Effect.annotateCurrentSpan("candidateCount", input.candidates.length)
     const limitedCandidates = [...input.candidates]
       .sort((left, right) => right.score - left.score)
@@ -73,4 +72,4 @@ export const rerankIssueCandidatesUseCase = (input: RerankIssueCandidatesInput) 
       matchedIssueUuid: matchedIssue.uuid,
       similarityScore: best.relevanceScore,
     } satisfies RetrievalResult
-  }).pipe(Effect.withSpan("issues.rerankIssueCandidates"))
+  })

--- a/packages/domain/issues/src/use-cases/sync-projections.ts
+++ b/packages/domain/issues/src/use-cases/sync-projections.ts
@@ -9,32 +9,34 @@ export interface SyncIssueProjectionsInput {
   readonly issueId: string
 }
 
-export const syncIssueProjectionsUseCase = Effect.fn("issues.syncProjections")(function* (input: SyncIssueProjectionsInput) {
-    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
-    const issueProjectionRepository = yield* IssueProjectionRepository
-    const issueRepository = yield* IssueRepository
+export const syncIssueProjectionsUseCase = Effect.fn("issues.syncProjections")(function* (
+  input: SyncIssueProjectionsInput,
+) {
+  yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+  const issueProjectionRepository = yield* IssueProjectionRepository
+  const issueRepository = yield* IssueRepository
 
-    const issue = yield* issueRepository
-      .findById(IssueId(input.issueId))
-      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-    if (!issue) {
-      return
-    }
+  const issue = yield* issueRepository
+    .findById(IssueId(input.issueId))
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (!issue) {
+    return
+  }
 
-    const vector = normalizeIssueCentroid(issue.centroid)
-    if (vector.length === 0) {
-      yield* issueProjectionRepository.delete({
-        projectId: issue.projectId,
-        uuid: issue.uuid,
-      })
-      return
-    }
-
-    yield* issueProjectionRepository.upsert({
+  const vector = normalizeIssueCentroid(issue.centroid)
+  if (vector.length === 0) {
+    yield* issueProjectionRepository.delete({
       projectId: issue.projectId,
       uuid: issue.uuid,
-      title: issue.name,
-      description: issue.description,
-      vector,
     })
+    return
+  }
+
+  yield* issueProjectionRepository.upsert({
+    projectId: issue.projectId,
+    uuid: issue.uuid,
+    title: issue.name,
+    description: issue.description,
+    vector,
   })
+})

--- a/packages/domain/issues/src/use-cases/sync-projections.ts
+++ b/packages/domain/issues/src/use-cases/sync-projections.ts
@@ -9,8 +9,7 @@ export interface SyncIssueProjectionsInput {
   readonly issueId: string
 }
 
-export const syncIssueProjectionsUseCase = (input: SyncIssueProjectionsInput) =>
-  Effect.gen(function* () {
+export const syncIssueProjectionsUseCase = Effect.fn("issues.syncProjections")(function* (input: SyncIssueProjectionsInput) {
     yield* Effect.annotateCurrentSpan("issueId", input.issueId)
     const issueProjectionRepository = yield* IssueProjectionRepository
     const issueRepository = yield* IssueRepository
@@ -38,4 +37,4 @@ export const syncIssueProjectionsUseCase = (input: SyncIssueProjectionsInput) =>
       description: issue.description,
       vector,
     })
-  }).pipe(Effect.withSpan("issues.syncProjections"))
+  })

--- a/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
+++ b/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
@@ -5,28 +5,28 @@ import { OrganizationRepository } from "../ports/organization-repository.ts"
 
 const MAX_SLUG_ATTEMPTS = 20
 
-export const generateUniqueOrganizationSlugUseCase = Effect.fn(
-  "organizations.generateUniqueOrganizationSlug",
-)(function* (input: { name: string }) {
-  const repository = yield* OrganizationRepository
+export const generateUniqueOrganizationSlugUseCase = Effect.fn("organizations.generateUniqueOrganizationSlug")(
+  function* (input: { name: string }) {
+    const repository = yield* OrganizationRepository
 
-  let slugBase = toSlug(input.name)
+    let slugBase = toSlug(input.name)
 
-  if (!slugBase) {
-    slugBase = `workspace-${generateId().slice(0, 8)}`
-  }
-
-  let slug = slugBase
-  for (let i = 1; i <= MAX_SLUG_ATTEMPTS; i += 1) {
-    const exists = yield* repository.existsBySlug(slug)
-    if (!exists) {
-      return slug
+    if (!slugBase) {
+      slugBase = `workspace-${generateId().slice(0, 8)}`
     }
-    slug = `${slugBase}-${i}`
-  }
 
-  // If we exhausted all attempts, return an error effect
-  return yield* new SlugGenerationError({
-    message: `Could not generate a unique slug after ${MAX_SLUG_ATTEMPTS} attempts`,
-  })
-})
+    let slug = slugBase
+    for (let i = 1; i <= MAX_SLUG_ATTEMPTS; i += 1) {
+      const exists = yield* repository.existsBySlug(slug)
+      if (!exists) {
+        return slug
+      }
+      slug = `${slugBase}-${i}`
+    }
+
+    // If we exhausted all attempts, return an error effect
+    return yield* new SlugGenerationError({
+      message: `Could not generate a unique slug after ${MAX_SLUG_ATTEMPTS} attempts`,
+    })
+  },
+)

--- a/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
+++ b/packages/domain/organizations/src/use-cases/generate-unique-organization-slug.ts
@@ -5,27 +5,28 @@ import { OrganizationRepository } from "../ports/organization-repository.ts"
 
 const MAX_SLUG_ATTEMPTS = 20
 
-export const generateUniqueOrganizationSlugUseCase = (input: { name: string }) =>
-  Effect.gen(function* () {
-    const repository = yield* OrganizationRepository
+export const generateUniqueOrganizationSlugUseCase = Effect.fn(
+  "organizations.generateUniqueOrganizationSlug",
+)(function* (input: { name: string }) {
+  const repository = yield* OrganizationRepository
 
-    let slugBase = toSlug(input.name)
+  let slugBase = toSlug(input.name)
 
-    if (!slugBase) {
-      slugBase = `workspace-${generateId().slice(0, 8)}`
+  if (!slugBase) {
+    slugBase = `workspace-${generateId().slice(0, 8)}`
+  }
+
+  let slug = slugBase
+  for (let i = 1; i <= MAX_SLUG_ATTEMPTS; i += 1) {
+    const exists = yield* repository.existsBySlug(slug)
+    if (!exists) {
+      return slug
     }
+    slug = `${slugBase}-${i}`
+  }
 
-    let slug = slugBase
-    for (let i = 1; i <= MAX_SLUG_ATTEMPTS; i += 1) {
-      const exists = yield* repository.existsBySlug(slug)
-      if (!exists) {
-        return slug
-      }
-      slug = `${slugBase}-${i}`
-    }
-
-    // If we exhausted all attempts, return an error effect
-    return yield* new SlugGenerationError({
-      message: `Could not generate a unique slug after ${MAX_SLUG_ATTEMPTS} attempts`,
-    })
-  }).pipe(Effect.withSpan("organizations.generateUniqueOrganizationSlug"))
+  // If we exhausted all attempts, return an error effect
+  return yield* new SlugGenerationError({
+    message: `Could not generate a unique slug after ${MAX_SLUG_ATTEMPTS} attempts`,
+  })
+})

--- a/packages/domain/organizations/src/use-cases/remove-member.ts
+++ b/packages/domain/organizations/src/use-cases/remove-member.ts
@@ -8,24 +8,22 @@ export interface RemoveMemberInput {
   readonly requestingUserId: string
 }
 
-export const removeMemberUseCase = Effect.fn("organizations.removeMember")(
-  function* (input: RemoveMemberInput) {
-    yield* Effect.annotateCurrentSpan("membershipId", input.membershipId)
+export const removeMemberUseCase = Effect.fn("organizations.removeMember")(function* (input: RemoveMemberInput) {
+  yield* Effect.annotateCurrentSpan("membershipId", input.membershipId)
 
-    const repository = yield* MembershipRepository
+  const repository = yield* MembershipRepository
 
-    const membership = yield* repository
-      .findById(input.membershipId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new MembershipNotFoundError({ membershipId: input.membershipId })),
-        ),
-      )
+  const membership = yield* repository
+    .findById(input.membershipId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new MembershipNotFoundError({ membershipId: input.membershipId })),
+      ),
+    )
 
-    if (membership.userId === input.requestingUserId) {
-      return yield* new CannotRemoveSelfError({ userId: input.requestingUserId })
-    }
+  if (membership.userId === input.requestingUserId) {
+    return yield* new CannotRemoveSelfError({ userId: input.requestingUserId })
+  }
 
-    yield* repository.delete(input.membershipId)
-  },
-)
+  yield* repository.delete(input.membershipId)
+})

--- a/packages/domain/organizations/src/use-cases/remove-member.ts
+++ b/packages/domain/organizations/src/use-cases/remove-member.ts
@@ -8,8 +8,8 @@ export interface RemoveMemberInput {
   readonly requestingUserId: string
 }
 
-export const removeMemberUseCase = (input: RemoveMemberInput) =>
-  Effect.gen(function* () {
+export const removeMemberUseCase = Effect.fn("organizations.removeMember")(
+  function* (input: RemoveMemberInput) {
     yield* Effect.annotateCurrentSpan("membershipId", input.membershipId)
 
     const repository = yield* MembershipRepository
@@ -27,4 +27,5 @@ export const removeMemberUseCase = (input: RemoveMemberInput) =>
     }
 
     yield* repository.delete(input.membershipId)
-  }).pipe(Effect.withSpan("organizations.removeMember"))
+  },
+)

--- a/packages/domain/organizations/src/use-cases/transfer-ownership.ts
+++ b/packages/domain/organizations/src/use-cases/transfer-ownership.ts
@@ -15,9 +15,9 @@ export interface TransferOwnershipInput {
   readonly newOwnerUserId: UserId
 }
 
-export const transferOwnershipUseCase = Effect.fn(
-  "organizations.transferOwnership",
-)(function* (input: TransferOwnershipInput) {
+export const transferOwnershipUseCase = Effect.fn("organizations.transferOwnership")(function* (
+  input: TransferOwnershipInput,
+) {
   yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
   yield* Effect.annotateCurrentSpan("newOwnerUserId", input.newOwnerUserId)
 

--- a/packages/domain/organizations/src/use-cases/transfer-ownership.ts
+++ b/packages/domain/organizations/src/use-cases/transfer-ownership.ts
@@ -15,54 +15,55 @@ export interface TransferOwnershipInput {
   readonly newOwnerUserId: UserId
 }
 
-export const transferOwnershipUseCase = (input: TransferOwnershipInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("newOwnerUserId", input.newOwnerUserId)
+export const transferOwnershipUseCase = Effect.fn(
+  "organizations.transferOwnership",
+)(function* (input: TransferOwnershipInput) {
+  yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("newOwnerUserId", input.newOwnerUserId)
 
-    const repository = yield* MembershipRepository
+  const repository = yield* MembershipRepository
 
-    // Check if current owner is actually the owner
-    const currentOwnerMembership = yield* repository
-      .findByOrganizationAndUser(input.organizationId, input.currentOwnerUserId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new MembershipNotFoundError({ userId: input.currentOwnerUserId })),
-        ),
-      )
+  // Check if current owner is actually the owner
+  const currentOwnerMembership = yield* repository
+    .findByOrganizationAndUser(input.organizationId, input.currentOwnerUserId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new MembershipNotFoundError({ userId: input.currentOwnerUserId })),
+      ),
+    )
 
-    if (currentOwnerMembership.role !== "owner") {
-      return yield* new NotOwnerError({ userId: input.currentOwnerUserId })
-    }
+  if (currentOwnerMembership.role !== "owner") {
+    return yield* new NotOwnerError({ userId: input.currentOwnerUserId })
+  }
 
-    // Cannot transfer to self
-    if (input.currentOwnerUserId === input.newOwnerUserId) {
-      return yield* new CannotTransferToSelfError({ userId: input.currentOwnerUserId })
-    }
+  // Cannot transfer to self
+  if (input.currentOwnerUserId === input.newOwnerUserId) {
+    return yield* new CannotTransferToSelfError({ userId: input.currentOwnerUserId })
+  }
 
-    // Find target member's membership
-    const newOwnerMembership = yield* repository
-      .findByOrganizationAndUser(input.organizationId, input.newOwnerUserId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new CannotTransferToNonMemberError({ userId: input.newOwnerUserId })),
-        ),
-      )
+  // Find target member's membership
+  const newOwnerMembership = yield* repository
+    .findByOrganizationAndUser(input.organizationId, input.newOwnerUserId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new CannotTransferToNonMemberError({ userId: input.newOwnerUserId })),
+      ),
+    )
 
-    // Swap roles: current owner becomes admin, new owner becomes owner
-    const updatedCurrentOwnerMembership: Membership = {
-      ...currentOwnerMembership,
-      role: "admin",
-    }
+  // Swap roles: current owner becomes admin, new owner becomes owner
+  const updatedCurrentOwnerMembership: Membership = {
+    ...currentOwnerMembership,
+    role: "admin",
+  }
 
-    const updatedNewOwnerMembership: Membership = {
-      ...newOwnerMembership,
-      role: "owner",
-    }
+  const updatedNewOwnerMembership: Membership = {
+    ...newOwnerMembership,
+    role: "owner",
+  }
 
-    // Save both memberships
-    yield* repository.save(updatedCurrentOwnerMembership)
-    yield* repository.save(updatedNewOwnerMembership)
+  // Save both memberships
+  yield* repository.save(updatedCurrentOwnerMembership)
+  yield* repository.save(updatedNewOwnerMembership)
 
-    return { success: true }
-  }).pipe(Effect.withSpan("organizations.transferOwnership"))
+  return { success: true }
+})

--- a/packages/domain/organizations/src/use-cases/update-member-role.ts
+++ b/packages/domain/organizations/src/use-cases/update-member-role.ts
@@ -16,46 +16,47 @@ export interface UpdateMemberRoleInput {
   readonly newRole: MembershipRole
 }
 
-export const updateMemberRoleUseCase = (input: UpdateMemberRoleInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("targetUserId", input.targetUserId)
-    yield* Effect.annotateCurrentSpan("newRole", input.newRole)
+export const updateMemberRoleUseCase = Effect.fn(
+  "organizations.updateMemberRole",
+)(function* (input: UpdateMemberRoleInput) {
+  yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("targetUserId", input.targetUserId)
+  yield* Effect.annotateCurrentSpan("newRole", input.newRole)
 
-    const repository = yield* MembershipRepository
+  const repository = yield* MembershipRepository
 
-    // Check if requesting user is an admin
-    const isAdmin = yield* repository.isAdmin(input.organizationId, input.requestingUserId)
-    if (!isAdmin) {
-      return yield* new NotAdminError({ userId: input.requestingUserId })
-    }
+  // Check if requesting user is an admin
+  const isAdmin = yield* repository.isAdmin(input.organizationId, input.requestingUserId)
+  if (!isAdmin) {
+    return yield* new NotAdminError({ userId: input.requestingUserId })
+  }
 
-    // Cannot change your own role
-    if (input.requestingUserId === input.targetUserId) {
-      return yield* new CannotChangeOwnRoleError({ userId: input.requestingUserId })
-    }
+  // Cannot change your own role
+  if (input.requestingUserId === input.targetUserId) {
+    return yield* new CannotChangeOwnRoleError({ userId: input.requestingUserId })
+  }
 
-    // Find target member's membership
-    const targetMembership = yield* repository
-      .findByOrganizationAndUser(input.organizationId, input.targetUserId)
-      .pipe(
-        Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new TargetMembershipNotFoundError({ userId: input.targetUserId })),
-        ),
-      )
+  // Find target member's membership
+  const targetMembership = yield* repository
+    .findByOrganizationAndUser(input.organizationId, input.targetUserId)
+    .pipe(
+      Effect.catchTag("NotFoundError", () =>
+        Effect.fail(new TargetMembershipNotFoundError({ userId: input.targetUserId })),
+      ),
+    )
 
-    // Cannot change owner's role directly
-    if (targetMembership.role === "owner") {
-      return yield* new CannotChangeOwnerRoleError({ userId: input.targetUserId })
-    }
+  // Cannot change owner's role directly
+  if (targetMembership.role === "owner") {
+    return yield* new CannotChangeOwnerRoleError({ userId: input.targetUserId })
+  }
 
-    // Update the role
-    const updatedMembership: Membership = {
-      ...targetMembership,
-      role: input.newRole,
-    }
+  // Update the role
+  const updatedMembership: Membership = {
+    ...targetMembership,
+    role: input.newRole,
+  }
 
-    yield* repository.save(updatedMembership)
+  yield* repository.save(updatedMembership)
 
-    return { success: true }
-  }).pipe(Effect.withSpan("organizations.updateMemberRole"))
+  return { success: true }
+})

--- a/packages/domain/organizations/src/use-cases/update-member-role.ts
+++ b/packages/domain/organizations/src/use-cases/update-member-role.ts
@@ -16,9 +16,9 @@ export interface UpdateMemberRoleInput {
   readonly newRole: MembershipRole
 }
 
-export const updateMemberRoleUseCase = Effect.fn(
-  "organizations.updateMemberRole",
-)(function* (input: UpdateMemberRoleInput) {
+export const updateMemberRoleUseCase = Effect.fn("organizations.updateMemberRole")(function* (
+  input: UpdateMemberRoleInput,
+) {
   yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
   yield* Effect.annotateCurrentSpan("targetUserId", input.targetUserId)
   yield* Effect.annotateCurrentSpan("newRole", input.newRole)

--- a/packages/domain/organizations/src/use-cases/update-organization.ts
+++ b/packages/domain/organizations/src/use-cases/update-organization.ts
@@ -9,21 +9,22 @@ export interface UpdateOrganizationInput {
   readonly settings?: OrganizationSettings | undefined
 }
 
-export const updateOrganizationUseCase = (input: UpdateOrganizationInput) =>
-  Effect.gen(function* () {
-    const sqlClient = yield* SqlClient
-    const repo = yield* OrganizationRepository
+export const updateOrganizationUseCase = Effect.fn(
+  "organizations.updateOrganization",
+)(function* (input: UpdateOrganizationInput) {
+  const sqlClient = yield* SqlClient
+  const repo = yield* OrganizationRepository
 
-    const org = yield* repo.findById(sqlClient.organizationId)
+  const org = yield* repo.findById(sqlClient.organizationId)
 
-    const updated: Organization = {
-      ...org,
-      ...(input.name !== undefined ? { name: input.name } : {}),
-      ...(input.settings !== undefined ? { settings: input.settings } : {}),
-      updatedAt: new Date(),
-    }
+  const updated: Organization = {
+    ...org,
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.settings !== undefined ? { settings: input.settings } : {}),
+    updatedAt: new Date(),
+  }
 
-    yield* repo.save(updated)
+  yield* repo.save(updated)
 
-    return updated
-  }).pipe(Effect.withSpan("organizations.updateOrganization"))
+  return updated
+})

--- a/packages/domain/organizations/src/use-cases/update-organization.ts
+++ b/packages/domain/organizations/src/use-cases/update-organization.ts
@@ -9,9 +9,9 @@ export interface UpdateOrganizationInput {
   readonly settings?: OrganizationSettings | undefined
 }
 
-export const updateOrganizationUseCase = Effect.fn(
-  "organizations.updateOrganization",
-)(function* (input: UpdateOrganizationInput) {
+export const updateOrganizationUseCase = Effect.fn("organizations.updateOrganization")(function* (
+  input: UpdateOrganizationInput,
+) {
   const sqlClient = yield* SqlClient
   const repo = yield* OrganizationRepository
 

--- a/packages/domain/projects/src/use-cases/create-project.ts
+++ b/packages/domain/projects/src/use-cases/create-project.ts
@@ -21,95 +21,94 @@ export interface CreateProjectInput {
 
 export type CreateProjectError = RepositoryError | ValidationError | ConflictError | InvalidProjectNameError
 
-export const createProjectUseCase = (input: CreateProjectInput) =>
-  Effect.gen(function* () {
-    if (input.id) {
-      yield* Effect.annotateCurrentSpan("project.id", input.id)
-    }
-    const trimmedName = input.name.trim()
-    const sqlClient = yield* SqlClient
-    const { organizationId } = sqlClient
+export const createProjectUseCase = Effect.fn("projects.createProject")(function* (input: CreateProjectInput) {
+  if (input.id) {
+    yield* Effect.annotateCurrentSpan("project.id", input.id)
+  }
+  const trimmedName = input.name.trim()
+  const sqlClient = yield* SqlClient
+  const { organizationId } = sqlClient
 
-    if (!trimmedName || trimmedName.length === 0) {
-      return yield* new InvalidProjectNameError({
-        field: input.name,
-        message: "Name cannot be empty",
-      })
-    }
+  if (!trimmedName || trimmedName.length === 0) {
+    return yield* new InvalidProjectNameError({
+      field: input.name,
+      message: "Name cannot be empty",
+    })
+  }
 
-    if (trimmedName.length > 256) {
-      return yield* new InvalidProjectNameError({
-        field: input.name,
-        message: "Name exceeds 256 characters",
-      })
-    }
+  if (trimmedName.length > 256) {
+    return yield* new InvalidProjectNameError({
+      field: input.name,
+      message: "Name exceeds 256 characters",
+    })
+  }
 
-    const trimmedSlug = toSlug(trimmedName)
-    if (!trimmedSlug || trimmedSlug.length === 0) {
-      return yield* new InvalidProjectNameError({
-        field: trimmedSlug,
-        message: "Slug cannot be empty",
-      })
-    }
+  const trimmedSlug = toSlug(trimmedName)
+  if (!trimmedSlug || trimmedSlug.length === 0) {
+    return yield* new InvalidProjectNameError({
+      field: trimmedSlug,
+      message: "Slug cannot be empty",
+    })
+  }
 
-    if (trimmedSlug.length > 256) {
-      return yield* new InvalidProjectNameError({
-        field: trimmedSlug,
-        message: "Slug exceeds 256 characters, try with a shorter project name.",
-      })
-    }
+  if (trimmedSlug.length > 256) {
+    return yield* new InvalidProjectNameError({
+      field: trimmedSlug,
+      message: "Slug exceeds 256 characters, try with a shorter project name.",
+    })
+  }
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const repo = yield* ProjectRepository
-        const outboxEventWriter = yield* OutboxEventWriter
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* ProjectRepository
+      const outboxEventWriter = yield* OutboxEventWriter
 
-        // Generate unique slug by appending numbers if needed
-        let uniqueSlug = trimmedSlug
-        let found = false
-        for (let i = 1; i <= 100; i++) {
-          const exists = yield* repo.existsBySlug(uniqueSlug)
-          if (!exists) {
-            found = true
-            break
-          }
-          uniqueSlug = `${trimmedSlug}-${i}`
+      // Generate unique slug by appending numbers if needed
+      let uniqueSlug = trimmedSlug
+      let found = false
+      for (let i = 1; i <= 100; i++) {
+        const exists = yield* repo.existsBySlug(uniqueSlug)
+        if (!exists) {
+          found = true
+          break
         }
+        uniqueSlug = `${trimmedSlug}-${i}`
+      }
 
-        if (!found) {
-          return yield* new InvalidProjectNameError({
-            field: trimmedSlug,
-            message: "Could not generate a unique project slug, try with a different project name.",
-          })
-        }
-
-        const project = createProject({
-          id: input.id,
-          organizationId,
-          name: trimmedName,
-          slug: uniqueSlug,
+      if (!found) {
+        return yield* new InvalidProjectNameError({
+          field: trimmedSlug,
+          message: "Could not generate a unique project slug, try with a different project name.",
         })
+      }
 
-        yield* repo.save(project)
+      const project = createProject({
+        id: input.id,
+        organizationId,
+        name: trimmedName,
+        slug: uniqueSlug,
+      })
 
-        // Publish ProjectCreated event for downstream provisioning
-        yield* outboxEventWriter
-          .write({
-            eventName: "ProjectCreated",
-            aggregateType: "project",
-            aggregateId: project.id,
+      yield* repo.save(project)
+
+      // Publish ProjectCreated event for downstream provisioning
+      yield* outboxEventWriter
+        .write({
+          eventName: "ProjectCreated",
+          aggregateType: "project",
+          aggregateId: project.id,
+          organizationId: project.organizationId,
+          payload: {
             organizationId: project.organizationId,
-            payload: {
-              organizationId: project.organizationId,
-              actorUserId: input.actorUserId ?? "",
-              projectId: project.id,
-              name: project.name,
-              slug: project.slug,
-            },
-          })
-          .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
+            actorUserId: input.actorUserId ?? "",
+            projectId: project.id,
+            name: project.name,
+            slug: project.slug,
+          },
+        })
+        .pipe(Effect.mapError((error) => toRepositoryError(error, "write")))
 
-        return project
-      }),
-    )
-  }).pipe(Effect.withSpan("projects.createProject"))
+      return project
+    }),
+  )
+})

--- a/packages/domain/projects/src/use-cases/update-project.ts
+++ b/packages/domain/projects/src/use-cases/update-project.ts
@@ -26,67 +26,66 @@ export type UpdateProjectError =
   | ProjectNotFoundError
   | InvalidProjectNameError
 
-export const updateProjectUseCase = (input: UpdateProjectInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("project.id", input.id)
-    const sqlClient = yield* SqlClient
-    const { organizationId } = sqlClient
+export const updateProjectUseCase = Effect.fn("projects.updateProject")(function* (input: UpdateProjectInput) {
+  yield* Effect.annotateCurrentSpan("project.id", input.id)
+  const sqlClient = yield* SqlClient
+  const { organizationId } = sqlClient
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const repo = yield* ProjectRepository
-        const existingProject = yield* repo
-          .findById(input.id)
-          .pipe(
-            Effect.catchTag("NotFoundError", () =>
-              Effect.fail(new ProjectNotFoundError({ id: input.id, organizationId })),
-            ),
-          )
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* ProjectRepository
+      const existingProject = yield* repo
+        .findById(input.id)
+        .pipe(
+          Effect.catchTag("NotFoundError", () =>
+            Effect.fail(new ProjectNotFoundError({ id: input.id, organizationId })),
+          ),
+        )
 
-        let nextName = existingProject.name
+      let nextName = existingProject.name
 
-        if (input.name !== undefined) {
-          const trimmedName = input.name.trim()
+      if (input.name !== undefined) {
+        const trimmedName = input.name.trim()
 
-          if (!trimmedName) {
-            return yield* new InvalidProjectNameError({
-              name: input.name,
-              reason: "Name cannot be empty",
-            })
-          }
-
-          if (trimmedName.length > 256) {
-            return yield* new InvalidProjectNameError({
-              name: input.name,
-              reason: "Name exceeds 256 characters",
-            })
-          }
-
-          if (trimmedName !== existingProject.name) {
-            const nameExists = yield* repo.existsByName(trimmedName)
-            if (nameExists) {
-              return yield* new InvalidProjectNameError({
-                name: trimmedName,
-                reason: "Project name already exists in this organization",
-              })
-            }
-          }
-
-          nextName = trimmedName
+        if (!trimmedName) {
+          return yield* new InvalidProjectNameError({
+            name: input.name,
+            reason: "Name cannot be empty",
+          })
         }
 
-        const now = new Date()
-        const updatedProject: Project = {
-          ...existingProject,
-          name: nextName,
-          ...(input.settings !== undefined ? { settings: input.settings } : {}),
-          lastEditedAt: now,
-          updatedAt: now,
+        if (trimmedName.length > 256) {
+          return yield* new InvalidProjectNameError({
+            name: input.name,
+            reason: "Name exceeds 256 characters",
+          })
         }
 
-        yield* repo.save(updatedProject)
+        if (trimmedName !== existingProject.name) {
+          const nameExists = yield* repo.existsByName(trimmedName)
+          if (nameExists) {
+            return yield* new InvalidProjectNameError({
+              name: trimmedName,
+              reason: "Project name already exists in this organization",
+            })
+          }
+        }
 
-        return updatedProject
-      }),
-    )
-  }).pipe(Effect.withSpan("projects.updateProject"))
+        nextName = trimmedName
+      }
+
+      const now = new Date()
+      const updatedProject: Project = {
+        ...existingProject,
+        name: nextName,
+        ...(input.settings !== undefined ? { settings: input.settings } : {}),
+        lastEditedAt: now,
+        updatedAt: now,
+      }
+
+      yield* repo.save(updatedProject)
+
+      return updatedProject
+    }),
+  )
+})

--- a/packages/domain/scores/src/use-cases/list-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-scores.ts
@@ -34,38 +34,36 @@ const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, message: str
 
 export type ListScoresError = RepositoryError | BadRequestError
 
-export const listProjectScoresUseCase = (input: ListProjectScoresInput) =>
-  Effect.gen(function* () {
-    const parsedInput = yield* parseOrBadRequest(listProjectScoresInputSchema, input, "Invalid project score query")
-    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
-    const repository = yield* ScoreRepository
+export const listProjectScoresUseCase = Effect.fn("scores.listProjectScores")(function* (input: ListProjectScoresInput) {
+  const parsedInput = yield* parseOrBadRequest(listProjectScoresInputSchema, input, "Invalid project score query")
+  yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+  const repository = yield* ScoreRepository
 
-    return yield* repository.listByProjectId({
-      projectId: parsedInput.projectId,
-      options: {
-        limit: parsedInput.limit,
-        offset: parsedInput.offset,
-        draftMode: parsedInput.draftMode,
-      },
-    })
-  }).pipe(Effect.withSpan("scores.listProjectScores"))
+  return yield* repository.listByProjectId({
+    projectId: parsedInput.projectId,
+    options: {
+      limit: parsedInput.limit,
+      offset: parsedInput.offset,
+      draftMode: parsedInput.draftMode,
+    },
+  })
+})
 
-export const listSourceScoresUseCase = (input: ListSourceScoresInput) =>
-  Effect.gen(function* () {
-    const parsedInput = yield* parseOrBadRequest(listSourceScoresInputSchema, input, "Invalid source query")
-    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
-    yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
-    yield* Effect.annotateCurrentSpan("score.sourceId", parsedInput.sourceId)
-    const repository = yield* ScoreRepository
+export const listSourceScoresUseCase = Effect.fn("scores.listSourceScores")(function* (input: ListSourceScoresInput) {
+  const parsedInput = yield* parseOrBadRequest(listSourceScoresInputSchema, input, "Invalid source query")
+  yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+  yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
+  yield* Effect.annotateCurrentSpan("score.sourceId", parsedInput.sourceId)
+  const repository = yield* ScoreRepository
 
-    return yield* repository.listBySourceId({
-      projectId: parsedInput.projectId,
-      source: parsedInput.source,
-      sourceId: parsedInput.sourceId,
-      options: {
-        limit: parsedInput.limit,
-        offset: parsedInput.offset,
-        draftMode: parsedInput.draftMode,
-      },
-    })
-  }).pipe(Effect.withSpan("scores.listSourceScores"))
+  return yield* repository.listBySourceId({
+    projectId: parsedInput.projectId,
+    source: parsedInput.source,
+    sourceId: parsedInput.sourceId,
+    options: {
+      limit: parsedInput.limit,
+      offset: parsedInput.offset,
+      draftMode: parsedInput.draftMode,
+    },
+  })
+})

--- a/packages/domain/scores/src/use-cases/list-scores.ts
+++ b/packages/domain/scores/src/use-cases/list-scores.ts
@@ -34,7 +34,9 @@ const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, message: str
 
 export type ListScoresError = RepositoryError | BadRequestError
 
-export const listProjectScoresUseCase = Effect.fn("scores.listProjectScores")(function* (input: ListProjectScoresInput) {
+export const listProjectScoresUseCase = Effect.fn("scores.listProjectScores")(function* (
+  input: ListProjectScoresInput,
+) {
   const parsedInput = yield* parseOrBadRequest(listProjectScoresInputSchema, input, "Invalid project score query")
   yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
   const repository = yield* ScoreRepository

--- a/packages/domain/scores/src/use-cases/save-score-analytics.ts
+++ b/packages/domain/scores/src/use-cases/save-score-analytics.ts
@@ -9,23 +9,22 @@ export interface SyncScoreAnalyticsInput {
   readonly scoreId: string
 }
 
-export const syncScoreAnalyticsUseCase = (input: SyncScoreAnalyticsInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("score.scoreId", input.scoreId)
-    const scoreRepository = yield* ScoreRepository
-    const analyticsRepository = yield* ScoreAnalyticsRepository
+export const syncScoreAnalyticsUseCase = Effect.fn("scores.syncScoreAnalytics")(function* (input: SyncScoreAnalyticsInput) {
+  yield* Effect.annotateCurrentSpan("score.scoreId", input.scoreId)
+  const scoreRepository = yield* ScoreRepository
+  const analyticsRepository = yield* ScoreAnalyticsRepository
 
-    const score = yield* scoreRepository
-      .findById(ScoreId(input.scoreId))
-      .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-    if (!score || !isImmutableScore(score)) {
-      return
-    }
+  const score = yield* scoreRepository
+    .findById(ScoreId(input.scoreId))
+    .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+  if (!score || !isImmutableScore(score)) {
+    return
+  }
 
-    const alreadyStoredInAnalytics = yield* analyticsRepository.existsById(score.id)
-    if (alreadyStoredInAnalytics) {
-      return
-    }
+  const alreadyStoredInAnalytics = yield* analyticsRepository.existsById(score.id)
+  if (alreadyStoredInAnalytics) {
+    return
+  }
 
-    yield* analyticsRepository.insert(score)
-  }).pipe(Effect.withSpan("scores.syncScoreAnalytics"))
+  yield* analyticsRepository.insert(score)
+})

--- a/packages/domain/scores/src/use-cases/save-score-analytics.ts
+++ b/packages/domain/scores/src/use-cases/save-score-analytics.ts
@@ -9,7 +9,9 @@ export interface SyncScoreAnalyticsInput {
   readonly scoreId: string
 }
 
-export const syncScoreAnalyticsUseCase = Effect.fn("scores.syncScoreAnalytics")(function* (input: SyncScoreAnalyticsInput) {
+export const syncScoreAnalyticsUseCase = Effect.fn("scores.syncScoreAnalytics")(function* (
+  input: SyncScoreAnalyticsInput,
+) {
   yield* Effect.annotateCurrentSpan("score.scoreId", input.scoreId)
   const scoreRepository = yield* ScoreRepository
   const analyticsRepository = yield* ScoreAnalyticsRepository

--- a/packages/domain/scores/src/use-cases/write-score.ts
+++ b/packages/domain/scores/src/use-cases/write-score.ts
@@ -142,67 +142,66 @@ const buildScore = ({
   )
 }
 
-export const writeScoreUseCase = (input: WriteScoreInput) =>
-  Effect.gen(function* () {
-    const parsedInput = yield* parseOrBadRequest(writeScoreInputSchema, input, "Invalid score write input")
-    yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
-    yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
-    const sqlClient = yield* SqlClient
+export const writeScoreUseCase = Effect.fn("scores.writeScore")(function* (input: WriteScoreInput) {
+  const parsedInput = yield* parseOrBadRequest(writeScoreInputSchema, input, "Invalid score write input")
+  yield* Effect.annotateCurrentSpan("score.projectId", parsedInput.projectId)
+  yield* Effect.annotateCurrentSpan("score.source", parsedInput.source)
+  const sqlClient = yield* SqlClient
 
-    const score = yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const scoreRepository = yield* ScoreRepository
-        const outboxEventWriter = yield* OutboxEventWriter
+  const score = yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const scoreRepository = yield* ScoreRepository
+      const outboxEventWriter = yield* OutboxEventWriter
 
-        const existingScore = parsedInput.id
-          ? yield* scoreRepository
-              .findById(parsedInput.id)
-              .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-          : null
+      const existingScore = parsedInput.id
+        ? yield* scoreRepository
+            .findById(parsedInput.id)
+            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+        : null
 
-        if (existingScore && existingScore.draftedAt === null) {
-          return yield* new ScoreDraftClosedError({ scoreId: existingScore.id })
+      if (existingScore && existingScore.draftedAt === null) {
+        return yield* new ScoreDraftClosedError({ scoreId: existingScore.id })
+      }
+
+      if (existingScore) {
+        const conflict = validateDraftUpdate(existingScore, parsedInput)
+        if (conflict) {
+          return yield* conflict
         }
+      }
 
-        if (existingScore) {
-          const conflict = validateDraftUpdate(existingScore, parsedInput)
-          if (conflict) {
-            return yield* conflict
-          }
-        }
-
-        const score = yield* buildScore({
-          input: parsedInput,
-          organizationId: sqlClient.organizationId,
-          existingScore,
-        })
-
-        yield* scoreRepository.save(score)
-
-        yield* outboxEventWriter.write({
-          eventName: "ScoreCreated",
-          aggregateType: "score",
-          aggregateId: score.id,
-          organizationId: score.organizationId,
-          payload: {
-            organizationId: score.organizationId,
-            projectId: score.projectId,
-            scoreId: score.id,
-            issueId: scoreDiscoveryPayloadIssueId(score, existingScore),
-            status: score.draftedAt === null ? "published" : "draft",
-          },
-        })
-
-        return score
-      }),
-    )
-
-    if (isImmutableScore(score)) {
-      yield* syncScoreAnalyticsUseCase({
-        organizationId: score.organizationId,
-        scoreId: score.id,
+      const score = yield* buildScore({
+        input: parsedInput,
+        organizationId: sqlClient.organizationId,
+        existingScore,
       })
-    }
 
-    return score
-  }).pipe(Effect.withSpan("scores.writeScore"))
+      yield* scoreRepository.save(score)
+
+      yield* outboxEventWriter.write({
+        eventName: "ScoreCreated",
+        aggregateType: "score",
+        aggregateId: score.id,
+        organizationId: score.organizationId,
+        payload: {
+          organizationId: score.organizationId,
+          projectId: score.projectId,
+          scoreId: score.id,
+          issueId: scoreDiscoveryPayloadIssueId(score, existingScore),
+          status: score.draftedAt === null ? "published" : "draft",
+        },
+      })
+
+      return score
+    }),
+  )
+
+  if (isImmutableScore(score)) {
+    yield* syncScoreAnalyticsUseCase({
+      organizationId: score.organizationId,
+      scoreId: score.id,
+    })
+  }
+
+  return score
+})

--- a/packages/domain/spans/package.json
+++ b/packages/domain/spans/package.json
@@ -6,7 +6,10 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "browser": "./src/browser.ts",
+      "default": "./src/index.ts"
+    },
     "./otlp": "./src/otlp.ts",
     "./testing": "./src/testing/index.ts"
   },

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -1,0 +1,122 @@
+export {
+  SESSION_ID_MAX_LENGTH,
+  SPAN_ID_LENGTH,
+  TRACE_END_DEBOUNCE_MS,
+  TRACE_ID_LENGTH,
+} from "./constants.ts"
+export type { Session } from "./entities/session.ts"
+export { sessionSchema } from "./entities/session.ts"
+export type { Operation, Span, SpanDetail, SpanKind, SpanStatusCode, ToolDefinition } from "./entities/span.ts"
+export {
+  operationSchema,
+  spanDetailSchema,
+  spanKindSchema,
+  spanSchema,
+  spanStatusCodeSchema,
+  toolDefinitionSchema,
+} from "./entities/span.ts"
+export type { Trace, TraceDetail } from "./entities/trace.ts"
+export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
+export { SpanDecodingError, TraceCohortUnavailableError } from "./errors.ts"
+export {
+  isLlmCompletionOperation,
+  resolveLastLlmCompletionSpanId,
+} from "./helpers/resolve-last-llm-completion-span.ts"
+export {
+  alignUnixSecondsToHistogramBucket,
+  denseTraceTimeHistogramBuckets,
+  mergeTraceHistogramTimeFilters,
+  parseStartTimeBoundsFromFilters,
+  pickTraceHistogramBucketSeconds,
+  resolveTraceCohortFilters,
+  resolveTraceHistogramRangeIso,
+} from "./helpers.ts"
+export type {
+  SessionDistinctColumn,
+  SessionListCursor,
+  SessionListOptions,
+  SessionListPage,
+  SessionMetrics,
+  SessionRepositoryShape,
+} from "./ports/session-repository.ts"
+export { emptySessionMetrics, SessionRepository } from "./ports/session-repository.ts"
+export type { SpanListOptions, SpanMessagesData, SpanRepositoryShape } from "./ports/span-repository.ts"
+export { SpanRepository } from "./ports/span-repository.ts"
+export type {
+  NumericRollup,
+  TraceDistinctColumn,
+  TraceListCursor,
+  TraceListOptions,
+  TraceListPage,
+  TraceMetrics,
+  TraceRepositoryShape,
+  TraceTimeHistogramBucket,
+} from "./ports/trace-repository.ts"
+export { emptyTraceMetrics, TraceRepository } from "./ports/trace-repository.ts"
+export {
+  buildTraceCohortListingSpec,
+  buildTraceCohortSummaryEntries,
+  buildTraceMetricBaseline,
+  buildTraceMetricBaselines,
+  emptyTraceCohortSummaryEntry,
+  evaluateTraceResourceOutliers,
+  getTraceCohortMetricValue,
+  getTraceMetricPercentileThreshold,
+  isTraceCohortKeyAvailable,
+  isTraceCohortMetricEligible,
+  isTraceMetricPercentileAvailable,
+  TRACE_COHORT_MEDIAN_X3_MIN_SAMPLES,
+  TRACE_COHORT_P90_MIN_SAMPLES,
+  TRACE_COHORT_P95_MIN_SAMPLES,
+  TRACE_COHORT_P99_MIN_SAMPLES,
+  TRACE_RESOURCE_OUTLIER_MULTIPLIER,
+  type TraceCohortBaselineData,
+  type TraceCohortKey,
+  type TraceCohortListingSpec,
+  type TraceCohortMetric,
+  type TraceCohortSummary,
+  type TraceCohortSummaryEntry,
+  type TraceCohortThresholdMode,
+  type TraceCohortUnavailableReason,
+  type TraceMetricBaseline,
+  type TraceMetricPercentileLevel,
+  type TraceMetricPercentiles,
+  type TraceResourceOutlierEvaluation,
+  type TraceResourceOutlierReason,
+  traceCohortKeys,
+  traceCohortMetrics,
+  traceResourceOutlierSeverityRank,
+} from "./trace-cohorts.ts"
+export type {
+  BuildTraceCohortListingSpecError,
+  BuildTraceCohortListingSpecInput,
+} from "./use-cases/build-trace-cohort-listing-spec.ts"
+export { buildTraceCohortListingSpecUseCase } from "./use-cases/build-trace-cohort-listing-spec.ts"
+export type {
+  EvaluateTraceResourceOutliersError,
+  EvaluateTraceResourceOutliersInput,
+} from "./use-cases/evaluate-trace-resource-outliers.ts"
+export { evaluateTraceResourceOutliersUseCase } from "./use-cases/evaluate-trace-resource-outliers.ts"
+export type { GetTraceCohortSummaryInput } from "./use-cases/get-trace-cohort-summary.ts"
+export { getTraceCohortSummaryUseCase } from "./use-cases/get-trace-cohort-summary.ts"
+export type {
+  LoadTraceForTraceEndFound,
+  LoadTraceForTraceEndResult,
+  LoadTraceForTraceEndSkipped,
+} from "./use-cases/load-trace-for-trace-end.ts"
+export { loadTraceForTraceEndUseCase } from "./use-cases/load-trace-for-trace-end.ts"
+export { buildConversationSpanMaps } from "./use-cases/map-conversation-to-spans.ts"
+export type {
+  SelectTraceEndItemsError,
+  TraceEndSelectionDecision,
+  TraceEndSelectionInput,
+  TraceEndSelectionReason,
+  TraceEndSelectionResult,
+  TraceEndSelectionSpec,
+} from "./use-cases/select-trace-end-items.ts"
+export { selectTraceEndItemsUseCase } from "./use-cases/select-trace-end-items.ts"
+export type { TraceEndItemDecisionCounts } from "./use-cases/summarize-trace-end-item-decisions.ts"
+export { summarizeTraceEndItemDecisions } from "./use-cases/summarize-trace-end-item-decisions.ts"
+
+// Intentionally omit OTLP ingestion exports from the browser entry so Vite's client
+// resolver does not pull in protobufjs or @domain/models transitively.

--- a/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
@@ -13,7 +13,9 @@ export interface BuildTraceCohortListingSpecInput {
 
 export type BuildTraceCohortListingSpecError = TraceCohortUnavailableError | RepositoryError
 
-export const buildTraceCohortListingSpecUseCase = Effect.fn("spans.buildTraceCohortListingSpec")(function* (input: BuildTraceCohortListingSpecInput) {
+export const buildTraceCohortListingSpecUseCase = Effect.fn("spans.buildTraceCohortListingSpec")(function* (
+  input: BuildTraceCohortListingSpecInput,
+) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
   yield* Effect.annotateCurrentSpan("cohort", input.cohort)
 

--- a/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
+++ b/packages/domain/spans/src/use-cases/build-trace-cohort-listing-spec.ts
@@ -13,25 +13,24 @@ export interface BuildTraceCohortListingSpecInput {
 
 export type BuildTraceCohortListingSpecError = TraceCohortUnavailableError | RepositoryError
 
-export const buildTraceCohortListingSpecUseCase = (input: BuildTraceCohortListingSpecInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("cohort", input.cohort)
+export const buildTraceCohortListingSpecUseCase = Effect.fn("spans.buildTraceCohortListingSpec")(function* (input: BuildTraceCohortListingSpecInput) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("cohort", input.cohort)
 
-    const traceRepository = yield* TraceRepository
-    const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      ...(input.filters ? { filters: input.filters } : {}),
+  const traceRepository = yield* TraceRepository
+  const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    ...(input.filters ? { filters: input.filters } : {}),
+  })
+  const baselines = buildTraceMetricBaselines(baselineData)
+  const spec = buildTraceCohortListingSpec(input.cohort, baselines)
+  if (spec.unavailableReason) {
+    return yield* new TraceCohortUnavailableError({
+      cohort: input.cohort,
+      reason: spec.unavailableReason,
     })
-    const baselines = buildTraceMetricBaselines(baselineData)
-    const spec = buildTraceCohortListingSpec(input.cohort, baselines)
-    if (spec.unavailableReason) {
-      return yield* new TraceCohortUnavailableError({
-        cohort: input.cohort,
-        reason: spec.unavailableReason,
-      })
-    }
+  }
 
-    return spec
-  }).pipe(Effect.withSpan("spans.buildTraceCohortListingSpec"))
+  return spec
+})

--- a/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
+++ b/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
@@ -13,24 +13,23 @@ export interface EvaluateTraceResourceOutliersInput {
 
 export type EvaluateTraceResourceOutliersError = NotFoundError | RepositoryError
 
-export const evaluateTraceResourceOutliersUseCase = (input: EvaluateTraceResourceOutliersInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("traceId", input.traceId)
+export const evaluateTraceResourceOutliersUseCase = Effect.fn("spans.evaluateTraceResourceOutliers")(function* (input: EvaluateTraceResourceOutliersInput) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("traceId", input.traceId)
 
-    const traceRepository = yield* TraceRepository
-    const trace = yield* traceRepository.findByTraceId({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      traceId: input.traceId,
-    })
-    const effectiveFilters = resolveTraceCohortFilters(input.filters, trace.startTime.getTime()).effectiveFilters
-    const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      filters: effectiveFilters,
-      excludeTraceId: input.traceId,
-    })
+  const traceRepository = yield* TraceRepository
+  const trace = yield* traceRepository.findByTraceId({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    traceId: input.traceId,
+  })
+  const effectiveFilters = resolveTraceCohortFilters(input.filters, trace.startTime.getTime()).effectiveFilters
+  const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    filters: effectiveFilters,
+    excludeTraceId: input.traceId,
+  })
 
-    return evaluateTraceResourceOutliers(trace, buildTraceMetricBaselines(baselineData))
-  }).pipe(Effect.withSpan("spans.evaluateTraceResourceOutliers"))
+  return evaluateTraceResourceOutliers(trace, buildTraceMetricBaselines(baselineData))
+})

--- a/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
+++ b/packages/domain/spans/src/use-cases/evaluate-trace-resource-outliers.ts
@@ -13,7 +13,9 @@ export interface EvaluateTraceResourceOutliersInput {
 
 export type EvaluateTraceResourceOutliersError = NotFoundError | RepositoryError
 
-export const evaluateTraceResourceOutliersUseCase = Effect.fn("spans.evaluateTraceResourceOutliers")(function* (input: EvaluateTraceResourceOutliersInput) {
+export const evaluateTraceResourceOutliersUseCase = Effect.fn("spans.evaluateTraceResourceOutliers")(function* (
+  input: EvaluateTraceResourceOutliersInput,
+) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
   yield* Effect.annotateCurrentSpan("traceId", input.traceId)
 

--- a/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
@@ -11,7 +11,9 @@ export interface GetTraceCohortSummaryInput {
   readonly effectiveRangeEndIso: string
 }
 
-export const getTraceCohortSummaryUseCase = Effect.fn("spans.getTraceCohortSummary")(function* (input: GetTraceCohortSummaryInput) {
+export const getTraceCohortSummaryUseCase = Effect.fn("spans.getTraceCohortSummary")(function* (
+  input: GetTraceCohortSummaryInput,
+) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
 
   const traceRepository = yield* TraceRepository

--- a/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
+++ b/packages/domain/spans/src/use-cases/get-trace-cohort-summary.ts
@@ -11,22 +11,21 @@ export interface GetTraceCohortSummaryInput {
   readonly effectiveRangeEndIso: string
 }
 
-export const getTraceCohortSummaryUseCase = (input: GetTraceCohortSummaryInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+export const getTraceCohortSummaryUseCase = Effect.fn("spans.getTraceCohortSummary")(function* (input: GetTraceCohortSummaryInput) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
 
-    const traceRepository = yield* TraceRepository
-    const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
-      organizationId: input.organizationId,
-      projectId: input.projectId,
-      ...(input.filters ? { filters: input.filters } : {}),
-    })
-    const baselines = buildTraceMetricBaselines(baselineData)
+  const traceRepository = yield* TraceRepository
+  const baselineData = yield* traceRepository.getCohortBaselineByProjectId({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    ...(input.filters ? { filters: input.filters } : {}),
+  })
+  const baselines = buildTraceMetricBaselines(baselineData)
 
-    return {
-      effectiveRangeStartIso: input.effectiveRangeStartIso,
-      effectiveRangeEndIso: input.effectiveRangeEndIso,
-      traceCount: baselineData.traceCount,
-      baselines,
-    } satisfies TraceCohortSummary
-  }).pipe(Effect.withSpan("spans.getTraceCohortSummary"))
+  return {
+    effectiveRangeStartIso: input.effectiveRangeStartIso,
+    effectiveRangeEndIso: input.effectiveRangeEndIso,
+    traceCount: baselineData.traceCount,
+    baselines,
+  } satisfies TraceCohortSummary
+})

--- a/packages/domain/spans/src/use-cases/select-trace-end-items.ts
+++ b/packages/domain/spans/src/use-cases/select-trace-end-items.ts
@@ -97,69 +97,68 @@ const buildFilterBatch = (entries: readonly [string, TraceEndSelectionSpec][]) =
     })) satisfies readonly FilterBatchEntry[]
   })
 
-export const selectTraceEndItemsUseCase = (input: TraceEndSelectionInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
-    yield* Effect.annotateCurrentSpan("traceId", input.traceId)
-    yield* Effect.annotateCurrentSpan("selection.itemCount", Object.keys(input.items).length)
+export const selectTraceEndItemsUseCase = Effect.fn("spans.selectTraceEndItems")(function* (input: TraceEndSelectionInput) {
+  yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("selection.itemCount", Object.keys(input.items).length)
 
-    const decisions: Record<string, TraceEndSelectionDecision> = {}
-    const sampledIn: Array<[string, TraceEndSelectionSpec]> = []
+  const decisions: Record<string, TraceEndSelectionDecision> = {}
+  const sampledIn: Array<[string, TraceEndSelectionSpec]> = []
 
-    for (const [itemKey, spec] of Object.entries(input.items)) {
-      const samplingKey = spec.sampleKey ?? itemKey
-      const isSampled = yield* Effect.promise(() =>
-        deterministicSampling({
-          sampling: spec.sampling,
-          keyParts: [input.organizationId, input.projectId, samplingKey, input.traceId],
-        }),
-      )
+  for (const [itemKey, spec] of Object.entries(input.items)) {
+    const samplingKey = spec.sampleKey ?? itemKey
+    const isSampled = yield* Effect.promise(() =>
+      deterministicSampling({
+        sampling: spec.sampling,
+        keyParts: [input.organizationId, input.projectId, samplingKey, input.traceId],
+      }),
+    )
 
-      if (!isSampled) {
-        decisions[itemKey] = skippedDecision("sampled-out")
-        continue
-      }
-
-      const normalizedFilter = normalizeFilterSet(spec.filter)
-      if (!normalizedFilter) {
-        decisions[itemKey] = selectedDecision()
-        continue
-      }
-
-      sampledIn.push([itemKey, { ...spec, filter: normalizedFilter }])
+    if (!isSampled) {
+      decisions[itemKey] = skippedDecision("sampled-out")
+      continue
     }
 
-    if (sampledIn.length === 0) {
-      return decisions satisfies TraceEndSelectionResult
+    const normalizedFilter = normalizeFilterSet(spec.filter)
+    if (!normalizedFilter) {
+      decisions[itemKey] = selectedDecision()
+      continue
     }
 
-    const filterBatch = yield* buildFilterBatch(sampledIn)
-    if (filterBatch.length === 0) {
-      return decisions satisfies TraceEndSelectionResult
-    }
+    sampledIn.push([itemKey, { ...spec, filter: normalizedFilter }])
+  }
 
-    const traceRepository = yield* TraceRepository
-    const matchingFingerprints = yield* traceRepository.listMatchingFilterIdsByTraceId({
-      organizationId: OrganizationId(input.organizationId),
-      projectId: ProjectId(input.projectId),
-      traceId: TraceId(input.traceId),
-      filterSets: filterBatch.map((entry) => ({
-        filterId: entry.fingerprint,
-        filters: entry.filter,
-      })),
-    })
-
-    const matchingFingerprintSet = new Set(matchingFingerprints)
-
-    for (const entry of filterBatch) {
-      const decision = matchingFingerprintSet.has(entry.fingerprint)
-        ? selectedDecision()
-        : skippedDecision("filter-miss")
-
-      for (const itemKey of entry.itemKeys) {
-        decisions[itemKey] = decision
-      }
-    }
-
+  if (sampledIn.length === 0) {
     return decisions satisfies TraceEndSelectionResult
-  }).pipe(Effect.withSpan("spans.selectTraceEndItems"))
+  }
+
+  const filterBatch = yield* buildFilterBatch(sampledIn)
+  if (filterBatch.length === 0) {
+    return decisions satisfies TraceEndSelectionResult
+  }
+
+  const traceRepository = yield* TraceRepository
+  const matchingFingerprints = yield* traceRepository.listMatchingFilterIdsByTraceId({
+    organizationId: OrganizationId(input.organizationId),
+    projectId: ProjectId(input.projectId),
+    traceId: TraceId(input.traceId),
+    filterSets: filterBatch.map((entry) => ({
+      filterId: entry.fingerprint,
+      filters: entry.filter,
+    })),
+  })
+
+  const matchingFingerprintSet = new Set(matchingFingerprints)
+
+  for (const entry of filterBatch) {
+    const decision = matchingFingerprintSet.has(entry.fingerprint)
+      ? selectedDecision()
+      : skippedDecision("filter-miss")
+
+    for (const itemKey of entry.itemKeys) {
+      decisions[itemKey] = decision
+    }
+  }
+
+  return decisions satisfies TraceEndSelectionResult
+})

--- a/packages/domain/spans/src/use-cases/select-trace-end-items.ts
+++ b/packages/domain/spans/src/use-cases/select-trace-end-items.ts
@@ -97,7 +97,9 @@ const buildFilterBatch = (entries: readonly [string, TraceEndSelectionSpec][]) =
     })) satisfies readonly FilterBatchEntry[]
   })
 
-export const selectTraceEndItemsUseCase = Effect.fn("spans.selectTraceEndItems")(function* (input: TraceEndSelectionInput) {
+export const selectTraceEndItemsUseCase = Effect.fn("spans.selectTraceEndItems")(function* (
+  input: TraceEndSelectionInput,
+) {
   yield* Effect.annotateCurrentSpan("projectId", input.projectId)
   yield* Effect.annotateCurrentSpan("traceId", input.traceId)
   yield* Effect.annotateCurrentSpan("selection.itemCount", Object.keys(input.items).length)
@@ -151,9 +153,7 @@ export const selectTraceEndItemsUseCase = Effect.fn("spans.selectTraceEndItems")
   const matchingFingerprintSet = new Set(matchingFingerprints)
 
   for (const entry of filterBatch) {
-    const decision = matchingFingerprintSet.has(entry.fingerprint)
-      ? selectedDecision()
-      : skippedDecision("filter-miss")
+    const decision = matchingFingerprintSet.has(entry.fingerprint) ? selectedDecision() : skippedDecision("filter-miss")
 
     for (const itemKey of entry.itemKeys) {
       decisions[itemKey] = decision

--- a/packages/domain/users/src/use-cases/delete-user.ts
+++ b/packages/domain/users/src/use-cases/delete-user.ts
@@ -6,14 +6,13 @@ export interface DeleteUserInput {
   readonly userId: string
 }
 
-export const deleteUserUseCase = (input: DeleteUserInput) =>
-  Effect.gen(function* () {
-    yield* Effect.annotateCurrentSpan("userId", input.userId)
+export const deleteUserUseCase = Effect.fn("users.deleteUser")(function* (input: DeleteUserInput) {
+  yield* Effect.annotateCurrentSpan("userId", input.userId)
 
-    // Clean up memberships and sole-member organizations
-    yield* cleanupUserMembershipsUseCase({ userId: input.userId })
+  // Clean up memberships and sole-member organizations
+  yield* cleanupUserMembershipsUseCase({ userId: input.userId })
 
-    // Delete the user record (cascades to sessions, accounts)
-    const userRepo = yield* UserRepository
-    yield* userRepo.delete(input.userId)
-  }).pipe(Effect.withSpan("users.deleteUser"))
+  // Delete the user record (cascades to sessions, accounts)
+  const userRepo = yield* UserRepository
+  yield* userRepo.delete(input.userId)
+})

--- a/packages/platform/op-gepa/src/gepa-optimizer.ts
+++ b/packages/platform/op-gepa/src/gepa-optimizer.ts
@@ -105,152 +105,151 @@ const resolveTrajectory = (input: {
 }
 
 export const GepaOptimizerLive = Layer.succeed(Optimizer, {
-  optimize: (input) =>
-    Effect.gen(function* () {
-      yield* Effect.annotateCurrentSpan("optimization.componentId", input.baselineCandidate.componentId)
-      yield* Effect.annotateCurrentSpan("optimization.trainsetSize", input.dataset.trainset.length)
-      yield* Effect.annotateCurrentSpan("optimization.valsetSize", input.dataset.valset.length)
+  optimize: Effect.fn("optimizations.gepaOptimize")(function* (input) {
+    yield* Effect.annotateCurrentSpan("optimization.componentId", input.baselineCandidate.componentId)
+    yield* Effect.annotateCurrentSpan("optimization.trainsetSize", input.dataset.trainset.length)
+    yield* Effect.annotateCurrentSpan("optimization.valsetSize", input.dataset.valset.length)
 
+    throwIfAborted(input.abortSignal)
+
+    const candidateByHash = new Map<string, OptimizationCandidate>([
+      [input.baselineCandidate.hash, input.baselineCandidate],
+    ])
+    const trajectoryById = new Map<string, OptimizationTrajectory>()
+    const client = new GepaClient(input.abortSignal ? { abortSignal: input.abortSignal } : {})
+
+    client.on(GEPA_RPC_METHODS.evaluate, evaluateParamsSchema, partialOutputSchema, async (params) => {
       throwIfAborted(input.abortSignal)
 
-      const candidateByHash = new Map<string, OptimizationCandidate>([
-        [input.baselineCandidate.hash, input.baselineCandidate],
-      ])
-      const trajectoryById = new Map<string, OptimizationTrajectory>()
-      const client = new GepaClient(input.abortSignal ? { abortSignal: input.abortSignal } : {})
-
-      client.on(GEPA_RPC_METHODS.evaluate, evaluateParamsSchema, partialOutputSchema, async (params) => {
-        throwIfAborted(input.abortSignal)
-
-        const candidate = resolveCandidate({
-          candidateByHash,
-          system: params.candidate,
-          componentId: input.baselineCandidate.componentId,
-        })
-
-        const result = await input.evaluate(
-          input.abortSignal
-            ? {
-                candidate,
-                example: { id: params.example.id },
-                abortSignal: input.abortSignal,
-              }
-            : {
-                candidate,
-                example: { id: params.example.id },
-              },
-        )
-
-        trajectoryById.set(result.trajectory.id, result.trajectory)
-
-        return {
-          id: result.trajectory.id,
-          score: result.trajectory.score,
-          expectedPositive: result.trajectory.expectedPositive,
-          predictedPositive: result.trajectory.predictedPositive,
-          totalTokens: result.trajectory.totalTokens,
-        }
+      const candidate = resolveCandidate({
+        candidateByHash,
+        system: params.candidate,
+        componentId: input.baselineCandidate.componentId,
       })
 
-      client.on(GEPA_RPC_METHODS.propose, proposeParamsSchema, proposeResultSchema, async (params) => {
-        throwIfAborted(input.abortSignal)
-
-        if (params.component !== input.baselineCandidate.componentId) {
-          throw new OptimizationProtocolError({
-            message: `GEPA referenced an unsupported component: ${params.component}`,
-          })
-        }
-
-        const currentCandidate = candidateByHash.get(params.script)
-        if (!currentCandidate) {
-          throw new OptimizationProtocolError({
-            message: `GEPA referenced an unknown script: ${params.script}`,
-          })
-        }
-
-        const context = params.context.map((trajectory: z.infer<typeof partialTrajectorySchema>) =>
-          resolveTrajectory({
-            trajectoryById,
-            trajectoryId: trajectory.id,
-          }),
-        )
-
-        const proposed = await input.propose(
-          input.abortSignal
-            ? {
-                candidate: currentCandidate,
-                context,
-                abortSignal: input.abortSignal,
-              }
-            : {
-                candidate: currentCandidate,
-                context,
-              },
-        )
-
-        candidateByHash.set(proposed.hash, proposed)
-
-        return {
-          script: proposed.hash,
-        }
-      })
-
-      const stopClient = Effect.tryPromise({
-        try: () => client.stop(),
-        catch: (cause: unknown) =>
-          new OptimizationTransportError({
-            operation: "stop",
-            cause,
-          }),
-      }).pipe(Effect.orDie)
-
-      yield* Effect.tryPromise({
-        try: () => client.start(),
-        catch: (cause: unknown) =>
-          new OptimizationTransportError({
-            operation: "start",
-            cause,
-          }),
-      })
-
-      const result = yield* Effect.tryPromise({
-        try: () =>
-          client.call(
-            GEPA_RPC_METHODS.optimize,
-            optimizeParamsSchema,
-            {
-              baseline: {
-                [input.baselineCandidate.componentId]: input.baselineCandidate.hash,
-              },
-              trainset: input.dataset.trainset.map((example) => ({ id: example.id })),
-              valset: input.dataset.valset.map((example) => ({ id: example.id })),
-              budget: {
-                time: input.budget?.time ?? GEPA_MAX_TIME,
-                tokens: input.budget?.tokens ?? GEPA_MAX_TOKENS,
-              },
+      const result = await input.evaluate(
+        input.abortSignal
+          ? {
+              candidate,
+              example: { id: params.example.id },
+              abortSignal: input.abortSignal,
+            }
+          : {
+              candidate,
+              example: { id: params.example.id },
             },
-            optimizeResultSchema,
-          ),
-        catch: (cause: unknown) =>
-          cause instanceof OptimizationAbortedError || cause instanceof OptimizationProtocolError
-            ? cause
-            : cause instanceof JsonRpcResponseError
-              ? new OptimizationProtocolError({
-                  message: cause.strippedMessage,
-                  cause: cause.remoteCause ?? cause,
-                })
-              : new OptimizationTransportError({
-                  operation: "optimize",
-                  cause,
-                }),
-      }).pipe(Effect.ensuring(stopClient))
+      )
+
+      trajectoryById.set(result.trajectory.id, result.trajectory)
 
       return {
-        optimizedCandidate: resolveCandidate({
-          candidateByHash,
-          system: result.optimized,
-          componentId: input.baselineCandidate.componentId,
-        }),
+        id: result.trajectory.id,
+        score: result.trajectory.score,
+        expectedPositive: result.trajectory.expectedPositive,
+        predictedPositive: result.trajectory.predictedPositive,
+        totalTokens: result.trajectory.totalTokens,
       }
-    }).pipe(Effect.withSpan("optimizations.gepaOptimize")),
+    })
+
+    client.on(GEPA_RPC_METHODS.propose, proposeParamsSchema, proposeResultSchema, async (params) => {
+      throwIfAborted(input.abortSignal)
+
+      if (params.component !== input.baselineCandidate.componentId) {
+        throw new OptimizationProtocolError({
+          message: `GEPA referenced an unsupported component: ${params.component}`,
+        })
+      }
+
+      const currentCandidate = candidateByHash.get(params.script)
+      if (!currentCandidate) {
+        throw new OptimizationProtocolError({
+          message: `GEPA referenced an unknown script: ${params.script}`,
+        })
+      }
+
+      const context = params.context.map((trajectory: z.infer<typeof partialTrajectorySchema>) =>
+        resolveTrajectory({
+          trajectoryById,
+          trajectoryId: trajectory.id,
+        }),
+      )
+
+      const proposed = await input.propose(
+        input.abortSignal
+          ? {
+              candidate: currentCandidate,
+              context,
+              abortSignal: input.abortSignal,
+            }
+          : {
+              candidate: currentCandidate,
+              context,
+            },
+      )
+
+      candidateByHash.set(proposed.hash, proposed)
+
+      return {
+        script: proposed.hash,
+      }
+    })
+
+    const stopClient = Effect.tryPromise({
+      try: () => client.stop(),
+      catch: (cause: unknown) =>
+        new OptimizationTransportError({
+          operation: "stop",
+          cause,
+        }),
+    }).pipe(Effect.orDie)
+
+    yield* Effect.tryPromise({
+      try: () => client.start(),
+      catch: (cause: unknown) =>
+        new OptimizationTransportError({
+          operation: "start",
+          cause,
+        }),
+    })
+
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        client.call(
+          GEPA_RPC_METHODS.optimize,
+          optimizeParamsSchema,
+          {
+            baseline: {
+              [input.baselineCandidate.componentId]: input.baselineCandidate.hash,
+            },
+            trainset: input.dataset.trainset.map((example) => ({ id: example.id })),
+            valset: input.dataset.valset.map((example) => ({ id: example.id })),
+            budget: {
+              time: input.budget?.time ?? GEPA_MAX_TIME,
+              tokens: input.budget?.tokens ?? GEPA_MAX_TOKENS,
+            },
+          },
+          optimizeResultSchema,
+        ),
+      catch: (cause: unknown) =>
+        cause instanceof OptimizationAbortedError || cause instanceof OptimizationProtocolError
+          ? cause
+          : cause instanceof JsonRpcResponseError
+            ? new OptimizationProtocolError({
+                message: cause.strippedMessage,
+                cause: cause.remoteCause ?? cause,
+              })
+            : new OptimizationTransportError({
+                operation: "optimize",
+                cause,
+              }),
+    }).pipe(Effect.ensuring(stopClient))
+
+    return {
+      optimizedCandidate: resolveCandidate({
+        candidateByHash,
+        system: result.optimized,
+        componentId: input.baselineCandidate.componentId,
+      }),
+    }
+  }),
 } satisfies OptimizerShape)


### PR DESCRIPTION
## Summary

Convert 63 use-case functions across 12 domain packages from the legacy `Effect.gen` + `Effect.withSpan` pattern to the new `Effect.fn` pattern.

This addresses TypeScript diagnostic TS41 warnings from the Effect plugin recommending the reusable function form.

## Pattern Change

**From:**
```typescript
export const someUseCase = (input: SomeInput) =>
  Effect.gen(function* () {
    // ... implementation
  }).pipe(Effect.withSpan("name"))
```

**To:**
```typescript
export const someUseCase = Effect.fn("name")(function* (input) {
  // ... implementation
})
```

## Packages Affected

| Package | Functions Converted |
|---------|---------------------|
| `@platform/op-gepa` | 1 |
| `@domain/annotation-queues` | 10 |
| `@domain/annotations` | 4 |
| `@domain/api-keys` | 3 |
| `@domain/datasets` | 14 |
| `@domain/evaluations` | 9 |
| `@domain/issues` | 6 |
| `@domain/organizations` | 5 |
| `@domain/projects` | 2 |
| `@domain/scores` | 4 |
| `@domain/spans` | 4 |
| `@domain/users` | 1 |

**Total: 61 files changed, 63 functions converted**

## Key Changes

- Input parameter moved from outer arrow function to generator function
- Removed `.pipe(Effect.withSpan("..."))` - span name now embedded in `Effect.fn()`
- More idiomatic Effect code with better built-in tracing
- Resolves ~800 TypeScript warnings from the Effect plugin

## Verification

- [x] Typecheck passes for all 48 packages
- [x] Biome formatting applied
- [x] All 800+ TS41 warnings resolved