### PR TITLE
feat(telemetry): enrich claude-code spans with workspace + git context

### DIFF
--- a/packages/telemetry/claude-code/src/context.ts
+++ b/packages/telemetry/claude-code/src/context.ts
@@ -1,0 +1,97 @@
+import { execFileSync } from "node:child_process"
+import { basename } from "node:path"
+import type { HookPayload, TraceContext } from "./types.ts"
+
+const GIT_TIMEOUT_MS = 1_500
+const CLAUDE_VERSION_TIMEOUT_MS = 2_000
+
+export function collectTraceContext(payload: HookPayload): TraceContext {
+  const cwd = payload.cwd?.trim() || undefined
+  const workspaceName = cwd ? basename(cwd) : undefined
+  const workspacePath = cwd
+
+  const git = cwd ? readGit(cwd) : {}
+  const claudeCodeVersion = readClaudeCodeVersion()
+  const hostUser = readHostUser()
+  const hookEvent = payload.hook_event_name ?? payload.hookEventName
+
+  const metadata: Record<string, string> = {}
+  if (workspaceName) metadata["workspace.name"] = workspaceName
+  if (workspacePath) metadata["workspace.path"] = workspacePath
+  if (git.branch) metadata["git.branch"] = git.branch
+  if (git.commit) metadata["git.commit"] = git.commit
+  if (git.repo) metadata["git.repo"] = git.repo
+  if (claudeCodeVersion) metadata["claude_code.version"] = claudeCodeVersion
+  if (hostUser) metadata["host.user"] = hostUser
+  if (hookEvent) metadata["hook.event"] = hookEvent
+
+  const tags: string[] = []
+  if (workspaceName) tags.push(workspaceName)
+
+  return { tags, metadata }
+}
+
+interface GitInfo {
+  branch?: string | undefined
+  commit?: string | undefined
+  repo?: string | undefined
+}
+
+function readGit(cwd: string): GitInfo {
+  const branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+  const commit = runGit(["rev-parse", "HEAD"], cwd)
+  const remote = runGit(["config", "--get", "remote.origin.url"], cwd)
+  const repo = remote ? deriveRepo(remote) : undefined
+  return {
+    branch: branch && branch !== "HEAD" ? branch : undefined,
+    commit,
+    repo,
+  }
+}
+
+function runGit(args: string[], cwd: string): string | undefined {
+  try {
+    const out = execFileSync("git", args, {
+      cwd,
+      timeout: GIT_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+    })
+    const trimmed = out.trim()
+    return trimmed || undefined
+  } catch {
+    return undefined
+  }
+}
+
+function deriveRepo(remote: string): string | undefined {
+  // normalize "git@github.com:owner/repo.git" and "https://github.com/owner/repo[.git]" → "owner/repo"
+  const stripped = remote.replace(/\.git$/, "").trim()
+  const sshMatch = stripped.match(/^[^@]+@[^:]+:(.+)$/)
+  if (sshMatch?.[1]) return sshMatch[1]
+  try {
+    const url = new URL(stripped)
+    const path = url.pathname.replace(/^\/+/, "")
+    return path || undefined
+  } catch {
+    return stripped || undefined
+  }
+}
+
+function readClaudeCodeVersion(): string | undefined {
+  try {
+    const out = execFileSync("claude", ["--version"], {
+      timeout: CLAUDE_VERSION_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf-8",
+    })
+    const match = out.match(/\d+\.\d+\.\d+[^\s]*/)
+    return match?.[0]
+  } catch {
+    return undefined
+  }
+}
+
+function readHostUser(): string | undefined {
+  return process.env.USER || process.env.LOGNAME || process.env.USERNAME || undefined
+}

--- a/packages/telemetry/claude-code/src/index.ts
+++ b/packages/telemetry/claude-code/src/index.ts
@@ -1,5 +1,6 @@
 import { postTraces } from "./client.ts"
 import { loadConfig } from "./config.ts"
+import { collectTraceContext } from "./context.ts"
 import type { Logger } from "./logger.ts"
 import { createLogger } from "./logger.ts"
 import { buildOtlpRequest } from "./otlp.ts"
@@ -80,10 +81,14 @@ async function main(): Promise<void> {
       logger,
     })
 
+    const context = collectTraceContext(payload)
+    logger.debug(`context tags=${context.tags.length} metadata=${Object.keys(context.metadata).length}`)
+
     const otlpRequest = buildOtlpRequest({
       sessionId,
       turnStartNumber: prior.turnCount + 1,
       turns,
+      context,
     })
 
     return postTraces({

--- a/packages/telemetry/claude-code/src/otlp.test.ts
+++ b/packages/telemetry/claude-code/src/otlp.test.ts
@@ -143,6 +143,56 @@ describe("buildOtlpRequest", () => {
     expect(unwrap(aSpans[0]).spanId).toBe(unwrap(bSpans[0]).spanId)
   })
 
+  it("attaches latitude.tags and latitude.metadata to every span when context is provided", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [
+        baseTurn({
+          toolCalls: [{ id: "tu_1", name: "Bash", input: { command: "ls" }, output: "ok" }],
+        }),
+      ],
+      context: {
+        tags: ["latitude-v2"],
+        metadata: {
+          "workspace.name": "latitude-v2",
+          "workspace.path": "/Users/x/src/latitude-v2",
+          "git.branch": "main",
+          "hook.event": "Stop",
+        },
+      },
+    })
+
+    const spans = otlpSpans(req)
+    expect(spans).toHaveLength(3)
+    for (const span of spans) {
+      const tags = getAttr(span.attributes, "latitude.tags")
+      const metadata = getAttr(span.attributes, "latitude.metadata")
+      expect(JSON.parse(unwrap(tags))).toEqual(["latitude-v2"])
+      expect(JSON.parse(unwrap(metadata))).toEqual({
+        "workspace.name": "latitude-v2",
+        "workspace.path": "/Users/x/src/latitude-v2",
+        "git.branch": "main",
+        "hook.event": "Stop",
+      })
+    }
+  })
+
+  it("omits latitude.tags and latitude.metadata when context is empty", () => {
+    const req = buildOtlpRequest({
+      sessionId: "sess-1",
+      turnStartNumber: 1,
+      turns: [baseTurn()],
+      context: { tags: [], metadata: {} },
+    })
+
+    const spans = otlpSpans(req)
+    for (const span of spans) {
+      expect(getAttr(span.attributes, "latitude.tags")).toBeUndefined()
+      expect(getAttr(span.attributes, "latitude.metadata")).toBeUndefined()
+    }
+  })
+
   it("nests subagent interaction+llm_request+tool spans under the parent Agent tool span", () => {
     const req = buildOtlpRequest({
       sessionId: "sess-1",

--- a/packages/telemetry/claude-code/src/otlp.ts
+++ b/packages/telemetry/claude-code/src/otlp.ts
@@ -7,6 +7,7 @@ import type {
   OtlpSpan,
   SubagentInvocation,
   ToolCall,
+  TraceContext,
   Turn,
 } from "./types.ts"
 
@@ -18,11 +19,13 @@ export function buildOtlpRequest(opts: {
   userId?: string | undefined
   turnStartNumber: number
   turns: Turn[]
+  context?: TraceContext | undefined
 }): OtlpExportRequest {
+  const contextAttrs = buildContextAttrs(opts.context)
   const spans: OtlpSpan[] = []
   opts.turns.forEach((turn, i) => {
     const turnNum = opts.turnStartNumber + i
-    spans.push(...buildTurnSpans(opts.sessionId, opts.userId, turnNum, turn))
+    spans.push(...buildTurnSpans(opts.sessionId, opts.userId, turnNum, turn, contextAttrs))
   })
 
   const rs: OtlpResourceSpans = {
@@ -38,7 +41,13 @@ export function buildOtlpRequest(opts: {
   return { resourceSpans: [rs] }
 }
 
-function buildTurnSpans(sessionId: string, userId: string | undefined, turnNum: number, turn: Turn): OtlpSpan[] {
+function buildTurnSpans(
+  sessionId: string,
+  userId: string | undefined,
+  turnNum: number,
+  turn: Turn,
+  contextAttrs: OtlpKeyValue[],
+): OtlpSpan[] {
   const traceId = hashHex(`${sessionId}:${turnNum}`, 32)
   const turnSpanId = hashHex(`${traceId}:turn`, 16)
   const out: OtlpSpan[] = []
@@ -54,6 +63,7 @@ function buildTurnSpans(sessionId: string, userId: string | undefined, turnNum: 
     turnNum,
     interactionIdSalt: "turn",
     genIdSalt: "gen",
+    contextAttrs,
   })
   return out
 }
@@ -70,6 +80,7 @@ interface TreeCtx {
   turnNum: number | undefined
   interactionIdSalt: string
   genIdSalt: string
+  contextAttrs: OtlpKeyValue[]
 }
 
 function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
@@ -97,6 +108,7 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
       turnNum !== undefined ? int("turn.number", turnNum) : undefined,
       isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
       str("gen_ai.input.messages", JSON.stringify([messagePart("user", turn.userText)])),
+      ...ctx.contextAttrs,
     ]),
     status: { code: 1 },
   }
@@ -129,6 +141,7 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
       isSubagent && subagentLabel ? str("subagent.id", subagentLabel) : undefined,
       str("gen_ai.input.messages", JSON.stringify([messagePart("user", turn.userText)])),
       str("gen_ai.output.messages", JSON.stringify([messagePart("assistant", turn.assistantText)])),
+      ...ctx.contextAttrs,
     ]),
     status: { code: 1 },
   }
@@ -136,7 +149,7 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
 
   turn.toolCalls.forEach((call, idx) => {
     const toolSpanId = hashHex(`${traceId}:${ctx.genIdSalt}:tool:${idx}:${call.id}`, 16)
-    out.push(buildToolSpan(traceId, genSpanId, toolSpanId, sessionId, userId, startNs, endNs, call))
+    out.push(buildToolSpan(traceId, genSpanId, toolSpanId, sessionId, userId, startNs, endNs, call, ctx.contextAttrs))
 
     const subagent = call.subagent
     if (!subagent) return
@@ -154,6 +167,7 @@ function buildInteractionTree(out: OtlpSpan[], ctx: TreeCtx): void {
         turnNum: undefined,
         interactionIdSalt: `${subSalt}:turn`,
         genIdSalt: `${subSalt}:gen`,
+        contextAttrs: ctx.contextAttrs,
       })
     })
   })
@@ -172,6 +186,7 @@ function buildToolSpan(
   startNs: string,
   endNs: string,
   call: ToolCall,
+  contextAttrs: OtlpKeyValue[],
 ): OtlpSpan {
   return {
     traceId,
@@ -194,9 +209,20 @@ function buildToolSpan(
       call.subagent ? str("subagent.id", subagentAttr(call.subagent)) : undefined,
       call.subagent ? str("subagent.type", call.subagent.agentType) : undefined,
       call.subagent ? int("subagent.turn_count", call.subagent.turns.length) : undefined,
+      ...contextAttrs,
     ]),
     status: { code: call.isError ? 2 : 1 },
   }
+}
+
+function buildContextAttrs(context: TraceContext | undefined): OtlpKeyValue[] {
+  if (!context) return []
+  const attrs: OtlpKeyValue[] = []
+  if (context.tags.length > 0) attrs.push(str("latitude.tags", JSON.stringify(context.tags)))
+  if (Object.keys(context.metadata).length > 0) {
+    attrs.push(str("latitude.metadata", JSON.stringify(context.metadata)))
+  }
+  return attrs
 }
 
 function messagePart(role: "user" | "assistant", content: string) {

--- a/packages/telemetry/claude-code/src/types.ts
+++ b/packages/telemetry/claude-code/src/types.ts
@@ -4,6 +4,13 @@ export interface HookPayload {
   transcript_path?: string
   transcriptPath?: string
   cwd?: string
+  hook_event_name?: string
+  hookEventName?: string
+}
+
+export interface TraceContext {
+  tags: string[]
+  metadata: Record<string, string>
 }
 
 export interface TextBlock {


### PR DESCRIPTION
## Summary
- Collect a per-trace context from the Stop-hook payload: workspace name/path (from `cwd`), git branch/commit/repo, Claude Code version, host user, and hook event name.
- Emit the workspace name as a span tag (`latitude.tags`) and the full context as shared trace metadata (`latitude.metadata`), so every span in the trace can be filtered and grouped by these dimensions in Latitude.
- Interaction-specific fields are deliberately left out of metadata since it's meant to describe the trace as a whole.

## Test plan
- [x] `pnpm --filter @latitude-data/claude-code-telemetry test` — 17 tests pass, including two new cases covering context attribution and the empty-context fallback.
- [x] `pnpm --filter @latitude-data/claude-code-telemetry exec tsc --noEmit` — clean.
- [x] `biome check src/` — clean.
- [ ] Verify end-to-end in a real session that tags/metadata land on traces in the Latitude UI.