### PR TITLE
Fix docu integration CC - Latitude v2

### DIFF
--- a/docs/claude-code-telemetry.md
+++ b/docs/claude-code-telemetry.md
@@ -162,7 +162,7 @@ echo '{"session_id":"smoke","transcript_path":"/tmp/latitude-hook-smoke/transcri
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| No state file after a session | Hook never ran (PATH issue or async swallowing output) | Absolute node path; add `async: true` |
+| No state file after a session | Hook never ran (PATH issue) | Use an absolute node path |
 | State file updates but never a `2xx` line | `LATITUDE_API_KEY` or `LATITUDE_PROJECT` missing | Both must be in settings.json `env` — hooks don't inherit shell env |
 | HTTP 400 "X-Latitude-Project header is required" | `LATITUDE_PROJECT` unset | Add it to settings.json |
 | HTTP 404 "Project not found" | Slug mismatch or project not in this org | Run `pnpm seed` to create `default-project`; verify org via API key |

--- a/docs/claude-code-telemetry.md
+++ b/docs/claude-code-telemetry.md
@@ -19,7 +19,7 @@ Paste into `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "command": "npx -y @latitude-data/claude-code-telemetry"
           }
         ]
       }

--- a/docs/claude-code-telemetry.md
+++ b/docs/claude-code-telemetry.md
@@ -20,7 +20,6 @@ Paste into `~/.claude/settings.json`:
           {
             "type": "command",
             "command": "npx -y @latitude-data/claude-code-telemetry",
-            "async": true
           }
         ]
       }
@@ -110,7 +109,7 @@ Notes on the config:
 - `LATITUDE_BASE_URL` points at the local `apps/ingest` dev server (port 3002 by default).
 - `LATITUDE_DEBUG=1` logs each hook step to stderr.
 - **Do not** use `npx -y @latitude-data/claude-code-telemetry` in local dev — that pulls the published package and ignores your local changes.
-- Omit `"async": true` while debugging. With the default (synchronous), Claude Code waits for the hook and its stderr lands in the same terminal right after the assistant's response — you'll see the `[latitude-claude-code]` debug lines without hunting through log files. Flip `async` on once the setup works; the CLI logs only on failure in that mode.
+
 
 ### 3. Absolute node path (especially for the Desktop app)
 
@@ -163,7 +162,7 @@ echo '{"session_id":"smoke","transcript_path":"/tmp/latitude-hook-smoke/transcri
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| No state file after a session | Hook never ran (PATH issue or async swallowing output) | Absolute node path; remove `async: true` |
+| No state file after a session | Hook never ran (PATH issue or async swallowing output) | Absolute node path; add `async: true` |
 | State file updates but never a `2xx` line | `LATITUDE_API_KEY` or `LATITUDE_PROJECT` missing | Both must be in settings.json `env` — hooks don't inherit shell env |
 | HTTP 400 "X-Latitude-Project header is required" | `LATITUDE_PROJECT` unset | Add it to settings.json |
 | HTTP 404 "Project not found" | Slug mismatch or project not in this org | Run `pnpm seed` to create `default-project`; verify org via API key |

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -19,7 +19,7 @@ Add this to your `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "command": "npx -y @latitude-data/claude-code-telemetry"
           }
         ]
       }

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -20,7 +20,6 @@ Add this to your `~/.claude/settings.json`:
           {
             "type": "command",
             "command": "npx -y @latitude-data/claude-code-telemetry",
-            "async": true
           }
         ]
       }
@@ -32,8 +31,6 @@ Add this to your `~/.claude/settings.json`:
 That's it. The hook fires after every assistant turn, reads new lines from the session transcript, converts them into OTLP traces, and POSTs them to `${LATITUDE_BASE_URL}/v1/traces`.
 
 `LATITUDE_PROJECT` is the slug of the Latitude project you want traces to land in — same value you'd pass in the `X-Latitude-Project` header when using the ingest API directly. The project must already exist under the organization that owns your API key.
-
-`async: true` means Claude Code doesn't wait for the HTTP request — your terminal stays snappy.
 
 ## Environment variables
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that adjust recommended Claude Code hook configuration (not runtime code).
> 
> **Overview**
> Updates Claude Code telemetry docs to **stop recommending** configuring the `Stop` hook with `"async": true`, removing the related explanation from the package README.
> 
> Also adjusts local-dev troubleshooting guidance (notably the “no state file” fix) to match the new recommendation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb6a5c95c8fac4f6723068cfad52e7bd623c9a36. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->