### PR TITLE
feat(annotation-queues): publish scores directly for deterministic system signals

### DIFF
--- a/apps/workers/src/workers/trace-end.test.ts
+++ b/apps/workers/src/workers/trace-end.test.ts
@@ -425,6 +425,9 @@ describe("runTraceEndJob", () => {
           filterMissCount: 0,
           startedWorkflowCount: 1,
         },
+        deterministicSystemMatches: {
+          matchedSlugs: [],
+        },
       },
     })
 
@@ -574,6 +577,9 @@ describe("createRunHandler", () => {
         sampledOutCount: 0,
         filterMissCount: 0,
         startedWorkflowCount: 1,
+      },
+      deterministicSystemMatches: {
+        matchedSlugs: [],
       },
     })
   })

--- a/apps/workers/src/workers/trace-end.ts
+++ b/apps/workers/src/workers/trace-end.ts
@@ -5,6 +5,7 @@ import {
   getProjectSystemQueuesUseCase,
   orchestrateTraceEndLiveQueueMaterializationUseCase,
   orchestrateTraceEndSystemQueueWorkflowStartsUseCase,
+  runDeterministicSystemMatchersUseCase,
 } from "@domain/annotation-queues"
 import {
   buildTraceEndEvaluationSelectionInputs,
@@ -20,11 +21,17 @@ import {
   type TraceEndItemDecisionCounts,
 } from "@domain/spans"
 import { RedisCacheStoreLive, type RedisClient } from "@platform/cache-redis"
-import { type ClickHouseClient, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import {
+  type ClickHouseClient,
+  ScoreAnalyticsRepositoryLive,
+  TraceRepositoryLive,
+  withClickHouse,
+} from "@platform/db-clickhouse"
 import {
   AnnotationQueueItemRepositoryLive,
   AnnotationQueueRepositoryLive,
   EvaluationRepositoryLive,
+  OutboxEventWriterLive,
   type PostgresClient,
   ScoreRepositoryLive,
   withPostgres,
@@ -83,12 +90,17 @@ type SystemQueueSummary = TraceEndItemDecisionCounts & {
   readonly startedWorkflowCount: number
 }
 
+type DeterministicSystemMatchesSummary = {
+  readonly matchedSlugs: readonly string[]
+}
+
 type TraceEndRunSummary = {
   readonly traceId: string
   readonly sessionId: string | null
   readonly evaluations: EvaluationSummary
   readonly liveQueues: LiveQueueSummary
   readonly systemQueues: SystemQueueSummary
+  readonly deterministicSystemMatches: DeterministicSystemMatchesSummary
 }
 
 type TraceEndRunResult =
@@ -272,6 +284,8 @@ export const runTraceEndJob =
         selectedSystemQueues,
       })
 
+      const { matchedSlugs } = yield* runDeterministicSystemMatchersUseCase({ trace: traceDetail })
+
       return {
         action: "completed",
         summary: {
@@ -294,6 +308,7 @@ export const runTraceEndJob =
             systemQueuesScanned: systemQueues.length,
             startedWorkflowCount,
           },
+          deterministicSystemMatches: { matchedSlugs },
         },
       } satisfies TraceEndRunResult
     }).pipe(
@@ -302,12 +317,17 @@ export const runTraceEndJob =
           AnnotationQueueItemRepositoryLive,
           AnnotationQueueRepositoryLive,
           EvaluationRepositoryLive,
+          OutboxEventWriterLive,
           ScoreRepositoryLive,
         ),
         postgresClient,
         OrganizationId(payload.organizationId),
       ),
-      withClickHouse(TraceRepositoryLive, clickhouseClient, OrganizationId(payload.organizationId)),
+      withClickHouse(
+        Layer.mergeAll(ScoreAnalyticsRepositoryLive, TraceRepositoryLive),
+        clickhouseClient,
+        OrganizationId(payload.organizationId),
+      ),
       Effect.provide(RedisCacheStoreLive(redisClient)),
       withTracing,
     )
@@ -334,6 +354,7 @@ export const createRunHandler =
             evaluations: result.summary.evaluations,
             liveQueues: result.summary.liveQueues,
             systemQueues: result.summary.systemQueues,
+            deterministicSystemMatches: result.summary.deterministicSystemMatches,
           })
         }),
       ),

--- a/docs/annotation-queues.md
+++ b/docs/annotation-queues.md
@@ -28,7 +28,7 @@ When a project is created:
 5. **Soft-Delete Aware**: Excludes trashed queues (`deleted_at IS NULL`) when checking existence
 6. **Cache Eviction**: After provisioning, evicts the Redis cache entry for the project's system queues
 
-The system queues are created with fixed slugs (`jailbreaking`, `refusal`, `frustration`, `forgetting`, `laziness`, `nsfw`, `trashing`, `tool-call-errors`, `resource-outliers`, `output-schema-validation`, `empty-response`) derived from their names, enabling slug-based routing throughout the pipeline.
+The system queues are created with fixed slugs (`jailbreaking`, `refusal`, `frustration`, `forgetting`, `laziness`, `nsfw`, `trashing`, `resource-outliers`) derived from their names, enabling slug-based routing throughout the pipeline. Other deterministic telemetry signals (`tool-call-errors`, `output-schema-validation`, `empty-response`) do **not** create annotation queues; they publish annotation scores directly from the trace-end runtime — see [Direct Deterministic System Signals](#direct-deterministic-system-signals).
 
 ### Caching
 
@@ -100,10 +100,6 @@ The Temporal workflow orchestrates queue evaluation through a three-step process
 
 **Current matcher coverage**:
 
-- **Deterministic matchers implemented**:
-  - `tool-call-errors`: inspects conversation history for malformed or failed tool interactions
-  - `output-schema-validation`: inspects assistant output text for malformed or truncated structured-output JSON
-  - `empty-response`: detects empty, whitespace-only, or degenerate assistant responses while intentionally skipping tool-call-only delegations
 - **Matcher entrypoints present but currently noop**:
   - `jailbreaking`
   - `refusal`
@@ -115,6 +111,8 @@ The Temporal workflow orchestrates queue evaluation through a three-step process
 
 - **Shared deterministic matcher implemented**:
   - `resource-outliers`: evaluates duration, TTFT, token usage, and cost against project-scoped percentile and median-x3 baselines using the shared trace cohort evaluator in `@domain/spans`
+
+Deterministic signals for `tool-call-errors`, `output-schema-validation`, and `empty-response` no longer flow through this flagger workflow. They run inline in the trace-end runtime and publish annotation scores directly — see [Direct Deterministic System Signals](#direct-deterministic-system-signals).
 
 **Resource outliers: queue `matched` vs traces UI**
 
@@ -149,6 +147,44 @@ If matched:
 ```
 
 The workflow now fully automates the path from trace to reviewable draft annotation.
+
+### Direct Deterministic System Signals
+
+Some deterministic signals are code-driven (zero false positives) and do not benefit from human review before becoming issues. Those skip the annotation queue entirely and publish annotation scores directly from the trace-end runtime so the existing `issues:discovery` pipeline (embeddings + BM25 hybrid search) can cluster them.
+
+**Signals handled inline** (no queue, no Temporal workflow, no LLM annotator):
+
+- `tool-call-errors`: inspects conversation history for malformed tool interactions or failed tool responses, and writes a score with feedback like `Tool "<name>" returned error: <snippet>`.
+- `output-schema-validation`: inspects assistant output text for malformed or truncated structured-output JSON, and writes a score with feedback like `Assistant output failed JSON parse (malformed or truncated structured output)`.
+- `empty-response`: detects empty, whitespace-only, or single-character degenerate assistant responses, and writes a score with feedback like `Assistant response was empty or whitespace only`. Intentional tool-call-only delegations are skipped.
+
+**Score shape** for each match:
+
+- `source = "annotation"`, `sourceId = "SYSTEM"` (new sentinel added alongside `UI`/`API`)
+- `draftedAt = null` (published immediately — not a draft)
+- `annotatorId = null` (system-authored)
+- `passed = false`, `value = 0`, `feedback = <deterministic template>`
+- `metadata.rawFeedback = feedback`
+
+Published scores emit `ScoreCreated` inside the same transaction, so `issues:discovery` picks them up and clusters them by feedback text similarity — identical signals collapse into one issue, while meaningfully different ones (different tool names, different error classes) form distinct issues.
+
+**Flow**:
+
+```
+SpanIngested (domain event, debounced)
+    ↓
+domain-events dispatcher
+    ↓
+trace-end:run (loads TraceDetail once)
+    ↓
+runDeterministicSystemMatchersUseCase (inline detector evaluation; matching detectors then persist scores)
+    ↓
+For each matching detector → writeScoreUseCase(source="annotation", sourceId="SYSTEM", draftedAt=null)
+    ↓
+ScoreCreated published → issues:discovery picks it up → issue created or attached
+```
+
+Because these signals are not gated by a queue sampling setting, every trace is evaluated.
 
 ### Key Infrastructure Files
 
@@ -223,25 +259,10 @@ Every project starts with these system-created manual queues:
 - description: the agent cycles between tools without making progress
 - instructions: use this queue when the agent repeatedly invokes the same tools or tool sequences, oscillates between states, or accumulates tool calls without advancing toward the goal. Do not use this queue for legitimate retries after transient errors or for iterative refinement that is visibly converging.
 
-### Tool Call Errors
-
-- description: a tool call failed or returned an error state
-- instructions: use this queue when the trace conversation history shows a failed tool result, a malformed tool interaction, or another clear tool-call failure signal. The deterministic matcher currently inspects conversation history directly instead of calling the low-cost flagger model.
-
 ### Resource Outliers
 
 - description: the trace has unusually high latency, TTFT, token usage, or cost
 - instructions: use this queue when latency, time to first token, token usage, or cost materially exceeds project norms. The matcher uses the shared trace cohort evaluator and workflow-owned retry handling when the candidate trace has not materialized yet.
-
-### Output Schema Validation
-
-- description: a structured-output response did not conform to the declared schema
-- instructions: use this queue when a GenAI span was configured to produce structured output and the actual assistant output either failed to parse as JSON or was visibly truncated before completion. The current deterministic matcher inspects assistant output text directly.
-
-### Empty Response
-
-- description: the assistant returned an empty or degenerate response
-- instructions: use this queue when a GenAI span produced no meaningful output — the response is empty, whitespace-only, a single repeated character, or otherwise degenerate when a substantive answer was expected. The current deterministic matcher intentionally skips tool-call-only delegations where the assistant hands control to tools without returning text.
 
 ## Population Flows
 
@@ -261,7 +282,7 @@ Every project starts with these system-created manual queues:
 - whenever a `SpanIngested` domain event is observed for a project, the `domain-events` dispatcher debounces and publishes `trace-end:run` for that trace
 - `trace-end:run` lists the cached non-deleted `system = true` queues in that project, applies each queue's `settings.sampling`, and starts one `systemQueueFlaggerWorkflow` per selected queue
 - queue evaluation is centralized in `runSystemQueueFlaggerUseCase`, which dispatches by `queueSlug` to the domain matcher map
-- the currently implemented deterministic matchers are `tool-call-errors`, `output-schema-validation`, `empty-response`, and `resource-outliers`
+- the currently implemented deterministic matchers are `resource-outliers`; other deterministic signals (`tool-call-errors`, `output-schema-validation`, `empty-response`) publish annotation scores directly from the trace-end runtime without going through this flagger — see [Direct Deterministic System Signals](#direct-deterministic-system-signals)
 - the remaining system queues already have matcher entrypoints, but they currently return `false` until their concrete classifiers are implemented
 - the workflow returns a boolean decision per queue; a trace may match none of the system-created queues, or several of them
 - positive workflow matches trigger `draftAnnotate` (LLM feedback generation) followed by `persistAnnotation` (transactional queue item + draft creation)

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -206,7 +206,7 @@ For the initial reliability events, `SpanIngested` publishes directly through `c
 ### Annotation queues
 
 - annotation queues are trace-based review backlogs; session context is derived from related traces that share `session_id`
-- each project starts with default system-created manual queues such as `Jailbreaking`, `Refusal`, `Frustration`, `Forgetting`, `Laziness`, `NSFW`, `Tool Call Errors`, and `Resource Outliers`
+- each project starts with default system-created manual queues such as `Jailbreaking`, `Refusal`, `Frustration`, `Forgetting`, `Laziness`, `NSFW`, `Trashing`, and `Resource Outliers`; deterministic telemetry signals (`tool-call-errors`, `output-schema-validation`, `empty-response`) skip the queue path and publish annotation scores directly so `issues:discovery` can cluster them
 - user-managed manual queues are populated from the trace dashboard table and the sessions dashboard table; session selection resolves to the newest trace and still creates `annotation_queue_items` with `trace_id` only and `completedAt = null`
 - system-created manual queues are marked with `system = true`, provision `settings.sampling` from a named default constant, and let users tune that sampling later without changing the canonical queue definitions
 - system-created manual queues are populated asynchronously from debounced `SpanIngested`: the `domain-events` dispatcher publishes `trace-end:run`, that runtime samples system queues first, and it starts one `system-queue-flagger` workflow per selected queue; the workflow performs deterministic routing or a limited-context flagger pass and, when it confirms a match, writes the queue item and pending-review draft annotation with full context

--- a/packages/domain/annotation-queues/src/constants.ts
+++ b/packages/domain/annotation-queues/src/constants.ts
@@ -145,35 +145,11 @@ export const SYSTEM_QUEUE_DEFINITIONS: readonly SystemQueueDefinition[] = [
     sampling: 10,
   },
   {
-    slug: "tool-call-errors",
-    name: "Tool Call Errors",
-    description: "A tool call failed or returned an error state",
-    instructions:
-      "Use this queue when a tool span errored, a tool execution failed, a malformed tool interaction occurred, or the conversation includes a tool-result message that clearly indicates failure. This queue is primarily matched through deterministic rules rather than the low-cost flagger model.",
-    sampling: 100,
-  },
-  {
     slug: "resource-outliers",
     name: "Resource Outliers",
     description: "The trace has unusually high latency, TTFT, token usage, or cost",
     instructions:
       "Use this queue when latency, time to first token, token usage, or cost materially exceeds project norms. This queue is primarily matched through deterministic outlier checks against project percentiles, medians, and configured thresholds rather than the low-cost flagger model.",
-    sampling: 100,
-  },
-  {
-    slug: "output-schema-validation",
-    name: "Output Schema Validation",
-    description: "a structured-output response did not conform to the declared schema",
-    instructions:
-      "Use this queue when a GenAI span was configured to produce structured output (JSON schema, JSON object, or tool-call response format) and the actual output either failed to parse or was truncated before completion.",
-    sampling: 100,
-  },
-  {
-    slug: "empty-response",
-    name: "Empty Response",
-    description: "the assistant returned an empty or degenerate response",
-    instructions:
-      "Use this queue when a GenAI span produced no meaningful output — the response is empty, whitespace-only, a single repeated character, or otherwise degenerate when a substantive answer was expected. Do not use this queue for intentionally empty tool-call-only responses where the model delegates entirely to tool use, or for spans whose finish_reasons indicate a content filter block (those are a distinct failure mode).",
     sampling: 100,
   },
 ] as const

--- a/packages/domain/annotation-queues/src/helpers.test.ts
+++ b/packages/domain/annotation-queues/src/helpers.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest"
 import {
   annotationQueueItemStatus,
   annotationQueueItemStatusRankFromTimestamps,
-  matchesToolCallErrorsSystemQueue,
+  detectOutputSchemaValidationSystemQueue,
+  detectToolCallErrorsSystemQueue,
 } from "./helpers.ts"
 
 const d = (s: string) => new Date(s)
@@ -24,6 +25,17 @@ function toolResponse(id: string, response: unknown): TraceMessage {
   return {
     role: "tool",
     parts: [{ type: "tool_call_response", id, response }],
+  }
+}
+
+function makeOutputTrace(outputMessages: TraceDetail["outputMessages"]): TraceDetail {
+  return { outputMessages } as TraceDetail
+}
+
+function assistantText(content: string): TraceDetail["outputMessages"][number] {
+  return {
+    role: "assistant",
+    parts: [{ type: "text", content }],
   }
 }
 
@@ -49,140 +61,172 @@ describe("annotationQueueItemStatusRankFromTimestamps", () => {
   })
 })
 
-describe("matchesToolCallErrorsSystemQueue", () => {
-  it("matches failed tool result payloads in conversation history", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+describe("detectToolCallErrorsSystemQueue", () => {
+  it("matches failed tool result payloads and includes the tool name + error snippet", () => {
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { ok: false, error: "timeout" })]),
     )
 
-    expect(matched).toBe(true)
+    expect(result).toEqual({ matched: true, feedback: 'Tool "get_weather" returned error: timeout' })
   })
 
-  it("matches malformed tool interactions in conversation history", () => {
-    const matched = matchesToolCallErrorsSystemQueue(makeTrace([assistantToolCall("")]))
+  it("matches malformed tool interactions with empty tool_call id", () => {
+    const result = detectToolCallErrorsSystemQueue(makeTrace([assistantToolCall("")]))
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("Malformed tool call")
+      expect(result.feedback).toContain("get_weather")
+    }
   })
 
   it("does not match healthy tool interactions", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { temp: 22, condition: "sunny" })]),
     )
 
-    expect(matched).toBe(false)
+    expect(result).toEqual({ matched: false })
   })
 
   it("matches duplicated tool call ids", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), assistantToolCall("call-weather", "lookup_weather")]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("Duplicate tool_call id")
+      expect(result.feedback).toContain("lookup_weather")
+    }
   })
 
   it("matches tool calls with blank names after trimming", () => {
-    const matched = matchesToolCallErrorsSystemQueue(makeTrace([assistantToolCall("call-weather", "   ")]))
+    const result = detectToolCallErrorsSystemQueue(makeTrace([assistantToolCall("call-weather", "   ")]))
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("Malformed tool call")
+    }
   })
 
   it("matches tool responses that appear before any tool call", () => {
-    const matched = matchesToolCallErrorsSystemQueue(makeTrace([toolResponse("call-weather", { temp: 22 })]))
+    const result = detectToolCallErrorsSystemQueue(makeTrace([toolResponse("call-weather", { temp: 22 })]))
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("unknown tool_call id")
+    }
   })
 
   it("matches tool responses with unknown tool call ids", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-hotels", { temp: 22 })]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain("unknown tool_call id")
+    }
   })
 
-  it("matches plain-string error responses", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+  it("matches plain-string error responses and quotes the string as the snippet", () => {
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([
         assistantToolCall("call-weather"),
         toolResponse("call-weather", "BookingUnavailableError: no rooms available"),
       ]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe('Tool "get_weather" returned error: BookingUnavailableError: no rooms available')
+    }
   })
 
   it("matches stringified JSON responses with failure status", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", '{"status":"failed"}')]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain('Tool "get_weather" returned error')
+    }
   })
 
   it("matches explicit isError true responses", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { isError: true })]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe('Tool "get_weather" returned an error')
+    }
   })
 
   it("matches explicit success false responses", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { success: false })]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
   })
 
-  it("matches non-empty error fields", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
-      makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { error: { code: "timeout" } })]),
+  it("matches non-empty error object responses", () => {
+    const result = detectToolCallErrorsSystemQueue(
+      makeTrace([
+        assistantToolCall("call-weather"),
+        toolResponse("call-weather", { error: { code: "timeout", message: "upstream timeout" } }),
+      ]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toContain('Tool "get_weather" returned error: upstream timeout')
+    }
   })
 
   it("matches non-empty errors arrays", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([
         assistantToolCall("call-weather"),
         toolResponse("call-weather", { errors: [{ message: "timeout" }] }),
       ]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
   })
 
   it("matches nested array responses containing a failure", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", [{ ok: true }, { status: "error" }])]),
     )
 
-    expect(matched).toBe(true)
+    expect(result.matched).toBe(true)
   })
 
   it("does not match blank string responses", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", "   ")]),
     )
 
-    expect(matched).toBe(false)
+    expect(result).toEqual({ matched: false })
   })
 
   it("does not match responses with empty error fields", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([
         assistantToolCall("call-weather"),
         toolResponse("call-weather", { ok: true, error: "", errors: [], status: "success" }),
       ]),
     )
 
-    expect(matched).toBe(false)
+    expect(result).toEqual({ matched: false })
   })
 
   it("does not match multiple healthy tool call / response pairs", () => {
-    const matched = matchesToolCallErrorsSystemQueue(
+    const result = detectToolCallErrorsSystemQueue(
       makeTrace([
         assistantToolCall("call-weather"),
         toolResponse("call-weather", { temp: 22 }),
@@ -191,6 +235,58 @@ describe("matchesToolCallErrorsSystemQueue", () => {
       ]),
     )
 
-    expect(matched).toBe(false)
+    expect(result).toEqual({ matched: false })
+  })
+})
+
+describe("detectOutputSchemaValidationSystemQueue", () => {
+  it("does not match when the assistant output is valid JSON", () => {
+    const result = detectOutputSchemaValidationSystemQueue(makeOutputTrace([assistantText('{"a": 1, "b": 2}')]))
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("does not match when the assistant output is not JSON-looking", () => {
+    const result = detectOutputSchemaValidationSystemQueue(makeOutputTrace([assistantText("Hello! The answer is 42.")]))
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("matches with the trailing-comma message when JSON is truncated after a comma", () => {
+    // Order matters: the trailing-comma heuristic runs before JSON.parse so its
+    // specific clustering message takes precedence over the generic parse-failure one.
+    const result = detectOutputSchemaValidationSystemQueue(makeOutputTrace([assistantText('{"a": 1,')]))
+
+    expect(result).toEqual({
+      matched: true,
+      feedback: "Assistant output ended with a trailing comma, suggesting truncated JSON",
+    })
+  })
+
+  it("matches with the unclosed-string message when JSON is truncated mid-string", () => {
+    const result = detectOutputSchemaValidationSystemQueue(makeOutputTrace([assistantText('{"msg": "hello')]))
+
+    expect(result).toEqual({
+      matched: true,
+      feedback: "Assistant output contains an unclosed JSON string, suggesting truncated output",
+    })
+  })
+
+  it("ignores escaped quotes when detecting unclosed strings", () => {
+    // The outer string is properly closed — the \" inside should not flip the balance.
+    const result = detectOutputSchemaValidationSystemQueue(
+      makeOutputTrace([assistantText('{"msg": "quoted \\"ok\\" value"}')]),
+    )
+
+    expect(result).toEqual({ matched: false })
+  })
+
+  it("falls back to the generic parse-failure message when JSON is malformed but not a truncation pattern", () => {
+    const result = detectOutputSchemaValidationSystemQueue(makeOutputTrace([assistantText("{not valid json}")]))
+
+    expect(result).toEqual({
+      matched: true,
+      feedback: "Assistant output failed JSON parse (malformed or truncated structured output)",
+    })
   })
 })

--- a/packages/domain/annotation-queues/src/helpers.ts
+++ b/packages/domain/annotation-queues/src/helpers.ts
@@ -6,15 +6,25 @@ type TraceMessagesOnly = Pick<TraceDetail, "allMessages">
 const TOOL_RESULT_ERROR_TEXT = /(^error\b|error:\s*|\bfailed\b|\bfailure\b|\bexception\b|\btimeout\b|\bunavailable\b)/i
 const TOOL_RESULT_ERROR_STATUSES = new Set(["error", "failed", "failure"])
 
+const ERROR_SNIPPET_MAX_LENGTH = 160
+
+export type DeterministicSystemMatch =
+  | { readonly matched: true; readonly feedback: string }
+  | { readonly matched: false }
+
+const NO_MATCH: DeterministicSystemMatch = { matched: false }
+
+const match = (feedback: string): DeterministicSystemMatch => ({ matched: true, feedback })
+
 function coalesceInstant(v: Date | string | null | undefined): Date | null {
   if (v == null) return null
   const d = v instanceof Date ? v : new Date(v)
   return Number.isNaN(d.getTime()) ? null : d
 }
 
-/** Matches the Tool Call Errors system queue without any LLM classification. */
-export function matchesToolCallErrorsSystemQueue(trace: TraceMessagesOnly): boolean {
-  const seenToolCallIds = new Set<string>()
+/** Detects tool-call failures in the conversation and returns clusterable feedback on match. */
+export function detectToolCallErrorsSystemQueue(trace: TraceMessagesOnly): DeterministicSystemMatch {
+  const toolNameById = new Map<string, string>()
 
   for (const message of trace.allMessages) {
     for (const part of message.parts) {
@@ -22,28 +32,35 @@ export function matchesToolCallErrorsSystemQueue(trace: TraceMessagesOnly): bool
         const toolCallId = typeof part.id === "string" ? part.id.trim() : ""
         const toolName = typeof part.name === "string" ? part.name.trim() : ""
 
-        if (!toolCallId || !toolName || seenToolCallIds.has(toolCallId)) {
-          return true
+        if (!toolCallId || !toolName) {
+          const label = toolName ? `tool "${toolName}"` : "an unnamed tool"
+          return match(`Malformed tool call: ${label} with missing or empty tool_call id`)
         }
 
-        seenToolCallIds.add(toolCallId)
+        if (toolNameById.has(toolCallId)) {
+          return match(`Duplicate tool_call id emitted for tool "${toolName}"`)
+        }
+
+        toolNameById.set(toolCallId, toolName)
         continue
       }
 
       if (part.type !== "tool_call_response") continue
 
       const toolCallId = typeof part.id === "string" ? part.id.trim() : ""
-      if (!toolCallId || !seenToolCallIds.has(toolCallId)) {
-        return true
+      if (!toolCallId || !toolNameById.has(toolCallId)) {
+        return match(`Tool response references an unknown tool_call id "${toolCallId || "<empty>"}"`)
       }
 
       if (responseIndicatesFailure(part.response)) {
-        return true
+        const toolName = toolNameById.get(toolCallId) ?? "<unknown>"
+        const snippet = extractErrorSnippet(part.response)
+        return match(snippet ? `Tool "${toolName}" returned error: ${snippet}` : `Tool "${toolName}" returned an error`)
       }
     }
   }
 
-  return false
+  return NO_MATCH
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -52,6 +69,43 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function toNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim() !== "" ? value.trim() : null
+}
+
+function truncate(s: string | null): string | null {
+  if (!s) return null
+  return s.length > ERROR_SNIPPET_MAX_LENGTH ? `${s.slice(0, ERROR_SNIPPET_MAX_LENGTH)}…` : s
+}
+
+function extractErrorSnippet(response: unknown): string | null {
+  if (typeof response === "string") return truncate(response.trim() || null)
+
+  if (Array.isArray(response)) {
+    for (const item of response) {
+      const extracted = extractErrorSnippet(item)
+      if (extracted) return extracted
+    }
+    return null
+  }
+
+  if (!isRecord(response)) return null
+
+  const errorField = response.error
+  if (typeof errorField === "string") {
+    const snippet = truncate(errorField.trim() || null)
+    if (snippet) return snippet
+  }
+  if (isRecord(errorField)) {
+    const inner = toNonEmptyString(errorField.message) ?? toNonEmptyString(errorField.error)
+    if (inner) return truncate(inner)
+  }
+
+  const message = toNonEmptyString(response.message)
+  if (message) return truncate(message)
+
+  const status = toNonEmptyString(response.status)
+  if (status) return truncate(`status=${status}`)
+
+  return null
 }
 
 function responseIndicatesFailure(response: unknown): boolean {
@@ -95,8 +149,8 @@ function responseIndicatesFailure(response: unknown): boolean {
   return false
 }
 
-/** Matches the Output Schema Validation system queue without any LLM classification. */
-export function matchesOutputSchemaValidationSystemQueue(trace: TraceDetail): boolean {
+/** Detects malformed or truncated structured-output JSON in assistant text parts. */
+export function detectOutputSchemaValidationSystemQueue(trace: TraceDetail): DeterministicSystemMatch {
   for (const message of trace.outputMessages) {
     if (message.role !== "assistant") continue
 
@@ -109,21 +163,15 @@ export function matchesOutputSchemaValidationSystemQueue(trace: TraceDetail): bo
       // Only check content that looks like JSON (starts with { or [)
       if (!content.startsWith("{") && !content.startsWith("[")) continue
 
-      // Attempt to parse as JSON
-      try {
-        JSON.parse(content)
-      } catch {
-        // JSON parsing failed - malformed or truncated JSON detected
-        return true
-      }
+      // Run the specific truncation heuristics first so their clustering messages
+      // are preferred over the generic parse-failure fallback.
 
-      // Check for truncation patterns that might pass JSON.parse but are incomplete
-      // e.g., content ending with comma suggests more data expected
+      // Trailing comma suggests the output was cut off mid-collection
       if (content.endsWith(",")) {
-        return true
+        return match("Assistant output ended with a trailing comma, suggesting truncated JSON")
       }
 
-      // Check for unclosed strings (odd number of unescaped quotes)
+      // Unclosed string (odd number of unescaped quotes) suggests mid-string truncation
       let inString = false
       let escaped = false
       for (let i = 0; i < content.length; i++) {
@@ -141,16 +189,22 @@ export function matchesOutputSchemaValidationSystemQueue(trace: TraceDetail): bo
         }
       }
       if (inString) {
-        return true
+        return match("Assistant output contains an unclosed JSON string, suggesting truncated output")
+      }
+
+      try {
+        JSON.parse(content)
+      } catch {
+        return match("Assistant output failed JSON parse (malformed or truncated structured output)")
       }
     }
   }
 
-  return false
+  return NO_MATCH
 }
 
-/** Matches the Empty Response system queue without any LLM classification. */
-export function matchesEmptyResponseSystemQueue(trace: TraceDetail): boolean {
+/** Detects empty or degenerate assistant responses, skipping intentional tool-call-only delegations. */
+export function detectEmptyResponseSystemQueue(trace: TraceDetail): DeterministicSystemMatch {
   for (const message of trace.outputMessages) {
     if (message.role !== "assistant") continue
 
@@ -176,18 +230,20 @@ export function matchesEmptyResponseSystemQueue(trace: TraceDetail): boolean {
     // Skip tool-call-only responses (intentional delegation - don't flag)
     if (hasToolCall && !hasText) continue
 
-    // Check accumulated text content
     const accumulatedText = textParts.join("").trim()
 
-    // Empty or whitespace-only
-    if (accumulatedText === "") return true
+    if (accumulatedText === "") {
+      return match("Assistant response was empty or whitespace only")
+    }
 
-    // Degenerate pattern: single character repeated 3+ times
-    // Matches patterns like "...", "aaa", "!!!", "   "
-    if (accumulatedText.length >= 3 && new Set(accumulatedText).size === 1) return true
+    // Degenerate pattern: single character repeated 3+ times (e.g. "...", "aaa", "!!!")
+    if (accumulatedText.length >= 3 && new Set(accumulatedText).size === 1) {
+      const char = accumulatedText[0]
+      return match(`Assistant response was degenerate: only the character "${char}" repeated`)
+    }
   }
 
-  return false
+  return NO_MATCH
 }
 
 /** Accepts entity dates or ISO strings (e.g. from API records). */

--- a/packages/domain/annotation-queues/src/index.ts
+++ b/packages/domain/annotation-queues/src/index.ts
@@ -36,9 +36,10 @@ export type { TraceSelection } from "./helpers/bulk-create-from-traces-helpers.t
 export {
   annotationQueueItemStatus,
   annotationQueueItemStatusRankFromTimestamps,
-  matchesEmptyResponseSystemQueue,
-  matchesOutputSchemaValidationSystemQueue,
-  matchesToolCallErrorsSystemQueue,
+  type DeterministicSystemMatch,
+  detectEmptyResponseSystemQueue,
+  detectOutputSchemaValidationSystemQueue,
+  detectToolCallErrorsSystemQueue,
 } from "./helpers.ts"
 export {
   type AdjacentItems,
@@ -143,6 +144,13 @@ export {
   type RequestBulkQueueItemsInput,
   requestBulkQueueItems,
 } from "./use-cases/request-bulk-queue-items.ts"
+export {
+  DETERMINISTIC_SYSTEM_MATCHERS,
+  type RunDeterministicSystemMatchersError,
+  type RunDeterministicSystemMatchersInput,
+  type RunDeterministicSystemMatchersResult,
+  runDeterministicSystemMatchersUseCase,
+} from "./use-cases/run-deterministic-system-matchers.ts"
 export {
   type RunSystemQueueAnnotatorError,
   type RunSystemQueueAnnotatorInput,

--- a/packages/domain/annotation-queues/src/use-cases/run-deterministic-system-matchers.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-deterministic-system-matchers.test.ts
@@ -1,0 +1,201 @@
+import { OutboxEventWriter } from "@domain/events"
+import { ScoreAnalyticsRepository, ScoreRepository } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository, createFakeScoreRepository } from "@domain/scores/testing"
+import {
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  SqlClient,
+  TraceId,
+} from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import type { TraceDetail } from "@domain/spans"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { runDeterministicSystemMatchersUseCase } from "./run-deterministic-system-matchers.ts"
+
+const ORG_ID = OrganizationId("a".repeat(24))
+const PROJECT_ID = ProjectId("b".repeat(24))
+const TRACE_ID = TraceId("c".repeat(32))
+
+function createTestLayers() {
+  const events: Array<{ readonly eventName: string; readonly payload: unknown }> = []
+  const { repository: scoreRepository, scores: store } = createFakeScoreRepository()
+  const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository()
+
+  const layer = Layer.mergeAll(
+    Layer.succeed(ScoreRepository, scoreRepository),
+    Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+    Layer.succeed(OutboxEventWriter, {
+      write: (event) =>
+        Effect.sync(() => {
+          events.push({ eventName: event.eventName, payload: event.payload })
+        }),
+    }),
+    Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+  )
+
+  return { store, events, layer }
+}
+
+function makeTraceDetail(overrides?: Partial<TraceDetail>): TraceDetail {
+  return {
+    organizationId: ORG_ID,
+    projectId: PROJECT_ID,
+    traceId: TRACE_ID,
+    spanCount: 2,
+    errorCount: 0,
+    startTime: new Date("2026-01-01T00:00:00.000Z"),
+    endTime: new Date("2026-01-01T00:00:01.000Z"),
+    durationNs: 1_000_000,
+    timeToFirstTokenNs: 0,
+    tokensInput: 10,
+    tokensOutput: 5,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    tokensTotal: 15,
+    costInputMicrocents: 10,
+    costOutputMicrocents: 5,
+    costTotalMicrocents: 15,
+    sessionId: SessionId("session-1"),
+    userId: ExternalUserId("user-1"),
+    simulationId: SimulationId(""),
+    tags: [],
+    metadata: {},
+    models: ["gpt-4o-mini"],
+    providers: ["openai"],
+    serviceNames: ["web"],
+    rootSpanId: SpanId("r".repeat(16)),
+    rootSpanName: "root",
+    systemInstructions: [],
+    inputMessages: [],
+    outputMessages: [],
+    allMessages: [],
+    ...overrides,
+  }
+}
+
+describe("runDeterministicSystemMatchersUseCase", () => {
+  it("returns no matches and writes no scores when the trace is healthy", async () => {
+    const { store, events, layer } = createTestLayers()
+
+    const trace = makeTraceDetail({
+      allMessages: [
+        {
+          role: "user",
+          parts: [{ type: "text", content: "hi" }],
+        },
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello, how can I help?" }],
+        },
+      ],
+      outputMessages: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "Hello, how can I help?" }],
+        },
+      ],
+    })
+
+    const result = await Effect.runPromise(runDeterministicSystemMatchersUseCase({ trace }).pipe(Effect.provide(layer)))
+
+    expect(result).toEqual({ matchedSlugs: [] })
+    expect(store.size).toBe(0)
+    expect(events).toHaveLength(0)
+  })
+
+  it("writes a published annotation score with SYSTEM sourceId for tool-call-errors", async () => {
+    const { store, events, layer } = createTestLayers()
+
+    const trace = makeTraceDetail({
+      allMessages: [
+        {
+          role: "assistant",
+          parts: [{ type: "tool_call", id: "call-weather", name: "get_weather", arguments: { city: "BCN" } }],
+        },
+        {
+          role: "tool",
+          parts: [{ type: "tool_call_response", id: "call-weather", response: { ok: false, error: "timeout" } }],
+        },
+      ],
+    })
+
+    const result = await Effect.runPromise(runDeterministicSystemMatchersUseCase({ trace }).pipe(Effect.provide(layer)))
+
+    expect(result).toEqual({ matchedSlugs: ["tool-call-errors"] })
+    expect(store.size).toBe(1)
+
+    const [score] = [...store.values()]
+    expect(score.source).toBe("annotation")
+    expect(score.sourceId).toBe("SYSTEM")
+    expect(score.draftedAt).toBeNull()
+    expect(score.annotatorId).toBeNull()
+    expect(score.passed).toBe(false)
+    expect(score.value).toBe(0)
+    expect(score.feedback).toBe('Tool "get_weather" returned error: timeout')
+    if (score.source === "annotation") {
+      expect(score.metadata.rawFeedback).toBe('Tool "get_weather" returned error: timeout')
+    }
+
+    expect(events).toHaveLength(1)
+    expect(events[0].eventName).toBe("ScoreCreated")
+    expect(events[0].payload).toMatchObject({ status: "published" })
+  })
+
+  it("writes multiple scores when several matchers fire for the same trace", async () => {
+    const { store, events, layer } = createTestLayers()
+
+    const trace = makeTraceDetail({
+      allMessages: [
+        {
+          role: "assistant",
+          parts: [{ type: "tool_call", id: "call-weather", name: "get_weather", arguments: { city: "BCN" } }],
+        },
+        {
+          role: "tool",
+          parts: [{ type: "tool_call_response", id: "call-weather", response: { ok: false, error: "timeout" } }],
+        },
+      ],
+      outputMessages: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "" }],
+        },
+      ],
+    })
+
+    const result = await Effect.runPromise(runDeterministicSystemMatchersUseCase({ trace }).pipe(Effect.provide(layer)))
+
+    expect(result).toEqual({ matchedSlugs: ["tool-call-errors", "empty-response"] })
+    expect(store.size).toBe(2)
+    expect(events).toHaveLength(2)
+    for (const event of events) {
+      expect(event.eventName).toBe("ScoreCreated")
+      expect(event.payload).toMatchObject({ status: "published" })
+    }
+  })
+
+  it("coerces empty simulationId sentinel to null on the written score", async () => {
+    const { store, layer } = createTestLayers()
+
+    const trace = makeTraceDetail({
+      simulationId: SimulationId(""),
+      outputMessages: [
+        {
+          role: "assistant",
+          parts: [{ type: "text", content: "" }],
+        },
+      ],
+    })
+
+    await Effect.runPromise(runDeterministicSystemMatchersUseCase({ trace }).pipe(Effect.provide(layer)))
+
+    const [score] = [...store.values()]
+    expect(score.simulationId).toBeNull()
+  })
+})

--- a/packages/domain/annotation-queues/src/use-cases/run-deterministic-system-matchers.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-deterministic-system-matchers.ts
@@ -1,0 +1,82 @@
+import { type ScoreDraftClosedError, type ScoreDraftUpdateConflictError, writeScoreUseCase } from "@domain/scores"
+import type { BadRequestError, RepositoryError } from "@domain/shared"
+import type { TraceDetail } from "@domain/spans"
+import { Effect } from "effect"
+import {
+  type DeterministicSystemMatch,
+  detectEmptyResponseSystemQueue,
+  detectOutputSchemaValidationSystemQueue,
+  detectToolCallErrorsSystemQueue,
+} from "../helpers.ts"
+
+export interface RunDeterministicSystemMatchersInput {
+  readonly trace: TraceDetail
+}
+
+export interface RunDeterministicSystemMatchersResult {
+  readonly matchedSlugs: readonly string[]
+}
+
+export type RunDeterministicSystemMatchersError =
+  | RepositoryError
+  | BadRequestError
+  | ScoreDraftClosedError
+  | ScoreDraftUpdateConflictError
+
+interface DeterministicMatcherEntry {
+  readonly slug: string
+  readonly detect: (trace: TraceDetail) => DeterministicSystemMatch
+}
+
+export const DETERMINISTIC_SYSTEM_MATCHERS: readonly DeterministicMatcherEntry[] = [
+  { slug: "tool-call-errors", detect: detectToolCallErrorsSystemQueue },
+  { slug: "output-schema-validation", detect: detectOutputSchemaValidationSystemQueue },
+  { slug: "empty-response", detect: detectEmptyResponseSystemQueue },
+]
+
+/**
+ * Runs the deterministic system matchers against a trace and writes a published,
+ * system-authored annotation score for each match.
+ *
+ * The scores use `source="annotation"`, `sourceId="SYSTEM"`, `draftedAt=null`,
+ * `annotatorId=null`, `passed=false`, so the `ScoreCreated` event makes them
+ * immediately eligible for `issues:discovery` and the feedback text drives
+ * clustering via embedding + BM25.
+ */
+export const runDeterministicSystemMatchersUseCase = Effect.fn("annotationQueues.runDeterministicSystemMatchers")(
+  function* (input: RunDeterministicSystemMatchersInput) {
+    const { trace } = input
+    yield* Effect.annotateCurrentSpan("projectId", trace.projectId)
+    yield* Effect.annotateCurrentSpan("traceId", trace.traceId)
+
+    const simulationId = trace.simulationId === "" ? null : trace.simulationId
+    const matchedSlugs: string[] = []
+
+    for (const { slug, detect } of DETERMINISTIC_SYSTEM_MATCHERS) {
+      const result = detect(trace)
+      if (!result.matched) continue
+
+      yield* writeScoreUseCase({
+        projectId: trace.projectId,
+        source: "annotation",
+        sourceId: "SYSTEM",
+        sessionId: trace.sessionId,
+        traceId: trace.traceId,
+        spanId: null,
+        simulationId,
+        issueId: null,
+        annotatorId: null,
+        value: 0,
+        passed: false,
+        feedback: result.feedback,
+        metadata: { rawFeedback: result.feedback },
+        error: null,
+        draftedAt: null,
+      })
+
+      matchedSlugs.push(slug)
+    }
+
+    return { matchedSlugs } satisfies RunDeterministicSystemMatchersResult
+  },
+)

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.test.ts
@@ -55,37 +55,6 @@ function makeTraceDetail(
 }
 
 describe("runSystemQueueFlaggerUseCase", () => {
-  it("matches tool-call-errors from conversation history without calling AI", async () => {
-    const { repository } = createFakeTraceRepository({
-      findByTraceId: () =>
-        Effect.succeed(
-          makeTraceDetail([
-            {
-              role: "assistant",
-              parts: [{ type: "tool_call", id: "call-weather", name: "get_weather", arguments: { city: "BCN" } }],
-            },
-            {
-              role: "tool",
-              parts: [{ type: "tool_call_response", id: "call-weather", response: "timeout error" }],
-            },
-          ]),
-        ),
-    })
-
-    const { calls, layer: aiLayer } = createFakeAI({
-      generate: () => Effect.die("AI should not be called for deterministic flaggers"),
-    })
-
-    const result = await Effect.runPromise(
-      runSystemQueueFlaggerUseCase({ ...INPUT, queueSlug: "tool-call-errors" }).pipe(
-        Effect.provide(Layer.merge(Layer.succeed(TraceRepository, repository), aiLayer)),
-      ),
-    )
-
-    expect(result).toEqual({ matched: true })
-    expect(calls.generate).toHaveLength(0)
-  })
-
   it("uses the LLM flagger for jailbreaking", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -24,11 +24,6 @@ import {
   SYSTEM_QUEUE_FLAGGER_MAX_TOKENS,
   SYSTEM_QUEUE_FLAGGER_MODEL,
 } from "../constants.ts"
-import {
-  matchesEmptyResponseSystemQueue,
-  matchesOutputSchemaValidationSystemQueue,
-  matchesToolCallErrorsSystemQueue,
-} from "../helpers.ts"
 
 export interface RunSystemQueueFlaggerInput {
   readonly organizationId: string
@@ -44,11 +39,7 @@ export interface RunSystemQueueFlaggerResult {
 
 export type RunSystemQueueFlaggerError = NotFoundError | RepositoryError | AIError | AICredentialError
 
-type DeterministicSystemQueueSlug =
-  | "empty-response"
-  | "output-schema-validation"
-  | "resource-outliers"
-  | "tool-call-errors"
+type DeterministicSystemQueueSlug = "resource-outliers"
 type LlmSystemQueueSlug = "jailbreaking" | "refusal" | "frustration" | "forgetting" | "laziness" | "nsfw" | "trashing"
 
 // Effect-based matcher: loads trace via repository and returns full result with optional match reasons
@@ -58,26 +49,6 @@ type SystemQueueMatcher = (
 
 // Effect-based matchers that load trace and apply domain logic
 const deterministicQueueMatchers: Record<DeterministicSystemQueueSlug, SystemQueueMatcher> = {
-  "empty-response": (input) =>
-    Effect.gen(function* () {
-      const traceRepository = yield* TraceRepository
-      const trace = yield* traceRepository.findByTraceId({
-        organizationId: OrganizationId(input.organizationId),
-        projectId: ProjectId(input.projectId),
-        traceId: TraceId(input.traceId),
-      })
-      return { matched: matchesEmptyResponseSystemQueue(trace) }
-    }),
-  "output-schema-validation": (input) =>
-    Effect.gen(function* () {
-      const traceRepository = yield* TraceRepository
-      const trace = yield* traceRepository.findByTraceId({
-        organizationId: OrganizationId(input.organizationId),
-        projectId: ProjectId(input.projectId),
-        traceId: TraceId(input.traceId),
-      })
-      return { matched: matchesOutputSchemaValidationSystemQueue(trace) }
-    }),
   "resource-outliers": (input) =>
     Effect.gen(function* () {
       const evaluation = yield* evaluateTraceResourceOutliersUseCase({
@@ -86,16 +57,6 @@ const deterministicQueueMatchers: Record<DeterministicSystemQueueSlug, SystemQue
         traceId: TraceId(input.traceId),
       })
       return { matched: evaluation.matched, matchReasons: evaluation.reasons }
-    }),
-  "tool-call-errors": (input) =>
-    Effect.gen(function* () {
-      const traceRepository = yield* TraceRepository
-      const trace = yield* traceRepository.findByTraceId({
-        organizationId: OrganizationId(input.organizationId),
-        projectId: ProjectId(input.projectId),
-        traceId: TraceId(input.traceId),
-      })
-      return { matched: matchesToolCallErrorsSystemQueue(trace) }
     }),
 }
 

--- a/packages/domain/annotations/src/helpers/get-annotation-provenance.test.ts
+++ b/packages/domain/annotations/src/helpers/get-annotation-provenance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { getAnnotationProvenance } from "./get-annotation-provenance.ts"
+
+const CUID = "a".repeat(24)
+const USER_ID = "u".repeat(24)
+
+describe("getAnnotationProvenance", () => {
+  it('returns "human" whenever annotatorId is set, regardless of sourceId', () => {
+    for (const sourceId of ["UI", "API", "SYSTEM", CUID, "random"]) {
+      expect(getAnnotationProvenance({ sourceId, annotatorId: USER_ID })).toBe("human")
+    }
+  })
+
+  it('returns "api" when annotatorId is null and sourceId is "API"', () => {
+    expect(getAnnotationProvenance({ sourceId: "API", annotatorId: null })).toBe("api")
+  })
+
+  it('returns "agent" when annotatorId is null and sourceId is "SYSTEM"', () => {
+    expect(getAnnotationProvenance({ sourceId: "SYSTEM", annotatorId: null })).toBe("agent")
+  })
+
+  it('returns "agent" when annotatorId is null and sourceId is a cuid (legacy queue-id case)', () => {
+    expect(getAnnotationProvenance({ sourceId: CUID, annotatorId: null })).toBe("agent")
+  })
+
+  it('returns null when annotatorId is null and sourceId is the "UI" sentinel (no human is attached)', () => {
+    expect(getAnnotationProvenance({ sourceId: "UI", annotatorId: null })).toBeNull()
+  })
+
+  it("returns null when annotatorId is null and sourceId is neither a known sentinel nor a valid cuid", () => {
+    expect(getAnnotationProvenance({ sourceId: "something-else", annotatorId: null })).toBeNull()
+    expect(getAnnotationProvenance({ sourceId: "", annotatorId: null })).toBeNull()
+  })
+})

--- a/packages/domain/annotations/src/helpers/get-annotation-provenance.ts
+++ b/packages/domain/annotations/src/helpers/get-annotation-provenance.ts
@@ -15,7 +15,7 @@ export function getAnnotationProvenance(annotation: AnnotationProvenanceInput): 
 
   if (sourceId === "API") return "api"
 
-  if (isValidId(sourceId)) return "agent"
+  if (sourceId === "SYSTEM" || isValidId(sourceId)) return "agent"
 
   return null
 }

--- a/packages/domain/scores/src/constants.ts
+++ b/packages/domain/scores/src/constants.ts
@@ -1,6 +1,6 @@
 export const SCORE_SOURCES = ["evaluation", "annotation", "custom"] as const
 
-export const ANNOTATION_SCORE_PARTIAL_SOURCE_IDS = ["UI", "API"] as const
+export const ANNOTATION_SCORE_PARTIAL_SOURCE_IDS = ["UI", "API", "SYSTEM"] as const
 
 export const SCORE_SOURCE_ID_MAX_LENGTH = 128
 

--- a/tools/live-seeds/src/fixtures.ts
+++ b/tools/live-seeds/src/fixtures.ts
@@ -5,6 +5,7 @@ import { offServiceLiveQueueInFixture } from "./fixtures/off-service-live-queue-
 import { offServiceLiveQueueOutFixture } from "./fixtures/off-service-live-queue-out.ts"
 import { outputSchemaFixture } from "./fixtures/output-schema.ts"
 import { supportEvalsOutFixture } from "./fixtures/support-evals-out.ts"
+import { systemSignalsIssueProbeFixture } from "./fixtures/system-signals-issue-probe.ts"
 import { toolCallErrorFixture } from "./fixtures/tool-call-error.ts"
 import { warrantyEvalInFixture } from "./fixtures/warranty-eval-in.ts"
 
@@ -18,6 +19,7 @@ export const liveSeedFixtures = [
   toolCallErrorFixture,
   emptyResponseFixture,
   outputSchemaFixture,
+  systemSignalsIssueProbeFixture,
 ] as const
 
 export const liveSeedFixtureKeys = liveSeedFixtures.map((fixture) => fixture.key)

--- a/tools/live-seeds/src/fixtures/system-signals-issue-probe.ts
+++ b/tools/live-seeds/src/fixtures/system-signals-issue-probe.ts
@@ -1,0 +1,33 @@
+import type { LiveSeedFixtureDefinition } from "../types.ts"
+import { emptyResponseFixture } from "./empty-response.ts"
+import { outputSchemaFixture } from "./output-schema.ts"
+import { toolCallErrorFixture } from "./tool-call-error.ts"
+
+/**
+ * Exercises every deterministic system-signal detector in a single seed run.
+ *
+ * Each case cycles through `tool-call-errors`, `output-schema-validation`, and
+ * `empty-response` by `instanceIndex`, so running with `--count-per-fixture 9`
+ * (or any multiple of 3) produces a balanced distribution. Every generated
+ * trace is expected to hit the trace-end inline matcher, write a published
+ * annotation score with `sourceId = "SYSTEM"`, and surface as an issue via
+ * the `issues:discovery` pipeline.
+ */
+const DETECTOR_FIXTURES = [toolCallErrorFixture, outputSchemaFixture, emptyResponseFixture] as const
+
+export const systemSignalsIssueProbeFixture: LiveSeedFixtureDefinition = {
+  key: "system-signals-issue-probe",
+  description:
+    "Probe all three deterministic system-signal detectors (tool-call-errors, output-schema-validation, empty-response) end-to-end to verify that inline matches at trace-end become issues via issues:discovery.",
+  sampling: {
+    systemQueueSamples: {
+      frustration: false,
+    },
+  },
+  deterministicSystemMatches: ["tool-call-errors", "output-schema-validation", "empty-response"],
+  llmSystemIntents: [],
+  generateCase: (context) => {
+    const detector = DETECTOR_FIXTURES[context.instanceIndex % DETECTOR_FIXTURES.length]
+    return detector.generateCase({ ...context, fixtureKey: context.fixtureKey })
+  },
+}


### PR DESCRIPTION
## Summary

Deterministic system signals (`tool-call-errors`, `output-schema-validation`, `empty-response`) no longer create annotation queues with LLM-drafted review items. They now run inline in the trace-end runtime and write **published** annotation scores that flow straight into `issues:discovery` via `ScoreCreated`.

- **New sentinel** `SYSTEM` added to `ANNOTATION_SCORE_PARTIAL_SOURCE_IDS` (alongside `UI`/`API`), and treated as `"agent"` in `getAnnotationProvenance`.
- **New use case** `runDeterministicSystemMatchersUseCase` in `@domain/annotation-queues`: runs the 3 detectors against an already-loaded `TraceDetail` and, for each match, calls `writeScoreUseCase({ source: "annotation", sourceId: "SYSTEM", draftedAt: null, annotatorId: null, passed: false, value: 0, feedback: <deterministic template>, metadata: { rawFeedback: feedback } })`.
- **Matchers upgraded to detectors**: the boolean `matches*SystemQueue` helpers became `detect*SystemQueue` functions that return `{ matched: true, feedback }` so the feedback template lives alongside the detection logic and drives issue clustering.
- **Trace-end worker** calls the new use case after loading the trace; the `runTraceEndJob` summary now includes `deterministicSystemMatches.matchedSlugs`. Added `OutboxEventWriterLive` + `ScoreAnalyticsRepositoryLive` to its Postgres/ClickHouse layers (required by `writeScoreUseCase`).
- **Flagger path trimmed**: removed the 3 deterministic slugs from `SYSTEM_QUEUE_DEFINITIONS` (no new provisioning) and from `deterministicQueueMatchers` in `runSystemQueueFlaggerUseCase`. LLM queues + `resource-outliers` still go through `systemQueueFlaggerWorkflow` unchanged.
- **Docs**: `docs/annotation-queues.md` + `docs/reliability.md` updated with a new _Direct Deterministic System Signals_ section and trimmed queue lists.

## Feedback templates (drive issue clustering)

- `tool-call-errors` → `Tool "<name>" returned error: <snippet>`, `Malformed tool call: ...`, `Duplicate tool_call id ...`, `Tool response references an unknown tool_call id "<id>"`
- `output-schema-validation` → `Assistant output failed JSON parse (malformed or truncated structured output)`, `... trailing comma, suggesting truncated JSON`, `... unclosed JSON string, suggesting truncated output`
- `empty-response` → `Assistant response was empty or whitespace only`, `Assistant response was degenerate: only the character "<x>" repeated`

Identical signals collapse into one issue; meaningfully different ones (different tool names, different error classes) form distinct issues via the existing hybrid search.

## Not touched

- `resource-outliers` left as-is in both the flagger and `SYSTEM_QUEUE_DEFINITIONS`, per instruction.
- Existing legacy `Tool Call Errors` / `Output Schema Validation` / `Empty Response` queue rows on pre-existing projects are not migrated — users can delete them manually (no new items will be written to them).

## Test plan

- [x] `turbo typecheck` on `@domain/annotation-queues`, `@domain/scores`, `@domain/annotations`, `@app/workers`
- [x] `turbo test` on `@domain/annotation-queues` (130 tests incl. new `run-deterministic-system-matchers.test.ts` and updated `helpers.test.ts`)
- [x] `turbo test` on `@app/workers` (trace-end integration tests pass with new summary field)
- [x] Biome check clean
- [x] Smoke-test end-to-end: generate a trace with a failing tool call on a dev project, confirm an annotation score is created with `sourceId: "SYSTEM"` and that `issues:discovery` attaches it to an issue. Done with seed data tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)