### PR TITLE
Simplify trace annotations header by removing count display

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/trace-annotations-list.tsx
@@ -24,7 +24,7 @@ export function TraceAnnotationsList({
   readonly queueId?: string | undefined
   readonly selectedAnnotationId?: string | undefined
   readonly onAnnotationClick?: ((annotation: AnnotationRecord) => void) | undefined
-  /** When true, omit the Annotations title, count, and helper line (e.g. trace detail tab already shows the label). */
+  /** When true, omit the Annotations title and helper line (e.g. trace detail tab already shows the label). */
   readonly hideAnnotationIntro?: boolean | undefined
 }) {
   const {
@@ -110,15 +110,7 @@ export function TraceAnnotationsList({
       )}
       {!hideAnnotationIntro && (
         <div className="flex flex-col">
-          <div className="flex items-center gap-1">
-            <Text.H5M>Annotations</Text.H5M>
-            {annotationsError ? (
-              <Text.H5M color="foregroundMuted">–</Text.H5M>
-            ) : annotationsLoading ? null : annotations.length > 0 ? (
-              <Text.H5M color="foregroundMuted">{annotations.length}</Text.H5M>
-            ) : null}
-          </div>
-
+          <Text.H5M>Annotations</Text.H5M>
           <Text.H5 color="foregroundMuted">
             Select text, a message or annotate the entire conversation in this section
           </Text.H5>


### PR DESCRIPTION
## Summary
Simplified the annotations section header in the trace annotations list by removing the dynamic count display logic.

## Key Changes
- Removed the count badge that displayed the number of annotations next to the "Annotations" title
- Removed conditional rendering logic for error states, loading states, and empty states
- Simplified the header to just show the static "Annotations" title with the helper text below
- Updated the JSDoc comment to reflect that only the title and helper line are omitted when `hideAnnotationIntro` is true (removed mention of count)

## Implementation Details
The change removes approximately 8 lines of conditional rendering code that displayed:
- A dash (`–`) when annotations failed to load
- Nothing when annotations were loading
- The count when annotations were successfully loaded

This simplification reduces visual clutter and removes the need to track loading/error states in the header display.

https://claude.ai/code/session_01PQ3AQqenzF97oVN2vp7ej3