### PR TITLE
feat(telemetry): rewrite install CLI with @clack/prompts + env flags

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-04-20
+
+### Changed
+
+- **Install UX rewritten with [`@clack/prompts`](https://www.npmjs.com/package/@clack/prompts)** — the interactive wizard now opens with a proper welcome banner, renders each prompt inside a gutter with a description line explaining the field + the relevant Latitude URL to fetch it from, masks the API key input with `•` as you type, and ends with a "Next step" panel plus a direct link to your project's trace view. Spinners stream in as each install step completes.
+- **README restructured around `install` / `uninstall`** — the one-liner setup is now the first thing users see. The "paste this JSON into settings.json" walkthrough is pushed into a secondary "Configuration reference" section for users who don't want the wizard.
+
+### Added
+
+- **`--staging` and `--dev` environment flags** replace `--base-url`. They target:
+  - `--staging` → `https://staging.latitude.so` / `https://staging-ingest.latitude.so`
+  - `--dev` → `http://localhost:3000` / `http://localhost:3002`
+  - no flag → `https://app.latitude.so` / `https://ingest.latitude.so` (production default)
+  Every URL shown or written during install (API-keys link, project-creation link, ingest endpoint, trace-view link, About banner) is derived from the selected environment. The two environments are mutually exclusive; passing both errors out.
+- **Per-prompt inline help** — the API key prompt's description line tells you where to generate one (with the env-correct URL); the project slug prompt tells you where to create a project. Both include the current value as "(Enter to keep …)" hints when re-running.
+- **`picocolors` dependency** for minimal ANSI styling (cyan links, dim hints, yellow warnings for non-production envs).
+
+### Removed
+
+- **`--base-url` flag.** Replaced by the `--staging` / `--dev` flags above. Self-hosted users can still hand-edit `settings.json` / pass `LATITUDE_BASE_URL` via env.
+- **`LATITUDE_BASE_URL` interactive prompt.** It was flag-only in `0.0.4`; now the concept is subsumed entirely by the environment flags.
+- **Default-value placeholder on the project slug prompt** — the input now starts empty when there's no existing value, so nothing looks pre-filled.
+
+### Fixed
+
+- **No more auto-detection of environment from existing settings.** `install` with no env flag always targets production. Previously, an existing `LATITUDE_BASE_URL` pointing at staging would cause a flagless re-run to silently stay on staging; surprising.
+
 ## [0.0.4] - 2026-04-20
 
 ### Added

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -93,7 +93,7 @@ Everything the installer writes. Edit `~/.claude/settings.json` directly if you 
 | `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
 | `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
 | `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
-| `BUN_OPTIONS` | macOS: only written when you decline `launchctl` during install | — | `--preload=<absolute-path-to-intercept.js>`. See "how it works" above. |
+| `BUN_OPTIONS` | written when `launchctl` isn't used (all non-macOS platforms, or macOS with `--no-launchctl`) | — | `--preload=<absolute-path-to-intercept.js>`. See "how it works" above. |
 | `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to pause the hook without uninstalling. |
 | `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
 
@@ -101,10 +101,15 @@ Everything the installer writes. Edit `~/.claude/settings.json` directly if you 
 
 A single hook entry running `npx -y @latitude-data/claude-code-telemetry` after each turn (async).
 
+### Files on disk
+
+- `~/.claude/state/latitude/intercept.js` — the preload shim `BUN_OPTIONS` points at. Written on every platform.
+- `~/.claude/state/latitude/state.json` — per-session bookkeeping (transcript offsets, turn counts) so each hook invocation only processes new lines.
+- `~/.claude/state/latitude/requests/<message_id>.json` — request bodies captured by the preload. Transient: consumed by the Stop hook and deleted after each turn.
+
 ### macOS-only files
 
-- `~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist` — a one-shot launchd agent that `launchctl setenv BUN_OPTIONS …` on every login.
-- `~/.claude/state/latitude/intercept.js` — the preload shim `BUN_OPTIONS` points at.
+- `~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist` — a one-shot launchd agent that runs `launchctl setenv BUN_OPTIONS …` on every login. Only installed when you accept the launchctl prompt.
 
 ### Manual installation
 

--- a/packages/telemetry/claude-code/README.md
+++ b/packages/telemetry/claude-code/README.md
@@ -1,17 +1,120 @@
 # @latitude-data/claude-code-telemetry
 
-Claude Code `Stop` hook that streams session transcripts to [Latitude](https://latitude.so) as OTLP traces. Full conversation fidelity — user prompts, assistant responses, and tool I/O — without the truncation and flag combinatorics of Claude Code's native OpenTelemetry path.
+Claude Code `Stop` hook that streams session transcripts to [Latitude](https://latitude.so) as OTLP traces. Full conversation fidelity — user prompts, assistant responses, and tool I/O — plus the real system prompt and tool definitions that reached the model, without the truncation and flag combinatorics of Claude Code's native OpenTelemetry path.
 
-## Setup
+## Install
 
-Add this to your `~/.claude/settings.json`:
+```bash
+npx -y @latitude-data/claude-code-telemetry install
+```
+
+The installer walks you through the setup: prompts for your Latitude API key and project slug, wires the Stop hook into `~/.claude/settings.json`, and — on macOS — sets up `BUN_OPTIONS` via `launchctl` with a persistent `LaunchAgents` plist so the preload works for both terminal `claude` and the Claude Desktop app.
+
+Then fully quit and relaunch claude for the preload to attach:
+
+- **Terminal** — open a new terminal window.
+- **Claude Desktop** — ⌘Q to quit, then relaunch from Dock or Finder.
+
+That's it. Trace runs show up at `https://app.latitude.so/projects/<your-slug>`.
+
+### Install flags
+
+| Flag | What it does |
+| --- | --- |
+| `--api-key=<key>` | Pass the API key instead of being prompted. |
+| `--project=<slug>` | Pass the project slug instead of being prompted. |
+| `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
+| `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
+| `--no-launchctl` | Write `BUN_OPTIONS` into `settings.json` instead of setting it via `launchctl`. Useful if you only use terminal claude and don't want anything installed under `~/Library/LaunchAgents/`. |
+| `--yes` / `--no-prompt` | Skip all prompts. Required for non-TTY / CI invocations. |
+
+Re-running `install` is idempotent — existing values in `settings.json` are shown as defaults and the Stop hook isn't duplicated.
+
+## Uninstall
+
+```bash
+npx -y @latitude-data/claude-code-telemetry uninstall
+```
+
+Shows a plan and asks for confirmation before touching anything. Reverses only what the installer did:
+
+- Removes `LATITUDE_*` and (if it's ours) `BUN_OPTIONS` from `~/.claude/settings.json` (backup at `settings.json.latitude-bak`).
+- Removes the Stop hook entry — leaves any other hooks alone.
+- `launchctl unsetenv BUN_OPTIONS` only if it still points at our preload.
+- Unloads and removes `~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist`.
+- Deletes `~/.claude/state/latitude/` (preload, state, captured request files).
+
+## What gets sent
+
+For each turn, the hook emits one trace with three span kinds:
+
+- **`interaction`** — the user prompt and turn-level timing / counts.
+- **`llm_request`** — one per model call. Carries the model name, token usage (input/output/cache), input and output messages, and — when the preload is active — the full system prompt (`gen_ai.system_instructions`), tool schemas (`gen_ai.tool.definitions`), and exact request parameters. A tool-loop turn produces N sibling `llm_request` spans, one per distinct assistant `message.id`.
+- **`tool_execution`** — one per tool call. Canonical `gen_ai.tool.*` attributes: `name`, `call.id`, `call.arguments`, `call.result`. Failures set `error.type` and OTel status code 2.
+
+All spans share the session id so they group together in the Latitude UI.
+
+## How it works
+
+Two parts, and the installer wires both up:
+
+### 1. Stop hook → OTLP export
+
+Claude Code's `Stop` hook fires at the end of each turn. Our hook reads the new rows of the session's JSONL transcript, reconstructs user → assistant → tool_use → tool_result turns, and POSTs OTLP spans to `${LATITUDE_BASE_URL}/v1/traces`. State lives at `~/.claude/state/latitude/state.json` so each invocation only processes new lines.
+
+This alone gets you conversation-level fidelity. The transcript, however, doesn't contain the system prompt or the tool definitions that reached the model — those are composed by `claude` at runtime and never written to disk.
+
+### 2. Bun `--preload` fetch intercept (optional but installed by default)
+
+The installer ships a small ESM module (`~/.claude/state/latitude/intercept.js`) and wires `BUN_OPTIONS=--preload=<path>` so Bun loads it into the `claude` process. Inside claude, it wraps `globalThis.fetch`, tees the response of every POST to Anthropic's `/v1/messages`, and — the moment the first `message_start` SSE event arrives — writes the full request body to `~/.claude/state/latitude/requests/<message_id>.json`.
+
+The Stop hook then matches those files to their assistant calls by `message_id` and enriches each `llm_request` span with:
+
+- `gen_ai.system_instructions` — the full composed system prompt.
+- `gen_ai.tool.definitions` — every tool schema offered to the model.
+- `gen_ai.request.model` / `max_tokens` / `temperature` / `top_p` / `stream`.
+- `gen_ai.input.messages` — the real message array, overriding the transcript reconstruction.
+- `llm_request.captured = "true"` — marker so you can filter for enriched spans.
+
+Request files are deleted after the hook consumes them, and anything older than 24h is swept on each run.
+
+### Why `launchctl` on macOS
+
+Claude Desktop doesn't forward `env` from `~/.claude/settings.json` to the `claude` subprocess it spawns — that field only reaches hook subprocesses. So setting `BUN_OPTIONS` there works for terminal `claude` but is silently ignored by Desktop. `launchctl setenv` puts the var in launchd's environment, which the GUI app inherits. The installer also writes a `LaunchAgents` plist so this survives reboots.
+
+## Configuration reference
+
+Everything the installer writes. Edit `~/.claude/settings.json` directly if you want to tweak:
+
+### `env`
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
+| `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
+| `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
+| `BUN_OPTIONS` | macOS: only written when you decline `launchctl` during install | — | `--preload=<absolute-path-to-intercept.js>`. See "how it works" above. |
+| `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to pause the hook without uninstalling. |
+| `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
+
+### `hooks.Stop`
+
+A single hook entry running `npx -y @latitude-data/claude-code-telemetry` after each turn (async).
+
+### macOS-only files
+
+- `~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist` — a one-shot launchd agent that `launchctl setenv BUN_OPTIONS …` on every login.
+- `~/.claude/state/latitude/intercept.js` — the preload shim `BUN_OPTIONS` points at.
+
+### Manual installation
+
+If the installer doesn't fit your setup (e.g. you manage dotfiles with another tool), the equivalent settings.json is:
 
 ```json
 {
   "env": {
     "LATITUDE_API_KEY": "lat_xxx",
-    "LATITUDE_PROJECT": "my-project-slug",
-    "LATITUDE_BASE_URL": "https://ingest.latitude.so"
+    "LATITUDE_PROJECT": "my-project-slug"
   },
   "hooks": {
     "Stop": [
@@ -19,7 +122,8 @@ Add this to your `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y @latitude-data/claude-code-telemetry"
+            "command": "npx -y @latitude-data/claude-code-telemetry",
+            "async": true
           }
         ]
       }
@@ -28,161 +132,36 @@ Add this to your `~/.claude/settings.json`:
 }
 ```
 
-That's it. The hook fires after every assistant turn, reads new lines from the session transcript, converts them into OTLP traces, and POSTs them to `${LATITUDE_BASE_URL}/v1/traces`.
-
-`LATITUDE_PROJECT` is the slug of the Latitude project you want traces to land in — same value you'd pass in the `X-Latitude-Project` header when using the ingest API directly. The project must already exist under the organization that owns your API key.
-
-## Environment variables
-
-| Variable | Required | Default | Description |
-| --- | --- | --- | --- |
-| `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
-| `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
-| `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override for self-hosted deploys. |
-| `LATITUDE_CLAUDE_CODE_ENABLED` | no | `1` | Set to `0` to turn the hook off without removing it from `settings.json`. |
-| `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
-
-## Capturing the full system prompt and tool definitions (optional)
-
-By default the hook reconstructs each `llm_request` span's messages from the transcript on disk. That's good for the conversation — user prompts, assistant text, tool calls and results — but it doesn't include Claude Code's **system prompt** or the **tool definitions** sent to the model, because those aren't persisted to the transcript.
-
-If you want spans to carry the exact payload that reached Anthropic's API — the base prompt, every tool definition, request parameters like `max_tokens` and `temperature`, and the real message array — add a one-time preload that wraps `fetch` inside the `claude` process.
-
-1. Install the preload shim to a stable path:
-
-   ```bash
-   npx -y @latitude-data/claude-code-telemetry install
-   ```
-
-   This writes `intercept.js` to `~/.claude/state/latitude/intercept.js` and prints the env line to add.
-
-   On macOS, the install command will also offer to wire up `BUN_OPTIONS` via `launchctl` (covering both terminal `claude` and Claude Desktop). Say yes to the prompt and skip step 2.
-
-2. Expose `BUN_OPTIONS` to the `claude` runtime. Either:
-
-   **Option A — add it to `~/.claude/settings.json` under `env`:**
-   ```json
-   "env": {
-     "LATITUDE_API_KEY": "lat_xxx",
-     "LATITUDE_PROJECT": "my-project-slug",
-     "BUN_OPTIONS": "--preload=/Users/you/.claude/state/latitude/intercept.js"
-   }
-   ```
-
-   **Option B — export in your shell rc** (`~/.zshrc`, `~/.bashrc`):
-   ```bash
-   export BUN_OPTIONS="--preload=/Users/you/.claude/state/latitude/intercept.js"
-   ```
-
-   Use the absolute path printed by `install` — `~` isn't expanded inside these values.
-
-3. **Open a new terminal** (or restart your shell) so the env var takes effect, then start a new claude session.
-
-With this in place, every Anthropic `/v1/messages` request body is written to `~/.claude/state/latitude/requests/<message_id>.json` inside the `claude` process and consumed by the Stop hook, which attaches:
-
-- `gen_ai.system_instructions` — the full system prompt (base + CLAUDE.md + any billing/context blocks)
-- `gen_ai.tool.definitions` — every tool schema offered to the model
-- `gen_ai.request.model` / `max_tokens` / `temperature` / `top_p` / `stream`
-- `gen_ai.input.messages` — the real message array, overriding the transcript reconstruction
-- `llm_request.captured = "true"` — marker so you can filter for enriched spans
-
-Request files are pruned after the Stop hook consumes them, and anything older than 24h is swept on each run.
-
-### Using Claude Desktop (GUI) on macOS
-
-`BUN_OPTIONS` in `settings.json` and shell rc exports **do not reach the `claude` runtime** when claude is spawned by the Claude Desktop app — the GUI app doesn't forward `settings.json.env` to the claude subprocess, and GUI apps don't inherit shell rc. The workaround is to set it at macOS's launchd layer, which Claude Desktop (and terminal claude, and everything else you launch from the GUI) inherits:
-
-```bash
-launchctl setenv BUN_OPTIONS "--preload=/Users/you/.claude/state/latitude/intercept.js"
-```
-
-Then **fully quit Claude Desktop** (⌘Q) and relaunch from Finder/Dock.
-
-`launchctl setenv` resets on reboot. To persist it, save this as `~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>so.latitude.claude-code-telemetry</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>launchctl</string>
-    <string>setenv</string>
-    <string>BUN_OPTIONS</string>
-    <string>--preload=/Users/you/.claude/state/latitude/intercept.js</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-</dict></plist>
-```
-
-Then `launchctl load ~/Library/LaunchAgents/so.latitude.claude-code-telemetry.plist`.
-
-The `install` command can do all of this for you — run it on macOS and say yes to the launchctl prompt.
-
-### Uninstalling
-
-To remove everything this package configured:
-
-```bash
-npx -y @latitude-data/claude-code-telemetry uninstall
-```
-
-The uninstall command shows a plan and asks for confirmation before touching anything. It reverses only what the install touched:
-
-- Removes `LATITUDE_API_KEY` / `LATITUDE_PROJECT` / `LATITUDE_BASE_URL` / `BUN_OPTIONS` from `~/.claude/settings.json` (backs up to `settings.json.latitude-bak` first).
-- Removes our Stop hook entry from `settings.json` — leaves any other hooks alone.
-- If `launchctl` has `BUN_OPTIONS` pointing at our preload, `unsetenv`s it; leaves any other value alone.
-- Removes the LaunchAgents plist if present.
-- Deletes `~/.claude/state/latitude/` (preload, state, captured request files).
-
-### Setup walkthrough
-
-A one-shot interactive installer covers everything above:
-
-```bash
-npx -y @latitude-data/claude-code-telemetry install
-```
-
-It prompts for your `LATITUDE_API_KEY` and project slug, writes them to `settings.json` with the Stop hook entry, and — on macOS — offers to set `BUN_OPTIONS` via `launchctl` with persistent `LaunchAgents` wiring. Existing values in `settings.json` are shown as defaults; press Enter to keep them. A backup is always written first.
-
-Pass `--base-url=https://staging-ingest.latitude.so` (or self-hosted URL) to override the default ingest endpoint — that one's flag-only since most users never need to change it. Use `--yes` / `--no-prompt` for CI. Other flags: `--api-key=…`, `--project=…`, `--no-launchctl`.
-
-**Caveats:**
-- The `claude` CLI is a Bun-compiled standalone. The preload relies on Bun honoring `BUN_OPTIONS=--preload=...` (verified against 2.1.x). If a future release removes this, the hook falls back to reconstruction automatically — nothing else breaks.
-- If the preload path is missing or invalid, **`claude` itself will refuse to start** (Bun errors out). Either keep the path in place or remove `BUN_OPTIONS` from your env.
-- Request bodies are big (often 100KB+ per call). Steady-state disk is small because the Stop hook prunes them, but sessions with many turns between Stop events will accumulate briefly.
-
-## What gets sent
-
-For each turn, the hook emits:
-
-- One `interaction` span — the user prompt.
-- One `llm_request` span — model, token usage (input/output/cache), and the full assistant response.
-- One `tool_execution` span per tool call — tool name, input, output.
-
-All spans carry `session.id` so they group into a single session in the Latitude UI. State lives in `~/.claude/state/latitude/state.json` so each invocation only processes new transcript lines.
+You still need `BUN_OPTIONS=--preload=<abs-path>/intercept.js` in the claude runtime's environment to get the full-request capture. Either run `install` once to materialize the preload and set things up, or copy the shim out of `node_modules/@latitude-data/claude-code-telemetry/dist/intercept.js` and wire it up yourself.
 
 ## Privacy
 
-This hook reads your session transcript from disk and sends the **full content** to Latitude — prompts, assistant responses, and tool I/O (including file contents returned by `Read`, `Bash` output, etc.). There is no per-flag opt-in: the moment the hook is installed, everything gets shipped.
+This hook reads your session transcript from disk and sends the **full content** to Latitude — prompts, assistant responses, tool I/O (including file contents returned by `Read`, `Bash` output, etc.). With the preload installed, it also sends Claude Code's system prompt and the list of tool schemas available to the model. There is no per-flag opt-in: the moment the hook is installed, everything gets shipped.
 
 If that's not what you want, either:
+
 - Don't install the hook.
 - Set `LATITUDE_CLAUDE_CODE_ENABLED=0` in your shell before starting a sensitive session.
+- Run `uninstall`.
 
 ## Supported surfaces
 
 | Surface | Works |
 | --- | --- |
 | CLI (`claude` in terminal) | ✅ |
-| Desktop app (Mac/Windows) | ✅ |
+| Desktop app (macOS / Windows) | ✅ (uses `launchctl` on macOS) |
 | IDE extensions (VS Code, JetBrains) | ✅ |
 | Web app (`claude.ai/code`) | ❌ — runs in Anthropic's cloud; no local hooks. |
 
+## Caveats
+
+- The `claude` CLI is a Bun-compiled standalone. The preload relies on Bun honoring `BUN_OPTIONS=--preload=...` (verified against 2.1.x). If a future release changes this, the hook falls back to transcript-only reconstruction automatically — spans still work, they just lose `gen_ai.system_instructions` and `gen_ai.tool.definitions`.
+- If `BUN_OPTIONS` points at a missing preload file, **`claude` itself will refuse to start** (Bun exits 1). Either keep the file in place or run `uninstall` / remove the env var.
+- Captured request bodies are big (50–150KB each). Steady-state disk use is small because the Stop hook prunes them, but long sessions between Stop events can accumulate briefly.
+
 ## How it fails
 
-The hook is fail-open by design. If the API is unreachable, your key is wrong, or the transcript is malformed, the hook logs to stderr (when `LATITUDE_DEBUG=1`) and exits `0`. It never blocks Claude from finishing a turn.
+Fail-open by design. If the API is unreachable, your key is wrong, or the transcript is malformed, the hook logs to stderr (when `LATITUDE_DEBUG=1`) and exits `0`. It never blocks Claude from finishing a turn.
 
 ## License
 

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",
@@ -38,6 +38,10 @@
     "format": "biome format --write src && biome check --fix src",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --pool=forks --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@clack/prompts": "^1.2.0",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -278,6 +278,24 @@ async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
 
   const apiKey = flags.apiKey ?? existingEnv.LATITUDE_API_KEY ?? ""
   const project = flags.project ?? existingEnv.LATITUDE_PROJECT ?? ""
+
+  // Flag-driven mode can't fall back to prompts, so fail fast if either
+  // required value is missing. Writing settings.json with an empty key/project
+  // would look "installed" but the hook silently disables itself at runtime
+  // (loadConfig requires both), which is harder to diagnose than an exit 1 here.
+  const missing: string[] = []
+  if (!apiKey) missing.push("--api-key")
+  if (!project) missing.push("--project")
+  if (missing.length > 0) {
+    process.stderr.write(
+      `[latitude-claude-code] missing required value${missing.length === 1 ? "" : "s"} for non-interactive install: ${missing.join(", ")}\n`,
+    )
+    process.stderr.write(
+      `[latitude-claude-code] either pass ${missing.join(" + ")}, or drop --no-prompt to answer interactively.\n`,
+    )
+    process.exit(1)
+  }
+
   const envConfig = flags.environment ?? PRODUCTION_ENV
   const useLaunchctl = process.platform === "darwin" && !flags.noLaunchctl
 

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -78,16 +78,15 @@ interface InstallFlags {
 // ─── Install ─────────────────────────────────────────────────────────────────
 
 export async function runInstall(flags: InstallFlags = {}): Promise<void> {
-  // The preload file is materialized unconditionally — it's just a copy, and the
-  // hook's own runtime also refreshes it on every Stop, so a bare `install` in
-  // CI still produces the file that users later point `BUN_OPTIONS` at.
-  writeIntercept()
-
   const canPrompt = !flags.noPrompt && process.stdin.isTTY === true
   const hasAnyFlags = Boolean(flags.apiKey || flags.project || flags.environment || flags.noPrompt || flags.noLaunchctl)
 
   if (!canPrompt) {
     if (!hasAnyFlags) {
+      // No flags, no TTY — we can't prompt and there's nothing to write to
+      // settings.json. Materialize just the preload file so users who want to
+      // wire BUN_OPTIONS themselves have the file available, then return.
+      writeIntercept()
       printMinimalInstallInstructions()
       return
     }
@@ -244,8 +243,6 @@ async function applyChanges(args: ApplyArgs): Promise<void> {
   )
 
   step.start("Installing preload")
-  // Already copied at the top of runInstall(); we re-copy here to keep the UX
-  // honest — users see the step happen.
   writeIntercept()
   step.stop(`Preload at ${INTERCEPT_INSTALL_PATH}`)
 

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -394,7 +394,10 @@ function setLaunchctlBunOptions(): void {
   const value = `--preload=${INTERCEPT_INSTALL_PATH}`
   const res = spawnSync("launchctl", ["setenv", "BUN_OPTIONS", value], { encoding: "utf-8" })
   if (res.status !== 0) {
-    const details = [res.stderr, res.stdout].filter((s) => s && s.trim().length > 0).join(" ").trim()
+    const details = [res.stderr, res.stdout]
+      .filter((s) => s && s.trim().length > 0)
+      .join(" ")
+      .trim()
     process.stderr.write(
       `[latitude-claude-code] launchctl setenv failed (exit ${res.status})${details ? `: ${details}` : ""}. Continuing.\n`,
     )
@@ -424,7 +427,10 @@ function writePlist(): void {
   spawnSync("launchctl", ["unload", PLIST_PATH], { stdio: "ignore" })
   const res = spawnSync("launchctl", ["load", PLIST_PATH], { encoding: "utf-8" })
   if (res.status !== 0) {
-    const details = [res.stderr, res.stdout].filter((s) => s && s.trim().length > 0).join(" ").trim()
+    const details = [res.stderr, res.stdout]
+      .filter((s) => s && s.trim().length > 0)
+      .join(" ")
+      .trim()
     process.stderr.write(
       `[latitude-claude-code] launchctl load failed (exit ${res.status})${details ? `: ${details}` : ""}. Continuing.\n`,
     )
@@ -485,7 +491,7 @@ function buildUninstallPlan(): UninstallPlan {
   }
 
   const currentLaunchd = readLaunchctlBunOptions()
-  if (currentLaunchd && currentLaunchd.includes(INTERCEPT_INSTALL_PATH)) {
+  if (currentLaunchd?.includes(INTERCEPT_INSTALL_PATH)) {
     description.push(`launchctl: unsetenv BUN_OPTIONS (currently: ${currentLaunchd})`)
     steps.push(() => {
       spawnSync("launchctl", ["unsetenv", "BUN_OPTIONS"], { stdio: "ignore" })

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -2,8 +2,9 @@ import { spawnSync } from "node:child_process"
 import { copyFileSync, existsSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
-import { createInterface } from "node:readline/promises"
 import { fileURLToPath } from "node:url"
+import { cancel, confirm, intro, isCancel, log, note, outro, password, spinner, text } from "@clack/prompts"
+import pc from "picocolors"
 import {
   addLatitudeStopHook,
   backupSettings,
@@ -24,134 +25,323 @@ const REQUESTS_DIR = join(STATE_DIR, "requests")
 const STATE_FILE = join(STATE_DIR, "state.json")
 const PLIST_PATH = join(homedir(), "Library", "LaunchAgents", "so.latitude.claude-code-telemetry.plist")
 const PLIST_LABEL = "so.latitude.claude-code-telemetry"
-const DEFAULT_BASE_URL = "https://ingest.latitude.so"
 const DEFAULT_HOOK_COMMAND = "npx -y @latitude-data/claude-code-telemetry"
+const DOCS_URL = "https://docs.latitude.so/claude-code-telemetry"
+
+// Environments pick the app + ingest domain pair. Every URL shown or written
+// during install is derived from these two — there's no other source of truth.
+interface EnvironmentConfig {
+  name: "production" | "staging" | "dev"
+  label: string
+  app: string // user-facing dashboard + key management origin
+  ingest: string // OTLP ingest origin; stored in settings as LATITUDE_BASE_URL
+}
+
+const PRODUCTION_ENV: EnvironmentConfig = {
+  name: "production",
+  label: "production",
+  app: "https://app.latitude.so",
+  ingest: "https://ingest.latitude.so",
+}
+const STAGING_ENV: EnvironmentConfig = {
+  name: "staging",
+  label: "staging",
+  app: "https://staging.latitude.so",
+  ingest: "https://staging-ingest.latitude.so",
+}
+const DEV_ENV: EnvironmentConfig = {
+  name: "dev",
+  label: "local dev",
+  app: "http://localhost:3000",
+  ingest: "http://localhost:3002",
+}
+function urlsFor(env: EnvironmentConfig): {
+  apiKeys: string
+  projects: string
+  projectView: (slug: string) => string
+} {
+  return {
+    apiKeys: `${env.app}/settings/api-keys`,
+    projects: env.app,
+    projectView: (slug: string) => `${env.app}/projects/${slug}`,
+  }
+}
 
 interface InstallFlags {
   apiKey?: string | undefined
   project?: string | undefined
-  baseUrl?: string | undefined
+  environment?: EnvironmentConfig | undefined
   noLaunchctl?: boolean
   noPrompt?: boolean
 }
 
+// ─── Install ─────────────────────────────────────────────────────────────────
+
 export async function runInstall(flags: InstallFlags = {}): Promise<void> {
+  // The preload file is materialized unconditionally — it's just a copy, and the
+  // hook's own runtime also refreshes it on every Stop, so a bare `install` in
+  // CI still produces the file that users later point `BUN_OPTIONS` at.
   writeIntercept()
 
   const canPrompt = !flags.noPrompt && process.stdin.isTTY === true
-  const hasAnyFlags = Boolean(flags.apiKey || flags.project || flags.baseUrl || flags.noPrompt || flags.noLaunchctl)
+  const hasAnyFlags = Boolean(flags.apiKey || flags.project || flags.environment || flags.noPrompt || flags.noLaunchctl)
 
-  // Pure non-interactive (no TTY, no flags) = just install the preload silently so
-  // CI / scripts keep working. Adding any flag forces the wizard path (flag-driven
-  // when canPrompt is false).
-  if (!canPrompt && !hasAnyFlags) {
-    printMinimalInstallInstructions()
-    return
+  if (!canPrompt) {
+    if (!hasAnyFlags) {
+      printMinimalInstallInstructions()
+      return
+    }
+    return runFlagDrivenInstall(flags)
   }
 
-  const rl = canPrompt ? createInterface({ input: process.stdin, output: process.stdout }) : undefined
-  try {
-    process.stdout.write("\nLatitude Claude Code Telemetry — setup\n")
-    process.stdout.write("======================================\n\n")
+  await runInteractiveInstall(flags)
+}
 
-    const existing = readSettingsSafe()
-    const existingEnv = existing.env ?? {}
+async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
+  intro(pc.bgCyan(pc.black(" Latitude · Claude Code telemetry ")))
 
-    const apiKey =
-      flags.apiKey ??
-      (rl
-        ? await askWithDefault(rl, "LATITUDE_API_KEY", existingEnv.LATITUDE_API_KEY)
-        : (existingEnv.LATITUDE_API_KEY ?? ""))
-    const project =
-      flags.project ??
-      (rl
-        ? await askWithDefault(rl, "LATITUDE_PROJECT", existingEnv.LATITUDE_PROJECT)
-        : (existingEnv.LATITUDE_PROJECT ?? ""))
-    // Base URL is flag-only — most users never need to change it, so we skip the
-    // prompt. Pass `--base-url=https://...` to override the default.
-    const baseUrl = flags.baseUrl ?? existingEnv.LATITUDE_BASE_URL ?? DEFAULT_BASE_URL
+  const existing = readSettingsSafe()
+  const existingEnv = existing.env ?? {}
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  const urls = urlsFor(envConfig)
 
-    let useLaunchctl = false
-    if (process.platform === "darwin" && !flags.noLaunchctl) {
-      if (rl) {
-        process.stdout.write("\nmacOS detected.\n")
-        process.stdout.write("Set BUN_OPTIONS via launchctl? This lets the preload work for both terminal\n")
-        process.stdout.write("claude AND the Claude Desktop GUI, and persists across reboots.\n")
-        useLaunchctl = await confirm(rl, "Set up launchctl", true)
-      } else {
-        useLaunchctl = true // on macOS, default to launchctl when flag-driven unless --no-launchctl
-      }
-    }
+  const aboutLines = [
+    "Captures every Claude Code session and ships it to Latitude as",
+    "OpenTelemetry traces — full system prompt, tool defs, and",
+    "model I/O per call.",
+    "",
+    `${pc.dim("Docs")}   ${pc.cyan(DOCS_URL)}`,
+  ]
+  if (envConfig.name !== "production") {
+    aboutLines.push("", pc.yellow(`Using ${envConfig.label} environment (${envConfig.ingest})`))
+  }
+  note(aboutLines.join("\n"), "About")
 
-    let next = existing
-    if (apiKey) next = setEnv(next, "LATITUDE_API_KEY", apiKey)
-    if (project) next = setEnv(next, "LATITUDE_PROJECT", project)
-    if (baseUrl && baseUrl !== DEFAULT_BASE_URL) next = setEnv(next, "LATITUDE_BASE_URL", baseUrl)
-    else if (existingEnv.LATITUDE_BASE_URL === DEFAULT_BASE_URL) next = removeEnv(next, "LATITUDE_BASE_URL")
+  const apiKey = await promptApiKey(existingEnv.LATITUDE_API_KEY, flags.apiKey, urls.apiKeys)
+  const project = await promptProject(existingEnv.LATITUDE_PROJECT, flags.project, urls.projects)
 
-    if (useLaunchctl) {
-      // launchctl covers both CLI and GUI; remove the redundant settings.json entry.
-      next = removeEnv(next, "BUN_OPTIONS")
-    } else {
-      next = setEnv(next, "BUN_OPTIONS", `--preload=${INTERCEPT_INSTALL_PATH}`)
-    }
-
-    const addedHook = !hasLatitudeStopHook(next)
-    next = addLatitudeStopHook(next, DEFAULT_HOOK_COMMAND)
-
-    const backedUp = backupSettings()
-    writeSettings(next)
-
-    if (useLaunchctl) {
-      setLaunchctlBunOptions()
-      writePlist()
-    }
-
-    printInstallSummary({
-      backedUp,
-      addedHook,
-      useLaunchctl,
-      apiKey: Boolean(apiKey),
-      project: Boolean(project),
-      baseUrl: Boolean(baseUrl) && baseUrl !== DEFAULT_BASE_URL,
+  let useLaunchctl = false
+  if (process.platform === "darwin" && !flags.noLaunchctl) {
+    log.info(
+      [
+        "macOS Claude Desktop doesn't forward settings.json env vars to the",
+        "claude runtime. Wiring BUN_OPTIONS via launchctl covers both the",
+        "GUI app and terminal claude, and survives reboots.",
+      ].join("\n"),
+    )
+    const answer = await confirm({
+      message: "Set up launchctl? (recommended)",
+      initialValue: true,
     })
-    printRelaunchReminder()
-  } finally {
-    rl?.close()
+    if (isCancel(answer)) return onCancel()
+    useLaunchctl = answer === true
+  }
+
+  await applyChanges({ apiKey, project, envConfig, useLaunchctl, existing, interactive: true })
+
+  note(
+    [
+      "Quit claude fully and relaunch for the preload to attach.",
+      "",
+      `${pc.dim("  Terminal       ")}close and reopen your terminal`,
+      `${pc.dim("  Claude Desktop ")}⌘Q, then relaunch from Dock / Finder`,
+      "",
+      `View your traces at  ${pc.cyan(urls.projectView(project))}`,
+    ].join("\n"),
+    "Next step",
+  )
+
+  outro(pc.green("Installed."))
+}
+
+async function promptApiKey(
+  existing: string | undefined,
+  flag: string | undefined,
+  apiKeysUrl: string,
+): Promise<string> {
+  if (flag) return flag
+
+  const description = existing
+    ? `Your Latitude API key. Press Enter to keep the existing one (${maskKey(existing)}),\nor generate a new one at ${pc.cyan(apiKeysUrl)}`
+    : `Your Latitude API key. Generate one at ${pc.cyan(apiKeysUrl)}`
+
+  const input = await password({
+    message: `Latitude API key\n${pc.dim(description)}`,
+    mask: "•",
+    validate: (value) => {
+      if (!value && !existing) return `An API key is required. Create one at ${apiKeysUrl}`
+      return undefined
+    },
+  })
+  if (isCancel(input)) return onCancel() as never
+  return input || existing || ""
+}
+
+async function promptProject(
+  existing: string | undefined,
+  flag: string | undefined,
+  projectsUrl: string,
+): Promise<string> {
+  if (flag) return flag
+
+  const description = existing
+    ? `The slug of the Latitude project to route traces into.\nPress Enter to keep the existing one (${existing}),\nor create a new one at ${pc.cyan(projectsUrl)}.`
+    : `The slug of the Latitude project to route traces into.\nCreate one at ${pc.cyan(projectsUrl)} if you don't have one yet.`
+
+  const input = await text({
+    message: `Project slug\n${pc.dim(description)}`,
+    validate: (value) => {
+      if (!value?.trim() && !existing) return "A project slug is required"
+      return undefined
+    },
+  })
+  if (isCancel(input)) return onCancel() as never
+  return input.trim() || existing || ""
+}
+
+// ─── Apply changes (shared between interactive + flag-driven) ────────────────
+
+interface ApplyArgs {
+  apiKey: string
+  project: string
+  envConfig: EnvironmentConfig
+  useLaunchctl: boolean
+  existing: ClaudeSettings
+  interactive: boolean
+}
+
+async function applyChanges(args: ApplyArgs): Promise<void> {
+  const { apiKey, project, envConfig, useLaunchctl, existing, interactive } = args
+
+  let next = existing
+  if (apiKey) next = setEnv(next, "LATITUDE_API_KEY", apiKey)
+  if (project) next = setEnv(next, "LATITUDE_PROJECT", project)
+  // Only persist LATITUDE_BASE_URL when it differs from production — production is
+  // the implicit default on the hook side, and writing it explicitly just adds
+  // noise to settings.json.
+  if (envConfig.name === "production") next = removeEnv(next, "LATITUDE_BASE_URL")
+  else next = setEnv(next, "LATITUDE_BASE_URL", envConfig.ingest)
+
+  if (useLaunchctl) next = removeEnv(next, "BUN_OPTIONS")
+  else next = setEnv(next, "BUN_OPTIONS", `--preload=${INTERCEPT_INSTALL_PATH}`)
+
+  const hookAlreadyThere = hasLatitudeStopHook(next)
+  next = addLatitudeStopHook(next, DEFAULT_HOOK_COMMAND)
+
+  const step = stepLogger(interactive)
+
+  step.start("Writing ~/.claude/settings.json")
+  const backedUp = backupSettings()
+  writeSettings(next)
+  step.stop(
+    [
+      `~/.claude/settings.json updated`,
+      hookAlreadyThere ? "" : "  + Stop hook installed",
+      backedUp ? pc.dim(`  (backup at ${SETTINGS_BACKUP_PATH})`) : pc.dim("  (new file)"),
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  )
+
+  step.start("Installing preload")
+  // Already copied at the top of runInstall(); we re-copy here to keep the UX
+  // honest — users see the step happen.
+  writeIntercept()
+  step.stop(`Preload at ${INTERCEPT_INSTALL_PATH}`)
+
+  if (useLaunchctl) {
+    step.start("Setting BUN_OPTIONS via launchctl + installing persistence plist")
+    setLaunchctlBunOptions()
+    writePlist()
+    step.stop(`launchctl env set (persisted via ${PLIST_PATH})`)
   }
 }
 
+interface StepLogger {
+  start: (message: string) => void
+  stop: (message: string) => void
+}
+
+function stepLogger(interactive: boolean): StepLogger {
+  if (interactive) {
+    const s = spinner()
+    return { start: (m) => s.start(m), stop: (m) => s.stop(m) }
+  }
+  return {
+    start: (m) => process.stdout.write(`  … ${m}\n`),
+    stop: (m) => process.stdout.write(`  ✓ ${m.split("\n")[0]}\n`),
+  }
+}
+
+// ─── Flag-driven install (non-TTY or --no-prompt + flags) ────────────────────
+
+async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
+  const existing = readSettingsSafe()
+  const existingEnv = existing.env ?? {}
+
+  const apiKey = flags.apiKey ?? existingEnv.LATITUDE_API_KEY ?? ""
+  const project = flags.project ?? existingEnv.LATITUDE_PROJECT ?? ""
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  const useLaunchctl = process.platform === "darwin" && !flags.noLaunchctl
+
+  process.stdout.write(`Installing Latitude Claude Code telemetry (${envConfig.label})…\n`)
+  await applyChanges({ apiKey, project, envConfig, useLaunchctl, existing, interactive: false })
+  process.stdout.write(`\nInstalled. Quit claude and relaunch (new terminal, or ⌘Q + relaunch Claude Desktop).\n`)
+}
+
+// ─── Uninstall ───────────────────────────────────────────────────────────────
+
 export async function runUninstall(flags: { noPrompt?: boolean } = {}): Promise<void> {
   const interactive = !flags.noPrompt && process.stdin.isTTY === true
-
   const plan = buildUninstallPlan()
 
-  process.stdout.write("\nLatitude Claude Code Telemetry — uninstall\n")
-  process.stdout.write("==========================================\n\n")
-  process.stdout.write("The following will be removed:\n")
-  for (const line of plan.description) process.stdout.write(`  • ${line}\n`)
+  if (interactive) {
+    intro(pc.bgRed(pc.white(" Latitude · Claude Code telemetry ")))
+  } else {
+    process.stdout.write("Uninstalling Latitude Claude Code telemetry…\n")
+  }
+
   if (plan.description.length === 0) {
-    process.stdout.write("  (nothing to remove — install artifacts not found)\n")
+    if (interactive) {
+      log.info("Nothing to remove. You're already clean.")
+      outro(pc.dim("Nothing to do."))
+    } else {
+      process.stdout.write("Nothing to remove.\n")
+    }
     return
   }
 
   if (interactive) {
-    const rl = createInterface({ input: process.stdin, output: process.stdout })
-    try {
-      const ok = await confirm(rl, "\nProceed with uninstall", false)
-      if (!ok) {
-        process.stdout.write("Aborted.\n")
-        return
-      }
-    } finally {
-      rl.close()
-    }
+    note(plan.description.map((line) => pc.red("—  ") + line).join("\n"), "Will remove")
+
+    const ok = await confirm({ message: "Proceed?", initialValue: false })
+    if (isCancel(ok) || ok !== true) return onCancel("Uninstall cancelled.")
   }
 
-  plan.execute()
-  process.stdout.write("\nUninstall complete.\n")
-  process.stdout.write(`Settings backup: ${SETTINGS_BACKUP_PATH}\n`)
-  process.stdout.write("If launchctl was reset, open a new terminal / relaunch Claude Desktop to clear BUN_OPTIONS.\n")
+  if (interactive) {
+    const s = spinner()
+    s.start("Removing")
+    plan.execute()
+    s.stop("Removed")
+  } else {
+    plan.execute()
+    process.stdout.write("Removed.\n")
+  }
+
+  if (interactive) {
+    note(
+      [
+        `Settings backup kept at  ${pc.cyan(SETTINGS_BACKUP_PATH)}`,
+        "",
+        "If launchctl was cleared, open a new terminal or relaunch",
+        "Claude Desktop so the old BUN_OPTIONS fully drains.",
+      ].join("\n"),
+      "Cleanup notes",
+    )
+    outro(pc.green("Uninstalled."))
+  } else {
+    process.stdout.write(`Uninstalled. Backup at ${SETTINGS_BACKUP_PATH}\n`)
+  }
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -165,27 +355,14 @@ function readSettingsSafe(): ClaudeSettings {
   }
 }
 
-async function askWithDefault(
-  rl: ReturnType<typeof createInterface>,
-  label: string,
-  current: string | undefined,
-): Promise<string> {
-  const hint = current ? ` [${maskSecret(label, current)}]` : ""
-  const answer = (await rl.question(`${label}${hint}: `)).trim()
-  if (answer) return answer
-  return current ?? ""
+function maskKey(key: string): string {
+  if (key.length < 8) return "•".repeat(key.length)
+  return `${key.slice(0, 4)}${"•".repeat(3)}${key.slice(-3)}`
 }
 
-function maskSecret(label: string, value: string): string {
-  if (!/API_KEY|TOKEN|SECRET/i.test(label) || value.length <= 8) return value
-  return `${value.slice(0, 5)}…${value.slice(-3)}`
-}
-
-async function confirm(rl: ReturnType<typeof createInterface>, prompt: string, defaultYes: boolean): Promise<boolean> {
-  const hint = defaultYes ? "[Y/n]" : "[y/N]"
-  const answer = (await rl.question(`${prompt}? ${hint}: `)).trim().toLowerCase()
-  if (!answer) return defaultYes
-  return answer === "y" || answer === "yes"
+function onCancel(message = "Setup cancelled."): never {
+  cancel(message)
+  process.exit(0)
 }
 
 function writeIntercept(): void {
@@ -200,7 +377,7 @@ function writeIntercept(): void {
 
 function setLaunchctlBunOptions(): void {
   const value = `--preload=${INTERCEPT_INSTALL_PATH}`
-  const res = spawnSync("launchctl", ["setenv", "BUN_OPTIONS", value], { stdio: "inherit" })
+  const res = spawnSync("launchctl", ["setenv", "BUN_OPTIONS", value], { stdio: "ignore" })
   if (res.status !== 0) {
     process.stderr.write(`[latitude-claude-code] launchctl setenv failed (exit ${res.status}). Continuing.\n`)
   }
@@ -225,12 +402,23 @@ function writePlist(): void {
 </plist>
 `
   writeFileSync(PLIST_PATH, plist, "utf-8")
-  // (Re)load so it'll auto-set BUN_OPTIONS on every login.
   spawnSync("launchctl", ["unload", PLIST_PATH], { stdio: "ignore" })
-  const res = spawnSync("launchctl", ["load", PLIST_PATH], { stdio: "inherit" })
+  const res = spawnSync("launchctl", ["load", PLIST_PATH], { stdio: "ignore" })
   if (res.status !== 0) {
     process.stderr.write(`[latitude-claude-code] launchctl load failed (exit ${res.status}). Continuing.\n`)
   }
+}
+
+function printMinimalInstallInstructions(): void {
+  process.stdout.write(
+    [
+      `Installed intercept preload to: ${INTERCEPT_INSTALL_PATH}`,
+      "",
+      "Non-interactive mode — settings.json and launchctl not touched.",
+      "To complete setup, expose BUN_OPTIONS to the claude runtime. See the README for options.",
+      "",
+    ].join("\n"),
+  )
 }
 
 interface UninstallPlan {
@@ -242,7 +430,6 @@ function buildUninstallPlan(): UninstallPlan {
   const description: string[] = []
   const steps: Array<() => void> = []
 
-  // Settings.json cleanup
   if (existsSync(SETTINGS_PATH)) {
     let settings: ClaudeSettings
     try {
@@ -275,7 +462,6 @@ function buildUninstallPlan(): UninstallPlan {
     }
   }
 
-  // launchctl BUN_OPTIONS (only if it's ours)
   const currentLaunchd = readLaunchctlBunOptions()
   if (currentLaunchd && currentLaunchd.includes(INTERCEPT_INSTALL_PATH)) {
     description.push(`launchctl: unsetenv BUN_OPTIONS (currently: ${currentLaunchd})`)
@@ -286,7 +472,6 @@ function buildUninstallPlan(): UninstallPlan {
     description.push(`launchctl BUN_OPTIONS is set to something else (${currentLaunchd}); leaving it alone`)
   }
 
-  // LaunchAgents plist
   if (existsSync(PLIST_PATH)) {
     description.push(`~/Library/LaunchAgents/${PLIST_LABEL}.plist: unload + remove`)
     steps.push(() => {
@@ -299,7 +484,6 @@ function buildUninstallPlan(): UninstallPlan {
     })
   }
 
-  // State dir: intercept.js, requests/*.json, state.json
   if (existsSync(STATE_DIR)) {
     const pieces: string[] = []
     if (existsSync(INTERCEPT_INSTALL_PATH)) pieces.push("intercept.js")
@@ -335,47 +519,7 @@ function readLaunchctlBunOptions(): string | undefined {
   return out || undefined
 }
 
-function printMinimalInstallInstructions(): void {
-  process.stdout.write(
-    [
-      `Installed intercept preload to: ${INTERCEPT_INSTALL_PATH}`,
-      "",
-      "Non-interactive mode — settings.json and launchctl not touched.",
-      "To complete setup, expose BUN_OPTIONS to the claude runtime. See the README for options.",
-      "",
-    ].join("\n"),
-  )
-}
-
-function printInstallSummary(args: {
-  backedUp: boolean
-  addedHook: boolean
-  useLaunchctl: boolean
-  apiKey: boolean
-  project: boolean
-  baseUrl: boolean
-}): void {
-  process.stdout.write("\nDone. Summary:\n")
-  process.stdout.write(`  ✓ Preload installed at ${INTERCEPT_INSTALL_PATH}\n`)
-  if (args.backedUp) process.stdout.write(`  ✓ Backed up settings.json to ${SETTINGS_BACKUP_PATH}\n`)
-  process.stdout.write("  ✓ Updated ~/.claude/settings.json:\n")
-  if (args.apiKey) process.stdout.write("      - env.LATITUDE_API_KEY\n")
-  if (args.project) process.stdout.write("      - env.LATITUDE_PROJECT\n")
-  if (args.baseUrl) process.stdout.write("      - env.LATITUDE_BASE_URL\n")
-  if (args.useLaunchctl) process.stdout.write("      - env.BUN_OPTIONS (removed — now handled by launchctl)\n")
-  else process.stdout.write("      - env.BUN_OPTIONS (CLI path)\n")
-  if (args.addedHook) process.stdout.write("      - hooks.Stop (added our command)\n")
-  if (args.useLaunchctl) {
-    process.stdout.write(`  ✓ launchctl setenv BUN_OPTIONS "--preload=${INTERCEPT_INSTALL_PATH}"\n`)
-    process.stdout.write(`  ✓ Installed persistence plist at ${PLIST_PATH}\n`)
-  }
-}
-
-function printRelaunchReminder(): void {
-  process.stdout.write("\nNow fully quit and relaunch claude for the preload to take effect:\n")
-  process.stdout.write("  • Terminal: open a new terminal window\n")
-  process.stdout.write("  • Claude Desktop: ⌘Q to fully quit, then relaunch from Dock/Finder\n\n")
-}
+// ─── Flag parsing ────────────────────────────────────────────────────────────
 
 export function parseFlags(argv: string[]): { subcommand: string; flags: Record<string, string | boolean> } {
   const subcommand = argv[0] ?? ""
@@ -391,12 +535,25 @@ export function parseFlags(argv: string[]): { subcommand: string; flags: Record<
 
 export function normalizeInstallFlags(flags: Record<string, string | boolean>): InstallFlags {
   const str = (v: string | boolean | undefined): string | undefined => (typeof v === "string" ? v : undefined)
-  return {
-    apiKey: str(flags["api-key"] ?? flags.api_key),
-    project: str(flags.project),
-    // Accept kebab-case and snake_case for the URL flag.
-    baseUrl: str(flags["base-url"] ?? flags.base_url),
+
+  let environment: EnvironmentConfig | undefined
+  const dev = flags.dev === true
+  const staging = flags.staging === true
+  if (dev && staging) {
+    process.stderr.write("[latitude-claude-code] --dev and --staging are mutually exclusive\n")
+    process.exit(1)
+  }
+  if (dev) environment = DEV_ENV
+  else if (staging) environment = STAGING_ENV
+
+  const result: InstallFlags = {
     noLaunchctl: flags["no-launchctl"] === true || flags.no_launchctl === true,
     noPrompt: flags["no-prompt"] === true || flags.no_prompt === true || flags.yes === true,
   }
+  const apiKey = str(flags["api-key"] ?? flags.api_key)
+  if (apiKey !== undefined) result.apiKey = apiKey
+  const project = str(flags.project)
+  if (project !== undefined) result.project = project
+  if (environment !== undefined) result.environment = environment
+  return result
 }

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -392,9 +392,12 @@ function writeIntercept(): void {
 
 function setLaunchctlBunOptions(): void {
   const value = `--preload=${INTERCEPT_INSTALL_PATH}`
-  const res = spawnSync("launchctl", ["setenv", "BUN_OPTIONS", value], { stdio: "ignore" })
+  const res = spawnSync("launchctl", ["setenv", "BUN_OPTIONS", value], { encoding: "utf-8" })
   if (res.status !== 0) {
-    process.stderr.write(`[latitude-claude-code] launchctl setenv failed (exit ${res.status}). Continuing.\n`)
+    const details = [res.stderr, res.stdout].filter((s) => s && s.trim().length > 0).join(" ").trim()
+    process.stderr.write(
+      `[latitude-claude-code] launchctl setenv failed (exit ${res.status})${details ? `: ${details}` : ""}. Continuing.\n`,
+    )
   }
 }
 
@@ -417,10 +420,14 @@ function writePlist(): void {
 </plist>
 `
   writeFileSync(PLIST_PATH, plist, "utf-8")
+  // Unload may fail harmlessly if the agent was never loaded — we don't care.
   spawnSync("launchctl", ["unload", PLIST_PATH], { stdio: "ignore" })
-  const res = spawnSync("launchctl", ["load", PLIST_PATH], { stdio: "ignore" })
+  const res = spawnSync("launchctl", ["load", PLIST_PATH], { encoding: "utf-8" })
   if (res.status !== 0) {
-    process.stderr.write(`[latitude-claude-code] launchctl load failed (exit ${res.status}). Continuing.\n`)
+    const details = [res.stderr, res.stdout].filter((s) => s && s.trim().length > 0).join(" ").trim()
+    process.stderr.write(
+      `[latitude-claude-code] launchctl load failed (exit ${res.status})${details ? `: ${details}` : ""}. Continuing.\n`,
+    )
   }
 }
 

--- a/packages/telemetry/claude-code/src/setup.ts
+++ b/packages/telemetry/claude-code/src/setup.ts
@@ -531,7 +531,16 @@ export function parseFlags(argv: string[]): { subcommand: string; flags: Record<
 }
 
 export function normalizeInstallFlags(flags: Record<string, string | boolean>): InstallFlags {
-  const str = (v: string | boolean | undefined): string | undefined => (typeof v === "string" ? v : undefined)
+  // Coerce raw flag values into a non-empty string, or undefined if the user
+  // passed the flag without a value (`--api-key=`) or omitted it entirely.
+  // Empty-string values are treated as "not provided" so downstream code falls
+  // through to the interactive prompt or the existing settings.json value,
+  // instead of silently writing an empty key/project to disk.
+  const str = (v: string | boolean | undefined): string | undefined => {
+    if (typeof v !== "string") return undefined
+    const trimmed = v.trim()
+    return trimmed === "" ? undefined : trimmed
+  }
 
   let environment: EnvironmentConfig | undefined
   const dev = flags.dev === true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1616,6 +1616,13 @@ importers:
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/claude-code:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -2781,8 +2788,14 @@ packages:
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
 
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@clickhouse/client-common@1.18.2':
     resolution: {integrity: sha512-J0SG6q9V31ydxonglpj9xhNRsUxCsF71iEZ784yldqMYwsHixj/9xHFDgBDX3DuMiDx/kPDfXnf+pimp08wIBA==}
@@ -8380,8 +8393,17 @@ packages:
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
@@ -13257,10 +13279,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
   '@clack/prompts@0.11.0':
     dependencies:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
 
   '@clickhouse/client-common@1.18.2': {}
@@ -18968,7 +19002,17 @@ snapshots:
 
   fast-shallow-equal@1.0.0: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fast-xml-builder@1.1.5:
     dependencies:


### PR DESCRIPTION
Bumps `@latitude-data/claude-code-telemetry` to `0.0.5` — install is now the front door to this package, not a blob of JSON you paste into `settings.json`.

## Interactive install, rebuilt

`npx -y @latitude-data/claude-code-telemetry install` now uses [`@clack/prompts`](https://www.npmjs.com/package/@clack/prompts). The flow:

- Cyan-banner welcome + About panel.
- `◆ Latitude API key` prompt with a dim description line explaining what it is and linking to the key-management page. Input masked as `•` as you type. If a key already exists, the description shows it masked (`c34•••893`) and pressing Enter keeps it.
- `◆ Project slug` prompt with a description linking to the projects page. No prefill; existing value shown as "(Enter to keep …)" when re-running.
- `◆ Set up launchctl?` confirm on macOS, preceded by an info panel explaining why Claude Desktop needs it.
- Spinner-streamed apply phase (writes settings.json, copies preload, sets launchctl + plist).
- "Next step" panel at the end with quit/relaunch instructions and a direct link to the project's trace view.

Clack handles cancellation (⌘C) cleanly — nothing writes until all prompts complete.

## `--staging` / `--dev` environment flags

Replace the previous `--base-url` flag with two booleans:

| Flag | App | Ingest |
| --- | --- | --- |
| `--staging` | `https://staging.latitude.so` | `https://staging-ingest.latitude.so` |
| `--dev` | `http://localhost:3000` | `http://localhost:3002` |
| (none) | `https://app.latitude.so` | `https://ingest.latitude.so` |

Every URL shown or written during install (API-keys link, projects link, ingest endpoint, trace-view link, About banner) derives from the active environment. Passing both → error, exit 1. `LATITUDE_BASE_URL` is only written to settings.json when the environment is non-production.

## Behaviour cleanups

- Dropped the LATITUDE_BASE_URL interactive prompt (was already flag-only in 0.0.4; now subsumed by the env flags).
- Dropped the "auto-detect environment from existing settings.json" logic — flag-less install now always targets production. Previous behaviour silently kept you on staging if `LATITUDE_BASE_URL` in settings.json pointed at staging-ingest, which is surprising.
- Default placeholder on the project-slug prompt removed; input starts empty when there's no existing value.
- Non-interactive flag path (`--no-prompt` + flags) uses plain `…/✓` step markers instead of the spinner, so CI logs don't have cursor-hide ANSI codes.

## README restructure

The top of the README now opens with **Install** and **Uninstall** as the first two sections. The former "paste this JSON into settings.json" walkthrough is pushed to a secondary **Configuration reference → Manual installation** block for users who manage dotfiles outside the wizard. **How it works** now explains the Stop-hook + Bun-preload architecture up front, since install doesn't explain it anymore.

## Dependencies added

- `@clack/prompts@^1.2.0` — runtime, ~50KB, the prompts engine.
- `picocolors@^1.1.1` — runtime, ~3KB, ANSI styling for the non-clack bits (cyan links, yellow warnings, dim hints).

Both land in `dependencies` (not bundled); npm users get them installed alongside.

## Test plan

- [x] `pnpm --filter @latitude-data/claude-code-telemetry test` — 26 pass.
- [x] `pnpm --filter @latitude-data/claude-code-telemetry exec tsc --noEmit` — clean.
- [x] `biome check src/` — clean.
- [x] Interactive install (real TTY): production, `--staging`, `--dev` — correct URLs rendered in prompts and "Next step" panel in each case.
- [x] Flag-driven install (`--no-prompt` + `--api-key` + `--project` + `--dev`): `LATITUDE_BASE_URL` written as `http://localhost:3002`, no clack ANSI leakage.
- [x] `--dev --staging` together → exits 1 with clear error.
- [x] Re-running install is idempotent — existing Stop-hook entry recognised (both npm and dev dist paths) and not duplicated.
- [x] Uninstall round-trip (interactive + `--no-prompt`) reverses settings.json, launchctl, plist, and state dir cleanly.
- [ ] After merge, confirm `Publish Claude Code Telemetry` workflow ships `0.0.5` to npm.