### PR TITLE
fix(posthog): identify organization when name becomes available

### DIFF
--- a/apps/web/src/lib/posthog/posthog-provider.tsx
+++ b/apps/web/src/lib/posthog/posthog-provider.tsx
@@ -1,4 +1,5 @@
 import { useMountEffect } from "@repo/ui"
+import { useEffect } from "react"
 import { identifyOrganization, identifyUser, initPostHog, resetPostHog } from "./posthog-client.ts"
 
 export function PostHogProvider() {
@@ -31,11 +32,13 @@ export function PostHogIdentity({
         email: userEmail,
         ...(userName != null ? { name: userName } : {}),
       })
-      await identifyOrganization({
-        id: organizationId,
-        ...(organizationName != null ? { name: organizationName } : {}),
-      })
     })()
   })
+
+  useEffect(() => {
+    if (!organizationName) return
+    void identifyOrganization({ id: organizationId, name: organizationName })
+  }, [organizationId, organizationName])
+
   return null
 }


### PR DESCRIPTION
The previous implementation used useMountEffect for organization identification, which ran once on mount before the org collection loaded. This caused posthog.group to be called without the organization name. Now organization identification uses a separate useEffect keyed on [organizationId, organizationName] that waits until the name is available before calling identifyOrganization.

https://claude.ai/code/session_01Azr3PDo54EmwLEJXxAgE3t