### PR TITLE
feat(web): blankslates for traces and datasets

### DIFF
--- a/apps/web/src/routes/_authenticated/-components/create-project-modal.tsx
+++ b/apps/web/src/routes/_authenticated/-components/create-project-modal.tsx
@@ -1,0 +1,92 @@
+import { Button, CloseTrigger, FormWrapper, Input, Modal, useToast } from "@repo/ui"
+import { useForm } from "@tanstack/react-form"
+import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "@tanstack/react-router"
+import { createProjectMutation } from "../../../domains/projects/projects.collection.ts"
+import type { ProjectRecord } from "../../../domains/projects/projects.functions.ts"
+import { toUserMessage } from "../../../lib/errors.ts"
+import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../lib/form-server-action.ts"
+
+export function CreateProjectModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const form = useForm({
+    defaultValues: {
+      name: "",
+    },
+    onSubmit: createFormSubmitHandler(
+      async (value) => {
+        const { projectId, transaction } = createProjectMutation(value.name)
+        await transaction.isPersisted.promise
+        return { projectId }
+      },
+      {
+        onSuccess: async ({ projectId }) => {
+          const projects = queryClient.getQueryData<ProjectRecord[]>(["projects"])
+          const slug = projects?.find((p) => p.id === projectId)?.slug
+          if (slug) {
+            await router.navigate({
+              to: "/projects/$projectSlug",
+              params: { projectSlug: slug },
+            })
+          }
+          onClose()
+        },
+        onError: (error) => {
+          toast({
+            variant: "destructive",
+            title: "Error creating project",
+            description: toUserMessage(error),
+          })
+        },
+      },
+    ),
+  })
+
+  return (
+    <Modal
+      open={open}
+      dismissible
+      onOpenChange={onClose}
+      title="Create Project"
+      description="Create a new project to start adding your prompts."
+      footer={
+        <>
+          <CloseTrigger />
+          <Button
+            type="submit"
+            onClick={() => {
+              void form.handleSubmit()
+            }}
+          >
+            Create Project
+          </Button>
+        </>
+      }
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
+        <FormWrapper>
+          <form.Field name="name">
+            {(field) => (
+              <Input
+                required
+                type="text"
+                label="Name"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                errors={fieldErrorsAsStrings(field.state.meta.errors)}
+                placeholder="My awesome project"
+              />
+            )}
+          </form.Field>
+        </FormWrapper>
+      </form>
+    </Modal>
+  )
+}

--- a/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
+++ b/apps/web/src/routes/_authenticated/-components/project-breadcrumb-segment.tsx
@@ -2,15 +2,17 @@ import { DropdownMenu, Text } from "@repo/ui"
 import { extractLeadingEmoji } from "@repo/utils"
 import { eq } from "@tanstack/react-db"
 import { useParams } from "@tanstack/react-router"
-import { ChevronsUpDown } from "lucide-react"
+import { ChevronsUpDown, PlusIcon } from "lucide-react"
+import { useState } from "react"
 import { useProjectsCollection } from "../../../domains/projects/projects.collection.ts"
-import { BreadcrumbText } from "./breadcrumb-ui.tsx"
+import { CreateProjectModal } from "./create-project-modal.tsx"
 
 /**
  * Project switcher / label for the header breadcrumb. Registered on `projects/$projectSlug`.
  */
 export function ProjectBreadcrumbSegment() {
   const { projectSlug } = useParams({ strict: false })
+  const [createOpen, setCreateOpen] = useState(false)
 
   const { data: project } = useProjectsCollection(
     (projects) => projects.where(({ project: p }) => eq(p.slug, projectSlug ?? "\u0000")).findOne(),
@@ -18,39 +20,41 @@ export function ProjectBreadcrumbSegment() {
   )
 
   const { data: allProjects } = useProjectsCollection()
-  const hasMultipleProjects = (allProjects?.length ?? 0) > 1
 
   if (!project || !projectSlug) return null
 
   const [emoji, title] = extractLeadingEmoji(project.name)
 
-  return hasMultipleProjects ? (
-    <DropdownMenu
-      side="bottom"
-      align="start"
-      options={
-        allProjects?.map((p) => ({
-          label: p.name,
-          onClick: () => {
-            window.location.href = `/projects/${p.slug}`
+  return (
+    <>
+      <DropdownMenu
+        side="bottom"
+        align="start"
+        options={[
+          ...(allProjects?.map((p) => ({
+            label: p.name,
+            onClick: () => {
+              window.location.href = `/projects/${p.slug}`
+            },
+          })) ?? []),
+          {
+            label: "New project",
+            iconProps: { icon: PlusIcon, size: "sm" },
+            onClick: () => setCreateOpen(true),
           },
-        })) ?? []
-      }
-      trigger={() => (
-        <button
-          type="button"
-          className="flex items-center gap-1 px-2 py-1 rounded hover:bg-muted transition-colors cursor-pointer"
-        >
-          {emoji && <span className="text-sm">{emoji}</span>}
-          <Text.H5M color="foregroundMuted">{title}</Text.H5M>
-          <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
-        </button>
-      )}
-    />
-  ) : (
-    <BreadcrumbText variant="muted">
-      {emoji && `${emoji} `}
-      {title}
-    </BreadcrumbText>
+        ]}
+        trigger={() => (
+          <button
+            type="button"
+            className="flex items-center gap-1 px-2 py-1 rounded hover:bg-muted transition-colors cursor-pointer"
+          >
+            {emoji && <span className="text-sm">{emoji}</span>}
+            <Text.H5M color="foregroundMuted">{title}</Text.H5M>
+            <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+          </button>
+        )}
+      />
+      <CreateProjectModal open={createOpen} onClose={() => setCreateOpen(false)} />
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/index.tsx
+++ b/apps/web/src/routes/_authenticated/index.tsx
@@ -22,13 +22,11 @@ import {
 import { extractLeadingEmoji, formatCount } from "@repo/utils"
 import { eq } from "@tanstack/react-db"
 import { useForm } from "@tanstack/react-form"
-import { useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router"
 import { DatabaseIcon, PlusIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
 import { useState } from "react"
 import { useOrganizationsCollection } from "../../domains/organizations/organizations.collection.ts"
 import {
-  createProjectMutation,
   deleteProjectMutation,
   renameProjectMutation,
   useProjectsCollection,
@@ -37,6 +35,7 @@ import {
 import type { ProjectRecord } from "../../domains/projects/projects.functions.ts"
 import { toUserMessage } from "../../lib/errors.ts"
 import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../lib/form-server-action.ts"
+import { CreateProjectModal } from "./-components/create-project-modal.tsx"
 import { useAuthenticatedOrganizationId } from "./-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated/")({
@@ -287,90 +286,6 @@ function RenameProjectModal({ project, onClose }: { project: ProjectRecord; onCl
                 onChange={(e) => field.handleChange(e.target.value)}
                 errors={fieldErrorsAsStrings(field.state.meta.errors)}
                 placeholder="New project name"
-              />
-            )}
-          </form.Field>
-        </FormWrapper>
-      </form>
-    </Modal>
-  )
-}
-
-function CreateProjectModal({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const { toast } = useToast()
-  const router = useRouter()
-  const queryClient = useQueryClient()
-  const form = useForm({
-    defaultValues: {
-      name: "",
-    },
-    onSubmit: createFormSubmitHandler(
-      async (value) => {
-        const { projectId, transaction } = createProjectMutation(value.name)
-        await transaction.isPersisted.promise
-        return { projectId }
-      },
-      {
-        onSuccess: async ({ projectId }) => {
-          const projects = queryClient.getQueryData<ProjectRecord[]>(["projects"])
-          const slug = projects?.find((p) => p.id === projectId)?.slug
-          if (slug) {
-            await router.navigate({
-              to: "/projects/$projectSlug",
-              params: { projectSlug: slug },
-            })
-          }
-          onClose()
-        },
-        onError: (error) => {
-          toast({
-            variant: "destructive",
-            title: "Error creating project",
-            description: toUserMessage(error),
-          })
-        },
-      },
-    ),
-  })
-
-  return (
-    <Modal
-      open={open}
-      dismissible
-      onOpenChange={onClose}
-      title="Create Project"
-      description="Create a new project to start adding your prompts."
-      footer={
-        <>
-          <CloseTrigger />
-          <Button
-            type="submit"
-            onClick={() => {
-              void form.handleSubmit()
-            }}
-          >
-            Create Project
-          </Button>
-        </>
-      }
-    >
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          void form.handleSubmit()
-        }}
-      >
-        <FormWrapper>
-          <form.Field name="name">
-            {(field) => (
-              <Input
-                required
-                type="text"
-                label="Name"
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                errors={fieldErrorsAsStrings(field.state.meta.errors)}
-                placeholder="My awesome project"
               />
             )}
           </form.Field>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-empty-state.tsx
@@ -1,0 +1,24 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { TelescopeIcon } from "lucide-react"
+
+export function TracesEmptyState() {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={TelescopeIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3>No traces yet</Text.H3>
+          <Text.H5 color="foregroundMuted">
+            Traces capture every LLM call your application makes. Instrument your app with the Latitude SDK to start
+            streaming traces into this project.
+          </Text.H5>
+        </div>
+        <a href="https://docs.latitude.so" target="_blank" rel="noopener noreferrer">
+          <Button>Read the docs</Button>
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/annotation-queues-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/annotation-queues-empty-state.tsx
@@ -1,11 +1,7 @@
 import { Button, Icon, Text } from "@repo/ui"
 import { LayersIcon, LayersPlusIcon } from "lucide-react"
 
-export function AnnotationQueuesEmptyState({
-  onCreate,
-}: {
-  readonly onCreate: () => void
-}) {
+export function AnnotationQueuesEmptyState({ onCreate }: { readonly onCreate: () => void }) {
   return (
     <div className="h-full w-full flex items-center justify-center p-8">
       <div className="max-w-lg flex flex-col items-center gap-6 text-center">

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/annotation-queues-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/-components/annotation-queues-empty-state.tsx
@@ -1,0 +1,29 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { LayersIcon, LayersPlusIcon } from "lucide-react"
+
+export function AnnotationQueuesEmptyState({
+  onCreate,
+}: {
+  readonly onCreate: () => void
+}) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={LayersIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3>No annotation queues yet</Text.H3>
+          <Text.H5 color="foregroundMuted">
+            Annotation queues let you and your teammates review traces and label them for evaluation. Create your first
+            queue to get started.
+          </Text.H5>
+        </div>
+        <Button onClick={onCreate}>
+          <Icon size="sm" icon={LayersPlusIcon} />
+          Create queue
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/annotation-queues/index.tsx
@@ -25,6 +25,7 @@ import { useMemberByUserIdMap } from "../../../../../domains/members/members.col
 import { pickUsersFromMembersMap } from "../../../../../domains/members/pick-users-from-members.ts"
 import { useProjectsCollection } from "../../../../../domains/projects/projects.collection.ts"
 import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
+import { AnnotationQueuesEmptyState } from "./-components/annotation-queues-empty-state.tsx"
 import { AqListBreadcrumb } from "./-components/aq-list-breadcrumb.tsx"
 import { DeleteQueueModal } from "./-components/delete-queue-modal.tsx"
 import { QueueBadge } from "./-components/queue-badge.tsx"
@@ -187,6 +188,31 @@ function AnnotationQueuesPage() {
     setEditQueue(null)
     setDeleteQueue(null)
   }, [])
+
+  const hasNoQueues = queues.length === 0
+  const showEmptyState = !isLoading && hasNoQueues
+
+  if (isLoading && hasNoQueues) {
+    return null
+  }
+
+  if (showEmptyState) {
+    return (
+      <Layout>
+        <Layout.Content>
+          <AnnotationQueuesEmptyState onCreate={() => setCreateModalOpen(true)} />
+        </Layout.Content>
+        {createModalOpen && (
+          <QueueModal
+            open={createModalOpen}
+            onOpenChange={setCreateModalOpen}
+            projectId={projectId}
+            onSuccess={handleModalSuccess}
+          />
+        )}
+      </Layout>
+    )
+  }
 
   return (
     <Layout>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/-components/datasets-empty-state.tsx
@@ -1,0 +1,31 @@
+import { Button, DatabaseAddIcon, Icon, Text } from "@repo/ui"
+import { DatabaseIcon } from "lucide-react"
+
+export function DatasetsEmptyState({
+  onCreate,
+  creating,
+}: {
+  readonly onCreate: () => void
+  readonly creating: boolean
+}) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={DatabaseIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3>No datasets yet</Text.H3>
+          <Text.H5 color="foregroundMuted">
+            Datasets let you curate traces for evaluation and regression testing. Create your first dataset to get
+            started.
+          </Text.H5>
+        </div>
+        <Button onClick={onCreate} disabled={creating} isLoading={creating}>
+          <Icon size="sm" icon={DatabaseAddIcon} />
+          Create dataset
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/datasets/index.tsx
@@ -20,6 +20,7 @@ import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { useRouteProject } from "../-route-data.ts"
+import { DatasetsEmptyState } from "./-components/datasets-empty-state.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/datasets/")({
   component: DatasetsPage,
@@ -91,6 +92,9 @@ function DatasetsPage() {
 
   const getRowAriaLabel = useCallback((d: DatasetRecord) => `Open dataset ${d.name}`, [])
 
+  const hasNoDatasets = datasets.length === 0
+  const showEmptyState = !isLoading && hasNoDatasets
+
   const handleCreate = useCallback(async () => {
     setCreating(true)
     try {
@@ -110,6 +114,20 @@ function DatasetsPage() {
       setCreating(false)
     }
   }, [project, projectSlug, navigate, toast])
+
+  if (isLoading && hasNoDatasets) {
+    return null
+  }
+
+  if (showEmptyState) {
+    return (
+      <Layout>
+        <Layout.Content>
+          <DatasetsEmptyState onCreate={() => void handleCreate()} creating={creating} />
+        </Layout.Content>
+      </Layout>
+    )
+  }
 
   return (
     <Layout>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -19,6 +19,7 @@ import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "./-components/project-
 import { SessionsView } from "./-components/sessions-view.tsx"
 import { TimeFilterDropdown } from "./-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
+import { TracesEmptyState } from "./-components/traces-empty-state.tsx"
 import { TracesView } from "./-components/traces-view.tsx"
 import { useRouteProject } from "./-route-data.ts"
 import { AddToQueueModal } from "./annotation-queues/-components/add-to-queue-modal.tsx"
@@ -148,7 +149,7 @@ function ProjectPage() {
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  const { totalCount: totalTraceCount } = useTracesCount({
+  const { totalCount: totalTraceCount, isLoading: isTracesCountLoading } = useTracesCount({
     projectId: currentProject.id,
     ...(hasActiveFilters ? { filters } : {}),
   })
@@ -277,6 +278,21 @@ function ProjectPage() {
       options: { enabled: !!activeTraceId, ignoreInputs: true },
     },
   ])
+
+  const hasNoTraces = totalTraceCount === 0 && !hasActiveFilters
+  const showEmptyState = !isTracesCountLoading && hasNoTraces
+
+  if (isTracesCountLoading && hasNoTraces) {
+    return null
+  }
+
+  if (showEmptyState) {
+    return (
+      <Layout>
+        <TracesEmptyState />
+      </Layout>
+    )
+  }
 
   const sharedViewProps = {
     projectId: currentProject.id,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
@@ -1,15 +1,15 @@
 import { Button, Icon, Text } from "@repo/ui"
 import { Link } from "@tanstack/react-router"
-import { ShieldAlertIcon } from "lucide-react"
+import { SearchAlert } from "lucide-react"
 
 export function IssuesEmptyState({ projectSlug }: { projectSlug: string }) {
   return (
     <div className="h-full w-full flex items-center justify-center p-8">
       <div className="max-w-lg flex flex-col items-center gap-6 text-center">
         <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
-          <Icon icon={ShieldAlertIcon} size="lg" color="foregroundMuted" />
+          <Icon icon={SearchAlert} size="lg" color="foregroundMuted" />
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col items-center gap-2">
           <Text.H3>No issues yet</Text.H3>
           <Text.H5 color="foregroundMuted">
             Issues are discovered automatically by grouping failed annotations left on your traces. Start annotating

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-empty-state.tsx
@@ -1,0 +1,25 @@
+import { Button, Icon, Text } from "@repo/ui"
+import { Link } from "@tanstack/react-router"
+import { ShieldAlertIcon } from "lucide-react"
+
+export function IssuesEmptyState({ projectSlug }: { projectSlug: string }) {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="max-w-lg flex flex-col items-center gap-6 text-center">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={ShieldAlertIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Text.H3>No issues yet</Text.H3>
+          <Text.H5 color="foregroundMuted">
+            Issues are discovered automatically by grouping failed annotations left on your traces. Start annotating
+            traces to surface recurring problems here.
+          </Text.H5>
+        </div>
+        <Link to="/projects/$projectSlug/annotation-queues" params={{ projectSlug }}>
+          <Button>Go to annotation queues</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -246,7 +246,7 @@ export function IssuesView({
               direction: nextSorting.direction as IssuesTableSorting["direction"],
             })
           }
-          blankSlate="There are no issues yet."
+          blankSlate="No issues match the current filters"
         />
       </Layout.List>
     </Layout.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -148,7 +148,12 @@ function IssuesPage() {
   }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
 
   const hasActiveFilters = lifecycleGroup !== "active" || searchQuery !== "" || Boolean(timeRange)
-  const showEmptyState = !isLoading && issues.length === 0 && !hasActiveFilters
+  const hasNoIssues = issues.length === 0 && !hasActiveFilters
+  const showEmptyState = !isLoading && hasNoIssues
+
+  if (isLoading && hasNoIssues) {
+    return null
+  }
 
   if (showEmptyState) {
     return (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -14,6 +14,7 @@ import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { IssueDetailDrawer } from "./-components/issue-detail-drawer.tsx"
 import { IssuesAnalyticsPanel } from "./-components/issues-analytics-panel.tsx"
+import { IssuesEmptyState } from "./-components/issues-empty-state.tsx"
 import {
   ISSUES_COLUMN_OPTIONS,
   type IssuesColumnId,
@@ -145,6 +146,19 @@ function IssuesPage() {
       setExporting(false)
     }
   }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
+
+  const hasActiveFilters = lifecycleGroup !== "active" || searchQuery !== "" || Boolean(timeRange)
+  const showEmptyState = !isLoading && issues.length === 0 && !hasActiveFilters
+
+  if (showEmptyState) {
+    return (
+      <Layout>
+        <Layout.Content>
+          <IssuesEmptyState projectSlug={projectSlug} />
+        </Layout.Content>
+      </Layout>
+    )
+  }
 
   return (
     <Layout>


### PR DESCRIPTION
## Summary
- Added empty states for traces and datasets pages, matching the pattern used on issues
- Gated rendering on the initial loading state across issues/traces/datasets so the full UI no longer flashes before the empty state resolves
- Traces CTA opens `https://docs.latitude.so` in a new tab; datasets CTA triggers the same create-dataset flow as the header button

## Test plan
- [x] Fresh project with no traces → blank page briefly, then traces empty state (no flash of the full UI)
- [x] Click "Read the docs" on traces empty state → opens docs.latitude.so in a new tab
- [x] Project with no datasets → datasets empty state; clicking "Create dataset" creates and navigates to the new dataset
- [x] Project with no issues → issues empty state still renders correctly
- [x] Applying any filter on traces/issues hides the empty state even if results are zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)