### PR TITLE
feat(annotation-queues): thread scoreId through LLM telemetry and score row (Phase 2)

### DIFF
--- a/apps/workflows/src/activities/flagger-activities.ts
+++ b/apps/workflows/src/activities/flagger-activities.ts
@@ -57,6 +57,8 @@ interface DraftAnnotateOutput {
   readonly traceId: string
   readonly feedback: string
   readonly traceCreatedAt: string
+  /** Pre-generated score id; forwarded verbatim to `persistAnnotation`. */
+  readonly scoreId: string
 }
 
 export const draftAnnotate = async (input: {
@@ -97,6 +99,7 @@ export const persistAnnotation = async (input: {
   readonly queueId: string
   readonly feedback: string
   readonly traceCreatedAt: string
+  readonly scoreId: string
 }): Promise<SystemQueueAnnotateOutput> =>
   Effect.runPromise(
     persistSystemQueueAnnotationUseCase(input).pipe(

--- a/apps/workflows/src/workflows/system-queue-flagger-workflow.test.ts
+++ b/apps/workflows/src/workflows/system-queue-flagger-workflow.test.ts
@@ -10,6 +10,7 @@ const { mockActivities } = vi.hoisted(() => {
       traceId: "trace-1",
       feedback: "Test feedback",
       traceCreatedAt: "2024-01-15T10:00:00.000Z",
+      scoreId: "score-default",
     })),
     persistAnnotation: vi.fn(async () => ({
       queueId: "queue-1",
@@ -69,6 +70,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-from-draft",
     })
     mockActivities.persistAnnotation.mockResolvedValueOnce({
       queueId: "queue-123",
@@ -109,6 +111,9 @@ describe("systemQueueFlaggerWorkflow", () => {
       queueSlug: "refusal",
     })
     expect(mockActivities.persistAnnotation).toHaveBeenCalledTimes(1)
+    // The scoreId emitted by draftAnnotate must flow verbatim into
+    // persistAnnotation so the LLM telemetry span and the persisted score row
+    // share the same id (see PRD: "Identity strategy").
     expect(mockActivities.persistAnnotation).toHaveBeenCalledWith({
       organizationId: "org-1",
       projectId: "proj-1",
@@ -117,6 +122,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       queueId: "queue-123",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-from-draft",
     })
   })
 
@@ -127,6 +133,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-existing",
     })
     mockActivities.persistAnnotation.mockResolvedValueOnce({
       queueId: "queue-123",
@@ -182,6 +189,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Generated feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-persist-failure",
     })
     mockActivities.persistAnnotation.mockRejectedValueOnce(new Error("Persist failed"))
 
@@ -206,6 +214,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       traceId: "trace-1",
       feedback: "Tool call error feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-tool",
     })
     mockActivities.persistAnnotation.mockResolvedValueOnce({
       queueId: "queue-tool",
@@ -241,6 +250,7 @@ describe("systemQueueFlaggerWorkflow", () => {
       queueId: "queue-tool",
       feedback: "Tool call error feedback",
       traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-tool",
     })
   })
 })

--- a/apps/workflows/src/workflows/system-queue-flagger-workflow.ts
+++ b/apps/workflows/src/workflows/system-queue-flagger-workflow.ts
@@ -66,6 +66,7 @@ export const systemQueueFlaggerWorkflow = async (input: {
       queueId: draftResult.queueId,
       feedback: draftResult.feedback,
       traceCreatedAt: draftResult.traceCreatedAt,
+      scoreId: draftResult.scoreId,
     })
 
     log.info("System queue persist annotation completed", {

--- a/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.test.ts
@@ -1,0 +1,167 @@
+import { AI_GENERATE_TELEMETRY_TAGS } from "@domain/ai"
+import { createFakeAI } from "@domain/ai/testing"
+import {
+  AnnotationQueueId,
+  ExternalUserId,
+  OrganizationId,
+  ProjectId,
+  SessionId,
+  SimulationId,
+  SpanId,
+  TraceId,
+} from "@domain/shared"
+import { type TraceDetail, TraceRepository } from "@domain/spans"
+import { createFakeTraceRepository } from "@domain/spans/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AnnotationQueue } from "../entities/annotation-queue.ts"
+import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
+import { createFakeAnnotationQueueRepository } from "../testing/fake-annotation-queue-repository.ts"
+import { draftSystemQueueAnnotationUseCase } from "./draft-system-queue-annotation.ts"
+
+const ORG_ID = "a".repeat(24)
+const PROJECT_ID = "b".repeat(24)
+const TRACE_ID = "c".repeat(32)
+const QUEUE_ID = AnnotationQueueId("qqqqqqqqqqqqqqqqqqqqqqqq")
+
+const makeTraceDetail = (): TraceDetail => ({
+  organizationId: OrganizationId(ORG_ID),
+  projectId: ProjectId(PROJECT_ID),
+  traceId: TraceId(TRACE_ID),
+  spanCount: 1,
+  errorCount: 0,
+  startTime: new Date("2026-01-01T00:00:00.000Z"),
+  endTime: new Date("2026-01-01T00:00:01.000Z"),
+  durationNs: 1,
+  timeToFirstTokenNs: 0,
+  tokensInput: 0,
+  tokensOutput: 0,
+  tokensCacheRead: 0,
+  tokensCacheCreate: 0,
+  tokensReasoning: 0,
+  tokensTotal: 0,
+  costInputMicrocents: 0,
+  costOutputMicrocents: 0,
+  costTotalMicrocents: 0,
+  sessionId: SessionId("session"),
+  userId: ExternalUserId("user"),
+  simulationId: SimulationId(""),
+  tags: [],
+  metadata: {},
+  models: [],
+  providers: [],
+  serviceNames: [],
+  rootSpanId: SpanId("r".repeat(16)),
+  rootSpanName: "root",
+  systemInstructions: [],
+  inputMessages: [],
+  outputMessages: [],
+  allMessages: [{ role: "user", parts: [{ type: "text", content: "hello" }] }],
+})
+
+const makeSystemQueue = (): AnnotationQueue => ({
+  id: QUEUE_ID,
+  organizationId: OrganizationId(ORG_ID),
+  projectId: ProjectId(PROJECT_ID),
+  system: true,
+  name: "Jailbreaking",
+  slug: "jailbreaking",
+  description: "",
+  instructions: "",
+  settings: {},
+  assignees: [],
+  totalItems: 0,
+  completedItems: 0,
+  deletedAt: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+})
+
+describe("draftSystemQueueAnnotationUseCase", () => {
+  it("generates a scoreId, returns it in the output, and forwards it to the annotator's telemetry", async () => {
+    const { repository: traceRepo } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+    })
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([makeSystemQueue()])
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>() =>
+        Effect.succeed({
+          object: { feedback: "Draft feedback" } as T,
+          tokens: 10,
+          duration: 100,
+        }),
+    })
+
+    const result = await Effect.runPromise(
+      draftSystemQueueAnnotationUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        queueSlug: "jailbreaking",
+        traceId: TRACE_ID,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, traceRepo),
+            Layer.succeed(AnnotationQueueRepository, queueRepo),
+            aiLayer,
+          ),
+        ),
+      ),
+    )
+
+    // Output carries a non-empty scoreId alongside the annotator result.
+    expect(result.scoreId).toBeTruthy()
+    expect(typeof result.scoreId).toBe("string")
+    expect(result.scoreId.length).toBeGreaterThan(0)
+    expect(result.queueId).toBe(QUEUE_ID)
+    expect(result.feedback).toBe("Draft feedback")
+
+    // Identity: the same scoreId that's returned in the output MUST be the one
+    // stamped on the LLM telemetry metadata (the whole point of generating it
+    // upstream of the LLM call — see PRD: "Identity strategy").
+    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate[0].telemetry).toMatchObject({
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
+      metadata: expect.objectContaining({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        traceId: TRACE_ID,
+        queueSlug: "jailbreaking",
+        scoreId: result.scoreId,
+      }),
+    })
+  })
+
+  it("fails cleanly when the system queue does not exist in the project", async () => {
+    const { repository: traceRepo } = createFakeTraceRepository({
+      findByTraceId: () => Effect.succeed(makeTraceDetail()),
+    })
+    const { repository: queueRepo } = createFakeAnnotationQueueRepository([])
+    const { layer: aiLayer } = createFakeAI({
+      generate: <T>() => Effect.succeed({ object: { feedback: "unreachable" } as T, tokens: 0, duration: 0 }),
+    })
+
+    const exit = await Effect.runPromiseExit(
+      draftSystemQueueAnnotationUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        queueSlug: "not-provisioned",
+        traceId: TRACE_ID,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(TraceRepository, traceRepo),
+            Layer.succeed(AnnotationQueueRepository, queueRepo),
+            aiLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("BadRequestError")
+      expect(JSON.stringify(exit.cause)).toContain("not-provisioned")
+    }
+  })
+})

--- a/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/draft-system-queue-annotation.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, ProjectId, type RepositoryError } from "@domain/shared"
+import { BadRequestError, generateId, ProjectId, type RepositoryError, type ScoreId } from "@domain/shared"
 import { Effect } from "effect"
 import { z } from "zod"
 import { AnnotationQueueRepository } from "../ports/annotation-queue-repository.ts"
@@ -21,6 +21,17 @@ export interface DraftSystemQueueAnnotationOutput {
   readonly traceId: string
   readonly feedback: string
   readonly traceCreatedAt: string
+  /**
+   * Pre-generated id for the draft annotation score this use case will produce.
+   *
+   * Generated here (upstream of the LLM call) and passed through
+   * `telemetry.metadata` on `ai.generate(...)`. Latitude's span processor
+   * serializes it into the `latitude.metadata` JSON attribute on the exported
+   * span, which the dogfood tenant sees as `metadata.scoreId`. The persist
+   * step later writes the score row with this exact id. See PRD: "Identity
+   * strategy".
+   */
+  readonly scoreId: ScoreId
 }
 
 interface DraftSystemQueueAnnotationInput {
@@ -48,9 +59,15 @@ export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.dra
   yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
   yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
 
+  // Generate the score id up front so it can (a) flow into the annotator's
+  // `telemetry.metadata` and (b) satisfy the shared `systemQueueAnnotateInputSchema`
+  // which requires `scoreId` — that schema is also validated by the downstream
+  // `persistSystemQueueAnnotationUseCase` so both paths stay symmetric.
+  const scoreId = generateId<"ScoreId">()
+
   const parsedInput = yield* parseOrBadRequest(
     systemQueueAnnotateInputSchema,
-    input,
+    { ...input, scoreId },
     "Invalid system queue annotate input",
   )
 
@@ -75,6 +92,7 @@ export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.dra
     projectId: parsedInput.projectId,
     queueSlug: parsedInput.queueSlug,
     traceId: parsedInput.traceId,
+    scoreId,
   })
 
   return {
@@ -82,5 +100,6 @@ export const draftSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.dra
     traceId: parsedInput.traceId,
     feedback: annotatorResult.feedback,
     traceCreatedAt: annotatorResult.traceCreatedAt,
+    scoreId,
   } as DraftSystemQueueAnnotationOutput
 })

--- a/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
+++ b/packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts
@@ -1,6 +1,6 @@
 import { type PersistDraftAnnotationError, writeDraftAnnotationUseCase } from "@domain/annotations"
 import { ScoreRepository } from "@domain/scores"
-import { BadRequestError, generateId, ProjectId, type RepositoryError, SqlClient, TraceId } from "@domain/shared"
+import { BadRequestError, ProjectId, type RepositoryError, ScoreId, SqlClient, TraceId } from "@domain/shared"
 import { Effect } from "effect"
 import { z } from "zod"
 import { SYSTEM_QUEUE_DRAFT_DEFAULTS } from "../constants.ts"
@@ -122,7 +122,7 @@ export const persistSystemQueueAnnotationUseCase = Effect.fn("annotationQueues.p
         }
 
         const draftAnnotation = yield* writeDraftAnnotationUseCase({
-          id: generateId<"ScoreId">(),
+          id: ScoreId(parsedInput.scoreId),
           projectId,
           sourceId: queueId,
           traceId,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.test.ts
@@ -12,6 +12,7 @@ const INPUT: RunSystemQueueAnnotatorInput = {
   projectId: "b".repeat(24),
   queueSlug: "jailbreaking",
   traceId: "c".repeat(32),
+  scoreId: "s".repeat(24),
 }
 
 function makeTraceDetail(allMessages: TraceDetail["allMessages"]): TraceDetail {
@@ -107,6 +108,7 @@ describe("runSystemQueueAnnotatorUseCase", () => {
         projectId: INPUT.projectId,
         traceId: INPUT.traceId,
         queueSlug: INPUT.queueSlug,
+        scoreId: INPUT.scoreId,
       },
     })
   })

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -22,6 +22,16 @@ export interface RunSystemQueueAnnotatorInput {
   readonly projectId: string
   readonly queueSlug: string
   readonly traceId: string
+  /**
+   * Pre-generated score id for the draft annotation this LLM call will produce.
+   *
+   * Passed through `telemetry.metadata` on `ai.generate(...)`. Latitude's span
+   * processor serializes it into the `latitude.metadata` JSON attribute on the
+   * exported span, which the dogfood tenant sees as `metadata.scoreId` — the
+   * filter key the product-feedback flow (see PRD: "Identity strategy") uses
+   * to recover this trace later without a separate id field on the score row.
+   */
+  readonly scoreId: string
 }
 
 export interface RunSystemQueueAnnotatorResult {
@@ -121,7 +131,7 @@ export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSys
       tags: [...AI_GENERATE_TELEMETRY_TAGS.queueSystemDraft],
       metadata: buildProjectScopedAiMetadata(
         { organizationId: input.organizationId, projectId: input.projectId },
-        { traceId: input.traceId, queueSlug: input.queueSlug },
+        { traceId: input.traceId, queueSlug: input.queueSlug, scoreId: input.scoreId },
       ),
     },
   })

--- a/packages/domain/annotation-queues/src/use-cases/system-queue-annotator-contracts.test.ts
+++ b/packages/domain/annotation-queues/src/use-cases/system-queue-annotator-contracts.test.ts
@@ -12,6 +12,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "proj_456",
       queueSlug: "jailbreaking",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(true)
@@ -22,6 +23,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "proj_456",
       queueSlug: "jailbreaking",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -33,6 +35,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "proj_456",
       queueSlug: "jailbreaking",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -43,6 +46,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       organizationId: "org_123",
       queueSlug: "jailbreaking",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -54,6 +58,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "",
       queueSlug: "jailbreaking",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -64,6 +69,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       organizationId: "org_123",
       projectId: "proj_456",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -75,6 +81,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "proj_456",
       queueSlug: "",
       traceId: "trace_789",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -85,6 +92,7 @@ describe("systemQueueAnnotateInputSchema", () => {
       organizationId: "org_123",
       projectId: "proj_456",
       queueSlug: "jailbreaking",
+      scoreId: "score_abc",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)
@@ -96,6 +104,30 @@ describe("systemQueueAnnotateInputSchema", () => {
       projectId: "proj_456",
       queueSlug: "jailbreaking",
       traceId: "",
+      scoreId: "score_abc",
+    }
+    const result = systemQueueAnnotateInputSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects missing scoreId", () => {
+    const input = {
+      organizationId: "org_123",
+      projectId: "proj_456",
+      queueSlug: "jailbreaking",
+      traceId: "trace_789",
+    }
+    const result = systemQueueAnnotateInputSchema.safeParse(input)
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects empty scoreId", () => {
+    const input = {
+      organizationId: "org_123",
+      projectId: "proj_456",
+      queueSlug: "jailbreaking",
+      traceId: "trace_789",
+      scoreId: "",
     }
     const result = systemQueueAnnotateInputSchema.safeParse(input)
     expect(result.success).toBe(false)

--- a/packages/domain/annotation-queues/src/use-cases/system-queue-annotator-contracts.ts
+++ b/packages/domain/annotation-queues/src/use-cases/system-queue-annotator-contracts.ts
@@ -5,6 +5,13 @@ export const systemQueueAnnotateInputSchema = z.object({
   projectId: z.string().min(1),
   queueSlug: z.string().min(1),
   traceId: z.string().min(1),
+  /**
+   * Score id to use for the draft annotation row. Generated upstream by
+   * `draftSystemQueueAnnotationUseCase` so the Latitude telemetry span for the
+   * LLM call carries the same id as the persisted score (see PRD: "Identity
+   * strategy").
+   */
+  scoreId: z.string().min(1),
 })
 
 export type SystemQueueAnnotateInput = z.infer<typeof systemQueueAnnotateInputSchema>

--- a/packages/platform/ai-latitude/package.json
+++ b/packages/platform/ai-latitude/package.json
@@ -14,5 +14,12 @@
   "dependencies": {
     "@domain/ai": "workspace:*",
     "@latitude-data/telemetry": "workspace:*"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "catalog:",
+    "@opentelemetry/context-async-hooks": "^2.6.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
+    "@repo/vitest-config": "workspace:*",
+    "vitest": "catalog:"
   }
 }

--- a/packages/platform/ai-latitude/src/index.test.ts
+++ b/packages/platform/ai-latitude/src/index.test.ts
@@ -1,0 +1,143 @@
+import { LatitudeSpanProcessor } from "@latitude-data/telemetry"
+import { context, type TracerProvider, trace } from "@opentelemetry/api"
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
+import { BasicTracerProvider, InMemorySpanExporter } from "@opentelemetry/sdk-trace-base"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { runWithAiTelemetry } from "./index.ts"
+
+/**
+ * End-to-end contract test for the Latitude AI telemetry chain.
+ *
+ * Exercises the real pipeline:
+ *   runWithAiTelemetry
+ *     → @latitude-data/telemetry capture()
+ *     → LatitudeSpanProcessor.onStart (context -> span attributes)
+ *     → SimpleSpanProcessor export
+ *     → InMemorySpanExporter
+ *
+ * Motivated by the dogfood identity strategy (PRD: "Identity strategy") where
+ * the `scoreId` metadata key must survive every hop so Latitude-side trace
+ * filters can recover the upstream trace from a single id. But the contract
+ * under test is generic: **any metadata key passed via `telemetry.metadata`
+ * must reach the exported span as `latitude.metadata` JSON.**
+ *
+ * If a future refactor drops metadata propagation (processor change, capture
+ * rewrite, OTel SDK bump altering flush semantics, etc.) this test fails
+ * loudly instead of silently breaking every AI feature's observability.
+ */
+describe("runWithAiTelemetry metadata propagation (e2e)", () => {
+  const exporter = new InMemorySpanExporter()
+  let provider: BasicTracerProvider
+  let previousTracerProvider: TracerProvider
+
+  beforeAll(() => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+    previousTracerProvider = trace.getTracerProvider()
+    provider = new BasicTracerProvider({
+      spanProcessors: [
+        new LatitudeSpanProcessor("test-api-key", "test-project", {
+          exporter,
+          disableBatch: true,
+          disableRedact: true,
+        }),
+      ],
+    })
+    trace.setGlobalTracerProvider(provider)
+  })
+
+  beforeEach(() => {
+    exporter.reset()
+  })
+
+  afterAll(async () => {
+    // Restore the prior tracer provider before shutting ours down so any
+    // follow-up test files in the same Vitest worker don't accidentally get
+    // a shut-down tracer (noop-on-read but silently dropping spans).
+    trace.setGlobalTracerProvider(previousTracerProvider)
+    await provider.shutdown()
+  })
+
+  const parseMetadata = (raw: unknown): Record<string, unknown> => {
+    expect(typeof raw).toBe("string")
+    return JSON.parse(raw as string) as Record<string, unknown>
+  }
+
+  it("propagates scoreId from telemetry.metadata onto the exported span", async () => {
+    const scoreId = "score-abc-def-ghi"
+
+    const result = await runWithAiTelemetry(
+      {
+        spanName: "queue.system.draft",
+        tags: ["system-queue:draft"],
+        metadata: {
+          organizationId: "org-1",
+          projectId: "proj-1",
+          traceId: "trace-1",
+          queueSlug: "refusal",
+          scoreId,
+        },
+      },
+      async () => "fake-ai-response",
+    )
+
+    expect(result).toBe("fake-ai-response")
+    await provider.forceFlush()
+
+    const [exported] = exporter.getFinishedSpans()
+    expect(exported).toBeDefined()
+
+    const metadata = parseMetadata(exported?.attributes["latitude.metadata"])
+    expect(metadata.scoreId).toBe(scoreId)
+    expect(metadata.organizationId).toBe("org-1")
+    expect(metadata.queueSlug).toBe("refusal")
+  })
+
+  it("propagates arbitrary metadata keys — not specific to scoreId", async () => {
+    await runWithAiTelemetry(
+      {
+        spanName: "annotation.enrich.publication",
+        tags: ["annotation:enrichment"],
+        metadata: {
+          arbitraryKeyA: "value-a",
+          arbitraryKeyB: 42,
+          arbitraryKeyC: true,
+        },
+      },
+      async () => undefined,
+    )
+
+    await provider.forceFlush()
+
+    const [exported] = exporter.getFinishedSpans()
+    const metadata = parseMetadata(exported?.attributes["latitude.metadata"])
+    expect(metadata.arbitraryKeyA).toBe("value-a")
+    expect(metadata.arbitraryKeyB).toBe(42)
+    expect(metadata.arbitraryKeyC).toBe(true)
+  })
+
+  it("stamps the span name and tags alongside metadata", async () => {
+    await runWithAiTelemetry(
+      {
+        spanName: "queue.system.draft",
+        tags: ["system-queue:draft"],
+        metadata: { scoreId: "score-xyz" },
+      },
+      async () => undefined,
+    )
+
+    await provider.forceFlush()
+
+    const [exported] = exporter.getFinishedSpans()
+    expect(exported?.name).toBe("queue.system.draft")
+    expect(exported?.attributes["latitude.capture.name"]).toBe("queue.system.draft")
+    expect(exported?.attributes["latitude.tags"]).toBe(JSON.stringify(["system-queue:draft"]))
+  })
+
+  it("does not emit a span when telemetry is undefined", async () => {
+    const result = await runWithAiTelemetry(undefined, async () => "bare-call")
+    expect(result).toBe("bare-call")
+    await provider.forceFlush()
+
+    expect(exporter.getFinishedSpans()).toHaveLength(0)
+  })
+})

--- a/packages/platform/ai-latitude/vitest.config.ts
+++ b/packages/platform/ai-latitude/vitest.config.ts
@@ -1,0 +1,4 @@
+import base from "@repo/vitest-config"
+import { defineConfig, mergeConfig } from "vitest/config"
+
+export default mergeConfig(base, defineConfig({}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1154,6 +1154,22 @@ importers:
       '@latitude-data/telemetry':
         specifier: workspace:*
         version: link:../../telemetry/typescript
+    devDependencies:
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.6.0
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@repo/vitest-config':
+        specifier: workspace:*
+        version: link:../../vitest-config
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/platform/ai-vercel:
     dependencies:

--- a/prd/annotate-annotated-flagger-and-enrichment-dogfood.md
+++ b/prd/annotate-annotated-flagger-and-enrichment-dogfood.md
@@ -51,7 +51,7 @@ The UI surface (approve/reject buttons, enrichment thumbs-up/down) is visible to
    - Textarea: optional on Approve, **required** on Reject. Submit disabled until non-empty on Reject.
    - Buttons: *Skip* (approve path only — closes with no comment) and *Submit*.
 4. On submit, the UI POSTs the comment to a web-route that runs on our backend, which **enqueues a BullMQ job** (`product-feedback:submit-system-annotator-review`) and returns 202 immediately. The user is not blocked on the API round-trip to latitude.so.
-5. The background worker consumes the job, builds an annotation payload, and writes it to the Latitude dogfood project via the generated SDK. The payload identifies the upstream telemetry trace by filtering Latitude spans where `attributes.scoreId == <upstream draft annotation id>` — see **Identity strategy** below. Retries on 5xx/network errors use BullMQ's built-in retry policy. Permanent 4xx errors log `warn` and complete the job.
+5. The background worker consumes the job, builds an annotation payload, and writes it to the Latitude dogfood project via the generated SDK. The payload identifies the upstream telemetry trace by filtering Latitude spans where `metadata.scoreId == <upstream draft annotation id>` — see **Identity strategy** below. Retries on 5xx/network errors use BullMQ's built-in retry policy. Permanent 4xx errors log `warn` and complete the job.
 
 ### Flow 2 — Good / Bad on enrichment result
 
@@ -60,7 +60,7 @@ The UI surface (approve/reject buttons, enrichment thumbs-up/down) is visible to
    - 👍 **Good**: one click. Fires immediately; no textarea.
    - 👎 **Bad**: one click. A textarea slides into the popover with a **required** reason; submit enqueues.
 3. On submit, the UI POSTs to the same backend route pattern used for the System Annotator flow, which enqueues `product-feedback:submit-enrichment-review`.
-4. The worker builds an annotation payload and writes it to the Latitude dogfood project via the SDK. The payload identifies the upstream telemetry trace by filtering Latitude spans where `attributes.scoreId == <published score id>` — see **Identity strategy** below.
+4. The worker builds an annotation payload and writes it to the Latitude dogfood project via the SDK. The payload identifies the upstream telemetry trace by filtering Latitude spans where `metadata.scoreId == <published score id>` — see **Identity strategy** below.
 5. After submit, the controls disable in the popover and show *"Thanks — feedback recorded"* until page reload, preventing accidental duplicate submissions.
 
 ## Architecture
@@ -240,7 +240,7 @@ Naming rationale: `submit` captures "public-API entry point that takes a caller-
 
 The annotation we write into the Latitude dogfood project must reference the trace that produced the thing being reviewed — **not** the end-user trace being annotated (which is what `score.traceId` already stores).
 
-Rather than invent a new identifier, we reuse the id we already need: the **`scoreId`**. In both the System Annotator and Enrichment flows the score row ends up with a generated CUID. The same CUID is stamped onto the Latitude telemetry span that produced it, so later we can filter Latitude's traces by `attributes.scoreId == <cuid>` to find the exact trace.
+Rather than invent a new identifier, we reuse the id we already need: the **`scoreId`**. In both the System Annotator and Enrichment flows the score row ends up with a generated CUID. The same CUID is stamped onto the Latitude telemetry span that produced it, so later we can filter Latitude's traces by `metadata.scoreId == <cuid>` to find the exact trace.
 
 The key constraint we have to respect: the LLM call (which emits the telemetry span) happens in a **different code path** from the row persistence (which generates the id today). So we need to move id generation upstream — before the LLM call — and pass it through both sides.
 
@@ -253,15 +253,16 @@ Today the Temporal workflow in `apps/workflows/src/workflows/system-queue-flagge
 
 The two moments are decoupled, which means the telemetry span today has no way to reference the future `scoreId`.
 
-**Change**: move the `scoreId` generation up into the workflow itself, pass it through both activities, and stamp it onto the telemetry span during `draftAnnotate`.
+**Change**: move the `scoreId` generation upstream of the LLM call, and stamp it onto the telemetry span during `draftAnnotate` so the later persist step can reuse the same id.
+
+**Where generation happens**: not in the workflow. `generateId()` uses `cuid2.createId()` which reads `crypto.getRandomValues` — non-deterministic and unsafe inside a Temporal workflow (workflow replay would reshuffle the ids). The generation lives inside `draftSystemQueueAnnotationUseCase` (which runs inside the `draftAnnotate` activity, where non-determinism is expected).
 
 Concretely:
 
-1. In `system-queue-flagger-workflow.ts`, before invoking `draftAnnotate`, generate `scoreId = generateId<"ScoreId">()`.
-2. Extend the `draftAnnotate` activity input with `scoreId` and forward it to `runSystemQueueAnnotatorUseCase`.
-3. In `runSystemQueueAnnotatorUseCase`, include `scoreId` in the `telemetry.metadata` passed to `ai.generate(...)` (`run-system-queue-annotator.ts:155`). Latitude telemetry already forwards metadata to span attributes, so the resulting span carries `attributes.scoreId = <cuid>`.
-4. Extend the `persistAnnotation` activity input with `scoreId` and forward it to `persistSystemQueueAnnotationUseCase`.
-5. In `persistSystemQueueAnnotationUseCase`, replace `id: generateId<"ScoreId">()` (`persist-system-queue-annotation.ts:125`) with `id: input.scoreId`. This preserves idempotency because the existing early-return branches still read from `scoreRepository.findQueueDraftByTraceId` before attempting insertion.
+1. `draftSystemQueueAnnotationUseCase` generates `scoreId = generateId<"ScoreId">()` before invoking `runSystemQueueAnnotatorUseCase`, and returns it in the use case output alongside `queueId` / `feedback` / `traceCreatedAt`.
+2. `runSystemQueueAnnotatorUseCase` accepts `scoreId` as input and includes it in the `telemetry.metadata` passed to `ai.generate(...)`. Latitude telemetry already forwards metadata to a `latitude.metadata` span attribute (JSON), so the resulting trace ingested by Latitude carries `metadata.scoreId = <cuid>`.
+3. The `draftAnnotate` activity output surfaces `scoreId` up to the workflow, which forwards it verbatim to the `persistAnnotation` activity input.
+4. `persistSystemQueueAnnotationUseCase` accepts `scoreId` and passes it as the `id` argument to `writeDraftAnnotationUseCase`, replacing the previous inline `generateId<"ScoreId">()`. Idempotency is preserved — the existing early-return branches still read from `scoreRepository.findQueueDraftByTraceId` before attempting insertion.
 
 After this change: the UI has `annotation.id` (the draft annotation's `scoreId`) directly at hand when the reviewer clicks Approve/Reject. No extra metadata field is needed on the annotation row.
 
@@ -269,7 +270,7 @@ After this change: the UI has `annotation.id` (the draft annotation's `scoreId`)
 
 The score row **already exists** when enrichment runs — it is the published human annotation being enriched. No id needs to be pre-generated; the existing `score.id` plays the same role as the pre-generated CUID above.
 
-**Change**: in `enrichAnnotationForPublicationUseCase`, add `scoreId` to the `telemetry.metadata` of the enrichment `ai.generate(...)` call. That stamps `attributes.scoreId = <cuid>` on the enrichment LLM's Latitude telemetry span. When the reviewer clicks 👍/👎 in the enrichment popover, the UI already has `annotation.id`, which is the same `scoreId`.
+**Change**: in `enrichAnnotationForPublicationUseCase`, add `scoreId` to the `telemetry.metadata` of the enrichment `ai.generate(...)` call. That stamps `metadata.scoreId = <cuid>` on the enrichment LLM's Latitude telemetry span. When the reviewer clicks 👍/👎 in the enrichment popover, the UI already has `annotation.id`, which is the same `scoreId`.
 
 ### Product-feedback payload
 
@@ -279,7 +280,7 @@ In both flows, the BullMQ worker calls `POST /v1/.../annotations` on the Latitud
 {
   trace: {
     by: "filters",
-    filters: { "attributes.scoreId": [{ op: "eq", value: upstreamScoreId }] }
+    filters: { "metadata.scoreId": [{ op: "eq", value: upstreamScoreId }] }
   },
   draft: false,
   passed, value, feedback,
@@ -316,7 +317,7 @@ Mapping UI action → outbound annotation payload. All writes use `draft: false`
 | Enrichment 👍 | `true` | `1` | `"Good enrichment"` | `{ kind: "enrichment-review", rawFeedback, enrichedFeedback }` |
 | Enrichment 👎 | `false` | `0` | reason (required) | `{ kind: "enrichment-review", rawFeedback, enrichedFeedback }` |
 
-`trace` is always resolved via `{ by: "filters", filters: { "attributes.scoreId": [{ op: "eq", value: upstreamScoreId }] } }` — see **Identity strategy**. The upstream score id is not duplicated in `metadata` because it is already the trace-lookup key.
+`trace` is always resolved via `{ by: "filters", filters: { "metadata.scoreId": [{ op: "eq", value: upstreamScoreId }] } }` — see **Identity strategy**. The upstream score id is not duplicated in `metadata` because it is already the trace-lookup key.
 
 ## Testing
 
@@ -325,7 +326,7 @@ Mapping UI action → outbound annotation payload. All writes use `draft: false`
 - **Unit tests** for `recordSystemAnnotatorReviewUseCase` / `recordEnrichmentReviewUseCase` with an in-memory `ProductFeedbackClient` fake.
 - **Adapter test** for `@platform/latitude-api` using Fern's custom-fetcher option to assert request shape.
 - **Worker test** for the `product-feedback` queue consuming a job and invoking the domain use case.
-- **End-to-end identity test** that runs a real `ai.generate` call with a known `scoreId` in `telemetry.metadata`, flushes the span pipeline, and asserts the span reaches the export sink with `attributes.scoreId` set. Guards against a future regression in `span-filter.ts` or the OTel sampler config silently breaking the filter lookup.
+- **End-to-end identity test** that runs a real `ai.generate` call with a known `scoreId` in `telemetry.metadata`, flushes the span pipeline, and asserts the span reaches the export sink with `metadata.scoreId` set. Guards against a future regression in `span-filter.ts` or the OTel sampler config silently breaking the filter lookup.
 - **UI**: start the dev server, approve with no comment, approve with a comment, reject without a comment (submit must stay disabled), reject with a comment. Exercise 👍 (no textarea) and 👎 (required textarea) in the enrichment popover. Confirm the existing approve/reject business logic fires before the popover opens and independently of whether the comment is submitted.
 
 ## Implementation plan
@@ -354,19 +355,22 @@ Checkpoint:
 
 Scope:
 
-- [ ] In `apps/workflows/src/workflows/system-queue-flagger-workflow.ts:46-70`, generate `scoreId = generateId<"ScoreId">()` and pass to both activities.
-- [ ] Extend `draftAnnotate` activity input with `scoreId`.
-- [ ] Extend `persistAnnotation` activity input with `scoreId`.
-- [ ] In `packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts:152-159`, include `scoreId` in the `telemetry.metadata` passed to `ai.generate(...)`.
-- [ ] In `packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts:125`, replace `id: generateId<"ScoreId">()` with the forwarded `scoreId`.
-- [ ] In `packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts` (around line 173), add `scoreId` to the enrichment `ai.generate(...)` `telemetry.metadata`.
-- [ ] End-to-end identity test: real `ai.generate` with a known `scoreId`, flush span pipeline, assert exported span has `attributes.scoreId` set.
+- [x] ~~In `apps/workflows/src/workflows/system-queue-flagger-workflow.ts:46-70`, generate `scoreId = generateId<"ScoreId">()` and pass to both activities.~~ **Design deviation**: `generateId()` uses `cuid2.createId()` which reads `crypto.getRandomValues` — non-deterministic and unsafe inside a Temporal workflow (breaks replay). Moved generation inside `draftSystemQueueAnnotationUseCase` (runs inside the `draftAnnotate` activity). The use case returns the `scoreId` alongside `queueId`/`feedback`, the workflow forwards it verbatim to `persistAnnotation`. Same net effect — the LLM telemetry span and the persisted score row share the id — but generation happens in activity scope, not workflow scope.
+- [x] Extend `draftAnnotate` activity **output** with `scoreId` (not input — the id is generated by the use case inside the activity).
+- [x] Extend `persistAnnotation` activity input with `scoreId`.
+- [x] In `packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts`, include `scoreId` in the `telemetry.metadata` passed to `ai.generate(...)`.
+- [x] In `packages/domain/annotation-queues/src/use-cases/persist-system-queue-annotation.ts`, replace `id: generateId<"ScoreId">()` with the forwarded `scoreId`.
+- [x] ~~In `packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts`~~ — **already landed on `main` before Phase 2 started**: the enrichment `ai.generate(...)` already passes `scoreId` in its `telemetry.metadata`. No change needed.
+- [x] End-to-end contract test in `packages/platform/ai-latitude/src/index.test.ts`: a real `runWithAiTelemetry` call (with a stub `execute` fn — no network, no AI provider) routed through `LatitudeSpanProcessor` → `InMemorySpanExporter`, asserting the exported span's `latitude.metadata` JSON contains the passed metadata. Covers `scoreId` but the contract is generic: any metadata key must survive the full chain. Guards against future regressions in `capture()`, the processor, or OTel SDK bumps.
 
 Checkpoint:
 
-- [ ] `pnpm --filter @domain/annotation-queues --filter @domain/annotations --filter @apps/workflows test` green.
-- [ ] Identity test green.
-- [ ] No user-visible behavior change (verified by reading diff).
+- [x] `pnpm --filter @domain/annotation-queues test` → 141/141 green (includes new contract tests for `systemQueueAnnotateInputSchema.scoreId` and updated `runSystemQueueAnnotatorUseCase` telemetry metadata assertions).
+- [x] `pnpm --filter @app/workflows test` → 51/51 green (workflow test now asserts `scoreId` flows from `draftAnnotate` output into `persistAnnotation` input).
+- [x] `pnpm --filter @platform/ai-latitude test` → 4/4 green (new e2e contract test).
+- [x] `pnpm --filter @domain/annotations test` → still green (phase 1 + enrichment untouched).
+- [x] All three packages typecheck and Biome-lint clean.
+- [x] No user-visible behavior change (the LLM span now carries `scoreId` but nothing observes it yet; that wire-up lands in Phase 4).
 
 ### Phase 3 — OpenAPI emission and Fern SDK
 


### PR DESCRIPTION
# What?

**Phase 2 of the Latitude dogfood epic** — see the full plan in [`prd/annotate-annotated-flagger-and-enrichment-dogfood.md`](./prd/annotate-annotated-flagger-and-enrichment-dogfood.md).

The System Annotator's draft annotation score id is now generated *before* the LLM call, stamped onto the Latitude telemetry span as metadata, and persisted verbatim on the score row — so the telemetry span and the score row share the same id. This is the identity primitive the product-feedback dogfood flow (landing in Phase 4/5) needs to recover the upstream LLM trace from a single id.

Phase 1 (publish-by-default API + trace ref union) is already on `main` (#2812). This PR depends on nothing from Phase 1 directly — they're independent scope items that happen to sequence in the PRD.

## Pipeline changes (`@domain/annotation-queues` + `@app/workflows`)

- `draftSystemQueueAnnotationUseCase` generates the `scoreId` before invoking the annotator and returns it in its output alongside `queueId` / `feedback` / `traceCreatedAt`.
- `runSystemQueueAnnotatorUseCase` accepts `scoreId` as input and passes it through `buildProjectScopedAiMetadata` so `ai.generate(...).telemetry.metadata` carries `{ ..., scoreId }`. `LatitudeSpanProcessor` serializes that to the `latitude.metadata` JSON attribute on the exported span, which the dogfood tenant sees as `metadata.scoreId`.
- `systemQueueFlaggerWorkflow` forwards `draftResult.scoreId` verbatim to the `persistAnnotation` activity input.
- `persistSystemQueueAnnotationUseCase` accepts `scoreId` and passes it as the `id` argument to `writeDraftAnnotationUseCase`, replacing the previous inline `generateId<\"ScoreId\">()`. Idempotency is preserved via the existing `findQueueDraftByTraceId` early-return branches.
- `systemQueueAnnotateInputSchema` enforces `scoreId: z.string().min(1)` with matching *rejects missing/empty scoreId* contract tests.

## Design deviation from the PRD

The PRD originally proposed generating `scoreId` at the top of the Temporal workflow. `generateId()` uses `cuid2.createId()` which reads `crypto.getRandomValues` — **non-deterministic** and unsafe inside a workflow (would break replay).

Generation now lives inside the `draftAnnotate` activity (via `draftSystemQueueAnnotationUseCase`) where non-determinism is expected. The workflow just forwards the value verbatim. Same net effect — the LLM telemetry span and the persisted score row share the id — just generated in activity scope, not workflow scope. PRD updated to reflect this.

## Enrichment

Already stamps `scoreId` on its `telemetry.metadata` on `main` (`packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts`). No change needed — Phase 2 was a partial no-op for this path.

## End-to-end contract test (`@platform/ai-latitude`)

New integration test covering the full telemetry chain:

```
runWithAiTelemetry
  -> @latitude-data/telemetry capture()
    -> LatitudeSpanProcessor.onStart (context -> span attributes)
      -> SimpleSpanProcessor export
        -> InMemorySpanExporter
```

No AI provider, no network — `execute` is a stub returning a canned response. What's tested is the **telemetry wrapping chain**: if a future refactor drops metadata propagation (processor change, capture rewrite, OTel SDK bump altering flush semantics, …), this fails loudly instead of silently breaking every AI feature's observability.

The test lives in `@platform/ai-latitude` as a general contract test — not specific to Phase 2. It covers `scoreId` but asserts a generic property: *any* metadata key passed via `telemetry.metadata` must reach the exported span as `latitude.metadata` JSON.

## Coverage

- `@domain/annotation-queues`: **141/141** green (3 new contract tests for `scoreId` required/empty, existing annotator test now asserts `telemetry.metadata.scoreId`).
- `@app/workflows`: **51/51** green (workflow test now asserts `scoreId` flows from `draftAnnotate` output into `persistAnnotation` input verbatim).
- `@platform/ai-latitude`: **4/4** new e2e tests pass.
- All three packages typecheck + Biome clean.

## Not in this PR

- Phase 3 (OpenAPI emission + Fern SDK + publish workflow)
- Phase 4 (`@domain/product-feedback` + `@platform/latitude-api` + BullMQ worker)
- Phase 5 (web UI: post-decision popover + enrichment 👍/👎)

These stay separate per the PRD's phased plan.

## Test plan

- [ ] CI green on this branch.
- [ ] Manual smoke: trigger a System Annotator run (e.g. via a debug script or trace that hits a seeded system queue), inspect Datadog for the outer Effect span `annotationQueues.runSystemQueueAnnotator` and the inner Latitude capture span `queue.system.draft` — the Latitude span's `latitude.metadata` should contain a `scoreId` matching the newly-persisted annotation row's id.