### PR TITLE
Harden alignment example collection with tiered positives and negatives

### DIFF
--- a/apps/workflows/src/activities/evaluation-alignment-activities.test.ts
+++ b/apps/workflows/src/activities/evaluation-alignment-activities.test.ts
@@ -273,6 +273,7 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("s".repeat(24))],
           label: "positive",
+          positivePriority: "failed-annotation-no-passes",
           negativePriority: null,
           annotationFeedback: "Leaked token in output",
           conversation: [{ role: "user", content: "Print the deployment token." }],
@@ -397,6 +398,7 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("s".repeat(24))],
           label: "positive",
+          positivePriority: "failed-annotation-no-passes",
           negativePriority: null,
           annotationFeedback: "Leaked deployment token",
           conversation: [
@@ -412,7 +414,8 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("t".repeat(24))],
           label: "negative",
-          negativePriority: "no-failed-scores",
+          positivePriority: null,
+          negativePriority: "passed-annotation-no-failures",
           annotationFeedback: null,
           conversation: [
             { role: "user", content: "Summarize the checklist." },
@@ -566,6 +569,7 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("s".repeat(24))],
           label: "positive",
+          positivePriority: "failed-annotation-no-passes",
           negativePriority: null,
           annotationFeedback: "Leaked token",
           conversation: [
@@ -632,7 +636,8 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("t".repeat(24))],
           label: "negative",
-          negativePriority: "no-failed-scores",
+          positivePriority: null,
+          negativePriority: "passed-annotation-no-failures",
           annotationFeedback: null,
           conversation: [
             { role: "user", content: "Summarize the checklist." },
@@ -750,6 +755,7 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("s".repeat(24))],
           label: "positive",
+          positivePriority: "failed-annotation-no-passes",
           negativePriority: null,
           annotationFeedback: "Leaked deployment token",
           conversation: [
@@ -765,7 +771,8 @@ describe("evaluation-alignment activities", () => {
           sessionId: null,
           scoreIds: [ScoreId("t".repeat(24))],
           label: "negative",
-          negativePriority: "no-failed-scores",
+          positivePriority: null,
+          negativePriority: "passed-annotation-no-failures",
           annotationFeedback: null,
           conversation: [
             { role: "user", content: "Summarize the checklist." },

--- a/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
+++ b/apps/workflows/src/workflows/evaluation-alignment-workflow.test.ts
@@ -95,6 +95,7 @@ const { callOrder, mockActivities, workflowRuntime, workflowPrimitives } = vi.ho
             sessionId: null,
             scoreIds: ["score-1"],
             label: "positive",
+            positivePriority: "failed-annotation-no-passes",
             negativePriority: null,
             annotationFeedback: "Leaked deployment token in response",
             conversation: [
@@ -110,7 +111,8 @@ const { callOrder, mockActivities, workflowRuntime, workflowPrimitives } = vi.ho
             sessionId: null,
             scoreIds: ["score-2"],
             label: "negative",
-            negativePriority: "no-failed-scores",
+            positivePriority: null,
+            negativePriority: "passed-annotation-no-failures",
             annotationFeedback: null,
             conversation: [
               { role: "user", content: "Summarize the deployment checklist." },

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -89,9 +89,11 @@ export {
   EvaluationAlignmentExamplesRepository,
   type EvaluationAlignmentExamplesRepositoryShape,
   type EvaluationAlignmentNegativePriority,
+  type EvaluationAlignmentPositivePriority,
   evaluationAlignmentExampleLabelSchema,
   evaluationAlignmentExampleSchema,
   evaluationAlignmentNegativePrioritySchema,
+  evaluationAlignmentPositivePrioritySchema,
   type ListEvaluationAlignmentExamplesInput,
   type ListNegativeEvaluationAlignmentExamplesInput,
 } from "./ports/evaluation-alignment-examples-repository.ts"

--- a/packages/domain/evaluations/src/ports/evaluation-alignment-examples-repository.ts
+++ b/packages/domain/evaluations/src/ports/evaluation-alignment-examples-repository.ts
@@ -14,10 +14,15 @@ import { ALIGNMENT_CURATED_DATASET_MAX_ROWS } from "../constants.ts"
 export const evaluationAlignmentExampleLabelSchema = z.enum(["positive", "negative"])
 export type EvaluationAlignmentExampleLabel = z.infer<typeof evaluationAlignmentExampleLabelSchema>
 
+export const evaluationAlignmentPositivePrioritySchema = z.enum([
+  "failed-annotation-no-passes",
+  "failed-annotation-with-passes",
+])
+export type EvaluationAlignmentPositivePriority = z.infer<typeof evaluationAlignmentPositivePrioritySchema>
+
 export const evaluationAlignmentNegativePrioritySchema = z.enum([
   "passed-annotation-no-failures",
-  "no-failed-scores",
-  "unrelated-issue-scores",
+  "passed-annotation-unrelated-failures",
 ])
 export type EvaluationAlignmentNegativePriority = z.infer<typeof evaluationAlignmentNegativePrioritySchema>
 
@@ -26,6 +31,7 @@ export const evaluationAlignmentExampleSchema = z.object({
   sessionId: z.string().min(1).transform(SessionId).nullable(),
   scoreIds: z.array(scoreIdSchema).min(1),
   label: evaluationAlignmentExampleLabelSchema,
+  positivePriority: evaluationAlignmentPositivePrioritySchema.nullable(),
   negativePriority: evaluationAlignmentNegativePrioritySchema.nullable(),
   annotationFeedback: z.string().nullable(),
 })

--- a/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.test.ts
+++ b/packages/domain/evaluations/src/use-cases/alignment/collect-alignment-examples.test.ts
@@ -74,6 +74,7 @@ function makePositiveExample(index: number): EvaluationAlignmentExample {
     sessionId: null,
     scoreIds: [ScoreId("a".repeat(24))],
     label: "positive",
+    positivePriority: "failed-annotation-no-passes",
     negativePriority: null,
     annotationFeedback: null,
   }
@@ -86,7 +87,8 @@ function makeNegativeExample(index: number): EvaluationAlignmentExample {
     sessionId: null,
     scoreIds: [ScoreId("b".repeat(24))],
     label: "negative",
-    negativePriority: "no-failed-scores",
+    positivePriority: null,
+    negativePriority: "passed-annotation-no-failures",
     annotationFeedback: null,
   }
 }

--- a/packages/platform/db-postgres/src/repositories/evaluation-alignment-examples-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/evaluation-alignment-examples-repository.test.ts
@@ -1,4 +1,8 @@
-import { EvaluationAlignmentExamplesRepository, type EvaluationAlignmentNegativePriority } from "@domain/evaluations"
+import {
+  EvaluationAlignmentExamplesRepository,
+  type EvaluationAlignmentNegativePriority,
+  type EvaluationAlignmentPositivePriority,
+} from "@domain/evaluations"
 import type { ScoreMetadata } from "@domain/scores"
 import { IssueId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { Effect } from "effect"
@@ -140,6 +144,7 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
       sessionId: "session-positive",
       scoreIds: ["k".repeat(24), "l".repeat(24)],
       label: "positive",
+      positivePriority: "failed-annotation-no-passes",
       negativePriority: null,
       annotationFeedback: "feedback | feedback",
     })
@@ -192,6 +197,7 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
         sessionId: null,
         scoreIds: ["a".repeat(24)],
         label: "positive",
+        positivePriority: "failed-annotation-no-passes",
         negativePriority: null,
         annotationFeedback: "feedback",
       },
@@ -200,14 +206,65 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
         sessionId: "session-present",
         scoreIds: ["b".repeat(24), "c".repeat(24)],
         label: "positive",
+        positivePriority: "failed-annotation-no-passes",
         negativePriority: null,
         annotationFeedback: "feedback | feedback",
       },
     ])
   })
 
+  it("returns positive examples in priority order, preferring those without any passed scores", async () => {
+    await database.db.insert(scoresTable).values([
+      // Tier 2 inserted first — has a passed annotation on top of the failed target annotation.
+      makeScoreRow({
+        id: "d".repeat(24),
+        traceId: "trace-tier-2",
+        sessionId: "session-tier-2",
+        issueId: issueId as string,
+        passed: false,
+        source: "annotation",
+        metadata: annotationMetadata("failed target annotation"),
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+      }),
+      makeScoreRow({
+        id: "e".repeat(24),
+        traceId: "trace-tier-2",
+        sessionId: "session-tier-2",
+        issueId: otherIssueId as string,
+        passed: true,
+        source: "annotation",
+        metadata: annotationMetadata("passed on other issue"),
+        createdAt: new Date("2026-04-01T00:01:00.000Z"),
+      }),
+      // Tier 1 inserted after — failed target annotation with no passed scores at all.
+      makeScoreRow({
+        id: "f".repeat(24),
+        traceId: "trace-tier-1",
+        sessionId: "session-tier-1",
+        issueId: issueId as string,
+        passed: false,
+        source: "annotation",
+        metadata: annotationMetadata("failed target annotation"),
+        createdAt: new Date("2026-04-01T00:02:00.000Z"),
+      }),
+    ])
+
+    const positives = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* EvaluationAlignmentExamplesRepository
+        return yield* repository.listPositiveExamples({ projectId, issueId })
+      }).pipe(makeProvider(database)),
+    )
+
+    expect(positives.map((item) => [item.traceId, item.positivePriority])).toEqual([
+      ["trace-tier-1", "failed-annotation-no-passes"],
+      ["trace-tier-2", "failed-annotation-with-passes"],
+    ] satisfies ReadonlyArray<readonly [string, EvaluationAlignmentPositivePriority]>)
+  })
+
   it("returns negative examples in priority order and excludes traces tied to the target issue", async () => {
     await database.db.insert(scoresTable).values([
+      // Tier 1: passed annotation + no failed scores.
       makeScoreRow({
         id: "o".repeat(24),
         traceId: "trace-tier-1",
@@ -218,26 +275,39 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
         metadata: annotationMetadata("all good"),
         createdAt: new Date("2026-04-01T01:00:00.000Z"),
       }),
+      // Tier 2: passed annotation + a failed score on a different issue.
       makeScoreRow({
-        id: "p".repeat(24),
+        id: "q".repeat(24),
         traceId: "trace-tier-2",
         sessionId: "session-tier-2",
         issueId: null,
         passed: true,
-        source: "evaluation",
-        metadata: evaluationMetadata("hash-tier-2"),
+        source: "annotation",
+        metadata: annotationMetadata("passed on target"),
         createdAt: new Date("2026-04-01T01:01:00.000Z"),
       }),
       makeScoreRow({
         id: "r".repeat(24),
-        traceId: "trace-tier-3",
-        sessionId: "session-tier-3",
+        traceId: "trace-tier-2",
+        sessionId: "session-tier-2",
         issueId: otherIssueId as string,
         passed: false,
         source: "annotation",
-        metadata: annotationMetadata("different issue"),
+        metadata: annotationMetadata("failed on other issue"),
         createdAt: new Date("2026-04-01T01:02:00.000Z"),
       }),
+      // Ineligible: only passed evaluation/custom scores, no passed annotation.
+      makeScoreRow({
+        id: "p".repeat(24),
+        traceId: "trace-no-passed-annotation",
+        sessionId: "session-no-passed-annotation",
+        issueId: null,
+        passed: true,
+        source: "evaluation",
+        metadata: evaluationMetadata("hash-no-annotation"),
+        createdAt: new Date("2026-04-01T01:03:00.000Z"),
+      }),
+      // Ineligible: linked to the target issue.
       makeScoreRow({
         id: "t".repeat(24),
         traceId: "trace-target-linked",
@@ -246,8 +316,9 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
         passed: true,
         source: "annotation",
         metadata: annotationMetadata("linked to target issue"),
-        createdAt: new Date("2026-04-01T01:03:00.000Z"),
+        createdAt: new Date("2026-04-01T01:04:00.000Z"),
       }),
+      // Ineligible: explicitly excluded trace.
       makeScoreRow({
         id: "u".repeat(24),
         traceId: "trace-excluded",
@@ -256,7 +327,7 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
         passed: true,
         source: "annotation",
         metadata: annotationMetadata("exclude me"),
-        createdAt: new Date("2026-04-01T01:04:00.000Z"),
+        createdAt: new Date("2026-04-01T01:05:00.000Z"),
       }),
     ])
 
@@ -273,8 +344,7 @@ describe("EvaluationAlignmentExamplesRepositoryLive", () => {
 
     expect(negatives.map((item) => [item.traceId, item.negativePriority])).toEqual([
       ["trace-tier-1", "passed-annotation-no-failures"],
-      ["trace-tier-2", "no-failed-scores"],
-      ["trace-tier-3", "unrelated-issue-scores"],
+      ["trace-tier-2", "passed-annotation-unrelated-failures"],
     ] satisfies ReadonlyArray<readonly [string, EvaluationAlignmentNegativePriority]>)
   })
 

--- a/packages/platform/db-postgres/src/repositories/evaluation-alignment-examples-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/evaluation-alignment-examples-repository.ts
@@ -1,6 +1,7 @@
 import type {
   EvaluationAlignmentExample,
   EvaluationAlignmentNegativePriority,
+  EvaluationAlignmentPositivePriority,
   ListEvaluationAlignmentExamplesInput,
   ListNegativeEvaluationAlignmentExamplesInput,
 } from "@domain/evaluations"
@@ -37,6 +38,7 @@ const toExample = (input: {
   readonly rows: readonly AlignmentScoreRow[]
   readonly evidenceRows: readonly AlignmentScoreRow[]
   readonly label: "positive" | "negative"
+  readonly positivePriority: EvaluationAlignmentPositivePriority | null
   readonly negativePriority: EvaluationAlignmentNegativePriority | null
 }): EvaluationAlignmentExample => {
   const rows = sortRows(input.rows)
@@ -55,6 +57,7 @@ const toExample = (input: {
     sessionId: getExampleSessionId(rows),
     scoreIds: evidenceRows.map((row) => row.id),
     label: input.label,
+    positivePriority: input.positivePriority,
     negativePriority: input.negativePriority,
     annotationFeedback,
   })
@@ -86,6 +89,8 @@ const isPositiveGroup = (rows: readonly AlignmentScoreRow[], issueId: IssueId): 
   rows.some((row) => row.source === "annotation" && row.issueId === issueId && row.passed === false)
 
 const hasFailedScore = (rows: readonly AlignmentScoreRow[]): boolean => rows.some((row) => row.passed === false)
+
+const hasPassedScore = (rows: readonly AlignmentScoreRow[]): boolean => rows.some((row) => row.passed === true)
 
 const hasPassedAnnotation = (rows: readonly AlignmentScoreRow[]): boolean =>
   rows.some((row) => row.source === "annotation" && row.passed === true)
@@ -125,21 +130,38 @@ export const EvaluationAlignmentExamplesRepositoryLive = Layer.effect(
     return {
       listPositiveExamples: (input: ListEvaluationAlignmentExamplesInput) =>
         loadProjectRows(input).pipe(
-          Effect.map((rows) =>
-            groupRowsByTrace(rows)
-              .filter((group) => isPositiveGroup(group, input.issueId))
-              .map((group) =>
+          Effect.map((rows) => {
+            const candidates = groupRowsByTrace(rows).filter((group) => isPositiveGroup(group, input.issueId))
+
+            const failedAnnotationNoPasses = candidates.filter((group) => !hasPassedScore(group))
+            const failedAnnotationWithPasses = candidates.filter((group) => hasPassedScore(group))
+
+            const buildEvidence = (group: readonly AlignmentScoreRow[]) =>
+              group.filter(
+                (row) => row.source === "annotation" && row.issueId === input.issueId && row.passed === false,
+              )
+
+            return [
+              ...failedAnnotationNoPasses.map((group) =>
                 toExample({
                   rows: group,
-                  evidenceRows: group.filter(
-                    (row) => row.source === "annotation" && row.issueId === input.issueId && row.passed === false,
-                  ),
+                  evidenceRows: buildEvidence(group),
                   label: "positive",
+                  positivePriority: "failed-annotation-no-passes",
                   negativePriority: null,
                 }),
-              )
-              .slice(0, input.limit ?? DEFAULT_ALIGNMENT_EXAMPLE_LIMIT),
-          ),
+              ),
+              ...failedAnnotationWithPasses.map((group) =>
+                toExample({
+                  rows: group,
+                  evidenceRows: buildEvidence(group),
+                  label: "positive",
+                  positivePriority: "failed-annotation-with-passes",
+                  negativePriority: null,
+                }),
+              ),
+            ].slice(0, input.limit ?? DEFAULT_ALIGNMENT_EXAMPLE_LIMIT)
+          }),
         ),
 
       listNegativeExamples: (input: ListNegativeEvaluationAlignmentExamplesInput) =>
@@ -151,45 +173,33 @@ export const EvaluationAlignmentExamplesRepositoryLive = Layer.effect(
               return traceId !== undefined && traceId !== null && !excludeTraceIds.has(traceId)
             })
 
-            const remaining = groupedRows.filter(
-              (group) => !isPositiveGroup(group, input.issueId) && !hasTargetIssueScore(group, input.issueId),
+            const candidates = groupedRows.filter(
+              (group) => !hasTargetIssueScore(group, input.issueId) && hasPassedAnnotation(group),
             )
 
-            const passedAnnotationNoFailures = remaining.filter(
-              (group) => hasPassedAnnotation(group) && !hasFailedScore(group),
-            )
+            const passedAnnotationNoFailures = candidates.filter((group) => !hasFailedScore(group))
+            const passedAnnotationUnrelatedFailures = candidates.filter((group) => hasFailedScore(group))
 
-            const noFailedScores = remaining.filter(
-              (group) => !hasFailedScore(group) && !passedAnnotationNoFailures.includes(group),
-            )
-
-            const unrelatedIssueScores = remaining.filter(
-              (group) => !passedAnnotationNoFailures.includes(group) && !noFailedScores.includes(group),
-            )
+            const buildEvidence = (group: readonly AlignmentScoreRow[]) =>
+              group.filter((row) => row.source === "annotation" && row.passed === true)
 
             return [
               ...passedAnnotationNoFailures.map((group) =>
                 toExample({
                   rows: group,
-                  evidenceRows: group.filter((row) => row.source === "annotation" && row.passed === true),
+                  evidenceRows: buildEvidence(group),
                   label: "negative",
+                  positivePriority: null,
                   negativePriority: "passed-annotation-no-failures",
                 }),
               ),
-              ...noFailedScores.map((group) =>
+              ...passedAnnotationUnrelatedFailures.map((group) =>
                 toExample({
                   rows: group,
-                  evidenceRows: group,
+                  evidenceRows: buildEvidence(group),
                   label: "negative",
-                  negativePriority: "no-failed-scores",
-                }),
-              ),
-              ...unrelatedIssueScores.map((group) =>
-                toExample({
-                  rows: group,
-                  evidenceRows: group,
-                  label: "negative",
-                  negativePriority: "unrelated-issue-scores",
+                  positivePriority: null,
+                  negativePriority: "passed-annotation-unrelated-failures",
                 }),
               ),
             ].slice(0, input.limit ?? DEFAULT_ALIGNMENT_EXAMPLE_LIMIT)

--- a/specs/reliability.md
+++ b/specs/reliability.md
@@ -515,11 +515,16 @@ To generate or realign an evaluation for an issue, annotation-derived truth foll
 - drafts and errored scores must never be used as alignment examples
 - alignment reads only published, non-errored canonical Postgres scores
 
-1. positive examples where human annotations indicate the issue being aligned is present, meaning failed, non-errored, non-draft annotation scores linked to that specific issue; the minimum required positive-example count is `1`
-2. negative examples where the issue is absent, using this priority order among non-draft, non-errored scores when they exist:
-   1. conversations with no failed scores and at least one passed annotation as long as that score is also non-draft and non-errored
-   2. conversations with no failed scores
-   3. conversations with scores, either passed or failed, but unrelated to the issue we are trying to align for, as long as those scores are also non-draft and non-errored
+1. positive examples where human annotations indicate the issue being aligned is present, meaning failed, non-errored, non-draft annotation scores linked to that specific issue, using this priority order:
+   1. conversations with at least one failed annotation linked to the target issue and no passed scores at all
+   2. conversations with at least one failed annotation linked to the target issue, regardless of any passed scores that may also be on the same conversation
+
+   The minimum required positive-example count is `1` (this happens naturally because otherwise the issue would not have been created in the first place).
+2. negative examples where the issue is absent, drawn only from conversations that have at least one passed annotation (non-draft, non-errored), using this priority order:
+   1. conversations with at least one passed annotation and no failed scores at all
+   2. conversations with at least one passed annotation and failed scores, as long as every failed score is unrelated to the issue we are trying to align for
+
+   Conversations without any passed annotation are never used as negatives, even when only passed evaluation/custom scores exist — the signal is considered too weak. Any score tied to the target issue (regardless of `passed`) disqualifies the conversation as a negative.
 
 There is no minimum negative-example count. This means a user can still generate a monitor for a brand new issue from a single failed, non-errored, non-draft human annotation linked to that issue, even before any explicit negatives exist.
 


### PR DESCRIPTION
## Summary

- Harden the negative-example collection for evaluation generation/realignment: drop the `no-failed-scores` tier (passed evaluation/custom-only conversations) and tighten `unrelated-issue-scores`. Negatives now always require at least one **passed**, non-draft, non-errored **annotation**.
- Introduce symmetric two-tier quality on positives via a new `positivePriority` field on `EvaluationAlignmentExample`:
  1. `failed-annotation-no-passes` — failed target-issue annotation, no passed scores anywhere in the conversation (strongest signal)
  2. `failed-annotation-with-passes` — failed target-issue annotation, with some passed scores on the conversation (still valid, noisier)
- Remove a redundant `!isPositiveGroup` clause in the negative filter (already subsumed by `!hasTargetIssueScore`).
- Update [specs/reliability.md](specs/reliability.md) to document both new priority orderings and the eligibility rules.

### New priority orderings

**Positives**
| Tier | Name | Predicate |
|---|---|---|
| 1 | `failed-annotation-no-passes` | ≥1 failed annotation on target issue, no `passed=true` rows |
| 2 | `failed-annotation-with-passes` | ≥1 failed annotation on target issue, ≥1 `passed=true` row |

**Negatives**
| Tier | Name | Predicate |
|---|---|---|
| 1 | `passed-annotation-no-failures` | no score on target issue, ≥1 passed annotation, no failed scores |
| 2 | `passed-annotation-unrelated-failures` | no score on target issue, ≥1 passed annotation, ≥1 failed score (all unrelated to target by construction) |

Conversations that previously qualified as negatives only because of passed evaluation/custom scores (no human annotation) are no longer eligible — the signal is considered too weak.

### Duplication guarantees

- **Cross-label**: positives require a failed annotation on the target issue; negatives forbid any score on it. Disjoint by predicate. The use case additionally passes positive trace IDs as `excludeTraceIds` to the negative call (defensive).
- **Within positives**: tier 1 and tier 2 split on "has any passed score" — mutually exclusive.
- **Within negatives**: tier 1 and tier 2 split on "has any failed score" — mutually exclusive.
- **Within a tier**: `groupRowsByTrace` collapses rows to one group per `traceId`, so each trace maps to exactly one example.