### PR TITLE
feat(ai): nudge annotation and issue generator prompts toward simpler wording

### DIFF
--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -56,6 +56,8 @@ Your task is to review the full conversation below and provide structured feedba
 - Neutral and descriptive in tone
 - Focused on the underlying issue, not incidental details
 
+Use the simplest wording that still carries the full meaning. Prefer short, everyday words over formal or technical synonyms when both fit, and keep the feedback only as long as it needs to be — no padding, no restatement, no meta-commentary. The original context and nuance must still come through; simpler wording is the goal, not less information.
+
 You do NOT need to decide whether the conversation matches the queue — that has already been determined. Your job is only to draft the annotation text that explains the match.
 
 Respond with structured data containing a single "feedback" field with your analysis.

--- a/packages/domain/issues/src/use-cases/generate-issue-details.ts
+++ b/packages/domain/issues/src/use-cases/generate-issue-details.ts
@@ -107,6 +107,8 @@ You must:
 - avoid user-specific, trace-specific, or date-specific details
 - keep the title short and searchable
 - keep the description concise and human-readable
+
+Use the simplest wording that still carries the full meaning. Prefer short, everyday words over formal or technical synonyms when both fit, and keep both the title and description only as long as they need to be. The original context and nuance must still come through; simpler wording is the goal, not less information.
 `.trim()
 
 export const generateIssueDetailsUseCase = (input: GenerateIssueDetailsInput) =>


### PR DESCRIPTION
## Summary

Both AI prompts were producing output in a stiff, verbose register. Example output they were producing today:

- Annotation: *"Unnecessary conversational closing statement appended to the end of the response that detracts from the encyclopedic tone."*
- Issue title: *"Conversational closing statement undermines encyclopedic tone"*

The user originally wrote *"I dont like this"* — the AI output is three times longer and uses words no reviewer would actually say.

The original instructions (specific / actionable / neutral / focused on the underlying issue) were already doing a good job of capturing the right **content**. The gap is only in **wording** — the model defaults to formal synonyms when simpler words would carry the same meaning.

## What changed

Kept the original instructions fully intact. Added a single paragraph to each system prompt that asks for the simplest wording that still preserves the full meaning, with an explicit reminder that context and nuance must still come through — simpler wording is the goal, not less information.

- [run-system-queue-annotator.ts:44](packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts#L44)
- [generate-issue-details.ts:99](packages/domain/issues/src/use-cases/generate-issue-details.ts#L99)

Four-line diff; no behavior change to the surrounding use-cases, schemas, or tests.

## Test plan

- [ ] Trigger the annotation drafter on a sample trace and confirm the feedback still captures the full context but reads more plainly
- [ ] Trigger issue-details generation on a cluster and confirm the title/description preserves meaning while dropping filler
- [ ] Spot-check a few before/after generations to confirm the register shift is visible