### PR TITLE
fix(observability): parent Effect spans to active OTel traces

### DIFF
--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -22,6 +22,7 @@
     "@effect/opentelemetry": "catalog:",
     "@latitude-data/telemetry": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/context-async-hooks": "^2.6.0",
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
     "@opentelemetry/sdk-node": "^0.213.0",

--- a/packages/observability/src/effect-tracer.test.ts
+++ b/packages/observability/src/effect-tracer.test.ts
@@ -1,0 +1,55 @@
+import type { TracerProvider } from "@opentelemetry/api"
+import { context, trace } from "@opentelemetry/api"
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { Effect } from "effect"
+import { afterEach, beforeAll, describe, expect, it } from "vitest"
+import { withTracing } from "./effect-tracer.ts"
+
+describe("withTracing", () => {
+  let originalProvider: TracerProvider | undefined
+
+  beforeAll(() => {
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+  })
+
+  afterEach(async () => {
+    if (originalProvider) {
+      trace.setGlobalTracerProvider(originalProvider)
+      originalProvider = undefined
+    }
+  })
+
+  it("parents Effect spans to the active OTel span", async () => {
+    originalProvider = trace.getTracerProvider()
+
+    const exporter = new InMemorySpanExporter()
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    })
+
+    trace.setGlobalTracerProvider(provider)
+
+    const tracer = trace.getTracer("observability-test")
+    let parentSpanId: string | undefined
+    let parentTraceId: string | undefined
+
+    tracer.startActiveSpan("worker.root", (span) => {
+      const spanContext = span.spanContext()
+      parentSpanId = spanContext.spanId
+      parentTraceId = spanContext.traceId
+
+      Effect.runSync(Effect.void.pipe(Effect.withSpan("effect.child"), withTracing))
+
+      span.end()
+    })
+
+    await provider.forceFlush()
+
+    const childSpan = exporter.getFinishedSpans().find((span) => span.name === "effect.child")
+
+    expect(childSpan).toBeDefined()
+    expect(childSpan?.spanContext().traceId).toBe(parentTraceId)
+    expect(childSpan?.spanContext().spanId).not.toBe(parentSpanId)
+  })
+})

--- a/packages/observability/src/effect-tracer.ts
+++ b/packages/observability/src/effect-tracer.ts
@@ -1,16 +1,28 @@
-import { Resource, Tracer } from "@effect/opentelemetry"
+import { Tracer as EffectOtelTracer, Resource } from "@effect/opentelemetry"
+import { trace } from "@opentelemetry/api"
 import { Effect, Layer } from "effect"
 
 /**
  * Bridges Effect's Tracer to the already-running OTel TracerProvider.
  *
- * Tracer.layerGlobal reads the global OTel TracerProvider (set by NodeSDK.start())
- * and picks up active OTel spans as parents (e.g. HTTP request spans from Hono middleware).
+ * Tracer.layerGlobal reads the global OTel TracerProvider (set by NodeSDK.start()).
+ * Parenting to an already-active non-Effect OTel span is handled in `withTracing`
+ * so request / worker root spans remain the parent of nested Effect spans.
  *
  * Resource.layerFromEnv reads OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES,
  * both already set by startTracing() in otel.ts.
  */
-export const EffectOtelTracerLive = Tracer.layerGlobal.pipe(Layer.provide(Resource.layerFromEnv()))
+export const EffectOtelTracerLive = EffectOtelTracer.layerGlobal.pipe(Layer.provide(Resource.layerFromEnv()))
+
+const bridgeActiveOtelSpan = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> => {
+  const activeSpan = trace.getActiveSpan()
+
+  if (!activeSpan) {
+    return effect
+  }
+
+  return effect.pipe(EffectOtelTracer.withSpanContext(activeSpan.spanContext()))
+}
 
 /**
  * Pipe combinator to provide the OTel tracer layer to any effect.
@@ -25,4 +37,5 @@ export const EffectOtelTracerLive = Tracer.layerGlobal.pipe(Layer.provide(Resour
  * )
  * ```
  */
-export const withTracing = <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.provide(effect, EffectOtelTracerLive)
+export const withTracing = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.suspend((): Effect.Effect<A, E, R> => Effect.provide(bridgeActiveOtelSpan(effect), EffectOtelTracerLive))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1115,6 +1115,9 @@ importers:
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.71.0
         version: 0.71.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.6.0
+        version: 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.213.0
         version: 0.213.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## Summary
- bridge the active OpenTelemetry span into `withTracing` so nested Effect spans stay under the worker or request trace instead of starting a separate trace
- add a regression test for the observability package that exercises the bridge with a real OTel context manager and in-memory span exporter
- add the test dependency and lockfile entry needed to run that regression coverage locally and in CI

## Verification
- pnpm check --filter @repo/observability
- pnpm test --filter @repo/observability
- pnpm typecheck --filter @repo/observability