### PR TITLE
fix(db-postgres): capture call site for RepositoryError stack traces

### DIFF
--- a/packages/domain/shared/src/errors.test.ts
+++ b/packages/domain/shared/src/errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   BadRequestError,
   ConflictError,
+  captureCallSite,
   NotFoundError,
   PermissionError,
   RepositoryError,
@@ -32,6 +33,24 @@ describe("static httpStatus and httpMessage", () => {
     const err = new RepositoryError({ cause, operation: "findById" })
 
     expect(err.stack).toBe(cause.stack)
+  })
+
+  it("composes stack with call-site frames and a Caused by block", () => {
+    const cause = new Error("Failed query: insert into scores ...")
+    cause.stack = ["Error: Failed query: insert into scores ...", "    at drizzle (session.ts:70:11)"].join("\n")
+
+    const issueUpsert = () => captureCallSite("SqlClient.query")
+    const callSite = issueUpsert()
+
+    const err = new RepositoryError({ cause, operation: "query", callSite })
+
+    expect(err.stack?.split("\n")[0]).toBe(
+      "RepositoryError: Repository query failed: Failed query: insert into scores ...",
+    )
+    expect(err.stack).toContain("at issueUpsert")
+    expect(err.stack).toContain("Caused by: Error: Failed query: insert into scores ...")
+    expect(err.stack).toContain("at drizzle (session.ts:70:11)")
+    expect(err.stack).not.toContain("at captureCallSite")
   })
 
   it("includes nested cause messages for wrapped database errors", () => {

--- a/packages/domain/shared/src/errors.ts
+++ b/packages/domain/shared/src/errors.ts
@@ -61,11 +61,29 @@ const findCauseStack = (cause: unknown): string | undefined => {
   return undefined
 }
 
+/**
+ * Capture a synchronous stack trace at the call site of a `SqlClient.query` /
+ * `SqlClient.transaction` invocation. The underlying database error (from
+ * drizzle / node-postgres) is created several microtasks later, past
+ * `processTicksAndRejections`, so V8's async stack traces do not reach back to
+ * the repository or use-case that issued the query. Capturing here preserves
+ * that context so `RepositoryError.stack` shows *where in our code* the
+ * failing query originated.
+ */
+export const captureCallSite = (label: string): Error => {
+  const error = new Error(label)
+  if (typeof Error.captureStackTrace === "function") {
+    Error.captureStackTrace(error, captureCallSite)
+  }
+  return error
+}
+
 export class RepositoryError extends Data.TaggedError("RepositoryError")<{
   readonly cause: unknown
   readonly operation: string
+  readonly callSite?: Error
 }> {
-  constructor(args: { readonly cause: unknown; readonly operation: string }) {
+  constructor(args: { readonly cause: unknown; readonly operation: string; readonly callSite?: Error }) {
     super(args)
 
     const causeMessages = collectCauseMessages(args.cause)
@@ -75,13 +93,25 @@ export class RepositoryError extends Data.TaggedError("RepositoryError")<{
         : `Repository ${args.operation} failed`
 
     const causeStack = findCauseStack(args.cause)
-    if (causeStack) {
+    const callSiteFrames = extractStackFrames(args.callSite)
+
+    if (callSiteFrames) {
+      const causedBy = causeStack ? `\nCaused by: ${causeStack}` : ""
+      this.stack = `RepositoryError: ${this.message}\n${callSiteFrames}${causedBy}`
+    } else if (causeStack) {
       this.stack = causeStack
     }
   }
 
   readonly httpStatus = 500
   readonly httpMessage = "Internal server error"
+}
+
+const extractStackFrames = (error: Error | undefined): string => {
+  const stack = error?.stack
+  if (!stack) return ""
+  const newlineIdx = stack.indexOf("\n")
+  return newlineIdx === -1 ? "" : stack.slice(newlineIdx + 1)
 }
 
 /**
@@ -177,8 +207,8 @@ export type DomainError =
   | BadRequestError
   | PermissionError
 
-export const toRepositoryError = (cause: unknown, operation: string): RepositoryError =>
-  new RepositoryError({ cause, operation })
+export const toRepositoryError = (cause: unknown, operation: string, callSite?: Error): RepositoryError =>
+  new RepositoryError(callSite ? { cause, operation, callSite } : { cause, operation })
 
 export const isNotFoundError = (error: unknown): error is NotFoundError => error instanceof NotFoundError
 

--- a/packages/platform/db-postgres/src/sql-client.test.ts
+++ b/packages/platform/db-postgres/src/sql-client.test.ts
@@ -336,6 +336,143 @@ describe("SqlClientLive", () => {
     })
   })
 
+  describe("RepositoryError call-site capture", () => {
+    const drizzleLikeError = () => {
+      const err = new Error("Failed query: insert into scores ...")
+      err.stack = [
+        "Error: Failed query: insert into scores ...",
+        "    at drizzle-orm/src/pg-core/async/session.ts:70:11",
+      ].join("\n")
+      return err
+    }
+
+    async function captureQueryFailureFromNamedCaller(
+      client: PostgresClient,
+      orgId: OrganizationId,
+    ): Promise<{ _tag: string; stack?: string; message: string }> {
+      try {
+        await runWithSqlClient(client, orgId, (sql) =>
+          sql.query(async () => {
+            throw drizzleLikeError()
+          }),
+        )
+      } catch (err) {
+        return err as { _tag: string; stack?: string; message: string }
+      }
+      throw new Error("expected query to reject")
+    }
+
+    it("wraps a failed query() in RepositoryError with a composed stack", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-query")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err._tag).toBe("RepositoryError")
+      expect(err.message).toBe("Repository query failed: Failed query: insert into scores ...")
+      expect(err.stack).toBeDefined()
+    })
+
+    it("puts the RepositoryError header on the first line of the stack", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-header")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err.stack?.split("\n")[0]).toBe(
+        "RepositoryError: Repository query failed: Failed query: insert into scores ...",
+      )
+    })
+
+    it("includes the SqlClient method frame from sql-client.ts in the stack", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-sqlclient-frame")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err.stack).toContain("sql-client.ts")
+    })
+
+    it("includes a frame from the calling test file", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-caller-frame")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err.stack).toContain("sql-client.test.ts")
+    })
+
+    it("appends the underlying driver error as a Caused by: block", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-causedby")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err.stack).toContain("Caused by: Error: Failed query: insert into scores ...")
+      expect(err.stack).toContain("drizzle-orm/src/pg-core/async/session.ts:70:11")
+    })
+
+    it("does not leak the captureCallSite helper frame", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-helper-stripped")
+
+      const err = await captureQueryFailureFromNamedCaller(client, orgId)
+
+      expect(err.stack).not.toContain("at captureCallSite")
+    })
+
+    it("includes the generator frame from a domain-style repository method", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-generator")
+
+      // Mimic a domain repository: export a function that returns an Effect
+      // built with Effect.gen and yields sql.query(...). This is the shape
+      // real repositories (e.g. ScoreRepository.save) use to run queries.
+      const fakeScoreRepositorySave = (sql: import("@domain/shared").SqlClientShape<Operator>) =>
+        Effect.gen(function* fakeScoreRepositorySave() {
+          return yield* sql.query(async () => {
+            throw drizzleLikeError()
+          })
+        })
+
+      let caught: { _tag: string; stack?: string } | undefined
+      try {
+        await runWithSqlClient(client, orgId, (sql) => fakeScoreRepositorySave(sql))
+      } catch (err) {
+        caught = err as { _tag: string; stack?: string }
+      }
+
+      expect(caught?._tag).toBe("RepositoryError")
+      // The generator function name shows up in V8's stack frames for
+      // generator invocations — this is the real "domain frame" a production
+      // RepositoryError would surface.
+      expect(caught?.stack).toContain("fakeScoreRepositorySave")
+      expect(caught?.stack).toContain("Caused by: Error: Failed query: insert into scores ...")
+    })
+
+    it("threads the call site through query() when executed inside an open transaction", async () => {
+      const client = createMockPostgresClient(state)
+      const orgId = OrganizationId("org-callsite-in-tx")
+
+      let caught: { _tag: string; stack?: string } | undefined
+      try {
+        await runWithSqlClient(client, orgId, (sql) =>
+          sql.transaction(
+            sql.query(async () => {
+              throw drizzleLikeError()
+            }),
+          ),
+        )
+      } catch (err) {
+        caught = err as { _tag: string; stack?: string }
+      }
+
+      expect(caught?._tag).toBe("RepositoryError")
+      expect(caught?.stack).toContain("sql-client.test.ts")
+      expect(caught?.stack).toContain("Caused by: Error: Failed query: insert into scores ...")
+    })
+  })
+
   describe("failure and rollback", () => {
     it("propagates failure from inner effect and does not commit", async () => {
       const client = createMockPostgresClient(state)

--- a/packages/platform/db-postgres/src/sql-client.ts
+++ b/packages/platform/db-postgres/src/sql-client.ts
@@ -1,5 +1,6 @@
 import {
   ConcurrentSqlTransactionError,
+  captureCallSite,
   OrganizationId,
   SqlClient,
   type SqlClientShape,
@@ -54,6 +55,7 @@ export const SqlClientLive = (client: PostgresClient, organizationId: Organizati
           }
 
           txOpening = true
+          const callSite = captureCallSite("SqlClient.transaction")
 
           return Effect.gen(function* () {
             let resolveTxReady!: (tx: Operator) => void
@@ -78,7 +80,7 @@ export const SqlClientLive = (client: PostgresClient, organizationId: Organizati
               try: () => txReady,
               catch: (e) => {
                 txOpening = false
-                return toRepositoryError(e, "transaction")
+                return toRepositoryError(e, "transaction", callSite)
               },
             })
 
@@ -94,7 +96,7 @@ export const SqlClientLive = (client: PostgresClient, organizationId: Organizati
               resolveEffectDone({ ok: true, value: exit.value })
               yield* Effect.tryPromise({
                 try: () => txPromise,
-                catch: (e) => toRepositoryError(e, "transaction"),
+                catch: (e) => toRepositoryError(e, "transaction", callSite),
               })
               return exit.value
             }
@@ -115,19 +117,20 @@ export const SqlClientLive = (client: PostgresClient, organizationId: Organizati
                     )
                   }
                 }),
-              catch: (e) => toRepositoryError(e, "transaction"),
+              catch: (e) => toRepositoryError(e, "transaction", callSite),
             })
             return yield* exit
           })
         },
 
-        query: <T>(fn: (tx: Operator, organizationId: OrganizationId) => Promise<T>) =>
-          Effect.gen(function* () {
+        query: <T>(fn: (tx: Operator, organizationId: OrganizationId) => Promise<T>) => {
+          const callSite = captureCallSite("SqlClient.query")
+          return Effect.gen(function* () {
             const currentTx = activeTx
             if (currentTx) {
               return yield* Effect.tryPromise({
                 try: () => fn(currentTx, organizationId),
-                catch: (error) => toRepositoryError(error, "query"),
+                catch: (error) => toRepositoryError(error, "query", callSite),
               })
             }
 
@@ -137,9 +140,10 @@ export const SqlClientLive = (client: PostgresClient, organizationId: Organizati
                   await setRlsContext(tx as Operator, organizationId)
                   return fn(tx as Operator, organizationId)
                 }),
-              catch: (error) => toRepositoryError(error, "query"),
+              catch: (error) => toRepositoryError(error, "query", callSite),
             })
-          }),
+          })
+        },
       } satisfies SqlClientShape<Operator>
     }),
   )


### PR DESCRIPTION
## Summary
- `RepositoryError` from `SqlClient.query` / `SqlClient.transaction` now surfaces with a composed stack: the SqlClient frame, the domain repo / use-case generator frame, then the original drizzle/pg stack under `Caused by:`.
- Previously the stack had *only* drizzle-orm frames (`pg-core/async/session.ts:70`), because the pg driver's Error is created several microtasks after the Promise kicks off, past `processTicksAndRejections`, so V8's async stack traces could not reach back to the code that issued the query.
- This blocked triage of the DD Error Tracking issue [`874dbf2a-3e42-11f1-965d-da7ad0900005`](https://app.datadoghq.eu/error-tracking?query=service%3A%2A&link_source=monitor_notif&monitor_id=90296800&monitor_sub_type=.new%28%29&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22874dbf2a-3e42-11f1-965d-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1776773200000&to_ts=1776859600000&live=false) (scores UPSERT RLS violation under `process trace-end`) — we had to reconstruct the caller chain by reading code.

## How it works
- New `captureCallSite(label)` helper in `@domain/shared/errors.ts` creates an `Error` and immediately strips itself via `Error.captureStackTrace(err, captureCallSite)`, so the top visible frame is the caller of `captureCallSite` — i.e. `SqlClient.query` / `SqlClient.transaction`.
- `SqlClient.query` and `SqlClient.transaction` now capture a call site synchronously before any Promise is created, and thread it through `toRepositoryError(error, operation, callSite)`.
- `RepositoryError` accepts an optional `callSite?: Error`. When present it composes `this.stack` as:
    ```
    RepositoryError: Repository <operation> failed: ...
        at <SqlClient method in sql-client.ts>
        at <domain repo / use-case frame>
        at ... (Effect runtime frames)
    Caused by: Error: Failed query: ...
        at <drizzle session.ts:70:11>
        at process.processTicksAndRejections
    ```
- Backwards-compatible: callers without a `callSite` (ClickHouse / Weaviate / fakes / ad-hoc code) keep the old cause-stack-reuse behavior.

## Test plan
- [x] `pnpm --filter @domain/shared test src/errors.test.ts` — 12 pass (new case asserts composed header, frames, `Caused by:`, and that `captureCallSite` is stripped).
- [x] `pnpm --filter @platform/db-postgres test src/sql-client.test.ts` — 23 pass, incl. 8 new cases for the capture path: composed stack shape, header line, SqlClient frame, caller frame, `Caused by:` block, helper frame stripped, tx-wrapped `query` still carries the call site, and an `Effect.gen(function* fakeScoreRepositorySave() { ... })` case proving the domain generator frame lands in the stack.
- [x] `pnpm turbo typecheck` across all likely-affected packages — clean (29 tasks).
- [x] `pnpm biome check` on changed files — clean.
- [ ] Merge + deploy — verify the next `RepositoryError` in DD surfaces real app frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)