### PR TITLE
fix(usage): Usage was incorrectly calculated in UI breakdown

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildCostSegments,
+  buildTokenSegments,
+  computeTotalTokens,
+  hasAnyUsage,
+  type UsageData,
+} from "./usage-summary.tsx"
+
+function makeUsage(overrides: Partial<UsageData> = {}): UsageData {
+  return {
+    tokensInput: 0,
+    tokensOutput: 0,
+    tokensCacheRead: 0,
+    tokensCacheCreate: 0,
+    tokensReasoning: 0,
+    costInputMicrocents: 0,
+    costOutputMicrocents: 0,
+    costTotalMicrocents: 0,
+    ...overrides,
+  }
+}
+
+describe("computeTotalTokens", () => {
+  it("sums all five additive parts", () => {
+    const data = makeUsage({
+      tokensInput: 100,
+      tokensOutput: 50,
+      tokensCacheRead: 30,
+      tokensCacheCreate: 20,
+      tokensReasoning: 10,
+    })
+    expect(computeTotalTokens(data)).toBe(210)
+  })
+
+  it("includes cache and reasoning (not just input + output)", () => {
+    const data = makeUsage({
+      tokensInput: 0,
+      tokensOutput: 0,
+      tokensCacheRead: 1000,
+      tokensCacheCreate: 500,
+      tokensReasoning: 200,
+    })
+    expect(computeTotalTokens(data)).toBe(1700)
+  })
+
+  it("is zero for empty usage", () => {
+    expect(computeTotalTokens(makeUsage())).toBe(0)
+  })
+})
+
+describe("hasAnyUsage", () => {
+  it("returns false when all token counts are zero", () => {
+    expect(hasAnyUsage(makeUsage())).toBe(false)
+  })
+
+  it("returns true when only cache read is non-zero", () => {
+    expect(hasAnyUsage(makeUsage({ tokensCacheRead: 1 }))).toBe(true)
+  })
+
+  it("returns true when only cache create is non-zero", () => {
+    expect(hasAnyUsage(makeUsage({ tokensCacheCreate: 1 }))).toBe(true)
+  })
+
+  it("returns true when only reasoning is non-zero", () => {
+    expect(hasAnyUsage(makeUsage({ tokensReasoning: 1 }))).toBe(true)
+  })
+})
+
+describe("buildTokenSegments", () => {
+  it("uses additive values directly without re-subtracting sub-categories", () => {
+    // tokensInput is already non-cached (additive). Cache read/write are
+    // separate subsets of total input. Re-subtracting would under-count.
+    const data = makeUsage({
+      tokensInput: 100,
+      tokensCacheRead: 30,
+      tokensCacheCreate: 20,
+      tokensOutput: 50,
+      tokensReasoning: 10,
+    })
+
+    const segments = buildTokenSegments(data)
+    const byLabel = Object.fromEntries(segments.map((s) => [s.label, s.value]))
+
+    expect(byLabel.Prompt).toBe(100)
+    expect(byLabel["Cache Read"]).toBe(30)
+    expect(byLabel["Cache Write"]).toBe(20)
+    expect(byLabel.Completion).toBe(50)
+    expect(byLabel.Reasoning).toBe(10)
+  })
+
+  it("does not treat cache write as an output subcategory", () => {
+    // Regression: prior bug subtracted tokensCacheCreate from completion.
+    const data = makeUsage({ tokensOutput: 80, tokensCacheCreate: 500 })
+    const segments = buildTokenSegments(data)
+    const completion = segments.find((s) => s.label === "Completion")
+    expect(completion?.value).toBe(80)
+  })
+
+  it("emits segments in fixed order: Cache Read, Cache Write, Prompt, Reasoning, Completion", () => {
+    const data = makeUsage({
+      tokensInput: 1,
+      tokensOutput: 1,
+      tokensCacheRead: 1,
+      tokensCacheCreate: 1,
+      tokensReasoning: 1,
+    })
+    const labels = buildTokenSegments(data).map((s) => s.label)
+    expect(labels).toEqual(["Cache Read", "Cache Write", "Prompt", "Reasoning", "Completion"])
+  })
+
+  it("omits zero-value segments", () => {
+    const data = makeUsage({ tokensInput: 10, tokensOutput: 5 })
+    const labels = buildTokenSegments(data).map((s) => s.label)
+    expect(labels).toEqual(["Prompt", "Completion"])
+  })
+
+  it("returns no segments when usage is empty", () => {
+    expect(buildTokenSegments(makeUsage())).toEqual([])
+  })
+
+  it("segment sum equals computeTotalTokens", () => {
+    const data = makeUsage({
+      tokensInput: 100,
+      tokensOutput: 50,
+      tokensCacheRead: 30,
+      tokensCacheCreate: 20,
+      tokensReasoning: 10,
+    })
+    const segmentSum = buildTokenSegments(data).reduce((acc, s) => acc + s.value, 0)
+    expect(segmentSum).toBe(computeTotalTokens(data))
+  })
+})
+
+describe("buildCostSegments", () => {
+  it("emits input and output segments when both are non-zero", () => {
+    const data = makeUsage({ costInputMicrocents: 100, costOutputMicrocents: 200 })
+    const segments = buildCostSegments(data)
+    expect(segments.map((s) => s.label)).toEqual(["Input", "Output"])
+    expect(segments.map((s) => s.value)).toEqual([100, 200])
+  })
+
+  it("omits zero-cost segments", () => {
+    const data = makeUsage({ costInputMicrocents: 0, costOutputMicrocents: 200 })
+    expect(buildCostSegments(data).map((s) => s.label)).toEqual(["Output"])
+  })
+
+  it("returns no segments when both costs are zero", () => {
+    expect(buildCostSegments(makeUsage())).toEqual([])
+  })
+})

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -16,16 +16,16 @@ export interface UsageData {
 }
 
 const TOKEN_COLORS = {
+  cacheRead: "#d8b4fe",
+  cacheCreate: "#a855f7",
   prompt: "#3b82f6",
-  cached: "#93c5fd",
-  completion: "#22c55e",
-  reasoning: "#86efac",
-  cacheCreate: "#fbbf24",
+  reasoning: "#16a34a",
+  completion: "#4ade80",
 } as const
 
 const COST_COLORS = {
   input: "#3b82f6",
-  output: "#22c55e",
+  output: "#4ade80",
 } as const
 
 export function hasAnyUsage(data: UsageData): boolean {
@@ -39,18 +39,18 @@ export function hasAnyUsage(data: UsageData): boolean {
 }
 
 function buildTokenSegments(data: UsageData): SegmentBarItem[] {
-  const prompt = Math.max(0, data.tokensInput - data.tokensCacheRead)
-  const cached = data.tokensCacheRead
-  const completion = Math.max(0, data.tokensOutput - data.tokensReasoning - data.tokensCacheCreate)
-  const reasoning = data.tokensReasoning
+  const prompt = data.tokensInput
+  const cacheRead = data.tokensCacheRead
   const cacheCreate = data.tokensCacheCreate
+  const completion = data.tokensOutput
+  const reasoning = data.tokensReasoning
 
   const segments: SegmentBarItem[] = []
-  if (prompt > 0) segments.push({ label: "Prompt", value: prompt, color: TOKEN_COLORS.prompt })
-  if (cached > 0) segments.push({ label: "Cached", value: cached, color: TOKEN_COLORS.cached })
-  if (completion > 0) segments.push({ label: "Completion", value: completion, color: TOKEN_COLORS.completion })
-  if (reasoning > 0) segments.push({ label: "Reasoning", value: reasoning, color: TOKEN_COLORS.reasoning })
+  if (cacheRead > 0) segments.push({ label: "Cache Read", value: cacheRead, color: TOKEN_COLORS.cacheRead })
   if (cacheCreate > 0) segments.push({ label: "Cache Write", value: cacheCreate, color: TOKEN_COLORS.cacheCreate })
+  if (prompt > 0) segments.push({ label: "Prompt", value: prompt, color: TOKEN_COLORS.prompt })
+  if (reasoning > 0) segments.push({ label: "Reasoning", value: reasoning, color: TOKEN_COLORS.reasoning })
+  if (completion > 0) segments.push({ label: "Completion", value: completion, color: TOKEN_COLORS.completion })
   return segments
 }
 
@@ -138,10 +138,10 @@ function UsageRow({
       </Tooltip>
 
       <div className="flex items-center gap-2 self-center">
-        {badges}
         <Text.H5 color="foreground" noWrap>
           {formattedTotal}
         </Text.H5>
+        {badges}
       </div>
     </div>
   )
@@ -161,7 +161,8 @@ export function UsageSummary({
   const tokenSegments = useMemo(() => buildTokenSegments(data), [data])
   const costSegments = useMemo(() => buildCostSegments(data), [data])
 
-  const totalTokens = data.tokensInput + data.tokensOutput
+  const totalTokens =
+    data.tokensInput + data.tokensCacheRead + data.tokensCacheCreate + data.tokensOutput + data.tokensReasoning
   const hasCost = data.costTotalMicrocents > 0
   const hasTokens = hasAnyUsage(data)
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/usage-summary.tsx
@@ -38,7 +38,11 @@ export function hasAnyUsage(data: UsageData): boolean {
   )
 }
 
-function buildTokenSegments(data: UsageData): SegmentBarItem[] {
+export function computeTotalTokens(data: UsageData): number {
+  return data.tokensInput + data.tokensCacheRead + data.tokensCacheCreate + data.tokensOutput + data.tokensReasoning
+}
+
+export function buildTokenSegments(data: UsageData): SegmentBarItem[] {
   const prompt = data.tokensInput
   const cacheRead = data.tokensCacheRead
   const cacheCreate = data.tokensCacheCreate
@@ -54,7 +58,7 @@ function buildTokenSegments(data: UsageData): SegmentBarItem[] {
   return segments
 }
 
-function buildCostSegments(data: UsageData): SegmentBarItem[] {
+export function buildCostSegments(data: UsageData): SegmentBarItem[] {
   const input = data.costInputMicrocents
   const output = data.costOutputMicrocents
 
@@ -161,8 +165,7 @@ export function UsageSummary({
   const tokenSegments = useMemo(() => buildTokenSegments(data), [data])
   const costSegments = useMemo(() => buildCostSegments(data), [data])
 
-  const totalTokens =
-    data.tokensInput + data.tokensCacheRead + data.tokensCacheCreate + data.tokensOutput + data.tokensReasoning
+  const totalTokens = computeTotalTokens(data)
   const hasCost = data.costTotalMicrocents > 0
   const hasTokens = hasAnyUsage(data)
 

--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
@@ -12,15 +12,6 @@ const inputKeyedCandidates = [
   keyedFromInt("input_tokens"), // Claude Code (additive: non-cached input only)
 ]
 
-const outputCandidates = [
-  fromInt("gen_ai.usage.output_tokens"),
-  fromInt("gen_ai.usage.completion_tokens"),
-  fromInt("llm.token_count.completion"),
-  fromInt("ai.usage.completionTokens"),
-  fromInt("ai.usage.outputTokens"),
-  fromInt("output_tokens"), // Claude Code
-]
-
 const cacheReadCandidates = [
   fromInt("gen_ai.usage.cache_read.input_tokens"),
   fromInt("gen_ai.usage.cache_read_input_tokens"),
@@ -35,6 +26,15 @@ const cacheCreateCandidates = [
   fromInt("llm.token_count.prompt_details.cache_write"),
   fromInt("ai.usage.inputTokenDetails.cacheWriteTokens"),
   fromInt("cache_creation_tokens"), // Claude Code
+]
+
+const outputCandidates = [
+  fromInt("gen_ai.usage.output_tokens"),
+  fromInt("gen_ai.usage.completion_tokens"),
+  fromInt("llm.token_count.completion"),
+  fromInt("ai.usage.completionTokens"),
+  fromInt("ai.usage.outputTokens"),
+  fromInt("output_tokens"), // Claude Code
 ]
 
 const reasoningCandidates = [


### PR DESCRIPTION
Fixes this huge discrepancy:
<img width="321" height="117" alt="image" src="https://github.com/user-attachments/assets/df7f56c7-022c-4c68-85d8-47e381b2227b" />


Basically, `cacheCreate` was being treated as part of the output, instead of the input, which made the total calculation wrong.

I am also using this PR to update the color and position of some of the components, to make it easier to read and understand semantically.