### PR TITLE
fix(auth): send correct magic-link email for new vs returning users

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -53,10 +53,7 @@ function LoginPage() {
     setIsLoading(true)
     setError(undefined)
 
-    const callbackPath = redirectPath ?? "/"
-    const emailFlow = redirectPath ? "signin" : undefined
-    const separator = callbackPath.includes("?") ? "&" : "?"
-    const callbackURL = emailFlow ? `${callbackPath}${separator}emailFlow=${emailFlow}` : callbackPath
+    const callbackURL = redirectPath ?? "/"
     const tracking = pickTrackingParams(window.location.search)
     const newUserCallbackURL = appendTrackingParams(redirectPath ?? "/welcome", { ...tracking, signup: "email" })
 

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -30,23 +30,6 @@ let temporalClientPromise: ReturnType<typeof createTemporalClient> | undefined
 let workflowStarterPromise: Promise<WorkflowStarterShape> | undefined
 let workflowQuerierPromise: Promise<WorkflowQuerierShape> | undefined
 
-const getEmailFlowFromMagicLinkUrl = ({
-  magicLinkUrl,
-  webUrl,
-}: {
-  magicLinkUrl: string
-  webUrl: string
-}): "signin" | "signup" | null => {
-  const parsedMagicLinkUrl = new URL(magicLinkUrl)
-  const callbackUrl = parsedMagicLinkUrl.searchParams.get("callbackURL")
-
-  if (!callbackUrl) return null
-
-  const parsedCallbackUrl = new URL(callbackUrl, webUrl)
-  const emailFlowRaw = parsedCallbackUrl.searchParams.get("emailFlow")
-  return emailFlowRaw === "signin" || emailFlowRaw === "signup" ? emailFlowRaw : null
-}
-
 /**
  * Postgres client using the admin (superuser) connection.
  * Use this only for cross-org operations that must bypass RLS:
@@ -208,8 +191,6 @@ export const getBetterAuth = () => {
         )
       },
       sendMagicLink: async ({ email, url }) => {
-        const emailFlow = getEmailFlowFromMagicLinkUrl({ magicLinkUrl: url, webUrl })
-
         await Effect.runPromise(
           outboxWriter
             .write({
@@ -221,7 +202,6 @@ export const getBetterAuth = () => {
                 email,
                 magicLinkUrl: url,
                 organizationId: "system",
-                emailFlow,
               },
             })
             .pipe(withTracing),

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -40,7 +40,6 @@ describe("domain-events dispatcher", () => {
     const envelope = makeEnvelope("MagicLinkEmailRequested", {
       email: "a@b.com",
       magicLinkUrl: "https://x",
-      emailFlow: null,
       organizationId: "org-1",
     })
 
@@ -52,7 +51,6 @@ describe("domain-events dispatcher", () => {
     expect(published[0]?.payload).toEqual({
       email: "a@b.com",
       magicLinkUrl: "https://x",
-      emailFlow: null,
       organizationId: "org-1",
     })
     expect(published[0]?.options?.dedupeKey).toBe(`emails:magic-link:${magicLinkHash}`)

--- a/apps/workers/src/workers/domain-events/magic-link-email.ts
+++ b/apps/workers/src/workers/domain-events/magic-link-email.ts
@@ -35,7 +35,7 @@ export const createMagicLinkEmailWorker = ({ consumer }: MagicLinkEmailDeps) => 
 
         let rendered: RenderedEmail
 
-        if (payload.emailFlow === "signup") {
+        if (user === null) {
           rendered = yield* Effect.tryPromise(() =>
             signupMagicLinkTemplate({ userName, magicLinkUrl: payload.magicLinkUrl }),
           )

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -10,7 +10,6 @@ export interface EventPayloads {
   MagicLinkEmailRequested: {
     readonly email: string
     readonly magicLinkUrl: string
-    readonly emailFlow: string | null
     readonly organizationId: string
   }
   InvitationEmailRequested: {

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -22,7 +22,6 @@ const _registry = {
     send: {
       readonly email: string
       readonly magicLinkUrl: string
-      readonly emailFlow: string | null
       readonly organizationId: string
     }
   }>(),


### PR DESCRIPTION
## Summary
- New signups were receiving the "Welcome back" magic-link email, which implied the user already had an account.
- Root cause: the worker decided the template based on an `emailFlow` hint set by the login UI, but the UI only ever emitted `"signin"` or `undefined` — never `"signup"`. The `emailFlow === "signup"` branch was unreachable, so every email fell through to `magicLinkTemplate` (Welcome back).
- Fix: derive the template from DB ground truth in the worker (`user === null` → signup template, else welcome-back). The worker already did the `findByEmail` lookup; it just wasn't using the result.
- Dropped the now-unused `emailFlow` field from the `MagicLinkEmailRequested` event payload, the `magic-link-email.send` queue payload, the outbox writer, the login form, and the test fixture.

## Test plan
- [x] `pnpm turbo run typecheck --filter=@app/web --filter=@app/workers` passes
- [x] `pnpm --filter=@app/workers test -- domain-events` passes
- [x] Manually verify: sign in with a brand-new email → receive the "Hey there, let's get you set up" email
- [x] Manually verify: sign in with an existing email → receive the "Welcome back" email

🤖 Generated with [Claude Code](https://claude.com/claude-code)