### PR TITLE
Add keyboard shortcut support for saving annotations

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/annotations/annotation-input.tsx
@@ -2,7 +2,10 @@ import { Button, cn, Icon, Select, type SelectOption, Text, Textarea, ThumbButto
 import { InfoIcon, SparklesIcon } from "lucide-react"
 import { memo, useRef, useState } from "react"
 import { useDebounce } from "react-use"
+import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import { useIssue, useIssues } from "../../../../../../domains/issues/issues.collection.ts"
+
+const SAVE_HOTKEY = "Mod+Enter"
 
 const ISSUE_SELECTOR_BATCH_SIZE = 50
 const ISSUE_SELECTOR_SEARCH_DEBOUNCE_MS = 300
@@ -171,6 +174,11 @@ export function AnnotationInput({
             if (e.key === "Escape" && onCancel) {
               e.preventDefault()
               onCancel()
+              return
+            }
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault()
+              handleSave()
             }
           }}
           placeholder={commentPlaceholder}
@@ -219,6 +227,7 @@ export function AnnotationInput({
           )}
           <Button variant="default" size="sm" isLoading={isLoading} onClick={handleSave}>
             Save
+            <HotkeyBadge hotkey={SAVE_HOTKEY} />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Added keyboard shortcut support to the annotation input component, allowing users to save annotations using Mod+Enter (Cmd+Enter on Mac, Ctrl+Enter on Windows/Linux).

## Key Changes
- Added `SAVE_HOTKEY` constant defining the Mod+Enter keyboard shortcut
- Implemented keyboard event handler to trigger `handleSave()` when Mod+Enter is pressed
- Added visual indicator of the keyboard shortcut using the `HotkeyBadge` component on the Save button
- Fixed Escape key handler to properly return after canceling to prevent further event processing

## Implementation Details
- The keyboard shortcut handler checks for both `metaKey` (Cmd on Mac) and `ctrlKey` (Ctrl on Windows/Linux) to support cross-platform usage
- The event is prevented from propagating with `e.preventDefault()` to avoid unintended side effects
- The `HotkeyBadge` component displays the hotkey hint next to the Save button for better UX discoverability

https://claude.ai/code/session_01Poap514jqtyh8WRt6spgBg