### PR TITLE
Add span count badge to spans tab in trace detail drawer

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer.tsx
@@ -63,7 +63,7 @@ function isTraceDetailTab(v: string): v is TabId {
   return v === "trace" || v === "conversation" || v === "spans" || v === "annotations"
 }
 
-const annotationTabCountPillClass =
+const tabCountPillClass =
   "inline-flex min-h-5 min-w-[1.125rem] shrink-0 items-center justify-center rounded-full bg-muted px-1.5 text-[0.6875rem] font-medium leading-none text-muted-foreground"
 
 function getAnnotationTabSuffix({
@@ -76,7 +76,7 @@ function getAnnotationTabSuffix({
   readonly annotationCount: number
 }): ReactNode {
   if (annotationsByTraceError) {
-    return <span className={annotationTabCountPillClass}>–</span>
+    return <span className={tabCountPillClass}>–</span>
   }
   if (annotationsByTraceLoading) {
     return null
@@ -84,7 +84,14 @@ function getAnnotationTabSuffix({
   if (annotationCount === 0) {
     return null
   }
-  return <span className={cn(annotationTabCountPillClass, "tabular-nums")}>{annotationCount}</span>
+  return <span className={cn(tabCountPillClass, "tabular-nums")}>{annotationCount}</span>
+}
+
+function getSpansTabSuffix(spanCount: number | undefined): ReactNode {
+  if (spanCount === undefined || spanCount === 0) {
+    return null
+  }
+  return <span className={cn(tabCountPillClass, "tabular-nums")}>{spanCount}</span>
 }
 
 export function TraceDetailDrawer({
@@ -135,12 +142,18 @@ export function TraceDetailDrawer({
       }),
     [annotationsByTraceError, annotationsByTraceLoading, annotationCount],
   )
-  const tabsWithAnnotationCount = useMemo<TabOption<TabId>[]>(
-    () => TABS.map((tab) => (tab.id === "annotations" ? { ...tab, suffix: annotationTabSuffix } : tab)),
-    [annotationTabSuffix],
-  )
   const isRecordLoading = !trace && !traceDetail
   const traceRecord: TraceRecord | undefined = traceDetail ?? trace
+  const spansTabSuffix = useMemo(() => getSpansTabSuffix(traceRecord?.spanCount), [traceRecord?.spanCount])
+  const tabsWithCounts = useMemo<TabOption<TabId>[]>(
+    () =>
+      TABS.map((tab) => {
+        if (tab.id === "annotations") return { ...tab, suffix: annotationTabSuffix }
+        if (tab.id === "spans") return { ...tab, suffix: spansTabSuffix }
+        return tab
+      }),
+    [annotationTabSuffix, spansTabSuffix],
+  )
   const [activeTab, setActiveTab] = useParamState("traceDetailTab", "trace", {
     validate: isTraceDetailTab,
   })
@@ -292,7 +305,7 @@ export function TraceDetailDrawer({
             <CopyableText value={traceId} displayValue={traceId.slice(0, 7)} size="sm" tooltip="Copy trace ID" />
           </div>
 
-          <Tabs options={tabsWithAnnotationCount} active={activeTab} onSelect={handleSetActiveTab} />
+          <Tabs options={tabsWithCounts} active={activeTab} onSelect={handleSetActiveTab} />
         </>
       }
     >


### PR DESCRIPTION
## Summary
This PR extends the tab count badge functionality to display the span count on the spans tab, in addition to the existing annotation count badge.

## Key Changes
- Renamed `annotationTabCountPillClass` to `tabCountPillClass` to reflect its broader usage across multiple tabs
- Created a new `getSpansTabSuffix()` function to generate the span count badge, following the same pattern as the annotation count badge
- Updated the tab configuration logic to apply count badges to both the annotations and spans tabs
- Renamed `tabsWithAnnotationCount` to `tabsWithCounts` to better represent that multiple tabs now have count badges
- Added `spansTabSuffix` memoization to efficiently compute the span count badge based on `traceRecord?.spanCount`

## Implementation Details
The span count badge follows the same display logic as annotations:
- Returns `null` if span count is undefined or zero (no badge shown)
- Displays the numeric count in a styled pill when span count is greater than zero
- Uses the shared `tabCountPillClass` styling with `tabular-nums` for consistent number formatting

https://claude.ai/code/session_01PpEPniUo86zXNRreggWArr