### PR TITLE
refactor(annotation-queues): extract trace-free classify and annotate use cases

### DIFF
--- a/packages/domain/annotation-queues/src/index.ts
+++ b/packages/domain/annotation-queues/src/index.ts
@@ -184,12 +184,16 @@ export {
   runDeterministicSystemMatchersUseCase,
 } from "./use-cases/run-deterministic-system-matchers.ts"
 export {
+  type AnnotateTraceForQueueInput,
+  annotateTraceForQueueUseCase,
   type RunSystemQueueAnnotatorError,
   type RunSystemQueueAnnotatorInput,
   type RunSystemQueueAnnotatorResult,
   runSystemQueueAnnotatorUseCase,
 } from "./use-cases/run-system-queue-annotator.ts"
 export {
+  type ClassifyTraceForQueueInput,
+  classifyTraceForQueueUseCase,
   type RunSystemQueueFlaggerError,
   type RunSystemQueueFlaggerInput,
   type RunSystemQueueFlaggerResult,

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -8,7 +8,7 @@ import {
   formatGenAIMessage,
 } from "@domain/ai"
 import { OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
-import { TraceRepository } from "@domain/spans"
+import { type TraceDetail, TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import {
   SYSTEM_QUEUE_ANNOTATOR_MAX_TOKENS,
@@ -40,6 +40,21 @@ export interface RunSystemQueueAnnotatorResult {
 }
 
 export type RunSystemQueueAnnotatorError = RepositoryError | AIError | AICredentialError
+
+/**
+ * Input for the pure annotator (no repository dependency).
+ *
+ * Callers that already hold a `TraceDetail` use this shape with
+ * {@link annotateTraceForQueueUseCase}.
+ */
+export interface AnnotateTraceForQueueInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly queueSlug: string
+  readonly traceId: string
+  readonly scoreId: string
+  readonly trace: TraceDetail
+}
 
 const ANNOTATOR_SYSTEM_PROMPT_TEMPLATE = `
 You are an annotation assistant reviewing LLM conversations for a specific quality queue.
@@ -101,8 +116,16 @@ const loadTraceDetail = (input: RunSystemQueueAnnotatorInput) =>
     })
   })
 
-export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (
-  input: RunSystemQueueAnnotatorInput,
+/**
+ * Draft annotation feedback from an already-loaded trace.
+ *
+ * Pure annotator — no repository dependency, no data loading. Callers that
+ * already hold a `TraceDetail` (eval harnesses, experiment runners) use this
+ * directly; production paths use {@link runSystemQueueAnnotatorUseCase}, which
+ * fetches the trace and delegates here.
+ */
+export const annotateTraceForQueueUseCase = Effect.fn("annotationQueues.annotateTraceForQueue")(function* (
+  input: AnnotateTraceForQueueInput,
 ) {
   yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
   yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
@@ -111,13 +134,11 @@ export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSys
 
   const ai = yield* AI
 
-  const trace = yield* loadTraceDetail(input)
-
   const systemPrompt = buildAnnotatorSystemPrompt(input.queueSlug)
 
   const conversationText =
-    trace.allMessages.length > 0
-      ? formatConversationForAnnotator(trace.allMessages)
+    input.trace.allMessages.length > 0
+      ? formatConversationForAnnotator(input.trace.allMessages)
       : "<no conversation messages available>"
 
   const prompt = `Full conversation context:\n\n${conversationText}\n\nProvide your feedback analysis per the schema.`
@@ -140,6 +161,19 @@ export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSys
 
   return {
     feedback: result.object.feedback,
-    traceCreatedAt: trace.startTime.toISOString(),
+    traceCreatedAt: input.trace.startTime.toISOString(),
   }
+})
+
+/**
+ * Load the trace via the repository, then draft its annotation.
+ *
+ * Production entry point — used by the Temporal activity in
+ * `systemQueueFlaggerWorkflow` after a match.
+ */
+export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (
+  input: RunSystemQueueAnnotatorInput,
+) {
+  const trace = yield* loadTraceDetail(input)
+  return yield* annotateTraceForQueueUseCase({ ...input, trace })
 })

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-annotator.ts
@@ -127,11 +127,6 @@ const loadTraceDetail = (input: RunSystemQueueAnnotatorInput) =>
 export const annotateTraceForQueueUseCase = Effect.fn("annotationQueues.annotateTraceForQueue")(function* (
   input: AnnotateTraceForQueueInput,
 ) {
-  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
-  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
-
   const ai = yield* AI
 
   const systemPrompt = buildAnnotatorSystemPrompt(input.queueSlug)
@@ -174,6 +169,11 @@ export const annotateTraceForQueueUseCase = Effect.fn("annotationQueues.annotate
 export const runSystemQueueAnnotatorUseCase = Effect.fn("annotationQueues.runSystemQueueAnnotator")(function* (
   input: RunSystemQueueAnnotatorInput,
 ) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+
   const trace = yield* loadTraceDetail(input)
   return yield* annotateTraceForQueueUseCase({ ...input, trace })
 })

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -26,6 +26,21 @@ export interface RunSystemQueueFlaggerResult {
 
 export type RunSystemQueueFlaggerError = NotFoundError | RepositoryError | AIError | AICredentialError
 
+/**
+ * Input for the pure classifier (no repository dependency).
+ *
+ * Callers that already hold a `TraceDetail` — eval harnesses, experiment runners,
+ * any non-production code that shouldn't touch Clickhouse — use this shape with
+ * {@link classifyTraceForQueueUseCase}.
+ */
+export interface ClassifyTraceForQueueInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly traceId: string
+  readonly queueSlug: string
+  readonly trace: TraceDetail
+}
+
 const systemQueueFlaggerOutputSchema = z.object({
   matched: z.boolean().optional().default(false),
 })
@@ -55,7 +70,7 @@ const isSchemaMismatchCause = (cause: unknown): boolean => {
 /**
  * Run LLM flagger with the given strategy.
  */
-const runLlmFlagger = (input: RunSystemQueueFlaggerInput, trace: TraceDetail) =>
+const runLlmFlagger = (input: ClassifyTraceForQueueInput) =>
   Effect.gen(function* () {
     const ai = yield* AI
     const strategy = getQueueStrategy(input.queueSlug)
@@ -67,8 +82,8 @@ const runLlmFlagger = (input: RunSystemQueueFlaggerInput, trace: TraceDetail) =>
     const result = yield* ai.generate({
       ...SYSTEM_QUEUE_FLAGGER_MODEL,
       maxTokens: SYSTEM_QUEUE_FLAGGER_MAX_TOKENS,
-      system: strategy.buildSystemPrompt(trace),
-      prompt: strategy.buildPrompt(trace),
+      system: strategy.buildSystemPrompt(input.trace),
+      prompt: strategy.buildPrompt(input.trace),
       schema: systemQueueFlaggerOutputSchema,
       telemetry: {
         spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.queueSystemClassify,
@@ -96,50 +111,53 @@ function runDeterministicDetection(queueSlug: string, trace: TraceDetail): Detec
   return strategy.detectDeterministically(trace)
 }
 
-export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSystemQueueFlagger")(function* (
-  input: RunSystemQueueFlaggerInput,
+/**
+ * Classify an already-loaded trace for a system queue.
+ *
+ * This is the pure classifier layer: no data loading, no repository dependency.
+ * The deterministic pre-filter runs first; only ambiguous cases fall through to
+ * the LLM.
+ *
+ * Production callers that start from a traceId should use
+ * {@link runSystemQueueFlaggerUseCase}, which fetches the trace and then delegates here.
+ */
+export const classifyTraceForQueueUseCase = Effect.fn("annotationQueues.classifyTraceForQueue")(function* (
+  input: ClassifyTraceForQueueInput,
 ) {
   yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
   yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
   yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
   yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
 
-  // Check if this is a known queue slug
   if (!hasQueueStrategy(input.queueSlug)) {
-    // Unknown slug - short circuit with no match
     return { matched: false }
   }
 
-  const trace = yield* loadTraceDetail(input)
   const strategy = getQueueStrategy(input.queueSlug)
-
   if (!strategy) {
     return { matched: false }
   }
 
-  // Check if required context is present
-  if (!strategy.hasRequiredContext(trace)) {
+  if (!strategy.hasRequiredContext(input.trace)) {
     return { matched: false }
   }
 
   // Phase 1: Try deterministic detection if available
-  const deterministicResult = runDeterministicDetection(input.queueSlug, trace)
+  const deterministicResult = runDeterministicDetection(input.queueSlug, input.trace)
 
   if (deterministicResult) {
     switch (deterministicResult.kind) {
       case "matched":
-        // Deterministic match - queue it immediately without LLM
         return { matched: true }
       case "no-match":
-        // Deterministic clean - skip it immediately without LLM
         return { matched: false }
       case "ambiguous":
-      // Ambiguous - fall through to LLM
+      // Ambiguous — fall through to LLM
     }
   }
 
   // Phase 2: LLM fallback for ambiguous cases or strategies without deterministic detection
-  const decisions = yield* runLlmFlagger(input, trace).pipe(
+  const decisions = yield* runLlmFlagger(input).pipe(
     Effect.catchIf(
       (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
       () =>
@@ -153,4 +171,28 @@ export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSyste
   return {
     matched: decisions.matched,
   } satisfies RunSystemQueueFlaggerResult
+})
+
+/**
+ * Load the trace via the repository, then classify it.
+ *
+ * This is the production entry point — the one called by the Temporal activity
+ * in `systemQueueFlaggerWorkflow`. For unknown queue slugs it short-circuits
+ * BEFORE hitting the repository, so legacy workflow activations for removed
+ * queues don't cost a Clickhouse roundtrip.
+ */
+export const runSystemQueueFlaggerUseCase = Effect.fn("annotationQueues.runSystemQueueFlagger")(function* (
+  input: RunSystemQueueFlaggerInput,
+) {
+  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
+  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
+  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
+  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
+
+  if (!hasQueueStrategy(input.queueSlug)) {
+    return { matched: false }
+  }
+
+  const trace = yield* loadTraceDetail(input)
+  return yield* classifyTraceForQueueUseCase({ ...input, trace })
 })

--- a/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
+++ b/packages/domain/annotation-queues/src/use-cases/run-system-queue-flagger.ts
@@ -124,11 +124,6 @@ function runDeterministicDetection(queueSlug: string, trace: TraceDetail): Detec
 export const classifyTraceForQueueUseCase = Effect.fn("annotationQueues.classifyTraceForQueue")(function* (
   input: ClassifyTraceForQueueInput,
 ) {
-  yield* Effect.annotateCurrentSpan("queue.organizationId", input.organizationId)
-  yield* Effect.annotateCurrentSpan("queue.projectId", input.projectId)
-  yield* Effect.annotateCurrentSpan("queue.traceId", input.traceId)
-  yield* Effect.annotateCurrentSpan("queue.queueSlug", input.queueSlug)
-
   if (!hasQueueStrategy(input.queueSlug)) {
     return { matched: false }
   }


### PR DESCRIPTION
## Why

The system-queue flagger and annotator today both follow the same shape: take a `traceId`, fetch the trace from `TraceRepository` (ClickHouse-backed), then run strategy dispatch + LLM classification against the resulting `TraceDetail`.

That coupling is a problem for evaluation work: to evaluate a flagger or annotator offline against fixture traces, we'd need to stand up a fake `TraceRepository` layer for something that fundamentally doesn't need one. The business logic works against `TraceDetail`; only the entry point needs a database.

This PR extracts the pure classifier/annotator as their own use cases and makes the existing entry points thin wrappers that fetch then delegate. It unblocks the upcoming flagger-eval harness (see PRD `prd/llm-flagger-evaluation-system.md` on PR #2842) without changing any production behavior.

## What changed

- **New inner use cases** (no repository dependency):
  - `classifyTraceForQueueUseCase({ ...input, trace })` — strategy dispatch, deterministic pre-filter, LLM fallback, schema-mismatch recovery. All the real logic.
  - `annotateTraceForQueueUseCase({ ...input, trace })` — annotator prompt build + `ai.generate` call.
- **Existing outer use cases** (unchanged signatures, unchanged behavior):
  - `runSystemQueueFlaggerUseCase` — short-circuits unknown slugs before the repo, fetches the trace, delegates to `classifyTraceForQueueUseCase`.
  - `runSystemQueueAnnotatorUseCase` — fetches the trace, delegates to `annotateTraceForQueueUseCase`.
- Barrel exports add the two new use cases and their `Input` types.

## Why no new tests

The existing 151 tests exercise the outer use cases end-to-end. Since the outer delegates to the inner, every inner code path runs in those tests — adding inner-level duplicates would be redundant. The "no `TraceRepository` needed" contract is already enforced at compile time by TypeScript: the inner function's Effect context doesn't include `TraceRepository`, so any caller trying to use it without providing one gets a type error, not a runtime failure.

## Verification

- `pnpm --filter @domain/annotation-queues test` — all 151 existing tests pass, unchanged.
- `pnpm --filter @domain/annotation-queues typecheck` — clean.
- `pnpm format` + `pnpm knip` — clean.
- `systemQueueFlaggerWorkflow` (the Temporal consumer) is not touched; the outer use case's signature and behavior are preserved.

## Test plan

- [x] Review that the outer use cases' observable behavior (span names, metadata, error types, result shape) matches `main`
- [x] Confirm the Temporal activity wiring in `apps/workflows` is unaffected
- [ ] Sanity-check that no other caller outside `apps/workflows` imports the outer use cases in a way that would expose the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)