### PR TITLE
Pretty-print compact JSON assistant responses

### DIFF
--- a/packages/domain/shared/src/seeds.ts
+++ b/packages/domain/shared/src/seeds.ts
@@ -237,6 +237,12 @@ export const SEED_ALIGNMENT_FIXTURE_SPAN_IDS: readonly string[] = Array.from({ l
   fixedSpanHex("bf", 100 + i),
 )
 
+/** 4 demo trace IDs for JSON-formatted assistant responses (compact + prettified). */
+export const SEED_JSON_RESPONSE_TRACE_IDS: readonly string[] = Array.from({ length: 4 }, (_, i) =>
+  fixedTraceHex("1f", i),
+)
+export const SEED_JSON_RESPONSE_SPAN_IDS: readonly string[] = Array.from({ length: 4 }, (_, i) => fixedSpanHex("1f", i))
+
 /** 5 lifecycle score trace IDs */
 export const SEED_LIFECYCLE_TRACE_IDS: readonly string[] = [
   "11111111111111111111111111111111",

--- a/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
+++ b/packages/platform/db-clickhouse/src/seeds/spans/fixed-traces.ts
@@ -15,6 +15,8 @@ import {
   SEED_COMBINATION_SIMULATION_SPAN_IDS,
   SEED_COMBINATION_SIMULATION_TRACE_IDS,
   SEED_ISSUE_FIXTURES_BY_ID,
+  SEED_JSON_RESPONSE_SPAN_IDS,
+  SEED_JSON_RESPONSE_TRACE_IDS,
   SEED_LIFECYCLE_SPAN_IDS,
   SEED_LIFECYCLE_TRACE_IDS,
   SEED_ORG_ID,
@@ -205,6 +207,62 @@ function buildIssueOccurrenceTraceSpans(): SpanRow[] {
   })
 }
 
+function buildJsonResponseSpans(): SpanRow[] {
+  const prettyOrderDetails = JSON.stringify(
+    {
+      orderId: "ACM-98731",
+      status: "delivered",
+      customer: { id: "cust_2041", name: "Wile E. Coyote" },
+      items: [
+        { sku: "RKT-SKT-01", name: "Rocket Skates Pro", quantity: 1, priceCents: 29_900 },
+        { sku: "SFT-GEAR-02", name: "Deluxe Safety Gear Bundle", quantity: 1, priceCents: 7_999 },
+      ],
+      shipping: { carrier: "FastShip", trackingNumber: "FS654321987", deliveredAt: "2026-04-22T16:04:11Z" },
+      totalCents: 37_899,
+    },
+    null,
+    2,
+  )
+
+  const specs = [
+    {
+      userPrompt: "Give me the latest metrics snapshot in JSON.",
+      assistantResponse:
+        '{"period":"last_24h","requests":18432,"errors":47,"p50_ms":112,"p95_ms":418,"p99_ms":1024,"topEndpoints":[{"path":"/v1/traces","share":0.61},{"path":"/v1/projects","share":0.22},{"path":"/v1/issues","share":0.11}]}',
+    },
+    {
+      userPrompt: "Return the warranty policy as a structured JSON object.",
+      assistantResponse:
+        '{"policy":"Acme Standard Warranty","durationDays":90,"covers":["manufacturing_defects","normal_wear_and_tear"],"excludes":["roadrunner_incidents","cliff_falls","physics_violations"],"extension":{"name":"Protection Plus","priceCents":4999,"extraDays":640}}',
+    },
+    {
+      userPrompt: "List three upcoming releases as a JSON array.",
+      assistantResponse:
+        '[{"id":"rel-2026-17","title":"Faster semantic search","ship":"2026-04-30"},{"id":"rel-2026-18","title":"Trace comparison view","ship":"2026-05-07"},{"id":"rel-2026-19","title":"Issue auto-triage","ship":"2026-05-14"}]',
+    },
+    {
+      userPrompt: "Show me the order details for ACM-98731.",
+      assistantResponse: prettyOrderDetails,
+    },
+  ] as const
+
+  return specs.map((spec, i) => {
+    const time = generateTime(0, 10 + i, 30)
+    return createFixedSpan({
+      traceId: requiredAt(SEED_JSON_RESPONSE_TRACE_IDS, i),
+      spanId: requiredAt(SEED_JSON_RESPONSE_SPAN_IDS, i),
+      startTime: time.start,
+      endTime: time.end,
+      userPrompt: spec.userPrompt,
+      assistantResponse: spec.assistantResponse,
+      systemInstruction: SUPPORT_AGENT_SYSTEM_PROMPT,
+      serviceName: "acme-support-agent",
+      tags: ["support", "json-response"],
+      metadata: { story: "json-assistant-response-demo" },
+    })
+  })
+}
+
 function buildLifecycleSpans(): SpanRow[] {
   const specs = [
     {
@@ -284,6 +342,7 @@ const allFixedSpans = [
   ...buildAnnotationTraceSpans(),
   ...buildAlignmentFixtureSpans(),
   ...buildIssueOccurrenceTraceSpans(),
+  ...buildJsonResponseSpans(),
   ...buildLifecycleSpans(),
   ...buildSimulationTraceSpans({
     rows: WARRANTY_DATASET_ROWS,

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
@@ -65,9 +65,10 @@ describe("MarkdownContent", () => {
     expect(markup).toContain('data-content-type="json"')
     expect(markup).toContain("data-source-start")
     expect(markup).toContain("data-source-end")
-    // Concatenated text content must equal the original source verbatim —
-    // this is the invariant annotation offsets depend on.
-    expect(textContentOf(markup)).toBe(json)
+    // Compact JSON is pretty-printed with 2-space indent, and the DOM text
+    // matches the prettified string verbatim (the invariant that annotation
+    // offsets depend on holds against that string).
+    expect(textContentOf(markup)).toBe(JSON.stringify(JSON.parse(json), null, 2))
     // Must NOT go through Markdown: no <p>, no <strong>.
     expect(markup).not.toContain("<p>")
   })
@@ -77,18 +78,27 @@ describe("MarkdownContent", () => {
     const markup = renderToStaticMarkup(<MarkdownContent content={json} />)
 
     expect(markup).toContain('data-content-type="json"')
-    expect(textContentOf(markup)).toBe(json)
+    expect(textContentOf(markup)).toBe(JSON.stringify(JSON.parse(json), null, 2))
   })
 
-  it("renders verbatim: JSON offsets index into the original content", () => {
-    const json = '{ "a": 1 }'
+  it("keeps already-multiline JSON verbatim so producer formatting is preserved", () => {
+    const json = '{\n  "a": 1\n}'
     const markup = renderToStaticMarkup(<MarkdownContent content={json} />)
 
-    // Offsets start at 0 and the final segment reaches the full content length
-    // (with syntax highlighting the content is split into tokens, but together
-    // they cover the whole range).
+    expect(markup).toContain('data-content-type="json"')
+    expect(textContentOf(markup)).toBe(json)
     expect(markup).toContain(`data-source-start="0"`)
     expect(markup).toContain(`data-source-end="${json.length}"`)
+  })
+
+  it("pretty-prints compact JSON so offsets index into the reformatted content", () => {
+    const json = '{ "a": 1 }'
+    const pretty = JSON.stringify(JSON.parse(json), null, 2)
+    const markup = renderToStaticMarkup(<MarkdownContent content={json} />)
+
+    // Offsets start at 0 and the final segment reaches the prettified length.
+    expect(markup).toContain(`data-source-start="0"`)
+    expect(markup).toContain(`data-source-end="${pretty.length}"`)
   })
 
   it("applies JSON syntax highlighting to JsonContent", () => {
@@ -105,14 +115,15 @@ describe("MarkdownContent", () => {
 
   it("preserves source-offset coverage through the full JSON after tokenization", () => {
     const json = '{"key":"value"}'
+    const pretty = JSON.stringify(JSON.parse(json), null, 2)
     const markup = renderToStaticMarkup(<MarkdownContent content={json} />)
 
-    // All source offsets together should cover the full content: first starts
-    // at 0 and the last one ends at content.length.
+    // All source offsets together should cover the full prettified content:
+    // first starts at 0 and the last one ends at pretty.length.
     const starts = [...markup.matchAll(/data-source-start="(\d+)"/g)].map((m) => Number(m[1]))
     const ends = [...markup.matchAll(/data-source-end="(\d+)"/g)].map((m) => Number(m[1]))
     expect(Math.min(...starts)).toBe(0)
-    expect(Math.max(...ends)).toBe(json.length)
+    expect(Math.max(...ends)).toBe(pretty.length)
   })
 
   it("applies syntax highlighting to Markdown code fences", () => {

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
@@ -52,6 +52,18 @@ export function isJsonBlock(content: string): boolean {
   }
 }
 
+// Reformat compact (single-line) JSON so nested structures render with
+// indentation. Already-multiline JSON is kept verbatim so any producer-side
+// formatting (and annotation offsets saved against it) is preserved.
+function prettifyCompactJson(content: string): string {
+  if (content.includes("\n")) return content
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2)
+  } catch {
+    return content
+  }
+}
+
 export function MarkdownContent({
   content,
   messageIndex,
@@ -97,7 +109,7 @@ export function MarkdownContent({
   }
 
   if (isJson) {
-    return <JsonContent content={content} messageIndex={messageIndex} partIndex={partIndex} />
+    return <JsonContent content={prettifyCompactJson(content)} messageIndex={messageIndex} partIndex={partIndex} />
   }
 
   return (


### PR DESCRIPTION
Re-serialize single-line JSON with 2-space indent before rendering so nested structures are readable. Multiline JSON is kept verbatim so any producer-side formatting is preserved. Adds four JSON-response seed traces at the top of the traces table to exercise both paths.