### PR TITLE
refactor(claude-code-telemetry): remove sync I/O from fetch intercept hot path

### DIFF
--- a/packages/telemetry/claude-code/CHANGELOG.md
+++ b/packages/telemetry/claude-code/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-04-24
+
+### Changed
+
+- **`fetch` intercept no longer does sync I/O on the response hot path.** Replaced `writeFileSync` with `fs/promises.writeFile` so writing the captured request file never blocks the event loop at `message_start`. The scan branch of the tee'd response now cancels itself right after writing the request file instead of draining the stream to EOF, removing any backpressure coupling between the scan branch and the caller's branch for the rest of the response. Request body extraction now runs concurrently with the outbound fetch rather than gating it. The wrapped `Response` also strips the upstream `content-length` header to avoid runtimes/proxies second-guessing the re-wrapped stream. Hygiene changes — no behavior change and none of these were shown to cause user-perceptible latency, but sync I/O inside a `fetch` interceptor is a footgun worth removing.
+
 ## [0.0.6] - 2026-04-21
 
 ### Fixed

--- a/packages/telemetry/claude-code/package.json
+++ b/packages/telemetry/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/claude-code-telemetry",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Claude Code Stop-hook that streams session transcripts to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/claude-code/src/intercept.ts
+++ b/packages/telemetry/claude-code/src/intercept.ts
@@ -7,7 +7,8 @@
 // This runs inside the claude process. It has zero dependencies, uses only node
 // built-ins, and is fail-silent: any error falls through to the original fetch.
 
-import { mkdirSync, writeFileSync } from "node:fs"
+import { mkdirSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
@@ -37,30 +38,37 @@ async function interceptedFetch(
     return originalFetch(input, init)
   }
 
-  let bodyText: string | undefined
-  try {
-    bodyText = await extractBody(input, init)
-  } catch {
-    bodyText = undefined
-  }
-
-  const response = await originalFetch(input, init)
+  // Extract the body in parallel with the outbound fetch so we don't gate TTFB on
+  // reading the request payload. For the common case where init.body is already a
+  // string this resolves synchronously; for Request inputs we clone up-front (while
+  // the body is still undisturbed) and read the clone's text concurrently with the
+  // network call.
+  const bodyPromise = extractBody(input, init).catch(() => undefined)
+  const responsePromise = originalFetch(input, init)
+  const response = await responsePromise
+  const bodyText = await bodyPromise
 
   if (!bodyText || !response.ok || !response.body) return response
 
   try {
     // Tee the response stream: one side goes to the caller (the Anthropic SDK), the
     // other side we scan for the message_start SSE event. As soon as that event
-    // arrives, we know the message id and write the request file synchronously —
-    // well before the Stop hook can fire, eliminating the race we'd have if we
-    // waited for the full response to drain.
+    // arrives, we know the message id, write the request file asynchronously, then
+    // cancel this branch so the caller's branch is no longer coupled to us via tee
+    // backpressure for the rest of the response.
     const [forCaller, forScan] = response.body.tee()
     void scanForMessageIdAndWrite(forScan, bodyText, url)
+
+    // Strip content-length; the upstream value refers to the original body and
+    // can confuse runtimes/proxies that inspect the wrapped stream. SSE responses
+    // use chunked transfer encoding anyway.
+    const headers = new Headers(response.headers)
+    headers.delete("content-length")
 
     return new Response(forCaller, {
       status: response.status,
       statusText: response.statusText,
-      headers: response.headers,
+      headers,
     })
   } catch (err) {
     if (DEBUG) process.stderr.write(`[latitude-intercept] tee failed: ${String(err)}\n`)
@@ -81,18 +89,16 @@ async function scanForMessageIdAndWrite(
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
-      // Once we've written the file we no longer need to decode or buffer any
-      // more bytes — we just keep pulling from our tee branch so the underlying
-      // source isn't back-pressured while the SDK consumes the other branch.
-      if (wrote) continue
       if (value) buffered += decoder.decode(value, { stream: true })
       const messageId = extractMessageId(buffered)
       if (messageId) {
-        writeRequest(messageId, bodyText, url)
         wrote = true
-        // Free the buffer promptly so memory doesn't hold the partial SSE prefix
-        // for the rest of a long stream.
         buffered = ""
+        // Fire-and-forget the write so we can cancel this tee branch immediately.
+        // Cancelling frees the caller's branch from any backpressure coupling for
+        // the rest of the response.
+        void writeRequest(messageId, bodyText, url)
+        break
       }
     }
     if (!wrote && DEBUG) {
@@ -101,6 +107,11 @@ async function scanForMessageIdAndWrite(
   } catch (err) {
     if (DEBUG) process.stderr.write(`[latitude-intercept] scan failed: ${String(err)}\n`)
   } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // best-effort
+    }
     try {
       reader.releaseLock()
     } catch {
@@ -182,7 +193,7 @@ function extractMessageId(sseText: string): string | undefined {
   return undefined
 }
 
-function writeRequest(messageId: string, bodyText: string, url: string): void {
+async function writeRequest(messageId: string, bodyText: string, url: string): Promise<void> {
   const safeId = messageId.replace(/[^a-zA-Z0-9_-]/g, "_")
   const filename = join(REQUESTS_DIR, `${safeId}.json`)
   try {
@@ -192,7 +203,7 @@ function writeRequest(messageId: string, bodyText: string, url: string): void {
       url,
       request: safeParse(bodyText),
     }
-    writeFileSync(filename, JSON.stringify(payload), "utf-8")
+    await writeFile(filename, JSON.stringify(payload), "utf-8")
     if (DEBUG) process.stderr.write(`[latitude-intercept] wrote ${filename}\n`)
   } catch (err) {
     if (DEBUG) process.stderr.write(`[latitude-intercept] write failed: ${String(err)}\n`)


### PR DESCRIPTION
## Summary

Four small hygiene fixes to the Bun `--preload` fetch interceptor in `@latitude-data/claude-code-telemetry` that captures Anthropic `/v1/messages` request bodies for Stop-hook enrichment. None were shown to cause user-perceptible latency, but sync I/O inside a `fetch` interceptor is a footgun worth removing.

- **Async file write** — replace `writeFileSync` with `fs/promises.writeFile` so writing the captured request file never blocks the event loop at `message_start`. This is the only one of the four that could plausibly cost a few ms of stream-stall; the rest are purely defensive.
- **Cancel the scan tee branch after writing** — instead of draining the response to EOF on the scan side (which keeps the tee's two branches coupled by backpressure for the entire response), we cancel the scan branch as soon as we've written the request file. Web Streams `tee()` does not cancel the source when only one branch is cancelled, so the caller's branch keeps flowing.
- **Parallelize body extraction with the outbound fetch** — previously we awaited `extractBody(...)` before even dispatching `originalFetch(...)`. For typical string bodies this was effectively free, but for `Request` inputs that required `clone().text()` it serialized the body-read with the network call. Now both run concurrently.
- **Strip `content-length` from the wrapped Response headers** — the upstream value refers to the original body and can confuse runtimes/proxies inspecting the re-wrapped stream. SSE responses use chunked transfer encoding anyway.

Bumps the package to `0.0.7`.

## Test plan

- [x] `pnpm --filter @latitude-data/claude-code-telemetry typecheck` passes
- [x] `pnpm --filter @latitude-data/claude-code-telemetry test` passes (26 tests)
- [x] `pnpm --filter @latitude-data/claude-code-telemetry check` passes
- [x] `pnpm --filter @latitude-data/claude-code-telemetry build` produces `dist/intercept.js` + `dist/index.js`
- [ ] Manual: install the hook, run a `claude` session, confirm request files still land under `~/.claude/state/latitude/requests/` and Stop-hook spans still carry `gen_ai.system_instructions` / `gen_ai.tool.definitions` / `llm_request.captured = "true"`.