### PR TITLE
feat(openclaw-telemetry): new plugin streaming OpenClaw runs to Latitude

### DIFF
--- a/packages/telemetry/openclaw/CHANGELOG.md
+++ b/packages/telemetry/openclaw/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the OpenClaw Telemetry plugin will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2026-04-24
+
+### Added
+
+- Initial release. OpenClaw plugin that streams every agent run to Latitude as OTLP traces by subscribing to OpenClaw's typed `llm_input` / `llm_output` / `before_tool_call` / `after_tool_call` / `agent_end` hooks.
+- Per-run state accumulator keyed by `runId` that pairs LLM input/output into single calls, nests tool invocations under their parent LLM call, and handles out-of-order tool events defensively.
+- OTLP span tree with three span kinds — `interaction` (per agent run), `llm_request` (per LLM call), `tool_execution` (per tool invocation). Every span carries `openclaw.agent.id` and `openclaw.agent.name` so multi-agent setups are filterable in the Latitude UI.
+- `llm_request` spans capture everything OpenClaw surfaces: provider, request/response model, resolved ref, system prompt, full message history, current prompt, assistant text, tool call parts, and full token usage (input/output/cache_read/cache_creation/total) under both canonical `gen_ai.*` keys and legacy aliases.
+- Installer CLI (`npx @latitude-data/openclaw-telemetry install`) that writes a plugin entry with `hooks.allowConversationAccess: true` and `LATITUDE_*` env vars to `~/.openclaw/openclaw.json`, plus matching `uninstall`.
+- Supports production / `--staging` / `--dev` environment flags and non-interactive `--api-key` / `--project` / `--yes` flags for CI.

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -1,0 +1,141 @@
+# @latitude-data/openclaw-telemetry
+
+OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) as OTLP traces. Full fidelity — exact system prompt, message history, assistant output, token usage, tool I/O, and the running agent's name on every span.
+
+## Install
+
+```bash
+npx -y @latitude-data/openclaw-telemetry install
+```
+
+The installer prompts for your Latitude API key and project slug, then writes a plugin entry to `~/.openclaw/openclaw.json` with `hooks.allowConversationAccess: true` so OpenClaw forwards raw conversation content to our handlers.
+
+Restart the OpenClaw gateway after install:
+
+```bash
+openclaw gateway restart
+```
+
+That's it. Traces show up at `https://console.latitude.so/projects/<your-slug>`.
+
+### Install flags
+
+| Flag | What it does |
+| --- | --- |
+| `--api-key=<key>` | Pass the API key instead of being prompted. |
+| `--project=<slug>` | Pass the project slug instead of being prompted. |
+| `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
+| `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
+| `--yes` / `--no-prompt` | Skip all prompts. Required for non-TTY / CI invocations. |
+
+Re-running `install` is idempotent — existing values are preserved.
+
+## Uninstall
+
+```bash
+npx -y @latitude-data/openclaw-telemetry uninstall
+```
+
+Shows a plan, asks for confirmation, then removes the plugin entry and the `LATITUDE_*` env vars from `~/.openclaw/openclaw.json`. A backup is saved at `openclaw.json.latitude-bak`.
+
+## What gets sent
+
+For each agent run, the plugin emits one trace with three span kinds:
+
+- **`interaction`** — the agent run. Carries `openclaw.session.key`, `openclaw.agent.id`, `openclaw.agent.name`, aggregated token usage across all LLM calls, run duration, success/error status, and the first user prompt.
+- **`llm_request`** — one per LLM call. Carries provider, request/response model, `gen_ai.system_instructions`, `gen_ai.input.messages` (full history + current prompt), `gen_ai.output.messages` (assistant text + tool_call parts), and full token usage (input/output/cache_read/cache_creation/total) — under both canonical `gen_ai.*` keys and legacy aliases.
+- **`tool_execution`** — one per tool call. Canonical `gen_ai.tool.*` attributes: `name`, `call.id`, `call.arguments`, `call.result`. Failures set `error.type`, `error.message`, and OTel status code 2.
+
+Every span carries `openclaw.agent.id` and `openclaw.agent.name`. Multi-agent OpenClaw setups (sub-agents) naturally produce spans tagged with the invoking agent's id, letting you filter and group by agent in the Latitude UI.
+
+All spans share the run id and trace id so they group together.
+
+## How it works
+
+OpenClaw ships typed plugin hooks that fire per-LLM-call with the complete payload (`src/plugins/hook-types.ts` in the OpenClaw source). We subscribe to:
+
+- `llm_input` — full system prompt, prompt text, history messages, provider, model.
+- `llm_output` — assistant text, last assistant message, full token usage (input/output/cacheRead/cacheWrite/total), resolved provider/model ref.
+- `before_tool_call` / `after_tool_call` — tool name, arguments, result, error, duration.
+- `agent_end` — run completion signal. This is when we build the OTLP trace and POST it.
+- `session_start` — currently a no-op; reserved for future session-level metadata.
+
+OpenClaw runs LLM hooks **fire-and-forget** (see [`src/plugins/hooks.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/hooks.ts) — `runLlmInput`/`runLlmOutput` are documented as parallel, and the call site in [`src/agents/pi-embedded-runner/run/attempt.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run/attempt.ts) wraps them with `void hookRunner.run*(...).catch(...)`). Our handlers can never slow down the agent loop.
+
+**No runtime wrapping.** Unlike existing third-party OpenClaw observability plugins that try to monkey-patch `@mariozechner/pi-ai` (and run into jiti's CJS/ESM module isolation), we stay inside the supported plugin API. The hooks give us everything, at lower risk of breaking on OpenClaw updates.
+
+## Configuration reference
+
+Everything the installer writes. You can edit `~/.openclaw/openclaw.json` directly if you want to tweak:
+
+### `env`
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
+| `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
+| `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
+| `LATITUDE_OPENCLAW_ENABLED` | no | `1` | Set to `0` to pause the plugin without uninstalling. |
+| `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
+
+### `plugins.entries`
+
+```json
+{
+  "@latitude-data/openclaw-telemetry": {
+    "enabled": true,
+    "hooks": {
+      "allowConversationAccess": true
+    }
+  }
+}
+```
+
+`allowConversationAccess` is load-bearing — OpenClaw scrubs payloads from `llm_input` / `llm_output` / `agent_end` for third-party plugins unless they opt in explicitly.
+
+### Manual installation
+
+If the installer doesn't fit your setup, the equivalent `openclaw.json` is:
+
+```jsonc
+{
+  "env": {
+    "LATITUDE_API_KEY": "lat_xxx",
+    "LATITUDE_PROJECT": "my-openclaw-project"
+  },
+  "plugins": {
+    "entries": {
+      "@latitude-data/openclaw-telemetry": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        }
+      }
+    }
+  }
+}
+```
+
+Then ensure the package is installed where OpenClaw can load it (either in your OpenClaw workspace, or globally via `npm i -g @latitude-data/openclaw-telemetry`).
+
+## Privacy
+
+This plugin reads every LLM input and output and sends the **full content** to Latitude — system prompts, user prompts, assistant responses, tool I/O. There is no per-flag opt-in once `allowConversationAccess` is set: everything gets shipped.
+
+If that's not what you want:
+
+- Don't install the plugin.
+- Set `LATITUDE_OPENCLAW_ENABLED=0` in your shell before starting a sensitive session.
+- Run `uninstall`.
+
+## Supported OpenClaw versions
+
+Requires OpenClaw **2026.3.0+** for the `llm_input` / `llm_output` hooks. Older versions lack these hooks and would only surface metadata via `model.usage` diagnostics — not enough for full trace fidelity.
+
+## How it fails
+
+Fail-open by design. If the API is unreachable, your key is wrong, or a hook payload is malformed, the plugin logs to stderr (when `LATITUDE_DEBUG=1`) and the agent run continues unaffected.
+
+## License
+
+MIT

--- a/packages/telemetry/openclaw/package.json
+++ b/packages/telemetry/openclaw/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@latitude-data/openclaw-telemetry",
+  "version": "0.0.1",
+  "description": "OpenClaw plugin that streams LLM calls, tool executions, and agent runs to Latitude as OTLP traces",
+  "author": "Latitude Data SL <hello@latitude.so>",
+  "license": "MIT",
+  "keywords": [
+    "openclaw",
+    "telemetry",
+    "otlp",
+    "opentelemetry",
+    "latitude",
+    "observability"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw"
+  },
+  "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "latitude-openclaw": "./dist/cli.js"
+  },
+  "main": "./dist/plugin.js",
+  "types": "./dist/plugin.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "default": "./dist/plugin.js"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "default": "./dist/cli.js"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --pool=forks --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@clack/prompts": "^1.2.0",
+    "picocolors": "^1.1.1"
+  },
+  "peerDependencies": {
+    "typescript": "^6.0.3"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/telemetry/openclaw/src/cli.ts
+++ b/packages/telemetry/openclaw/src/cli.ts
@@ -1,0 +1,23 @@
+import { normalizeInstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
+
+async function main(): Promise<void> {
+  const { subcommand, flags } = parseFlags(process.argv.slice(2))
+  if (subcommand === "install" || subcommand === undefined) {
+    await runInstall(normalizeInstallFlags(flags))
+    return
+  }
+  if (subcommand === "uninstall") {
+    await runUninstall({ noPrompt: flags["no-prompt"] === true || flags.yes === true })
+    return
+  }
+  process.stderr.write(`unknown subcommand: ${subcommand}\n`)
+  process.stderr.write(
+    "usage: latitude-openclaw [install|uninstall] [--api-key=...] [--project=...] [--staging|--dev] [--yes]\n",
+  )
+  process.exit(1)
+}
+
+main().catch((err) => {
+  process.stderr.write(`${String(err)}\n`)
+  process.exit(1)
+})

--- a/packages/telemetry/openclaw/src/client.ts
+++ b/packages/telemetry/openclaw/src/client.ts
@@ -1,0 +1,47 @@
+import type { Logger } from "./logger.ts"
+import type { OtlpExportRequest } from "./types.ts"
+
+export async function postTraces({
+  baseUrl,
+  apiKey,
+  project,
+  payload,
+  logger,
+  timeoutMs = 10_000,
+}: {
+  baseUrl: string
+  apiKey: string
+  project: string
+  payload: OtlpExportRequest
+  logger: Logger
+  timeoutMs?: number
+}): Promise<void> {
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/traces`
+  const bodyText = JSON.stringify(payload)
+  logger.debug(`POST ${url} (project=${project}, ${bodyText.length} bytes)`)
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "X-Latitude-Project": project,
+      },
+      body: bodyText,
+      signal: controller.signal,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => "")
+      logger.warn(`ingest HTTP ${res.status}: ${text.slice(0, 500)}`)
+    } else {
+      logger.debug(`ingest HTTP ${res.status}`)
+    }
+  } catch (err) {
+    logger.warn(`ingest failed: ${String(err)}`)
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/packages/telemetry/openclaw/src/config.ts
+++ b/packages/telemetry/openclaw/src/config.ts
@@ -1,0 +1,16 @@
+export interface Config {
+  apiKey: string
+  baseUrl: string
+  project: string
+  enabled: boolean
+  debug: boolean
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const apiKey = env.LATITUDE_API_KEY ?? ""
+  const baseUrl = env.LATITUDE_BASE_URL ?? "https://ingest.latitude.so"
+  const project = env.LATITUDE_PROJECT ?? ""
+  const enabled = (env.LATITUDE_OPENCLAW_ENABLED ?? "1") !== "0" && apiKey !== "" && project !== ""
+  const debug = env.LATITUDE_DEBUG === "1"
+  return { apiKey, baseUrl, project, enabled, debug }
+}

--- a/packages/telemetry/openclaw/src/logger.ts
+++ b/packages/telemetry/openclaw/src/logger.ts
@@ -1,0 +1,13 @@
+const PREFIX = "[latitude-openclaw]"
+
+export interface Logger {
+  debug: (msg: string) => void
+  warn: (msg: string) => void
+}
+
+export function createLogger(debugEnabled: boolean): Logger {
+  return {
+    debug: debugEnabled ? (msg) => process.stderr.write(`${PREFIX} ${msg}\n`) : () => {},
+    warn: (msg) => process.stderr.write(`${PREFIX} ${msg}\n`),
+  }
+}

--- a/packages/telemetry/openclaw/src/otlp.test.ts
+++ b/packages/telemetry/openclaw/src/otlp.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest"
+import { buildOtlpRequest } from "./otlp.ts"
+import type { OtlpKeyValue, RunRecord } from "./types.ts"
+
+function attrMap(attrs: OtlpKeyValue[]): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const { key, value } of attrs) {
+    if (value.stringValue !== undefined) out[key] = value.stringValue
+    else if (value.intValue !== undefined) out[key] = value.intValue
+    else if (value.boolValue !== undefined) out[key] = String(value.boolValue)
+  }
+  return out
+}
+
+function sampleRun(overrides: Partial<RunRecord> = {}): RunRecord {
+  return {
+    runId: "run-1",
+    sessionId: "s-1",
+    sessionKey: "sk-1",
+    agentId: "router-agent",
+    workspaceDir: "/w",
+    messageProvider: "chat",
+    trigger: "message",
+    channelId: "ch-1",
+    modelProviderId: "openai",
+    modelId: "gpt-5",
+    startMs: 1_000,
+    endMs: 1_500,
+    success: true,
+    error: undefined,
+    llmCalls: [
+      {
+        runId: "run-1",
+        sessionId: "s-1",
+        sessionKey: "sk-1",
+        agentId: "router-agent",
+        provider: "openai",
+        requestModel: "gpt-5",
+        responseModel: "gpt-5-2026-04-01",
+        resolvedRef: "openai/gpt-5",
+        systemPrompt: "you are helpful",
+        prompt: "hello",
+        historyMessages: [
+          { role: "user", content: "prior question" },
+          { role: "assistant", content: "prior answer" },
+        ],
+        imagesCount: 0,
+        assistantTexts: ["hi"],
+        lastAssistant: { role: "assistant", content: "hi" },
+        usage: { input: 42, output: 7, cacheRead: 3, cacheWrite: 1, total: 49 },
+        startMs: 1_100,
+        endMs: 1_400,
+        error: undefined,
+        toolCalls: [
+          {
+            toolCallId: "tc-1",
+            toolName: "read_file",
+            params: { path: "/x" },
+            result: { content: "data" },
+            error: undefined,
+            startMs: 1_200,
+            endMs: 1_250,
+            durationMs: 50,
+            agentId: "router-agent",
+          },
+        ],
+      },
+    ],
+    orphanTools: [],
+    ...overrides,
+  }
+}
+
+describe("buildOtlpRequest", () => {
+  it("emits an interaction + llm_request + tool_execution span tree", () => {
+    const req = buildOtlpRequest(sampleRun())
+    const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
+    expect(spans).toHaveLength(3)
+    const [interaction, llm, tool] = spans
+
+    expect(interaction?.name).toBe("interaction")
+    expect(interaction?.parentSpanId).toBe("")
+    expect(llm?.name).toBe("llm_request")
+    expect(llm?.parentSpanId).toBe(interaction?.spanId)
+    expect(tool?.name).toBe("tool:read_file")
+    expect(tool?.parentSpanId).toBe(interaction?.spanId)
+    expect(tool?.traceId).toBe(interaction?.traceId)
+  })
+
+  it("tags every span with the agent name", () => {
+    const req = buildOtlpRequest(sampleRun())
+    const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
+    for (const s of spans) {
+      const attrs = attrMap(s.attributes)
+      expect(attrs["openclaw.agent.id"]).toBe("router-agent")
+      expect(attrs["openclaw.agent.name"]).toBe("router-agent")
+    }
+  })
+
+  it("captures everything on the llm_request span", () => {
+    const req = buildOtlpRequest(sampleRun())
+    const llm = req.resourceSpans[0]?.scopeSpans[0]?.spans[1]
+    const attrs = attrMap(llm?.attributes ?? [])
+
+    expect(attrs.span_type ?? attrs["span.type"]).toBe("llm_request")
+    expect(attrs["gen_ai.system"]).toBe("openai")
+    expect(attrs["gen_ai.request.model"]).toBe("gpt-5")
+    expect(attrs["gen_ai.response.model"]).toBe("gpt-5-2026-04-01")
+    expect(attrs["openclaw.resolved.ref"]).toBe("openai/gpt-5")
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe("42")
+    expect(attrs["gen_ai.usage.output_tokens"]).toBe("7")
+    expect(attrs["gen_ai.usage.cache_read_input_tokens"]).toBe("3")
+    expect(attrs["gen_ai.usage.cache_creation_input_tokens"]).toBe("1")
+    expect(attrs["gen_ai.usage.total_tokens"]).toBe("49")
+    expect(attrs["openclaw.session.key"]).toBe("sk-1")
+    expect(attrs["openclaw.run.id"]).toBe("run-1")
+    expect(attrs.llm_request_captured ?? attrs["llm_request.captured"]).toBe("true")
+
+    const system = JSON.parse(attrs["gen_ai.system_instructions"] ?? "[]") as Array<{
+      type: string
+      content: string
+    }>
+    expect(system[0]?.content).toBe("you are helpful")
+
+    const input = JSON.parse(attrs["gen_ai.input.messages"] ?? "[]") as Array<{
+      role: string
+      parts: Array<{ type: string; content?: string }>
+    }>
+    // History (2) + current user prompt (1).
+    expect(input).toHaveLength(3)
+    expect(input[2]?.role).toBe("user")
+    expect(input[2]?.parts[0]?.content).toBe("hello")
+
+    const output = JSON.parse(attrs["gen_ai.output.messages"] ?? "[]") as Array<{
+      role: string
+      parts: Array<{ type: string; content?: string; name?: string }>
+    }>
+    expect(output[0]?.role).toBe("assistant")
+    // text part + tool_call part invoked during this call.
+    expect(output[0]?.parts.some((p) => p.type === "text" && p.content === "hi")).toBe(true)
+    expect(output[0]?.parts.some((p) => p.type === "tool_call" && p.name === "read_file")).toBe(true)
+  })
+
+  it("captures tool arguments and results on the tool span", () => {
+    const req = buildOtlpRequest(sampleRun())
+    const tool = req.resourceSpans[0]?.scopeSpans[0]?.spans[2]
+    const attrs = attrMap(tool?.attributes ?? [])
+    expect(attrs["gen_ai.tool.name"]).toBe("read_file")
+    expect(attrs["gen_ai.tool.call.id"]).toBe("tc-1")
+    expect(JSON.parse(attrs["gen_ai.tool.call.arguments"] ?? "{}")).toEqual({ path: "/x" })
+    expect(JSON.parse(attrs["gen_ai.tool.call.result"] ?? "{}")).toEqual({ content: "data" })
+    expect(attrs.success).toBe("true")
+    expect(attrs["tool.duration_ms"]).toBe("50")
+  })
+
+  it("aggregates token usage across multiple LLM calls on the interaction span", () => {
+    const run = sampleRun()
+    const firstCall = run.llmCalls[0]
+    if (!firstCall) throw new Error("expected a first call")
+    run.llmCalls.push({
+      ...firstCall,
+      usage: { input: 8, output: 2, total: 10 },
+      toolCalls: [],
+    })
+    const req = buildOtlpRequest(run)
+    const interaction = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    const attrs = attrMap(interaction?.attributes ?? [])
+    expect(attrs["gen_ai.usage.input_tokens"]).toBe("50")
+    expect(attrs["gen_ai.usage.output_tokens"]).toBe("9")
+    expect(attrs["gen_ai.usage.total_tokens"]).toBe("59")
+    expect(attrs["interaction.call_count"]).toBe("2")
+  })
+
+  it("marks tool error spans with status code 2", () => {
+    const run = sampleRun()
+    const tool = run.llmCalls[0]?.toolCalls[0]
+    if (!tool) throw new Error("expected a tool call")
+    tool.error = "boom"
+    tool.result = undefined
+    const req = buildOtlpRequest(run)
+    const toolSpan = req.resourceSpans[0]?.scopeSpans[0]?.spans[2]
+    expect(toolSpan?.status.code).toBe(2)
+    const attrs = attrMap(toolSpan?.attributes ?? [])
+    expect(attrs["error.message"]).toBe("boom")
+    expect(attrs.success).toBe("false")
+  })
+
+  it("marks failed runs with interaction status code 2", () => {
+    const run = sampleRun({ success: false, error: "run failed" })
+    const req = buildOtlpRequest(run)
+    const interaction = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+    expect(interaction?.status.code).toBe(2)
+    const attrs = attrMap(interaction?.attributes ?? [])
+    expect(attrs["openclaw.run.error"]).toBe("run failed")
+    expect(attrs["openclaw.run.success"]).toBe("false")
+  })
+
+  it("emits orphan tool spans parented on the interaction", () => {
+    const run = sampleRun()
+    run.orphanTools.push({
+      toolCallId: "tc-orphan",
+      toolName: "drift",
+      params: { q: 1 },
+      result: "ok",
+      error: undefined,
+      startMs: 1_000,
+      endMs: 1_050,
+      durationMs: 50,
+      agentId: "router-agent",
+    })
+    const req = buildOtlpRequest(run)
+    const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
+    const orphan = spans.find((s) => s.name === "tool:drift")
+    expect(orphan).toBeDefined()
+    expect(orphan?.parentSpanId).toBe(spans[0]?.spanId)
+  })
+})

--- a/packages/telemetry/openclaw/src/otlp.ts
+++ b/packages/telemetry/openclaw/src/otlp.ts
@@ -1,0 +1,391 @@
+import { createHash } from "node:crypto"
+import { arch, hostname, platform, release } from "node:os"
+import type {
+  LlmCallRecord,
+  OtlpExportRequest,
+  OtlpKeyValue,
+  OtlpResourceSpans,
+  OtlpSpan,
+  RunRecord,
+  ToolCallRecord,
+} from "./types.ts"
+
+const SCOPE_NAME = "@latitude-data/openclaw-telemetry"
+const SCOPE_VERSION = "0.0.1"
+
+/** Build an OTLP export request for a single completed agent run. */
+export function buildOtlpRequest(run: RunRecord): OtlpExportRequest {
+  const spans = buildRunSpans(run)
+  const rs: OtlpResourceSpans = {
+    resource: { attributes: resourceAttrs() },
+    scopeSpans: [{ scope: { name: SCOPE_NAME, version: SCOPE_VERSION }, spans }],
+  }
+  return { resourceSpans: [rs] }
+}
+
+function buildRunSpans(run: RunRecord): OtlpSpan[] {
+  const traceId = hashHex(`${run.sessionId ?? "session"}:${run.runId}`, 32)
+  const interactionSpanId = hashHex(`${traceId}:run`, 16)
+  const out: OtlpSpan[] = [buildInteractionSpan(traceId, interactionSpanId, run)]
+
+  run.llmCalls.forEach((call, idx) => {
+    const callSpanId = hashHex(`${traceId}:call:${idx}`, 16)
+    out.push(buildLlmSpan(traceId, interactionSpanId, callSpanId, call, idx, run))
+    // Tool spans are siblings of the llm_request, parented on the interaction
+    // span so the run timeline renders as: llm → tool → llm → tool → ...
+    call.toolCalls.forEach((tool, tIdx) => {
+      const toolSpanId = hashHex(`${traceId}:call:${idx}:tool:${tIdx}`, 16)
+      out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run))
+    })
+  })
+  run.orphanTools.forEach((tool, idx) => {
+    const toolSpanId = hashHex(`${traceId}:orphan-tool:${idx}`, 16)
+    out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run))
+  })
+
+  return out
+}
+
+function buildInteractionSpan(traceId: string, spanId: string, run: RunRecord): OtlpSpan {
+  const startNs = msToNs(run.startMs)
+  const endNs = msToNs(run.endMs ?? run.startMs)
+  const totalTools = run.llmCalls.reduce((sum, c) => sum + c.toolCalls.length, 0) + run.orphanTools.length
+  const totalUsage = aggregateUsage(run.llmCalls)
+
+  return {
+    traceId,
+    spanId,
+    parentSpanId: "",
+    name: "interaction",
+    kind: 1,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "interaction"),
+      str("interaction.kind", "agent_run"),
+      str("openclaw.run.id", run.runId),
+      run.sessionId ? str("openclaw.session.id", run.sessionId) : undefined,
+      run.sessionId ? str("session.id", run.sessionId) : undefined,
+      run.sessionKey ? str("openclaw.session.key", run.sessionKey) : undefined,
+      run.agentId ? str("openclaw.agent.id", run.agentId) : undefined,
+      run.agentId ? str("openclaw.agent.name", run.agentId) : undefined,
+      run.workspaceDir ? str("openclaw.workspace.dir", run.workspaceDir) : undefined,
+      run.messageProvider ? str("openclaw.message.provider", run.messageProvider) : undefined,
+      run.channelId ? str("openclaw.channel.id", run.channelId) : undefined,
+      run.trigger ? str("openclaw.trigger", run.trigger) : undefined,
+      run.modelProviderId ? str("openclaw.model.provider.id", run.modelProviderId) : undefined,
+      run.modelId ? str("openclaw.model.id", run.modelId) : undefined,
+      int("interaction.duration_ms", durationMs(run.startMs, run.endMs)),
+      int("interaction.call_count", run.llmCalls.length),
+      int("interaction.tool_call_count", totalTools),
+      run.success !== undefined ? bool("openclaw.run.success", run.success) : undefined,
+      run.error ? str("openclaw.run.error", run.error) : undefined,
+      totalUsage.input !== undefined ? int("gen_ai.usage.input_tokens", totalUsage.input) : undefined,
+      totalUsage.output !== undefined ? int("gen_ai.usage.output_tokens", totalUsage.output) : undefined,
+      totalUsage.cacheRead !== undefined
+        ? int("gen_ai.usage.cache_read_input_tokens", totalUsage.cacheRead)
+        : undefined,
+      totalUsage.cacheWrite !== undefined
+        ? int("gen_ai.usage.cache_creation_input_tokens", totalUsage.cacheWrite)
+        : undefined,
+      totalUsage.total !== undefined ? int("gen_ai.usage.total_tokens", totalUsage.total) : undefined,
+      // Surface the first user prompt so the Latitude UI has something
+      // recognisable in the interaction list.
+      run.llmCalls[0]?.prompt ? str("user_prompt", run.llmCalls[0].prompt) : undefined,
+    ]),
+    status: { code: run.success === false ? 2 : 1 },
+  }
+}
+
+function buildLlmSpan(
+  traceId: string,
+  parentSpanId: string,
+  spanId: string,
+  call: LlmCallRecord,
+  callIdx: number,
+  run: RunRecord,
+): OtlpSpan {
+  const startNs = msToNs(call.startMs)
+  const endNs = msToNs(call.endMs ?? call.startMs)
+
+  const inputMessages = buildInputMessages(call)
+  const outputMessages = buildOutputMessages(call)
+  const systemInstructions = call.systemPrompt
+    ? JSON.stringify([{ type: "text", content: call.systemPrompt }])
+    : undefined
+
+  return {
+    traceId,
+    spanId,
+    parentSpanId,
+    name: "llm_request",
+    kind: 3,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "llm_request"),
+      str("gen_ai.operation.name", "chat"),
+      str("llm_request.context", "interaction"),
+      int("llm_request.call_index", callIdx),
+      // Provider/model — capture every variant OpenClaw exposes so consumers
+      // can filter on whichever form they already use.
+      str("gen_ai.system", call.provider),
+      str("openclaw.provider", call.provider),
+      str("gen_ai.request.model", call.requestModel),
+      str("model", call.requestModel),
+      call.responseModel ? str("gen_ai.response.model", call.responseModel) : undefined,
+      call.resolvedRef ? str("openclaw.resolved.ref", call.resolvedRef) : undefined,
+      // Identity — the agent name tag the user specifically asked for is here
+      // under both canonical and convenience keys.
+      run.sessionId ? str("session.id", run.sessionId) : undefined,
+      run.sessionKey ? str("openclaw.session.key", run.sessionKey) : undefined,
+      str("openclaw.run.id", call.runId),
+      call.agentId ? str("openclaw.agent.id", call.agentId) : undefined,
+      call.agentId ? str("openclaw.agent.name", call.agentId) : undefined,
+      // Token usage — input / output / cache / total, in both gen_ai.* and
+      // legacy aliases for backwards compatibility with existing dashboards.
+      call.usage?.input !== undefined ? int("gen_ai.usage.input_tokens", call.usage.input) : undefined,
+      call.usage?.input !== undefined ? int("input_tokens", call.usage.input) : undefined,
+      call.usage?.output !== undefined ? int("gen_ai.usage.output_tokens", call.usage.output) : undefined,
+      call.usage?.output !== undefined ? int("output_tokens", call.usage.output) : undefined,
+      call.usage?.cacheRead !== undefined
+        ? int("gen_ai.usage.cache_read_input_tokens", call.usage.cacheRead)
+        : undefined,
+      call.usage?.cacheRead !== undefined ? int("cache_read_tokens", call.usage.cacheRead) : undefined,
+      call.usage?.cacheWrite !== undefined
+        ? int("gen_ai.usage.cache_creation_input_tokens", call.usage.cacheWrite)
+        : undefined,
+      call.usage?.cacheWrite !== undefined ? int("cache_creation_tokens", call.usage.cacheWrite) : undefined,
+      call.usage?.total !== undefined ? int("gen_ai.usage.total_tokens", call.usage.total) : undefined,
+      // Content — system prompt + full message arrays.
+      systemInstructions ? str("gen_ai.system_instructions", systemInstructions) : undefined,
+      str("gen_ai.input.messages", JSON.stringify(inputMessages)),
+      str("gen_ai.output.messages", JSON.stringify(outputMessages)),
+      // Misc signals.
+      int("openclaw.images.count", call.imagesCount),
+      int("llm_request.tool_call_count", call.toolCalls.length),
+      int("llm_request.duration_ms", durationMs(call.startMs, call.endMs)),
+      call.error ? str("error.type", "llm_error") : undefined,
+      call.error ? str("error.message", call.error) : undefined,
+      str("success", call.error ? "false" : "true"),
+      str("llm_request.captured", "true"),
+    ]),
+    status: { code: call.error ? 2 : 1 },
+  }
+}
+
+function buildToolSpan(
+  traceId: string,
+  parentSpanId: string,
+  spanId: string,
+  tool: ToolCallRecord,
+  run: RunRecord,
+): OtlpSpan {
+  const startNs = msToNs(tool.startMs)
+  const endNs = msToNs(tool.endMs ?? tool.startMs)
+  const isError = Boolean(tool.error)
+  return {
+    traceId,
+    spanId,
+    parentSpanId,
+    name: `tool:${tool.toolName}`,
+    kind: 1,
+    startTimeUnixNano: startNs,
+    endTimeUnixNano: endNs,
+    attributes: stripUndef([
+      str("span.type", "tool_execution"),
+      str("gen_ai.operation.name", "execute_tool"),
+      str("gen_ai.tool.name", tool.toolName),
+      str("gen_ai.tool.call.id", tool.toolCallId),
+      str("gen_ai.tool.call.arguments", safeJson(tool.params)),
+      tool.result !== undefined ? str("gen_ai.tool.call.result", safeJson(tool.result)) : undefined,
+      isError ? str("error.type", "tool_error") : undefined,
+      isError ? str("error.message", tool.error ?? "") : undefined,
+      bool("tool.is_error", isError),
+      str("success", isError ? "false" : "true"),
+      tool.durationMs !== undefined ? int("tool.duration_ms", tool.durationMs) : undefined,
+      run.sessionId ? str("session.id", run.sessionId) : undefined,
+      run.sessionKey ? str("openclaw.session.key", run.sessionKey) : undefined,
+      str("openclaw.run.id", run.runId),
+      tool.agentId ? str("openclaw.agent.id", tool.agentId) : undefined,
+      tool.agentId ? str("openclaw.agent.name", tool.agentId) : undefined,
+    ]),
+    status: { code: isError ? 2 : 1 },
+  }
+}
+
+// ─── Message shape helpers ──────────────────────────────────────────────────
+//
+// Latitude UI expects `{ role, parts: [{ type, content|... }] }` objects.
+// Build both the input (history + current prompt) and output (assistant + any
+// tool_calls from this call) arrays in that shape, passing through whatever
+// OpenClaw handed us as-is where the shape is already usable.
+
+interface MessagePart {
+  type: string
+  [key: string]: unknown
+}
+
+interface Message {
+  role: "system" | "user" | "assistant" | "tool"
+  parts: MessagePart[]
+}
+
+function buildInputMessages(call: LlmCallRecord): Message[] {
+  const out: Message[] = []
+  // OpenClaw's `historyMessages` is typed `unknown[]`; we trust it enough to
+  // pass through but normalize simple shapes so the Latitude UI has something
+  // to render. Complex objects fall back to a JSON stringification.
+  for (const msg of call.historyMessages) {
+    const normalized = normalizeHistoryMessage(msg)
+    if (normalized) out.push(normalized)
+  }
+  if (call.prompt.length > 0) {
+    out.push({ role: "user", parts: [{ type: "text", content: call.prompt }] })
+  }
+  return out
+}
+
+function normalizeHistoryMessage(raw: unknown): Message | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  const role = typeof obj.role === "string" ? (obj.role as Message["role"]) : "user"
+  const content = obj.content ?? obj.text ?? obj.message
+  if (typeof content === "string") {
+    return { role, parts: [{ type: "text", content }] }
+  }
+  if (Array.isArray(content)) {
+    const parts: MessagePart[] = []
+    for (const block of content) {
+      const part = normalizeContentBlock(block)
+      if (part) parts.push(part)
+    }
+    return { role, parts: parts.length > 0 ? parts : [{ type: "text", content: JSON.stringify(content) }] }
+  }
+  // Unknown shape — dump it as JSON so nothing is silently lost.
+  return { role, parts: [{ type: "text", content: safeJson(raw) }] }
+}
+
+function normalizeContentBlock(raw: unknown): MessagePart | undefined {
+  if (typeof raw === "string") return { type: "text", content: raw }
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as Record<string, unknown>
+  const type = typeof obj.type === "string" ? obj.type : "text"
+  if (type === "text" && typeof obj.text === "string") return { type: "text", content: obj.text }
+  if (type === "tool_use") {
+    return {
+      type: "tool_call",
+      id: typeof obj.id === "string" ? obj.id : "",
+      name: typeof obj.name === "string" ? obj.name : "",
+      arguments: obj.input ?? {},
+    }
+  }
+  if (type === "tool_result") {
+    return {
+      type: "tool_call_response",
+      id: typeof obj.tool_use_id === "string" ? obj.tool_use_id : "",
+      response: obj.content ?? "",
+    }
+  }
+  if (type === "image") {
+    return { type: "uri", modality: "image", uri: safeJson(obj.source ?? obj) }
+  }
+  return { type, content: safeJson(raw) }
+}
+
+function buildOutputMessages(call: LlmCallRecord): Message[] {
+  const parts: MessagePart[] = []
+  for (const text of call.assistantTexts) {
+    if (text.length > 0) parts.push({ type: "text", content: text })
+  }
+  // Attach tool_call parts from tools invoked during this call so the output
+  // message reads like the assistant message the model actually produced.
+  for (const tool of call.toolCalls) {
+    parts.push({
+      type: "tool_call",
+      id: tool.toolCallId,
+      name: tool.toolName,
+      arguments: tool.params,
+    })
+  }
+  // Fall back to `lastAssistant` if we have no text/tools (edge case — empty
+  // SSE response, failed run).
+  if (parts.length === 0 && call.lastAssistant !== undefined) {
+    parts.push({ type: "text", content: safeJson(call.lastAssistant) })
+  }
+  return [{ role: "assistant", parts }]
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+function aggregateUsage(calls: LlmCallRecord[]): Required<Partial<import("./types.ts").OpenClawLlmUsage>> {
+  const agg = {
+    input: undefined as number | undefined,
+    output: undefined as number | undefined,
+    cacheRead: undefined as number | undefined,
+    cacheWrite: undefined as number | undefined,
+    total: undefined as number | undefined,
+  }
+  const add = (k: keyof typeof agg, v: number | undefined): void => {
+    if (v === undefined) return
+    agg[k] = (agg[k] ?? 0) + v
+  }
+  for (const c of calls) {
+    if (!c.usage) continue
+    add("input", c.usage.input)
+    add("output", c.usage.output)
+    add("cacheRead", c.usage.cacheRead)
+    add("cacheWrite", c.usage.cacheWrite)
+    add("total", c.usage.total)
+  }
+  return agg as Required<Partial<import("./types.ts").OpenClawLlmUsage>>
+}
+
+function resourceAttrs(): OtlpKeyValue[] {
+  return [
+    str("service.name", "openclaw"),
+    str("service.version", SCOPE_VERSION),
+    str("host.name", hostname()),
+    str("host.arch", arch()),
+    str("os.type", platform()),
+    str("os.version", release()),
+  ]
+}
+
+function str(key: string, value: string): OtlpKeyValue {
+  return { key, value: { stringValue: value } }
+}
+
+function int(key: string, value: number): OtlpKeyValue {
+  return { key, value: { intValue: String(Math.trunc(value)) } }
+}
+
+function bool(key: string, value: boolean): OtlpKeyValue {
+  return { key, value: { boolValue: value } }
+}
+
+function stripUndef(items: Array<OtlpKeyValue | undefined>): OtlpKeyValue[] {
+  return items.filter((x): x is OtlpKeyValue => x !== undefined)
+}
+
+function hashHex(input: string, length: number): string {
+  return createHash("sha256").update(input).digest("hex").slice(0, length)
+}
+
+function msToNs(ms: number): string {
+  return (BigInt(Math.trunc(ms)) * 1_000_000n).toString()
+}
+
+function durationMs(startMs: number, endMs: number | undefined): number {
+  if (endMs === undefined) return 0
+  return Math.max(0, endMs - startMs)
+}
+
+function safeJson(value: unknown): string {
+  try {
+    if (typeof value === "string") return value
+    return JSON.stringify(value)
+  } catch {
+    return ""
+  }
+}

--- a/packages/telemetry/openclaw/src/otlp.ts
+++ b/packages/telemetry/openclaw/src/otlp.ts
@@ -246,10 +246,20 @@ function buildInputMessages(call: LlmCallRecord): Message[] {
   return out
 }
 
+const ALLOWED_ROLES: ReadonlySet<Message["role"]> = new Set(["system", "user", "assistant", "tool"])
+
+function normalizeRole(raw: unknown): Message["role"] {
+  // Provider adapters occasionally emit roles outside the canonical set
+  // (e.g. OpenAI's "developer"). Coerce unknown roles to "user" so the
+  // downstream Latitude UI gets a payload it can render.
+  if (typeof raw !== "string") return "user"
+  return ALLOWED_ROLES.has(raw as Message["role"]) ? (raw as Message["role"]) : "user"
+}
+
 function normalizeHistoryMessage(raw: unknown): Message | undefined {
   if (!raw || typeof raw !== "object") return undefined
   const obj = raw as Record<string, unknown>
-  const role = typeof obj.role === "string" ? (obj.role as Message["role"]) : "user"
+  const role = normalizeRole(obj.role)
   const content = obj.content ?? obj.text ?? obj.message
   if (typeof content === "string") {
     return { role, parts: [{ type: "text", content }] }

--- a/packages/telemetry/openclaw/src/plugin.test.ts
+++ b/packages/telemetry/openclaw/src/plugin.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest"
+import registerLatitudePlugin, { type OpenClawPluginApiLike } from "./plugin.ts"
+import type { RunRecord } from "./types.ts"
+
+function makeApi(): {
+  api: OpenClawPluginApiLike
+  fire: (hookName: string, event: unknown, ctx: unknown) => Promise<void>
+} {
+  const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => unknown>>()
+  const api: OpenClawPluginApiLike = {
+    on: (hookName, handler) => {
+      const list = handlers.get(hookName) ?? []
+      list.push(handler as (event: unknown, ctx: unknown) => unknown)
+      handlers.set(hookName, list)
+    },
+  }
+  async function fire(hookName: string, event: unknown, ctx: unknown): Promise<void> {
+    for (const h of handlers.get(hookName) ?? []) await h(event, ctx)
+  }
+  return { api, fire }
+}
+
+describe("registerLatitudePlugin", () => {
+  it("does nothing when config is disabled", () => {
+    const { api } = makeApi()
+    const spy = vi.spyOn(api, "on")
+    registerLatitudePlugin(api, {
+      config: { apiKey: "", project: "", baseUrl: "", enabled: false, debug: false },
+    })
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("builds a run from the full hook sequence and emits it", async () => {
+    const { api, fire } = makeApi()
+    const emitted: RunRecord[] = []
+    registerLatitudePlugin(api, {
+      config: {
+        apiKey: "x",
+        project: "p",
+        baseUrl: "http://localhost:0", // unreachable — fetch will fail silently via logger.warn
+        enabled: true,
+        debug: false,
+      },
+      onEmit: (r) => emitted.push(r),
+    })
+
+    const ctx = { runId: "r-1", sessionId: "s-1", sessionKey: "sk-1", agentId: "router" }
+
+    await fire(
+      "llm_input",
+      {
+        runId: "r-1",
+        sessionId: "s-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "sys",
+        prompt: "hi",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      ctx,
+    )
+    await fire("before_tool_call", { toolName: "grep", params: { q: "x" }, runId: "r-1", toolCallId: "tc-1" }, ctx)
+    await fire(
+      "after_tool_call",
+      {
+        toolName: "grep",
+        params: { q: "x" },
+        runId: "r-1",
+        toolCallId: "tc-1",
+        result: "1 match",
+      },
+      ctx,
+    )
+    await fire(
+      "llm_output",
+      {
+        runId: "r-1",
+        sessionId: "s-1",
+        provider: "openai",
+        model: "gpt-5",
+        assistantTexts: ["done"],
+        lastAssistant: { role: "assistant", content: "done" },
+        usage: { input: 10, output: 2, total: 12 },
+      },
+      ctx,
+    )
+    await fire("agent_end", { messages: [], success: true, durationMs: 200 }, ctx)
+
+    expect(emitted).toHaveLength(1)
+    const run = emitted[0]
+    if (!run) throw new Error("expected run")
+    expect(run.llmCalls).toHaveLength(1)
+    expect(run.llmCalls[0]?.toolCalls).toHaveLength(1)
+    expect(run.llmCalls[0]?.toolCalls[0]?.result).toBe("1 match")
+    expect(run.agentId).toBe("router")
+  })
+})

--- a/packages/telemetry/openclaw/src/plugin.ts
+++ b/packages/telemetry/openclaw/src/plugin.ts
@@ -1,0 +1,123 @@
+import { postTraces } from "./client.ts"
+import { type Config, loadConfig } from "./config.ts"
+import { createLogger, type Logger } from "./logger.ts"
+import { buildOtlpRequest } from "./otlp.ts"
+import { TurnBuilder } from "./turn-builder.ts"
+import type {
+  OpenClawAfterToolCallEvent,
+  OpenClawAgentContext,
+  OpenClawAgentEndEvent,
+  OpenClawBeforeToolCallEvent,
+  OpenClawLlmInputEvent,
+  OpenClawLlmOutputEvent,
+  OpenClawSessionStartEvent,
+  RunRecord,
+} from "./types.ts"
+
+/**
+ * Minimal structural type for OpenClaw's plugin API — only the fields we
+ * touch. We avoid importing from `openclaw/plugin-sdk` so the package stays
+ * usable when OpenClaw isn't installed (the CLI and tests don't need it),
+ * and so we're robust to small signature changes across OpenClaw versions.
+ */
+export interface OpenClawPluginApiLike {
+  logger?: Logger
+  on: <K extends string>(
+    hookName: K,
+    handler: (event: unknown, ctx: unknown) => unknown,
+    opts?: { priority?: number },
+  ) => void
+}
+
+export interface RegisterOptions {
+  /** Override the config, mostly for tests. */
+  config?: Config
+  /** Override the logger. */
+  logger?: Logger
+  /**
+   * Hook to observe the emitted run right before it's posted. Used by tests;
+   * not a stable public API.
+   */
+  onEmit?: (run: RunRecord) => void
+}
+
+/**
+ * Register the Latitude plugin against an OpenClaw plugin API. OpenClaw calls
+ * this once at plugin activation; we wire up `llm_input`, `llm_output`, tool
+ * and lifecycle hooks to stream traces to Latitude.
+ *
+ * Every handler is fire-and-forget on OpenClaw's side (see
+ * `src/plugins/hooks.ts` — runLlmInput/runLlmOutput are documented as
+ * parallel and wrapped with `.catch()` at the call site in attempt.ts), so
+ * nothing we do here can slow the agent loop.
+ */
+export default function registerLatitudePlugin(api: OpenClawPluginApiLike, opts: RegisterOptions = {}): void {
+  const config = opts.config ?? loadConfig()
+  const logger = opts.logger ?? createLogger(config.debug)
+
+  if (!config.enabled) {
+    if (config.apiKey === "") logger.debug("disabled: LATITUDE_API_KEY is empty")
+    if (config.project === "") logger.debug("disabled: LATITUDE_PROJECT is empty")
+    return
+  }
+  logger.debug(`enabled: project=${config.project} base=${config.baseUrl}`)
+
+  const builder = new TurnBuilder()
+
+  api.on("session_start", (evt, ctx) => {
+    builder.onSessionStart(evt as OpenClawSessionStartEvent, ctx as OpenClawAgentContext)
+  })
+
+  api.on("llm_input", (evt, ctx) => {
+    try {
+      builder.onLlmInput(evt as OpenClawLlmInputEvent, ctx as OpenClawAgentContext)
+    } catch (err) {
+      logger.warn(`llm_input handler failed: ${String(err)}`)
+    }
+  })
+
+  api.on("before_tool_call", (evt, ctx) => {
+    try {
+      builder.onBeforeToolCall(evt as OpenClawBeforeToolCallEvent, ctx as OpenClawAgentContext)
+    } catch (err) {
+      logger.warn(`before_tool_call handler failed: ${String(err)}`)
+    }
+  })
+
+  api.on("after_tool_call", (evt, ctx) => {
+    try {
+      builder.onAfterToolCall(evt as OpenClawAfterToolCallEvent, ctx as OpenClawAgentContext)
+    } catch (err) {
+      logger.warn(`after_tool_call handler failed: ${String(err)}`)
+    }
+  })
+
+  api.on("llm_output", (evt, ctx) => {
+    try {
+      builder.onLlmOutput(evt as OpenClawLlmOutputEvent, ctx as OpenClawAgentContext)
+    } catch (err) {
+      logger.warn(`llm_output handler failed: ${String(err)}`)
+    }
+  })
+
+  api.on("agent_end", (evt, ctx) => {
+    try {
+      const run = builder.onAgentEnd(evt as OpenClawAgentEndEvent, ctx as OpenClawAgentContext)
+      if (!run) {
+        logger.debug("agent_end fired without a matching run in flight")
+        return
+      }
+      opts.onEmit?.(run)
+      const payload = buildOtlpRequest(run)
+      void postTraces({
+        baseUrl: config.baseUrl,
+        apiKey: config.apiKey,
+        project: config.project,
+        payload,
+        logger,
+      })
+    } catch (err) {
+      logger.warn(`agent_end handler failed: ${String(err)}`)
+    }
+  })
+}

--- a/packages/telemetry/openclaw/src/settings-file.ts
+++ b/packages/telemetry/openclaw/src/settings-file.ts
@@ -1,0 +1,99 @@
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export const SETTINGS_PATH = join(homedir(), ".openclaw", "openclaw.json")
+export const SETTINGS_BACKUP_PATH = join(homedir(), ".openclaw", "openclaw.json.latitude-bak")
+
+export const PLUGIN_ID = "@latitude-data/openclaw-telemetry"
+
+interface OpenClawPluginEntry {
+  enabled?: boolean
+  hooks?: {
+    allowPromptInjection?: boolean
+    allowConversationAccess?: boolean
+  }
+  config?: Record<string, unknown>
+}
+
+interface OpenClawSettings {
+  plugins?: {
+    enabled?: boolean
+    entries?: Record<string, OpenClawPluginEntry>
+    [key: string]: unknown
+  }
+  env?: Record<string, string>
+  [key: string]: unknown
+}
+
+export function readSettings(): OpenClawSettings {
+  if (!existsSync(SETTINGS_PATH)) return {}
+  try {
+    const raw = readFileSync(SETTINGS_PATH, "utf-8")
+    const parsed = JSON.parse(raw) as OpenClawSettings
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeSettings(settings: OpenClawSettings): void {
+  writeFileSync(SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+}
+
+export function backupSettings(): void {
+  if (existsSync(SETTINGS_PATH)) copyFileSync(SETTINGS_PATH, SETTINGS_BACKUP_PATH)
+}
+
+export function ensurePluginEntry(settings: OpenClawSettings): OpenClawPluginEntry {
+  const plugins = settings.plugins ?? {}
+  const entries = plugins.entries ?? {}
+  const existing = entries[PLUGIN_ID] ?? {}
+  const entry: OpenClawPluginEntry = {
+    ...existing,
+    enabled: true,
+    hooks: {
+      ...(existing.hooks ?? {}),
+      // Required for third-party plugins to read raw conversation content
+      // from llm_input/llm_output/agent_end. Without this the hooks fire but
+      // payloads are scrubbed — which is exactly the silent failure mode that
+      // the existing third-party OpenClaw observability plugin runs into.
+      allowConversationAccess: true,
+    },
+  }
+  entries[PLUGIN_ID] = entry
+  plugins.entries = entries
+  settings.plugins = plugins
+  return entry
+}
+
+export function removePluginEntry(settings: OpenClawSettings): boolean {
+  const plugins = settings.plugins
+  if (!plugins?.entries) return false
+  if (!(PLUGIN_ID in plugins.entries)) return false
+  delete plugins.entries[PLUGIN_ID]
+  return true
+}
+
+export function setEnv(settings: OpenClawSettings, key: string, value: string): void {
+  const env = settings.env ?? {}
+  env[key] = value
+  settings.env = env
+}
+
+export function removeEnv(settings: OpenClawSettings, keys: string[]): boolean {
+  const env = settings.env
+  if (!env) return false
+  let removed = false
+  for (const k of keys) {
+    if (k in env) {
+      delete env[k]
+      removed = true
+    }
+  }
+  return removed
+}
+
+export function hasLatitudePlugin(settings: OpenClawSettings): boolean {
+  return Boolean(settings.plugins?.entries && PLUGIN_ID in settings.plugins.entries)
+}

--- a/packages/telemetry/openclaw/src/setup.ts
+++ b/packages/telemetry/openclaw/src/setup.ts
@@ -1,0 +1,250 @@
+import { existsSync, mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+import { cancel, confirm, intro, isCancel, log, note, outro, password, spinner, text } from "@clack/prompts"
+import pc from "picocolors"
+import {
+  backupSettings,
+  ensurePluginEntry,
+  hasLatitudePlugin,
+  PLUGIN_ID,
+  readSettings,
+  removeEnv,
+  removePluginEntry,
+  SETTINGS_BACKUP_PATH,
+  SETTINGS_PATH,
+  setEnv,
+  writeSettings,
+} from "./settings-file.ts"
+
+const DOCS_URL = "https://docs.latitude.so/openclaw-telemetry"
+
+interface EnvironmentConfig {
+  name: "production" | "staging" | "dev"
+  label: string
+  app: string
+  ingest: string
+}
+
+const PRODUCTION_ENV: EnvironmentConfig = {
+  name: "production",
+  label: "production",
+  app: "https://console.latitude.so",
+  ingest: "https://ingest.latitude.so",
+}
+const STAGING_ENV: EnvironmentConfig = {
+  name: "staging",
+  label: "staging",
+  app: "https://staging.latitude.so",
+  ingest: "https://staging-ingest.latitude.so",
+}
+const DEV_ENV: EnvironmentConfig = {
+  name: "dev",
+  label: "local dev",
+  app: "http://localhost:3000",
+  ingest: "http://localhost:3002",
+}
+
+function urlsFor(env: EnvironmentConfig): {
+  apiKeys: string
+  projects: string
+  projectView: (slug: string) => string
+} {
+  return {
+    apiKeys: `${env.app}/settings/api-keys`,
+    projects: env.app,
+    projectView: (slug: string) => `${env.app}/projects/${slug}`,
+  }
+}
+
+interface InstallFlags {
+  apiKey?: string | undefined
+  project?: string | undefined
+  environment?: EnvironmentConfig | undefined
+  noPrompt?: boolean
+  yes?: boolean
+}
+
+export function parseFlags(argv: string[]): {
+  subcommand: string | undefined
+  flags: Record<string, string | boolean>
+} {
+  const [subcommand, ...rest] = argv
+  const flags: Record<string, string | boolean> = {}
+  for (const arg of rest) {
+    if (!arg.startsWith("--")) continue
+    const eq = arg.indexOf("=")
+    if (eq >= 0) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1)
+    } else {
+      flags[arg.slice(2)] = true
+    }
+  }
+  return { subcommand, flags }
+}
+
+export function normalizeInstallFlags(flags: Record<string, string | boolean>): InstallFlags {
+  let environment: EnvironmentConfig | undefined
+  if (flags.staging === true) environment = STAGING_ENV
+  if (flags.dev === true) {
+    if (environment) throw new Error("--staging and --dev are mutually exclusive")
+    environment = DEV_ENV
+  }
+  return {
+    apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
+    project: typeof flags.project === "string" ? flags.project : undefined,
+    environment,
+    noPrompt: flags["no-prompt"] === true || flags.yes === true,
+    yes: flags.yes === true,
+  }
+}
+
+// ─── Install ────────────────────────────────────────────────────────────────
+
+export async function runInstall(flags: InstallFlags = {}): Promise<void> {
+  const canPrompt = !flags.noPrompt && process.stdin.isTTY === true
+  if (!canPrompt) return runFlagDrivenInstall(flags)
+  await runInteractiveInstall(flags)
+}
+
+async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
+  intro(pc.bgCyan(pc.black(" Latitude · OpenClaw telemetry ")))
+
+  const existing = readSettings()
+  const existingEnv = existing.env ?? {}
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  const urls = urlsFor(envConfig)
+
+  const aboutLines = [
+    "Captures every OpenClaw agent run and ships it to Latitude as",
+    "OpenTelemetry traces — full system prompt, tool I/O, messages,",
+    "token usage, and agent name on every span.",
+    "",
+    `${pc.dim("Docs")}   ${pc.cyan(DOCS_URL)}`,
+  ]
+  if (envConfig.name !== "production") {
+    aboutLines.push("", pc.yellow(`Using ${envConfig.label} environment (${envConfig.ingest})`))
+  }
+  note(aboutLines.join("\n"), "About")
+
+  log.info(`Get an API key at ${pc.cyan(urls.apiKeys)}`)
+  log.info(`Create a project at ${pc.cyan(urls.projects)}`)
+
+  const apiKey = await promptApiKey(existingEnv.LATITUDE_API_KEY, flags.apiKey)
+  const project = await promptProject(existingEnv.LATITUDE_PROJECT, flags.project)
+
+  await applyChanges({ apiKey, project, envConfig })
+
+  note(
+    [
+      "Restart the OpenClaw gateway for the plugin to load:",
+      pc.dim("  openclaw gateway restart"),
+      "",
+      `View your traces at  ${pc.cyan(urls.projectView(project))}`,
+    ].join("\n"),
+    "Next step",
+  )
+  outro(pc.green("✓ Installed"))
+}
+
+async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
+  const apiKey = flags.apiKey
+  const project = flags.project
+  if (!apiKey || !project) {
+    throw new Error("Non-interactive install requires --api-key=... and --project=... (or run in a TTY).")
+  }
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  await applyChanges({ apiKey, project, envConfig })
+  process.stdout.write(`Installed Latitude plugin in ${SETTINGS_PATH}\n`)
+}
+
+async function promptApiKey(_existing: string | undefined, flag: string | undefined): Promise<string> {
+  if (flag) return flag
+  const result = await password({
+    message: "Latitude API key",
+    mask: "•",
+    validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+  })
+  if (isCancel(result)) return onCancel()
+  return result
+}
+
+async function promptProject(existing: string | undefined, flag: string | undefined): Promise<string> {
+  if (flag) return flag
+  const result = await text({
+    message: "Latitude project slug",
+    placeholder: existing ?? "my-openclaw-project",
+    ...(existing ? { initialValue: existing } : {}),
+    validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+  })
+  if (isCancel(result)) return onCancel()
+  return result
+}
+
+function onCancel(): never {
+  cancel("Cancelled — nothing was changed")
+  process.exit(1)
+}
+
+interface ApplyParams {
+  apiKey: string
+  project: string
+  envConfig: EnvironmentConfig
+}
+
+async function applyChanges({ apiKey, project, envConfig }: ApplyParams): Promise<void> {
+  const s = spinner()
+  s.start("Updating openclaw.json")
+  ensureSettingsDir()
+  backupSettings()
+  const settings = readSettings()
+  ensurePluginEntry(settings)
+  setEnv(settings, "LATITUDE_API_KEY", apiKey)
+  setEnv(settings, "LATITUDE_PROJECT", project)
+  if (envConfig.name !== "production") setEnv(settings, "LATITUDE_BASE_URL", envConfig.ingest)
+  writeSettings(settings)
+  s.stop(`Updated ${SETTINGS_PATH}`)
+  if (existsSync(SETTINGS_BACKUP_PATH)) log.info(`Backup saved at ${pc.dim(SETTINGS_BACKUP_PATH)}`)
+}
+
+function ensureSettingsDir(): void {
+  const dir = dirname(SETTINGS_PATH)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+}
+
+// ─── Uninstall ──────────────────────────────────────────────────────────────
+
+interface UninstallFlags {
+  noPrompt?: boolean
+}
+
+export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
+  intro(pc.bgYellow(pc.black(" Latitude · OpenClaw telemetry — uninstall ")))
+  const settings = readSettings()
+
+  if (!hasLatitudePlugin(settings)) {
+    note("No Latitude plugin entry found — nothing to remove.", "Status")
+    outro(pc.dim("Nothing changed"))
+    return
+  }
+
+  const plan = [
+    `Remove "${PLUGIN_ID}" plugin entry from ${SETTINGS_PATH}`,
+    "Remove LATITUDE_API_KEY / LATITUDE_PROJECT / LATITUDE_BASE_URL from env",
+    `Backup saved at ${SETTINGS_BACKUP_PATH}`,
+  ]
+  note(plan.join("\n"), "Plan")
+
+  if (!flags.noPrompt && process.stdin.isTTY === true) {
+    const ok = await confirm({ message: "Proceed?", initialValue: true })
+    if (isCancel(ok) || ok !== true) return onCancel()
+  }
+
+  const s = spinner()
+  s.start("Reverting settings")
+  backupSettings()
+  removePluginEntry(settings)
+  removeEnv(settings, ["LATITUDE_API_KEY", "LATITUDE_PROJECT", "LATITUDE_BASE_URL"])
+  writeSettings(settings)
+  s.stop("Done")
+  outro(pc.green("✓ Uninstalled"))
+}

--- a/packages/telemetry/openclaw/src/setup.ts
+++ b/packages/telemetry/openclaw/src/setup.ts
@@ -200,7 +200,13 @@ async function applyChanges({ apiKey, project, envConfig }: ApplyParams): Promis
   ensurePluginEntry(settings)
   setEnv(settings, "LATITUDE_API_KEY", apiKey)
   setEnv(settings, "LATITUDE_PROJECT", project)
-  if (envConfig.name !== "production") setEnv(settings, "LATITUDE_BASE_URL", envConfig.ingest)
+  if (envConfig.name !== "production") {
+    setEnv(settings, "LATITUDE_BASE_URL", envConfig.ingest)
+  } else {
+    // Clear any stale BASE_URL left over from a prior --staging/--dev install so
+    // re-running `install` without flags is idempotent back to production.
+    removeEnv(settings, ["LATITUDE_BASE_URL"])
+  }
   writeSettings(settings)
   s.stop(`Updated ${SETTINGS_PATH}`)
   if (existsSync(SETTINGS_BACKUP_PATH)) log.info(`Backup saved at ${pc.dim(SETTINGS_BACKUP_PATH)}`)

--- a/packages/telemetry/openclaw/src/turn-builder.test.ts
+++ b/packages/telemetry/openclaw/src/turn-builder.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest"
+import { TurnBuilder } from "./turn-builder.ts"
+import type {
+  OpenClawAfterToolCallEvent,
+  OpenClawAgentContext,
+  OpenClawBeforeToolCallEvent,
+  OpenClawLlmInputEvent,
+  OpenClawLlmOutputEvent,
+} from "./types.ts"
+
+function ctx(overrides: Partial<OpenClawAgentContext> = {}): OpenClawAgentContext {
+  return {
+    runId: "run-1",
+    sessionId: "s-1",
+    sessionKey: "sk-1",
+    agentId: "router-agent",
+    ...overrides,
+  }
+}
+
+function llmInput(overrides: Partial<OpenClawLlmInputEvent> = {}): OpenClawLlmInputEvent {
+  return {
+    runId: "run-1",
+    sessionId: "s-1",
+    provider: "openai",
+    model: "gpt-5",
+    systemPrompt: "you are helpful",
+    prompt: "hello",
+    historyMessages: [],
+    imagesCount: 0,
+    ...overrides,
+  }
+}
+
+function llmOutput(overrides: Partial<OpenClawLlmOutputEvent> = {}): OpenClawLlmOutputEvent {
+  return {
+    runId: "run-1",
+    sessionId: "s-1",
+    provider: "openai",
+    model: "gpt-5",
+    assistantTexts: ["hi"],
+    lastAssistant: { role: "assistant", content: "hi" },
+    usage: { input: 10, output: 5, total: 15 },
+    ...overrides,
+  }
+}
+
+describe("TurnBuilder", () => {
+  it("pairs llm_input and llm_output by runId into a single call", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    const run = b.onAgentEnd({ messages: [], success: true, durationMs: 100 }, ctx())
+
+    expect(run).toBeDefined()
+    expect(run?.llmCalls).toHaveLength(1)
+    const call = run?.llmCalls[0]
+    expect(call?.assistantTexts).toEqual(["hi"])
+    expect(call?.usage?.total).toBe(15)
+    expect(call?.endMs).toBeDefined()
+    expect(call?.agentId).toBe("router-agent")
+  })
+
+  it("records multiple LLM calls in a tool loop on the same runId", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput({ prompt: "first" }), ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    b.onLlmInput(llmInput({ prompt: "second" }), ctx())
+    b.onLlmOutput(llmOutput({ assistantTexts: ["done"] }), ctx())
+    const run = b.onAgentEnd({ messages: [], success: true }, ctx())
+
+    expect(run?.llmCalls).toHaveLength(2)
+    expect(run?.llmCalls[0]?.prompt).toBe("first")
+    expect(run?.llmCalls[1]?.prompt).toBe("second")
+    expect(run?.llmCalls[1]?.assistantTexts).toEqual(["done"])
+  })
+
+  it("attaches tool calls arriving between llm_input and llm_output", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    const tool: OpenClawBeforeToolCallEvent = {
+      toolName: "read_file",
+      params: { path: "/foo" },
+      runId: "run-1",
+      toolCallId: "tc-1",
+    }
+    b.onBeforeToolCall(tool, ctx())
+    const after: OpenClawAfterToolCallEvent = {
+      toolName: "read_file",
+      params: { path: "/foo" },
+      runId: "run-1",
+      toolCallId: "tc-1",
+      result: { content: "hello" },
+      durationMs: 42,
+    }
+    b.onAfterToolCall(after, ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    const run = b.onAgentEnd({ messages: [], success: true }, ctx())
+
+    expect(run?.llmCalls[0]?.toolCalls).toHaveLength(1)
+    const t = run?.llmCalls[0]?.toolCalls[0]
+    expect(t?.toolName).toBe("read_file")
+    expect(t?.result).toEqual({ content: "hello" })
+    expect(t?.durationMs).toBe(42)
+    expect(t?.error).toBeUndefined()
+  })
+
+  it("marks tool calls with errors correctly", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    b.onBeforeToolCall({ toolName: "crash", params: {}, runId: "run-1", toolCallId: "tc-x" }, ctx())
+    b.onAfterToolCall({ toolName: "crash", params: {}, runId: "run-1", toolCallId: "tc-x", error: "boom" }, ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    const run = b.onAgentEnd({ messages: [], success: true }, ctx())
+
+    expect(run?.llmCalls[0]?.toolCalls[0]?.error).toBe("boom")
+  })
+
+  it("stores tool calls as orphans when no LLM call is open", () => {
+    const b = new TurnBuilder()
+    // Tool before any llm_input — shouldn't happen in practice but we
+    // defend against OpenClaw firing hooks out of the canonical order.
+    b.onBeforeToolCall({ toolName: "lonely", params: {}, runId: "run-1", toolCallId: "tc-o" }, ctx())
+    b.onAfterToolCall({ toolName: "lonely", params: {}, runId: "run-1", toolCallId: "tc-o", result: "ok" }, ctx())
+    const run = b.onAgentEnd({ messages: [], success: true }, ctx())
+
+    expect(run).toBeDefined()
+    expect(run?.orphanTools).toHaveLength(1)
+    expect(run?.orphanTools[0]?.result).toBe("ok")
+  })
+
+  it("falls back to name-based matching when toolCallId is missing on after_tool_call", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    b.onBeforeToolCall({ toolName: "grep", params: { q: "foo" }, runId: "run-1", toolCallId: "tc-1" }, ctx())
+    b.onAfterToolCall({ toolName: "grep", params: { q: "foo" }, runId: "run-1", result: "3 matches" }, ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    const run = b.onAgentEnd({ messages: [], success: true }, ctx())
+
+    expect(run?.llmCalls[0]?.toolCalls[0]?.result).toBe("3 matches")
+  })
+
+  it("propagates agent_end success/error into the RunRecord", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    b.onLlmOutput(llmOutput(), ctx())
+    const run = b.onAgentEnd({ messages: [], success: false, error: "budget exceeded", durationMs: 5 }, ctx())
+
+    expect(run?.success).toBe(false)
+    expect(run?.error).toBe("budget exceeded")
+  })
+
+  it("closes still-open LLM calls on agent_end", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput(), ctx())
+    // No llm_output — e.g. runtime crashed.
+    const run = b.onAgentEnd({ messages: [], success: false, error: "crashed" }, ctx())
+    expect(run?.llmCalls[0]?.endMs).toBeDefined()
+    expect(run?.llmCalls[0]?.error).toBe("crashed")
+  })
+
+  it("keeps runs keyed independently by runId so subagent runs don't collide", () => {
+    const b = new TurnBuilder()
+    b.onLlmInput(llmInput({ runId: "parent" }), ctx({ runId: "parent", agentId: "parent-agent" }))
+    b.onLlmInput(llmInput({ runId: "child" }), ctx({ runId: "child", agentId: "subagent-a", sessionKey: "sk-child" }))
+    b.onLlmOutput(llmOutput({ runId: "child" }), ctx({ runId: "child" }))
+    const childRun = b.onAgentEnd({ messages: [], success: true }, ctx({ runId: "child" }))
+    expect(childRun?.runId).toBe("child")
+    expect(childRun?.agentId).toBe("subagent-a")
+
+    b.onLlmOutput(llmOutput({ runId: "parent" }), ctx({ runId: "parent" }))
+    const parentRun = b.onAgentEnd({ messages: [], success: true }, ctx({ runId: "parent", agentId: "parent-agent" }))
+    expect(parentRun?.runId).toBe("parent")
+    expect(parentRun?.agentId).toBe("parent-agent")
+  })
+})

--- a/packages/telemetry/openclaw/src/turn-builder.ts
+++ b/packages/telemetry/openclaw/src/turn-builder.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto"
 import type {
   LlmCallRecord,
   OpenClawAfterToolCallEvent,
@@ -70,7 +71,10 @@ export class TurnBuilder {
     const run = this.runs.get(evt.runId) ?? this.ensureRun(evt.runId, ctx)
 
     const tool: ToolCallRecord = {
-      toolCallId: evt.toolCallId ?? `${evt.toolName}:${run.llmCalls.length}:${Date.now()}`,
+      // Use a UUID when OpenClaw elides the id — name+timestamp can collide for
+      // multiple invocations of the same tool within the same millisecond,
+      // which would then cause `after_tool_call` to update the wrong record.
+      toolCallId: evt.toolCallId ?? `${evt.toolName}:${randomUUID()}`,
       toolName: evt.toolName,
       params: evt.params,
       result: undefined,

--- a/packages/telemetry/openclaw/src/turn-builder.ts
+++ b/packages/telemetry/openclaw/src/turn-builder.ts
@@ -1,0 +1,214 @@
+import type {
+  LlmCallRecord,
+  OpenClawAfterToolCallEvent,
+  OpenClawAgentContext,
+  OpenClawAgentEndEvent,
+  OpenClawBeforeToolCallEvent,
+  OpenClawLlmInputEvent,
+  OpenClawLlmOutputEvent,
+  OpenClawSessionStartEvent,
+  RunRecord,
+  ToolCallRecord,
+} from "./types.ts"
+
+/**
+ * Accumulates OpenClaw hook events per agent run (keyed by `runId`) into a
+ * `RunRecord` ready to be converted to OTLP spans. All mutation is synchronous
+ * and non-blocking so the hook runner can stay fire-and-forget.
+ *
+ * Event ordering assumptions (verified against OpenClaw
+ * src/agents/pi-embedded-runner/run/attempt.ts):
+ *
+ *   session_start? -> [ llm_input -> (before_tool_call -> after_tool_call)* -> llm_output ]+ -> agent_end
+ *
+ * Tool calls arriving between an `llm_input` and its `llm_output` are attached
+ * to the currently-open LLM call. Tools arriving outside that window (e.g.
+ * `after_tool_call` fires after `llm_output` has already closed the call) are
+ * stored on the run's `orphanTools` list so we don't drop them.
+ */
+export class TurnBuilder {
+  private readonly runs = new Map<string, RunRecord>()
+
+  onSessionStart(_evt: OpenClawSessionStartEvent, _ctx: OpenClawAgentContext): void {
+    // No-op for now — we lazily create RunRecords on the first `llm_input` for
+    // a given runId. Kept as a hook point so we can later emit a
+    // session-level span or capture `resumedFrom` metadata.
+  }
+
+  onLlmInput(evt: OpenClawLlmInputEvent, ctx: OpenClawAgentContext): LlmCallRecord {
+    const run = this.ensureRun(evt.runId, ctx)
+    const call: LlmCallRecord = {
+      runId: evt.runId,
+      sessionId: evt.sessionId,
+      sessionKey: ctx.sessionKey,
+      agentId: ctx.agentId,
+      provider: evt.provider,
+      requestModel: evt.model,
+      responseModel: undefined,
+      resolvedRef: undefined,
+      systemPrompt: evt.systemPrompt,
+      prompt: evt.prompt,
+      historyMessages: evt.historyMessages,
+      imagesCount: evt.imagesCount,
+      assistantTexts: [],
+      lastAssistant: undefined,
+      usage: undefined,
+      startMs: Date.now(),
+      endMs: undefined,
+      error: undefined,
+      toolCalls: [],
+    }
+    run.llmCalls.push(call)
+    return call
+  }
+
+  onBeforeToolCall(evt: OpenClawBeforeToolCallEvent, ctx: OpenClawAgentContext): void {
+    if (!evt.runId) return
+    // Create the run record lazily if a tool fires before we've seen llm_input
+    // for this runId — rare but possible, and we prefer capturing an orphan
+    // tool over dropping the event.
+    const run = this.runs.get(evt.runId) ?? this.ensureRun(evt.runId, ctx)
+
+    const tool: ToolCallRecord = {
+      toolCallId: evt.toolCallId ?? `${evt.toolName}:${run.llmCalls.length}:${Date.now()}`,
+      toolName: evt.toolName,
+      params: evt.params,
+      result: undefined,
+      error: undefined,
+      startMs: Date.now(),
+      endMs: undefined,
+      durationMs: undefined,
+      agentId: ctx.agentId,
+    }
+    const openCall = this.currentOpenCall(run)
+    if (openCall) {
+      openCall.toolCalls.push(tool)
+    } else {
+      run.orphanTools.push(tool)
+    }
+  }
+
+  onAfterToolCall(evt: OpenClawAfterToolCallEvent, _ctx: OpenClawAgentContext): void {
+    if (!evt.runId) return
+    const run = this.runs.get(evt.runId)
+    if (!run) return
+    const tool = this.findToolRecord(run, evt.toolCallId, evt.toolName)
+    if (!tool) return
+    tool.result = evt.result
+    tool.error = evt.error
+    tool.durationMs = evt.durationMs
+    tool.endMs = Date.now()
+  }
+
+  onLlmOutput(evt: OpenClawLlmOutputEvent, _ctx: OpenClawAgentContext): LlmCallRecord | undefined {
+    const run = this.runs.get(evt.runId)
+    if (!run) return undefined
+    // Close the most recently-opened call that doesn't yet have an endMs —
+    // the LLM loop is sequential, so this pairs 1:1 with `llm_input`.
+    const openCall = this.currentOpenCall(run)
+    if (!openCall) return undefined
+    openCall.endMs = Date.now()
+    openCall.assistantTexts = evt.assistantTexts
+    openCall.lastAssistant = evt.lastAssistant
+    openCall.usage = evt.usage
+    openCall.responseModel = evt.model
+    openCall.resolvedRef = evt.resolvedRef
+    return openCall
+  }
+
+  onAgentEnd(evt: OpenClawAgentEndEvent, ctx: OpenClawAgentContext): RunRecord | undefined {
+    const runId = ctx.runId
+    if (!runId) return undefined
+    const run = this.runs.get(runId)
+    if (!run) return undefined
+    run.endMs = Date.now()
+    run.success = evt.success
+    run.error = evt.error
+    // Best-effort: close any still-open LLM call that never saw an `llm_output`
+    // (e.g. when the run errored mid-call) so the span still has an end time.
+    for (const call of run.llmCalls) {
+      if (call.endMs === undefined) {
+        call.endMs = run.endMs
+        if (evt.error && call.error === undefined) call.error = evt.error
+      }
+      for (const tool of call.toolCalls) {
+        if (tool.endMs === undefined) tool.endMs = run.endMs
+      }
+    }
+    for (const tool of run.orphanTools) {
+      if (tool.endMs === undefined) tool.endMs = run.endMs
+    }
+    this.runs.delete(runId)
+    return run
+  }
+
+  /** Drop a run without emitting — used on errors from the emit path. */
+  abandon(runId: string): void {
+    this.runs.delete(runId)
+  }
+
+  /** Active runs count, for debug logging. */
+  inflightCount(): number {
+    return this.runs.size
+  }
+
+  private ensureRun(runId: string, ctx: OpenClawAgentContext): RunRecord {
+    let run = this.runs.get(runId)
+    if (run) return run
+    run = {
+      runId,
+      sessionId: ctx.sessionId,
+      sessionKey: ctx.sessionKey,
+      agentId: ctx.agentId,
+      workspaceDir: ctx.workspaceDir,
+      messageProvider: ctx.messageProvider,
+      trigger: ctx.trigger,
+      channelId: ctx.channelId,
+      modelProviderId: ctx.modelProviderId,
+      modelId: ctx.modelId,
+      startMs: Date.now(),
+      endMs: undefined,
+      success: undefined,
+      error: undefined,
+      llmCalls: [],
+      orphanTools: [],
+    }
+    this.runs.set(runId, run)
+    return run
+  }
+
+  private currentOpenCall(run: RunRecord): LlmCallRecord | undefined {
+    for (let i = run.llmCalls.length - 1; i >= 0; i--) {
+      const call = run.llmCalls[i]
+      if (call && call.endMs === undefined) return call
+    }
+    return undefined
+  }
+
+  private findToolRecord(run: RunRecord, toolCallId: string | undefined, toolName: string): ToolCallRecord | undefined {
+    // Try matching by toolCallId first since it's unique. Fall back to the
+    // most recent unfinished record for the same name if the id is missing
+    // or no record matches — defensive coverage for OpenClaw versions that
+    // elide toolCallId on after_tool_call.
+    const matchesId = (t: ToolCallRecord): boolean => Boolean(toolCallId && t.toolCallId === toolCallId)
+
+    for (const call of run.llmCalls) {
+      for (const t of call.toolCalls) if (matchesId(t)) return t
+    }
+    for (const t of run.orphanTools) if (matchesId(t)) return t
+
+    for (let i = run.llmCalls.length - 1; i >= 0; i--) {
+      const call = run.llmCalls[i]
+      if (!call) continue
+      for (let j = call.toolCalls.length - 1; j >= 0; j--) {
+        const t = call.toolCalls[j]
+        if (t && t.toolName === toolName && t.endMs === undefined) return t
+      }
+    }
+    for (let i = run.orphanTools.length - 1; i >= 0; i--) {
+      const t = run.orphanTools[i]
+      if (t && t.toolName === toolName && t.endMs === undefined) return t
+    }
+    return undefined
+  }
+}

--- a/packages/telemetry/openclaw/src/types.ts
+++ b/packages/telemetry/openclaw/src/types.ts
@@ -1,0 +1,182 @@
+// OTLP wire types (shared with @latitude-data/claude-code-telemetry). We hand-roll
+// these rather than depending on the OTel JS SDK because the export payload is a
+// small, stable subset of the spec and pulling in the SDK would dominate bundle
+// size for no benefit.
+
+export interface OtlpAnyValue {
+  stringValue?: string
+  intValue?: string
+  boolValue?: boolean
+  doubleValue?: number
+  arrayValue?: { values: OtlpAnyValue[] }
+}
+
+export interface OtlpKeyValue {
+  key: string
+  value: OtlpAnyValue
+}
+
+export interface OtlpSpan {
+  traceId: string
+  spanId: string
+  parentSpanId: string
+  name: string
+  kind: number
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  attributes: OtlpKeyValue[]
+  status: { code: number }
+}
+
+export interface OtlpResourceSpans {
+  resource: { attributes: OtlpKeyValue[] }
+  scopeSpans: Array<{
+    scope: { name: string; version: string }
+    spans: OtlpSpan[]
+  }>
+}
+
+export interface OtlpExportRequest {
+  resourceSpans: OtlpResourceSpans[]
+}
+
+// ─── OpenClaw hook event shapes ─────────────────────────────────────────────
+//
+// Mirrored from OpenClaw's src/plugins/hook-types.ts — we keep our own copies
+// rather than importing from `openclaw/plugin-sdk` because the plugin-sdk export
+// surface is large and version-skew risk across OpenClaw minor releases is
+// lower when we depend only on the event-shape subset we actually read.
+
+export interface OpenClawLlmInputEvent {
+  runId: string
+  sessionId: string
+  provider: string
+  model: string
+  systemPrompt?: string
+  prompt: string
+  historyMessages: unknown[]
+  imagesCount: number
+}
+
+export interface OpenClawLlmUsage {
+  input?: number
+  output?: number
+  cacheRead?: number
+  cacheWrite?: number
+  total?: number
+}
+
+export interface OpenClawLlmOutputEvent {
+  runId: string
+  sessionId: string
+  provider: string
+  model: string
+  resolvedRef?: string
+  assistantTexts: string[]
+  lastAssistant?: unknown
+  usage?: OpenClawLlmUsage
+}
+
+export interface OpenClawAgentContext {
+  runId?: string
+  agentId?: string
+  sessionKey?: string
+  sessionId?: string
+  workspaceDir?: string
+  modelProviderId?: string
+  modelId?: string
+  messageProvider?: string
+  trigger?: string
+  channelId?: string
+  trace?: unknown
+}
+
+export interface OpenClawBeforeToolCallEvent {
+  toolName: string
+  params: Record<string, unknown>
+  runId?: string
+  toolCallId?: string
+}
+
+export interface OpenClawAfterToolCallEvent {
+  toolName: string
+  params: Record<string, unknown>
+  runId?: string
+  toolCallId?: string
+  result?: unknown
+  error?: string
+  durationMs?: number
+}
+
+export interface OpenClawAgentEndEvent {
+  messages: unknown[]
+  success: boolean
+  error?: string
+  durationMs?: number
+}
+
+export interface OpenClawSessionStartEvent {
+  sessionId: string
+  sessionKey?: string
+  resumedFrom?: string
+}
+
+// ─── In-memory state shapes ─────────────────────────────────────────────────
+
+export interface LlmCallRecord {
+  runId: string
+  sessionId: string
+  sessionKey: string | undefined
+  agentId: string | undefined
+  provider: string
+  requestModel: string
+  responseModel: string | undefined
+  resolvedRef: string | undefined
+  systemPrompt: string | undefined
+  prompt: string
+  historyMessages: unknown[]
+  imagesCount: number
+  assistantTexts: string[]
+  lastAssistant: unknown
+  usage: OpenClawLlmUsage | undefined
+  startMs: number
+  endMs: number | undefined
+  error: string | undefined
+  toolCalls: ToolCallRecord[]
+}
+
+export interface ToolCallRecord {
+  toolCallId: string
+  toolName: string
+  params: Record<string, unknown>
+  result: unknown
+  error: string | undefined
+  startMs: number
+  endMs: number | undefined
+  durationMs: number | undefined
+  agentId: string | undefined
+}
+
+export interface RunRecord {
+  runId: string
+  sessionId: string | undefined
+  sessionKey: string | undefined
+  agentId: string | undefined
+  workspaceDir: string | undefined
+  messageProvider: string | undefined
+  trigger: string | undefined
+  channelId: string | undefined
+  modelProviderId: string | undefined
+  modelId: string | undefined
+  startMs: number
+  endMs: number | undefined
+  success: boolean | undefined
+  error: string | undefined
+  llmCalls: LlmCallRecord[]
+  /**
+   * Tool calls queued by `before_tool_call` but not yet matched to an `llm_call`
+   * because the most recent `llm_output` has already closed the call for this
+   * runId. Retained so `after_tool_call` can still complete the record.
+   */
+  orphanTools: ToolCallRecord[]
+}

--- a/packages/telemetry/openclaw/tsconfig.json
+++ b/packages/telemetry/openclaw/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "incremental": false,
+    "composite": false
+  }
+}

--- a/packages/telemetry/openclaw/tsdown.config.ts
+++ b/packages/telemetry/openclaw/tsdown.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig([
+  {
+    entry: ["src/plugin.ts"],
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+    target: "node20",
+    fixedExtension: false,
+  },
+  {
+    entry: ["src/cli.ts"],
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: false,
+    target: "node20",
+    fixedExtension: false,
+    banner: { js: "#!/usr/bin/env node" },
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,7 +420,7 @@ importers:
         version: 1.16.0
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.6(65009cac6ff13872779cdb437a09c047)
+        version: 1.5.6(94b9053055f63c41893e1598ac99f147)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.4
@@ -429,7 +429,7 @@ importers:
         version: 1.9.0(react@19.2.5)
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@azure/identity@4.13.1)(@electric-sql/pglite@0.3.15)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))(giget@3.2.0)(jiti@2.6.1)(lru-cache@11.3.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.260311-beta(@azure/identity@4.13.1)(@electric-sql/pglite@0.3.15)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))(giget@3.2.0)(jiti@2.6.1)(lru-cache@11.3.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
       posthog-js:
         specifier: ^1.369.3
         version: 1.371.3
@@ -1428,7 +1428,7 @@ importers:
         version: 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/stripe':
         specifier: 1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(better-auth@1.5.6(84dfafb224bba819d6eb7ad8d8ce5060))(better-call@1.1.8(zod@4.3.6))(stripe@22.1.0(@types/node@24.12.2))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(better-auth@1.5.6(5c7529447c9a87b46edf2aa924854bba))(better-call@1.1.8(zod@4.3.6))(stripe@22.1.0(@types/node@24.12.2))
       '@domain/annotation-queues':
         specifier: workspace:*
         version: link:../../domain/annotation-queues
@@ -1479,10 +1479,10 @@ importers:
         version: link:../../utils
       better-auth:
         specifier: 'catalog:'
-        version: 1.5.6(84dfafb224bba819d6eb7ad8d8ce5060)
+        version: 1.5.6(5c7529447c9a87b46edf2aa924854bba)
       drizzle-orm:
         specifier: 1.0.0-beta.15-859cf75
-        version: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6)
+        version: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6)
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.4
@@ -1498,7 +1498,7 @@ importers:
     devDependencies:
       '@better-auth/cli':
         specifier: ^1.4.22
-        version: 1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.3.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.3.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typebox@1.1.28)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))
       '@electric-sql/pglite':
         specifier: 0.3.15
         version: 0.3.15
@@ -1793,6 +1793,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/telemetry/openclaw:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.4.6
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/telemetry/typescript:
     dependencies:
       '@opentelemetry/api':
@@ -1858,7 +1886,7 @@ importers:
         version: 2.4.6
       '@google-cloud/vertexai':
         specifier: ^1.10.4
-        version: 1.12.0
+        version: 1.12.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
       '@langchain/core':
         specifier: ^1.1.39
         version: 1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
@@ -1879,10 +1907,10 @@ importers:
         version: 7.21.0
       langchain:
         specifier: ^1.2.39
-        version: 1.3.4(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        version: 1.3.4(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       llamaindex:
         specifier: ^0.12.1
-        version: 0.12.1(hono@4.12.14)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
+        version: 0.12.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6)
       openai:
         specifier: ^6.33.0
         version: 6.34.0(ws@8.20.0)(zod@4.3.6)
@@ -4049,6 +4077,16 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mrleebo/prisma-ast@0.13.1':
     resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
@@ -7193,6 +7231,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -7524,6 +7566,10 @@ packages:
   bl@6.1.6:
     resolution: {integrity: sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -7565,6 +7611,10 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   c12@3.3.4:
     resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
     peerDependencies:
@@ -7583,6 +7633,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   camelcase@6.3.0:
@@ -7751,6 +7805,14 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -7760,6 +7822,10 @@ packages:
 
   cookie-es@2.0.1:
     resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -7918,6 +7984,10 @@ packages:
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -8120,6 +8190,9 @@ packages:
   echarts@6.0.0:
     resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   effect@4.0.0-beta.4:
     resolution: {integrity: sha512-oS7yB+gWK1JQDD15JlWh+rF9lfV04TDCN+ui2YOShMjyFPIWsuStaUYWGRmqjheP128NDr3mvMtU9+leEksqhw==}
 
@@ -8146,6 +8219,10 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -8245,6 +8322,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -8298,6 +8378,10 @@ packages:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -8312,6 +8396,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -8387,6 +8481,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
@@ -8441,9 +8539,17 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fractional-indexing@3.2.0:
     resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -8674,6 +8780,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -8758,6 +8868,10 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -8822,6 +8936,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -9245,10 +9362,18 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memfs@4.57.2:
     resolution: {integrity: sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==}
     peerDependencies:
       tslib: 2.8.1
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -9659,6 +9784,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -9670,6 +9799,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -9781,6 +9914,10 @@ packages:
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
@@ -9795,6 +9932,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -9861,6 +10001,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -9972,6 +10116,10 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -9982,11 +10130,23 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -10238,6 +10398,10 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rtl-css-js@1.16.1:
     resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
 
@@ -10285,6 +10449,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   seroval-plugins@1.5.2:
     resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
     engines: {node: '>=10'}
@@ -10295,6 +10463,10 @@ packages:
     resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -10304,6 +10476,9 @@ packages:
   set-harmonic-interval@1.0.1:
     resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
     engines: {node: '>=6.9'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -10319,6 +10494,22 @@ packages:
 
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -10463,6 +10654,10 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -10686,6 +10881,10 @@ packages:
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
@@ -10820,6 +11019,13 @@ packages:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typebox@1.1.28:
+    resolution: {integrity: sha512-OqHTHRfBpQHWPipoeFVkNgxKjjXhGY49UgekFrOuaC9O59/Hws8KHjGa1AUfNYnxWSfuNRkTB81FAL/QbTWFrg==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -10883,6 +11089,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -11371,6 +11581,11 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -12619,7 +12834,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@better-auth/cli@1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.3.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@better-auth/cli@1.4.22(@better-fetch/fetch@1.1.21)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7)))(@types/mssql@9.1.11(@azure/core-client@1.10.1))(better-call@1.1.8(zod@4.3.6))(drizzle-kit@1.0.0-beta.15-859cf75)(jose@6.2.2)(kysely@0.28.16)(mssql@11.0.1(@azure/core-client@1.10.1))(nanostores@1.3.0)(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typebox@1.1.28)(vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
@@ -12631,13 +12846,13 @@ snapshots:
       '@mrleebo/prisma-ast': 0.13.1
       '@prisma/client': 5.22.0
       '@types/pg': 8.16.0
-      better-auth: 1.4.22(146889b40cca6359f6606dd3b2e8d0fd)
+      better-auth: 1.4.22(9449ac470365b02ee369ddc512e99e0b)
       better-sqlite3: 12.9.0
       c12: 3.3.4
       chalk: 5.6.2
       commander: 12.1.0
       dotenv: 17.3.1
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)
       open: 10.2.0
       pg: 8.20.0
       prettier: 3.8.3
@@ -12740,19 +12955,19 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6))':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6)
 
-  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))':
+  '@better-auth/drizzle-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.3.1
     optionalDependencies:
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)
 
   '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.16)':
     dependencies:
@@ -12802,10 +13017,10 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 5.22.0
 
-  '@better-auth/stripe@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(better-auth@1.5.6(84dfafb224bba819d6eb7ad8d8ce5060))(better-call@1.1.8(zod@4.3.6))(stripe@22.1.0(@types/node@24.12.2))':
+  '@better-auth/stripe@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(better-auth@1.5.6(5c7529447c9a87b46edf2aa924854bba))(better-call@1.1.8(zod@4.3.6))(stripe@22.1.0(@types/node@24.12.2))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      better-auth: 1.5.6(84dfafb224bba819d6eb7ad8d8ce5060)
+      better-auth: 1.5.6(5c7529447c9a87b46edf2aa924854bba)
       better-call: 1.1.8(zod@4.3.6)
       defu: 6.1.7
       stripe: 22.1.0(@types/node@24.12.2)
@@ -13338,9 +13553,9 @@ snapshots:
 
   '@gar/promise-retry@1.0.3': {}
 
-  '@google-cloud/vertexai@1.12.0':
+  '@google-cloud/vertexai@1.12.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
-      '@google/genai': 1.50.1
+      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
       google-auth-library: 9.15.1
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -13349,12 +13564,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@1.50.1':
+  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.5
       ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -13714,7 +13931,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@langchain/langgraph@1.2.9(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)':
+  '@langchain/langgraph@1.2.9(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@langchain/core': 1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
@@ -13722,6 +13939,8 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 4.3.6
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -13778,17 +13997,18 @@ snapshots:
       tree-sitter: 0.22.4
       web-tree-sitter: 0.24.7
 
-  '@llamaindex/workflow-core@1.3.4(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)':
+  '@llamaindex/workflow-core@1.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)':
     optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       hono: 4.12.14
       rxjs: 7.8.2
       zod: 4.3.6
 
-  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)':
+  '@llamaindex/workflow@1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)':
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
-      '@llamaindex/workflow-core': 1.3.4(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)
+      '@llamaindex/workflow-core': 1.3.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - hono
@@ -13800,6 +14020,31 @@ snapshots:
   '@logdna/tail-file@2.2.0': {}
 
   '@marijn/find-cluster-break@1.0.2': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.0(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@mrleebo/prisma-ast@0.13.1':
     dependencies:
@@ -17124,7 +17369,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.14.1
+      '@types/node': 22.19.17
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
@@ -17345,6 +17590,12 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    optional: true
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -17481,7 +17732,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.21: {}
 
-  better-auth@1.4.22(146889b40cca6359f6606dd3b2e8d0fd):
+  better-auth@1.4.22(9449ac470365b02ee369ddc512e99e0b):
     dependencies:
       '@better-auth/core': 1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/telemetry': 1.4.22(@better-auth/core@1.4.22(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))
@@ -17500,50 +17751,17 @@ snapshots:
       '@tanstack/react-start': 1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
       better-sqlite3: 12.9.0
       drizzle-kit: 1.0.0-beta.15-859cf75
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pg: 8.20.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
-  better-auth@1.5.6(65009cac6ff13872779cdb437a09c047):
+  better-auth@1.5.6(5c7529447c9a87b46edf2aa924854bba):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))
-      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.16)
-      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
-      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
-      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(@prisma/client@5.22.0)
-      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.7
-      jose: 6.2.2
-      kysely: 0.28.16
-      nanostores: 1.3.0
-      zod: 4.3.6
-    optionalDependencies:
-      '@prisma/client': 5.22.0
-      '@tanstack/react-start': 1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
-      better-sqlite3: 12.9.0
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      pg: 8.20.0
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.5.6(84dfafb224bba819d6eb7ad8d8ce5060):
-    dependencies:
-      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6))
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6))
       '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.16)
       '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
       '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
@@ -17564,9 +17782,42 @@ snapshots:
       '@tanstack/react-start': 1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
       better-sqlite3: 12.9.0
       drizzle-kit: 1.0.0-beta.15-859cf75
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       pg: 8.16.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.5.6(94b9053055f63c41893e1598ac99f147):
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))
+      '@better-auth/kysely-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
+      '@better-auth/mongo-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)
+      '@better-auth/prisma-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.3.1)(@prisma/client@5.22.0)
+      '@better-auth/telemetry': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.2(zod@4.3.6)
+      defu: 6.1.7
+      jose: 6.2.2
+      kysely: 0.28.16
+      nanostores: 1.3.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@prisma/client': 5.22.0
+      '@tanstack/react-start': 1.167.16(crossws@0.4.5(srvx@0.11.15))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
+      better-sqlite3: 12.9.0
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      pg: 8.20.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -17632,6 +17883,21 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 4.7.0
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   boolbase@1.0.0: {}
 
   bowser@2.14.1: {}
@@ -17686,6 +17952,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bytes@3.1.2:
+    optional: true
+
   c12@3.3.4:
     dependencies:
       chokidar: 5.0.0
@@ -17720,6 +17989,12 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    optional: true
 
   camelcase@6.3.0: {}
 
@@ -17897,6 +18172,12 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0:
+    optional: true
+
+  content-type@1.0.5:
+    optional: true
+
   convert-source-map@2.0.0: {}
 
   convict@6.2.5:
@@ -17905,6 +18186,9 @@ snapshots:
       yargs-parser: 20.2.9
 
   cookie-es@2.0.1: {}
+
+  cookie-signature@1.2.2:
+    optional: true
 
   cookie@0.7.2: {}
 
@@ -17980,11 +18264,11 @@ snapshots:
 
   date-fns@3.6.0: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       better-sqlite3: 12.9.0
-      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)
+      drizzle-orm: 1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)
 
   debounce-fn@6.0.0:
     dependencies:
@@ -18026,6 +18310,9 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
+
+  depd@2.0.0:
+    optional: true
 
   dequal@2.0.3: {}
 
@@ -18078,7 +18365,7 @@ snapshots:
       esbuild: 0.25.12
       jiti: 2.6.1
 
-  drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(zod@4.3.6):
+  drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.16.0)(typebox@1.1.28)(zod@4.3.6):
     dependencies:
       '@types/mssql': 9.1.11(@azure/core-client@1.10.1)
       mssql: 11.0.1(@azure/core-client@1.10.1)
@@ -18089,9 +18376,10 @@ snapshots:
       '@types/pg': 8.16.0
       better-sqlite3: 12.9.0
       pg: 8.16.0
+      typebox: 1.1.28
       zod: 4.3.6
 
-  drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6):
+  drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6):
     dependencies:
       '@types/mssql': 9.1.11(@azure/core-client@1.10.1)
       mssql: 11.0.1(@azure/core-client@1.10.1)
@@ -18102,6 +18390,7 @@ snapshots:
       '@types/pg': 8.16.0
       better-sqlite3: 12.9.0
       pg: 8.20.0
+      typebox: 1.1.28
       zod: 4.3.6
 
   dts-resolver@2.1.3(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
@@ -18141,6 +18430,9 @@ snapshots:
       tslib: 2.8.1
       zrender: 6.0.0
 
+  ee-first@1.1.1:
+    optional: true
+
   effect@4.0.0-beta.4:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -18169,6 +18461,9 @@ snapshots:
   emoticon@4.1.0: {}
 
   empathic@2.0.0: {}
+
+  encodeurl@2.0.0:
+    optional: true
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -18334,6 +18629,9 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3:
+    optional: true
+
   escape-string-regexp@5.0.0: {}
 
   eslint-scope@5.1.1:
@@ -18369,6 +18667,11 @@ snapshots:
 
   eventsource-parser@3.0.8: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+    optional: true
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -18386,6 +18689,46 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.4.0(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+    optional: true
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   exsolve@1.0.8: {}
 
@@ -18455,6 +18798,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   find-my-way-ts@0.1.6: {}
 
   flattie@1.1.1: {}
@@ -18505,7 +18860,13 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  forwarded@0.2.0:
+    optional: true
+
   fractional-indexing@3.2.0: {}
+
+  fresh@2.0.0:
+    optional: true
 
   fs-constants@1.0.0: {}
 
@@ -18795,6 +19156,15 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    optional: true
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -18892,6 +19262,9 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  ipaddr.js@1.9.1:
+    optional: true
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -18936,6 +19309,9 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0:
+    optional: true
 
   is-stream@2.0.1: {}
 
@@ -19101,10 +19477,10 @@ snapshots:
 
   kysely@0.28.16: {}
 
-  langchain@1.3.4(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
+  langchain@1.3.4(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
-      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
+      '@langchain/langgraph': 1.2.9(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.41(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       langsmith: 0.5.23(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.0(@opentelemetry/api@1.9.1))(openai@6.34.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       uuid: 11.1.0
@@ -19185,12 +19561,12 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
-  llamaindex@0.12.1(hono@4.12.14)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
+  llamaindex@0.12.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)(zod@4.3.6):
     dependencies:
       '@llamaindex/core': 0.6.22
       '@llamaindex/env': 0.1.30
       '@llamaindex/node-parser': 2.0.22(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(tree-sitter@0.22.4)(web-tree-sitter@0.24.7)
-      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)
+      '@llamaindex/workflow': 1.1.24(@llamaindex/core@0.6.22)(@llamaindex/env@0.1.30)(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(hono@4.12.14)(rxjs@7.8.2)(zod@4.3.6)
       '@types/lodash': 4.17.24
       '@types/node': 24.12.2
       lodash: 4.18.1
@@ -19462,6 +19838,9 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0:
+    optional: true
+
   memfs@4.57.2(tslib@2.8.1):
     dependencies:
       '@jsonjoy.com/fs-core': 4.57.2(tslib@2.8.1)
@@ -19478,6 +19857,9 @@ snapshots:
       thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
+
+  merge-descriptors@2.0.0:
+    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -19847,11 +20229,11 @@ snapshots:
       abort-controller-x: 0.5.0
       nice-grpc-common: 2.0.3
 
-  nitro@3.0.260311-beta(@azure/identity@4.13.1)(@electric-sql/pglite@0.3.15)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))(giget@3.2.0)(jiti@2.6.1)(lru-cache@11.3.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260311-beta(@azure/identity@4.13.1)(@electric-sql/pglite@0.3.15)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.3.1)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))(giget@3.2.0)(jiti@2.6.1)(lru-cache@11.3.5)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.5(srvx@0.11.15)
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))
       env-runner: 0.1.7
       h3: 2.0.1-rc.20(crossws@0.4.5(srvx@0.11.15))
       hookable: 6.1.1
@@ -19862,7 +20244,7 @@ snapshots:
       rolldown: 1.0.0-rc.17
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(@azure/identity@4.13.1)(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(@azure/identity@4.13.1)(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.3.1
       giget: 3.2.0
@@ -20026,6 +20408,9 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-inspect@1.13.4:
+    optional: true
+
   obug@2.1.1: {}
 
   ocache@0.1.4:
@@ -20035,6 +20420,11 @@ snapshots:
   ofetch@2.0.0-alpha.3: {}
 
   ohash@2.0.11: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+    optional: true
 
   once@1.4.0:
     dependencies:
@@ -20256,6 +20646,9 @@ snapshots:
       leac: 0.6.0
       peberminta: 0.9.0
 
+  parseurl@1.3.3:
+    optional: true
+
   path-expression-matcher@1.5.0: {}
 
   path-key@3.1.1: {}
@@ -20266,6 +20659,9 @@ snapshots:
     dependencies:
       lru-cache: 11.3.5
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2:
+    optional: true
 
   pathe@1.1.2: {}
 
@@ -20329,6 +20725,9 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
 
   pkg-types@2.3.0:
     dependencies:
@@ -20457,6 +20856,12 @@ snapshots:
       '@types/node': 22.19.17
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    optional: true
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -20466,9 +20871,25 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
+
   quansync@1.0.0: {}
 
   query-selector-shadow-dom@1.0.1: {}
+
+  range-parser@1.2.1:
+    optional: true
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    optional: true
 
   rc9@3.0.1:
     dependencies:
@@ -20869,6 +21290,17 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   rtl-css-js@1.16.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -20908,17 +21340,47 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   seroval-plugins@1.5.2(seroval@1.5.2):
     dependencies:
       seroval: 1.5.2
 
   seroval@1.5.2: {}
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 
   set-harmonic-interval@1.0.1: {}
+
+  setprototypeof@1.2.0:
+    optional: true
 
   sharp@0.34.5:
     dependencies:
@@ -20959,6 +21421,38 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shimmer@1.2.1: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    optional: true
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    optional: true
 
   siginfo@2.0.0: {}
 
@@ -21116,6 +21610,9 @@ snapshots:
       stacktrace-gps: 3.1.2
 
   standard-as-callback@2.1.0: {}
+
+  statuses@2.0.2:
+    optional: true
 
   std-env@4.1.0: {}
 
@@ -21349,6 +21846,9 @@ snapshots:
 
   toggle-selection@1.0.6: {}
 
+  toidentifier@1.0.1:
+    optional: true
+
   toml@3.0.0: {}
 
   tough-cookie@6.0.1:
@@ -21498,6 +21998,16 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    optional: true
+
+  typebox@1.1.28:
+    optional: true
+
   typescript@6.0.3: {}
 
   ufo@1.6.3: {}
@@ -21567,6 +22077,9 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0:
+    optional: true
+
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -21578,12 +22091,12 @@ snapshots:
     dependencies:
       rolldown: 1.0.0-rc.17
 
-  unstorage@2.0.0-alpha.7(@azure/identity@4.13.1)(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(@azure/identity@4.13.1)(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6)))(lru-cache@11.3.5)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       '@azure/identity': 4.13.1
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(zod@4.3.6))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(better-sqlite3@12.9.0)(drizzle-orm@1.0.0-beta.15-859cf75(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@5.22.0)(@types/mssql@9.1.11(@azure/core-client@1.10.1))(@types/pg@8.16.0)(better-sqlite3@12.9.0)(mssql@11.0.1(@azure/core-client@1.10.1))(pg@8.20.0)(typebox@1.1.28)(zod@4.3.6))
       lru-cache: 11.3.5
       ofetch: 2.0.0-alpha.3
 
@@ -21994,6 +22507,11 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+    optional: true
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

New package `@latitude-data/openclaw-telemetry` — an OpenClaw plugin that subscribes to the typed `llm_input` / `llm_output` / `before_tool_call` / `after_tool_call` / `agent_end` hooks and emits one OTLP trace per agent run to Latitude. Full fidelity: exact system prompt, message history, assistant output, token usage, tool I/O, and the running agent's name on every span.

## Why a new plugin

Two existing options both fall short:

- **Built-in `diagnostics-otel` plugin** is broken across multiple OpenClaw versions ([openclaw#6989](https://github.com/openclaw/openclaw/issues/6989) missing `@opentelemetry/api` dep, [#10385](https://github.com/openclaw/openclaw/issues/10385) `Resource is not a constructor` from OTel v2.x, [#7201](https://github.com/openclaw/openclaw/issues/7201) plugin-not-found, [#28222](https://github.com/openclaw/openclaw/issues/28222) doesn't work). This matches the user-reported "not capturing anything" exactly.
- **[henrikrexed/openclaw-observability-plugin](https://github.com/henrikrexed/openclaw-observability-plugin)** captures only metadata because it tried to monkey-patch `@mariozechner/pi-ai` and ran into jiti's CJS/ESM module isolation. Their README literally says *"All telemetry is captured via hooks, not direct SDK instrumentation."* — but they only subscribe to `model.usage` diagnostic events, not the `llm_input`/`llm_output` hooks that expose full content.

We stay inside the supported plugin API. OpenClaw's [`src/plugins/hook-types.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/hook-types.ts) exposes `llm_input` and `llm_output` with the complete payloads (system prompt, message history, provider, model, assistant text, full token usage). Hooks are [documented as fire-and-forget](https://github.com/openclaw/openclaw/blob/main/src/plugins/hooks.ts) and the [call site in `attempt.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/pi-embedded-runner/run/attempt.ts) wraps them with `void hookRunner.run*(...).catch(...)`, so our handlers can never slow the agent loop.

## Span model

Mirrors our [`claude-code-telemetry`](packages/telemetry/claude-code) package:

- **`interaction`** — the agent run. Carries `openclaw.session.key`, `openclaw.agent.id`, aggregated token usage across all LLM calls, duration, success/error status, and the first user prompt.
- **`llm_request`** — one per LLM call. Provider, request/response model, `gen_ai.system_instructions`, `gen_ai.input.messages` (full history + current prompt), `gen_ai.output.messages` (assistant text + `tool_call` parts), and full token usage (input/output/cache_read/cache_creation/total) under both canonical `gen_ai.*` keys and legacy aliases.
- **`tool_execution`** — one per tool call. Canonical `gen_ai.tool.*` attributes. Failures set `error.type`, `error.message`, status code 2.

Every span carries `openclaw.agent.id` and `openclaw.agent.name` — this is the multi-agent tag story. Subagent runs produce spans with different `agentId` values, naturally filterable in the Latitude UI.

## Installer

`npx @latitude-data/openclaw-telemetry install` writes a plugin entry to `~/.openclaw/openclaw.json` with `hooks.allowConversationAccess: true`. That flag is load-bearing — OpenClaw scrubs conversation content from third-party plugins unless they opt in explicitly. Matching `uninstall` command reverses everything.

## Test plan

- [x] `pnpm --filter @latitude-data/openclaw-telemetry typecheck` passes
- [x] `pnpm --filter @latitude-data/openclaw-telemetry test` passes (19 tests — tool loops, subagent runs, error propagation, missing toolCallIds, agent_end closing still-open calls, fire-and-forget end-to-end emission)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry check` passes
- [x] `pnpm --filter @latitude-data/openclaw-telemetry build` produces `dist/plugin.js` + `dist/cli.js`
- [ ] Manual: install into a real OpenClaw setup, run a multi-agent session, confirm spans land at Latitude with `openclaw.agent.id` on each span and full message content on `gen_ai.input.messages` / `gen_ai.output.messages`.

## Requires

OpenClaw **2026.3.0+** for the `llm_input` / `llm_output` hooks.