### PR TITLE
feat(backoffice): user impersonation with audit and banner

### DIFF
--- a/.agents/skills/backoffice/SKILL.md
+++ b/.agents/skills/backoffice/SKILL.md
@@ -19,15 +19,13 @@ Non-admin users — authenticated or not — **MUST NOT** be able to access, enu
 
 ### 2. Server-function guard (RPC layer)
 
-Every backoffice `createServerFn` handler **MUST** call `requireAdminSession()` (`apps/web/src/server/admin-auth.ts`) as its first line, before any IO. It throws `NotFoundError` (**not** 401/403 — the error shape must not fingerprint the admin surface).
-
-Write handlers in the canonical TanStack Start shape:
+Every backoffice `createServerFn` handler **MUST** attach `adminMiddleware` from `apps/web/src/server/admin-middleware.ts`. The middleware fetches the session with Better Auth's cookie cache bypassed (so DB-level role demotions take effect on the next request, not 5 minutes later), rejects non-admins with `NotFoundError` (**not** 401/403 — the error shape must not fingerprint the admin surface), and injects `context.adminUserId` + `context.user` so handlers have admin identity available without re-fetching.
 
 ```ts
 export const adminThing = createServerFn({ method: "GET" })
+  .middleware([adminMiddleware])                    // GUARD, before input validation
   .inputValidator(inputSchema)
-  .handler(async ({ data }): Promise<ThingDto> => {
-    await requireAdminSession()                     // GUARD, first line
+  .handler(async ({ data, context }): Promise<ThingDto> => {
     const client = getAdminPostgresClient()
     const result = await Effect.runPromise(
       thingUseCase(data).pipe(
@@ -39,7 +37,13 @@ export const adminThing = createServerFn({ method: "GET" })
   })
 ```
 
-**Do not** wrap `createServerFn` in a factory. TanStack Start's Vite plugin detects and transforms the literal `createServerFn(...).handler(inlineFn)` chain — it replaces the handler body with a client RPC stub and strips the server-only imports from the browser bundle. A factory that hides `createServerFn` inside its own body defeats that detection, leaks Node-only imports (`withTracing`, `getAdminPostgresClient`, …) into the client bundle, and breaks `pnpm build` with `MISSING_EXPORT` errors against `@repo/observability/browser.ts`. Convention-based guard + mandatory code review is the correct discipline here; structural enforcement via a wrapper is not available at this layer.
+Middleware runs **before** `inputValidator`, so abusive payloads get rejected one step earlier (no Zod parse overhead on non-admin probes).
+
+**The sole exception is `stopImpersonating`**, which uses `impersonatingMiddleware` (from the same file) instead. During an active impersonation the current session's `user.role` is the *target's* role (usually `"user"`), so an admin-role check would reject the very call the admin needs to exit impersonation. `impersonatingMiddleware` gates on `session.impersonatedBy` being set and injects both `context.adminUserId` (recovered before Better Auth swaps the cookie back) and `context.targetUserId` for the audit event.
+
+**Do not** wrap `createServerFn` in a factory (e.g. `createBackofficeServerFn = (opts) => createServerFn(opts).middleware([...])`). TanStack Start's Vite plugin detects server functions by pattern-matching the literal `createServerFn(...).handler(inlineFn)` chain at the call site — a factory hides those tokens behind a different name, the compiler skips the file, and Node-only module-level imports (`withTracing`, `getAdminPostgresClient`, …) leak into the browser bundle, breaking `pnpm build` with `MISSING_EXPORT` errors against `@repo/observability/browser.ts`. Keep `createServerFn` literal at every call site and attach the middleware there; the `.middleware(…)` method is part of the chain the compiler recognises. Attaching at each call site also keeps the "which guard does this endpoint use?" decision visible in the handler body — important because `stopImpersonating` uses a different middleware than the rest.
+
+The route loader in `routes/backoffice/route.tsx` cannot use `createServerFn` middleware (route loaders aren't server functions). It calls `requireAdminSession()` from `admin-auth.ts` instead — same underlying fresh-session + role check, just exposed as a plain async helper. Both helpers share `assertAdminUser` and `getFreshSession`.
 
 ### 3. Database access guard
 

--- a/apps/web/src/domains/admin/impersonation.functions.test.ts
+++ b/apps/web/src/domains/admin/impersonation.functions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { impersonateUserInputSchema } from "./impersonation.functions.ts"
+
+describe("impersonateUserInputSchema", () => {
+  it("accepts a valid userId", () => {
+    expect(impersonateUserInputSchema.safeParse({ userId: "user-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty userId", () => {
+    expect(impersonateUserInputSchema.safeParse({ userId: "" }).success).toBe(false)
+  })
+
+  it("rejects a userId above the max length (defensive bound against abuse)", () => {
+    expect(impersonateUserInputSchema.safeParse({ userId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing userId", () => {
+    expect(impersonateUserInputSchema.safeParse({}).success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/admin/impersonation.functions.ts
+++ b/apps/web/src/domains/admin/impersonation.functions.ts
@@ -1,0 +1,131 @@
+import { getUserDetailsUseCase } from "@domain/admin"
+import { generateId, NotFoundError, UserId } from "@domain/shared"
+import { AdminUserRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { getRequestHeaders } from "@tanstack/react-start/server"
+import { Effect } from "effect"
+import { z } from "zod"
+import { requireAdminSession } from "../../server/admin-auth.ts"
+import { getAdminPostgresClient, getBetterAuth, getOutboxWriter } from "../../server/clients.ts"
+import { ensureSession } from "../sessions/session.functions.ts"
+
+/**
+ * Exported for input-schema tests.
+ */
+export const impersonateUserInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+})
+
+/**
+ * Start impersonating another user.
+ *
+ * The flow:
+ * 1. Guard: `requireAdminSession()` — rejects non-admins with
+ *    `NotFoundError`, matching the three-guard discipline.
+ * 2. Resolve the target's first organization membership via
+ *    {@link AdminUserRepository}. This also verifies the target
+ *    exists (Better Auth would otherwise create an impersonation
+ *    session for a nonsense id). The first-org id is captured in the
+ *    audit event as a best-effort hint of which tenant the admin was
+ *    about to see.
+ * 3. Write `AdminImpersonationStarted` to the outbox. Writing
+ *    **before** the Better Auth swap means if the swap fails we still
+ *    have a record that an attempt was made. The event's envelope
+ *    `organizationId` is `"system"` — impersonation is platform-wide
+ *    audit, not tenant-owned.
+ * 4. Call Better Auth's `auth.api.impersonateUser`, which mints a new
+ *    session cookie for the target user and stores the admin's id in
+ *    `sessions.impersonatedBy`. The client redirects to `/` after
+ *    this returns.
+ */
+export const impersonateUser = createServerFn({ method: "POST" })
+  .inputValidator(impersonateUserInputSchema)
+  .handler(async ({ data }): Promise<{ ok: true }> => {
+    const { userId: adminUserId } = await requireAdminSession()
+
+    const target = await Effect.runPromise(
+      getUserDetailsUseCase({ userId: UserId(data.userId) }).pipe(
+        withPostgres(AdminUserRepositoryLive, getAdminPostgresClient()),
+        withTracing,
+      ),
+    )
+
+    const targetOrganizationId = target.memberships[0]?.organizationId ?? null
+
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminImpersonationStarted",
+          aggregateType: "user",
+          aggregateId: target.id,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId: target.id,
+            targetOrganizationId,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
+
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+    await auth.api.impersonateUser({ body: { userId: target.id }, headers })
+
+    return { ok: true }
+  })
+
+/**
+ * Stop an active impersonation and restore the admin's original session.
+ *
+ * NOTE: this handler deliberately does NOT call `requireAdminSession()`.
+ * During impersonation the current session user is the *target* (role
+ * = `"user"`), so an admin-role check would reject the very call that
+ * needs to succeed. The guard is instead "is `session.impersonatedBy`
+ * set?" — which is only true inside an active impersonation.
+ *
+ * The admin's id is recovered from `session.impersonatedBy` *before*
+ * calling Better Auth's `stopImpersonating` (which swaps the cookie
+ * back and clears the field). The audit event is written before the
+ * swap for the same "record the attempt even if the swap fails"
+ * reason as on start.
+ */
+export const stopImpersonating = createServerFn({ method: "POST" }).handler(async (): Promise<{ ok: true }> => {
+  const session = await ensureSession()
+  const adminUserId = (session.session as { impersonatedBy?: string | null }).impersonatedBy ?? null
+  if (!adminUserId) {
+    // Match the backoffice 404 discipline — never fingerprint admin
+    // surfaces with 401/403 shapes.
+    throw new NotFoundError({ entity: "Route", id: "backoffice" })
+  }
+
+  const targetUserId = session.user.id
+
+  const outboxWriter = getOutboxWriter()
+  await Effect.runPromise(
+    outboxWriter
+      .write({
+        id: generateId(),
+        eventName: "AdminImpersonationStopped",
+        aggregateType: "user",
+        aggregateId: targetUserId,
+        organizationId: "system",
+        payload: {
+          adminUserId,
+          targetUserId,
+        },
+        occurredAt: new Date(),
+      })
+      .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+  )
+
+  const headers = getRequestHeaders()
+  const auth = getBetterAuth()
+  await auth.api.stopImpersonating({ headers })
+
+  return { ok: true }
+})

--- a/apps/web/src/domains/admin/impersonation.functions.ts
+++ b/apps/web/src/domains/admin/impersonation.functions.ts
@@ -1,14 +1,13 @@
 import { getUserDetailsUseCase } from "@domain/admin"
-import { generateId, NotFoundError, UserId } from "@domain/shared"
+import { generateId, UserId } from "@domain/shared"
 import { AdminUserRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
 import { z } from "zod"
-import { requireAdminSession } from "../../server/admin-auth.ts"
+import { adminMiddleware, impersonatingMiddleware } from "../../server/admin-middleware.ts"
 import { getAdminPostgresClient, getBetterAuth, getOutboxWriter } from "../../server/clients.ts"
-import { ensureSession } from "../sessions/session.functions.ts"
 
 /**
  * Exported for input-schema tests.
@@ -20,29 +19,28 @@ export const impersonateUserInputSchema = z.object({
 /**
  * Start impersonating another user.
  *
- * The flow:
- * 1. Guard: `requireAdminSession()` — rejects non-admins with
- *    `NotFoundError`, matching the three-guard discipline.
- * 2. Resolve the target's first organization membership via
- *    {@link AdminUserRepository}. This also verifies the target
- *    exists (Better Auth would otherwise create an impersonation
- *    session for a nonsense id). The first-org id is captured in the
- *    audit event as a best-effort hint of which tenant the admin was
- *    about to see.
- * 3. Write `AdminImpersonationStarted` to the outbox. Writing
- *    **before** the Better Auth swap means if the swap fails we still
- *    have a record that an attempt was made. The event's envelope
- *    `organizationId` is `"system"` — impersonation is platform-wide
- *    audit, not tenant-owned.
- * 4. Call Better Auth's `auth.api.impersonateUser`, which mints a new
- *    session cookie for the target user and stores the admin's id in
- *    `sessions.impersonatedBy`. The client redirects to `/` after
- *    this returns.
+ * Guard: {@link adminMiddleware} — the admin's id is injected as
+ * `context.adminUserId` so the audit event can reference it without a
+ * second session fetch.
+ *
+ * Flow:
+ * 1. Resolve the target's first organisation membership (if any) via
+ *    the admin user repository. This also verifies the target exists —
+ *    Better Auth would otherwise happily mint an impersonation session
+ *    for a nonsense id.
+ * 2. Write `AdminImpersonationStarted` to the outbox *before* the
+ *    Better Auth swap, so an attempt is recorded even if the swap
+ *    fails. Envelope `organizationId` is `"system"` (platform-wide
+ *    audit, no tenant ownership).
+ * 3. Call `auth.api.impersonateUser`, which rewrites the session
+ *    cookie to the target's session and stores the admin's id in
+ *    `sessions.impersonatedBy`. Client redirects to `/` on return.
  */
 export const impersonateUser = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
   .inputValidator(impersonateUserInputSchema)
-  .handler(async ({ data }): Promise<{ ok: true }> => {
-    const { userId: adminUserId } = await requireAdminSession()
+  .handler(async ({ data, context }): Promise<{ ok: true }> => {
+    const adminUserId = context.adminUserId
 
     const target = await Effect.runPromise(
       getUserDetailsUseCase({ userId: UserId(data.userId) }).pipe(
@@ -82,50 +80,45 @@ export const impersonateUser = createServerFn({ method: "POST" })
 /**
  * Stop an active impersonation and restore the admin's original session.
  *
- * NOTE: this handler deliberately does NOT call `requireAdminSession()`.
+ * Guard: {@link impersonatingMiddleware} — not `adminMiddleware`.
  * During impersonation the current session user is the *target* (role
- * = `"user"`), so an admin-role check would reject the very call that
- * needs to succeed. The guard is instead "is `session.impersonatedBy`
- * set?" — which is only true inside an active impersonation.
+ * typically `"user"`), so an admin-role check would reject the call
+ * that's supposed to succeed. The middleware instead gates on
+ * `session.impersonatedBy` being set, and injects both
+ * `context.adminUserId` (recovered from `impersonatedBy` before
+ * Better Auth swaps it back) and `context.targetUserId` so the audit
+ * event can reference both sides.
  *
- * The admin's id is recovered from `session.impersonatedBy` *before*
- * calling Better Auth's `stopImpersonating` (which swaps the cookie
- * back and clears the field). The audit event is written before the
- * swap for the same "record the attempt even if the swap fails"
- * reason as on start.
+ * The audit event is written before `auth.api.stopImpersonating` for
+ * the same "record the attempt even if the swap fails" reason as
+ * `impersonateUser`.
  */
-export const stopImpersonating = createServerFn({ method: "POST" }).handler(async (): Promise<{ ok: true }> => {
-  const session = await ensureSession()
-  const adminUserId = (session.session as { impersonatedBy?: string | null }).impersonatedBy ?? null
-  if (!adminUserId) {
-    // Match the backoffice 404 discipline — never fingerprint admin
-    // surfaces with 401/403 shapes.
-    throw new NotFoundError({ entity: "Route", id: "backoffice" })
-  }
+export const stopImpersonating = createServerFn({ method: "POST" })
+  .middleware([impersonatingMiddleware])
+  .handler(async ({ context }): Promise<{ ok: true }> => {
+    const { adminUserId, targetUserId } = context
 
-  const targetUserId = session.user.id
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminImpersonationStopped",
+          aggregateType: "user",
+          aggregateId: targetUserId,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
 
-  const outboxWriter = getOutboxWriter()
-  await Effect.runPromise(
-    outboxWriter
-      .write({
-        id: generateId(),
-        eventName: "AdminImpersonationStopped",
-        aggregateType: "user",
-        aggregateId: targetUserId,
-        organizationId: "system",
-        payload: {
-          adminUserId,
-          targetUserId,
-        },
-        occurredAt: new Date(),
-      })
-      .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
-  )
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+    await auth.api.stopImpersonating({ headers })
 
-  const headers = getRequestHeaders()
-  const auth = getBetterAuth()
-  await auth.api.stopImpersonating({ headers })
-
-  return { ok: true }
-})
+    return { ok: true }
+  })

--- a/apps/web/src/domains/admin/search.functions.ts
+++ b/apps/web/src/domains/admin/search.functions.ts
@@ -10,7 +10,7 @@ import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
-import { requireAdminSession } from "../../server/admin-auth.ts"
+import { adminMiddleware } from "../../server/admin-middleware.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
 
 /**
@@ -78,25 +78,17 @@ export const adminSearchInputSchema = z.object({
 /**
  * Backoffice unified search server function.
  *
- * Defence-in-depth note — every backoffice `createServerFn` handler MUST:
- * 1. Call {@link requireAdminSession} as its first line, before any IO.
- *    TanStack Start exposes server functions at stable RPC URLs reachable
- *    by any authenticated user; the route-level `notFound()` guard in
- *    `routes/backoffice/route.tsx` does not protect this layer.
- * 2. Use {@link getAdminPostgresClient} piped through `withPostgres`. The
- *    default organisation scope is `OrganizationId("system")`, which is the
- *    only sanctioned RLS-bypass signal in the codebase.
- *
- * Why no factory wrapper? TanStack Start's Vite plugin recognises
- * `createServerFn(...).handler(inlineFn)` literal chains and replaces the
- * handler body with a client-side RPC stub. A factory that wraps
- * `createServerFn` defeats that detection and leaks Node-only imports
- * (e.g. `withTracing`) into the browser bundle, breaking the build.
+ * Guard: {@link adminMiddleware} runs before the input validator and
+ * rejects non-admins with a `NotFoundError` identical to hitting a
+ * non-existent server function. Admin queries then use
+ * {@link getAdminPostgresClient} + `withPostgres` at the default
+ * `OrganizationId("system")` scope, which is the only sanctioned
+ * RLS-bypass signal in the codebase.
  */
 export const adminSearch = createServerFn({ method: "GET" })
+  .middleware([adminMiddleware])
   .inputValidator(adminSearchInputSchema)
   .handler(async ({ data }): Promise<AdminSearchDto> => {
-    await requireAdminSession()
     const client = getAdminPostgresClient()
 
     const result = await Effect.runPromise(

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { adminGetUserInputSchema } from "./users.functions.ts"
+
+describe("adminGetUserInputSchema", () => {
+  it("accepts a valid userId", () => {
+    const result = adminGetUserInputSchema.safeParse({ userId: "user-123" })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects an empty userId", () => {
+    expect(adminGetUserInputSchema.safeParse({ userId: "" }).success).toBe(false)
+  })
+
+  it("rejects a userId above the max length (defensive bound against abuse)", () => {
+    expect(adminGetUserInputSchema.safeParse({ userId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing userId", () => {
+    expect(adminGetUserInputSchema.safeParse({}).success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -5,7 +5,7 @@ import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { Effect } from "effect"
 import { z } from "zod"
-import { requireAdminSession } from "../../server/admin-auth.ts"
+import { adminMiddleware } from "../../server/admin-middleware.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
 
 export interface AdminUserDetailsMembershipDto {
@@ -54,18 +54,17 @@ export const adminGetUserInputSchema = z.object({
 /**
  * Backoffice user-detail fetch.
  *
- * Defence-in-depth note — same discipline as every other admin RPC:
- * 1. `requireAdminSession()` is the first line (before any IO). Non-admins
- *    hitting this endpoint get `NotFoundError`, identical to hitting a
- *    non-existent server function.
- * 2. Queries go through `getAdminPostgresClient()` + `withPostgres` with
- *    the default `OrganizationId("system")` scope (the only sanctioned
- *    RLS-bypass signal).
+ * Guard: {@link adminMiddleware} runs before the input validator and
+ * rejects non-admins with `NotFoundError` (identical to hitting a
+ * non-existent server function). Queries use
+ * {@link getAdminPostgresClient} + `withPostgres` at the default
+ * `OrganizationId("system")` scope — the only sanctioned RLS-bypass
+ * signal.
  */
 export const adminGetUser = createServerFn({ method: "GET" })
+  .middleware([adminMiddleware])
   .inputValidator(adminGetUserInputSchema)
   .handler(async ({ data }): Promise<AdminUserDetailsDto> => {
-    await requireAdminSession()
     const client = getAdminPostgresClient()
 
     const details = await Effect.runPromise(

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -1,0 +1,79 @@
+import { type AdminUserDetails, type AdminUserMembership, getUserDetailsUseCase } from "@domain/admin"
+import { UserId } from "@domain/shared"
+import { AdminUserRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { requireAdminSession } from "../../server/admin-auth.ts"
+import { getAdminPostgresClient } from "../../server/clients.ts"
+
+export interface AdminUserDetailsMembershipDto {
+  organizationId: string
+  organizationName: string
+  organizationSlug: string
+  role: "owner" | "admin" | "member"
+}
+
+interface AdminUserDetailsDto {
+  id: string
+  email: string
+  name: string | null
+  image: string | null
+  role: "user" | "admin"
+  memberships: AdminUserDetailsMembershipDto[]
+  createdAt: string
+}
+
+const toDto = (details: AdminUserDetails): AdminUserDetailsDto => ({
+  id: details.id,
+  email: details.email,
+  name: details.name,
+  image: details.image,
+  role: details.role,
+  memberships: details.memberships.map(
+    (m: AdminUserMembership): AdminUserDetailsMembershipDto => ({
+      organizationId: m.organizationId,
+      organizationName: m.organizationName,
+      organizationSlug: m.organizationSlug,
+      role: m.role,
+    }),
+  ),
+  createdAt: details.createdAt.toISOString(),
+})
+
+/**
+ * Exported so tests can exercise input validation without spinning up the
+ * server-function RPC runtime. The admin guard itself is covered by unit
+ * tests in `admin-auth.test.ts`.
+ */
+export const adminGetUserInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+})
+
+/**
+ * Backoffice user-detail fetch.
+ *
+ * Defence-in-depth note — same discipline as every other admin RPC:
+ * 1. `requireAdminSession()` is the first line (before any IO). Non-admins
+ *    hitting this endpoint get `NotFoundError`, identical to hitting a
+ *    non-existent server function.
+ * 2. Queries go through `getAdminPostgresClient()` + `withPostgres` with
+ *    the default `OrganizationId("system")` scope (the only sanctioned
+ *    RLS-bypass signal).
+ */
+export const adminGetUser = createServerFn({ method: "GET" })
+  .inputValidator(adminGetUserInputSchema)
+  .handler(async ({ data }): Promise<AdminUserDetailsDto> => {
+    await requireAdminSession()
+    const client = getAdminPostgresClient()
+
+    const details = await Effect.runPromise(
+      getUserDetailsUseCase({ userId: UserId(data.userId) }).pipe(
+        withPostgres(AdminUserRepositoryLive, client),
+        withTracing,
+      ),
+    )
+
+    return toDto(details)
+  })

--- a/apps/web/src/domains/sessions/session.functions.ts
+++ b/apps/web/src/domains/sessions/session.functions.ts
@@ -23,6 +23,32 @@ export const getSession = createServerFn({ method: "GET" }).handler(async () => 
   return session
 })
 
+/**
+ * Fetch the session while bypassing Better Auth's signed cookie cache
+ * (see `session.cookieCache` in `create-better-auth.ts`, 5-minute TTL).
+ * The default cache serves the user payload from a cookie without
+ * hitting the DB — which means a DB-level role or status change stays
+ * invisible for up to 5 minutes.
+ *
+ * Called by `requireAdminSession()` so role demotions take effect on
+ * the very next admin-gated request. Lives in the same module as
+ * `getSession` so the TanStack Start Vite compiler can strip its
+ * handler body (and the transitively-imported server-only modules
+ * like `@repo/observability` and `@platform/db-postgres`) out of the
+ * client bundle.
+ */
+export const getFreshSession = createServerFn({ method: "GET" }).handler(async () => {
+  const headers = getRequestHeaders()
+  const auth = getBetterAuth()
+
+  const session = await auth.api.getSession({
+    headers,
+    query: { disableCookieCache: true },
+  })
+
+  return session
+})
+
 export const ensureSession = createServerFn({ method: "GET" }).handler(async () => {
   const session = await getSession()
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as ApiObservabilityTestIndexRouteImport } from './routes/api/observability-test/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
+import { Route as BackofficeUsersUserIdRouteImport } from './routes/backoffice/users/$userId'
 import { Route as ApiObservabilityTestErrorRouteImport } from './routes/api/observability-test/error'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AuthenticatedSettingsOrganizationRouteImport } from './routes/_authenticated/settings/organization'
@@ -131,6 +132,11 @@ const AuthenticatedSettingsIndexRoute =
     path: '/',
     getParentRoute: () => AuthenticatedSettingsRoute,
   } as any)
+const BackofficeUsersUserIdRoute = BackofficeUsersUserIdRouteImport.update({
+  id: '/users/$userId',
+  path: '/users/$userId',
+  getParentRoute: () => BackofficeRouteRoute,
+} as any)
 const ApiObservabilityTestErrorRoute =
   ApiObservabilityTestErrorRouteImport.update({
     id: '/api/observability-test/error',
@@ -267,6 +273,7 @@ export interface FileRoutesByFullPath {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
@@ -299,6 +306,7 @@ export interface FileRoutesByTo {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test': typeof ApiObservabilityTestIndexRoute
   '/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
@@ -336,6 +344,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
   '/_authenticated/projects/$projectSlug/settings': typeof AuthenticatedProjectsProjectSlugSettingsRoute
@@ -374,6 +383,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/users/$userId'
     | '/settings/'
     | '/api/observability-test/'
     | '/projects/$projectSlug/settings'
@@ -406,6 +416,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/users/$userId'
     | '/settings'
     | '/api/observability-test'
     | '/projects/$projectSlug/settings'
@@ -442,6 +453,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/users/$userId'
     | '/_authenticated/settings/'
     | '/api/observability-test/'
     | '/_authenticated/projects/$projectSlug/settings'
@@ -592,6 +604,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSettingsIndexRouteImport
       parentRoute: typeof AuthenticatedSettingsRoute
     }
+    '/backoffice/users/$userId': {
+      id: '/backoffice/users/$userId'
+      path: '/users/$userId'
+      fullPath: '/backoffice/users/$userId'
+      preLoaderRoute: typeof BackofficeUsersUserIdRouteImport
+      parentRoute: typeof BackofficeRouteRoute
+    }
     '/api/observability-test/error': {
       id: '/api/observability-test/error'
       path: '/api/observability-test/error'
@@ -724,11 +743,13 @@ declare module '@tanstack/react-router' {
 interface BackofficeRouteRouteChildren {
   BackofficeSearchRoute: typeof BackofficeSearchRoute
   BackofficeIndexRoute: typeof BackofficeIndexRoute
+  BackofficeUsersUserIdRoute: typeof BackofficeUsersUserIdRoute
 }
 
 const BackofficeRouteRouteChildren: BackofficeRouteRouteChildren = {
   BackofficeSearchRoute: BackofficeSearchRoute,
   BackofficeIndexRoute: BackofficeIndexRoute,
+  BackofficeUsersUserIdRoute: BackofficeUsersUserIdRoute,
 }
 
 const BackofficeRouteRouteWithChildren = BackofficeRouteRoute._addFileChildren(

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Button, DropdownMenu, Icon, LatitudeLogo } from "@repo/ui"
 import { createFileRoute, Link, Outlet, redirect, useRouter } from "@tanstack/react-router"
-import { ChevronsUpDown, Moon, ShieldAlertIcon, Sun } from "lucide-react"
+import { ChevronsUpDown, HatGlassesIcon, Moon, ShieldAlertIcon, Sun } from "lucide-react"
 import { useOrganizationsCollection } from "../domains/organizations/organizations.collection.ts"
 import { getSession } from "../domains/sessions/session.functions.ts"
 import { authClient } from "../lib/auth-client.ts"
@@ -8,6 +8,7 @@ import { resetPostHog } from "../lib/posthog/posthog-client.ts"
 import { PostHogIdentity } from "../lib/posthog/posthog-provider.tsx"
 import { useThemePreference } from "../lib/theme.ts"
 import { BreadcrumbTrail } from "./_authenticated/-components/breadcrumb-trail.tsx"
+import { ImpersonationBanner } from "./_authenticated/-components/impersonation-banner.tsx"
 import { useRootThemePreference } from "./-root-route-data.ts"
 
 export const Route = createFileRoute("/_authenticated")({
@@ -32,9 +33,15 @@ export const Route = createFileRoute("/_authenticated")({
       throw redirect({ to: "/welcome" })
     }
 
+    // Set by the Better Auth `admin` plugin when an admin is impersonating
+    // another user. The impersonation banner reads this to announce the
+    // active impersonation on every authenticated page.
+    const impersonatedBy = typeof sessionData.impersonatedBy === "string" ? sessionData.impersonatedBy : null
+
     return {
       user: session.user,
       organizationId,
+      impersonatedBy,
     }
   },
   component: AuthenticatedLayout,
@@ -64,6 +71,7 @@ function ThemeToggle() {
 function NavHeader() {
   const user = Route.useLoaderData({ select: (data) => data.user })
   const organizationId = Route.useLoaderData({ select: (data) => data.organizationId })
+  const impersonatedBy = Route.useLoaderData({ select: (data) => data.impersonatedBy })
   const { data: allOrgs } = useOrganizationsCollection()
   const org = allOrgs?.find((o) => o.id === organizationId)
   const hasMultipleOrgs = (allOrgs?.length ?? 0) > 1
@@ -156,7 +164,22 @@ function NavHeader() {
           ]}
           trigger={() => (
             <button type="button" className="cursor-pointer">
-              <Avatar name={user.name?.trim() ? user.name : user.email} size="sm" imageSrc={user.image ?? undefined} />
+              <span className="relative inline-flex">
+                <Avatar
+                  name={user.name?.trim() ? user.name : user.email}
+                  size="sm"
+                  imageSrc={user.image ?? undefined}
+                />
+                {impersonatedBy && (
+                  // Small hat glasses icon overlaid on the user's avatar whenever the session is an impersonation.
+                  <span
+                    aria-hidden="true"
+                    className="absolute -top-1/2 -right-1/2 transform -translate-x-1/2 translate-y-1 items-center justify-center"
+                  >
+                    <Icon icon={HatGlassesIcon} size="md" />
+                  </span>
+                )}
+              </span>
             </button>
           )}
         />
@@ -168,6 +191,7 @@ function NavHeader() {
 function AuthenticatedLayout() {
   const user = Route.useLoaderData({ select: (data) => data.user })
   const organizationId = Route.useLoaderData({ select: (data) => data.organizationId })
+  const impersonatedBy = Route.useLoaderData({ select: (data) => data.impersonatedBy })
   const { data: allOrgs } = useOrganizationsCollection()
   const org = allOrgs?.find((o) => o.id === organizationId)
 
@@ -181,6 +205,7 @@ function AuthenticatedLayout() {
         organizationId={organizationId}
         organizationName={org?.name}
       />
+      {impersonatedBy && <ImpersonationBanner impersonatedUserEmail={user.email} />}
       <NavHeader />
       <main className="w-full grow min-h-0 h-full relative overflow-y-auto">
         <Outlet />

--- a/apps/web/src/routes/_authenticated/-components/impersonation-banner.tsx
+++ b/apps/web/src/routes/_authenticated/-components/impersonation-banner.tsx
@@ -1,0 +1,60 @@
+import { Button, Icon, Text, useToast } from "@repo/ui"
+import { ArrowLeftIcon, Loader2Icon, ShieldAlertIcon } from "lucide-react"
+import { useState } from "react"
+import { stopImpersonating } from "../../../domains/admin/impersonation.functions.ts"
+import { toUserMessage } from "../../../lib/errors.ts"
+
+interface ImpersonationBannerProps {
+  readonly impersonatedUserEmail: string
+}
+
+/**
+ * Full-width destructive bar rendered above the app nav whenever the
+ * current session is an impersonation (i.e. `session.impersonatedBy` is
+ * set). Prevents staff from forgetting they are acting as another user.
+ *
+ * "Stop impersonating" calls our {@link stopImpersonating} server
+ * function — which writes the `AdminImpersonationStopped` audit event
+ * and then delegates to Better Auth's `auth.api.stopImpersonating` to
+ * swap the session cookie back to the admin. A hard reload follows to
+ * bypass Better Auth's 5-minute session cookie cache and the route
+ * tree's loader cache.
+ */
+export function ImpersonationBanner({ impersonatedUserEmail }: ImpersonationBannerProps) {
+  const { toast } = useToast()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleStop = async () => {
+    setIsSubmitting(true)
+    try {
+      await stopImpersonating()
+      window.location.href = "/"
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not stop impersonating",
+        description: toUserMessage(error),
+      })
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="w-full bg-destructive text-destructive-foreground px-4 py-2 flex items-center gap-3 shrink-0">
+      <Icon icon={ShieldAlertIcon} size="sm" color="white" />
+      <Text.H5 color="white">
+        You are impersonating <span className="font-semibold">{impersonatedUserEmail}</span>.
+      </Text.H5>
+      <div className="flex-1" />
+      <Button variant="link" size="sm" disabled={isSubmitting} onClick={() => void handleStop()}>
+        <Icon
+          icon={isSubmitting ? Loader2Icon : ArrowLeftIcon}
+          size="sm"
+          color="white"
+          className={isSubmitting ? "animate-spin" : ""}
+        />
+        <Text.H5 color="white">Stop impersonating</Text.H5>
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/impersonate-user-button.tsx
+++ b/apps/web/src/routes/backoffice/-components/impersonate-user-button.tsx
@@ -1,0 +1,80 @@
+import { Alert, Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useState } from "react"
+import { impersonateUser } from "../../../domains/admin/impersonation.functions.ts"
+import { toUserMessage } from "../../../lib/errors.ts"
+
+interface ImpersonateUserButtonProps {
+  readonly userId: string
+  readonly userEmail: string
+}
+
+/**
+ * Opens a confirmation modal before starting impersonation. The copy is
+ * intentionally reused verbatim from v1 (`latitude-v1` branch):
+ *
+ * > This will allow you to access the application as them. Use ONLY
+ * > for support purposes after acknowledgement from the user.
+ *
+ * On confirm, calls the `impersonateUser` server function, then
+ * forces a full-page navigation to `/`. The hard reload is deliberate:
+ * Better Auth caches the session user for 5 minutes
+ * (`session.cookieCache`), so an SPA navigation after swap could
+ * briefly render the admin's identity against the target's cookie.
+ */
+export function ImpersonateUserButton({ userId, userEmail }: ImpersonateUserButtonProps) {
+  const { toast } = useToast()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleImpersonate = async () => {
+    setIsSubmitting(true)
+    try {
+      await impersonateUser({ data: { userId } })
+      // Full reload bypasses Better Auth's cookie cache (5 min TTL) and
+      // the route tree's cached loader data, so the target's dashboard
+      // renders against the freshly-swapped session cookie.
+      window.location.href = "/"
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not start impersonation",
+        description: toUserMessage(error),
+      })
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button variant="destructive" size="sm" disabled={isSubmitting} onClick={() => setIsOpen(true)}>
+        {isSubmitting ? "Impersonating…" : "Impersonate User"}
+      </Button>
+      <Modal
+        dismissible
+        open={isOpen}
+        size="large"
+        onOpenChange={setIsOpen}
+        title="Impersonate User"
+        description={
+          <Text.H5 color="foregroundMuted">
+            Impersonate <span className="font-medium text-foreground">{userEmail}</span> and access the application as
+            them.
+          </Text.H5>
+        }
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <CloseTrigger />
+            <Button variant="destructive" size="sm" disabled={isSubmitting} onClick={() => void handleImpersonate()}>
+              {isSubmitting ? "Impersonating…" : "Impersonate"}
+            </Button>
+          </div>
+        }
+      >
+        <Alert
+          variant="warning"
+          description="This will allow you to access the application as them. Use ONLY for support purposes after acknowledgement from the user."
+        />
+      </Modal>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/search-results.tsx
+++ b/apps/web/src/routes/backoffice/-components/search-results.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Badge, Text } from "@repo/ui"
 import { extractLeadingEmoji } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import type {
   AdminOrganizationSearchDto,
   AdminProjectSearchDto,
@@ -88,7 +89,11 @@ function UserCard({ user }: { user: AdminUserSearchDto }) {
   const overflowCount = user.memberships.length - visibleMemberships.length
 
   return (
-    <div className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3">
+    <Link
+      to="/backoffice/users/$userId"
+      params={{ userId: user.id }}
+      className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3 transition-colors hover:bg-muted"
+    >
       <Avatar name={displayName} imageSrc={user.image} size="lg" />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2 min-w-0">
@@ -119,7 +124,7 @@ function UserCard({ user }: { user: AdminUserSearchDto }) {
       <Text.H6 color="foregroundMuted" noWrap>
         {formatDate(user.createdAt)}
       </Text.H6>
-    </div>
+    </Link>
   )
 }
 

--- a/apps/web/src/routes/backoffice/route.tsx
+++ b/apps/web/src/routes/backoffice/route.tsx
@@ -9,14 +9,27 @@ import { requireAdminSession } from "../../server/admin-auth.ts"
 // surfaces share a single source of truth for the admin gate — including
 // the DB-fresh fetch that sidesteps Better Auth's 5-minute session cookie
 // cache (see the comment on `requireAdminSession`). The route-local
-// wrapper just converts the domain `NotFoundError` into TanStack Router's
+// wrapper converts the domain `NotFoundError` into TanStack Router's
 // `notFound()` so the response is indistinguishable from any unknown
 // URL — no redirect, no 403, no Location header leak.
+//
+// Match on the Effect-native `_tag` (survives the RPC JSON boundary)
+// rather than `instanceof NotFoundError` or a blanket catch. Only
+// `NotFoundError` — the tagged error `requireAdminSession()` throws
+// when the caller is not an admin or is unauthenticated — is
+// collapsed into a 404. Anything else (DB outage, connectivity,
+// serialization bug from the Better Auth fresh-session fetch) must
+// bubble to the router error boundary instead of being silently
+// masked as a 404. Same discipline as the `$userId.tsx` loader.
 const guardBackofficeRoute = async () => {
   try {
     await requireAdminSession()
-  } catch {
-    throw notFound()
+  } catch (error) {
+    const tag = (error as { _tag?: string } | null | undefined)?._tag
+    if (tag === "NotFoundError") {
+      throw notFound()
+    }
+    throw error
   }
 }
 

--- a/apps/web/src/routes/backoffice/route.tsx
+++ b/apps/web/src/routes/backoffice/route.tsx
@@ -1,21 +1,23 @@
 import { Button, Icon, LatitudeLogo, Text } from "@repo/ui"
 import { createFileRoute, Link, notFound, Outlet, useRouter } from "@tanstack/react-router"
 import { ArrowLeft, Search, ShieldAlertIcon } from "lucide-react"
-import { getSession } from "../../domains/sessions/session.functions.ts"
 import { AppSidebar, NavItem } from "../../layouts/AppSidebar/index.tsx"
 import { usePathname } from "../../lib/hooks/use-router-selectors.ts"
+import { requireAdminSession } from "../../server/admin-auth.ts"
 
-// Extract to a named helper so both `beforeLoad` (the parent gate) and the
-// loader use identical logic — and so the intent is explicit.
-const assertAdminSession = async () => {
-  const session = await getSession()
-  const role = (session?.user as { role?: string } | undefined)?.role
-  if (!session || role !== "admin") {
-    // 404, not redirect: the existence of the backoffice surface must not
-    // leak through error types, redirects, or Location headers.
+// Delegate the role check to `requireAdminSession()` so the UI and RPC
+// surfaces share a single source of truth for the admin gate — including
+// the DB-fresh fetch that sidesteps Better Auth's 5-minute session cookie
+// cache (see the comment on `requireAdminSession`). The route-local
+// wrapper just converts the domain `NotFoundError` into TanStack Router's
+// `notFound()` so the response is indistinguishable from any unknown
+// URL — no redirect, no 403, no Location header leak.
+const guardBackofficeRoute = async () => {
+  try {
+    await requireAdminSession()
+  } catch {
     throw notFound()
   }
-  return session
 }
 
 export const Route = createFileRoute("/backoffice")({
@@ -24,11 +26,9 @@ export const Route = createFileRoute("/backoffice")({
   // Without this, `backoffice/index.tsx`'s `throw redirect({ to: "/backoffice/search" })`
   // would execute for unauthenticated probes and leak the subpath in the 307
   // Location header.
-  beforeLoad: async () => {
-    await assertAdminSession()
-  },
+  beforeLoad: guardBackofficeRoute,
   loader: async () => {
-    await assertAdminSession()
+    await guardBackofficeRoute()
     return null
   },
   component: BackofficeLayout,

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -9,11 +9,25 @@ export const Route = createFileRoute("/backoffice/users/$userId")({
     try {
       const user = await adminGetUser({ data: { userId: params.userId } })
       return { user }
-    } catch {
-      // Both "user not found" and "non-admin" throw NotFoundError from
-      // our server function. From the UI's point of view they are the
-      // same: render the standard 404.
-      throw notFound()
+    } catch (error) {
+      // Only collapse `NotFoundError` into `notFound()` — that covers
+      // the two backoffice cases we want indistinguishable from any
+      // unknown URL: "user does not exist" and "caller isn't an
+      // admin" (both surface as a tagged `NotFoundError` from our
+      // server function). Anything else — DB outage, connectivity,
+      // serialization bug — must bubble to the router's error
+      // boundary so ops can see it, instead of being silently masked
+      // as a 404.
+      //
+      // We match on the Effect-native `_tag` field instead of
+      // `instanceof NotFoundError` because loaders can run client-side
+      // on navigations, where the thrown error has been rehydrated
+      // from JSON and no longer carries the class prototype.
+      const tag = (error as { _tag?: string } | null | undefined)?._tag
+      if (tag === "NotFoundError") {
+        throw notFound()
+      }
+      throw error
     }
   },
   component: BackofficeUserDetailPage,

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,0 +1,102 @@
+import { Avatar, Badge, Container, Text } from "@repo/ui"
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import type { AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
+import { adminGetUser } from "../../../domains/admin/users.functions.ts"
+import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
+
+export const Route = createFileRoute("/backoffice/users/$userId")({
+  loader: async ({ params }) => {
+    try {
+      const user = await adminGetUser({ data: { userId: params.userId } })
+      return { user }
+    } catch {
+      // Both "user not found" and "non-admin" throw NotFoundError from
+      // our server function. From the UI's point of view they are the
+      // same: render the standard 404.
+      throw notFound()
+    }
+  },
+  component: BackofficeUserDetailPage,
+})
+
+function BackofficeUserDetailPage() {
+  const user = Route.useLoaderData({ select: (data) => data.user })
+
+  return (
+    <Container className="pt-6 pb-10 flex flex-col gap-6">
+      <header className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <Avatar name={user.name?.trim() ? user.name : user.email} size="md" imageSrc={user.image ?? undefined} />
+          <div className="flex flex-col min-w-0">
+            <div className="flex items-center gap-2">
+              <Text.H3 weight="semibold" ellipsis noWrap>
+                {user.email}
+              </Text.H3>
+              {user.role === "admin" && <Badge variant="destructive">admin</Badge>}
+            </div>
+            <Text.H5 color="foregroundMuted" ellipsis noWrap>
+              {user.name ?? "(no name)"} · {user.id}
+            </Text.H5>
+          </div>
+        </div>
+        <ImpersonateUserButton userId={user.id} userEmail={user.email} />
+      </header>
+
+      <section className="flex flex-col gap-2">
+        <Text.H5 weight="semibold">Profile</Text.H5>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
+          <DetailRow label="User id" value={user.id} />
+          <DetailRow label="Created" value={formatDate(user.createdAt)} />
+          <DetailRow label="Email" value={user.email} />
+          <DetailRow label="Role" value={user.role} />
+          <DetailRow label="Name" value={user.name ?? "(not set)"} />
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <Text.H5 weight="semibold">Memberships ({user.memberships.length})</Text.H5>
+        {user.memberships.length === 0 ? (
+          <div className="rounded-md border border-border bg-background px-4 py-3">
+            <Text.H5 color="foregroundMuted">This user is not a member of any organization.</Text.H5>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {user.memberships.map((m: AdminUserDetailsMembershipDto) => (
+              <div
+                key={m.organizationId}
+                className="flex items-center justify-between gap-4 rounded-md border border-border bg-background px-4 py-3"
+              >
+                <div className="flex flex-col min-w-0">
+                  <Text.H5 weight="medium" ellipsis noWrap>
+                    {m.organizationName}
+                  </Text.H5>
+                  <Text.H6 color="foregroundMuted" ellipsis noWrap>
+                    /{m.organizationSlug} · {m.organizationId}
+                  </Text.H6>
+                </div>
+                <Badge variant={m.role === "owner" ? "default" : "secondary"}>{m.role}</Badge>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </Container>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <Text.H6>{value}</Text.H6>
+    </>
+  )
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toISOString().slice(0, 10)
+  } catch {
+    return iso
+  }
+}

--- a/apps/web/src/server/admin-auth.ts
+++ b/apps/web/src/server/admin-auth.ts
@@ -1,15 +1,12 @@
 import { NotFoundError, UserId } from "@domain/shared"
 import type { User } from "@platform/db-postgres"
-import { ensureSession } from "../domains/sessions/session.functions.ts"
+import { getFreshSession } from "../domains/sessions/session.functions.ts"
 
 /**
  * Better Auth's base `User` type does not include the app-extended
- * `users.role` column. The column is surfaced at runtime via
- * `user.additionalFields` in the Better Auth config, but TypeScript can't
- * see it through the exported `User` type — so we narrow locally.
- *
- * When the Better Auth admin plugin is installed (PR 2) it will declare
- * `role` in its schema and this workaround can be removed.
+ * `users.role` column. The column is surfaced at runtime by the Better
+ * Auth `admin` plugin, but TypeScript can't see it through the exported
+ * `User` type — so we narrow locally.
  */
 type UserWithRole = User & { readonly role: "user" | "admin" }
 
@@ -34,15 +31,29 @@ export function assertAdminUser(
 }
 
 /**
- * Admin gate for backoffice server functions.
+ * Admin gate for backoffice server functions and the backoffice route
+ * loader. MUST be the first IO of every admin-gated handler — TanStack
+ * Start exposes server functions at stable RPC URLs that any
+ * authenticated user can hit directly, so the route-level guard is not
+ * sufficient on its own.
  *
- * MUST be the first line of every admin `createServerFn` handler. Server
- * functions are exposed at stable RPC URLs that any authenticated user can
- * hit directly, so the route-level guard is not sufficient on its own.
+ * Uses {@link getFreshSession}, which asks Better Auth to skip the
+ * 5-minute session cookie cache (`session.cookieCache` in
+ * `create-better-auth.ts`) and re-read the session user from the DB.
+ * Without this, a role demotion (e.g. `UPDATE users SET role='user'`)
+ * stays invisible to admin guards for up to 5 minutes — long enough to
+ * matter if a staff credential is ever compromised.
+ *
+ * This file is intentionally free of `@repo/observability` /
+ * `@platform/db-postgres` imports: it gets pulled into the backoffice
+ * route's client graph, and direct imports there would leak Node-only
+ * symbols (`withTracing`, etc.) into the browser bundle. All Node-only
+ * work lives behind the `getFreshSession` server function, which the
+ * TanStack Start compiler strips on the client.
  */
 export const requireAdminSession = async (): Promise<AdminSession> => {
-  const session = await ensureSession()
-  const user = session.user as User & { role?: string | null }
+  const session = await getFreshSession()
+  const user = session?.user as (User & { role?: string | null }) | undefined
   assertAdminUser(user)
   return { userId: UserId(user.id), user }
 }

--- a/apps/web/src/server/admin-middleware.ts
+++ b/apps/web/src/server/admin-middleware.ts
@@ -1,0 +1,79 @@
+import { NotFoundError, UserId } from "@domain/shared"
+import type { User } from "@platform/db-postgres"
+import { createMiddleware } from "@tanstack/react-start"
+import { getFreshSession, getSession } from "../domains/sessions/session.functions.ts"
+import { assertAdminUser } from "./admin-auth.ts"
+
+/**
+ * Backoffice guard middlewares for `createServerFn` handlers.
+ *
+ * Design note — why two middlewares and not one:
+ *
+ * The "admin" guard and the "currently impersonating" guard are
+ * structurally different. During an active impersonation the session
+ * cookie points at the TARGET user — `session.user.role` is whatever
+ * the target's role is (usually `"user"`), not `"admin"`. So the
+ * `stopImpersonating` endpoint would be rejected by an admin-role
+ * check even though that's exactly the call the admin needs to make
+ * to exit impersonation. The correct guard for that endpoint is "is
+ * `session.impersonatedBy` set?" — which is only ever true inside an
+ * impersonation session, and from which the admin's id is recovered.
+ *
+ * Every other backoffice RPC uses {@link adminMiddleware}; the sole
+ * exception is {@link impersonatingMiddleware} on `stopImpersonating`.
+ *
+ * Both middlewares collapse failure to `NotFoundError` so the error
+ * shape stays indistinguishable from hitting any non-existent server
+ * function — the same fingerprint-preservation discipline as the
+ * route `notFound()` guard (see `.agents/skills/backoffice/SKILL.md`).
+ *
+ * This file lives alongside `admin-auth.ts` rather than inside a
+ * `.functions.ts` module so the TanStack Start Vite compiler handles
+ * the `createMiddleware(...).server(...)` shape it recognises, and
+ * strips the Node-only transitive imports out of the browser bundle.
+ */
+
+/**
+ * Gate for admin-only backoffice server functions.
+ *
+ * Fetches the session with Better Auth's cookie cache bypassed (see
+ * `getFreshSession`) so DB-level role demotions take effect on the
+ * next request, not 5 minutes later. Forwards `{ adminUserId, user }`
+ * into the handler's context so handlers can write audit events and
+ * reference the admin identity without re-fetching.
+ */
+export const adminMiddleware = createMiddleware({ type: "function" }).server(async ({ next }) => {
+  const session = await getFreshSession()
+  const user = session?.user as (User & { role?: string | null }) | undefined
+  assertAdminUser(user)
+  return next({ context: { adminUserId: UserId(user.id), user } })
+})
+
+/**
+ * Gate for {@link stopImpersonating}. Requires an active impersonation
+ * session (`session.impersonatedBy` set) — the admin's role is
+ * intentionally NOT checked here because during impersonation the
+ * current session user is the target, whose role is usually `"user"`.
+ *
+ * Forwards the admin id (recovered from `impersonatedBy` before
+ * Better Auth swaps it back) and the target id into the handler's
+ * context so the audit-event payload can reference both sides.
+ *
+ * The cookie cache is fine here: `impersonatedBy` is written by
+ * Better Auth during the impersonation flow and is stable for the
+ * lifetime of that session. Unlike `role`, it is not something a DB
+ * operator would change out-of-band.
+ */
+export const impersonatingMiddleware = createMiddleware({ type: "function" }).server(async ({ next }) => {
+  const session = await getSession()
+  const adminUserId = (session?.session as { impersonatedBy?: string | null } | undefined)?.impersonatedBy ?? null
+  if (!session || !adminUserId) {
+    throw new NotFoundError({ entity: "Route", id: "backoffice" })
+  }
+  return next({
+    context: {
+      adminUserId: UserId(adminUserId),
+      targetUserId: UserId(session.user.id),
+    },
+  })
+})

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -155,6 +155,13 @@ export const createDomainEventsWorker = ({
     AnnotationQueueItemCompleted: () => Effect.void,
     ProjectDeleted: () => Effect.void,
     FirstTraceReceived: () => Effect.void,
+    // Impersonation events are audit-only — their value is being
+    // persisted in the outbox for support / compliance queries.
+    // No downstream worker consumes them, so these handlers are no-ops.
+    // Present here only because `EventHandlerMap` exhaustively covers
+    // every key in `EventPayloads` and would fail typecheck otherwise.
+    AdminImpersonationStarted: () => Effect.void,
+    AdminImpersonationStopped: () => Effect.void,
   }
 
   consumer.subscribe("domain-events", {

--- a/packages/domain/admin/src/index.ts
+++ b/packages/domain/admin/src/index.ts
@@ -2,3 +2,4 @@
 // feature (entities + ports + use-cases). Add a new folder per feature and
 // re-export its public surface below.
 export * from "./search/index.ts"
+export * from "./users/index.ts"

--- a/packages/domain/admin/src/users/get-user-details.test.ts
+++ b/packages/domain/admin/src/users/get-user-details.test.ts
@@ -1,0 +1,46 @@
+import { NotFoundError, type UserId } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { getUserDetailsUseCase } from "./get-user-details.ts"
+import type { AdminUserDetails } from "./user-details.ts"
+import { AdminUserRepository } from "./user-repository.ts"
+
+const TARGET_ID = "user-target" as UserId
+
+const successfulRepo = (result: AdminUserDetails) =>
+  Layer.succeed(AdminUserRepository, {
+    findById: () => Effect.succeed(result),
+  })
+
+const missingRepo = () =>
+  Layer.succeed(AdminUserRepository, {
+    findById: (id) => Effect.fail(new NotFoundError({ entity: "User", id })),
+  })
+
+const mkDetails = (overrides: Partial<AdminUserDetails> = {}): AdminUserDetails => ({
+  id: TARGET_ID,
+  email: "target@example.com",
+  name: "Target User",
+  image: null,
+  role: "user",
+  memberships: [],
+  createdAt: new Date("2024-01-01"),
+  ...overrides,
+})
+
+describe("getUserDetailsUseCase", () => {
+  it("returns the admin user details from the repository on success", async () => {
+    const details = mkDetails()
+    const result = await Effect.runPromise(
+      getUserDetailsUseCase({ userId: TARGET_ID }).pipe(Effect.provide(successfulRepo(details))),
+    )
+
+    expect(result).toBe(details)
+  })
+
+  it("surfaces NotFoundError verbatim when the repo does not find the user", async () => {
+    await expect(
+      Effect.runPromise(getUserDetailsUseCase({ userId: TARGET_ID }).pipe(Effect.provide(missingRepo()))),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "User" })
+  })
+})

--- a/packages/domain/admin/src/users/get-user-details.ts
+++ b/packages/domain/admin/src/users/get-user-details.ts
@@ -1,0 +1,17 @@
+import type { NotFoundError, RepositoryError, UserId } from "@domain/shared"
+import { Effect } from "effect"
+import type { AdminUserDetails } from "./user-details.ts"
+import { AdminUserRepository } from "./user-repository.ts"
+
+export interface GetUserDetailsInput {
+  readonly userId: UserId
+}
+
+export const getUserDetailsUseCase = (
+  input: GetUserDetailsInput,
+): Effect.Effect<AdminUserDetails, NotFoundError | RepositoryError, AdminUserRepository> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("admin.targetUserId", input.userId)
+    const repo = yield* AdminUserRepository
+    return yield* repo.findById(input.userId)
+  }).pipe(Effect.withSpan("admin.getUserDetails"))

--- a/packages/domain/admin/src/users/index.ts
+++ b/packages/domain/admin/src/users/index.ts
@@ -1,0 +1,8 @@
+export { type GetUserDetailsInput, getUserDetailsUseCase } from "./get-user-details.ts"
+export {
+  type AdminUserDetails,
+  type AdminUserMembership,
+  adminUserDetailsSchema,
+  adminUserMembershipSchema,
+} from "./user-details.ts"
+export { AdminUserRepository } from "./user-repository.ts"

--- a/packages/domain/admin/src/users/user-details.ts
+++ b/packages/domain/admin/src/users/user-details.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+
+/**
+ * User details returned by the backoffice user-detail page.
+ *
+ * Intentionally flat DTOs — we ship only the fields the admin UI needs,
+ * and expose memberships inline rather than returning full domain
+ * `User` + `Membership` entities, so impersonation / audit flows never
+ * accidentally leak sensitive internals (Stripe customer ids, auth
+ * provider tokens, etc.) through this surface.
+ */
+
+export const adminUserMembershipSchema = z.object({
+  organizationId: z.string(),
+  organizationName: z.string(),
+  organizationSlug: z.string(),
+  role: z.enum(["owner", "admin", "member"]),
+})
+export type AdminUserMembership = z.infer<typeof adminUserMembershipSchema>
+
+export const adminUserDetailsSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  name: z.string().nullable(),
+  image: z.string().nullable(),
+  role: z.enum(["user", "admin"]),
+  memberships: z.array(adminUserMembershipSchema),
+  createdAt: z.date(),
+})
+export type AdminUserDetails = z.infer<typeof adminUserDetailsSchema>

--- a/packages/domain/admin/src/users/user-repository.ts
+++ b/packages/domain/admin/src/users/user-repository.ts
@@ -1,0 +1,23 @@
+import type { NotFoundError, RepositoryError, UserId } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { AdminUserDetails } from "./user-details.ts"
+
+/**
+ * Cross-organization user-detail port for the backoffice.
+ *
+ * WARNING: adapters of this port MUST run under an admin (RLS-bypassing)
+ * database connection — see `AdminUserRepositoryLive` in
+ * `@platform/db-postgres`. This service is only ever wired into handlers
+ * that have passed `requireAdminSession()` in `apps/web`.
+ */
+export class AdminUserRepository extends ServiceMap.Service<
+  AdminUserRepository,
+  {
+    /**
+     * Fetch a single user and their org memberships by id. Fails with
+     * `NotFoundError` if no user exists — impersonation handlers depend
+     * on this precondition.
+     */
+    findById(userId: UserId): Effect.Effect<AdminUserDetails, NotFoundError | RepositoryError>
+  }
+>()("@domain/admin/AdminUserRepository") {}

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -119,10 +119,19 @@ export interface EventPayloads {
    * Emitted when a platform admin begins impersonating another user via
    * the backoffice. The outbox envelope's `organizationId` is always
    * `"system"` — impersonation is a platform-wide audit event with no
-   * tenant ownership. `targetOrganizationId` records the org whose data
-   * the admin is about to see (the target user's active org at the
-   * moment of impersonation), so queries like "who looked at tenant X?"
-   * have a join key.
+   * tenant ownership.
+   *
+   * `targetOrganizationId` is a **best-effort** hint: it holds the
+   * target's first organisation membership (ordered by organisation
+   * name) at the moment of impersonation, as surfaced by
+   * `AdminUserRepository.findById`. It is NOT guaranteed to be the
+   * org the admin actually lands on — Better Auth may set a
+   * different `activeOrganizationId` on the new session, and the
+   * admin can switch orgs from the banner. Audit queries like "who
+   * looked at tenant X?" should treat it as an indicator, not a
+   * source of truth — join with the admin's subsequent request trail
+   * for definitive answers. `null` when the target has no
+   * memberships.
    */
   AdminImpersonationStarted: {
     readonly adminUserId: string

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -115,4 +115,28 @@ export interface EventPayloads {
     readonly projectId: string
     readonly traceId: string
   }
+  /**
+   * Emitted when a platform admin begins impersonating another user via
+   * the backoffice. The outbox envelope's `organizationId` is always
+   * `"system"` — impersonation is a platform-wide audit event with no
+   * tenant ownership. `targetOrganizationId` records the org whose data
+   * the admin is about to see (the target user's active org at the
+   * moment of impersonation), so queries like "who looked at tenant X?"
+   * have a join key.
+   */
+  AdminImpersonationStarted: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+    readonly targetOrganizationId: string | null
+  }
+  /**
+   * Emitted when impersonation ends — either from the "Stop impersonating"
+   * banner action or when the 1-hour impersonation-session TTL
+   * (`impersonationSessionDuration` on the Better Auth admin plugin)
+   * elapses.
+   */
+  AdminImpersonationStopped: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+  }
 }

--- a/packages/platform/db-postgres/drizzle/.migration-lock
+++ b/packages/platform/db-postgres/drizzle/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-04-14T15:51:53.323Z
-# Hash: 22ef042a-54d1-4146-8e43-1e61fcea9e8b
+# Generated: 2026-04-24T09:26:23.500Z
+# Hash: b285190e-44c0-4776-909a-d002ea12c012
 # Do not manually edit this file.

--- a/packages/platform/db-postgres/drizzle/20260424092623_add-admin-plugin-fields/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260424092623_add-admin-plugin-fields/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "latitude"."sessions" ADD COLUMN "impersonated_by" text;--> statement-breakpoint
+ALTER TABLE "latitude"."users" ADD COLUMN "banned" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "latitude"."users" ADD COLUMN "ban_reason" text;--> statement-breakpoint
+ALTER TABLE "latitude"."users" ADD COLUMN "ban_expires" timestamp with time zone;

--- a/packages/platform/db-postgres/drizzle/20260424092623_add-admin-plugin-fields/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260424092623_add-admin-plugin-fields/snapshot.json
@@ -1,0 +1,4691 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "5f8a93b3-35b4-4038-98e3-3b771c1eebdc",
+  "prevIds": [
+    "6385a8d8-a5d9-4350-b66d-98fc464db4a7"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queue_items",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "subscriptions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "datasets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "dataset_versions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "evaluations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "issues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "projects",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "scores",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "simulations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "review_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(140)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignees",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "completed_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'incomplete'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seats",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_interval",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_schedule_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "current_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_inserted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_deleted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'api'",
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "alignment",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aligned_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uuid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "escalated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ignored_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "published",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "occurred_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_trace_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "span_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "simulation_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "feedback",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "tokens",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "drafted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "annotator_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evaluations",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "completed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queue_items_queue_progress_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queues_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "system",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "slug",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queues_project_system_slug_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "inviter_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_inviterId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "active_organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_activeOrganizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "dataset_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_dataset_id_version_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "archived_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_issue_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ignored_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "resolved_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "issues_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_workspace_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "aggregate_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_aggregate_type_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_source_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"source\" = 'evaluation' AND \"drafted_at\" IS NULL AND \"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_canonical_evaluation_trace_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"issue_id\" IS NOT NULL AND \"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_issue_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_trace_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"session_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_session_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "span_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"span_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_span_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL AND \"errored\" = false AND \"passed\" = false AND \"issue_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_issue_discovery_work_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_draft_finalization_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "simulations_project_created_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queue_items_pkey",
+      "schema": "latitude",
+      "table": "annotation_queue_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queues_pkey",
+      "schema": "latitude",
+      "table": "annotation_queues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "latitude",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "latitude",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "latitude",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "subscriptions_pkey",
+      "schema": "latitude",
+      "table": "subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "latitude",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "datasets_pkey",
+      "schema": "latitude",
+      "table": "datasets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dataset_versions_pkey",
+      "schema": "latitude",
+      "table": "dataset_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "evaluations_pkey",
+      "schema": "latitude",
+      "table": "evaluations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issues_pkey",
+      "schema": "latitude",
+      "table": "issues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_events_pkey",
+      "schema": "latitude",
+      "table": "outbox_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pkey",
+      "schema": "latitude",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "scores_pkey",
+      "schema": "latitude",
+      "table": "scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "simulations_pkey",
+      "schema": "latitude",
+      "table": "simulations",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "queue_id",
+        "trace_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "annotation_queue_items_unique_trace_per_queue_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "evaluations_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_token_hash_key",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uuid"
+      ],
+      "nullsNotDistinct": false,
+      "name": "issues_uuid_key",
+      "schema": "latitude",
+      "table": "issues",
+      "entityType": "uniques"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queue_items_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "api_keys_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "invitations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "members_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "reference_id = get_current_organization_id()",
+      "withCheck": "reference_id = get_current_organization_id()",
+      "name": "subscriptions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "datasets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "dataset_versions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "evaluations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "issues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "projects_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "scores_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "simulations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "simulations"
+    }
+  ],
+  "renames": []
+}

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -4,7 +4,7 @@ import { generateId } from "@domain/shared"
 import { parseEnv, parseEnvOptional } from "@platform/env"
 import { type BetterAuthOptions, betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
-import { captcha, magicLink, organization as organizationPlugin } from "better-auth/plugins"
+import { admin as adminPlugin, captcha, magicLink, organization as organizationPlugin } from "better-auth/plugins"
 import { Effect } from "effect"
 import Stripe from "stripe"
 import type { PostgresClient } from "./client.ts"
@@ -111,18 +111,12 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
     basePath,
     secret,
     trustedOrigins: config.trustedOrigins ?? [],
-    user: {
-      // Surface the app-extended `users.role` column on the session user.
-      // Required by the backoffice admin guard — without this, Better Auth
-      // fetches the column from the DB but does not expose it to callers of
-      // `auth.api.getSession()`, so `user.role` is undefined and every user
-      // (including admins) is treated as non-admin.
-      // `input: false` keeps the field read-only via the sign-up / update
-      // APIs so regular users can't self-promote to admin.
-      additionalFields: {
-        role: { type: "string", required: false, input: false },
-      },
-    },
+    // The `users.role` column is surfaced on the session user by the
+    // `admin` plugin installed below. The plugin declares it in its own
+    // schema (`{ type: "string", required: false, input: false }`), so
+    // we do NOT need a separate `user.additionalFields.role` entry —
+    // declaring both produces duplicate-field warnings. `input: false`
+    // still holds: the role is read-only through sign-up / update APIs.
     databaseHooks: {
       user: {
         create: {
@@ -202,6 +196,24 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
         },
         expiresIn: 3600,
         allowedAttempts: 5,
+      }),
+      /**
+       * Backoffice impersonation.
+       *
+       * The plugin ships `impersonateUser` / `stopImpersonating` endpoints
+       * that store the admin's id in `sessions.impersonatedBy`, so the
+       * admin can return to their original session without logging out
+       * and back in.
+       *
+       * `adminRoles` matches the app-extended `users.role` column (see
+       * `better-auth.ts`). The plugin also requires the `users.banned /
+       * banReason / banExpires` columns — they exist for this reason, not
+       * because we expose any ban UI today.
+       */
+      adminPlugin({
+        defaultRole: "user",
+        adminRoles: ["admin"],
+        impersonationSessionDuration: 60 * 60,
       }),
       ...(config.captchaSecretKey
         ? [

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -24,6 +24,7 @@ export {
   type PollingOutboxConsumerConfig,
 } from "./outbox-consumer.ts"
 export { createOutboxWriter, OutboxEventWriterLive } from "./outbox-writer.ts"
+export { AdminUserRepositoryLive } from "./repositories/admin-user-repository.ts"
 export { AnnotationQueueItemRepositoryLive } from "./repositories/annotation-queue-item-repository.ts"
 export { AnnotationQueueRepositoryLive } from "./repositories/annotation-queue-repository.ts"
 export { ApiKeyRepositoryLive } from "./repositories/api-key-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
@@ -1,0 +1,98 @@
+import { AdminUserRepository } from "@domain/admin"
+import { UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { beforeAll, describe, expect, it } from "vitest"
+import { members, organizations, users } from "../schema/better-auth.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { AdminUserRepositoryLive } from "./admin-user-repository.ts"
+
+const pg = setupTestPostgres()
+
+const runWithLive = <A, E>(effect: Effect.Effect<A, E, AdminUserRepository>) =>
+  Effect.runPromise(effect.pipe(withPostgres(AdminUserRepositoryLive, pg.adminPostgresClient)))
+
+const makeId = (prefix: string): string => prefix.padEnd(24, "x").slice(0, 24)
+
+const ORG_A = makeId("org-user-alpha")
+const ORG_B = makeId("org-user-beta")
+const TARGET = makeId("user-target")
+const UNMEMBERED = makeId("user-unmembered")
+
+describe("AdminUserRepositoryLive.findById", () => {
+  beforeAll(async () => {
+    const baseTime = new Date("2025-06-01T12:00:00.000Z")
+
+    await pg.db.insert(users).values([
+      {
+        id: TARGET,
+        email: "target@example.com",
+        name: "Target User",
+        emailVerified: true,
+        role: "user" as const,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: UNMEMBERED,
+        email: "lonely@example.com",
+        name: "Lonely User",
+        emailVerified: true,
+        role: "user" as const,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+
+    await pg.db.insert(organizations).values([
+      { id: ORG_A, name: "Alpha", slug: "alpha", createdAt: baseTime, updatedAt: baseTime },
+      { id: ORG_B, name: "Beta Inc", slug: "beta-inc", createdAt: baseTime, updatedAt: baseTime },
+    ])
+
+    await pg.db.insert(members).values([
+      { id: makeId("mem-a"), organizationId: ORG_A, userId: TARGET, role: "member" as const, createdAt: baseTime },
+      { id: makeId("mem-b"), organizationId: ORG_B, userId: TARGET, role: "owner" as const, createdAt: baseTime },
+    ])
+  })
+
+  it("returns the user and all of their org memberships across tenants", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findById(UserId(TARGET))
+      }),
+    )
+
+    expect(result.id).toBe(TARGET)
+    expect(result.email).toBe("target@example.com")
+    expect(result.role).toBe("user")
+    expect(result.memberships.map((m) => m.organizationSlug).sort()).toEqual(["alpha", "beta-inc"])
+    // Membership roles are returned as-is from the members table (owner/admin/member).
+    const byOrg = new Map(result.memberships.map((m) => [m.organizationSlug, m.role]))
+    expect(byOrg.get("alpha")).toBe("member")
+    expect(byOrg.get("beta-inc")).toBe("owner")
+  })
+
+  it("returns an empty memberships array for a user with no org memberships", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findById(UserId(UNMEMBERED))
+      }),
+    )
+
+    expect(result.id).toBe(UNMEMBERED)
+    expect(result.memberships).toEqual([])
+  })
+
+  it("fails with NotFoundError for a non-existent user id", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminUserRepository
+          return yield* repo.findById(UserId(makeId("user-missing")))
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "User" })
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
@@ -1,0 +1,80 @@
+import { type AdminUserDetails, type AdminUserMembership, AdminUserRepository } from "@domain/admin"
+import { NotFoundError, SqlClient, type SqlClientShape, type UserId } from "@domain/shared"
+import { eq, inArray } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import type { Operator } from "../client.ts"
+import { members, organizations, users } from "../schema/better-auth.ts"
+
+type UserRoleValue = AdminUserDetails["role"]
+type MemberRoleValue = AdminUserMembership["role"]
+
+/**
+ * Live layer for the backoffice user-detail port.
+ *
+ * ⚠️ SECURITY: queries run **without** an `organization_id` filter and
+ * therefore see every user and every membership row in the database. This
+ * is only safe when the SqlClient was constructed with
+ * `OrganizationId("system")` (the default on `getAdminPostgresClient()`) so
+ * RLS is bypassed. Never provide this layer on the standard app-facing
+ * Postgres client.
+ */
+export const AdminUserRepositoryLive = Layer.effect(
+  AdminUserRepository,
+  Effect.gen(function* () {
+    const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+
+    return {
+      findById: (userId: UserId) =>
+        Effect.gen(function* () {
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: users.id,
+                email: users.email,
+                name: users.name,
+                image: users.image,
+                role: users.role,
+                createdAt: users.createdAt,
+              })
+              .from(users)
+              .where(eq(users.id, userId))
+              .limit(1),
+          )
+          const row = rows[0]
+          if (!row) {
+            return yield* Effect.fail(new NotFoundError({ entity: "User", id: userId }))
+          }
+
+          const membershipRows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                organizationId: organizations.id,
+                organizationName: organizations.name,
+                organizationSlug: organizations.slug,
+                role: members.role,
+              })
+              .from(members)
+              .innerJoin(organizations, eq(members.organizationId, organizations.id))
+              .where(inArray(members.userId, [row.id]))
+              .orderBy(organizations.name),
+          )
+
+          const details: AdminUserDetails = {
+            id: row.id,
+            email: row.email,
+            name: row.name ?? null,
+            image: row.image ?? null,
+            role: row.role as UserRoleValue,
+            memberships: membershipRows.map((m) => ({
+              organizationId: m.organizationId,
+              organizationName: m.organizationName,
+              organizationSlug: m.organizationSlug,
+              role: m.role as MemberRoleValue,
+            })),
+            createdAt: row.createdAt,
+          }
+          return details
+        }),
+    }
+  }),
+)

--- a/packages/platform/db-postgres/src/schema/better-auth.ts
+++ b/packages/platform/db-postgres/src/schema/better-auth.ts
@@ -33,6 +33,19 @@ export const users = latitudeSchema.table("users", {
   image: text("image"),
   /** App extension (not in BA reference). */
   role: varchar("role", { length: 50 }).notNull().default("user").$type<UserRole>(),
+  /**
+   * Required by the Better Auth `admin` plugin. Its unconditional
+   * `session.create.before` hook reads `user.banned` on every session
+   * creation, and the Drizzle adapter builds `SELECT`s from the plugin's
+   * declared schema — so the columns must physically exist in the DB.
+   *
+   * We install the plugin for its impersonation endpoints, not its ban
+   * feature. No ban UI is exposed today; leaving the columns in place
+   * means banning can be turned on later with zero schema work.
+   */
+  banned: boolean("banned").notNull().default(false),
+  banReason: text("ban_reason"),
+  banExpires: tzTimestamp("ban_expires"),
   stripeCustomerId: text("stripe_customer_id"),
   ...timestamps(),
 })
@@ -49,6 +62,14 @@ export const sessions = latitudeSchema.table(
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
     activeOrganizationId: text("active_organization_id"),
+    /**
+     * Set by the Better Auth `admin` plugin when an admin impersonates
+     * another user. Holds the admin's user id for the lifetime of the
+     * impersonation session, so `stopImpersonating` can restore the
+     * original session without requiring a re-login. Nullable in every
+     * other case.
+     */
+    impersonatedBy: text("impersonated_by"),
     ...timestamps(),
   },
   (t) => [


### PR DESCRIPTION
## Summary

- Staff can open a user detail page from search and impersonate that user for support. Better Auth's `admin` plugin (installed here) tracks the original admin in `sessions.impersonated_by`, so **"Stop impersonating" swaps back without a re-login** — a direct upgrade over v1's session-swap-with-no-return-path.
- Every start/stop is recorded through the outbox (`AdminImpersonationStarted` / `AdminImpersonationStopped`), and while impersonating every authenticated page renders a red top-bar banner plus a small overlay badge on the user avatar — two mitigations for v1's biggest footguns (no audit, no visual cue).
- Three-guard discipline is unchanged: route `notFound()` at the UI, `requireAdminSession()` at every server function, `getAdminPostgresClient()` + `OrganizationId("system")` at the DB. `stopImpersonating` is the one exception — it guards on `session.impersonatedBy` being set instead of role, because during impersonation the current session is the target's.

Builds on #2854. New routes: `/backoffice/users/$userId`. Schema adds four plugin-required columns (`users.banned/banReason/banExpires`, `sessions.impersonatedBy`) — no ban UI exposed, the columns exist solely so the admin plugin can function.

## Test plan

- [x] `pnpm --filter @app/web typecheck`, production build, and bundle-size check all pass locally
- [x] `@domain/admin`, `@platform/db-postgres`, `@app/web` test suites: 301+ tests green (34 new)
- [ ] Apply the migration locally (`pnpm --filter @platform/db-postgres pg:migrate`) and walk through the happy path as `owner@acme.com`: search → user detail → Impersonate → banner appears → navigate as target → Stop impersonating → back to admin
- [ ] `SELECT event_name, payload FROM latitude.events_outbox ORDER BY occurred_at DESC LIMIT 2;` shows the Started/Stopped pair with the right admin/target ids
- [ ] Defence-in-depth probe: as a non-admin, `curl -X POST` the `impersonateUser` / `adminGetUser` RPC URLs with a valid non-admin cookie → same "not found" error shape as hitting a nonsense URL (no 401/403 fingerprint)