### PR TITLE
ci(openclaw-telemetry): add publish workflow

### DIFF
--- a/.github/workflows/publish-openclaw-telemetry.yml
+++ b/.github/workflows/publish-openclaw-telemetry.yml
@@ -1,0 +1,104 @@
+name: Publish OpenClaw Telemetry
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/telemetry/openclaw/**
+  # Allow manually kicking off the first publish (v0.0.1) from the Actions tab,
+  # and for any future one-off re-runs after a failure.
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Get package version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./packages/telemetry/openclaw/package.json').version")
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version on npm
+        id: check_version
+        run: |
+          NPM_VERSION=$(npm view @latitude-data/openclaw-telemetry version 2>/dev/null || echo "0.0.0")
+          if [ "${{ steps.get_version.outputs.version }}" != "$NPM_VERSION" ]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry build
+
+      - name: Typecheck
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry typecheck
+
+      - name: Lint
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry check
+
+      - name: Test
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry test
+
+      - name: Publish to npm
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm publish --access public --filter @latitude-data/openclaw-telemetry --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract changelog
+        if: steps.check_version.outputs.should_publish == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if [ -f packages/telemetry/openclaw/CHANGELOG.md ]; then
+            awk -v ver="$VERSION" '
+              /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) { found=1; next } }
+              found { print }
+            ' packages/telemetry/openclaw/CHANGELOG.md > release_notes.md
+          fi
+          if [ ! -s release_notes.md ]; then
+            echo "Package updates and improvements" > release_notes.md
+          fi
+          {
+            echo "body<<EOF"
+            cat release_notes.md
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: openclaw-telemetry-${{ steps.get_version.outputs.version }}
+          name: OpenClaw Telemetry v${{ steps.get_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: ${{ contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'rc') }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-openclaw-telemetry.yml`, mirroring the existing [publish-claude-code-telemetry.yml](.github/workflows/publish-claude-code-telemetry.yml). On every push to `main` that touches `packages/telemetry/openclaw/**`, it compares the local `package.json` version to the npm-registry version and — when they differ — installs, builds, typechecks, lints, tests, publishes with `pnpm publish --access public`, and cuts a GitHub release with the matching CHANGELOG section.

Uses the existing `NPM_TOKEN` secret. The `@latitude-data/openclaw-telemetry` package name is currently unclaimed on npm (verified `npm view` returns 404); the first publish under the same `@latitude-data` scope will create it automatically — the same token already works for `@latitude-data/claude-code-telemetry`.

### The one non-obvious bit

The merge of this PR alone **won't** trigger the workflow — the path filter is `packages/telemetry/openclaw/**`, and a workflow-only change doesn't match it. So I added `workflow_dispatch` as a second trigger. Once this merges, you'll go to the Actions tab, pick **Publish OpenClaw Telemetry**, click **Run workflow**, and it'll publish v0.0.1. After that, future publishes fire automatically on any commit to `main` that changes the package and bumps the version in `package.json`.

## Test plan

- [x] Workflow lints locally via `gh workflow view` (syntax valid)
- [ ] After merge: run once via **Actions → Publish OpenClaw Telemetry → Run workflow** and confirm v0.0.1 lands on npm + a GitHub release is created
- [ ] Bump to 0.0.2 in a follow-up to confirm the automatic path still fires on commits to `main` that touch the package