### PR TITLE
fix(filters): clear input when a suggestion is selected

### DIFF
--- a/apps/web/src/components/filters-builder/multi-select-filter.tsx
+++ b/apps/web/src/components/filters-builder/multi-select-filter.tsx
@@ -69,7 +69,10 @@ export function MultiSelectFilter({
       autoHighlight
       modal
       value={[...selected]}
-      onValueChange={onChange}
+      onValueChange={(values: string[]) => {
+        onChange(values)
+        setInputValue("")
+      }}
       items={allItems}
       itemToStringValue={(v) => v}
       isItemEqualToValue={(a, b) => a === b}


### PR DESCRIPTION
The MultiSelectFilter kept the typed text in the input after a suggestion was accepted, so selecting "support" after typing "sup" rendered the chip plus the stale "sup" text in the input.