### PR TITLE
Open traces in new tab instead of navigating

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -51,6 +51,8 @@ interface ProjectTracesTableProps {
   readonly rowInteractionRole?: "button" | "link"
   /** When provided, renders the name column as a real link for accessibility (e.g., open in new tab). */
   readonly getTraceHref?: (trace: TraceRecord) => string
+  /** Target for the name-column link. Defaults to same-tab; use "_blank" to open in a new tab. */
+  readonly linkTarget?: "_self" | "_blank"
   readonly traceMetrics?: TraceMetrics | null | undefined
   readonly metricsLoading?: boolean | undefined
   readonly scrollAreaLayout?: "fill" | "intrinsic"
@@ -74,6 +76,7 @@ export function ProjectTracesTable({
   getTraceRowAriaLabel,
   rowInteractionRole,
   getTraceHref,
+  linkTarget,
   traceMetrics,
   metricsLoading,
   scrollAreaLayout,
@@ -106,6 +109,7 @@ export function ProjectTracesTable({
                 to={getTraceHref(trace)}
                 onClick={(e: React.MouseEvent) => e.stopPropagation()}
                 className="hover:underline"
+                {...(linkTarget === "_blank" ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               >
                 {displayName}
               </Link>
@@ -270,7 +274,7 @@ export function ProjectTracesTable({
           : {}),
       },
     ]
-  }, [showMetricSubheaders, traceMetrics, metricsLoading, projectId, getTraceHref])
+  }, [showMetricSubheaders, traceMetrics, metricsLoading, projectId, getTraceHref, linkTarget])
 
   const columns = useMemo(
     () => allColumns.filter((column) => visibleColumnIds.includes(column.key as TraceColumnId)),

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -265,11 +265,13 @@ function ProjectPage() {
   const hasNoTraces = totalTraceCount === 0 && !hasActiveFilters
   const showEmptyState = !isTracesCountLoading && hasNoTraces
 
-  if (isTracesCountLoading && hasNoTraces) {
+  // Navigating in with a `traceId` (e.g. from the issue detail panel) must
+  // not fall through to the loading/empty shortcut — those skip the drawer.
+  if (isTracesCountLoading && hasNoTraces && !activeTraceId) {
     return null
   }
 
-  if (showEmptyState) {
+  if (showEmptyState && !activeTraceId) {
     return (
       <Layout>
         <TracesEmptyState />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -265,13 +265,11 @@ function ProjectPage() {
   const hasNoTraces = totalTraceCount === 0 && !hasActiveFilters
   const showEmptyState = !isTracesCountLoading && hasNoTraces
 
-  // Navigating in with a `traceId` (e.g. from the issue detail panel) must
-  // not fall through to the loading/empty shortcut — those skip the drawer.
-  if (isTracesCountLoading && hasNoTraces && !activeTraceId) {
+  if (isTracesCountLoading && hasNoTraces) {
     return null
   }
 
-  if (showEmptyState && !activeTraceId) {
+  if (showEmptyState) {
     return (
       <Layout>
         <TracesEmptyState />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -14,7 +14,6 @@ import {
 } from "@repo/ui"
 import { formatCount } from "@repo/utils"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { useNavigate } from "@tanstack/react-router"
 import {
   ArrowDownIcon,
   ArrowDownRightIcon,
@@ -155,7 +154,6 @@ export function IssueDetailDrawer({
   readonly canNavigateNext: boolean
   readonly canNavigatePrev: boolean
 }) {
-  const navigate = useNavigate()
   const { toast } = useToast()
   const { data: issue, isLoading } = useIssueDetail({ projectId, issueId })
   const {
@@ -175,25 +173,17 @@ export function IssueDetailDrawer({
     issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
   const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
 
-  const handleTraceClick = (traceId: string) => {
-    void navigate({
-      to: "/projects/$projectSlug",
-      params: { projectSlug },
-      search: {
-        tab: "traces",
-        traceId,
-        traceDetailTab: "annotations",
-      },
-    })
-  }
-
   const getTraceHref = (trace: { readonly traceId: string }) => {
     return `/projects/${projectSlug}?tab=traces&traceId=${trace.traceId}&traceDetailTab=annotations`
   }
 
+  const openTraceInNewTab = (traceId: string) => {
+    window.open(getTraceHref({ traceId }), "_blank", "noopener,noreferrer")
+  }
+
   const getTraceRowAriaLabel = (input: { readonly traceId: string; readonly rootSpanName: string }) => {
     const shortName = input.rootSpanName || input.traceId.slice(0, 8)
-    return `Open trace ${shortName} with annotations tab in traces dashboard`
+    return `Open trace ${shortName} with annotations tab in a new tab`
   }
 
   const runLifecycleCommand = async (command: "resolve" | "unresolve" | "ignore" | "unignore", override?: boolean) => {
@@ -431,9 +421,10 @@ export function IssueDetailDrawer({
               isLoading={tracesLoading}
               visibleColumnIds={ISSUE_TRACE_COLUMN_IDS}
               defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
-              onTraceClick={(trace) => handleTraceClick(trace.traceId)}
+              onTraceClick={(trace) => openTraceInNewTab(trace.traceId)}
               getTraceRowAriaLabel={getTraceRowAriaLabel}
               getTraceHref={getTraceHref}
+              linkTarget="_blank"
               rowInteractionRole="link"
               infiniteScroll={infiniteScroll}
               blankSlate="This issue has not been seen on any traces yet."


### PR DESCRIPTION
## Summary
Changed trace navigation behavior to open traces in a new tab instead of navigating within the same tab. This improves UX by preserving the current issue detail view while allowing users to inspect traces in parallel.

## Key Changes
- Removed `useNavigate` hook from `IssueDetailDrawer` component
- Replaced `handleTraceClick` function that used programmatic navigation with `openTraceInNewTab` that uses `window.open()` with `_blank` target
- Added `linkTarget` prop to `ProjectTracesTable` component to support configurable link targets (`_self` or `_blank`)
- Updated trace name column links to conditionally apply `target="_blank"` and `rel="noopener noreferrer"` attributes based on the `linkTarget` prop
- Updated aria-label text from "in traces dashboard" to "in a new tab" to reflect the new behavior
- Added `linkTarget` to the dependency array of the columns memoization hook

## Implementation Details
- The `getTraceHref` function continues to generate the correct trace URL with query parameters
- The new `openTraceInNewTab` function wraps `window.open()` with security attributes (`noopener,noreferrer`) to prevent the opened page from accessing the `window.opener` property
- The `ProjectTracesTable` component now supports both same-tab and new-tab navigation patterns through the `linkTarget` prop, making it more flexible for different use cases

https://claude.ai/code/session_01YHZvZjJYWGFkvVRVTNA5mH