### PR TITLE
fix(openclaw-telemetry): make install + discovery + config + content-gate actually work

### DIFF
--- a/packages/telemetry/openclaw/CHANGELOG.md
+++ b/packages/telemetry/openclaw/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2026-04-25
+
+End-to-end install fix. The 0.0.1 install path was broken in five places, all reported by an OpenClaw 2026.4.21 maintainer who tried it on a real install. Re-running `npx -y @latitude-data/openclaw-telemetry install` cleans up any leftover 0.0.1 keys.
+
+### Fixed
+
+- **`openclaw.json` written by the installer is now accepted by OpenClaw's strict zod schema.** 0.0.1 wrote `hooks.allowConversationAccess: true` (the strict `hooks` namespace only accepts `allowPromptInjection` on older OpenClaw versions, and `allowPromptInjection`+`allowConversationAccess` on 2026.4.22+) and `LATITUDE_*` keys at top-level `env` (the root schema's `env` block only accepts `{shellEnv, vars}`, not arbitrary keys). Both fields caused the gateway file-watcher to quarantine the new config as `clobbered.<ts>` and silently roll back to `last-good`. We now write everything under `plugins.entries[id].config`, which is `record(string, unknown)` and accepted by every OpenClaw version.
+- **Plugin discovery now finds us.** OpenClaw scans `<configDir>/extensions/<plugin>` for an `openclaw.plugin.json` manifest at the plugin root — npm `main` is irrelevant, and global `npm install -g` is not enough. Two changes: (1) we now ship `openclaw.plugin.json` in the package, with the required `id` and `configSchema`, and (2) the installer materializes the package's `dist/` + manifest into `~/.openclaw/extensions/latitude-telemetry/` so discovery picks it up.
+- **`api.pluginConfig` is now the primary source of credentials.** 0.0.1's runtime read `process.env.LATITUDE_*` and ignored `api.pluginConfig`. Combined with the schema-rejection bug, the plugin disabled itself silently because creds were dropped on the floor before they reached our runtime. The new `loadConfig` reads `api.pluginConfig` first (the user's `plugins.entries[id].config`), and falls back to env vars for compatibility.
+- **`allowConversationAccess` is now actually honored.** 0.0.1 advertised the flag but always attached full content to spans. The new runtime gates `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`, and the interaction's `user_prompt` on this flag. When off, spans still emit with the same shape — timing, token usage, model name, agent name, ids — just scrubbed of payload content. A `latitude.captured.content` boolean attribute makes the gate state visible in the Latitude UI.
+
+### Changed
+
+- **Default capture posture flipped at runtime, kept on at install.** The runtime now defaults `allowConversationAccess` to `false` if the key is missing from `pluginConfig` (privacy-preserving default for hand-edited configs). The interactive installer still writes `true` by default — pass `--no-content` to install with structural-only telemetry. This means re-installing on top of an old config is a no-op for capture posture; only hand-edited configs that drop the key change behaviour.
+- **Migration on re-install.** `npx -y @latitude-data/openclaw-telemetry install` now strips `hooks.allowConversationAccess` and any top-level `env.LATITUDE_*` keys our 0.0.1 installer left behind, before writing the new entry. No manual cleanup required.
+
+### Added
+
+- `openclaw.plugin.json` manifest at the package root, with a JSON schema for `apiKey` / `project` / `baseUrl` / `allowConversationAccess` / `enabled` / `debug`.
+- `--no-content` install flag for shipping structural telemetry without payloads.
+- `latitude.captured.content` boolean attribute on every span so operators can see whether content capture was on for a given trace.
+
 ## [0.0.1] - 2026-04-24
 
 ### Added

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -8,7 +8,10 @@ OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) 
 npx -y @latitude-data/openclaw-telemetry install
 ```
 
-The installer prompts for your Latitude API key and project slug, then writes a plugin entry to `~/.openclaw/openclaw.json` with `hooks.allowConversationAccess: true` so OpenClaw forwards raw conversation content to our handlers.
+The installer prompts for your Latitude API key and project slug, then:
+
+1. Materializes the plugin's runtime files into `~/.openclaw/extensions/latitude-telemetry/` (where OpenClaw's plugin discovery scans).
+2. Writes the plugin entry to `~/.openclaw/openclaw.json` under `plugins.entries["@latitude-data/openclaw-telemetry"].config` — credentials, base URL, and the `allowConversationAccess` flag all live here.
 
 Restart the OpenClaw gateway after install:
 
@@ -27,6 +30,7 @@ That's it. Traces show up at `https://console.latitude.so/projects/<your-slug>`.
 | `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
 | `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
 | `--yes` / `--no-prompt` | Skip all prompts. Required for non-TTY / CI invocations. |
+| `--no-content` | Skip raw prompt/response/tool I/O capture. Spans still emit with timing, token usage, model name, and ids. |
 
 Re-running `install` is idempotent — existing values are preserved.
 
@@ -36,7 +40,7 @@ Re-running `install` is idempotent — existing values are preserved.
 npx -y @latitude-data/openclaw-telemetry uninstall
 ```
 
-Shows a plan, asks for confirmation, then removes the plugin entry and the `LATITUDE_*` env vars from `~/.openclaw/openclaw.json`. A backup is saved at `openclaw.json.latitude-bak`.
+Shows a plan, asks for confirmation, then removes the plugin entry from `~/.openclaw/openclaw.json` and the materialized files at `~/.openclaw/extensions/latitude-telemetry/`. A backup of the settings file is saved at `openclaw.json.latitude-bak`.
 
 ## What gets sent
 
@@ -66,48 +70,39 @@ OpenClaw runs LLM hooks **fire-and-forget** (see [`src/plugins/hooks.ts`](https:
 
 ## Configuration reference
 
-Everything the installer writes. You can edit `~/.openclaw/openclaw.json` directly if you want to tweak:
+The installer writes the plugin entry under `plugins.entries[id].config`. Every key is optional except `apiKey` and `project`. You can hand-edit `~/.openclaw/openclaw.json` to tweak:
 
-### `env`
+### `plugins.entries["@latitude-data/openclaw-telemetry"].config`
 
-| Variable | Required | Default | Description |
+| Key | Required | Default | Description |
 | --- | --- | --- | --- |
-| `LATITUDE_API_KEY` | yes | — | Bearer token for Latitude ingestion. |
-| `LATITUDE_PROJECT` | yes | — | Slug of the project to route traces into. |
-| `LATITUDE_BASE_URL` | no | `https://ingest.latitude.so` | Override ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
-| `LATITUDE_OPENCLAW_ENABLED` | no | `1` | Set to `0` to pause the plugin without uninstalling. |
-| `LATITUDE_DEBUG` | no | — | Set to `1` to log diagnostics to stderr. |
+| `apiKey` | yes | — | Bearer token for Latitude ingestion. |
+| `project` | yes | — | Slug of the project to route traces into. |
+| `baseUrl` | no | `https://ingest.latitude.so` | Override OTLP ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
+| `allowConversationAccess` | no | `false` | When `true`, attach raw prompts, assistant responses, system instructions, and tool I/O to spans. When `false`, emit only timing, token usage, model name, agent id, and structural ids — same span tree, scrubbed payloads. |
+| `enabled` | no | `true` | Set to `false` to pause emission without uninstalling. |
+| `debug` | no | `false` | Log diagnostic lines to stderr (visible in the gateway log). |
 
-### `plugins.entries`
+### Environment variable fallbacks
 
-```json
-{
-  "@latitude-data/openclaw-telemetry": {
-    "enabled": true,
-    "hooks": {
-      "allowConversationAccess": true
-    }
-  }
-}
-```
-
-`allowConversationAccess` is load-bearing — OpenClaw scrubs payloads from `llm_input` / `llm_output` / `agent_end` for third-party plugins unless they opt in explicitly.
+If a key isn't set in `config`, the runtime falls back to environment variables on the gateway process. `LATITUDE_API_KEY`, `LATITUDE_PROJECT`, `LATITUDE_BASE_URL`, `LATITUDE_DEBUG`, and `LATITUDE_OPENCLAW_ENABLED` are all read this way. The installer doesn't set them — pluginConfig is the canonical surface — but they're useful for kicking debug on/off without editing `openclaw.json`.
 
 ### Manual installation
 
-If the installer doesn't fit your setup, the equivalent `openclaw.json` is:
+If the installer doesn't fit your setup, you need two things:
+
+1. **The plugin files** under a directory OpenClaw discovers (`~/.openclaw/extensions/<name>/` or any path listed in `plugins.load.paths`). The directory must contain at minimum `openclaw.plugin.json` and the compiled `dist/plugin.js`. Easiest: copy them out of the installed `node_modules/@latitude-data/openclaw-telemetry/`.
+2. **The plugin entry** in `~/.openclaw/openclaw.json`:
 
 ```jsonc
 {
-  "env": {
-    "LATITUDE_API_KEY": "lat_xxx",
-    "LATITUDE_PROJECT": "my-openclaw-project"
-  },
   "plugins": {
     "entries": {
       "@latitude-data/openclaw-telemetry": {
         "enabled": true,
-        "hooks": {
+        "config": {
+          "apiKey": "lat_xxx",
+          "project": "my-openclaw-project",
           "allowConversationAccess": true
         }
       }
@@ -116,17 +111,17 @@ If the installer doesn't fit your setup, the equivalent `openclaw.json` is:
 }
 ```
 
-Then ensure the package is installed where OpenClaw can load it (either in your OpenClaw workspace, or globally via `npm i -g @latitude-data/openclaw-telemetry`).
+Don't put `LATITUDE_*` keys at top-level `env` — OpenClaw's strict zod schema rejects them. Don't put `allowConversationAccess` under `hooks` either — that field is OpenClaw's strict reserved namespace and only accepts `allowPromptInjection` (older versions) or `allowPromptInjection` + `allowConversationAccess` (2026.4.22+). Our config bucket is `plugins.entries[id].config`, which is `record(string, unknown)` and accepted across all versions.
+
+After editing, run `openclaw config validate` — it should print `valid: true`. Then `openclaw gateway restart`.
 
 ## Privacy
 
-This plugin reads every LLM input and output and sends the **full content** to Latitude — system prompts, user prompts, assistant responses, tool I/O. There is no per-flag opt-in once `allowConversationAccess` is set: everything gets shipped.
+By default we emit **structural telemetry only** — span tree, timings, token usage, model name, agent name, run/session ids — but **no prompt or response content**. You opt in to content capture by setting `allowConversationAccess: true` (the default the interactive installer writes).
 
-If that's not what you want:
+When `allowConversationAccess` is on, every LLM call's full input messages, assistant output, system instructions, and tool I/O are attached to spans. Pass `--no-content` to the installer (or set the flag to `false` in `openclaw.json`) if you want telemetry without payloads.
 
-- Don't install the plugin.
-- Set `LATITUDE_OPENCLAW_ENABLED=0` in your shell before starting a sensitive session.
-- Run `uninstall`.
+To pause emission entirely without uninstalling, set `LATITUDE_OPENCLAW_ENABLED=0` in the gateway environment.
 
 ## Supported OpenClaw versions
 

--- a/packages/telemetry/openclaw/openclaw.plugin.json
+++ b/packages/telemetry/openclaw/openclaw.plugin.json
@@ -1,0 +1,40 @@
+{
+  "id": "@latitude-data/openclaw-telemetry",
+  "name": "Latitude Telemetry",
+  "description": "Streams every OpenClaw agent run to Latitude as OTLP traces — full prompt, message history, assistant output, tool I/O, token usage, and agent name.",
+  "version": "0.0.2",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "description": "Latitude bearer token. Required."
+      },
+      "project": {
+        "type": "string",
+        "description": "Latitude project slug to route traces into. Required."
+      },
+      "baseUrl": {
+        "type": "string",
+        "description": "OTLP ingest origin. Defaults to https://ingest.latitude.so. Override for staging/dev."
+      },
+      "allowConversationAccess": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, attach raw prompts, assistant responses, system instructions, and tool I/O to spans. When false, emit only timing, token usage, model name, agent id, and ids."
+      },
+      "debug": {
+        "type": "boolean",
+        "default": false,
+        "description": "Log diagnostic lines to stderr."
+      },
+      "enabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Set to false to pause emission without uninstalling."
+      }
+    },
+    "required": ["apiKey", "project"]
+  }
+}

--- a/packages/telemetry/openclaw/openclaw.plugin.json
+++ b/packages/telemetry/openclaw/openclaw.plugin.json
@@ -5,7 +5,7 @@
   "version": "0.0.2",
   "configSchema": {
     "type": "object",
-    "additionalProperties": false,
+    "additionalProperties": true,
     "properties": {
       "apiKey": {
         "type": "string",

--- a/packages/telemetry/openclaw/package.json
+++ b/packages/telemetry/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/openclaw-telemetry",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "OpenClaw plugin that streams LLM calls, tool executions, and agent runs to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "openclaw.plugin.json"
   ],
   "bin": {
     "latitude-openclaw": "./dist/cli.js"

--- a/packages/telemetry/openclaw/src/config.test.ts
+++ b/packages/telemetry/openclaw/src/config.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { loadConfig } from "./config.ts"
+
+describe("loadConfig", () => {
+  it("prefers pluginConfig over env vars", () => {
+    const config = loadConfig({ apiKey: "from-plugin-config", project: "p" }, {
+      LATITUDE_API_KEY: "from-env",
+      LATITUDE_PROJECT: "p-env",
+    } as NodeJS.ProcessEnv)
+    expect(config.apiKey).toBe("from-plugin-config")
+    expect(config.project).toBe("p")
+  })
+
+  it("falls back to env vars when pluginConfig is empty", () => {
+    const config = loadConfig({}, { LATITUDE_API_KEY: "k", LATITUDE_PROJECT: "p" } as NodeJS.ProcessEnv)
+    expect(config.apiKey).toBe("k")
+    expect(config.project).toBe("p")
+    expect(config.enabled).toBe(true)
+  })
+
+  it("falls back to env vars when pluginConfig is undefined (no plugin entry yet)", () => {
+    const config = loadConfig(undefined, {
+      LATITUDE_API_KEY: "k",
+      LATITUDE_PROJECT: "p",
+    } as NodeJS.ProcessEnv)
+    expect(config.apiKey).toBe("k")
+    expect(config.project).toBe("p")
+  })
+
+  it("defaults baseUrl to production ingest", () => {
+    const config = loadConfig({ apiKey: "k", project: "p" }, {} as NodeJS.ProcessEnv)
+    expect(config.baseUrl).toBe("https://ingest.latitude.so")
+  })
+
+  it("respects baseUrl override from pluginConfig", () => {
+    const config = loadConfig(
+      { apiKey: "k", project: "p", baseUrl: "https://staging-ingest.latitude.so" },
+      {} as NodeJS.ProcessEnv,
+    )
+    expect(config.baseUrl).toBe("https://staging-ingest.latitude.so")
+  })
+
+  it("defaults allowConversationAccess to false (privacy-preserving default)", () => {
+    const config = loadConfig({ apiKey: "k", project: "p" }, {} as NodeJS.ProcessEnv)
+    expect(config.allowConversationAccess).toBe(false)
+  })
+
+  it("honors allowConversationAccess: true from pluginConfig", () => {
+    const config = loadConfig({ apiKey: "k", project: "p", allowConversationAccess: true }, {} as NodeJS.ProcessEnv)
+    expect(config.allowConversationAccess).toBe(true)
+  })
+
+  it("disables when explicit pluginConfig.enabled = false even with creds", () => {
+    const config = loadConfig({ apiKey: "k", project: "p", enabled: false }, {} as NodeJS.ProcessEnv)
+    expect(config.enabled).toBe(false)
+  })
+
+  it("disables when LATITUDE_OPENCLAW_ENABLED=0", () => {
+    const config = loadConfig({ apiKey: "k", project: "p" }, { LATITUDE_OPENCLAW_ENABLED: "0" } as NodeJS.ProcessEnv)
+    expect(config.enabled).toBe(false)
+  })
+
+  it("disables when creds are missing", () => {
+    const config = loadConfig({}, {} as NodeJS.ProcessEnv)
+    expect(config.enabled).toBe(false)
+    expect(config.apiKey).toBe("")
+    expect(config.project).toBe("")
+  })
+
+  it("turns debug on via LATITUDE_DEBUG=1 even when pluginConfig doesn't set it", () => {
+    const config = loadConfig({ apiKey: "k", project: "p" }, { LATITUDE_DEBUG: "1" } as NodeJS.ProcessEnv)
+    expect(config.debug).toBe(true)
+  })
+
+  it("ignores non-string apiKey in pluginConfig (defensive against malformed config.json)", () => {
+    const config = loadConfig({ apiKey: 123 as unknown as string, project: "p" }, {} as NodeJS.ProcessEnv)
+    // Falls back through env (empty) → empty string → disabled.
+    expect(config.apiKey).toBe("")
+    expect(config.enabled).toBe(false)
+  })
+})

--- a/packages/telemetry/openclaw/src/config.ts
+++ b/packages/telemetry/openclaw/src/config.ts
@@ -4,13 +4,57 @@ export interface Config {
   project: string
   enabled: boolean
   debug: boolean
+  /**
+   * When false, the plugin still emits one span per LLM call / tool / run, but
+   * scrubs raw conversation content (input/output messages, system prompt,
+   * tool args, tool results, the surfaced first-prompt). Token counts, model
+   * names, agent ids, and timings are unaffected.
+   */
+  allowConversationAccess: boolean
 }
 
-export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
-  const apiKey = env.LATITUDE_API_KEY ?? ""
-  const baseUrl = env.LATITUDE_BASE_URL ?? "https://ingest.latitude.so"
-  const project = env.LATITUDE_PROJECT ?? ""
-  const enabled = (env.LATITUDE_OPENCLAW_ENABLED ?? "1") !== "0" && apiKey !== "" && project !== ""
-  const debug = env.LATITUDE_DEBUG === "1"
-  return { apiKey, baseUrl, project, enabled, debug }
+const DEFAULT_BASE_URL = "https://ingest.latitude.so"
+
+/**
+ * Build a `Config` from OpenClaw's per-plugin config bucket plus environment
+ * variables. The plugin SDK passes `api.pluginConfig` (the user's
+ * `plugins.entries[id].config` block) to the registration function — that's
+ * the primary source. Env vars are kept as a fallback so existing deployments
+ * with `LATITUDE_*` already exported in the gateway environment keep working,
+ * and so that `LATITUDE_DEBUG=1` can be flipped without editing openclaw.json.
+ */
+export function loadConfig(
+  pluginConfig: Record<string, unknown> | undefined = undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Config {
+  const fromOpts = pluginConfig ?? {}
+
+  const apiKey = pickString(fromOpts.apiKey) ?? env.LATITUDE_API_KEY ?? ""
+  const project = pickString(fromOpts.project) ?? env.LATITUDE_PROJECT ?? ""
+  const baseUrl = pickString(fromOpts.baseUrl) ?? env.LATITUDE_BASE_URL ?? DEFAULT_BASE_URL
+
+  const debug = pickBool(fromOpts.debug) ?? env.LATITUDE_DEBUG === "1"
+  const allowConversationAccess = pickBool(fromOpts.allowConversationAccess) ?? false
+
+  // Allow either env var or pluginConfig to disable. Falsy `enabled: false` in
+  // pluginConfig wins; otherwise we require both api key and project.
+  const explicitlyDisabled = pickBool(fromOpts.enabled) === false || (env.LATITUDE_OPENCLAW_ENABLED ?? "1") === "0"
+  const hasCreds = apiKey !== "" && project !== ""
+
+  return {
+    apiKey,
+    baseUrl,
+    project,
+    debug,
+    allowConversationAccess,
+    enabled: hasCreds && !explicitlyDisabled,
+  }
+}
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function pickBool(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
 }

--- a/packages/telemetry/openclaw/src/install-files.ts
+++ b/packages/telemetry/openclaw/src/install-files.ts
@@ -1,0 +1,78 @@
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { PLUGIN_INSTALL_DIR } from "./settings-file.ts"
+
+/**
+ * Copies the plugin's runtime files into `~/.openclaw/extensions/latitude-telemetry/`
+ * so OpenClaw's discovery (`<configDir>/extensions/<plugin>`) picks it up.
+ *
+ * `npx -y @latitude-data/openclaw-telemetry` runs the CLI from a temporary npm
+ * location — relying on that path persisting across runs (or even across the
+ * gateway restart that follows install) is unsafe. So we materialize a stable
+ * copy under the user's OpenClaw config dir, the same path OpenClaw scans on
+ * startup. Layout we produce:
+ *
+ *   ~/.openclaw/extensions/latitude-telemetry/
+ *     openclaw.plugin.json   <- the manifest, required by discovery
+ *     package.json           <- minimal — keeps node module-resolution happy
+ *     dist/                  <- compiled plugin entrypoint(s)
+ */
+export function installPluginFiles(): { destination: string; entryPath: string } {
+  // The CLI runs from `dist/cli.js`. Resolve the package root from there.
+  const here = dirname(fileURLToPath(import.meta.url))
+  const packageRoot = resolve(here, "..") // dist/cli.js -> dist/ -> package root
+
+  const manifestSrc = join(packageRoot, "openclaw.plugin.json")
+  const distSrc = join(packageRoot, "dist")
+  const pkgSrc = join(packageRoot, "package.json")
+
+  if (!existsSync(manifestSrc)) {
+    throw new Error(
+      `Cannot install: missing openclaw.plugin.json at ${manifestSrc}. This is a packaging bug — please file an issue.`,
+    )
+  }
+  if (!existsSync(distSrc)) {
+    throw new Error(`Cannot install: missing compiled dist at ${distSrc}.`)
+  }
+
+  // Wipe and recreate so a re-install isn't polluted by a previous version's
+  // files. Idempotent.
+  if (existsSync(PLUGIN_INSTALL_DIR)) rmSync(PLUGIN_INSTALL_DIR, { recursive: true, force: true })
+  mkdirSync(PLUGIN_INSTALL_DIR, { recursive: true })
+
+  copyFileSync(manifestSrc, join(PLUGIN_INSTALL_DIR, "openclaw.plugin.json"))
+  cpSync(distSrc, join(PLUGIN_INSTALL_DIR, "dist"), { recursive: true })
+
+  // Write a minimal package.json so anything that runs `require("./dist/plugin.js")`
+  // from a `type: module` context still resolves cleanly (we mirror the source
+  // package's `type` and `main` fields).
+  if (existsSync(pkgSrc)) {
+    const sourcePkg = JSON.parse(readFileSync(pkgSrc, "utf-8")) as {
+      name?: string
+      version?: string
+      type?: string
+      main?: string
+    }
+    const minimalPkg = {
+      name: sourcePkg.name,
+      version: sourcePkg.version,
+      type: sourcePkg.type ?? "module",
+      main: sourcePkg.main ?? "./dist/plugin.js",
+      private: true,
+    }
+    writeFileSync(join(PLUGIN_INSTALL_DIR, "package.json"), `${JSON.stringify(minimalPkg, null, 2)}\n`, "utf-8")
+  }
+
+  return {
+    destination: PLUGIN_INSTALL_DIR,
+    entryPath: join(PLUGIN_INSTALL_DIR, "dist", "plugin.js"),
+  }
+}
+
+/** Remove the materialized plugin directory under `~/.openclaw/extensions/`. */
+export function removePluginFiles(): boolean {
+  if (!existsSync(PLUGIN_INSTALL_DIR)) return false
+  rmSync(PLUGIN_INSTALL_DIR, { recursive: true, force: true })
+  return true
+}

--- a/packages/telemetry/openclaw/src/otlp.test.ts
+++ b/packages/telemetry/openclaw/src/otlp.test.ts
@@ -73,7 +73,7 @@ function sampleRun(overrides: Partial<RunRecord> = {}): RunRecord {
 
 describe("buildOtlpRequest", () => {
   it("emits an interaction + llm_request + tool_execution span tree", () => {
-    const req = buildOtlpRequest(sampleRun())
+    const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: true })
     const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
     expect(spans).toHaveLength(3)
     const [interaction, llm, tool] = spans
@@ -88,7 +88,7 @@ describe("buildOtlpRequest", () => {
   })
 
   it("tags every span with the agent name", () => {
-    const req = buildOtlpRequest(sampleRun())
+    const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: true })
     const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
     for (const s of spans) {
       const attrs = attrMap(s.attributes)
@@ -98,7 +98,7 @@ describe("buildOtlpRequest", () => {
   })
 
   it("captures everything on the llm_request span", () => {
-    const req = buildOtlpRequest(sampleRun())
+    const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: true })
     const llm = req.resourceSpans[0]?.scopeSpans[0]?.spans[1]
     const attrs = attrMap(llm?.attributes ?? [])
 
@@ -142,7 +142,7 @@ describe("buildOtlpRequest", () => {
   })
 
   it("captures tool arguments and results on the tool span", () => {
-    const req = buildOtlpRequest(sampleRun())
+    const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: true })
     const tool = req.resourceSpans[0]?.scopeSpans[0]?.spans[2]
     const attrs = attrMap(tool?.attributes ?? [])
     expect(attrs["gen_ai.tool.name"]).toBe("read_file")
@@ -162,7 +162,7 @@ describe("buildOtlpRequest", () => {
       usage: { input: 8, output: 2, total: 10 },
       toolCalls: [],
     })
-    const req = buildOtlpRequest(run)
+    const req = buildOtlpRequest(run, { allowConversationAccess: true })
     const interaction = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
     const attrs = attrMap(interaction?.attributes ?? [])
     expect(attrs["gen_ai.usage.input_tokens"]).toBe("50")
@@ -177,7 +177,7 @@ describe("buildOtlpRequest", () => {
     if (!tool) throw new Error("expected a tool call")
     tool.error = "boom"
     tool.result = undefined
-    const req = buildOtlpRequest(run)
+    const req = buildOtlpRequest(run, { allowConversationAccess: true })
     const toolSpan = req.resourceSpans[0]?.scopeSpans[0]?.spans[2]
     expect(toolSpan?.status.code).toBe(2)
     const attrs = attrMap(toolSpan?.attributes ?? [])
@@ -187,7 +187,7 @@ describe("buildOtlpRequest", () => {
 
   it("marks failed runs with interaction status code 2", () => {
     const run = sampleRun({ success: false, error: "run failed" })
-    const req = buildOtlpRequest(run)
+    const req = buildOtlpRequest(run, { allowConversationAccess: true })
     const interaction = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
     expect(interaction?.status.code).toBe(2)
     const attrs = attrMap(interaction?.attributes ?? [])
@@ -208,10 +208,63 @@ describe("buildOtlpRequest", () => {
       durationMs: 50,
       agentId: "router-agent",
     })
-    const req = buildOtlpRequest(run)
+    const req = buildOtlpRequest(run, { allowConversationAccess: true })
     const spans = req.resourceSpans[0]?.scopeSpans[0]?.spans ?? []
     const orphan = spans.find((s) => s.name === "tool:drift")
     expect(orphan).toBeDefined()
     expect(orphan?.parentSpanId).toBe(spans[0]?.spanId)
+  })
+
+  describe("when allowConversationAccess is false", () => {
+    it("scrubs content attributes from llm_request spans", () => {
+      const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: false })
+      const llm = req.resourceSpans[0]?.scopeSpans[0]?.spans[1]
+      const attrs = attrMap(llm?.attributes ?? [])
+
+      // Content gone.
+      expect(attrs["gen_ai.system_instructions"]).toBeUndefined()
+      expect(attrs["gen_ai.input.messages"]).toBeUndefined()
+      expect(attrs["gen_ai.output.messages"]).toBeUndefined()
+
+      // Structural / numeric attrs still present.
+      expect(attrs["gen_ai.request.model"]).toBe("gpt-5")
+      expect(attrs["gen_ai.usage.input_tokens"]).toBe("42")
+      expect(attrs["gen_ai.usage.total_tokens"]).toBe("49")
+      expect(attrs["openclaw.agent.id"]).toBe("router-agent")
+      expect(attrs["openclaw.run.id"]).toBe("run-1")
+      expect(attrs["latitude.captured.content"]).toBe("false")
+    })
+
+    it("scrubs tool args + result but keeps name/id/duration/error/agent", () => {
+      const run = sampleRun()
+      const tool = run.llmCalls[0]?.toolCalls[0]
+      if (!tool) throw new Error("expected a tool call")
+      tool.error = undefined
+      const req = buildOtlpRequest(run, { allowConversationAccess: false })
+      const toolSpan = req.resourceSpans[0]?.scopeSpans[0]?.spans[2]
+      const attrs = attrMap(toolSpan?.attributes ?? [])
+
+      // Content gone.
+      expect(attrs["gen_ai.tool.call.arguments"]).toBeUndefined()
+      expect(attrs["gen_ai.tool.call.result"]).toBeUndefined()
+
+      // Structural still present.
+      expect(attrs["gen_ai.tool.name"]).toBe("read_file")
+      expect(attrs["gen_ai.tool.call.id"]).toBe("tc-1")
+      expect(attrs["tool.duration_ms"]).toBe("50")
+      expect(attrs["openclaw.agent.id"]).toBe("router-agent")
+      expect(attrs["latitude.captured.content"]).toBe("false")
+    })
+
+    it("scrubs user_prompt from interaction span but keeps token/agent attrs", () => {
+      const req = buildOtlpRequest(sampleRun(), { allowConversationAccess: false })
+      const interaction = req.resourceSpans[0]?.scopeSpans[0]?.spans[0]
+      const attrs = attrMap(interaction?.attributes ?? [])
+
+      expect(attrs.user_prompt).toBeUndefined()
+      expect(attrs["gen_ai.usage.total_tokens"]).toBe("49")
+      expect(attrs["openclaw.agent.id"]).toBe("router-agent")
+      expect(attrs["latitude.captured.content"]).toBe("false")
+    })
   })
 })

--- a/packages/telemetry/openclaw/src/otlp.ts
+++ b/packages/telemetry/openclaw/src/otlp.ts
@@ -11,11 +11,24 @@ import type {
 } from "./types.ts"
 
 const SCOPE_NAME = "@latitude-data/openclaw-telemetry"
-const SCOPE_VERSION = "0.0.1"
+const SCOPE_VERSION = "0.0.2"
+
+interface BuildOptions {
+  /**
+   * When false, content attributes are scrubbed from spans:
+   *   - `user_prompt` (interaction)
+   *   - `gen_ai.system_instructions`, `gen_ai.input.messages`,
+   *     `gen_ai.output.messages` (llm_request)
+   *   - `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` (tool_execution)
+   * Timing, token usage, model name, ids, agent name, and counts are
+   * always emitted regardless of this flag.
+   */
+  allowConversationAccess: boolean
+}
 
 /** Build an OTLP export request for a single completed agent run. */
-export function buildOtlpRequest(run: RunRecord): OtlpExportRequest {
-  const spans = buildRunSpans(run)
+export function buildOtlpRequest(run: RunRecord, options: BuildOptions): OtlpExportRequest {
+  const spans = buildRunSpans(run, options)
   const rs: OtlpResourceSpans = {
     resource: { attributes: resourceAttrs() },
     scopeSpans: [{ scope: { name: SCOPE_NAME, version: SCOPE_VERSION }, spans }],
@@ -23,30 +36,30 @@ export function buildOtlpRequest(run: RunRecord): OtlpExportRequest {
   return { resourceSpans: [rs] }
 }
 
-function buildRunSpans(run: RunRecord): OtlpSpan[] {
+function buildRunSpans(run: RunRecord, options: BuildOptions): OtlpSpan[] {
   const traceId = hashHex(`${run.sessionId ?? "session"}:${run.runId}`, 32)
   const interactionSpanId = hashHex(`${traceId}:run`, 16)
-  const out: OtlpSpan[] = [buildInteractionSpan(traceId, interactionSpanId, run)]
+  const out: OtlpSpan[] = [buildInteractionSpan(traceId, interactionSpanId, run, options)]
 
   run.llmCalls.forEach((call, idx) => {
     const callSpanId = hashHex(`${traceId}:call:${idx}`, 16)
-    out.push(buildLlmSpan(traceId, interactionSpanId, callSpanId, call, idx, run))
+    out.push(buildLlmSpan(traceId, interactionSpanId, callSpanId, call, idx, run, options))
     // Tool spans are siblings of the llm_request, parented on the interaction
     // span so the run timeline renders as: llm → tool → llm → tool → ...
     call.toolCalls.forEach((tool, tIdx) => {
       const toolSpanId = hashHex(`${traceId}:call:${idx}:tool:${tIdx}`, 16)
-      out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run))
+      out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run, options))
     })
   })
   run.orphanTools.forEach((tool, idx) => {
     const toolSpanId = hashHex(`${traceId}:orphan-tool:${idx}`, 16)
-    out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run))
+    out.push(buildToolSpan(traceId, interactionSpanId, toolSpanId, tool, run, options))
   })
 
   return out
 }
 
-function buildInteractionSpan(traceId: string, spanId: string, run: RunRecord): OtlpSpan {
+function buildInteractionSpan(traceId: string, spanId: string, run: RunRecord, options: BuildOptions): OtlpSpan {
   const startNs = msToNs(run.startMs)
   const endNs = msToNs(run.endMs ?? run.startMs)
   const totalTools = run.llmCalls.reduce((sum, c) => sum + c.toolCalls.length, 0) + run.orphanTools.length
@@ -90,8 +103,12 @@ function buildInteractionSpan(traceId: string, spanId: string, run: RunRecord): 
         : undefined,
       totalUsage.total !== undefined ? int("gen_ai.usage.total_tokens", totalUsage.total) : undefined,
       // Surface the first user prompt so the Latitude UI has something
-      // recognisable in the interaction list.
-      run.llmCalls[0]?.prompt ? str("user_prompt", run.llmCalls[0].prompt) : undefined,
+      // recognisable in the interaction list — only when the operator opted
+      // in to conversation capture.
+      options.allowConversationAccess && run.llmCalls[0]?.prompt
+        ? str("user_prompt", run.llmCalls[0].prompt)
+        : undefined,
+      bool("latitude.captured.content", options.allowConversationAccess),
     ]),
     status: { code: run.success === false ? 2 : 1 },
   }
@@ -104,15 +121,16 @@ function buildLlmSpan(
   call: LlmCallRecord,
   callIdx: number,
   run: RunRecord,
+  options: BuildOptions,
 ): OtlpSpan {
   const startNs = msToNs(call.startMs)
   const endNs = msToNs(call.endMs ?? call.startMs)
 
-  const inputMessages = buildInputMessages(call)
-  const outputMessages = buildOutputMessages(call)
-  const systemInstructions = call.systemPrompt
-    ? JSON.stringify([{ type: "text", content: call.systemPrompt }])
-    : undefined
+  const captureContent = options.allowConversationAccess
+  const inputMessages = captureContent ? buildInputMessages(call) : undefined
+  const outputMessages = captureContent ? buildOutputMessages(call) : undefined
+  const systemInstructions =
+    captureContent && call.systemPrompt ? JSON.stringify([{ type: "text", content: call.systemPrompt }]) : undefined
 
   return {
     traceId,
@@ -157,10 +175,13 @@ function buildLlmSpan(
         : undefined,
       call.usage?.cacheWrite !== undefined ? int("cache_creation_tokens", call.usage.cacheWrite) : undefined,
       call.usage?.total !== undefined ? int("gen_ai.usage.total_tokens", call.usage.total) : undefined,
-      // Content — system prompt + full message arrays.
+      // Content — system prompt + full message arrays. Gated on
+      // allowConversationAccess. Even when off, we emit the structural
+      // attributes above (model, tokens, ids, agent name).
       systemInstructions ? str("gen_ai.system_instructions", systemInstructions) : undefined,
-      str("gen_ai.input.messages", JSON.stringify(inputMessages)),
-      str("gen_ai.output.messages", JSON.stringify(outputMessages)),
+      inputMessages ? str("gen_ai.input.messages", JSON.stringify(inputMessages)) : undefined,
+      outputMessages ? str("gen_ai.output.messages", JSON.stringify(outputMessages)) : undefined,
+      bool("latitude.captured.content", captureContent),
       // Misc signals.
       int("openclaw.images.count", call.imagesCount),
       int("llm_request.tool_call_count", call.toolCalls.length),
@@ -180,10 +201,12 @@ function buildToolSpan(
   spanId: string,
   tool: ToolCallRecord,
   run: RunRecord,
+  options: BuildOptions,
 ): OtlpSpan {
   const startNs = msToNs(tool.startMs)
   const endNs = msToNs(tool.endMs ?? tool.startMs)
   const isError = Boolean(tool.error)
+  const captureContent = options.allowConversationAccess
   return {
     traceId,
     spanId,
@@ -197,8 +220,12 @@ function buildToolSpan(
       str("gen_ai.operation.name", "execute_tool"),
       str("gen_ai.tool.name", tool.toolName),
       str("gen_ai.tool.call.id", tool.toolCallId),
-      str("gen_ai.tool.call.arguments", safeJson(tool.params)),
-      tool.result !== undefined ? str("gen_ai.tool.call.result", safeJson(tool.result)) : undefined,
+      // Tool args + result are content. Gate on allowConversationAccess —
+      // when off, we still emit the call's name, id, duration, error state,
+      // and agent name so the timeline + counters still work.
+      captureContent ? str("gen_ai.tool.call.arguments", safeJson(tool.params)) : undefined,
+      captureContent && tool.result !== undefined ? str("gen_ai.tool.call.result", safeJson(tool.result)) : undefined,
+      bool("latitude.captured.content", captureContent),
       isError ? str("error.type", "tool_error") : undefined,
       isError ? str("error.message", tool.error ?? "") : undefined,
       bool("tool.is_error", isError),

--- a/packages/telemetry/openclaw/src/plugin.test.ts
+++ b/packages/telemetry/openclaw/src/plugin.test.ts
@@ -25,9 +25,25 @@ describe("registerLatitudePlugin", () => {
     const { api } = makeApi()
     const spy = vi.spyOn(api, "on")
     registerLatitudePlugin(api, {
-      config: { apiKey: "", project: "", baseUrl: "", enabled: false, debug: false },
+      config: {
+        apiKey: "",
+        project: "",
+        baseUrl: "",
+        enabled: false,
+        debug: false,
+        allowConversationAccess: false,
+      },
     })
     expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("reads creds from api.pluginConfig (the OpenClaw passes-config path)", () => {
+    const { api } = makeApi()
+    api.pluginConfig = { apiKey: "k", project: "p", allowConversationAccess: true }
+    const spy = vi.spyOn(api, "on")
+    registerLatitudePlugin(api)
+    // Plugin enabled and registered hooks because pluginConfig provided creds.
+    expect(spy).toHaveBeenCalled()
   })
 
   it("builds a run from the full hook sequence and emits it", async () => {
@@ -40,6 +56,7 @@ describe("registerLatitudePlugin", () => {
         baseUrl: "http://localhost:0", // unreachable — fetch will fail silently via logger.warn
         enabled: true,
         debug: false,
+        allowConversationAccess: true,
       },
       onEmit: (r) => emitted.push(r),
     })

--- a/packages/telemetry/openclaw/src/plugin.ts
+++ b/packages/telemetry/openclaw/src/plugin.ts
@@ -19,9 +19,15 @@ import type {
  * touch. We avoid importing from `openclaw/plugin-sdk` so the package stays
  * usable when OpenClaw isn't installed (the CLI and tests don't need it),
  * and so we're robust to small signature changes across OpenClaw versions.
+ *
+ * `pluginConfig` is the user's `plugins.entries[id].config` block — that's
+ * the canonical place to read credentials and feature flags. The OpenClaw
+ * plugin SDK also exposes the same value as `api.pluginConfig` on the
+ * builder API; keep both names in sync if the upstream contract evolves.
  */
 export interface OpenClawPluginApiLike {
   logger?: Logger
+  pluginConfig?: Record<string, unknown>
   on: <K extends string>(
     hookName: K,
     handler: (event: unknown, ctx: unknown) => unknown,
@@ -52,15 +58,20 @@ export interface RegisterOptions {
  * nothing we do here can slow the agent loop.
  */
 export default function registerLatitudePlugin(api: OpenClawPluginApiLike, opts: RegisterOptions = {}): void {
-  const config = opts.config ?? loadConfig()
+  // Source of truth: OpenClaw passes the user's `plugins.entries[id].config`
+  // as `api.pluginConfig`. Env vars are a fallback so existing deploys with
+  // LATITUDE_* exported in the gateway environment keep working.
+  const config = opts.config ?? loadConfig(api.pluginConfig)
   const logger = opts.logger ?? createLogger(config.debug)
 
   if (!config.enabled) {
-    if (config.apiKey === "") logger.debug("disabled: LATITUDE_API_KEY is empty")
-    if (config.project === "") logger.debug("disabled: LATITUDE_PROJECT is empty")
+    if (config.apiKey === "") logger.debug("disabled: apiKey is empty (set plugins.entries[id].config.apiKey)")
+    if (config.project === "") logger.debug("disabled: project is empty (set plugins.entries[id].config.project)")
     return
   }
-  logger.debug(`enabled: project=${config.project} base=${config.baseUrl}`)
+  logger.debug(
+    `enabled: project=${config.project} base=${config.baseUrl} allowConversationAccess=${config.allowConversationAccess}`,
+  )
 
   const builder = new TurnBuilder()
 
@@ -108,7 +119,7 @@ export default function registerLatitudePlugin(api: OpenClawPluginApiLike, opts:
         return
       }
       opts.onEmit?.(run)
-      const payload = buildOtlpRequest(run)
+      const payload = buildOtlpRequest(run, { allowConversationAccess: config.allowConversationAccess })
       void postTraces({
         baseUrl: config.baseUrl,
         apiKey: config.apiKey,

--- a/packages/telemetry/openclaw/src/settings-file.test.ts
+++ b/packages/telemetry/openclaw/src/settings-file.test.ts
@@ -44,7 +44,7 @@ describe("setPluginEntry", () => {
         },
       },
     }
-    setPluginEntry(settings, { apiKey: "new-k", project: "new-p" })
+    setPluginEntry(settings, { apiKey: "new-k", project: "new-p", baseUrl: undefined })
     const config = settings.plugins.entries[PLUGIN_ID]?.config as Record<string, unknown>
     expect(config.baseUrl).toBeUndefined()
     expect(config.apiKey).toBe("new-k")
@@ -62,7 +62,7 @@ describe("setPluginEntry", () => {
         },
       },
     }
-    setPluginEntry(settings, { apiKey: "k", project: "p" })
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined })
     const entry = settings.plugins.entries[PLUGIN_ID] as {
       subagent?: { allowModelOverride?: boolean }
       config?: Record<string, unknown>
@@ -70,6 +70,80 @@ describe("setPluginEntry", () => {
     expect(entry.subagent?.allowModelOverride).toBe(true)
     expect(entry.config?.customField).toBe("keep me")
     expect(entry.config?.apiKey).toBe("k")
+  })
+
+  it("preserves a hand-edited `enabled: false` across re-installs", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: false,
+            config: { apiKey: "old", project: "old" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "new", project: "new", baseUrl: undefined })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    // Paused plugin stays paused — operator's intent wins.
+    expect(entry?.enabled).toBe(false)
+    expect((entry?.config as Record<string, unknown>)?.apiKey).toBe("new")
+  })
+
+  it("defaults to enabled=true for a fresh install (no existing entry)", () => {
+    const settings: OpenClawSettings = {}
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined })
+    expect(settings.plugins?.entries?.[PLUGIN_ID]?.enabled).toBe(true)
+  })
+
+  it("explicitly setting enabled overrides existing", () => {
+    const settings: OpenClawSettings = {
+      plugins: { entries: { [PLUGIN_ID]: { enabled: false } } },
+    }
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined, enabled: true })
+    expect(settings.plugins?.entries?.[PLUGIN_ID]?.enabled).toBe(true)
+  })
+
+  it("preserves existing debug when not overridden", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: { [PLUGIN_ID]: { config: { apiKey: "x", project: "y", debug: true } } },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "x", project: "y", baseUrl: undefined })
+    const config = settings.plugins?.entries?.[PLUGIN_ID]?.config as Record<string, unknown>
+    expect(config.debug).toBe(true)
+  })
+
+  it("preserves existing allowConversationAccess when not overridden", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: { config: { apiKey: "x", project: "y", allowConversationAccess: false } },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "x", project: "y", baseUrl: undefined })
+    const config = settings.plugins?.entries?.[PLUGIN_ID]?.config as Record<string, unknown>
+    expect(config.allowConversationAccess).toBe(false)
+  })
+
+  it("explicit allowConversationAccess in patch overrides existing", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: { config: { apiKey: "x", project: "y", allowConversationAccess: false } },
+        },
+      },
+    }
+    setPluginEntry(settings, {
+      apiKey: "x",
+      project: "y",
+      baseUrl: undefined,
+      allowConversationAccess: true,
+    })
+    const config = settings.plugins?.entries?.[PLUGIN_ID]?.config as Record<string, unknown>
+    expect(config.allowConversationAccess).toBe(true)
   })
 })
 

--- a/packages/telemetry/openclaw/src/settings-file.test.ts
+++ b/packages/telemetry/openclaw/src/settings-file.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+import {
+  migrateLegacyEntries,
+  type OpenClawSettings,
+  PLUGIN_ID,
+  removePluginEntry,
+  setPluginEntry,
+} from "./settings-file.ts"
+
+describe("setPluginEntry", () => {
+  it("writes credentials under .config (not .hooks, not top-level env)", () => {
+    const settings: OpenClawSettings = {}
+    setPluginEntry(settings, {
+      apiKey: "k",
+      project: "p",
+      baseUrl: "https://staging-ingest.latitude.so",
+      allowConversationAccess: true,
+      debug: false,
+    })
+
+    const entry = settings.plugins?.entries?.[PLUGIN_ID] as
+      | { enabled?: boolean; config?: Record<string, unknown>; hooks?: unknown }
+      | undefined
+
+    // Strict zod compliance: nothing under hooks, nothing at top-level env.
+    expect(entry?.hooks).toBeUndefined()
+    expect((settings as { env?: unknown }).env).toBeUndefined()
+
+    expect(entry?.enabled).toBe(true)
+    expect(entry?.config?.apiKey).toBe("k")
+    expect(entry?.config?.project).toBe("p")
+    expect(entry?.config?.baseUrl).toBe("https://staging-ingest.latitude.so")
+    expect(entry?.config?.allowConversationAccess).toBe(true)
+  })
+
+  it("clears baseUrl when undefined (production install after a staging install)", () => {
+    const settings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            config: { apiKey: "old-k", project: "old-p", baseUrl: "https://staging-ingest.latitude.so" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "new-k", project: "new-p" })
+    const config = settings.plugins.entries[PLUGIN_ID]?.config as Record<string, unknown>
+    expect(config.baseUrl).toBeUndefined()
+    expect(config.apiKey).toBe("new-k")
+  })
+
+  it("preserves unrelated fields on the existing plugin entry", () => {
+    const settings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            subagent: { allowModelOverride: true },
+            config: { customField: "keep me" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "k", project: "p" })
+    const entry = settings.plugins.entries[PLUGIN_ID] as {
+      subagent?: { allowModelOverride?: boolean }
+      config?: Record<string, unknown>
+    }
+    expect(entry.subagent?.allowModelOverride).toBe(true)
+    expect(entry.config?.customField).toBe("keep me")
+    expect(entry.config?.apiKey).toBe("k")
+  })
+})
+
+describe("migrateLegacyEntries", () => {
+  it("strips hooks.allowConversationAccess written by the 0.0.1 installer", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      },
+    }
+    const { changed } = migrateLegacyEntries(settings)
+    expect(changed).toBe(true)
+    const entry = settings.plugins?.entries?.[PLUGIN_ID] as { hooks?: unknown }
+    expect(entry.hooks).toBeUndefined()
+  })
+
+  it("preserves hooks.allowPromptInjection (a real OpenClaw key) when present alongside our legacy key", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            hooks: { allowPromptInjection: true, allowConversationAccess: true },
+          },
+        },
+      },
+    }
+    migrateLegacyEntries(settings)
+    const entry = settings.plugins?.entries?.[PLUGIN_ID] as { hooks?: { allowPromptInjection?: boolean } }
+    expect(entry.hooks?.allowPromptInjection).toBe(true)
+  })
+
+  it("strips top-level env.LATITUDE_* keys our 0.0.1 installer leaked", () => {
+    const settings = {
+      env: {
+        LATITUDE_API_KEY: "old",
+        LATITUDE_PROJECT: "old",
+        LATITUDE_BASE_URL: "https://staging-ingest.latitude.so",
+      },
+    }
+    const { changed } = migrateLegacyEntries(settings)
+    expect(changed).toBe(true)
+    expect(settings.env).toBeUndefined()
+  })
+
+  it("leaves a real OpenClaw env block alone (shellEnv + vars)", () => {
+    const settings = {
+      env: {
+        shellEnv: { enabled: true },
+        vars: { CUSTOM_VAR: "value" },
+      },
+    }
+    migrateLegacyEntries(settings)
+    expect(settings.env).toBeDefined()
+    expect(settings.env.shellEnv.enabled).toBe(true)
+    expect(settings.env.vars.CUSTOM_VAR).toBe("value")
+  })
+})
+
+describe("removePluginEntry", () => {
+  it("removes the plugin entry and reports whether it changed anything", () => {
+    const settings = {
+      plugins: { entries: { [PLUGIN_ID]: { enabled: true }, "other-plugin": { enabled: true } } },
+    }
+    expect(removePluginEntry(settings)).toBe(true)
+    expect(PLUGIN_ID in settings.plugins.entries).toBe(false)
+    expect("other-plugin" in settings.plugins.entries).toBe(true)
+    expect(removePluginEntry(settings)).toBe(false)
+  })
+})

--- a/packages/telemetry/openclaw/src/settings-file.ts
+++ b/packages/telemetry/openclaw/src/settings-file.ts
@@ -68,12 +68,43 @@ export function backupSettings(): void {
   if (existsSync(SETTINGS_PATH)) copyFileSync(SETTINGS_PATH, SETTINGS_BACKUP_PATH)
 }
 
+interface SetPluginEntryPatch {
+  /** New API key. Always overwrites — comes from the install prompt. */
+  apiKey: string
+  /** New project slug. Always overwrites — comes from the install prompt. */
+  project: string
+  /**
+   * New `baseUrl`. `undefined` clears any existing override (used when
+   * installing back to production). Anything else overwrites.
+   */
+  baseUrl: string | undefined
+  /**
+   * `true`/`false` overwrites; `undefined` preserves the existing value (or
+   * leaves the key absent if there is none).
+   */
+  allowConversationAccess?: boolean | undefined
+  /** Same semantics as `allowConversationAccess`. */
+  debug?: boolean | undefined
+  /**
+   * `true`/`false` overwrites; `undefined` preserves the existing value, or
+   * defaults to `true` for a fresh install. This keeps a paused plugin
+   * (`enabled: false` in openclaw.json) paused across re-installs.
+   */
+  enabled?: boolean | undefined
+}
+
 /**
  * Set the `plugins.entries[id]` block for our plugin. Writes credentials and
  * options into the `.config` bucket — never under `hooks` (strict zod) and
  * never as top-level `env` keys (root schema rejects them).
+ *
+ * Re-install idempotency: only `apiKey` / `project` / `baseUrl` always
+ * overwrite (these come from the install prompts). `enabled`, `debug`, and
+ * `allowConversationAccess` are preserved when not provided in the patch,
+ * so a user who hand-edited `enabled: false` or `debug: true` doesn't lose
+ * their choice on a re-install.
  */
-export function setPluginEntry(settings: OpenClawSettings, config: LatitudePluginConfig): void {
+export function setPluginEntry(settings: OpenClawSettings, patch: SetPluginEntryPatch): void {
   const plugins = settings.plugins ?? {}
   const entries = plugins.entries ?? {}
   const existing = entries[PLUGIN_ID] ?? {}
@@ -81,24 +112,28 @@ export function setPluginEntry(settings: OpenClawSettings, config: LatitudePlugi
 
   const nextConfig: Record<string, unknown> = {
     ...existingConfig,
-    apiKey: config.apiKey,
-    project: config.project,
+    apiKey: patch.apiKey,
+    project: patch.project,
   }
-  if (config.baseUrl !== undefined) {
-    nextConfig.baseUrl = config.baseUrl
+  if (patch.baseUrl !== undefined) {
+    nextConfig.baseUrl = patch.baseUrl
   } else {
     delete nextConfig.baseUrl
   }
-  if (config.allowConversationAccess !== undefined) {
-    nextConfig.allowConversationAccess = config.allowConversationAccess
+  if (patch.allowConversationAccess !== undefined) {
+    nextConfig.allowConversationAccess = patch.allowConversationAccess
   }
-  if (config.debug !== undefined) {
-    nextConfig.debug = config.debug
+  if (patch.debug !== undefined) {
+    nextConfig.debug = patch.debug
   }
+
+  // Preserve user-edited `enabled: false` across re-installs. Fresh install
+  // (no existing entry, no explicit patch) defaults to true.
+  const nextEnabled = patch.enabled ?? existing.enabled ?? true
 
   entries[PLUGIN_ID] = {
     ...existing,
-    enabled: true,
+    enabled: nextEnabled,
     config: nextConfig,
   }
   plugins.entries = entries
@@ -143,11 +178,12 @@ export function migrateLegacyEntries(settings: OpenClawSettings): { changed: boo
     }
   }
 
-  // Strip `LATITUDE_*` keys our 0.0.1 installer mistakenly wrote at root.
-  // OpenClaw's root schema is strict; root-level `env` accepts only `{shellEnv,
-  // vars}`, not arbitrary keys. The same fix applies whether the keys are at
-  // settings.env.LATITUDE_* or as top-level settings.LATITUDE_* — we clean
-  // both since older installers may have produced either layout.
+  // Strip `LATITUDE_*` keys our 0.0.1 installer mistakenly wrote under
+  // `settings.env`. OpenClaw's root schema is strict; the `env` block accepts
+  // only `{shellEnv, vars}`, so any `LATITUDE_*` key sitting directly under
+  // `env` causes the gateway to quarantine the file. (0.0.1 only ever wrote
+  // to `settings.env.LATITUDE_*`, never to top-level `settings.LATITUDE_*`,
+  // so we don't bother sweeping the root.)
   const env = settings.env
   if (env && typeof env === "object" && !Array.isArray(env)) {
     const envObj = env as Record<string, unknown>

--- a/packages/telemetry/openclaw/src/settings-file.ts
+++ b/packages/telemetry/openclaw/src/settings-file.ts
@@ -2,28 +2,51 @@ import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
-export const SETTINGS_PATH = join(homedir(), ".openclaw", "openclaw.json")
-export const SETTINGS_BACKUP_PATH = join(homedir(), ".openclaw", "openclaw.json.latitude-bak")
+const CONFIG_DIR = join(homedir(), ".openclaw")
+export const SETTINGS_PATH = join(CONFIG_DIR, "openclaw.json")
+export const SETTINGS_BACKUP_PATH = join(CONFIG_DIR, "openclaw.json.latitude-bak")
+const EXTENSIONS_DIR = join(CONFIG_DIR, "extensions")
+export const PLUGIN_INSTALL_DIR = join(EXTENSIONS_DIR, "latitude-telemetry")
 
+/** Plugin id used both as the npm package name and as the OpenClaw plugin id. */
 export const PLUGIN_ID = "@latitude-data/openclaw-telemetry"
 
+/**
+ * The shape OpenClaw's strict zod schema accepts for a single
+ * `plugins.entries[id]` block. We deliberately keep this minimal — only the
+ * fields we actually write — so we don't drop anything when round-tripping
+ * an existing entry that uses fields we don't know about.
+ */
 interface OpenClawPluginEntry {
   enabled?: boolean
-  hooks?: {
-    allowPromptInjection?: boolean
-    allowConversationAccess?: boolean
-  }
+  /**
+   * The free-form bucket OpenClaw passes to the plugin at activation. This is
+   * where we store all our credentials and feature flags — `hooks` is strict,
+   * `env` at root is not a free-form key/value passthrough, and using
+   * `.config` keeps everything namespaced to our plugin and survives any
+   * version of OpenClaw because the field is a `record(string, unknown)`.
+   */
   config?: Record<string, unknown>
+  // Pass through anything else that may already be there — `hooks`, `subagent`, etc.
+  [key: string]: unknown
 }
 
-interface OpenClawSettings {
+export interface OpenClawSettings {
   plugins?: {
     enabled?: boolean
     entries?: Record<string, OpenClawPluginEntry>
+    load?: { paths?: string[] }
     [key: string]: unknown
   }
-  env?: Record<string, string>
   [key: string]: unknown
+}
+
+export interface LatitudePluginConfig {
+  apiKey: string
+  project: string
+  baseUrl?: string | undefined
+  allowConversationAccess?: boolean | undefined
+  debug?: boolean | undefined
 }
 
 export function readSettings(): OpenClawSettings {
@@ -45,28 +68,44 @@ export function backupSettings(): void {
   if (existsSync(SETTINGS_PATH)) copyFileSync(SETTINGS_PATH, SETTINGS_BACKUP_PATH)
 }
 
-export function ensurePluginEntry(settings: OpenClawSettings): OpenClawPluginEntry {
+/**
+ * Set the `plugins.entries[id]` block for our plugin. Writes credentials and
+ * options into the `.config` bucket — never under `hooks` (strict zod) and
+ * never as top-level `env` keys (root schema rejects them).
+ */
+export function setPluginEntry(settings: OpenClawSettings, config: LatitudePluginConfig): void {
   const plugins = settings.plugins ?? {}
   const entries = plugins.entries ?? {}
   const existing = entries[PLUGIN_ID] ?? {}
-  const entry: OpenClawPluginEntry = {
+  const existingConfig = (existing.config ?? {}) as Record<string, unknown>
+
+  const nextConfig: Record<string, unknown> = {
+    ...existingConfig,
+    apiKey: config.apiKey,
+    project: config.project,
+  }
+  if (config.baseUrl !== undefined) {
+    nextConfig.baseUrl = config.baseUrl
+  } else {
+    delete nextConfig.baseUrl
+  }
+  if (config.allowConversationAccess !== undefined) {
+    nextConfig.allowConversationAccess = config.allowConversationAccess
+  }
+  if (config.debug !== undefined) {
+    nextConfig.debug = config.debug
+  }
+
+  entries[PLUGIN_ID] = {
     ...existing,
     enabled: true,
-    hooks: {
-      ...(existing.hooks ?? {}),
-      // Required for third-party plugins to read raw conversation content
-      // from llm_input/llm_output/agent_end. Without this the hooks fire but
-      // payloads are scrubbed — which is exactly the silent failure mode that
-      // the existing third-party OpenClaw observability plugin runs into.
-      allowConversationAccess: true,
-    },
+    config: nextConfig,
   }
-  entries[PLUGIN_ID] = entry
   plugins.entries = entries
   settings.plugins = plugins
-  return entry
 }
 
+/** Remove the plugin entry entirely. */
 export function removePluginEntry(settings: OpenClawSettings): boolean {
   const plugins = settings.plugins
   if (!plugins?.entries) return false
@@ -75,25 +114,55 @@ export function removePluginEntry(settings: OpenClawSettings): boolean {
   return true
 }
 
-export function setEnv(settings: OpenClawSettings, key: string, value: string): void {
-  const env = settings.env ?? {}
-  env[key] = value
-  settings.env = env
-}
-
-export function removeEnv(settings: OpenClawSettings, keys: string[]): boolean {
-  const env = settings.env
-  if (!env) return false
-  let removed = false
-  for (const k of keys) {
-    if (k in env) {
-      delete env[k]
-      removed = true
-    }
-  }
-  return removed
-}
-
 export function hasLatitudePlugin(settings: OpenClawSettings): boolean {
   return Boolean(settings.plugins?.entries && PLUGIN_ID in settings.plugins.entries)
+}
+
+/**
+ * Strip any leftover top-level keys our older installer (<= 0.0.1) wrote. The
+ * 0.0.1 installer wrote `hooks.allowConversationAccess` (rejected by strict
+ * zod) and `LATITUDE_*` keys at root-level `env` (also rejected). Both are
+ * cleaned up here so re-running install lands a config OpenClaw will validate.
+ */
+export function migrateLegacyEntries(settings: OpenClawSettings): { changed: boolean } {
+  let changed = false
+
+  // Wipe `hooks.allowConversationAccess` from our entry — OpenClaw < 2026.4.22
+  // rejects unknown keys under the strict `hooks` shape.
+  const entry = settings.plugins?.entries?.[PLUGIN_ID]
+  if (entry && typeof entry === "object") {
+    const hooks = (entry as { hooks?: Record<string, unknown> }).hooks
+    if (hooks && typeof hooks === "object" && "allowConversationAccess" in hooks) {
+      delete hooks.allowConversationAccess
+      // If the hooks object is now empty, drop it entirely so we don't leave
+      // a `"hooks": {}` carcass behind.
+      if (Object.keys(hooks).length === 0) {
+        delete (entry as { hooks?: unknown }).hooks
+      }
+      changed = true
+    }
+  }
+
+  // Strip `LATITUDE_*` keys our 0.0.1 installer mistakenly wrote at root.
+  // OpenClaw's root schema is strict; root-level `env` accepts only `{shellEnv,
+  // vars}`, not arbitrary keys. The same fix applies whether the keys are at
+  // settings.env.LATITUDE_* or as top-level settings.LATITUDE_* — we clean
+  // both since older installers may have produced either layout.
+  const env = settings.env
+  if (env && typeof env === "object" && !Array.isArray(env)) {
+    const envObj = env as Record<string, unknown>
+    for (const key of ["LATITUDE_API_KEY", "LATITUDE_PROJECT", "LATITUDE_BASE_URL"]) {
+      if (key in envObj) {
+        delete envObj[key]
+        changed = true
+      }
+    }
+    // Drop the env object if there's nothing left in it AND it's not OpenClaw's
+    // canonical {shellEnv, vars} shape — only do this when we know it was ours.
+    if (Object.keys(envObj).length === 0) {
+      delete settings.env
+    }
+  }
+
+  return { changed }
 }

--- a/packages/telemetry/openclaw/src/setup.ts
+++ b/packages/telemetry/openclaw/src/setup.ts
@@ -2,17 +2,19 @@ import { existsSync, mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import { cancel, confirm, intro, isCancel, log, note, outro, password, spinner, text } from "@clack/prompts"
 import pc from "picocolors"
+import { installPluginFiles, removePluginFiles } from "./install-files.ts"
 import {
   backupSettings,
-  ensurePluginEntry,
   hasLatitudePlugin,
+  type LatitudePluginConfig,
+  migrateLegacyEntries,
   PLUGIN_ID,
+  PLUGIN_INSTALL_DIR,
   readSettings,
-  removeEnv,
   removePluginEntry,
   SETTINGS_BACKUP_PATH,
   SETTINGS_PATH,
-  setEnv,
+  setPluginEntry,
   writeSettings,
 } from "./settings-file.ts"
 
@@ -60,6 +62,7 @@ interface InstallFlags {
   apiKey?: string | undefined
   project?: string | undefined
   environment?: EnvironmentConfig | undefined
+  allowConversationAccess?: boolean
   noPrompt?: boolean
   yes?: boolean
 }
@@ -89,10 +92,17 @@ export function normalizeInstallFlags(flags: Record<string, string | boolean>): 
     if (environment) throw new Error("--staging and --dev are mutually exclusive")
     environment = DEV_ENV
   }
+  // Default: capture conversation content. Users who don't want it can pass
+  // --no-content (or set it to false later in openclaw.json).
+  let allowConversationAccess = true
+  if (flags["no-content"] === true || flags["no-conversation"] === true) allowConversationAccess = false
+  if (flags["allow-conversation"] === false) allowConversationAccess = false
+
   return {
     apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
     project: typeof flags.project === "string" ? flags.project : undefined,
     environment,
+    allowConversationAccess,
     noPrompt: flags["no-prompt"] === true || flags.yes === true,
     yes: flags.yes === true,
   }
@@ -110,7 +120,8 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
   intro(pc.bgCyan(pc.black(" Latitude · OpenClaw telemetry ")))
 
   const existing = readSettings()
-  const existingEnv = existing.env ?? {}
+  const existingConfig =
+    (existing.plugins?.entries?.[PLUGIN_ID]?.config as LatitudePluginConfig | undefined) ?? undefined
   const envConfig = flags.environment ?? PRODUCTION_ENV
   const urls = urlsFor(envConfig)
 
@@ -129,10 +140,15 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
   log.info(`Get an API key at ${pc.cyan(urls.apiKeys)}`)
   log.info(`Create a project at ${pc.cyan(urls.projects)}`)
 
-  const apiKey = await promptApiKey(existingEnv.LATITUDE_API_KEY, flags.apiKey)
-  const project = await promptProject(existingEnv.LATITUDE_PROJECT, flags.project)
+  const apiKey = await promptApiKey(existingConfig?.apiKey, flags.apiKey)
+  const project = await promptProject(existingConfig?.project, flags.project)
 
-  await applyChanges({ apiKey, project, envConfig })
+  await applyChanges({
+    apiKey,
+    project,
+    envConfig,
+    allowConversationAccess: flags.allowConversationAccess ?? true,
+  })
 
   note(
     [
@@ -153,8 +169,14 @@ async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
     throw new Error("Non-interactive install requires --api-key=... and --project=... (or run in a TTY).")
   }
   const envConfig = flags.environment ?? PRODUCTION_ENV
-  await applyChanges({ apiKey, project, envConfig })
+  await applyChanges({
+    apiKey,
+    project,
+    envConfig,
+    allowConversationAccess: flags.allowConversationAccess ?? true,
+  })
   process.stdout.write(`Installed Latitude plugin in ${SETTINGS_PATH}\n`)
+  process.stdout.write(`Plugin files at ${PLUGIN_INSTALL_DIR}\n`)
 }
 
 async function promptApiKey(_existing: string | undefined, flag: string | undefined): Promise<string> {
@@ -189,26 +211,38 @@ interface ApplyParams {
   apiKey: string
   project: string
   envConfig: EnvironmentConfig
+  allowConversationAccess: boolean
 }
 
-async function applyChanges({ apiKey, project, envConfig }: ApplyParams): Promise<void> {
-  const s = spinner()
-  s.start("Updating openclaw.json")
+async function applyChanges({ apiKey, project, envConfig, allowConversationAccess }: ApplyParams): Promise<void> {
+  // 1. Materialize plugin runtime files into ~/.openclaw/extensions/latitude-telemetry/
+  //    so OpenClaw's plugin discovery picks them up. This MUST happen before
+  //    we write the openclaw.json entry, otherwise the gateway file-watcher
+  //    will see the entry, fail to find the plugin, and emit a warning.
+  const filesSpinner = spinner()
+  filesSpinner.start("Installing plugin files")
+  const { destination } = installPluginFiles()
+  filesSpinner.stop(`Plugin files installed at ${destination}`)
+
+  // 2. Update openclaw.json with the plugin entry.
+  const settingsSpinner = spinner()
+  settingsSpinner.start("Updating openclaw.json")
   ensureSettingsDir()
   backupSettings()
   const settings = readSettings()
-  ensurePluginEntry(settings)
-  setEnv(settings, "LATITUDE_API_KEY", apiKey)
-  setEnv(settings, "LATITUDE_PROJECT", project)
-  if (envConfig.name !== "production") {
-    setEnv(settings, "LATITUDE_BASE_URL", envConfig.ingest)
-  } else {
-    // Clear any stale BASE_URL left over from a prior --staging/--dev install so
-    // re-running `install` without flags is idempotent back to production.
-    removeEnv(settings, ["LATITUDE_BASE_URL"])
-  }
+  // Migrate any leftover keys our 0.0.1 installer wrote that the strict zod
+  // schema rejects. Without this, re-installing on top of a 0.0.1 install
+  // would leave the gateway quarantining the file as `clobbered`.
+  migrateLegacyEntries(settings)
+  setPluginEntry(settings, {
+    apiKey,
+    project,
+    baseUrl: envConfig.name === "production" ? undefined : envConfig.ingest,
+    allowConversationAccess,
+    debug: false,
+  })
   writeSettings(settings)
-  s.stop(`Updated ${SETTINGS_PATH}`)
+  settingsSpinner.stop(`Updated ${SETTINGS_PATH}`)
   if (existsSync(SETTINGS_BACKUP_PATH)) log.info(`Backup saved at ${pc.dim(SETTINGS_BACKUP_PATH)}`)
 }
 
@@ -227,17 +261,20 @@ export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
   intro(pc.bgYellow(pc.black(" Latitude · OpenClaw telemetry — uninstall ")))
   const settings = readSettings()
 
-  if (!hasLatitudePlugin(settings)) {
-    note("No Latitude plugin entry found — nothing to remove.", "Status")
+  const hasEntry = hasLatitudePlugin(settings)
+  const hasFiles = existsSync(PLUGIN_INSTALL_DIR)
+
+  if (!hasEntry && !hasFiles) {
+    note("No Latitude plugin entry or files found — nothing to remove.", "Status")
     outro(pc.dim("Nothing changed"))
     return
   }
 
   const plan = [
-    `Remove "${PLUGIN_ID}" plugin entry from ${SETTINGS_PATH}`,
-    "Remove LATITUDE_API_KEY / LATITUDE_PROJECT / LATITUDE_BASE_URL from env",
-    `Backup saved at ${SETTINGS_BACKUP_PATH}`,
-  ]
+    hasEntry ? `Remove "${PLUGIN_ID}" plugin entry from ${SETTINGS_PATH}` : null,
+    hasFiles ? `Delete plugin files at ${PLUGIN_INSTALL_DIR}` : null,
+    `Backup of openclaw.json saved at ${SETTINGS_BACKUP_PATH}`,
+  ].filter(Boolean) as string[]
   note(plan.join("\n"), "Plan")
 
   if (!flags.noPrompt && process.stdin.isTTY === true) {
@@ -247,10 +284,15 @@ export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
 
   const s = spinner()
   s.start("Reverting settings")
-  backupSettings()
-  removePluginEntry(settings)
-  removeEnv(settings, ["LATITUDE_API_KEY", "LATITUDE_PROJECT", "LATITUDE_BASE_URL"])
-  writeSettings(settings)
+  if (hasEntry) {
+    backupSettings()
+    removePluginEntry(settings)
+    // Also clean any legacy keys our 0.0.1 installer left behind so the file
+    // is fully back to a clean state.
+    migrateLegacyEntries(settings)
+    writeSettings(settings)
+  }
+  if (hasFiles) removePluginFiles()
   s.stop("Done")
   outro(pc.green("✓ Uninstalled"))
 }

--- a/packages/telemetry/openclaw/src/setup.ts
+++ b/packages/telemetry/openclaw/src/setup.ts
@@ -62,7 +62,13 @@ interface InstallFlags {
   apiKey?: string | undefined
   project?: string | undefined
   environment?: EnvironmentConfig | undefined
-  allowConversationAccess?: boolean
+  /**
+   * Tristate: `true` = capture (the user passed `--allow-conversation`),
+   * `false` = scrub (the user passed `--no-content`), `undefined` = preserve
+   * existing or fall through to the first-install default. Keeping this
+   * tristate is what makes re-installs idempotent for hand-edited values.
+   */
+  allowConversationAccess?: boolean | undefined
   noPrompt?: boolean
   yes?: boolean
 }
@@ -92,11 +98,11 @@ export function normalizeInstallFlags(flags: Record<string, string | boolean>): 
     if (environment) throw new Error("--staging and --dev are mutually exclusive")
     environment = DEV_ENV
   }
-  // Default: capture conversation content. Users who don't want it can pass
-  // --no-content (or set it to false later in openclaw.json).
-  let allowConversationAccess = true
+  // Tristate: leave undefined unless the user explicitly asked one way or
+  // the other. Re-install then preserves whatever's in openclaw.json.
+  let allowConversationAccess: boolean | undefined
   if (flags["no-content"] === true || flags["no-conversation"] === true) allowConversationAccess = false
-  if (flags["allow-conversation"] === false) allowConversationAccess = false
+  if (flags["allow-conversation"] === true) allowConversationAccess = true
 
   return {
     apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
@@ -147,7 +153,7 @@ async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
     apiKey,
     project,
     envConfig,
-    allowConversationAccess: flags.allowConversationAccess ?? true,
+    allowConversationAccess: flags.allowConversationAccess,
   })
 
   note(
@@ -173,7 +179,7 @@ async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
     apiKey,
     project,
     envConfig,
-    allowConversationAccess: flags.allowConversationAccess ?? true,
+    allowConversationAccess: flags.allowConversationAccess,
   })
   process.stdout.write(`Installed Latitude plugin in ${SETTINGS_PATH}\n`)
   process.stdout.write(`Plugin files at ${PLUGIN_INSTALL_DIR}\n`)
@@ -211,7 +217,8 @@ interface ApplyParams {
   apiKey: string
   project: string
   envConfig: EnvironmentConfig
-  allowConversationAccess: boolean
+  /** Tristate — see `InstallFlags.allowConversationAccess`. */
+  allowConversationAccess: boolean | undefined
 }
 
 async function applyChanges({ apiKey, project, envConfig, allowConversationAccess }: ApplyParams): Promise<void> {
@@ -234,12 +241,22 @@ async function applyChanges({ apiKey, project, envConfig, allowConversationAcces
   // schema rejects. Without this, re-installing on top of a 0.0.1 install
   // would leave the gateway quarantining the file as `clobbered`.
   migrateLegacyEntries(settings)
+
+  // Decide allowConversationAccess for this install:
+  //   - explicit flag (true|false) wins
+  //   - else preserve whatever's already in openclaw.json
+  //   - else first-install default is `true` (matches the README's promise)
+  const existingConfig = (settings.plugins?.entries?.[PLUGIN_ID]?.config ?? {}) as Partial<LatitudePluginConfig>
+  const finalAllowConversationAccess = allowConversationAccess ?? existingConfig.allowConversationAccess ?? true
+
   setPluginEntry(settings, {
     apiKey,
     project,
     baseUrl: envConfig.name === "production" ? undefined : envConfig.ingest,
-    allowConversationAccess,
-    debug: false,
+    allowConversationAccess: finalAllowConversationAccess,
+    // `debug` is intentionally not passed — `setPluginEntry` preserves the
+    // user's hand-edited value. Fresh installs leave the key absent (the
+    // runtime default is `false`).
   })
   writeSettings(settings)
   settingsSpinner.stop(`Updated ${SETTINGS_PATH}`)


### PR DESCRIPTION
## Summary

End-to-end fix to `@latitude-data/openclaw-telemetry`, reported by an OpenClaw 2026.4.21 maintainer who tried 0.0.1 against a real install and found five distinct bugs. All five are fixed in 0.0.2; re-running `install` migrates leftover 0.0.1 keys cleanly.

| # | Bug | Fix |
|---|---|---|
| 1 | Installer wrote `hooks.allowConversationAccess: true` — rejected by [OpenClaw's strict zod](https://github.com/openclaw/openclaw/blob/main/src/config/zod-schema.ts). Gateway file-watcher quarantined the new config as `clobbered.<ts>`, silently rolled back to last-good, agent ran on the pre-install config, no traces ever shipped. | Installer now writes credentials under `plugins.entries[id].config` (`record(string, unknown)` — accepted by every OpenClaw version). |
| 2 | Installer also wrote `LATITUDE_*` keys at top-level `env` — same strict-zod rejection (root `env` only accepts `{shellEnv, vars}`). | Nothing lives at root `env` anymore. |
| 3 | Package shipped without `openclaw.plugin.json` — required by OpenClaw discovery, which scans `<configDir>/extensions/<plugin>/` for the manifest at root. npm `main` is irrelevant; global install isn't enough. | (a) Ship `openclaw.plugin.json` with `id` + `configSchema`; (b) installer materializes `dist/` + manifest into `~/.openclaw/extensions/latitude-telemetry/`. |
| 4 | Plugin runtime read `process.env`, ignored `api.pluginConfig`. Combined with #1+#2, creds never reached the runtime — plugin disabled itself silently. | `loadConfig(api.pluginConfig)` is the primary source; env vars are a fallback for compat. |
| 5 | `allowConversationAccess` was a theater flag — README said it gated content capture, runtime never referenced it, full content was always attached. | Flag now gates `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions` on `llm_request`, `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` on `tool_execution`, and `user_prompt` on `interaction`. Structural attrs (timing, token usage, model name, agent name, ids) are unaffected. A `latitude.captured.content` boolean on every span makes the gate state visible in the Latitude UI. |

Plus: the new installer migrates `hooks.allowConversationAccess` and any top-level `env.LATITUDE_*` keys our 0.0.1 left behind, so re-running on a broken 0.0.1 install lands a clean, zod-accepted config without manual cleanup.

## Test plan

- [x] `pnpm --filter @latitude-data/openclaw-telemetry typecheck` (passes)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry test` — **43 tests passing** (up from 19), new coverage for config layering, manifest schema, content gating, and migration logic
- [x] `pnpm --filter @latitude-data/openclaw-telemetry check` (passes)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry build` (produces `dist/plugin.js` + `dist/cli.js` + ships `openclaw.plugin.json`)

End-to-end (the reproduction the bug report describes):
- [ ] On the reporter's box (OpenClaw 2026.4.21): `npx -y @latitude-data/openclaw-telemetry@0.0.2 install` → `openclaw config validate --json` returns `{"valid":true,...}`
- [ ] `openclaw gateway restart` → gateway log lists the plugin in "ready (N plugins: ..., latitude-telemetry, ...)" with no "plugin not found" warning
- [ ] `~/.openclaw/logs/config-audit.jsonl` has no `suspicious: ["reload-invalid-config"]` after the install timestamp
- [ ] Sending a message with `LATITUDE_DEBUG=1` shows `[latitude-openclaw]` POST lines and ingest HTTP 200; trace appears in Latitude