### PR TITLE
feat(exports): ship dataset/traces/issues exports as .zip

### DIFF
--- a/apps/web/src/routes/downloads/export.ts
+++ b/apps/web/src/routes/downloads/export.ts
@@ -35,12 +35,10 @@ export const Route = createFileRoute("/downloads/export")({
           return new Response("Not found", { status: 404 })
         }
 
-        const filename = key.split("/").at(-1) ?? "export.csv.gz"
-        const isGzip = filename.endsWith(".csv.gz")
-        const contentType = isGzip ? "application/gzip" : "text/csv"
+        const filename = key.split("/").at(-1) ?? "export.zip"
         return new Response(webStream, {
           headers: {
-            "Content-Type": contentType,
+            "Content-Type": "application/zip",
             "Content-Disposition": `attachment; filename="${filename}"`,
           },
         })

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -51,6 +51,7 @@
     "@repo/observability": "workspace:*",
     "@repo/utils": "workspace:*",
     "effect": "catalog:",
+    "fflate": "^0.8.2",
     "tsx": "catalog:"
   },
   "devDependencies": {

--- a/apps/workers/src/workers/exports.ts
+++ b/apps/workers/src/workers/exports.ts
@@ -1,5 +1,3 @@
-import { promisify } from "node:util"
-import { gzip } from "node:zlib"
 import { buildDatasetExportUseCase } from "@domain/datasets"
 import { type EmailSender, exportReadyTemplate, type RenderedEmail, sendEmail } from "@domain/email"
 import type { ExportPayload } from "@domain/exports"
@@ -37,9 +35,8 @@ import { createEmailTransportSender } from "@platform/email-transport"
 import { createStorageDisk } from "@platform/storage-object"
 import { createLogger, withTracing } from "@repo/observability"
 import { Data, Effect, Layer } from "effect"
+import { strToU8, zip } from "fflate"
 import { getClickhouseClient, getPostgresClient, getRedisClient, getWeaviateClient } from "../clients.ts"
-
-const gzipAsync = promisify(gzip)
 
 class ExportError extends Data.TaggedError("ExportError")<{
   readonly cause: unknown
@@ -65,9 +62,17 @@ interface ExportsWorkerDeps {
   emailSender?: EmailSender
 }
 
-async function compressCsv(csv: string): Promise<Uint8Array> {
-  const compressed = await gzipAsync(csv)
-  return new Uint8Array(compressed.buffer, compressed.byteOffset, compressed.byteLength)
+function zipCsv(csv: string, innerFilename: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    zip({ [innerFilename]: strToU8(csv) }, { level: 9 }, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
+}
+
+function csvEntryNameForZip(zipFilename: string): string {
+  return zipFilename.endsWith(".zip") ? `${zipFilename.slice(0, -4)}.csv` : `${zipFilename}.csv`
 }
 
 type IssuesExportInput = {
@@ -236,7 +241,7 @@ export const createExportsWorker = ({
         const { csv, filename, exportName } = yield* dispatchExport(payload as ExportPayload)
 
         const content = yield* Effect.tryPromise({
-          try: () => compressCsv(csv),
+          try: () => zipCsv(csv, csvEntryNameForZip(filename)),
           catch: (cause) => new ExportError({ cause, kind }),
         })
 

--- a/packages/domain/exports/src/filenames.ts
+++ b/packages/domain/exports/src/filenames.ts
@@ -16,11 +16,11 @@ function formatExportTimestamp(value: Date): string {
 
 /**
  * Builds a filename for an export artifact.
- * All exports are compressed as `.csv.gz`.
+ * All exports are packaged as `.zip` archives containing a single `.csv` entry.
  */
 function buildExportFilename(kind: ExportKind, name: string, at = new Date()): string {
   const safeName = sanitizeExportFilename(name)
-  return `${safeName}_${kind}_export_${formatExportTimestamp(at)}.csv.gz`
+  return `${safeName}_${kind}_export_${formatExportTimestamp(at)}.zip`
 }
 
 /**

--- a/packages/domain/shared/src/storage.test.ts
+++ b/packages/domain/shared/src/storage.test.ts
@@ -37,7 +37,7 @@ describe("appendToDisk", () => {
         namespace: "exports",
         organizationId: OrganizationId("o".repeat(24)),
         projectId: ProjectId("p".repeat(24)),
-        filename: "issues.csv.gz",
+        filename: "issues.zip",
         content: "first",
       }),
     )
@@ -47,7 +47,7 @@ describe("appendToDisk", () => {
         namespace: "exports",
         organizationId: OrganizationId("o".repeat(24)),
         projectId: ProjectId("p".repeat(24)),
-        filename: "issues.csv.gz",
+        filename: "issues.zip",
         fileKey: firstKey,
         content: " second",
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.4
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       hono:
         specifier: 'catalog:'
         version: 4.12.15
@@ -8562,6 +8565,9 @@ packages:
 
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -18751,6 +18757,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   fflate@0.4.8: {}
+
+  fflate@0.8.2: {}
 
   file-uri-to-path@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Replace gzip compression with a single-entry zip archive for all exports (datasets, traces, issues). `.zip` is universally supported on Windows/macOS/Linux without extra tools, while `.csv.gz` regularly confuses users.
- Use [`fflate`](https://github.com/101arrowz/fflate) at compression level 9 to build the archive in the worker. fflate is small, pure JS, and produces output equivalent to other DEFLATE implementations at the same level.
- Drop the `application/gzip` content-type branch in the signed download route — all exports are now `application/zip`.

## Changes

- `apps/workers/src/workers/exports.ts` — replace `compressCsv` (gzip) with `zipCsv` using `fflate`. The inner `.csv` entry name mirrors the outer zip name.
- `packages/domain/exports/src/filenames.ts` — `buildExportFilename` now returns `.zip`.
- `apps/web/src/routes/downloads/export.ts` — always serve as `application/zip`.
- `apps/workers/package.json` — add `fflate@^0.8.2`.
- `packages/domain/shared/src/storage.test.ts` — update fixture filenames.

## Test plan

- [x] `pnpm --filter @domain/shared test` — passes (47 tests, including the updated storage append test)
- [x] `pnpm --filter @domain/exports test` — passes
- [x] `pnpm exec biome check` on all changed files — clean
- [ ] Manual: trigger a dataset export from the UI, receive the email, download the file, verify it is a valid `.zip` containing a single `.csv` and opens in Finder/Explorer/Numbers/Excel
- [ ] Manual: same for a traces export and an issues export

Note: existing `.csv.gz` artifacts already in object storage from in-flight signed URLs will fail to open correctly after this lands (Content-Type becomes `application/zip` for them too). Signed URLs expire after 7 days, so impact is bounded.