### PR TITLE
fix(issues): polish dashboard sorting, skeletons, and columns

### DIFF
--- a/apps/web/src/domains/issues/issues.collection.ts
+++ b/apps/web/src/domains/issues/issues.collection.ts
@@ -1,5 +1,5 @@
 import type { InfiniteTableInfiniteScroll } from "@repo/ui"
-import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useInfiniteQuery, useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 import { getQueryClient } from "../../lib/data/query-client.tsx"
 import type {
@@ -156,6 +156,7 @@ export function useIssues(input: {
   const {
     data: paginatedData,
     isLoading,
+    isPlaceholderData,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -165,6 +166,7 @@ export function useIssues(input: {
     initialPageParam: 0,
     getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined),
     staleTime: ISSUES_QUERY_STALE_TIME_MS,
+    placeholderData: keepPreviousData,
     enabled: (input.enabled ?? true) && input.projectId.length > 0,
   })
 
@@ -186,6 +188,10 @@ export function useIssues(input: {
     totalCount: firstPage?.totalCount ?? 0,
     occurrencesSum: firstPage?.occurrencesSum ?? 0,
     isLoading,
+    // True while a new query key is in flight and the previous result is being
+    // shown as placeholder (e.g. after a sort/filter change). Lets consumers
+    // surface skeleton states without unmounting the surrounding page layout.
+    isReloading: isPlaceholderData,
     infiniteScroll,
   }
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-formatters.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-formatters.ts
@@ -93,6 +93,12 @@ export function getLifecycleStatesForDisplay(states: readonly string[]): readonl
   ]
 }
 
+// Mirrors the backend's `getPrimaryStatePriority` so the table can display the
+// same single state used for sorting by status.
+export function getPrimaryLifecycleState(states: readonly string[]): string | undefined {
+  return getLifecycleStatesForDisplay(states)[0]
+}
+
 export function formatLifecycleLabel(state: string): string {
   switch (state) {
     case "new":

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -14,7 +14,7 @@ import {
   ListingLayout as Layout,
   listingLayoutIntrinsicScroll,
 } from "../../../../../../layouts/ListingLayout/index.tsx"
-import { formatPercent, formatSeenAgeParts } from "./issue-formatters.ts"
+import { formatPercent, formatSeenAgeParts, getPrimaryLifecycleState } from "./issue-formatters.ts"
 import { IssueLifecycleStatuses } from "./issue-lifecycle-statuses.tsx"
 import { IssueTrendBar } from "./issue-trend-bar.tsx"
 
@@ -31,8 +31,8 @@ export type IssuesColumnId = (typeof ISSUES_COLUMN_OPTIONS)[number]["id"]
 
 const ISSUE_COLUMN_WIDTH = 360
 const ISSUE_COLUMN_MIN_WIDTH = 280
-const STATUS_COLUMN_WIDTH = 200
-const STATUS_COLUMN_MIN_WIDTH = 160
+const STATUS_COLUMN_WIDTH = 104
+const STATUS_COLUMN_MIN_WIDTH = 96
 
 function SeenAtCell({
   lastSeenAtIso,
@@ -169,11 +169,14 @@ export function IssuesView({
       width: STATUS_COLUMN_WIDTH,
       minWidth: STATUS_COLUMN_MIN_WIDTH,
       sortKey: "state",
-      render: (issue) => (
-        <div className="flex min-w-0 items-center">
-          <IssueLifecycleStatuses states={issue.states} wrap={false} />
-        </div>
-      ),
+      render: (issue) => {
+        const primaryState = getPrimaryLifecycleState(issue.states)
+        return (
+          <div className="flex min-w-0 items-center">
+            <IssueLifecycleStatuses states={primaryState ? [primaryState] : []} wrap={false} />
+          </div>
+        )
+      },
     },
     {
       key: "trend",
@@ -192,6 +195,14 @@ export function IssuesView({
           showEscalationThresholdGuide
         />
       ),
+      renderSubheader: () => (
+        <div className="flex min-w-0 w-full items-center gap-0.5">
+          <Text.H6 color="foregroundMuted" className="min-w-0 truncate tabular-nums">
+            RANGE
+          </Text.H6>
+          <Text.H6B color="foreground">14d</Text.H6B>
+        </div>
+      ),
     },
     {
       key: "seenAt",
@@ -204,8 +215,8 @@ export function IssuesView({
     {
       key: "occurrences",
       header: "Occurrences",
-      width: 84,
-      minWidth: 84,
+      width: 76,
+      minWidth: 76,
       align: "end",
       sortKey: "occurrences",
       render: (issue) => formatCount(issue.occurrences),
@@ -221,8 +232,8 @@ export function IssuesView({
     {
       key: "affectedTraces",
       header: "Affected traces",
-      width: 89,
-      minWidth: 89,
+      width: 76,
+      minWidth: 76,
       align: "end",
       render: (issue) => formatPercent(issue.affectedTracesPercent),
     },

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -16,7 +16,11 @@ import { ActivityIcon, ArchiveIcon, CheckIcon, DownloadIcon, PauseIcon, SearchIc
 import { useCallback, useMemo, useRef, useState } from "react"
 import { useDebounce } from "react-use"
 import { invalidateIssueQueries, useIssues } from "../../../../../domains/issues/issues.collection.ts"
-import { applyBulkIssueLifecycleAction, enqueueIssuesExport } from "../../../../../domains/issues/issues.functions.ts"
+import {
+  applyBulkIssueLifecycleAction,
+  enqueueIssuesExport,
+  type IssueRecord,
+} from "../../../../../domains/issues/issues.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
@@ -38,6 +42,10 @@ import {
 const DEFAULT_SORTING: IssuesTableSorting = { column: "lastSeen", direction: "desc" }
 const DEFAULT_COLUMNS: IssuesColumnId[] = ISSUES_COLUMN_OPTIONS.map((column) => column.id)
 const ISSUE_SEARCH_DEBOUNCE_MS = 300
+const SORT_COLUMNS = ["lastSeen", "occurrences", "state"] as const satisfies readonly IssuesTableSorting["column"][]
+const SORT_DIRECTIONS = ["asc", "desc"] as const satisfies readonly IssuesTableSorting["direction"][]
+const SORT_PARAM_PATTERN = /^(lastSeen|occurrences|state):(asc|desc)$/
+const EMPTY_ISSUES: readonly IssueRecord[] = []
 
 function parseColumnIds(raw?: string): IssuesColumnId[] {
   const values = raw
@@ -56,6 +64,24 @@ function serializeColumnIds(columnIds: readonly IssuesColumnId[]): string {
   return Array.from(new Set(["issue", ...columnIds])).join(",")
 }
 
+function serializeSorting(sorting: IssuesTableSorting): string {
+  return `${sorting.column}:${sorting.direction}`
+}
+
+function parseSorting(raw: string): IssuesTableSorting {
+  const [column, direction] = raw.split(":")
+  if (
+    SORT_COLUMNS.includes(column as IssuesTableSorting["column"]) &&
+    SORT_DIRECTIONS.includes(direction as IssuesTableSorting["direction"])
+  ) {
+    return {
+      column: column as IssuesTableSorting["column"],
+      direction: direction as IssuesTableSorting["direction"],
+    }
+  }
+  return DEFAULT_SORTING
+}
+
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/issues/")({
   component: IssuesPage,
 })
@@ -72,7 +98,11 @@ function IssuesPage() {
   const [timeTo, setTimeTo] = useParamState("issuesTimeTo", "")
   const [searchQuery, setSearchQuery] = useParamState("issuesSearch", "")
   const [searchInput, setSearchInput] = useValueWithDefault(searchQuery)
-  const [sorting, setSorting] = useState<IssuesTableSorting>(DEFAULT_SORTING)
+  const [rawSorting, setRawSorting] = useParamState("issuesSort", serializeSorting(DEFAULT_SORTING), {
+    validate: (value): value is string => SORT_PARAM_PATTERN.test(value),
+  })
+  const sorting = useMemo(() => parseSorting(rawSorting), [rawSorting])
+  const setSorting = useCallback((next: IssuesTableSorting) => setRawSorting(serializeSorting(next)), [setRawSorting])
   const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
@@ -103,11 +133,12 @@ function IssuesPage() {
       : undefined
 
   const {
-    data: issues,
+    data: issuesData,
     analytics,
     occurrencesSum,
     totalCount,
     isLoading,
+    isReloading,
     infiniteScroll,
   } = useIssues({
     projectId: project.id,
@@ -116,6 +147,13 @@ function IssuesPage() {
     ...(searchQuery ? { searchQuery } : {}),
     ...(timeRange ? { timeRange } : {}),
   })
+
+  // While a filter/sort change is in flight we hide the (now stale) previous
+  // rows so the table and analytics fall back to their skeleton state. The
+  // surrounding page layout (filters, search, lifecycle tabs) keeps rendering
+  // because `isLoading` itself stays false during the placeholder window.
+  const showSkeletons = isLoading || isReloading
+  const issues = isReloading ? EMPTY_ISSUES : issuesData
 
   const currentIssueIndex = activeIssueId ? issueIdsRef.current.indexOf(activeIssueId) : -1
   const issueIds = useMemo(() => issues.map((issue) => issue.id), [issues])
@@ -250,8 +288,10 @@ function IssuesPage() {
   }, [lifecycleGroup, project.id, searchQuery, selection, sorting.column, sorting.direction, timeRange])
 
   const hasActiveFilters = lifecycleGroup !== "active" || searchQuery !== "" || Boolean(timeRange)
-  const hasNoIssues = issues.length === 0 && !hasActiveFilters
-  const showEmptyState = !isLoading && hasNoIssues
+  // Derived from the un-substituted data so a placeholder reload (which forces
+  // `issues` to []) does not falsely trigger the empty state.
+  const hasNoIssues = issuesData.length === 0 && !hasActiveFilters
+  const showEmptyState = !showSkeletons && hasNoIssues
 
   if (isLoading && hasNoIssues) {
     return null
@@ -351,7 +391,7 @@ function IssuesPage() {
         <div className="px-6">
           <IssuesAnalyticsPanel
             analytics={analytics}
-            isLoading={isLoading && issues.length === 0}
+            isLoading={showSkeletons}
             onRangeSelect={(range) => {
               setTimeFrom(range?.from ?? "")
               setTimeTo(range?.to ?? "")
@@ -360,7 +400,7 @@ function IssuesPage() {
         </div>
         <IssuesView
           issues={issues}
-          isLoading={isLoading}
+          isLoading={showSkeletons}
           infiniteScroll={infiniteScroll}
           sorting={sorting}
           occurrencesSum={occurrencesSum}


### PR DESCRIPTION
- **Sort persisted in the URL.** Sorting state moves from local React
  state to `?issuesSort=<column>:<direction>` via `useParamState`,
  matching the other issue filters. Default (`lastSeen:desc`) is
  stripped from the URL; tampered values fall back to the default via a
  regex validator.
- **Loading skeletons during refetches.** The original `useInfiniteQuery`
  call had no `placeholderData`, so every sort/filter change cleared
  data, flipped `isLoading` to `true`, and tripped the page-level early
  return — the whole dashboard blanked. We now use
  `placeholderData: keepPreviousData` and expose a separate
  `isReloading` (= `isPlaceholderData`) signal. The page-level layout
  keeps rendering, while `IssuesView` and `IssuesAnalyticsPanel`
  receive `isLoading={showSkeletons}` and an empty rows array, so the
  table + histogram skeletons fire on every filter/sort change without
  unmounting the surrounding chrome.
- **Single primary status in the table.** Issues can be in multiple
  states at once but the backend already orders by a single primary
  state (`getPrimaryStatePriority` in `list-issues.ts`). The Status
  column now mirrors that with a new `getPrimaryLifecycleState` helper
  and renders only that badge, freeing up significant horizontal space.
  The detail drawer still shows the full list of states.
- **Tighter number columns.** Occurrences (84 → 76) and Affected traces
  (89 → 76) now match the width of their formatted values rather than
  reserving space that nothing fills.
- **Static "RANGE 14d" subheader on Trend.** The trend window is hard-
  coded to 14 days in `resolveTrendTimeRange`; users now see that
  surfaced under the column header in the same SUM-style format used
  by Occurrences.