### PR TITLE
fix(openclaw-telemetry): plugin discovery + --version CLI flag (0.0.3)

### DIFF
--- a/packages/telemetry/openclaw/CHANGELOG.md
+++ b/packages/telemetry/openclaw/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-04-27
+
+### Fixed
+
+- **OpenClaw discovery now actually finds the plugin.** 0.0.2 shipped `openclaw.plugin.json` correctly (manifest with `id` + `configSchema`), but `package.json` was missing the `openclaw.extensions` field. OpenClaw's `resolvePackageExtensionEntries` reads `package.json["openclaw"].extensions` to know **where** the plugin entry lives — without it, discovery falls through to looking for `index.{ts,js,mjs,cjs}` at the directory root, doesn't find one, and skips us silently. The gateway then warns `plugin not found: @latitude-data/openclaw-telemetry (stale config entry ignored; remove it from plugins config)` even though everything else is in place. Now both the published `package.json` and the minimal `package.json` the installer writes into `~/.openclaw/extensions/latitude-telemetry/` declare `"openclaw": { "extensions": ["./dist/plugin.js"] }`. After re-running `install`, the gateway log lists `@latitude-data/openclaw-telemetry` in the ready-plugins line.
+
+### Added
+
+- `--version` / `-v` and `--help` / `-h` top-level flags on the CLI. Run `npx -y @latitude-data/openclaw-telemetry --version` to confirm which version is installed (or shadow-cached) on a given box.
+
 ## [0.0.2] - 2026-04-25
 
 End-to-end install fix. The 0.0.1 install path was broken in five places, all reported by an OpenClaw 2026.4.21 maintainer who tried it on a real install. Re-running `npx -y @latitude-data/openclaw-telemetry install` cleans up any leftover 0.0.1 keys.

--- a/packages/telemetry/openclaw/openclaw.plugin.json
+++ b/packages/telemetry/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "@latitude-data/openclaw-telemetry",
   "name": "Latitude Telemetry",
   "description": "Streams every OpenClaw agent run to Latitude as OTLP traces — full prompt, message history, assistant output, tool I/O, token usage, and agent name.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "configSchema": {
     "type": "object",
     "additionalProperties": true,

--- a/packages/telemetry/openclaw/package.json
+++ b/packages/telemetry/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/openclaw-telemetry",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "OpenClaw plugin that streams LLM calls, tool executions, and agent runs to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",
@@ -27,6 +27,9 @@
   },
   "main": "./dist/plugin.js",
   "types": "./dist/plugin.d.ts",
+  "openclaw": {
+    "extensions": ["./dist/plugin.js"]
+  },
   "exports": {
     ".": {
       "types": "./dist/plugin.d.ts",

--- a/packages/telemetry/openclaw/src/cli.ts
+++ b/packages/telemetry/openclaw/src/cli.ts
@@ -1,7 +1,52 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { normalizeInstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
 
+const USAGE = `usage: latitude-openclaw <command> [options]
+
+commands:
+  install               Install the plugin (interactive when stdin is a TTY)
+  uninstall             Remove the plugin entry and files
+  --version, -v         Print the package version
+  --help, -h            Print this message
+
+install options:
+  --api-key=<key>       Pass the API key non-interactively
+  --project=<slug>      Pass the project slug non-interactively
+  --staging             Target https://staging.latitude.so / staging-ingest
+  --dev                 Target http://localhost:3000 / 3002
+  --no-content          Skip raw prompt/response/tool I/O capture
+  --allow-conversation  Force conversation capture on (overrides existing config)
+  --yes / --no-prompt   Skip all prompts (required for non-TTY / CI)
+`
+
+function readVersion(): string {
+  // dist/cli.js → ../package.json
+  const here = dirname(fileURLToPath(import.meta.url))
+  const pkgPath = join(here, "..", "package.json")
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string }
+    return pkg.version ?? "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
 async function main(): Promise<void> {
-  const { subcommand, flags } = parseFlags(process.argv.slice(2))
+  const argv = process.argv.slice(2)
+  // Top-level --version / --help are handled before parseFlags so users can
+  // type them as the first arg without hitting the "unknown subcommand" path.
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    process.stdout.write(`${readVersion()}\n`)
+    return
+  }
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    process.stdout.write(USAGE)
+    return
+  }
+
+  const { subcommand, flags } = parseFlags(argv)
   if (subcommand === "install" || subcommand === undefined) {
     await runInstall(normalizeInstallFlags(flags))
     return
@@ -11,9 +56,7 @@ async function main(): Promise<void> {
     return
   }
   process.stderr.write(`unknown subcommand: ${subcommand}\n`)
-  process.stderr.write(
-    "usage: latitude-openclaw [install|uninstall] [--api-key=...] [--project=...] [--staging|--dev] [--yes]\n",
-  )
+  process.stderr.write(USAGE)
   process.exit(1)
 }
 

--- a/packages/telemetry/openclaw/src/install-files.ts
+++ b/packages/telemetry/openclaw/src/install-files.ts
@@ -35,6 +35,15 @@ export function installPluginFiles(): { destination: string; entryPath: string }
   if (!existsSync(distSrc)) {
     throw new Error(`Cannot install: missing compiled dist at ${distSrc}.`)
   }
+  if (!existsSync(pkgSrc)) {
+    // package.json is now load-bearing for OpenClaw discovery (it carries
+    // `openclaw.extensions`), so missing it would silently regress to the
+    // "plugin not found" failure mode 0.0.3 was meant to fix. Match the
+    // other packaging-bug checks above and fail loudly instead.
+    throw new Error(
+      `Cannot install: missing package.json at ${pkgSrc}. This is a packaging bug — please file an issue.`,
+    )
+  }
 
   // Wipe and recreate so a re-install isn't polluted by a previous version's
   // files. Idempotent.
@@ -55,29 +64,32 @@ export function installPluginFiles(): { destination: string; entryPath: string }
   //     falls through to looking for `index.{ts,js,mjs,cjs}` at the dir
   //     root, doesn't find one, and skips us — which manifests as
   //     "plugin not found" at gateway start.
-  if (existsSync(pkgSrc)) {
-    const sourcePkg = JSON.parse(readFileSync(pkgSrc, "utf-8")) as {
-      name?: string
-      version?: string
-      type?: string
-      main?: string
-      openclaw?: { extensions?: string[] }
-    }
-    const extensions = sourcePkg.openclaw?.extensions ?? ["./dist/plugin.js"]
-    const minimalPkg = {
-      name: sourcePkg.name,
-      version: sourcePkg.version,
-      type: sourcePkg.type ?? "module",
-      main: sourcePkg.main ?? "./dist/plugin.js",
-      private: true,
-      openclaw: { extensions },
-    }
-    writeFileSync(join(PLUGIN_INSTALL_DIR, "package.json"), `${JSON.stringify(minimalPkg, null, 2)}\n`, "utf-8")
+  const sourcePkg = JSON.parse(readFileSync(pkgSrc, "utf-8")) as {
+    name?: string
+    version?: string
+    type?: string
+    main?: string
+    openclaw?: { extensions?: string[] }
   }
+  const extensions = sourcePkg.openclaw?.extensions ?? ["./dist/plugin.js"]
+  const minimalPkg = {
+    name: sourcePkg.name,
+    version: sourcePkg.version,
+    type: sourcePkg.type ?? "module",
+    main: sourcePkg.main ?? "./dist/plugin.js",
+    private: true,
+    openclaw: { extensions },
+  }
+  writeFileSync(join(PLUGIN_INSTALL_DIR, "package.json"), `${JSON.stringify(minimalPkg, null, 2)}\n`, "utf-8")
 
+  // Derive the entry path from the resolved extensions rather than
+  // hard-coding it, so callers reading `entryPath` stay consistent if the
+  // package's openclaw.extensions ever points somewhere other than
+  // `./dist/plugin.js` (e.g. multi-entry plugins).
+  const primaryEntry = extensions[0] ?? "./dist/plugin.js"
   return {
     destination: PLUGIN_INSTALL_DIR,
-    entryPath: join(PLUGIN_INSTALL_DIR, "dist", "plugin.js"),
+    entryPath: resolve(PLUGIN_INSTALL_DIR, primaryEntry),
   }
 }
 

--- a/packages/telemetry/openclaw/src/install-files.ts
+++ b/packages/telemetry/openclaw/src/install-files.ts
@@ -44,22 +44,33 @@ export function installPluginFiles(): { destination: string; entryPath: string }
   copyFileSync(manifestSrc, join(PLUGIN_INSTALL_DIR, "openclaw.plugin.json"))
   cpSync(distSrc, join(PLUGIN_INSTALL_DIR, "dist"), { recursive: true })
 
-  // Write a minimal package.json so anything that runs `require("./dist/plugin.js")`
-  // from a `type: module` context still resolves cleanly (we mirror the source
-  // package's `type` and `main` fields).
+  // Write a minimal package.json. Three fields matter for OpenClaw:
+  //   - `name`/`version` for diagnostics.
+  //   - `type: "module"` so node treats `dist/plugin.js` as ESM.
+  //   - `openclaw.extensions: [...]` — THIS is what OpenClaw's plugin
+  //     discovery uses to find the plugin entry file. The
+  //     `openclaw.plugin.json` manifest provides id + configSchema, but
+  //     discovery's `resolvePackageExtensionEntries` reads
+  //     `package.json["openclaw"].extensions`. Without this, discovery
+  //     falls through to looking for `index.{ts,js,mjs,cjs}` at the dir
+  //     root, doesn't find one, and skips us — which manifests as
+  //     "plugin not found" at gateway start.
   if (existsSync(pkgSrc)) {
     const sourcePkg = JSON.parse(readFileSync(pkgSrc, "utf-8")) as {
       name?: string
       version?: string
       type?: string
       main?: string
+      openclaw?: { extensions?: string[] }
     }
+    const extensions = sourcePkg.openclaw?.extensions ?? ["./dist/plugin.js"]
     const minimalPkg = {
       name: sourcePkg.name,
       version: sourcePkg.version,
       type: sourcePkg.type ?? "module",
       main: sourcePkg.main ?? "./dist/plugin.js",
       private: true,
+      openclaw: { extensions },
     }
     writeFileSync(join(PLUGIN_INSTALL_DIR, "package.json"), `${JSON.stringify(minimalPkg, null, 2)}\n`, "utf-8")
   }


### PR DESCRIPTION
## Summary

Two fixes, both shipped together as 0.0.3:

### Critical: 0.0.2 plugin still wasn't being discovered

After installing 0.0.2 cleanly, the gateway was still emitting:

```
Config warnings:
  - plugins.entries.@latitude-data/openclaw-telemetry: plugin not found:
    @latitude-data/openclaw-telemetry (stale config entry ignored;
    remove it from plugins config)
```

Root cause: OpenClaw's [`resolvePackageExtensionEntries`](https://github.com/openclaw/openclaw/blob/main/src/plugins/manifest.ts) reads **`package.json["openclaw"].extensions`** to locate the plugin's entry file. `openclaw.plugin.json` only provides id + configSchema; the package.json field is what tells discovery *where* the runnable code lives. Without it, discovery falls through to looking for `index.{ts,js,mjs,cjs}` at the directory root, doesn't find one, and silently skips us — at which point the config validator correctly flags the openclaw.json entry as stale.

The bundled `anthropic` extension confirms the contract:

```json
{
  "openclaw": { "extensions": ["./index.ts"] }
}
```

Two changes:

1. The published `package.json` now declares `"openclaw": { "extensions": ["./dist/plugin.js"] }`.
2. `installPluginFiles` writes the same field into the minimal `package.json` it materializes at `~/.openclaw/extensions/latitude-telemetry/`.

After re-running install with 0.0.3 and `openclaw gateway restart`, the plugin should appear in the ready-plugins line and the warning should be gone.

### Quality of life: `--version` and `--help` CLI flags

The CLI rejected `--version` as an "unknown subcommand". Added an early short-circuit so `--version` prints the package.json version (read at runtime via `import.meta.url`) and `--help` prints a richer usage block covering all install flags. Useful for verifying which version a given box is actually running, especially when npm's cache might be serving stale tarballs.

## Test plan

- [x] `pnpm --filter @latitude-data/openclaw-telemetry typecheck` (passes)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry test` (49 tests passing — same coverage as 0.0.2; install-files.ts is integration code exercised end-to-end)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry check` (passes)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry build` produces `dist/plugin.js` + `dist/cli.js`
- [x] `node dist/cli.js --version` prints `0.0.3`
- [ ] After merge + publish, on the reporter's OpenClaw 2026.4.21 box: `npx -y @latitude-data/openclaw-telemetry@0.0.3 install --staging` → `openclaw gateway restart` → no "plugin not found" warning, plugin appears in ready-plugins line, traces actually flow.

## Caveat

If the user has an existing 0.0.2 install at `~/.openclaw/extensions/latitude-telemetry/`, re-running `install` cleanly overwrites it (the install dir is wiped + recreated on every run — see `installPluginFiles`). No manual cleanup needed.