### PR TITLE
feat(backoffice): dashboard layouts for user / project / organization pages

### DIFF
--- a/apps/web/scripts/check-bundle-size.mjs
+++ b/apps/web/scripts/check-bundle-size.mjs
@@ -8,6 +8,27 @@ const assetsDir = path.resolve(process.cwd(), ".output/public/assets")
 // Chunks that are known to exceed the limit and are lazy-loaded on demand.
 const ALLOWED_OVERSIZE = new Set(["echarts"])
 
+/**
+ * Recover the codeSplitting group name from a rolldown chunk filename
+ * like `echarts-7FKUQ-tc.js`. Naively stripping `-{hash}.js` does not
+ * work because rolldown sometimes produces hashes that themselves
+ * contain hyphens (e.g. `7FKUQ-tc`). We walk the dash-separated
+ * segments from longest-prefix to shortest and return the first
+ * candidate that's in the allowlist — that's robust to any number of
+ * hyphens in the hash. Returns null when no allowlisted prefix
+ * matches.
+ */
+function matchAllowedChunkName(basename) {
+  if (!basename.endsWith(".js")) return null
+  const stem = basename.slice(0, -".js".length)
+  const segments = stem.split("-")
+  for (let i = segments.length - 1; i >= 1; i--) {
+    const candidate = segments.slice(0, i).join("-")
+    if (ALLOWED_OVERSIZE.has(candidate)) return candidate
+  }
+  return null
+}
+
 async function collectFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true })
   const files = []
@@ -46,8 +67,7 @@ async function main() {
     }
 
     const basename = path.basename(file)
-    const chunkName = basename.replace(/-[\w]+\.js$/, "")
-    if (ALLOWED_OVERSIZE.has(chunkName)) {
+    if (matchAllowedChunkName(basename) !== null) {
       continue
     }
 

--- a/apps/web/src/domains/admin/organizations.functions.test.ts
+++ b/apps/web/src/domains/admin/organizations.functions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { adminGetOrganizationInputSchema } from "./organizations.functions.ts"
+
+describe("adminGetOrganizationInputSchema", () => {
+  it("accepts a valid organizationId", () => {
+    expect(adminGetOrganizationInputSchema.safeParse({ organizationId: "org-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty organizationId", () => {
+    expect(adminGetOrganizationInputSchema.safeParse({ organizationId: "" }).success).toBe(false)
+  })
+
+  it("rejects an organizationId above the max length (defensive abuse bound)", () => {
+    expect(adminGetOrganizationInputSchema.safeParse({ organizationId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing organizationId", () => {
+    expect(adminGetOrganizationInputSchema.safeParse({}).success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/admin/organizations.functions.ts
+++ b/apps/web/src/domains/admin/organizations.functions.ts
@@ -1,0 +1,97 @@
+import { type AdminOrganizationDetails, getOrganizationDetailsUseCase } from "@domain/admin"
+import { OrganizationId } from "@domain/shared"
+import { AdminOrganizationRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { adminMiddleware } from "../../server/admin-middleware.ts"
+import { getAdminPostgresClient } from "../../server/clients.ts"
+
+export interface AdminOrganizationMemberDto {
+  membershipId: string
+  role: "owner" | "admin" | "member"
+  user: {
+    id: string
+    email: string
+    name: string | null
+    image: string | null
+    role: "user" | "admin"
+  }
+}
+
+export interface AdminOrganizationProjectDto {
+  id: string
+  name: string
+  slug: string
+  createdAt: string
+}
+
+export interface AdminOrganizationDetailsDto {
+  id: string
+  name: string
+  slug: string
+  stripeCustomerId: string | null
+  members: AdminOrganizationMemberDto[]
+  projects: AdminOrganizationProjectDto[]
+  createdAt: string
+  updatedAt: string
+}
+
+const toDto = (details: AdminOrganizationDetails): AdminOrganizationDetailsDto => ({
+  id: details.id,
+  name: details.name,
+  slug: details.slug,
+  stripeCustomerId: details.stripeCustomerId,
+  members: details.members.map((m) => ({
+    membershipId: m.membershipId,
+    role: m.role,
+    user: {
+      id: m.user.id,
+      email: m.user.email,
+      name: m.user.name,
+      image: m.user.image,
+      role: m.user.role,
+    },
+  })),
+  projects: details.projects.map((p) => ({
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    createdAt: p.createdAt.toISOString(),
+  })),
+  createdAt: details.createdAt.toISOString(),
+  updatedAt: details.updatedAt.toISOString(),
+})
+
+/**
+ * Exported for input-schema tests.
+ */
+export const adminGetOrganizationInputSchema = z.object({
+  organizationId: z.string().min(1).max(256),
+})
+
+/**
+ * Backoffice organisation-detail fetch.
+ *
+ * Guard: {@link adminMiddleware} — runs before validation, rejects
+ * non-admins with `NotFoundError` (identical to hitting a non-existent
+ * server function). Queries use {@link getAdminPostgresClient} +
+ * `withPostgres` at the default `OrganizationId("system")` scope —
+ * the only sanctioned RLS-bypass signal.
+ */
+export const adminGetOrganization = createServerFn({ method: "GET" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminGetOrganizationInputSchema)
+  .handler(async ({ data }): Promise<AdminOrganizationDetailsDto> => {
+    const client = getAdminPostgresClient()
+
+    const details = await Effect.runPromise(
+      getOrganizationDetailsUseCase({ organizationId: OrganizationId(data.organizationId) }).pipe(
+        withPostgres(AdminOrganizationRepositoryLive, client),
+        withTracing,
+      ),
+    )
+
+    return toDto(details)
+  })

--- a/apps/web/src/domains/admin/organizations.functions.ts
+++ b/apps/web/src/domains/admin/organizations.functions.ts
@@ -27,7 +27,7 @@ export interface AdminOrganizationProjectDto {
   createdAt: string
 }
 
-export interface AdminOrganizationDetailsDto {
+interface AdminOrganizationDetailsDto {
   id: string
   name: string
   slug: string

--- a/apps/web/src/domains/admin/projects.functions.test.ts
+++ b/apps/web/src/domains/admin/projects.functions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { adminGetProjectInputSchema } from "./projects.functions.ts"
+
+describe("adminGetProjectInputSchema", () => {
+  it("accepts a valid projectId", () => {
+    expect(adminGetProjectInputSchema.safeParse({ projectId: "proj-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty projectId", () => {
+    expect(adminGetProjectInputSchema.safeParse({ projectId: "" }).success).toBe(false)
+  })
+
+  it("rejects a projectId above the max length (defensive abuse bound)", () => {
+    expect(adminGetProjectInputSchema.safeParse({ projectId: "x".repeat(257) }).success).toBe(false)
+  })
+
+  it("rejects missing projectId", () => {
+    expect(adminGetProjectInputSchema.safeParse({}).success).toBe(false)
+  })
+})

--- a/apps/web/src/domains/admin/projects.functions.ts
+++ b/apps/web/src/domains/admin/projects.functions.ts
@@ -8,13 +8,13 @@ import { z } from "zod"
 import { adminMiddleware } from "../../server/admin-middleware.ts"
 import { getAdminPostgresClient } from "../../server/clients.ts"
 
-export interface AdminProjectOrganizationDto {
+interface AdminProjectOrganizationDto {
   id: string
   name: string
   slug: string
 }
 
-export interface AdminProjectDetailsDto {
+interface AdminProjectDetailsDto {
   id: string
   name: string
   slug: string

--- a/apps/web/src/domains/admin/projects.functions.ts
+++ b/apps/web/src/domains/admin/projects.functions.ts
@@ -1,0 +1,73 @@
+import { type AdminProjectDetails, getProjectDetailsUseCase } from "@domain/admin"
+import { ProjectId } from "@domain/shared"
+import { AdminProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { withTracing } from "@repo/observability"
+import { createServerFn } from "@tanstack/react-start"
+import { Effect } from "effect"
+import { z } from "zod"
+import { adminMiddleware } from "../../server/admin-middleware.ts"
+import { getAdminPostgresClient } from "../../server/clients.ts"
+
+export interface AdminProjectOrganizationDto {
+  id: string
+  name: string
+  slug: string
+}
+
+export interface AdminProjectDetailsDto {
+  id: string
+  name: string
+  slug: string
+  organization: AdminProjectOrganizationDto
+  settings: { keepMonitoring?: boolean | undefined } | null
+  firstTraceAt: string | null
+  lastEditedAt: string
+  deletedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+const toDto = (details: AdminProjectDetails): AdminProjectDetailsDto => ({
+  id: details.id,
+  name: details.name,
+  slug: details.slug,
+  organization: details.organization,
+  settings: details.settings,
+  firstTraceAt: details.firstTraceAt ? details.firstTraceAt.toISOString() : null,
+  lastEditedAt: details.lastEditedAt.toISOString(),
+  deletedAt: details.deletedAt ? details.deletedAt.toISOString() : null,
+  createdAt: details.createdAt.toISOString(),
+  updatedAt: details.updatedAt.toISOString(),
+})
+
+/**
+ * Exported for input-schema tests.
+ */
+export const adminGetProjectInputSchema = z.object({
+  projectId: z.string().min(1).max(256),
+})
+
+/**
+ * Backoffice project-detail fetch.
+ *
+ * Guard: {@link adminMiddleware} — runs before validation, rejects
+ * non-admins with `NotFoundError` (identical to hitting a non-existent
+ * server function). Queries use {@link getAdminPostgresClient} +
+ * `withPostgres` at the default `OrganizationId("system")` scope —
+ * the only sanctioned RLS-bypass signal.
+ */
+export const adminGetProject = createServerFn({ method: "GET" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminGetProjectInputSchema)
+  .handler(async ({ data }): Promise<AdminProjectDetailsDto> => {
+    const client = getAdminPostgresClient()
+
+    const details = await Effect.runPromise(
+      getProjectDetailsUseCase({ projectId: ProjectId(data.projectId) }).pipe(
+        withPostgres(AdminProjectRepositoryLive, client),
+        withTracing,
+      ),
+    )
+
+    return toDto(details)
+  })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -15,7 +15,7 @@ export interface AdminUserDetailsMembershipDto {
   role: "owner" | "admin" | "member"
 }
 
-interface AdminUserDetailsDto {
+export interface AdminUserDetailsDto {
   id: string
   email: string
   name: string | null

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticat
 import { Route as ApiObservabilityTestIndexRouteImport } from './routes/api/observability-test/index'
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as BackofficeUsersUserIdRouteImport } from './routes/backoffice/users/$userId'
+import { Route as BackofficeProjectsProjectIdRouteImport } from './routes/backoffice/projects/$projectId'
 import { Route as ApiObservabilityTestErrorRouteImport } from './routes/api/observability-test/error'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AuthenticatedSettingsOrganizationRouteImport } from './routes/_authenticated/settings/organization'
@@ -137,6 +138,12 @@ const BackofficeUsersUserIdRoute = BackofficeUsersUserIdRouteImport.update({
   path: '/users/$userId',
   getParentRoute: () => BackofficeRouteRoute,
 } as any)
+const BackofficeProjectsProjectIdRoute =
+  BackofficeProjectsProjectIdRouteImport.update({
+    id: '/projects/$projectId',
+    path: '/projects/$projectId',
+    getParentRoute: () => BackofficeRouteRoute,
+  } as any)
 const ApiObservabilityTestErrorRoute =
   ApiObservabilityTestErrorRouteImport.update({
     id: '/api/observability-test/error',
@@ -273,6 +280,7 @@ export interface FileRoutesByFullPath {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
@@ -306,6 +314,7 @@ export interface FileRoutesByTo {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test': typeof ApiObservabilityTestIndexRoute
@@ -344,6 +353,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
   '/api/observability-test/': typeof ApiObservabilityTestIndexRoute
@@ -383,6 +393,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/settings/'
     | '/api/observability-test/'
@@ -416,6 +427,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/settings'
     | '/api/observability-test'
@@ -453,6 +465,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/_authenticated/settings/'
     | '/api/observability-test/'
@@ -611,6 +624,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BackofficeUsersUserIdRouteImport
       parentRoute: typeof BackofficeRouteRoute
     }
+    '/backoffice/projects/$projectId': {
+      id: '/backoffice/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/backoffice/projects/$projectId'
+      preLoaderRoute: typeof BackofficeProjectsProjectIdRouteImport
+      parentRoute: typeof BackofficeRouteRoute
+    }
     '/api/observability-test/error': {
       id: '/api/observability-test/error'
       path: '/api/observability-test/error'
@@ -743,12 +763,14 @@ declare module '@tanstack/react-router' {
 interface BackofficeRouteRouteChildren {
   BackofficeSearchRoute: typeof BackofficeSearchRoute
   BackofficeIndexRoute: typeof BackofficeIndexRoute
+  BackofficeProjectsProjectIdRoute: typeof BackofficeProjectsProjectIdRoute
   BackofficeUsersUserIdRoute: typeof BackofficeUsersUserIdRoute
 }
 
 const BackofficeRouteRouteChildren: BackofficeRouteRouteChildren = {
   BackofficeSearchRoute: BackofficeSearchRoute,
   BackofficeIndexRoute: BackofficeIndexRoute,
+  BackofficeProjectsProjectIdRoute: BackofficeProjectsProjectIdRoute,
   BackofficeUsersUserIdRoute: BackofficeUsersUserIdRoute,
 }
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as ApiObservabilityTestIndexRouteImport } from './routes/api/obse
 import { Route as AuthenticatedSettingsIndexRouteImport } from './routes/_authenticated/settings/index'
 import { Route as BackofficeUsersUserIdRouteImport } from './routes/backoffice/users/$userId'
 import { Route as BackofficeProjectsProjectIdRouteImport } from './routes/backoffice/projects/$projectId'
+import { Route as BackofficeOrganizationsOrganizationIdRouteImport } from './routes/backoffice/organizations/$organizationId'
 import { Route as ApiObservabilityTestErrorRouteImport } from './routes/api/observability-test/error'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as AuthenticatedSettingsOrganizationRouteImport } from './routes/_authenticated/settings/organization'
@@ -142,6 +143,12 @@ const BackofficeProjectsProjectIdRoute =
   BackofficeProjectsProjectIdRouteImport.update({
     id: '/projects/$projectId',
     path: '/projects/$projectId',
+    getParentRoute: () => BackofficeRouteRoute,
+  } as any)
+const BackofficeOrganizationsOrganizationIdRoute =
+  BackofficeOrganizationsOrganizationIdRouteImport.update({
+    id: '/organizations/$organizationId',
+    path: '/organizations/$organizationId',
     getParentRoute: () => BackofficeRouteRoute,
   } as any)
 const ApiObservabilityTestErrorRoute =
@@ -280,6 +287,7 @@ export interface FileRoutesByFullPath {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
   '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings/': typeof AuthenticatedSettingsIndexRoute
@@ -314,6 +322,7 @@ export interface FileRoutesByTo {
   '/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
   '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/settings': typeof AuthenticatedSettingsIndexRoute
@@ -353,6 +362,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/organization': typeof AuthenticatedSettingsOrganizationRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/observability-test/error': typeof ApiObservabilityTestErrorRoute
+  '/backoffice/organizations/$organizationId': typeof BackofficeOrganizationsOrganizationIdRoute
   '/backoffice/projects/$projectId': typeof BackofficeProjectsProjectIdRoute
   '/backoffice/users/$userId': typeof BackofficeUsersUserIdRoute
   '/_authenticated/settings/': typeof AuthenticatedSettingsIndexRoute
@@ -393,6 +403,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/organizations/$organizationId'
     | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/settings/'
@@ -427,6 +438,7 @@ export interface FileRouteTypes {
     | '/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/organizations/$organizationId'
     | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/settings'
@@ -465,6 +477,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/organization'
     | '/api/auth/$'
     | '/api/observability-test/error'
+    | '/backoffice/organizations/$organizationId'
     | '/backoffice/projects/$projectId'
     | '/backoffice/users/$userId'
     | '/_authenticated/settings/'
@@ -631,6 +644,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BackofficeProjectsProjectIdRouteImport
       parentRoute: typeof BackofficeRouteRoute
     }
+    '/backoffice/organizations/$organizationId': {
+      id: '/backoffice/organizations/$organizationId'
+      path: '/organizations/$organizationId'
+      fullPath: '/backoffice/organizations/$organizationId'
+      preLoaderRoute: typeof BackofficeOrganizationsOrganizationIdRouteImport
+      parentRoute: typeof BackofficeRouteRoute
+    }
     '/api/observability-test/error': {
       id: '/api/observability-test/error'
       path: '/api/observability-test/error'
@@ -763,6 +783,7 @@ declare module '@tanstack/react-router' {
 interface BackofficeRouteRouteChildren {
   BackofficeSearchRoute: typeof BackofficeSearchRoute
   BackofficeIndexRoute: typeof BackofficeIndexRoute
+  BackofficeOrganizationsOrganizationIdRoute: typeof BackofficeOrganizationsOrganizationIdRoute
   BackofficeProjectsProjectIdRoute: typeof BackofficeProjectsProjectIdRoute
   BackofficeUsersUserIdRoute: typeof BackofficeUsersUserIdRoute
 }
@@ -770,6 +791,8 @@ interface BackofficeRouteRouteChildren {
 const BackofficeRouteRouteChildren: BackofficeRouteRouteChildren = {
   BackofficeSearchRoute: BackofficeSearchRoute,
   BackofficeIndexRoute: BackofficeIndexRoute,
+  BackofficeOrganizationsOrganizationIdRoute:
+    BackofficeOrganizationsOrganizationIdRoute,
   BackofficeProjectsProjectIdRoute: BackofficeProjectsProjectIdRoute,
   BackofficeUsersUserIdRoute: BackofficeUsersUserIdRoute,
 }

--- a/apps/web/src/routes/backoffice/-components/dashboard/fact-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/fact-row.tsx
@@ -1,0 +1,42 @@
+import { Text } from "@repo/ui"
+import type { ReactNode } from "react"
+
+/**
+ * Label + value row used inside dashboard section panels.
+ *
+ * Replaces the old `<DetailRow>` pattern (a 2-column CSS grid that
+ * wrapped a `<>` fragment of two `<Text>` nodes). Cleaner because:
+ *
+ * - It's a real component, not a fragment masquerading as one.
+ * - Accepts a ReactNode value, so consumers can drop in links, badges,
+ *   icons inline.
+ * - No surrounding grid required — these stack vertically inside
+ *   `DashboardSection` and can live in a flex column.
+ *
+ * For dense key-value blocks (the bottom "properties" strip), prefer
+ * `PropertiesStrip` which renders things horizontally / muted instead
+ * of as a stack.
+ */
+export interface FactRowProps {
+  readonly label: ReactNode
+  readonly value: ReactNode
+}
+
+export function FactRow({ label, value }: FactRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-1.5 first:pt-0 last:pb-0">
+      <Text.H6 color="foregroundMuted" noWrap>
+        {label}
+      </Text.H6>
+      <div className="flex items-center justify-end min-w-0">
+        {typeof value === "string" || typeof value === "number" ? (
+          <Text.H6 ellipsis noWrap>
+            {value}
+          </Text.H6>
+        ) : (
+          value
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/dashboard/hero.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/hero.tsx
@@ -52,9 +52,7 @@ export function DashboardHero({ leading, title, badges, meta, actions }: Dashboa
             {badges}
           </div>
           {meta !== undefined && (
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
-              {meta}
-            </div>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">{meta}</div>
           )}
         </div>
       </div>

--- a/apps/web/src/routes/backoffice/-components/dashboard/hero.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/hero.tsx
@@ -1,0 +1,64 @@
+import { Text } from "@repo/ui"
+import type { ReactNode } from "react"
+
+/**
+ * Backoffice detail-page hero.
+ *
+ * Renders the top of every detail dashboard (user / project / org)
+ * with a consistent shape: a large leading visual on the left,
+ * stacked title + subtitle in the middle, and right-aligned action
+ * buttons. Each detail page customises the slots — emoji block vs
+ * avatar, what the inline subtitle aggregates, whether there are
+ * primary actions — so the pages share a silhouette without becoming
+ * identical.
+ *
+ * Deliberately not wrapped in a card. The rest of the dashboard uses
+ * card-shaped panels (`DashboardSection`); leaving the hero "open"
+ * gives the page visual hierarchy — this is the entity, those are its
+ * facets.
+ */
+export interface DashboardHeroProps {
+  /** Large visual identity element — avatar / emoji block / org icon. */
+  readonly leading: ReactNode
+  /** The entity's display name. Renders as a Text.H2-equivalent heading. */
+  readonly title: ReactNode
+  /**
+   * Inline status / role pills rendered next to the title, before the
+   * subtitle. Use for transient state ("deleted", "platform admin"),
+   * not for stats — stats go in {@link meta}.
+   */
+  readonly badges?: ReactNode
+  /**
+   * Single-line subtitle. Pages typically aggregate this from multiple
+   * facts joined with " · " (e.g. "/acme · 12 members · 4 projects ·
+   * created 6 months ago"). Caller is responsible for the joining
+   * because the right separators / linkable spans depend on context.
+   */
+  readonly meta?: ReactNode
+  /** Right-aligned action buttons — primary admin actions like Impersonate. */
+  readonly actions?: ReactNode
+}
+
+export function DashboardHero({ leading, title, badges, meta, actions }: DashboardHeroProps) {
+  return (
+    <header className="flex items-start justify-between gap-6">
+      <div className="flex min-w-0 items-start gap-4">
+        <div className="shrink-0">{leading}</div>
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <div className="flex flex-wrap items-center gap-2 min-w-0">
+            <Text.H2 weight="semibold" ellipsis noWrap>
+              {title}
+            </Text.H2>
+            {badges}
+          </div>
+          {meta !== undefined && (
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+              {meta}
+            </div>
+          )}
+        </div>
+      </div>
+      {actions !== undefined && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </header>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/dashboard/index.ts
+++ b/apps/web/src/routes/backoffice/-components/dashboard/index.ts
@@ -1,0 +1,11 @@
+export { DashboardHero, type DashboardHeroProps } from "./hero.tsx"
+export { FactRow, type FactRowProps } from "./fact-row.tsx"
+export {
+  NoneText,
+  PropertiesStrip,
+  type PropertiesStripEntry,
+  type PropertiesStripProps,
+  StripeCustomerLink,
+} from "./properties-strip.tsx"
+export { DashboardSection, type DashboardSectionProps } from "./section.tsx"
+export { DashboardSplit, type DashboardSplitProps } from "./split.tsx"

--- a/apps/web/src/routes/backoffice/-components/dashboard/index.ts
+++ b/apps/web/src/routes/backoffice/-components/dashboard/index.ts
@@ -1,11 +1,5 @@
-export { DashboardHero, type DashboardHeroProps } from "./hero.tsx"
-export { FactRow, type FactRowProps } from "./fact-row.tsx"
-export {
-  NoneText,
-  PropertiesStrip,
-  type PropertiesStripEntry,
-  type PropertiesStripProps,
-  StripeCustomerLink,
-} from "./properties-strip.tsx"
-export { DashboardSection, type DashboardSectionProps } from "./section.tsx"
-export { DashboardSplit, type DashboardSplitProps } from "./split.tsx"
+export { DashboardHero } from "./hero.tsx"
+export { FactRow } from "./fact-row.tsx"
+export { type PropertiesStripEntry, PropertiesStrip, StripeCustomerLink } from "./properties-strip.tsx"
+export { DashboardSection } from "./section.tsx"
+export { DashboardSplit } from "./split.tsx"

--- a/apps/web/src/routes/backoffice/-components/dashboard/index.ts
+++ b/apps/web/src/routes/backoffice/-components/dashboard/index.ts
@@ -1,5 +1,5 @@
-export { DashboardHero } from "./hero.tsx"
 export { FactRow } from "./fact-row.tsx"
-export { type PropertiesStripEntry, PropertiesStrip, StripeCustomerLink } from "./properties-strip.tsx"
+export { DashboardHero } from "./hero.tsx"
+export { PropertiesStrip, type PropertiesStripEntry, StripeCustomerLink } from "./properties-strip.tsx"
 export { DashboardSection } from "./section.tsx"
 export { DashboardSplit } from "./split.tsx"

--- a/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
@@ -33,7 +33,11 @@ export function PropertiesStrip({ entries }: PropertiesStripProps) {
         <span key={`${entry.label}:${idx}`} className="inline-flex items-center gap-1">
           <span className="text-muted-foreground/70">{entry.label}</span>
           {typeof entry.value === "string" ? <span className="font-mono">{entry.value}</span> : entry.value}
-          {idx < entries.length - 1 && <span aria-hidden="true" className="ml-1">·</span>}
+          {idx < entries.length - 1 && (
+            <span aria-hidden="true" className="ml-1">
+              ·
+            </span>
+          )}
         </span>
       ))}
     </footer>

--- a/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
@@ -1,4 +1,4 @@
-import { Icon, Text } from "@repo/ui"
+import { Icon } from "@repo/ui"
 import { ExternalLinkIcon } from "lucide-react"
 import type { ReactNode } from "react"
 
@@ -63,8 +63,4 @@ export function StripeCustomerLink({ customerId }: { customerId: string }) {
       <span className="sr-only">Open in Stripe dashboard</span>
     </a>
   )
-}
-
-export function NoneText() {
-  return <Text.H6 color="foregroundMuted">(none)</Text.H6>
 }

--- a/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/properties-strip.tsx
@@ -1,0 +1,70 @@
+import { Icon, Text } from "@repo/ui"
+import { ExternalLinkIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+/**
+ * Low-visual-weight strip at the bottom of every detail dashboard.
+ *
+ * Holds the "boring but sometimes-needed" metadata that doesn't merit
+ * its own panel: ids, slugs, raw timestamps, Stripe customer ids,
+ * settings JSON. Rendered in muted text so it informs without
+ * competing for attention.
+ *
+ * The shape is "label key · value" pairs separated by a soft middle-
+ * dot. Wraps freely. Each pair can be plain text (a string value) or a
+ * custom node (e.g. for the Stripe deeplink, where the value is a
+ * `<StripeCustomerLink>` with an external-link icon).
+ */
+export interface PropertiesStripProps {
+  readonly entries: ReadonlyArray<PropertiesStripEntry>
+}
+
+export interface PropertiesStripEntry {
+  readonly label: string
+  readonly value: ReactNode
+}
+
+export function PropertiesStrip({ entries }: PropertiesStripProps) {
+  if (entries.length === 0) return null
+
+  return (
+    <footer className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-border pt-4 text-xs text-muted-foreground">
+      {entries.map((entry, idx) => (
+        <span key={`${entry.label}:${idx}`} className="inline-flex items-center gap-1">
+          <span className="text-muted-foreground/70">{entry.label}</span>
+          {typeof entry.value === "string" ? <span className="font-mono">{entry.value}</span> : entry.value}
+          {idx < entries.length - 1 && <span aria-hidden="true" className="ml-1">·</span>}
+        </span>
+      ))}
+    </footer>
+  )
+}
+
+/**
+ * Stripe customer deep-link affordance. Renders the customer id as a
+ * monospace pill with a small external-link icon, opening the Stripe
+ * dashboard in a new tab. Used inside `PropertiesStrip` for the
+ * `stripeCustomerId` entries on user / organisation detail.
+ *
+ * Always opens in a new tab — staff context-switch between the app
+ * and Stripe constantly during support, so an in-tab nav would be
+ * destructive.
+ */
+export function StripeCustomerLink({ customerId }: { customerId: string }) {
+  return (
+    <a
+      href={`https://dashboard.stripe.com/customers/${customerId}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-mono underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+    >
+      {customerId}
+      <Icon icon={ExternalLinkIcon} size="xs" color="foregroundMuted" />
+      <span className="sr-only">Open in Stripe dashboard</span>
+    </a>
+  )
+}
+
+export function NoneText() {
+  return <Text.H6 color="foregroundMuted">(none)</Text.H6>
+}

--- a/apps/web/src/routes/backoffice/-components/dashboard/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/section.tsx
@@ -26,7 +26,9 @@ export interface DashboardSectionProps {
 
 export function DashboardSection({ title, count, aside, children, className }: DashboardSectionProps) {
   return (
-    <section className={["flex flex-col rounded-lg border border-border bg-background", className].filter(Boolean).join(" ")}>
+    <section
+      className={["flex flex-col rounded-lg border border-border bg-background", className].filter(Boolean).join(" ")}
+    >
       <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
         <div className="flex items-center gap-2 min-w-0">
           <Text.H6 weight="semibold" noWrap>

--- a/apps/web/src/routes/backoffice/-components/dashboard/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/section.tsx
@@ -1,0 +1,46 @@
+import { Text } from "@repo/ui"
+import type { ReactNode } from "react"
+
+/**
+ * A panel in a backoffice detail dashboard.
+ *
+ * Card-shaped (border + neutral bg), with a header strip (label +
+ * optional count chip + optional right-aligned aside) and a body that
+ * contains whatever the consumer renders. Used for the meaty
+ * cross-entity sections (Members, Projects, Memberships, Activity,
+ * Settings).
+ *
+ * The card wraps content; `DashboardHero` deliberately doesn't,
+ * giving the dashboard its visual rhythm: one open identity zone at
+ * the top, contained panels below.
+ */
+export interface DashboardSectionProps {
+  readonly title: ReactNode
+  /** Tiny pill rendered after the title — "(12)" → renders as the count chip. */
+  readonly count?: number
+  /** Right-aligned slot in the header — "Show all", "Refresh", etc. */
+  readonly aside?: ReactNode
+  readonly children: ReactNode
+  readonly className?: string
+}
+
+export function DashboardSection({ title, count, aside, children, className }: DashboardSectionProps) {
+  return (
+    <section className={["flex flex-col rounded-lg border border-border bg-background", className].filter(Boolean).join(" ")}>
+      <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <Text.H6 weight="semibold" noWrap>
+            {title}
+          </Text.H6>
+          {count !== undefined && (
+            <span className="rounded-full bg-muted px-1.5 text-xs leading-5 text-muted-foreground tabular-nums">
+              {count}
+            </span>
+          )}
+        </div>
+        {aside !== undefined && <div className="shrink-0">{aside}</div>}
+      </header>
+      <div className="flex flex-col p-4">{children}</div>
+    </section>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/dashboard/split.tsx
+++ b/apps/web/src/routes/backoffice/-components/dashboard/split.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react"
+
+/**
+ * Two-column responsive layout for dashboard panels.
+ *
+ * The breakpoint is `md` (≥768 px) — below that the panels stack
+ * full-width. Above, the columns split using the `ratio` prop. Pure
+ * CSS, no JS.
+ *
+ * Why a custom helper instead of inline tailwind: the math on flex
+ * basis values (`60%`, `40%`) is awkward to read at the call site,
+ * and four-five flex classes per layout muddies the page component.
+ */
+export interface DashboardSplitProps {
+  readonly primary: ReactNode
+  readonly secondary: ReactNode
+  /**
+   * Ratio between the two panels on `md+` screens. Defaults to 50/50.
+   * `wide-primary` makes the primary panel ~60% (the org page uses
+   * this — the members list is denser than the projects list).
+   */
+  readonly ratio?: "even" | "wide-primary"
+}
+
+export function DashboardSplit({ primary, secondary, ratio = "even" }: DashboardSplitProps) {
+  const primaryClasses =
+    ratio === "wide-primary" ? "md:basis-[60%] md:grow-0 md:shrink" : "md:basis-1/2 md:grow md:shrink"
+  const secondaryClasses =
+    ratio === "wide-primary" ? "md:basis-[40%] md:grow-0 md:shrink" : "md:basis-1/2 md:grow md:shrink"
+
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:gap-4">
+      <div className={`flex min-w-0 flex-col ${primaryClasses}`}>{primary}</div>
+      <div className={`flex min-w-0 flex-col ${secondaryClasses}`}>{secondary}</div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/omnibox.tsx
+++ b/apps/web/src/routes/backoffice/-components/omnibox.tsx
@@ -75,9 +75,11 @@ export function Omnibox({ value, onChange, entityType, onEntityTypeChange, resul
     }
   }
 
-  // Capture-phase keydown on the results container so we can intercept
-  // arrow / escape on whichever row currently has focus, without
-  // forcing every row component to wire up its own handler.
+  // Bubble-phase keydown listener on the results container so we can
+  // intercept arrow / escape on whichever row currently has focus,
+  // without forcing every row component to wire up its own handler.
+  // Capture-phase isn't necessary — rows are anchors and don't have
+  // their own keydown handlers, so there's nothing for us to outrun.
   useEffect(() => {
     const container = resultsContainerRef.current
     if (!container) return
@@ -131,6 +133,10 @@ export function Omnibox({ value, onChange, entityType, onEntityTypeChange, resul
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleInputKeyDown}
           placeholder="Search users, organizations, or projects…"
+          // The placeholder reads as the input's purpose to sighted
+          // users; `aria-label` mirrors it for assistive tech, since
+          // there's no visible `<label>` to associate with.
+          aria-label="Search backoffice"
           maxLength={100}
           // Suppress browser autocomplete / autocorrect / capitalisation —
           // staff are typing emails, slugs, ids; the browser's guesses are

--- a/apps/web/src/routes/backoffice/-components/omnibox.tsx
+++ b/apps/web/src/routes/backoffice/-components/omnibox.tsx
@@ -1,7 +1,7 @@
+import type { SearchEntityType } from "@domain/admin"
 import { Icon, type TabOption, Tabs } from "@repo/ui"
 import { SearchIcon } from "lucide-react"
 import { type Dispatch, type KeyboardEvent, type RefObject, type SetStateAction, useEffect, useRef } from "react"
-import type { SearchEntityType } from "@domain/admin"
 
 const entityTabs: readonly TabOption<SearchEntityType>[] = [
   { id: "all", label: "All" },

--- a/apps/web/src/routes/backoffice/-components/omnibox.tsx
+++ b/apps/web/src/routes/backoffice/-components/omnibox.tsx
@@ -1,0 +1,153 @@
+import { Icon, type TabOption, Tabs } from "@repo/ui"
+import { SearchIcon } from "lucide-react"
+import { type Dispatch, type KeyboardEvent, type RefObject, type SetStateAction, useEffect, useRef } from "react"
+import type { SearchEntityType } from "@domain/admin"
+
+const entityTabs: readonly TabOption<SearchEntityType>[] = [
+  { id: "all", label: "All" },
+  { id: "user", label: "Users" },
+  { id: "organization", label: "Organizations" },
+  { id: "project", label: "Projects" },
+]
+
+export interface OmniboxProps {
+  readonly value: string
+  readonly onChange: Dispatch<SetStateAction<string>>
+  readonly entityType: SearchEntityType
+  readonly onEntityTypeChange: Dispatch<SetStateAction<SearchEntityType>>
+  /**
+   * Container that wraps the result rows. When the user presses ↓ from
+   * the input we focus the first `<a>` inside this container, and ↑
+   * from the first row returns focus to the input. Letting the consumer
+   * pass the ref keeps the omnibox component decoupled from the
+   * results layout — it doesn't need to know what's rendered below.
+   */
+  readonly resultsContainerRef: RefObject<HTMLDivElement | null>
+}
+
+/**
+ * Spotlight-style omnibox.
+ *
+ * Visual identity is deliberately quiet: a single oversized centered
+ * input with a leading search icon and entity-type tabs as filter
+ * chips below. The page chrome around it is empty so the input itself
+ * is the only thing competing for attention — typical of
+ * command-palette / Spotlight UIs (Linear, Raycast, GitHub
+ * command bar).
+ *
+ * Keyboard ergonomics:
+ * - Input autofocuses on mount.
+ * - `↓` from the input moves focus to the first result row.
+ * - `↑` from the first row returns focus to the input.
+ * - `↑/↓` between rows walks the list (browser-default focus
+ *   behaviour on `<a>` elements after we override the keydown).
+ * - `Enter` on a focused row activates the link (browser default —
+ *   no extra wiring).
+ * - `Esc` from any focused row returns to the input. `Esc` from the
+ *   input clears the query.
+ *
+ * Focus management uses DOM querying (`querySelectorAll('a')` inside
+ * the results container) rather than a ref array — the row components
+ * stay focus-management-agnostic, which keeps them reusable on
+ * detail pages where this navigation doesn't apply.
+ */
+export function Omnibox({ value, onChange, entityType, onEntityTypeChange, resultsContainerRef }: OmniboxProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const focusFirstResult = () => {
+    const first = resultsContainerRef.current?.querySelector<HTMLAnchorElement>("a")
+    first?.focus()
+  }
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      focusFirstResult()
+      return
+    }
+    if (event.key === "Escape" && value.length > 0) {
+      event.preventDefault()
+      onChange("")
+    }
+  }
+
+  // Capture-phase keydown on the results container so we can intercept
+  // arrow / escape on whichever row currently has focus, without
+  // forcing every row component to wire up its own handler.
+  useEffect(() => {
+    const container = resultsContainerRef.current
+    if (!container) return
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown" && event.key !== "Escape") return
+
+      const target = event.target
+      if (!(target instanceof HTMLAnchorElement)) return
+
+      const rows = Array.from(container.querySelectorAll<HTMLAnchorElement>("a"))
+      const index = rows.indexOf(target)
+      if (index === -1) return
+
+      if (event.key === "Escape") {
+        event.preventDefault()
+        inputRef.current?.focus()
+        return
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault()
+        const next = rows[Math.min(index + 1, rows.length - 1)]
+        next?.focus()
+        return
+      }
+
+      // ArrowUp
+      event.preventDefault()
+      if (index === 0) {
+        inputRef.current?.focus()
+        return
+      }
+      rows[index - 1]?.focus()
+    }
+
+    container.addEventListener("keydown", onKeyDown)
+    return () => container.removeEventListener("keydown", onKeyDown)
+  }, [resultsContainerRef])
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="relative w-full">
+        <div className="pointer-events-none absolute inset-y-0 left-4 flex items-center">
+          <Icon icon={SearchIcon} size="default" color="foregroundMuted" />
+        </div>
+        <input
+          ref={inputRef}
+          type="search"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleInputKeyDown}
+          placeholder="Search users, organizations, or projects…"
+          maxLength={100}
+          // Suppress browser autocomplete / autocorrect / capitalisation —
+          // staff are typing emails, slugs, ids; the browser's guesses are
+          // always wrong.
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className={[
+            "w-full rounded-xl border border-border bg-background py-4 pl-12 pr-4 text-base",
+            "shadow-sm placeholder:text-muted-foreground",
+            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background",
+            "transition-shadow",
+          ].join(" ")}
+        />
+      </div>
+      <Tabs variant="bordered" size="sm" options={entityTabs} active={entityType} onSelect={onEntityTypeChange} />
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/recent-chips.tsx
+++ b/apps/web/src/routes/backoffice/-components/recent-chips.tsx
@@ -2,7 +2,7 @@ import { Avatar, Icon, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import { Building2Icon } from "lucide-react"
-import { useRecentBackofficeViews, type RecentBackofficeView } from "../-lib/recently-viewed.ts"
+import { type RecentBackofficeView, useRecentBackofficeViews } from "../-lib/recently-viewed.ts"
 
 const VISIBLE_COUNT = 6
 

--- a/apps/web/src/routes/backoffice/-components/recent-chips.tsx
+++ b/apps/web/src/routes/backoffice/-components/recent-chips.tsx
@@ -1,0 +1,107 @@
+import { Avatar, Icon, Text } from "@repo/ui"
+import { extractLeadingEmoji, relativeTime } from "@repo/utils"
+import { Building2Icon } from "lucide-react"
+import { useRecentBackofficeViews, type RecentBackofficeView } from "../-lib/recently-viewed.ts"
+
+const VISIBLE_COUNT = 6
+
+/**
+ * Quick-nav strip showing the 6 most-recently-viewed backoffice
+ * entities. Renders below the omnibox when the search input is empty —
+ * the page's primary "you have nothing typed yet" state.
+ *
+ * Each chip is an anchor straight to the entity's detail page.
+ * Storage is browser-only; during SSR this renders nothing (the parent
+ * uses a fixed-height container so there's no layout flicker).
+ *
+ * The component renders no header / "Recently viewed" label by
+ * default — when there's nothing, it should disappear cleanly. The
+ * caller is responsible for the section heading if it wants one.
+ */
+export function RecentChips() {
+  const recent = useRecentBackofficeViews()
+  if (recent.length === 0) return null
+
+  const visible = recent.slice(0, VISIBLE_COUNT)
+  return (
+    <section className="flex flex-col gap-3" aria-label="Recently viewed">
+      <div className="flex items-center gap-3">
+        <Text.H6 weight="semibold" color="foregroundMuted" noWrap>
+          Recently viewed
+        </Text.H6>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {visible.map((view) => (
+          <RecentChip key={`${view.kind}:${view.id}`} view={view} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function RecentChip({ view }: { view: RecentBackofficeView }) {
+  return (
+    <a
+      href={hrefFor(view)}
+      className={[
+        "group flex items-center gap-2 rounded-full border border-border bg-background py-1.5 pl-1.5 pr-3",
+        "transition-colors hover:bg-muted/60",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "max-w-[18rem]",
+      ].join(" ")}
+      title={`${view.primary}${view.secondary ? ` · ${view.secondary}` : ""} · viewed ${relativeTime(new Date(view.viewedAt))}`}
+    >
+      <RecentChipLeading view={view} />
+      <Text.H6 weight="medium" ellipsis noWrap>
+        {chipLabel(view)}
+      </Text.H6>
+    </a>
+  )
+}
+
+/**
+ * Avatar / icon for a recent chip. Mirrors the `leading` slot
+ * convention from the row components but at chip-scale (smaller
+ * avatar, no project-emoji block).
+ */
+function RecentChipLeading({ view }: { view: RecentBackofficeView }) {
+  if (view.kind === "user") {
+    return <Avatar name={view.primary} size="xs" />
+  }
+  if (view.kind === "organization") {
+    return <Avatar name={view.primary} size="xs" />
+  }
+  // project — surface the leading emoji if there is one, else a
+  // generic project glyph.
+  const [emoji] = extractLeadingEmoji(view.primary)
+  if (emoji) {
+    return (
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border bg-background text-xs leading-none">
+        {emoji}
+      </span>
+    )
+  }
+  return (
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md border border-border bg-background">
+      <Icon icon={Building2Icon} size="xs" color="foregroundMuted" />
+    </span>
+  )
+}
+
+const hrefFor = (view: RecentBackofficeView): string => {
+  switch (view.kind) {
+    case "user":
+      return `/backoffice/users/${view.id}`
+    case "organization":
+      return `/backoffice/organizations/${view.id}`
+    case "project":
+      return `/backoffice/projects/${view.id}`
+  }
+}
+
+const chipLabel = (view: RecentBackofficeView): string => {
+  if (view.kind !== "project") return view.primary
+  const [, rest] = extractLeadingEmoji(view.primary)
+  return rest || view.primary
+}

--- a/apps/web/src/routes/backoffice/-components/recent-chips.tsx
+++ b/apps/web/src/routes/backoffice/-components/recent-chips.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Icon, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import { Building2Icon } from "lucide-react"
 import { useRecentBackofficeViews, type RecentBackofficeView } from "../-lib/recently-viewed.ts"
 
@@ -40,23 +41,55 @@ export function RecentChips() {
   )
 }
 
+/**
+ * Each chip is a typed TanStack `<Link>`. Branching on `kind` per chip
+ * keeps the typed-route guarantee (params validated against the route
+ * registry) instead of bypassing it with a string `<a href>` — which
+ * also avoids triggering full-document navigations in dev. The visual
+ * shell is identical across kinds; only the route target differs.
+ */
 function RecentChip({ view }: { view: RecentBackofficeView }) {
-  return (
-    <a
-      href={hrefFor(view)}
-      className={[
-        "group flex items-center gap-2 rounded-full border border-border bg-background py-1.5 pl-1.5 pr-3",
-        "transition-colors hover:bg-muted/60",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-        "max-w-[18rem]",
-      ].join(" ")}
-      title={`${view.primary}${view.secondary ? ` · ${view.secondary}` : ""} · viewed ${relativeTime(new Date(view.viewedAt))}`}
-    >
+  const className = [
+    "group flex items-center gap-2 rounded-full border border-border bg-background py-1.5 pl-1.5 pr-3",
+    "transition-colors hover:bg-muted/60",
+    "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "max-w-[18rem]",
+  ].join(" ")
+  const title = `${view.primary}${view.secondary ? ` · ${view.secondary}` : ""} · viewed ${relativeTime(new Date(view.viewedAt))}`
+
+  const inner = (
+    <>
       <RecentChipLeading view={view} />
       <Text.H6 weight="medium" ellipsis noWrap>
         {chipLabel(view)}
       </Text.H6>
-    </a>
+    </>
+  )
+
+  if (view.kind === "user") {
+    return (
+      <Link to="/backoffice/users/$userId" params={{ userId: view.id }} className={className} title={title}>
+        {inner}
+      </Link>
+    )
+  }
+  if (view.kind === "organization") {
+    return (
+      <Link
+        to="/backoffice/organizations/$organizationId"
+        params={{ organizationId: view.id }}
+        className={className}
+        title={title}
+      >
+        {inner}
+      </Link>
+    )
+  }
+  // project
+  return (
+    <Link to="/backoffice/projects/$projectId" params={{ projectId: view.id }} className={className} title={title}>
+      {inner}
+    </Link>
   )
 }
 
@@ -87,17 +120,6 @@ function RecentChipLeading({ view }: { view: RecentBackofficeView }) {
       <Icon icon={Building2Icon} size="xs" color="foregroundMuted" />
     </span>
   )
-}
-
-const hrefFor = (view: RecentBackofficeView): string => {
-  switch (view.kind) {
-    case "user":
-      return `/backoffice/users/${view.id}`
-    case "organization":
-      return `/backoffice/organizations/${view.id}`
-    case "project":
-      return `/backoffice/projects/${view.id}`
-  }
 }
 
 const chipLabel = (view: RecentBackofficeView): string => {

--- a/apps/web/src/routes/backoffice/-components/role-badges.tsx
+++ b/apps/web/src/routes/backoffice/-components/role-badges.tsx
@@ -1,0 +1,63 @@
+import { Badge, LatitudeLogo } from "@repo/ui"
+import { CrownIcon, ShieldCheckIcon, UserIcon } from "lucide-react"
+
+/**
+ * Visual treatments for the two distinct concepts of "role" in the
+ * backoffice:
+ *
+ * - **Per-organisation role** (`members.role`: owner / admin / member) —
+ *   answers "what can this user do inside this org?". Rendered with
+ *   {@link MemberRoleBadge}: outline-muted pill + role-specific icon.
+ *   The three badges look identical except for the icon, which signals
+ *   "same kind of thing, different flavor".
+ *
+ * - **Global platform-staff flag** (`users.role === "admin"`) — answers
+ *   "is this a Latitude employee?". Rendered with
+ *   {@link PlatformStaffBadge}: solid destructive bg + uppercase
+ *   "Latitude staff" label. Visually distinct on purpose — it's not a
+ *   role within a tenant, it's a system-wide identity, and treating it
+ *   like another flavor of role would obscure the difference at a
+ *   glance.
+ *
+ * Both are intended to live next to each other in row trailing slots —
+ * see the org detail page's members list, where a member's per-org
+ * role and their staff status appear side by side.
+ */
+
+const ROLE_ICONS = {
+  owner: CrownIcon,
+  admin: ShieldCheckIcon,
+  member: UserIcon,
+} as const
+
+const ROLE_LABELS = {
+  owner: "owner",
+  admin: "admin",
+  member: "member",
+} as const
+
+export type MemberRole = keyof typeof ROLE_ICONS
+
+export function MemberRoleBadge({ role }: { role: MemberRole }) {
+  return (
+    <Badge variant="outlineMuted" iconProps={{ icon: ROLE_ICONS[role], placement: "start" }}>
+      {ROLE_LABELS[role]}
+    </Badge>
+  )
+}
+
+/**
+ * Solid destructive pill for the platform-staff identity. Not a role
+ * variant — see the file-level comment for why this is shaped
+ * differently from {@link MemberRoleBadge}.
+ */
+export function PlatformStaffBadge() {
+  return (
+    <Badge variant="accent">
+      <div className="flex items-center gap-1">
+        <LatitudeLogo className="h-3 w-3 shrink-0" />
+        staff
+      </div>
+    </Badge>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/role-badges.tsx
+++ b/apps/web/src/routes/backoffice/-components/role-badges.tsx
@@ -13,11 +13,14 @@ import { CrownIcon, ShieldCheckIcon, UserIcon } from "lucide-react"
  *
  * - **Global platform-staff flag** (`users.role === "admin"`) — answers
  *   "is this a Latitude employee?". Rendered with
- *   {@link PlatformStaffBadge}: solid destructive bg + uppercase
- *   "Latitude staff" label. Visually distinct on purpose — it's not a
- *   role within a tenant, it's a system-wide identity, and treating it
- *   like another flavor of role would obscure the difference at a
- *   glance.
+ *   {@link PlatformStaffBadge}: accent-tinted pill with the Latitude
+ *   logo and the word "staff". Visually distinct on purpose — it's
+ *   not a role within a tenant, it's a system-wide identity, and
+ *   treating it like another flavor of role would obscure the
+ *   difference at a glance. The logo carries the "this is a Latitude
+ *   employee" semantics directly without needing the heavier
+ *   destructive treatment of the impersonation banner (which
+ *   communicates a temporary hazardous state, not an identity).
  *
  * Both are intended to live next to each other in row trailing slots —
  * see the org detail page's members list, where a member's per-org
@@ -47,7 +50,7 @@ export function MemberRoleBadge({ role }: { role: MemberRole }) {
 }
 
 /**
- * Solid destructive pill for the platform-staff identity. Not a role
+ * Accent-tinted pill carrying the Latitude logo + "staff". Not a role
  * variant — see the file-level comment for why this is shaped
  * differently from {@link MemberRoleBadge}.
  */

--- a/apps/web/src/routes/backoffice/-components/rows/index.ts
+++ b/apps/web/src/routes/backoffice/-components/rows/index.ts
@@ -1,0 +1,4 @@
+export { OrganizationRow, type OrganizationRowProps } from "./organization-row.tsx"
+export { ProjectRow, type ProjectRowProps } from "./project-row.tsx"
+export { Row, type RowProps } from "./row.tsx"
+export { UserRow, type UserRowProps } from "./user-row.tsx"

--- a/apps/web/src/routes/backoffice/-components/rows/index.ts
+++ b/apps/web/src/routes/backoffice/-components/rows/index.ts
@@ -1,4 +1,8 @@
-export { OrganizationRow, type OrganizationRowProps } from "./organization-row.tsx"
-export { ProjectRow, type ProjectRowProps } from "./project-row.tsx"
-export { Row, type RowProps } from "./row.tsx"
-export { UserRow, type UserRowProps } from "./user-row.tsx"
+// `Row` is intentionally NOT re-exported here — it's an internal
+// shell consumed by the entity-specific row components (`UserRow`,
+// `OrganizationRow`, `ProjectRow`) via direct path imports. Public
+// callers should always go through the entity rows so the right
+// avatar / link / metadata wiring comes with them.
+export { OrganizationRow } from "./organization-row.tsx"
+export { ProjectRow } from "./project-row.tsx"
+export { UserRow } from "./user-row.tsx"

--- a/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
@@ -1,0 +1,53 @@
+import { Avatar, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import type { ReactNode } from "react"
+import type { AdminOrganizationSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { Row } from "./row.tsx"
+
+/**
+ * Listing row for a backoffice organisation. Used in search results and
+ * in cross-entity sections (e.g. a user's memberships list, where the
+ * `trailing` slot is overridden to show the user's per-org role).
+ *
+ * Wrapped in a plain anchor (rather than `<Link>`) until the
+ * `/backoffice/organizations/$organizationId` route file lands in a
+ * later commit of this PR — TanStack Router's `<Link>` is strictly
+ * typed against the registered route table and would error before the
+ * route exists. Once the route ships, swap `<a>` for `<Link>` here.
+ */
+export interface OrganizationRowProps {
+  readonly organization: Pick<AdminOrganizationSearchDto, "id" | "name" | "slug"> & {
+    readonly createdAt?: string
+  }
+  readonly trailing?: ReactNode
+}
+
+export function OrganizationRow({ organization, trailing }: OrganizationRowProps) {
+  const resolvedTrailing =
+    trailing !== undefined ? (
+      trailing
+    ) : organization.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(organization.createdAt)}
+      </Text.H6>
+    ) : undefined
+
+  return (
+    <a href={`/backoffice/organizations/${organization.id}`} className="block">
+      <Row
+        leading={<Avatar name={organization.name} size="lg" />}
+        primary={
+          <Text.H5 weight="medium" ellipsis noWrap>
+            {organization.name}
+          </Text.H5>
+        }
+        secondary={
+          <Text.H6 color="foregroundMuted" ellipsis noWrap>
+            /{organization.slug}
+          </Text.H6>
+        }
+        trailing={resolvedTrailing}
+      />
+    </a>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import type { AdminOrganizationSearchDto } from "../../../../domains/admin/search.functions.ts"
 import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
@@ -10,12 +11,6 @@ import { ViewedAgo } from "./viewed-ago.tsx"
  * Listing row for a backoffice organisation. Used in search results and
  * in cross-entity sections (e.g. a user's memberships list, where the
  * `trailing` slot is overridden to show the user's per-org role).
- *
- * Wrapped in a plain anchor (rather than `<Link>`) until the
- * `/backoffice/organizations/$organizationId` route file lands in a
- * later commit of this PR — TanStack Router's `<Link>` is strictly
- * typed against the registered route table and would error before the
- * route exists. Once the route ships, swap `<a>` for `<Link>` here.
  */
 export interface OrganizationRowProps {
   readonly organization: Pick<AdminOrganizationSearchDto, "id" | "name" | "slug"> & {
@@ -38,7 +33,11 @@ export function OrganizationRow({ organization, trailing }: OrganizationRowProps
           : undefined
 
   return (
-    <a href={`/backoffice/organizations/${organization.id}`} className="block">
+    <Link
+      to="/backoffice/organizations/$organizationId"
+      params={{ organizationId: organization.id }}
+      className="block"
+    >
       <Row
         leading={<Avatar name={organization.name} size="lg" />}
         primary={
@@ -53,6 +52,6 @@ export function OrganizationRow({ organization, trailing }: OrganizationRowProps
         }
         trailing={resolvedTrailing}
       />
-    </a>
+    </Link>
   )
 }

--- a/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
@@ -2,7 +2,9 @@ import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import type { ReactNode } from "react"
 import type { AdminOrganizationSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
 import { Row } from "./row.tsx"
+import { ViewedAgo } from "./viewed-ago.tsx"
 
 /**
  * Listing row for a backoffice organisation. Used in search results and
@@ -23,14 +25,17 @@ export interface OrganizationRowProps {
 }
 
 export function OrganizationRow({ organization, trailing }: OrganizationRowProps) {
+  // Trailing precedence: explicit prop > "viewed Xh ago" > created-at.
+  // See `UserRow` for the full rationale.
+  const viewedAt = useRecentlyViewedAt("organization", organization.id)
   const resolvedTrailing =
-    trailing !== undefined ? (
-      trailing
-    ) : organization.createdAt ? (
-      <Text.H6 color="foregroundMuted" noWrap>
-        {relativeTime(organization.createdAt)}
-      </Text.H6>
-    ) : undefined
+    trailing !== undefined
+      ? trailing
+      : viewedAt
+        ? <ViewedAgo at={viewedAt} />
+        : organization.createdAt
+          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(organization.createdAt)}</Text.H6>
+          : undefined
 
   return (
     <a href={`/backoffice/organizations/${organization.id}`} className="block">

--- a/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/organization-row.tsx
@@ -24,20 +24,18 @@ export function OrganizationRow({ organization, trailing }: OrganizationRowProps
   // See `UserRow` for the full rationale.
   const viewedAt = useRecentlyViewedAt("organization", organization.id)
   const resolvedTrailing =
-    trailing !== undefined
-      ? trailing
-      : viewedAt
-        ? <ViewedAgo at={viewedAt} />
-        : organization.createdAt
-          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(organization.createdAt)}</Text.H6>
-          : undefined
+    trailing !== undefined ? (
+      trailing
+    ) : viewedAt ? (
+      <ViewedAgo at={viewedAt} />
+    ) : organization.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(organization.createdAt)}
+      </Text.H6>
+    ) : undefined
 
   return (
-    <Link
-      to="/backoffice/organizations/$organizationId"
-      params={{ organizationId: organization.id }}
-      className="block"
-    >
+    <Link to="/backoffice/organizations/$organizationId" params={{ organizationId: organization.id }} className="block">
       <Row
         leading={<Avatar name={organization.name} size="lg" />}
         primary={

--- a/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
@@ -2,7 +2,9 @@ import { Avatar, Badge, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
 import type { ReactNode } from "react"
 import type { AdminProjectSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
 import { Row } from "./row.tsx"
+import { ViewedAgo } from "./viewed-ago.tsx"
 
 /**
  * Listing row for a backoffice project.
@@ -34,14 +36,17 @@ export function ProjectRow({ project, trailing }: ProjectRowProps) {
   const [, nameWithoutEmoji] = extractLeadingEmoji(project.name)
   const displayName = nameWithoutEmoji || project.name
 
+  // Trailing precedence: explicit prop > "viewed Xh ago" > created-at.
+  // See `UserRow` for the full rationale.
+  const viewedAt = useRecentlyViewedAt("project", project.id)
   const resolvedTrailing =
-    trailing !== undefined ? (
-      trailing
-    ) : project.createdAt ? (
-      <Text.H6 color="foregroundMuted" noWrap>
-        {relativeTime(project.createdAt)}
-      </Text.H6>
-    ) : undefined
+    trailing !== undefined
+      ? trailing
+      : viewedAt
+        ? <ViewedAgo at={viewedAt} />
+        : project.createdAt
+          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(project.createdAt)}</Text.H6>
+          : undefined
 
   return (
     <a href={`/backoffice/projects/${project.id}`} className="block">

--- a/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
@@ -1,0 +1,67 @@
+import { Avatar, Badge, Text } from "@repo/ui"
+import { extractLeadingEmoji, relativeTime } from "@repo/utils"
+import type { ReactNode } from "react"
+import type { AdminProjectSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { Row } from "./row.tsx"
+
+/**
+ * Listing row for a backoffice project.
+ *
+ * Wrapped in a plain anchor (rather than `<Link>`) until the
+ * `/backoffice/projects/$projectId` route file lands in a later commit
+ * of this PR — see the note on `OrganizationRow`.
+ */
+export interface ProjectRowProps {
+  readonly project: Pick<AdminProjectSearchDto, "id" | "name" | "slug" | "organizationName"> & {
+    readonly createdAt?: string
+  }
+  readonly trailing?: ReactNode
+}
+
+function ProjectIcon({ name }: { name: string }) {
+  const [emoji, rest] = extractLeadingEmoji(name)
+  if (emoji) {
+    return (
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-background">
+        <span className="text-base leading-none">{emoji}</span>
+      </div>
+    )
+  }
+  return <Avatar name={rest || name} size="lg" />
+}
+
+export function ProjectRow({ project, trailing }: ProjectRowProps) {
+  const [, nameWithoutEmoji] = extractLeadingEmoji(project.name)
+  const displayName = nameWithoutEmoji || project.name
+
+  const resolvedTrailing =
+    trailing !== undefined ? (
+      trailing
+    ) : project.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(project.createdAt)}
+      </Text.H6>
+    ) : undefined
+
+  return (
+    <a href={`/backoffice/projects/${project.id}`} className="block">
+      <Row
+        leading={<ProjectIcon name={project.name} />}
+        primary={
+          <Text.H5 weight="medium" ellipsis noWrap>
+            {displayName}
+          </Text.H5>
+        }
+        secondary={
+          <>
+            <Badge variant="muted">{project.organizationName}</Badge>
+            <Text.H6 color="foregroundMuted" ellipsis noWrap>
+              /{project.slug}
+            </Text.H6>
+          </>
+        }
+        trailing={resolvedTrailing}
+      />
+    </a>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
@@ -9,9 +9,15 @@ import { ViewedAgo } from "./viewed-ago.tsx"
 
 /**
  * Listing row for a backoffice project.
+ *
+ * `organizationName` is optional — when omitted, the row shows only
+ * the project slug in the secondary line. Used to suppress the
+ * redundant org chip when the row is rendered inside that very org's
+ * detail page.
  */
 export interface ProjectRowProps {
-  readonly project: Pick<AdminProjectSearchDto, "id" | "name" | "slug" | "organizationName"> & {
+  readonly project: Pick<AdminProjectSearchDto, "id" | "name" | "slug"> & {
+    readonly organizationName?: string
     readonly createdAt?: string
   }
   readonly trailing?: ReactNode
@@ -56,7 +62,7 @@ export function ProjectRow({ project, trailing }: ProjectRowProps) {
         }
         secondary={
           <>
-            <Badge variant="muted">{project.organizationName}</Badge>
+            {project.organizationName ? <Badge variant="muted">{project.organizationName}</Badge> : null}
             <Text.H6 color="foregroundMuted" ellipsis noWrap>
               /{project.slug}
             </Text.H6>

--- a/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
@@ -43,13 +43,15 @@ export function ProjectRow({ project, trailing }: ProjectRowProps) {
   // See `UserRow` for the full rationale.
   const viewedAt = useRecentlyViewedAt("project", project.id)
   const resolvedTrailing =
-    trailing !== undefined
-      ? trailing
-      : viewedAt
-        ? <ViewedAgo at={viewedAt} />
-        : project.createdAt
-          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(project.createdAt)}</Text.H6>
-          : undefined
+    trailing !== undefined ? (
+      trailing
+    ) : viewedAt ? (
+      <ViewedAgo at={viewedAt} />
+    ) : project.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(project.createdAt)}
+      </Text.H6>
+    ) : undefined
 
   return (
     <Link to="/backoffice/projects/$projectId" params={{ projectId: project.id }} className="block">

--- a/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/project-row.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Badge, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import type { AdminProjectSearchDto } from "../../../../domains/admin/search.functions.ts"
 import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
@@ -8,10 +9,6 @@ import { ViewedAgo } from "./viewed-ago.tsx"
 
 /**
  * Listing row for a backoffice project.
- *
- * Wrapped in a plain anchor (rather than `<Link>`) until the
- * `/backoffice/projects/$projectId` route file lands in a later commit
- * of this PR — see the note on `OrganizationRow`.
  */
 export interface ProjectRowProps {
   readonly project: Pick<AdminProjectSearchDto, "id" | "name" | "slug" | "organizationName"> & {
@@ -49,7 +46,7 @@ export function ProjectRow({ project, trailing }: ProjectRowProps) {
           : undefined
 
   return (
-    <a href={`/backoffice/projects/${project.id}`} className="block">
+    <Link to="/backoffice/projects/$projectId" params={{ projectId: project.id }} className="block">
       <Row
         leading={<ProjectIcon name={project.name} />}
         primary={
@@ -67,6 +64,6 @@ export function ProjectRow({ project, trailing }: ProjectRowProps) {
         }
         trailing={resolvedTrailing}
       />
-    </a>
+    </Link>
   )
 }

--- a/apps/web/src/routes/backoffice/-components/rows/row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/row.tsx
@@ -1,0 +1,62 @@
+import { Icon } from "@repo/ui"
+import { ChevronRightIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+/**
+ * Presentational shell for a backoffice list row.
+ *
+ * Used both on the search results page and as the building block for
+ * cross-entity sections on detail pages (e.g., a user's organisation
+ * memberships, an organisation's projects). Knows nothing about
+ * routing — the entity-specific row components (`UserRow`,
+ * `OrganizationRow`, `ProjectRow`) wrap this in a `<Link>` (or `<a>`
+ * pending route registration) and pass slots in.
+ *
+ * Visual contract:
+ * - subtle border + neutral background, no shadow at rest
+ * - on hover: faint bg shift + small upward lift + soft shadow + chevron
+ *   fades in on the right edge as a navigation affordance
+ * - left slot is a fixed-width visual identity column (avatar / icon /
+ *   project emoji), middle slot is two-tier text content, right slot
+ *   is metadata (date, badge, etc.). Chevron is always last.
+ */
+export interface RowProps {
+  /** Visual identity element on the left edge — typically an `<Avatar>` or icon block. */
+  readonly leading: ReactNode
+  /** Primary line — usually the entity's display name / email. Wrap in `<Text.H5>` for consistent type. */
+  readonly primary: ReactNode
+  /** Inline badges rendered immediately after `primary` (admin badge, status pill, etc.). */
+  readonly primaryBadges?: ReactNode
+  /** Secondary line below `primary`. Usually the slug, id, or supporting metadata. */
+  readonly secondary?: ReactNode
+  /** Right-edge metadata — usually a relative date or a role badge. Optional; if omitted, the chevron sits closer to the content. */
+  readonly trailing?: ReactNode
+}
+
+export function Row({ leading, primary, primaryBadges, secondary, trailing }: RowProps) {
+  return (
+    <div
+      className={[
+        "group flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3",
+        "transition-all duration-150",
+        "hover:bg-muted/60 hover:shadow-sm hover:-translate-y-px",
+      ].join(" ")}
+    >
+      <div className="shrink-0">{leading}</div>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2 min-w-0">
+          {primary}
+          {primaryBadges}
+        </div>
+        {secondary !== undefined && <div className="flex items-center gap-2 min-w-0">{secondary}</div>}
+      </div>
+      {trailing !== undefined && <div className="shrink-0">{trailing}</div>}
+      <Icon
+        icon={ChevronRightIcon}
+        size="sm"
+        color="foregroundMuted"
+        className="shrink-0 opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+      />
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
@@ -3,7 +3,9 @@ import { relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import type { AdminUserSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
 import { Row } from "./row.tsx"
+import { ViewedAgo } from "./viewed-ago.tsx"
 
 const MAX_MEMBERSHIP_CHIPS = 3
 
@@ -31,14 +33,24 @@ export function UserRow({ user, trailing }: UserRowProps) {
   const visibleMemberships = memberships.slice(0, MAX_MEMBERSHIP_CHIPS)
   const overflowCount = memberships.length - visibleMemberships.length
 
+  // Trailing precedence (same across all backoffice row components):
+  // 1. Explicit `trailing` prop wins — used by callers that want to
+  //    surface their own metadata (per-org role on a memberships list,
+  //    status pill, etc.). When the caller cares, the caller decides.
+  // 2. Otherwise, if the entity is in the user's recently-viewed
+  //    storage, render "viewed Xh ago". This nudge is more useful on a
+  //    list of search results than the entity's creation date — staff
+  //    care more about "have I been here?" than "when was it created?".
+  // 3. Fall back to relative created-at if available.
+  const viewedAt = useRecentlyViewedAt("user", user.id)
   const resolvedTrailing =
-    trailing !== undefined ? (
-      trailing
-    ) : user.createdAt ? (
-      <Text.H6 color="foregroundMuted" noWrap>
-        {relativeTime(user.createdAt)}
-      </Text.H6>
-    ) : undefined
+    trailing !== undefined
+      ? trailing
+      : viewedAt
+        ? <ViewedAgo at={viewedAt} />
+        : user.createdAt
+          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(user.createdAt)}</Text.H6>
+          : undefined
 
   return (
     <Link to="/backoffice/users/$userId" params={{ userId: user.id }} className="block">

--- a/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
@@ -1,0 +1,77 @@
+import { Avatar, Badge, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { Link } from "@tanstack/react-router"
+import type { ReactNode } from "react"
+import type { AdminUserSearchDto } from "../../../../domains/admin/search.functions.ts"
+import { Row } from "./row.tsx"
+
+const MAX_MEMBERSHIP_CHIPS = 3
+
+/**
+ * Listing row for a backoffice user — used in search results and (with a
+ * `trailing` override) wherever a user appears in a sub-list, e.g. an
+ * organisation's members section.
+ */
+export interface UserRowProps {
+  readonly user: Pick<AdminUserSearchDto, "id" | "email" | "name" | "image" | "role"> & {
+    readonly memberships?: AdminUserSearchDto["memberships"]
+    readonly createdAt?: string
+  }
+  /**
+   * Override for the right-edge metadata. Defaults to the relative
+   * created-at if `user.createdAt` is provided, undefined otherwise. Used
+   * by org-detail's members list to render per-org role badges instead.
+   */
+  readonly trailing?: ReactNode
+}
+
+export function UserRow({ user, trailing }: UserRowProps) {
+  const displayName = user.name?.trim() ? user.name : user.email
+  const memberships = user.memberships ?? []
+  const visibleMemberships = memberships.slice(0, MAX_MEMBERSHIP_CHIPS)
+  const overflowCount = memberships.length - visibleMemberships.length
+
+  const resolvedTrailing =
+    trailing !== undefined ? (
+      trailing
+    ) : user.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(user.createdAt)}
+      </Text.H6>
+    ) : undefined
+
+  return (
+    <Link to="/backoffice/users/$userId" params={{ userId: user.id }} className="block">
+      <Row
+        leading={<Avatar name={displayName} imageSrc={user.image} size="lg" />}
+        primary={
+          <Text.H5 weight="medium" ellipsis noWrap>
+            {user.email}
+          </Text.H5>
+        }
+        primaryBadges={user.role === "admin" ? <Badge variant="destructive">admin</Badge> : null}
+        secondary={
+          <>
+            <Text.H6 color="foregroundMuted" ellipsis noWrap>
+              {user.name?.trim() ? user.name : "(no name)"}
+            </Text.H6>
+            {memberships.length > 0 && (
+              <>
+                <Text.H6 color="foregroundMuted">·</Text.H6>
+                <div className="flex items-center gap-1 min-w-0">
+                  {visibleMemberships.map((m) => (
+                    <Badge key={m.organizationId} variant="muted">
+                      {m.organizationName}
+                    </Badge>
+                  ))}
+                  {overflowCount > 0 && <Badge variant="muted">+{overflowCount}</Badge>}
+                </div>
+              </>
+            )}
+          </>
+        }
+        trailing={resolvedTrailing}
+      />
+    </Link>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/user-row.tsx
@@ -4,6 +4,7 @@ import { Link } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import type { AdminUserSearchDto } from "../../../../domains/admin/search.functions.ts"
 import { useRecentlyViewedAt } from "../../-lib/recently-viewed.ts"
+import { PlatformStaffBadge } from "../role-badges.tsx"
 import { Row } from "./row.tsx"
 import { ViewedAgo } from "./viewed-ago.tsx"
 
@@ -44,13 +45,15 @@ export function UserRow({ user, trailing }: UserRowProps) {
   // 3. Fall back to relative created-at if available.
   const viewedAt = useRecentlyViewedAt("user", user.id)
   const resolvedTrailing =
-    trailing !== undefined
-      ? trailing
-      : viewedAt
-        ? <ViewedAgo at={viewedAt} />
-        : user.createdAt
-          ? <Text.H6 color="foregroundMuted" noWrap>{relativeTime(user.createdAt)}</Text.H6>
-          : undefined
+    trailing !== undefined ? (
+      trailing
+    ) : viewedAt ? (
+      <ViewedAgo at={viewedAt} />
+    ) : user.createdAt ? (
+      <Text.H6 color="foregroundMuted" noWrap>
+        {relativeTime(user.createdAt)}
+      </Text.H6>
+    ) : undefined
 
   return (
     <Link to="/backoffice/users/$userId" params={{ userId: user.id }} className="block">
@@ -58,14 +61,14 @@ export function UserRow({ user, trailing }: UserRowProps) {
         leading={<Avatar name={displayName} imageSrc={user.image} size="lg" />}
         primary={
           <Text.H5 weight="medium" ellipsis noWrap>
-            {user.email}
+            {displayName}
           </Text.H5>
         }
-        primaryBadges={user.role === "admin" ? <Badge variant="destructive">admin</Badge> : null}
+        primaryBadges={user.role === "admin" ? <PlatformStaffBadge /> : null}
         secondary={
           <>
             <Text.H6 color="foregroundMuted" ellipsis noWrap>
-              {user.name?.trim() ? user.name : "(no name)"}
+              {user.email}
             </Text.H6>
             {memberships.length > 0 && (
               <>

--- a/apps/web/src/routes/backoffice/-components/rows/viewed-ago.tsx
+++ b/apps/web/src/routes/backoffice/-components/rows/viewed-ago.tsx
@@ -1,0 +1,22 @@
+import { Icon, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { ClockIcon } from "lucide-react"
+
+/**
+ * Compact "viewed Xh ago" indicator for backoffice list rows.
+ *
+ * Used in the row components' trailing slot when the entity is in the
+ * user's recently-viewed storage. Visually quieter than a date — a
+ * small clock icon + relative time in muted text — so it sits next to
+ * the chevron without competing for attention.
+ */
+export function ViewedAgo({ at }: { at: Date }) {
+  return (
+    <div className="flex items-center gap-1" title={`Viewed ${relativeTime(at)}`}>
+      <Icon icon={ClockIcon} size="xs" color="foregroundMuted" />
+      <Text.H6 color="foregroundMuted" noWrap>
+        viewed {relativeTime(at)}
+      </Text.H6>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/search-results.tsx
+++ b/apps/web/src/routes/backoffice/-components/search-results.tsx
@@ -1,6 +1,8 @@
-import { Text } from "@repo/ui"
+import { Icon, Text } from "@repo/ui"
+import { SearchXIcon } from "lucide-react"
 import type { AdminSearchDto } from "../../../domains/admin/search.functions.ts"
 import { OrganizationRow, ProjectRow, UserRow } from "./rows/index.ts"
+import { SearchRowSkeletonStack } from "./search-row-skeleton.tsx"
 
 interface SearchResultsProps {
   readonly data: AdminSearchDto | undefined
@@ -11,17 +13,16 @@ interface SearchResultsProps {
 
 export function SearchResults({ data, isLoading, query, isQueryTooShort }: SearchResultsProps) {
   if (isQueryTooShort) {
-    return (
-      <div className="py-12 text-center">
-        <Text.H5 color="foregroundMuted">Type at least 2 characters to search.</Text.H5>
-      </div>
-    )
+    // No-op while the user is still typing the first character. The
+    // recently-viewed strip (added in a later commit) renders here
+    // instead — for now the omnibox is the only thing on screen.
+    return null
   }
 
   if (isLoading) {
     return (
-      <div className="py-12 text-center">
-        <Text.H5 color="foregroundMuted">Searching…</Text.H5>
+      <div data-backoffice-results className="flex flex-col gap-1.5">
+        <SearchRowSkeletonStack count={4} />
       </div>
     )
   }
@@ -32,15 +33,11 @@ export function SearchResults({ data, isLoading, query, isQueryTooShort }: Searc
 
   const total = data.users.length + data.organizations.length + data.projects.length
   if (total === 0) {
-    return (
-      <div className="py-12 text-center">
-        <Text.H5 color="foregroundMuted">No results for &ldquo;{query}&rdquo;.</Text.H5>
-      </div>
-    )
+    return <SearchEmptyState query={query} />
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-backoffice-results className="flex flex-col gap-6">
       {data.users.length > 0 && (
         <Section title="Users" count={data.users.length}>
           {data.users.map((user) => (
@@ -67,10 +64,9 @@ export function SearchResults({ data, isLoading, query, isQueryTooShort }: Searc
 }
 
 /**
- * Section header for a result group: a label-and-count chip on the left
- * with a subtle horizontal rule extending to the right edge. Reads more
- * like a divider than a heading, which matches "search results" rather
- * than "page title."
+ * Section header for a result group: a label + count chip with a soft
+ * horizontal rule extending to the right edge. Reads like a divider
+ * rather than a page heading, which matches "search results" framing.
  */
 function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
   return (
@@ -85,6 +81,22 @@ function Section({ title, count, children }: { title: string; count: number; chi
         <div className="h-px flex-1 bg-border" />
       </div>
       <div className="flex flex-col gap-1.5">{children}</div>
+    </div>
+  )
+}
+
+function SearchEmptyState({ query }: { query: string }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <Icon icon={SearchXIcon} size="md" color="foregroundMuted" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Text.H5 weight="medium">No matches</Text.H5>
+        <Text.H6 color="foregroundMuted">
+          Nothing found for &ldquo;<span className="font-medium text-foreground">{query}</span>&rdquo;.
+        </Text.H6>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/routes/backoffice/-components/search-results.tsx
+++ b/apps/web/src/routes/backoffice/-components/search-results.tsx
@@ -1,12 +1,6 @@
-import { Avatar, Badge, Text } from "@repo/ui"
-import { extractLeadingEmoji } from "@repo/utils"
-import { Link } from "@tanstack/react-router"
-import type {
-  AdminOrganizationSearchDto,
-  AdminProjectSearchDto,
-  AdminSearchDto,
-  AdminUserSearchDto,
-} from "../../../domains/admin/search.functions.ts"
+import { Text } from "@repo/ui"
+import type { AdminSearchDto } from "../../../domains/admin/search.functions.ts"
+import { OrganizationRow, ProjectRow, UserRow } from "./rows/index.ts"
 
 interface SearchResultsProps {
   readonly data: AdminSearchDto | undefined
@@ -48,23 +42,23 @@ export function SearchResults({ data, isLoading, query, isQueryTooShort }: Searc
   return (
     <div className="flex flex-col gap-6">
       {data.users.length > 0 && (
-        <Section title={`Users (${data.users.length})`}>
+        <Section title="Users" count={data.users.length}>
           {data.users.map((user) => (
-            <UserCard key={user.id} user={user} />
+            <UserRow key={user.id} user={user} />
           ))}
         </Section>
       )}
       {data.organizations.length > 0 && (
-        <Section title={`Organizations (${data.organizations.length})`}>
+        <Section title="Organizations" count={data.organizations.length}>
           {data.organizations.map((org) => (
-            <OrganizationCard key={org.id} organization={org} />
+            <OrganizationRow key={org.id} organization={org} />
           ))}
         </Section>
       )}
       {data.projects.length > 0 && (
-        <Section title={`Projects (${data.projects.length})`}>
+        <Section title="Projects" count={data.projects.length}>
           {data.projects.map((project) => (
-            <ProjectCard key={project.id} project={project} />
+            <ProjectRow key={project.id} project={project} />
           ))}
         </Section>
       )}
@@ -72,122 +66,25 @@ export function SearchResults({ data, isLoading, query, isQueryTooShort }: Searc
   )
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+/**
+ * Section header for a result group: a label-and-count chip on the left
+ * with a subtle horizontal rule extending to the right edge. Reads more
+ * like a divider than a heading, which matches "search results" rather
+ * than "page title."
+ */
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
   return (
-    <div className="flex flex-col gap-2">
-      <Text.H5 weight="semibold">{title}</Text.H5>
-      <div className="flex flex-col gap-1">{children}</div>
-    </div>
-  )
-}
-
-const MAX_MEMBERSHIP_CHIPS = 3
-
-function UserCard({ user }: { user: AdminUserSearchDto }) {
-  const displayName = user.name?.trim() ? user.name : user.email
-  const visibleMemberships = user.memberships.slice(0, MAX_MEMBERSHIP_CHIPS)
-  const overflowCount = user.memberships.length - visibleMemberships.length
-
-  return (
-    <Link
-      to="/backoffice/users/$userId"
-      params={{ userId: user.id }}
-      className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3 transition-colors hover:bg-muted"
-    >
-      <Avatar name={displayName} imageSrc={user.image} size="lg" />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <div className="flex items-center gap-2 min-w-0">
-          <Text.H5 weight="medium" ellipsis noWrap>
-            {user.email}
-          </Text.H5>
-          {user.role === "admin" && <Badge variant="destructive">admin</Badge>}
-        </div>
-        <div className="flex items-center gap-2 min-w-0">
-          <Text.H6 color="foregroundMuted" ellipsis noWrap>
-            {user.name ?? "(no name)"}
-          </Text.H6>
-          {user.memberships.length > 0 && (
-            <>
-              <Text.H6 color="foregroundMuted">·</Text.H6>
-              <div className="flex items-center gap-1 min-w-0">
-                {visibleMemberships.map((m) => (
-                  <Badge key={m.organizationId} variant="muted">
-                    {m.organizationName}
-                  </Badge>
-                ))}
-                {overflowCount > 0 && <Badge variant="muted">+{overflowCount}</Badge>}
-              </div>
-            </>
-          )}
-        </div>
-      </div>
-      <Text.H6 color="foregroundMuted" noWrap>
-        {formatDate(user.createdAt)}
-      </Text.H6>
-    </Link>
-  )
-}
-
-function OrganizationCard({ organization }: { organization: AdminOrganizationSearchDto }) {
-  return (
-    <div className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3">
-      <Avatar name={organization.name} size="lg" />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <Text.H5 weight="medium" ellipsis noWrap>
-          {organization.name}
-        </Text.H5>
-        <Text.H6 color="foregroundMuted" ellipsis noWrap>
-          /{organization.slug}
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <Text.H6 weight="semibold" color="foregroundMuted" noWrap>
+          {title}
         </Text.H6>
+        <span className="rounded-full bg-muted px-1.5 text-xs leading-5 text-muted-foreground tabular-nums">
+          {count}
+        </span>
+        <div className="h-px flex-1 bg-border" />
       </div>
-      <Text.H6 color="foregroundMuted" noWrap>
-        {formatDate(organization.createdAt)}
-      </Text.H6>
+      <div className="flex flex-col gap-1.5">{children}</div>
     </div>
   )
-}
-
-function ProjectIcon({ name }: { name: string }) {
-  const [emoji, rest] = extractLeadingEmoji(name)
-  if (emoji) {
-    return (
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border bg-white">
-        <span className="text-base leading-none">{emoji}</span>
-      </div>
-    )
-  }
-  return <Avatar name={rest || name} size="lg" />
-}
-
-function ProjectCard({ project }: { project: AdminProjectSearchDto }) {
-  const [, nameWithoutEmoji] = extractLeadingEmoji(project.name)
-  const displayName = nameWithoutEmoji || project.name
-
-  return (
-    <div className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3">
-      <ProjectIcon name={project.name} />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <Text.H5 weight="medium" ellipsis noWrap>
-          {displayName}
-        </Text.H5>
-        <div className="flex items-center gap-2 min-w-0">
-          <Badge variant="muted">{project.organizationName}</Badge>
-          <Text.H6 color="foregroundMuted" ellipsis noWrap>
-            /{project.slug}
-          </Text.H6>
-        </div>
-      </div>
-      <Text.H6 color="foregroundMuted" noWrap>
-        {formatDate(project.createdAt)}
-      </Text.H6>
-    </div>
-  )
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toISOString().slice(0, 10)
-  } catch {
-    return iso
-  }
 }

--- a/apps/web/src/routes/backoffice/-components/search-row-skeleton.tsx
+++ b/apps/web/src/routes/backoffice/-components/search-row-skeleton.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from "@repo/ui"
+
+/**
+ * Pulse-animated row placeholder used while a search request is in flight.
+ *
+ * Matches the dimensions of `<Row>` exactly so swapping it for real
+ * results doesn't shift the layout — same border, same padding, same
+ * leading-element size, same two-tier text height. This is what makes
+ * the omnibox feel responsive: the structure appears instantly, only
+ * the content streams in.
+ */
+export function SearchRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 rounded-md border border-border bg-background px-4 py-3">
+      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-3 w-3/4" />
+      </div>
+    </div>
+  )
+}
+
+export function SearchRowSkeletonStack({ count = 3 }: { count?: number }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {Array.from({ length: count }).map((_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton placeholders, never reorder.
+        <SearchRowSkeleton key={i} />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/search-row-skeleton.tsx
+++ b/apps/web/src/routes/backoffice/-components/search-row-skeleton.tsx
@@ -25,7 +25,6 @@ export function SearchRowSkeletonStack({ count = 3 }: { count?: number }) {
   return (
     <div className="flex flex-col gap-1.5">
       {Array.from({ length: count }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: Static skeleton placeholders, never reorder.
         <SearchRowSkeleton key={i} />
       ))}
     </div>

--- a/apps/web/src/routes/backoffice/-lib/recently-viewed.test.ts
+++ b/apps/web/src/routes/backoffice/-lib/recently-viewed.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  clearRecentViews,
+  loadRecentViews,
+  MAX_RECENT_ENTRIES,
+  recordRecentView,
+  STORAGE_KEY,
+} from "./recently-viewed.ts"
+
+/**
+ * jsdom's bundled `localStorage` is flaky across vitest versions
+ * (`.clear()` has been undefined in some matrices). Replace it with a
+ * deterministic in-memory store for the duration of these tests so we
+ * exercise our code, not the polyfill.
+ */
+const installInMemoryStorage = () => {
+  const data = new Map<string, string>()
+  const stub: Storage = {
+    get length() {
+      return data.size
+    },
+    clear: () => data.clear(),
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, String(value))
+    },
+    removeItem: (key) => {
+      data.delete(key)
+    },
+    key: (index) => Array.from(data.keys())[index] ?? null,
+  }
+  Object.defineProperty(window, "localStorage", { value: stub, configurable: true, writable: true })
+}
+
+const seedStorage = (raw: string) => window.localStorage.setItem(STORAGE_KEY, raw)
+
+describe("recently-viewed storage", () => {
+  beforeEach(() => {
+    installInMemoryStorage()
+  })
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  describe("loadRecentViews", () => {
+    it("returns an empty list when nothing is stored", () => {
+      expect(loadRecentViews()).toEqual([])
+    })
+
+    it("returns the stored list sorted newest first", () => {
+      seedStorage(
+        JSON.stringify([
+          { kind: "user", id: "1", primary: "old", viewedAt: 100 },
+          { kind: "user", id: "2", primary: "new", viewedAt: 200 },
+        ]),
+      )
+      const result = loadRecentViews()
+      expect(result.map((v) => v.id)).toEqual(["2", "1"])
+    })
+
+    it("returns an empty list when the JSON is malformed", () => {
+      seedStorage("{not json")
+      expect(loadRecentViews()).toEqual([])
+    })
+
+    it("returns an empty list when the stored value is not an array", () => {
+      seedStorage(JSON.stringify({ accidentally: "an object" }))
+      expect(loadRecentViews()).toEqual([])
+    })
+
+    it("filters out individual invalid entries instead of dropping the whole list", () => {
+      seedStorage(
+        JSON.stringify([
+          { kind: "user", id: "1", primary: "valid", viewedAt: 100 },
+          { kind: "wrong-kind", id: "2", primary: "invalid", viewedAt: 200 },
+          { primary: "no kind or id", viewedAt: 300 },
+          { kind: "organization", id: "3", primary: "also valid", viewedAt: 400 },
+        ]),
+      )
+      const result = loadRecentViews()
+      expect(result.map((v) => v.id)).toEqual(["3", "1"])
+    })
+
+    it("accepts entries with optional `secondary`", () => {
+      seedStorage(JSON.stringify([{ kind: "project", id: "p1", primary: "Foo", secondary: "/foo", viewedAt: 1 }]))
+      expect(loadRecentViews()[0]?.secondary).toBe("/foo")
+    })
+  })
+
+  describe("recordRecentView", () => {
+    it("inserts a new view at the top of the list", () => {
+      recordRecentView({ kind: "user", id: "u1", primary: "alice@example.com" })
+      const result = loadRecentViews()
+      expect(result.map((v) => v.id)).toEqual(["u1"])
+      expect(result[0]?.viewedAt).toBeGreaterThan(0)
+    })
+
+    it("dedupes by (kind, id) — revisiting moves the entry to the top instead of duplicating", () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"))
+      recordRecentView({ kind: "user", id: "u1", primary: "alice@example.com" })
+
+      vi.setSystemTime(new Date("2025-01-01T00:00:01.000Z"))
+      recordRecentView({ kind: "user", id: "u2", primary: "bob@example.com" })
+
+      vi.setSystemTime(new Date("2025-01-01T00:00:02.000Z"))
+      recordRecentView({ kind: "user", id: "u1", primary: "alice@example.com" })
+
+      const result = loadRecentViews()
+      expect(result.map((v) => v.id)).toEqual(["u1", "u2"])
+      expect(result).toHaveLength(2)
+      vi.useRealTimers()
+    })
+
+    it("does NOT dedupe entries with the same id but different kind", () => {
+      recordRecentView({ kind: "user", id: "shared", primary: "u" })
+      recordRecentView({ kind: "organization", id: "shared", primary: "o" })
+      expect(loadRecentViews()).toHaveLength(2)
+    })
+
+    it("refreshes cached primary / secondary text on revisit", () => {
+      recordRecentView({ kind: "organization", id: "o1", primary: "Old name", secondary: "/old" })
+      recordRecentView({ kind: "organization", id: "o1", primary: "New name", secondary: "/new" })
+      const [view] = loadRecentViews()
+      expect(view?.primary).toBe("New name")
+      expect(view?.secondary).toBe("/new")
+    })
+
+    it("trims the list to MAX_RECENT_ENTRIES, dropping oldest first", () => {
+      for (let i = 0; i < MAX_RECENT_ENTRIES + 5; i++) {
+        recordRecentView({ kind: "user", id: `u${i}`, primary: `user-${i}` })
+      }
+      const result = loadRecentViews()
+      expect(result).toHaveLength(MAX_RECENT_ENTRIES)
+      // Newest entries kept, oldest dropped.
+      expect(result[0]?.id).toBe(`u${MAX_RECENT_ENTRIES + 4}`)
+      expect(result[result.length - 1]?.id).toBe("u5")
+    })
+
+    it("dispatches the in-tab change event so subscribers in the same tab refresh", () => {
+      const listener = vi.fn()
+      window.addEventListener("backoffice:recently-viewed-changed", listener)
+      recordRecentView({ kind: "user", id: "u1", primary: "x" })
+      expect(listener).toHaveBeenCalledTimes(1)
+      window.removeEventListener("backoffice:recently-viewed-changed", listener)
+    })
+  })
+
+  describe("clearRecentViews", () => {
+    it("removes the stored list", () => {
+      recordRecentView({ kind: "user", id: "u1", primary: "x" })
+      expect(loadRecentViews()).toHaveLength(1)
+      clearRecentViews()
+      expect(loadRecentViews()).toEqual([])
+    })
+
+    it("dispatches the change event", () => {
+      const listener = vi.fn()
+      window.addEventListener("backoffice:recently-viewed-changed", listener)
+      clearRecentViews()
+      expect(listener).toHaveBeenCalledTimes(1)
+      window.removeEventListener("backoffice:recently-viewed-changed", listener)
+    })
+  })
+})

--- a/apps/web/src/routes/backoffice/-lib/recently-viewed.ts
+++ b/apps/web/src/routes/backoffice/-lib/recently-viewed.ts
@@ -37,7 +37,8 @@ import { useEffect, useMemo, useState } from "react"
  */
 
 export const STORAGE_KEY = "backoffice:recently-viewed"
-export const CHANGE_EVENT = "backoffice:recently-viewed-changed"
+/** Internal — fired by `recordRecentView` / `clearRecentViews` so other instances of `useRecentBackofficeViews` in the same tab refresh. The browser-built-in `storage` event only fires in OTHER tabs. */
+const CHANGE_EVENT = "backoffice:recently-viewed-changed"
 export const MAX_RECENT_ENTRIES = 20
 
 export type RecentBackofficeKind = "user" | "organization" | "project"

--- a/apps/web/src/routes/backoffice/-lib/recently-viewed.ts
+++ b/apps/web/src/routes/backoffice/-lib/recently-viewed.ts
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from "react"
+
+/**
+ * Recently-viewed backoffice navigation history.
+ *
+ * Stored in `localStorage` under {@link STORAGE_KEY}. Used to render the
+ * "Recently viewed" strip under the omnibox and the per-row "Viewed Xh
+ * ago" indicator on search results.
+ *
+ * Design choices worth knowing:
+ *
+ * - **Storage, not server-side.** The list is per-browser, per-device.
+ *   Staff who switch laptops start fresh. Server-side history would
+ *   need a new table + auth + cleanup; the value isn't worth it for a
+ *   nav-aid feature.
+ * - **Cap + dedupe.** The most-recent {@link MAX_RECENT_ENTRIES}
+ *   entries are kept; older ones rotate out. Revisiting an entry moves
+ *   it to the top instead of duplicating it.
+ * - **Cached display data.** Each entry stores `primary` and
+ *   `secondary` text (e.g. user email, org name) so the recent-strip
+ *   chips can render without re-fetching anything. The cached labels
+ *   may go slightly stale if an entity is renamed; the next visit to
+ *   that entity's detail page refreshes the cache via
+ *   {@link recordRecentView}. Live data on the detail page itself is
+ *   always fresh — only the chip caption can be stale.
+ * - **Cross-tab sync.** Updates dispatch a `storage` event (browser
+ *   default) and an in-tab `CustomEvent` so the omnibox in tab A
+ *   reacts the moment a detail page is opened in tab B (or in the
+ *   same tab via SPA navigation).
+ * - **SSR-safe.** Every function short-circuits when `window` is
+ *   undefined and returns the empty list. Hooks render an empty
+ *   placeholder during SSR and hydrate on mount; layout uses fixed
+ *   heights so there is no flicker.
+ *
+ * The storage layer is intentionally hand-rolled (no external state
+ * manager). It's a single key with a small JSON array.
+ */
+
+export const STORAGE_KEY = "backoffice:recently-viewed"
+export const CHANGE_EVENT = "backoffice:recently-viewed-changed"
+export const MAX_RECENT_ENTRIES = 20
+
+export type RecentBackofficeKind = "user" | "organization" | "project"
+
+export interface RecentBackofficeView {
+  readonly kind: RecentBackofficeKind
+  readonly id: string
+  /** What to render as the chip's primary text — email / org name / project name. */
+  readonly primary: string
+  /** Optional supporting text — slug, secondary identifier. Renders muted under `primary` on chips. */
+  readonly secondary?: string
+  /** ms epoch, set by {@link recordRecentView}. */
+  readonly viewedAt: number
+}
+
+const isRecentBackofficeKind = (value: unknown): value is RecentBackofficeKind =>
+  value === "user" || value === "organization" || value === "project"
+
+const isRecentBackofficeView = (value: unknown): value is RecentBackofficeView => {
+  if (!value || typeof value !== "object") return false
+  const v = value as Record<string, unknown>
+  return (
+    isRecentBackofficeKind(v.kind) &&
+    typeof v.id === "string" &&
+    v.id.length > 0 &&
+    typeof v.primary === "string" &&
+    (v.secondary === undefined || typeof v.secondary === "string") &&
+    typeof v.viewedAt === "number" &&
+    Number.isFinite(v.viewedAt)
+  )
+}
+
+const isBrowser = (): boolean => typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+
+/**
+ * Read the recently-viewed list from `localStorage`, sorted newest
+ * first. Returns an empty list on SSR, on missing key, or on any
+ * parse / validation failure (corrupted entry from an older schema is
+ * silently dropped — we'd rather lose the cache than crash the page).
+ */
+export function loadRecentViews(): readonly RecentBackofficeView[] {
+  if (!isBrowser()) return []
+  let raw: string | null
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY)
+  } catch {
+    // localStorage can throw on private-mode quota / disabled storage.
+    return []
+  }
+  if (!raw) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+  // Filter out entries that fail validation rather than failing the
+  // whole list. One bad entry from a schema migration shouldn't blank
+  // the user's whole history.
+  const valid = parsed.filter(isRecentBackofficeView)
+  return [...valid].sort((a, b) => b.viewedAt - a.viewedAt)
+}
+
+/**
+ * Record a visit. Moves the entry to the top if it already exists
+ * (de-duped on `(kind, id)`), pushes new entries on, and trims to
+ * {@link MAX_RECENT_ENTRIES}.
+ *
+ * Refreshes the cached `primary` / `secondary` text — calling this
+ * from a detail page's loader is the natural way to keep chip
+ * captions in sync with the live entity name.
+ *
+ * No-ops on the server.
+ */
+export function recordRecentView(input: Omit<RecentBackofficeView, "viewedAt">): void {
+  if (!isBrowser()) return
+  const current = loadRecentViews()
+  const next: RecentBackofficeView[] = [
+    { ...input, viewedAt: Date.now() },
+    ...current.filter((v) => !(v.kind === input.kind && v.id === input.id)),
+  ].slice(0, MAX_RECENT_ENTRIES)
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Quota exceeded / storage disabled. Drop silently — recent-views
+    // is a UX nicety, not a feature whose loss merits an error.
+    return
+  }
+  // Notify same-tab listeners. The browser-built-in `storage` event
+  // only fires in OTHER tabs, so we dispatch a custom event for the
+  // current tab.
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT))
+}
+
+/**
+ * Clear the recently-viewed list. Exposed primarily for tests and a
+ * future "Clear history" affordance.
+ */
+export function clearRecentViews(): void {
+  if (!isBrowser()) return
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    return
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT))
+}
+
+/**
+ * React hook returning the live recently-viewed list. Subscribes to
+ * `storage` events (other tabs) and the in-tab change event
+ * ({@link CHANGE_EVENT}) so the strip stays in sync without prop
+ * drilling.
+ *
+ * Returns the empty list during SSR — the consumer should render a
+ * stable placeholder layout to avoid hydration mismatch (use a fixed
+ * height on the chip strip's container).
+ */
+export function useRecentBackofficeViews(): readonly RecentBackofficeView[] {
+  const [views, setViews] = useState<readonly RecentBackofficeView[]>([])
+
+  useEffect(() => {
+    setViews(loadRecentViews())
+
+    const refresh = () => setViews(loadRecentViews())
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) refresh()
+    }
+    window.addEventListener("storage", onStorage)
+    window.addEventListener(CHANGE_EVENT, refresh as EventListener)
+    return () => {
+      window.removeEventListener("storage", onStorage)
+      window.removeEventListener(CHANGE_EVENT, refresh as EventListener)
+    }
+  }, [])
+
+  return views
+}
+
+/**
+ * Records a visit to a backoffice entity on mount. Call this from
+ * detail-page components / loaders so the entity reliably ends up in
+ * the recent list whenever staff land on it.
+ */
+export function useTrackRecentBackofficeView(input: Omit<RecentBackofficeView, "viewedAt"> | null): void {
+  const { kind, id, primary, secondary } = input ?? { kind: null, id: null, primary: null, secondary: undefined }
+  useEffect(() => {
+    if (!kind || !id || primary == null) return
+    // `secondary` is optional under `exactOptionalPropertyTypes`, so we
+    // include the key only when it has a value (omitting > undefined).
+    recordRecentView(secondary !== undefined ? { kind, id, primary, secondary } : { kind, id, primary })
+  }, [kind, id, primary, secondary])
+}
+
+/**
+ * Look up the timestamp at which a given entity was last viewed,
+ * `null` if never. Drives the per-row "viewed Xh ago" indicator.
+ */
+export function useRecentlyViewedAt(kind: RecentBackofficeKind, id: string): Date | null {
+  const views = useRecentBackofficeViews()
+  return useMemo(() => {
+    const found = views.find((v) => v.kind === kind && v.id === id)
+    return found ? new Date(found.viewedAt) : null
+  }, [views, kind, id])
+}

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Badge, Container, Text } from "@repo/ui"
+import { Avatar, Badge, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, notFound } from "@tanstack/react-router"
 import {
@@ -6,8 +6,16 @@ import {
   type AdminOrganizationProjectDto,
   adminGetOrganization,
 } from "../../../domains/admin/organizations.functions.ts"
-import { ProjectRow, UserRow } from "../-components/rows/index.ts"
+import {
+  DashboardHero,
+  DashboardSection,
+  DashboardSplit,
+  PropertiesStrip,
+  type PropertiesStripEntry,
+  StripeCustomerLink,
+} from "../-components/dashboard/index.ts"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
+import { ProjectRow, UserRow } from "../-components/rows/index.ts"
 
 export const Route = createFileRoute("/backoffice/organizations/$organizationId")({
   loader: async ({ params }) => {
@@ -35,116 +43,129 @@ function BackofficeOrganizationDetailPage() {
     secondary: organization.slug,
   })
 
-  return (
-    <Container className="pt-6 pb-10 flex flex-col gap-6">
-      <header className="flex items-start gap-4">
-        <Avatar name={organization.name} size="lg" />
-        <div className="flex flex-col min-w-0 flex-1 gap-1">
-          <Text.H3 weight="semibold" ellipsis noWrap>
-            {organization.name}
-          </Text.H3>
-          <Text.H5 color="foregroundMuted" ellipsis noWrap>
-            /{organization.slug} · {organization.id}
-          </Text.H5>
-        </div>
-      </header>
-
-      <section className="flex flex-col gap-2">
-        <Text.H5 weight="semibold">Organization</Text.H5>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
-          <DetailRow label="Organization id" value={organization.id} />
-          <DetailRow label="Created" value={relativeTime(organization.createdAt)} />
-          <DetailRow label="Slug" value={organization.slug} />
-          <DetailRow label="Updated" value={relativeTime(organization.updatedAt)} />
-          <DetailRow label="Stripe customer" value={organization.stripeCustomerId ?? "(none)"} />
-          <DetailRow label="Members" value={String(organization.members.length)} />
-          <DetailRow label="Projects" value={String(organization.projects.length)} />
-        </div>
-      </section>
-
-      <MembersSection members={organization.members} />
-      <ProjectsSection projects={organization.projects} />
-    </Container>
-  )
-}
-
-function MembersSection({ members }: { members: AdminOrganizationMemberDto[] }) {
-  return (
-    <section className="flex flex-col gap-2">
-      <Text.H5 weight="semibold">Members ({members.length})</Text.H5>
-      {members.length === 0 ? (
-        <div className="rounded-md border border-border bg-background px-4 py-3">
-          <Text.H5 color="foregroundMuted">This organization has no members.</Text.H5>
-        </div>
+  // The properties strip aggregates the "boring but sometimes needed"
+  // fields. Stripe customer id is rendered through `StripeCustomerLink`
+  // so it deeplinks into the Stripe dashboard — the most common
+  // follow-on action when staff are debugging billing.
+  const propertyEntries: PropertiesStripEntry[] = [
+    { label: "Org id", value: organization.id },
+    { label: "Created", value: new Date(organization.createdAt).toISOString() },
+    { label: "Updated", value: new Date(organization.updatedAt).toISOString() },
+    {
+      label: "Stripe customer",
+      value: organization.stripeCustomerId ? (
+        <StripeCustomerLink customerId={organization.stripeCustomerId} />
       ) : (
-        <div className="flex flex-col gap-1.5">
-          {members.map((member) => (
-            <UserRow
-              key={member.membershipId}
-              user={{
-                id: member.user.id,
-                email: member.user.email,
-                name: member.user.name,
-                image: member.user.image,
-                role: member.user.role,
-                // No memberships chips here — the org context is implicit on this page.
-                memberships: [],
-              }}
-              // Trailing surfaces *both* roles together: per-org role
-              // (always) and a small "platform admin" pill when the
-              // member is also a global admin. Two badges instead of
-              // one because they answer different questions: "what can
-              // they do in THIS org?" vs "are they staff?".
-              trailing={
-                <div className="flex items-center gap-1.5">
-                  {member.user.role === "admin" && <Badge variant="destructive">platform admin</Badge>}
-                  <Badge variant={member.role === "owner" ? "default" : "secondary"}>{member.role}</Badge>
-                </div>
-              }
-            />
-          ))}
-        </div>
-      )}
-    </section>
+        <span className="font-mono">(none)</span>
+      ),
+    },
+  ]
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pt-8 pb-12">
+      <DashboardHero
+        leading={<Avatar name={organization.name} size="lg" />}
+        title={organization.name}
+        meta={
+          <>
+            <span>/{organization.slug}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              <span className="font-medium text-foreground tabular-nums">{organization.members.length}</span>{" "}
+              {organization.members.length === 1 ? "member" : "members"}
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              <span className="font-medium text-foreground tabular-nums">{organization.projects.length}</span>{" "}
+              {organization.projects.length === 1 ? "project" : "projects"}
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              created <span className="font-medium text-foreground">{relativeTime(organization.createdAt)}</span>
+            </span>
+          </>
+        }
+      />
+
+      <DashboardSplit
+        ratio="wide-primary"
+        primary={
+          <DashboardSection title="Members" count={organization.members.length}>
+            {organization.members.length === 0 ? (
+              <Text.H6 color="foregroundMuted">This organization has no members.</Text.H6>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                {organization.members.map((member: AdminOrganizationMemberDto) => (
+                  <MemberRow key={member.membershipId} member={member} />
+                ))}
+              </div>
+            )}
+          </DashboardSection>
+        }
+        secondary={
+          <DashboardSection title="Projects" count={organization.projects.length}>
+            {organization.projects.length === 0 ? (
+              <Text.H6 color="foregroundMuted">No active projects.</Text.H6>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                {organization.projects.map((project: AdminOrganizationProjectDto) => (
+                  <ProjectRow
+                    key={project.id}
+                    project={{
+                      id: project.id,
+                      name: project.name,
+                      slug: project.slug,
+                      // `organizationName` deliberately omitted — these
+                      // rows are rendered inside the parent org's own
+                      // detail page, so the chip would be redundant.
+                      createdAt: project.createdAt,
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </DashboardSection>
+        }
+      />
+
+      <PropertiesStrip entries={propertyEntries} />
+    </div>
   )
 }
 
-function ProjectsSection({ projects }: { projects: AdminOrganizationProjectDto[] }) {
+/**
+ * Member row used inside the organisation's Members panel. Wraps the
+ * shared `<UserRow>` with a custom trailing slot:
+ *
+ * - Per-org role badge (always) — answers "what can they do here?"
+ * - Plus a `platform admin` pill when the member is also a global
+ *   admin — answers "are they staff?"
+ *
+ * The two badges live next to each other so the answer to both
+ * questions is visible at a single glance, which is the entire point
+ * of the org detail page.
+ */
+function MemberRow({ member }: { member: AdminOrganizationMemberDto }) {
   return (
-    <section className="flex flex-col gap-2">
-      <Text.H5 weight="semibold">Projects ({projects.length})</Text.H5>
-      {projects.length === 0 ? (
-        <div className="rounded-md border border-border bg-background px-4 py-3">
-          <Text.H5 color="foregroundMuted">This organization has no active projects.</Text.H5>
+    <UserRow
+      user={{
+        id: member.user.id,
+        email: member.user.email,
+        name: member.user.name,
+        image: member.user.image,
+        role: member.user.role,
+        // No memberships chips here — the org context is implicit on
+        // this page; rendering them would either be empty (we don't
+        // have the data) or noisy (every member's membership list
+        // would include this very org).
+        memberships: [],
+      }}
+      trailing={
+        <div className="flex items-center gap-1.5">
+          {member.user.role === "admin" && <Badge variant="destructive">platform admin</Badge>}
+          <Badge variant={member.role === "owner" ? "default" : "secondary"}>{member.role}</Badge>
         </div>
-      ) : (
-        <div className="flex flex-col gap-1.5">
-          {projects.map((project) => (
-            <ProjectRow
-              key={project.id}
-              project={{
-                id: project.id,
-                name: project.name,
-                slug: project.slug,
-                // `organizationName` deliberately omitted — the row is
-                // rendered inside the parent org's own detail page, so
-                // surfacing the org chip would be redundant. The row
-                // secondary line collapses to just the slug.
-                createdAt: project.createdAt,
-              }}
-            />
-          ))}
-        </div>
-      )}
-    </section>
-  )
-}
-
-function DetailRow({ label, value }: { label: string; value: string }) {
-  return (
-    <>
-      <Text.H6 color="foregroundMuted">{label}</Text.H6>
-      <Text.H6 ellipsis>{value}</Text.H6>
-    </>
+      }
+    />
   )
 }

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -14,8 +14,8 @@ import {
   type PropertiesStripEntry,
   StripeCustomerLink,
 } from "../-components/dashboard/index.ts"
-import { ProjectRow, UserRow } from "../-components/rows/index.ts"
 import { MemberRoleBadge, PlatformStaffBadge } from "../-components/role-badges.tsx"
+import { ProjectRow, UserRow } from "../-components/rows/index.ts"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/organizations/$organizationId")({

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Badge, Text } from "@repo/ui"
+import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, notFound } from "@tanstack/react-router"
 import {
@@ -14,8 +14,9 @@ import {
   type PropertiesStripEntry,
   StripeCustomerLink,
 } from "../-components/dashboard/index.ts"
-import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 import { ProjectRow, UserRow } from "../-components/rows/index.ts"
+import { MemberRoleBadge, PlatformStaffBadge } from "../-components/role-badges.tsx"
+import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/organizations/$organizationId")({
   loader: async ({ params }) => {
@@ -64,7 +65,7 @@ function BackofficeOrganizationDetailPage() {
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pt-8 pb-12">
       <DashboardHero
-        leading={<Avatar name={organization.name} size="lg" />}
+        leading={<Avatar name={organization.name} size="xl" />}
         title={organization.name}
         meta={
           <>
@@ -162,8 +163,8 @@ function MemberRow({ member }: { member: AdminOrganizationMemberDto }) {
       }}
       trailing={
         <div className="flex items-center gap-1.5">
-          {member.user.role === "admin" && <Badge variant="destructive">platform admin</Badge>}
-          <Badge variant={member.role === "owner" ? "default" : "secondary"}>{member.role}</Badge>
+          {member.user.role === "admin" && <PlatformStaffBadge />}
+          <MemberRoleBadge role={member.role} />
         </div>
       }
     />

--- a/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
+++ b/apps/web/src/routes/backoffice/organizations/$organizationId.tsx
@@ -1,0 +1,150 @@
+import { Avatar, Badge, Container, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import {
+  type AdminOrganizationMemberDto,
+  type AdminOrganizationProjectDto,
+  adminGetOrganization,
+} from "../../../domains/admin/organizations.functions.ts"
+import { ProjectRow, UserRow } from "../-components/rows/index.ts"
+import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
+
+export const Route = createFileRoute("/backoffice/organizations/$organizationId")({
+  loader: async ({ params }) => {
+    try {
+      const organization = await adminGetOrganization({ data: { organizationId: params.organizationId } })
+      return { organization }
+    } catch (error) {
+      const tag = (error as { _tag?: string } | null | undefined)?._tag
+      if (tag === "NotFoundError") {
+        throw notFound()
+      }
+      throw error
+    }
+  },
+  component: BackofficeOrganizationDetailPage,
+})
+
+function BackofficeOrganizationDetailPage() {
+  const organization = Route.useLoaderData({ select: (data) => data.organization })
+
+  useTrackRecentBackofficeView({
+    kind: "organization",
+    id: organization.id,
+    primary: organization.name,
+    secondary: organization.slug,
+  })
+
+  return (
+    <Container className="pt-6 pb-10 flex flex-col gap-6">
+      <header className="flex items-start gap-4">
+        <Avatar name={organization.name} size="lg" />
+        <div className="flex flex-col min-w-0 flex-1 gap-1">
+          <Text.H3 weight="semibold" ellipsis noWrap>
+            {organization.name}
+          </Text.H3>
+          <Text.H5 color="foregroundMuted" ellipsis noWrap>
+            /{organization.slug} · {organization.id}
+          </Text.H5>
+        </div>
+      </header>
+
+      <section className="flex flex-col gap-2">
+        <Text.H5 weight="semibold">Organization</Text.H5>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
+          <DetailRow label="Organization id" value={organization.id} />
+          <DetailRow label="Created" value={relativeTime(organization.createdAt)} />
+          <DetailRow label="Slug" value={organization.slug} />
+          <DetailRow label="Updated" value={relativeTime(organization.updatedAt)} />
+          <DetailRow label="Stripe customer" value={organization.stripeCustomerId ?? "(none)"} />
+          <DetailRow label="Members" value={String(organization.members.length)} />
+          <DetailRow label="Projects" value={String(organization.projects.length)} />
+        </div>
+      </section>
+
+      <MembersSection members={organization.members} />
+      <ProjectsSection projects={organization.projects} />
+    </Container>
+  )
+}
+
+function MembersSection({ members }: { members: AdminOrganizationMemberDto[] }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <Text.H5 weight="semibold">Members ({members.length})</Text.H5>
+      {members.length === 0 ? (
+        <div className="rounded-md border border-border bg-background px-4 py-3">
+          <Text.H5 color="foregroundMuted">This organization has no members.</Text.H5>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {members.map((member) => (
+            <UserRow
+              key={member.membershipId}
+              user={{
+                id: member.user.id,
+                email: member.user.email,
+                name: member.user.name,
+                image: member.user.image,
+                role: member.user.role,
+                // No memberships chips here — the org context is implicit on this page.
+                memberships: [],
+              }}
+              // Trailing surfaces *both* roles together: per-org role
+              // (always) and a small "platform admin" pill when the
+              // member is also a global admin. Two badges instead of
+              // one because they answer different questions: "what can
+              // they do in THIS org?" vs "are they staff?".
+              trailing={
+                <div className="flex items-center gap-1.5">
+                  {member.user.role === "admin" && <Badge variant="destructive">platform admin</Badge>}
+                  <Badge variant={member.role === "owner" ? "default" : "secondary"}>{member.role}</Badge>
+                </div>
+              }
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function ProjectsSection({ projects }: { projects: AdminOrganizationProjectDto[] }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <Text.H5 weight="semibold">Projects ({projects.length})</Text.H5>
+      {projects.length === 0 ? (
+        <div className="rounded-md border border-border bg-background px-4 py-3">
+          <Text.H5 color="foregroundMuted">This organization has no active projects.</Text.H5>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {projects.map((project) => (
+            <ProjectRow
+              key={project.id}
+              project={{
+                id: project.id,
+                name: project.name,
+                slug: project.slug,
+                // `organizationName` deliberately omitted — the row is
+                // rendered inside the parent org's own detail page, so
+                // surfacing the org chip would be redundant. The row
+                // secondary line collapses to just the slug.
+                createdAt: project.createdAt,
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <Text.H6 ellipsis>{value}</Text.H6>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/projects/$projectId.tsx
+++ b/apps/web/src/routes/backoffice/projects/$projectId.tsx
@@ -1,0 +1,137 @@
+import { Badge, Container, Icon, Text } from "@repo/ui"
+import { extractLeadingEmoji, relativeTime } from "@repo/utils"
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import { ArchiveIcon } from "lucide-react"
+import { adminGetProject } from "../../../domains/admin/projects.functions.ts"
+import { OrganizationRow } from "../-components/rows/index.ts"
+import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
+
+export const Route = createFileRoute("/backoffice/projects/$projectId")({
+  loader: async ({ params }) => {
+    try {
+      const project = await adminGetProject({ data: { projectId: params.projectId } })
+      return { project }
+    } catch (error) {
+      // Same `_tag`-discriminating error handling as `users/$userId.tsx`
+      // and the route-level `guardBackofficeRoute`. NotFound (= "project
+      // doesn't exist" or "caller isn't an admin") collapses to the
+      // standard 404; everything else (DB outage, connectivity,
+      // serialization bug) bubbles to the router error boundary.
+      const tag = (error as { _tag?: string } | null | undefined)?._tag
+      if (tag === "NotFoundError") {
+        throw notFound()
+      }
+      throw error
+    }
+  },
+  component: BackofficeProjectDetailPage,
+})
+
+function BackofficeProjectDetailPage() {
+  const project = Route.useLoaderData({ select: (data) => data.project })
+  const [emoji, nameWithoutEmoji] = extractLeadingEmoji(project.name)
+  const displayName = nameWithoutEmoji || project.name
+
+  // Record the visit so this project shows up in the recently-viewed
+  // strip on the search page and as a "viewed Xh ago" indicator on
+  // result rows. Cached labels refresh every visit.
+  useTrackRecentBackofficeView({
+    kind: "project",
+    id: project.id,
+    primary: project.name,
+    secondary: project.organization.name,
+  })
+
+  return (
+    <Container className="pt-6 pb-10 flex flex-col gap-6">
+      <header className="flex items-start gap-4">
+        <ProjectHeaderIcon emoji={emoji} name={displayName} />
+        <div className="flex flex-col min-w-0 flex-1 gap-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Text.H3 weight="semibold" ellipsis noWrap>
+              {displayName}
+            </Text.H3>
+            {project.deletedAt && (
+              <Badge variant="muted">
+                <Icon icon={ArchiveIcon} size="xs" /> deleted
+              </Badge>
+            )}
+          </div>
+          <Text.H5 color="foregroundMuted" ellipsis noWrap>
+            /{project.slug} · {project.id}
+          </Text.H5>
+        </div>
+      </header>
+
+      <section className="flex flex-col gap-2">
+        <Text.H5 weight="semibold">Project</Text.H5>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
+          <DetailRow label="Project id" value={project.id} />
+          <DetailRow label="Created" value={relativeTime(project.createdAt)} />
+          <DetailRow label="Slug" value={project.slug} />
+          <DetailRow label="Last edited" value={relativeTime(project.lastEditedAt)} />
+          <DetailRow
+            label="First trace"
+            value={project.firstTraceAt ? relativeTime(project.firstTraceAt) : "(no traces yet)"}
+          />
+          <DetailRow label="Updated" value={relativeTime(project.updatedAt)} />
+          <DetailRow
+            label="Settings · keepMonitoring"
+            value={project.settings?.keepMonitoring === true ? "enabled" : "disabled"}
+          />
+          {project.deletedAt && <DetailRow label="Deleted" value={relativeTime(project.deletedAt)} />}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-2">
+        <Text.H5 weight="semibold">Organization</Text.H5>
+        <OrganizationRow
+          organization={{
+            id: project.organization.id,
+            name: project.organization.name,
+            slug: project.organization.slug,
+          }}
+          // The default trailing slot is created-at; here we have no
+          // org timestamps loaded (we only fetched the join cells we
+          // need for navigation), so let the row render without
+          // trailing metadata. Keeps the visual identical to a search
+          // result row pointing at the same org.
+          trailing={null}
+        />
+      </section>
+    </Container>
+  )
+}
+
+/**
+ * Header icon block for a project. Mirrors the row component's
+ * `ProjectIcon` but at a larger header scale — emoji-in-card if the
+ * project name leads with one, fallback to a plain coloured square
+ * with the first letter.
+ */
+function ProjectHeaderIcon({ emoji, name }: { emoji: string | null; name: string }) {
+  if (emoji) {
+    return (
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-2xl leading-none">
+        {emoji}
+      </div>
+    )
+  }
+  const initial = name.trim()[0]?.toUpperCase() ?? "?"
+  return (
+    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
+      <Text.H3 weight="semibold" color="foregroundMuted">
+        {initial}
+      </Text.H3>
+    </div>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <Text.H6 color="foregroundMuted">{label}</Text.H6>
+      <Text.H6>{value}</Text.H6>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/projects/$projectId.tsx
+++ b/apps/web/src/routes/backoffice/projects/$projectId.tsx
@@ -1,7 +1,7 @@
-import { Badge, Icon, Text } from "@repo/ui"
+import { Icon, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { ArchiveIcon, ArrowRightIcon, CheckIcon, MinusIcon } from "lucide-react"
+import { ArrowRightIcon, CheckIcon, MinusIcon } from "lucide-react"
 import { adminGetProject } from "../../../domains/admin/projects.functions.ts"
 import {
   DashboardHero,
@@ -54,13 +54,6 @@ function BackofficeProjectDetailPage() {
       <DashboardHero
         leading={<ProjectHeroIcon emoji={emoji} name={displayName} />}
         title={displayName}
-        badges={
-          project.deletedAt ? (
-            <Badge variant="muted">
-              <Icon icon={ArchiveIcon} size="xs" /> deleted
-            </Badge>
-          ) : null
-        }
         meta={
           <>
             <span>/{project.slug}</span>
@@ -99,7 +92,6 @@ function BackofficeProjectDetailPage() {
             />
             <FactRow label="Last edited" value={relativeTime(project.lastEditedAt)} />
             <FactRow label="Updated" value={relativeTime(project.updatedAt)} />
-            {project.deletedAt && <FactRow label="Deleted" value={relativeTime(project.deletedAt)} />}
           </DashboardSection>
         }
         secondary={

--- a/apps/web/src/routes/backoffice/projects/$projectId.tsx
+++ b/apps/web/src/routes/backoffice/projects/$projectId.tsx
@@ -1,9 +1,15 @@
-import { Badge, Container, Icon, Text } from "@repo/ui"
+import { Badge, Icon, Text } from "@repo/ui"
 import { extractLeadingEmoji, relativeTime } from "@repo/utils"
-import { createFileRoute, notFound } from "@tanstack/react-router"
-import { ArchiveIcon } from "lucide-react"
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { ArchiveIcon, ArrowRightIcon, CheckIcon, MinusIcon } from "lucide-react"
 import { adminGetProject } from "../../../domains/admin/projects.functions.ts"
-import { OrganizationRow } from "../-components/rows/index.ts"
+import {
+  DashboardHero,
+  DashboardSection,
+  DashboardSplit,
+  FactRow,
+  PropertiesStrip,
+} from "../-components/dashboard/index.ts"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/projects/$projectId")({
@@ -12,11 +18,11 @@ export const Route = createFileRoute("/backoffice/projects/$projectId")({
       const project = await adminGetProject({ data: { projectId: params.projectId } })
       return { project }
     } catch (error) {
-      // Same `_tag`-discriminating error handling as `users/$userId.tsx`
-      // and the route-level `guardBackofficeRoute`. NotFound (= "project
-      // doesn't exist" or "caller isn't an admin") collapses to the
-      // standard 404; everything else (DB outage, connectivity,
-      // serialization bug) bubbles to the router error boundary.
+      // Same `_tag`-discriminating error handling as the other detail
+      // pages: NotFound (= "project doesn't exist" or "caller isn't an
+      // admin") collapses to the standard 404; everything else (DB
+      // outage, connectivity, serialization bug) bubbles to the router
+      // error boundary so ops can see it.
       const tag = (error as { _tag?: string } | null | undefined)?._tag
       if (tag === "NotFoundError") {
         throw notFound()
@@ -32,9 +38,10 @@ function BackofficeProjectDetailPage() {
   const [emoji, nameWithoutEmoji] = extractLeadingEmoji(project.name)
   const displayName = nameWithoutEmoji || project.name
 
-  // Record the visit so this project shows up in the recently-viewed
-  // strip on the search page and as a "viewed Xh ago" indicator on
-  // result rows. Cached labels refresh every visit.
+  // Record the visit so this project surfaces in the recently-viewed
+  // strip + per-row "viewed Xh ago" indicator on subsequent searches.
+  // Cached labels (`primary` / `secondary`) refresh every visit so
+  // chip captions stay in sync if the project is renamed.
   useTrackRecentBackofficeView({
     kind: "project",
     id: project.id,
@@ -43,95 +50,145 @@ function BackofficeProjectDetailPage() {
   })
 
   return (
-    <Container className="pt-6 pb-10 flex flex-col gap-6">
-      <header className="flex items-start gap-4">
-        <ProjectHeaderIcon emoji={emoji} name={displayName} />
-        <div className="flex flex-col min-w-0 flex-1 gap-1">
-          <div className="flex items-center gap-2 flex-wrap">
-            <Text.H3 weight="semibold" ellipsis noWrap>
-              {displayName}
-            </Text.H3>
-            {project.deletedAt && (
-              <Badge variant="muted">
-                <Icon icon={ArchiveIcon} size="xs" /> deleted
-              </Badge>
-            )}
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pt-8 pb-12">
+      <DashboardHero
+        leading={<ProjectHeroIcon emoji={emoji} name={displayName} />}
+        title={displayName}
+        badges={
+          project.deletedAt ? (
+            <Badge variant="muted">
+              <Icon icon={ArchiveIcon} size="xs" /> deleted
+            </Badge>
+          ) : null
+        }
+        meta={
+          <>
+            <span>/{project.slug}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              in{" "}
+              <Link
+                to="/backoffice/organizations/$organizationId"
+                params={{ organizationId: project.organization.id }}
+                className="font-medium text-foreground underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+              >
+                {project.organization.name}
+              </Link>
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              last edited <span className="font-medium text-foreground">{relativeTime(project.lastEditedAt)}</span>
+            </span>
+          </>
+        }
+      />
+
+      <DashboardSplit
+        primary={
+          <DashboardSection title="Activity">
+            <FactRow label="Created" value={relativeTime(project.createdAt)} />
+            <FactRow
+              label="First trace"
+              value={
+                project.firstTraceAt ? (
+                  relativeTime(project.firstTraceAt)
+                ) : (
+                  <Text.H6 color="foregroundMuted">(no traces yet)</Text.H6>
+                )
+              }
+            />
+            <FactRow label="Last edited" value={relativeTime(project.lastEditedAt)} />
+            <FactRow label="Updated" value={relativeTime(project.updatedAt)} />
+            {project.deletedAt && <FactRow label="Deleted" value={relativeTime(project.deletedAt)} />}
+          </DashboardSection>
+        }
+        secondary={
+          <DashboardSection title="Settings">
+            <FactRow
+              label="Monitoring"
+              value={
+                project.settings?.keepMonitoring === true ? (
+                  <span className="inline-flex items-center gap-1">
+                    <Icon icon={CheckIcon} size="xs" />
+                    <Text.H6>enabled</Text.H6>
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center gap-1">
+                    <Icon icon={MinusIcon} size="xs" color="foregroundMuted" />
+                    <Text.H6 color="foregroundMuted">disabled</Text.H6>
+                  </span>
+                )
+              }
+            />
+          </DashboardSection>
+        }
+      />
+
+      <DashboardSection
+        title="Organization"
+        aside={
+          <Link
+            to="/backoffice/organizations/$organizationId"
+            params={{ organizationId: project.organization.id }}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            View
+            <Icon icon={ArrowRightIcon} size="xs" />
+          </Link>
+        }
+      >
+        <Link
+          to="/backoffice/organizations/$organizationId"
+          params={{ organizationId: project.organization.id }}
+          className="-m-1 flex items-center gap-3 rounded-md p-1 transition-colors hover:bg-muted/60"
+        >
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Text.H6 weight="semibold" color="foregroundMuted">
+              {project.organization.name.trim()[0]?.toUpperCase() ?? "?"}
+            </Text.H6>
           </div>
-          <Text.H5 color="foregroundMuted" ellipsis noWrap>
-            /{project.slug} · {project.id}
-          </Text.H5>
-        </div>
-      </header>
+          <div className="flex min-w-0 flex-col">
+            <Text.H5 weight="medium" ellipsis noWrap>
+              {project.organization.name}
+            </Text.H5>
+            <Text.H6 color="foregroundMuted" ellipsis noWrap>
+              /{project.organization.slug}
+            </Text.H6>
+          </div>
+        </Link>
+      </DashboardSection>
 
-      <section className="flex flex-col gap-2">
-        <Text.H5 weight="semibold">Project</Text.H5>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
-          <DetailRow label="Project id" value={project.id} />
-          <DetailRow label="Created" value={relativeTime(project.createdAt)} />
-          <DetailRow label="Slug" value={project.slug} />
-          <DetailRow label="Last edited" value={relativeTime(project.lastEditedAt)} />
-          <DetailRow
-            label="First trace"
-            value={project.firstTraceAt ? relativeTime(project.firstTraceAt) : "(no traces yet)"}
-          />
-          <DetailRow label="Updated" value={relativeTime(project.updatedAt)} />
-          <DetailRow
-            label="Settings · keepMonitoring"
-            value={project.settings?.keepMonitoring === true ? "enabled" : "disabled"}
-          />
-          {project.deletedAt && <DetailRow label="Deleted" value={relativeTime(project.deletedAt)} />}
-        </div>
-      </section>
-
-      <section className="flex flex-col gap-2">
-        <Text.H5 weight="semibold">Organization</Text.H5>
-        <OrganizationRow
-          organization={{
-            id: project.organization.id,
-            name: project.organization.name,
-            slug: project.organization.slug,
-          }}
-          // The default trailing slot is created-at; here we have no
-          // org timestamps loaded (we only fetched the join cells we
-          // need for navigation), so let the row render without
-          // trailing metadata. Keeps the visual identical to a search
-          // result row pointing at the same org.
-          trailing={null}
-        />
-      </section>
-    </Container>
+      <PropertiesStrip
+        entries={[
+          { label: "Project id", value: project.id },
+          { label: "Org id", value: project.organization.id },
+          { label: "Created", value: new Date(project.createdAt).toISOString() },
+          { label: "Updated", value: new Date(project.updatedAt).toISOString() },
+        ]}
+      />
+    </div>
   )
 }
 
 /**
- * Header icon block for a project. Mirrors the row component's
- * `ProjectIcon` but at a larger header scale — emoji-in-card if the
- * project name leads with one, fallback to a plain coloured square
- * with the first letter.
+ * Header icon for a project. Emoji-in-card if the project name leads
+ * with one (mirrors the search-results row shape but at hero scale),
+ * otherwise a coloured letter block.
  */
-function ProjectHeaderIcon({ emoji, name }: { emoji: string | null; name: string }) {
+function ProjectHeroIcon({ emoji, name }: { emoji: string | null; name: string }) {
   if (emoji) {
     return (
-      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-border bg-background text-2xl leading-none">
+      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-border bg-background text-3xl leading-none">
         {emoji}
       </div>
     )
   }
   const initial = name.trim()[0]?.toUpperCase() ?? "?"
   return (
-    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
-      <Text.H3 weight="semibold" color="foregroundMuted">
+    <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-border bg-muted">
+      <Text.H2 weight="semibold" color="foregroundMuted">
         {initial}
-      </Text.H3>
+      </Text.H2>
     </div>
-  )
-}
-
-function DetailRow({ label, value }: { label: string; value: string }) {
-  return (
-    <>
-      <Text.H6 color="foregroundMuted">{label}</Text.H6>
-      <Text.H6>{value}</Text.H6>
-    </>
   )
 }

--- a/apps/web/src/routes/backoffice/route.tsx
+++ b/apps/web/src/routes/backoffice/route.tsx
@@ -59,8 +59,16 @@ function BackofficeLayout() {
           <Text.H5 weight="semibold">Backoffice</Text.H5>
         </Link>
         <div className="flex items-center gap-1 ml-2">
-          <Icon icon={ShieldAlertIcon} size="xs" color="destructive" />
-          <Text.H6 color="destructive">Platform staff only</Text.H6>
+          {/*
+           * The "Platform staff only" wayfinding cue stays — it's useful so
+           * staff know they're in the admin surface — but it's rendered in
+           * a muted neutral colour, not destructive. Across the backoffice
+           * red is reserved exclusively for the impersonation banner /
+           * avatar overlay, where it signals an actively-hazardous session
+           * state. Bleeding red into static chrome dilutes that signal.
+           */}
+          <Icon icon={ShieldAlertIcon} size="xs" color="foregroundMuted" />
+          <Text.H6 color="foregroundMuted">Platform staff only</Text.H6>
         </div>
         <div className="flex-1" />
         <Button variant="outline" size="sm" onClick={() => void router.navigate({ to: "/" })}>

--- a/apps/web/src/routes/backoffice/search.tsx
+++ b/apps/web/src/routes/backoffice/search.tsx
@@ -1,19 +1,22 @@
 import { MIN_SEARCH_QUERY_LENGTH, type SearchEntityType } from "@domain/admin"
-import { Container, Input, type TabOption, Tabs, Text } from "@repo/ui"
-import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useEffect, useRef, useState } from "react"
 import { adminSearch } from "../../domains/admin/search.functions.ts"
+import { Omnibox } from "./-components/omnibox.tsx"
 import { SearchResults } from "./-components/search-results.tsx"
 
-const DEBOUNCE_MS = 300
+/**
+ * Spotlight-feel search page.
+ *
+ * The omnibox is the page — no title bar, no description, no
+ * ornamentation. Result rows materialise directly underneath as the
+ * user types, with a debounced fetch and skeleton placeholders during
+ * the request so the layout never jumps. Keyboard navigation between
+ * input and rows is wired up in the `Omnibox` component.
+ */
 
-const entityTabs: readonly TabOption<SearchEntityType>[] = [
-  { id: "all", label: "All" },
-  { id: "user", label: "Users" },
-  { id: "organization", label: "Organizations" },
-  { id: "project", label: "Projects" },
-]
+const DEBOUNCE_MS = 300
 
 export const Route = createFileRoute("/backoffice/search")({
   component: BackofficeSearchPage,
@@ -32,6 +35,7 @@ function BackofficeSearchPage() {
   const [rawQuery, setRawQuery] = useState("")
   const [entityType, setEntityType] = useState<SearchEntityType>("all")
   const debouncedQuery = useDebouncedValue(rawQuery.trim(), DEBOUNCE_MS)
+  const resultsRef = useRef<HTMLDivElement>(null)
 
   const isQueryTooShort = debouncedQuery.length > 0 && debouncedQuery.length < MIN_SEARCH_QUERY_LENGTH
   const shouldFetch = debouncedQuery.length >= MIN_SEARCH_QUERY_LENGTH
@@ -43,28 +47,22 @@ function BackofficeSearchPage() {
   })
 
   return (
-    <Container className="pt-6 pb-10 flex flex-col gap-6">
-      <div className="flex flex-col gap-1">
-        <Text.H2 weight="semibold">Search</Text.H2>
-        <Text.H5 color="foregroundMuted">Cross-organization lookup for users, organizations, and projects.</Text.H5>
-      </div>
-      <div className="flex flex-col gap-3">
-        <Input
-          type="search"
-          placeholder="Email, name, slug, or id (min 2 characters)"
-          value={rawQuery}
-          onChange={(e) => setRawQuery(e.target.value)}
-          maxLength={100}
-          autoFocus
-        />
-        <Tabs variant="bordered" size="sm" options={entityTabs} active={entityType} onSelect={setEntityType} />
-      </div>
-      <SearchResults
-        data={data}
-        isLoading={shouldFetch && isFetching}
-        query={debouncedQuery}
-        isQueryTooShort={isQueryTooShort}
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 pt-12 pb-16">
+      <Omnibox
+        value={rawQuery}
+        onChange={setRawQuery}
+        entityType={entityType}
+        onEntityTypeChange={setEntityType}
+        resultsContainerRef={resultsRef}
       />
-    </Container>
+      <div ref={resultsRef}>
+        <SearchResults
+          data={data}
+          isLoading={shouldFetch && isFetching}
+          query={debouncedQuery}
+          isQueryTooShort={isQueryTooShort}
+        />
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/routes/backoffice/search.tsx
+++ b/apps/web/src/routes/backoffice/search.tsx
@@ -1,6 +1,6 @@
 import { MIN_SEARCH_QUERY_LENGTH, type SearchEntityType } from "@domain/admin"
-import { createFileRoute } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useRef, useState } from "react"
 import { adminSearch } from "../../domains/admin/search.functions.ts"
 import { Omnibox } from "./-components/omnibox.tsx"

--- a/apps/web/src/routes/backoffice/search.tsx
+++ b/apps/web/src/routes/backoffice/search.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useEffect, useRef, useState } from "react"
 import { adminSearch } from "../../domains/admin/search.functions.ts"
 import { Omnibox } from "./-components/omnibox.tsx"
+import { RecentChips } from "./-components/recent-chips.tsx"
 import { SearchResults } from "./-components/search-results.tsx"
 
 /**
@@ -46,6 +47,13 @@ function BackofficeSearchPage() {
     enabled: shouldFetch,
   })
 
+  // Show recent chips when the input is empty; hide them once the user
+  // starts typing so they don't compete with live results for attention.
+  // We key off the trimmed raw value (not the debounced one) so the
+  // chips disappear immediately on first keystroke instead of waiting
+  // out the 300 ms debounce.
+  const showRecent = rawQuery.trim().length === 0
+
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 pt-12 pb-16">
       <Omnibox
@@ -56,12 +64,16 @@ function BackofficeSearchPage() {
         resultsContainerRef={resultsRef}
       />
       <div ref={resultsRef}>
-        <SearchResults
-          data={data}
-          isLoading={shouldFetch && isFetching}
-          query={debouncedQuery}
-          isQueryTooShort={isQueryTooShort}
-        />
+        {showRecent ? (
+          <RecentChips />
+        ) : (
+          <SearchResults
+            data={data}
+            isLoading={shouldFetch && isFetching}
+            query={debouncedQuery}
+            isQueryTooShort={isQueryTooShort}
+          />
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,10 +1,7 @@
-import { Avatar, Badge, Text } from "@repo/ui"
+import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import type {
-  AdminUserDetailsDto,
-  AdminUserDetailsMembershipDto,
-} from "../../../domains/admin/users.functions.ts"
+import type { AdminUserDetailsDto, AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
 import {
   DashboardHero,
@@ -13,6 +10,7 @@ import {
   type PropertiesStripEntry,
 } from "../-components/dashboard/index.ts"
 import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
+import { MemberRoleBadge, PlatformStaffBadge } from "../-components/role-badges.tsx"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/users/$userId")({
@@ -48,7 +46,7 @@ function BackofficeUserDetailPage() {
     secondary: user.name?.trim() ? user.name : undefined,
   })
 
-  const displayName = user.name?.trim() ? user.name : "(no name)"
+  const displayName = user.name?.trim() ? user.name : user.email
   const memberships = user.memberships
   const ownedCount = memberships.filter((m: AdminUserDetailsMembershipDto) => m.role === "owner").length
 
@@ -67,12 +65,12 @@ function BackofficeUserDetailPage() {
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pt-8 pb-12">
       <DashboardHero
-        leading={<Avatar name={displayName === "(no name)" ? user.email : displayName} imageSrc={user.image} size="lg" />}
-        title={user.email}
-        badges={user.role === "admin" ? <Badge variant="destructive">platform admin</Badge> : null}
+        leading={<Avatar name={displayName} imageSrc={user.image} size="xl" />}
+        title={displayName}
+        badges={user.role === "admin" ? <PlatformStaffBadge /> : null}
         meta={
           <>
-            <span>{displayName}</span>
+            <span>{user.email}</span>
             <span aria-hidden="true">·</span>
             <span>
               joined <span className="font-medium text-foreground">{relativeTime(user.createdAt)}</span>
@@ -166,7 +164,7 @@ function MembershipCard({ membership }: { membership: AdminUserDetailsMembership
           /{membership.organizationSlug}
         </Text.H6>
       </div>
-      <Badge variant={membership.role === "owner" ? "default" : "secondary"}>{membership.role}</Badge>
+      <MemberRoleBadge role={membership.role} />
     </Link>
   )
 }

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router"
 import type { AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
 import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
+import { OrganizationRow } from "../-components/rows/index.ts"
 
 export const Route = createFileRoute("/backoffice/users/$userId")({
   loader: async ({ params }) => {
@@ -74,22 +75,20 @@ function BackofficeUserDetailPage() {
             <Text.H5 color="foregroundMuted">This user is not a member of any organization.</Text.H5>
           </div>
         ) : (
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1.5">
             {user.memberships.map((m: AdminUserDetailsMembershipDto) => (
-              <div
+              <OrganizationRow
                 key={m.organizationId}
-                className="flex items-center justify-between gap-4 rounded-md border border-border bg-background px-4 py-3"
-              >
-                <div className="flex flex-col min-w-0">
-                  <Text.H5 weight="medium" ellipsis noWrap>
-                    {m.organizationName}
-                  </Text.H5>
-                  <Text.H6 color="foregroundMuted" ellipsis noWrap>
-                    /{m.organizationSlug} · {m.organizationId}
-                  </Text.H6>
-                </div>
-                <Badge variant={m.role === "owner" ? "default" : "secondary"}>{m.role}</Badge>
-              </div>
+                organization={{
+                  id: m.organizationId,
+                  name: m.organizationName,
+                  slug: m.organizationSlug,
+                }}
+                // The user's per-org role replaces the default created-at trailing.
+                // Surfaces "is this user an owner of any of their orgs?" at a glance,
+                // which is the question staff are usually asking on this page.
+                trailing={<Badge variant={m.role === "owner" ? "default" : "secondary"}>{m.role}</Badge>}
+              />
             ))}
           </div>
         )}

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,9 +1,18 @@
-import { Avatar, Badge, Container, Text } from "@repo/ui"
-import { createFileRoute, notFound } from "@tanstack/react-router"
-import type { AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
+import { Avatar, Badge, Text } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import type {
+  AdminUserDetailsDto,
+  AdminUserDetailsMembershipDto,
+} from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
+import {
+  DashboardHero,
+  DashboardSection,
+  PropertiesStrip,
+  type PropertiesStripEntry,
+} from "../-components/dashboard/index.ts"
 import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
-import { OrganizationRow } from "../-components/rows/index.ts"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/users/$userId")({
@@ -12,19 +21,11 @@ export const Route = createFileRoute("/backoffice/users/$userId")({
       const user = await adminGetUser({ data: { userId: params.userId } })
       return { user }
     } catch (error) {
-      // Only collapse `NotFoundError` into `notFound()` — that covers
-      // the two backoffice cases we want indistinguishable from any
-      // unknown URL: "user does not exist" and "caller isn't an
-      // admin" (both surface as a tagged `NotFoundError` from our
-      // server function). Anything else — DB outage, connectivity,
-      // serialization bug — must bubble to the router's error
-      // boundary so ops can see it, instead of being silently masked
-      // as a 404.
-      //
-      // We match on the Effect-native `_tag` field instead of
-      // `instanceof NotFoundError` because loaders can run client-side
-      // on navigations, where the thrown error has been rehydrated
-      // from JSON and no longer carries the class prototype.
+      // Only collapse `NotFoundError` into `notFound()` — covers the two
+      // cases we want indistinguishable from any unknown URL: "user
+      // doesn't exist" and "caller isn't an admin". Anything else (DB
+      // outage, connectivity, serialization bug) bubbles to the router
+      // error boundary so ops can see it.
       const tag = (error as { _tag?: string } | null | undefined)?._tag
       if (tag === "NotFoundError") {
         throw notFound()
@@ -38,11 +39,8 @@ export const Route = createFileRoute("/backoffice/users/$userId")({
 function BackofficeUserDetailPage() {
   const user = Route.useLoaderData({ select: (data) => data.user })
 
-  // Record the visit so this user shows up in the recently-viewed
-  // strip on the search page and gets a "viewed Xh ago" indicator on
-  // result rows. Cached `primary` / `secondary` text is refreshed on
-  // every visit, so the chip caption stays in sync if the user is
-  // renamed.
+  // Record the visit so this user surfaces in the recently-viewed
+  // strip + per-row "viewed Xh ago" indicator on subsequent searches.
   useTrackRecentBackofficeView({
     kind: "user",
     id: user.id,
@@ -50,79 +48,125 @@ function BackofficeUserDetailPage() {
     secondary: user.name?.trim() ? user.name : undefined,
   })
 
+  const displayName = user.name?.trim() ? user.name : "(no name)"
+  const memberships = user.memberships
+  const ownedCount = memberships.filter((m: AdminUserDetailsMembershipDto) => m.role === "owner").length
+
+  // Properties strip — boring metadata that doesn't merit its own
+  // panel. Stripe customer id / banned status / email verified are
+  // stored on the `users` row but not surfaced through
+  // `AdminUserDetails` today; pulling them in would mean expanding
+  // the domain DTO and the repo. Worth a follow-up but out of scope
+  // for the dashboard refactor.
+  const propertyEntries: PropertiesStripEntry[] = [
+    { label: "User id", value: user.id },
+    { label: "Email", value: user.email },
+    { label: "Created", value: new Date(user.createdAt).toISOString() },
+  ]
+
   return (
-    <Container className="pt-6 pb-10 flex flex-col gap-6">
-      <header className="flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <Avatar name={user.name?.trim() ? user.name : user.email} size="md" imageSrc={user.image ?? undefined} />
-          <div className="flex flex-col min-w-0">
-            <div className="flex items-center gap-2">
-              <Text.H3 weight="semibold" ellipsis noWrap>
-                {user.email}
-              </Text.H3>
-              {user.role === "admin" && <Badge variant="destructive">admin</Badge>}
-            </div>
-            <Text.H5 color="foregroundMuted" ellipsis noWrap>
-              {user.name ?? "(no name)"} · {user.id}
-            </Text.H5>
-          </div>
-        </div>
-        <ImpersonateUserButton userId={user.id} userEmail={user.email} />
-      </header>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 pt-8 pb-12">
+      <DashboardHero
+        leading={<Avatar name={displayName === "(no name)" ? user.email : displayName} imageSrc={user.image} size="lg" />}
+        title={user.email}
+        badges={user.role === "admin" ? <Badge variant="destructive">platform admin</Badge> : null}
+        meta={
+          <>
+            <span>{displayName}</span>
+            <span aria-hidden="true">·</span>
+            <span>
+              joined <span className="font-medium text-foreground">{relativeTime(user.createdAt)}</span>
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              <span className="font-medium text-foreground tabular-nums">{memberships.length}</span>{" "}
+              {memberships.length === 1 ? "membership" : "memberships"}
+              {ownedCount > 0 && (
+                <span>
+                  {" "}
+                  (<span className="font-medium text-foreground tabular-nums">{ownedCount}</span> as owner)
+                </span>
+              )}
+            </span>
+          </>
+        }
+        actions={<ImpersonateUserButton userId={user.id} userEmail={user.email} />}
+      />
 
-      <section className="flex flex-col gap-2">
-        <Text.H5 weight="semibold">Profile</Text.H5>
-        <div className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border border-border bg-background px-4 py-3">
-          <DetailRow label="User id" value={user.id} />
-          <DetailRow label="Created" value={formatDate(user.createdAt)} />
-          <DetailRow label="Email" value={user.email} />
-          <DetailRow label="Role" value={user.role} />
-          <DetailRow label="Name" value={user.name ?? "(not set)"} />
-        </div>
-      </section>
-
-      <section className="flex flex-col gap-2">
-        <Text.H5 weight="semibold">Memberships ({user.memberships.length})</Text.H5>
-        {user.memberships.length === 0 ? (
-          <div className="rounded-md border border-border bg-background px-4 py-3">
-            <Text.H5 color="foregroundMuted">This user is not a member of any organization.</Text.H5>
-          </div>
+      <DashboardSection title="Memberships" count={memberships.length}>
+        {memberships.length === 0 ? (
+          <Text.H6 color="foregroundMuted">This user is not a member of any organization.</Text.H6>
         ) : (
-          <div className="flex flex-col gap-1.5">
-            {user.memberships.map((m: AdminUserDetailsMembershipDto) => (
-              <OrganizationRow
-                key={m.organizationId}
-                organization={{
-                  id: m.organizationId,
-                  name: m.organizationName,
-                  slug: m.organizationSlug,
-                }}
-                // The user's per-org role replaces the default created-at trailing.
-                // Surfaces "is this user an owner of any of their orgs?" at a glance,
-                // which is the question staff are usually asking on this page.
-                trailing={<Badge variant={m.role === "owner" ? "default" : "secondary"}>{m.role}</Badge>}
-              />
-            ))}
-          </div>
+          <MembershipsGrid memberships={memberships} />
         )}
-      </section>
-    </Container>
+      </DashboardSection>
+
+      <PropertiesStrip entries={propertyEntries} />
+    </div>
   )
 }
 
-function DetailRow({ label, value }: { label: string; value: string }) {
+const MAX_VISIBLE_MEMBERSHIPS = 8
+
+/**
+ * Memberships grid for the user-detail page.
+ *
+ * Three columns at `lg` and above (one per ~340 px of available
+ * width), two at `md`, single column on narrow viewports. Cap at
+ * `MAX_VISIBLE_MEMBERSHIPS` visible — anything beyond collapses into
+ * a "+N more" tile that just sits inert. We don't paginate or
+ * disclose them: a user with 30 orgs is rare, and when staff need
+ * the full list they can search the org name directly.
+ *
+ * Each card is its own clickable target into the org detail page —
+ * with hover lift, role badge inline, and a chevron affordance on
+ * the right.
+ */
+function MembershipsGrid({ memberships }: { memberships: AdminUserDetailsDto["memberships"] }) {
+  const visible = memberships.slice(0, MAX_VISIBLE_MEMBERSHIPS)
+  const overflow = memberships.length - visible.length
+
   return (
-    <>
-      <Text.H6 color="foregroundMuted">{label}</Text.H6>
-      <Text.H6>{value}</Text.H6>
-    </>
+    <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
+      {visible.map((m: AdminUserDetailsMembershipDto) => (
+        <MembershipCard key={m.organizationId} membership={m} />
+      ))}
+      {overflow > 0 && (
+        <div className="flex items-center justify-center rounded-md border border-dashed border-border bg-muted/30 px-4 py-3">
+          <Text.H6 color="foregroundMuted">
+            +<span className="tabular-nums">{overflow}</span> more
+          </Text.H6>
+        </div>
+      )}
+    </div>
   )
 }
 
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toISOString().slice(0, 10)
-  } catch {
-    return iso
-  }
+function MembershipCard({ membership }: { membership: AdminUserDetailsMembershipDto }) {
+  return (
+    <Link
+      to="/backoffice/organizations/$organizationId"
+      params={{ organizationId: membership.organizationId }}
+      className={[
+        "group flex items-center gap-3 rounded-md border border-border bg-background px-3 py-3",
+        "transition-all duration-150",
+        "hover:bg-muted/60 hover:shadow-sm hover:-translate-y-px",
+      ].join(" ")}
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+        <Text.H5 weight="semibold" color="foregroundMuted">
+          {membership.organizationName.trim()[0]?.toUpperCase() ?? "?"}
+        </Text.H5>
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text.H5 weight="medium" ellipsis noWrap>
+          {membership.organizationName}
+        </Text.H5>
+        <Text.H6 color="foregroundMuted" ellipsis noWrap>
+          /{membership.organizationSlug}
+        </Text.H6>
+      </div>
+      <Badge variant={membership.role === "owner" ? "default" : "secondary"}>{membership.role}</Badge>
+    </Link>
+  )
 }

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -4,6 +4,7 @@ import type { AdminUserDetailsMembershipDto } from "../../../domains/admin/users
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
 import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
 import { OrganizationRow } from "../-components/rows/index.ts"
+import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/users/$userId")({
   loader: async ({ params }) => {
@@ -36,6 +37,18 @@ export const Route = createFileRoute("/backoffice/users/$userId")({
 
 function BackofficeUserDetailPage() {
   const user = Route.useLoaderData({ select: (data) => data.user })
+
+  // Record the visit so this user shows up in the recently-viewed
+  // strip on the search page and gets a "viewed Xh ago" indicator on
+  // result rows. Cached `primary` / `secondary` text is refreshed on
+  // every visit, so the chip caption stays in sync if the user is
+  // renamed.
+  useTrackRecentBackofficeView({
+    kind: "user",
+    id: user.id,
+    primary: user.email,
+    secondary: user.name?.trim() ? user.name : undefined,
+  })
 
   return (
     <Container className="pt-6 pb-10 flex flex-col gap-6">

--- a/packages/domain/admin/src/index.ts
+++ b/packages/domain/admin/src/index.ts
@@ -1,5 +1,6 @@
 // Feature-grouped barrel. Each folder under `src/` owns one backoffice
 // feature (entities + ports + use-cases). Add a new folder per feature and
 // re-export its public surface below.
+export * from "./projects/index.ts"
 export * from "./search/index.ts"
 export * from "./users/index.ts"

--- a/packages/domain/admin/src/index.ts
+++ b/packages/domain/admin/src/index.ts
@@ -1,6 +1,7 @@
 // Feature-grouped barrel. Each folder under `src/` owns one backoffice
 // feature (entities + ports + use-cases). Add a new folder per feature and
 // re-export its public surface below.
+export * from "./organizations/index.ts"
 export * from "./projects/index.ts"
 export * from "./search/index.ts"
 export * from "./users/index.ts"

--- a/packages/domain/admin/src/organizations/get-organization-details.test.ts
+++ b/packages/domain/admin/src/organizations/get-organization-details.test.ts
@@ -1,0 +1,48 @@
+import { NotFoundError, type OrganizationId } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { getOrganizationDetailsUseCase } from "./get-organization-details.ts"
+import type { AdminOrganizationDetails } from "./organization-details.ts"
+import { AdminOrganizationRepository } from "./organization-repository.ts"
+
+const TARGET = "org-target" as OrganizationId
+
+const successfulRepo = (result: AdminOrganizationDetails) =>
+  Layer.succeed(AdminOrganizationRepository, {
+    findById: () => Effect.succeed(result),
+  })
+
+const missingRepo = () =>
+  Layer.succeed(AdminOrganizationRepository, {
+    findById: (id) => Effect.fail(new NotFoundError({ entity: "Organization", id })),
+  })
+
+const mkDetails = (overrides: Partial<AdminOrganizationDetails> = {}): AdminOrganizationDetails => ({
+  id: TARGET,
+  name: "Acme",
+  slug: "acme",
+  stripeCustomerId: null,
+  members: [],
+  projects: [],
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+  ...overrides,
+})
+
+describe("getOrganizationDetailsUseCase", () => {
+  it("returns the organisation details from the repository", async () => {
+    const details = mkDetails()
+    const result = await Effect.runPromise(
+      getOrganizationDetailsUseCase({ organizationId: TARGET }).pipe(Effect.provide(successfulRepo(details))),
+    )
+    expect(result).toBe(details)
+  })
+
+  it("propagates NotFoundError verbatim when the organisation does not exist", async () => {
+    await expect(
+      Effect.runPromise(
+        getOrganizationDetailsUseCase({ organizationId: TARGET }).pipe(Effect.provide(missingRepo())),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Organization" })
+  })
+})

--- a/packages/domain/admin/src/organizations/get-organization-details.test.ts
+++ b/packages/domain/admin/src/organizations/get-organization-details.test.ts
@@ -40,9 +40,7 @@ describe("getOrganizationDetailsUseCase", () => {
 
   it("propagates NotFoundError verbatim when the organisation does not exist", async () => {
     await expect(
-      Effect.runPromise(
-        getOrganizationDetailsUseCase({ organizationId: TARGET }).pipe(Effect.provide(missingRepo())),
-      ),
+      Effect.runPromise(getOrganizationDetailsUseCase({ organizationId: TARGET }).pipe(Effect.provide(missingRepo()))),
     ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Organization" })
   })
 })

--- a/packages/domain/admin/src/organizations/get-organization-details.ts
+++ b/packages/domain/admin/src/organizations/get-organization-details.ts
@@ -1,0 +1,17 @@
+import type { NotFoundError, OrganizationId, RepositoryError } from "@domain/shared"
+import { Effect } from "effect"
+import type { AdminOrganizationDetails } from "./organization-details.ts"
+import { AdminOrganizationRepository } from "./organization-repository.ts"
+
+export interface GetOrganizationDetailsInput {
+  readonly organizationId: OrganizationId
+}
+
+export const getOrganizationDetailsUseCase = (
+  input: GetOrganizationDetailsInput,
+): Effect.Effect<AdminOrganizationDetails, NotFoundError | RepositoryError, AdminOrganizationRepository> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("admin.targetOrganizationId", input.organizationId)
+    const repo = yield* AdminOrganizationRepository
+    return yield* repo.findById(input.organizationId)
+  }).pipe(Effect.withSpan("admin.getOrganizationDetails"))

--- a/packages/domain/admin/src/organizations/index.ts
+++ b/packages/domain/admin/src/organizations/index.ts
@@ -1,10 +1,10 @@
 export { type GetOrganizationDetailsInput, getOrganizationDetailsUseCase } from "./get-organization-details.ts"
 export {
   type AdminOrganizationDetails,
-  adminOrganizationDetailsSchema,
   type AdminOrganizationMember,
-  adminOrganizationMemberSchema,
   type AdminOrganizationProject,
+  adminOrganizationDetailsSchema,
+  adminOrganizationMemberSchema,
   adminOrganizationProjectSchema,
 } from "./organization-details.ts"
 export { AdminOrganizationRepository } from "./organization-repository.ts"

--- a/packages/domain/admin/src/organizations/index.ts
+++ b/packages/domain/admin/src/organizations/index.ts
@@ -1,0 +1,10 @@
+export { type GetOrganizationDetailsInput, getOrganizationDetailsUseCase } from "./get-organization-details.ts"
+export {
+  type AdminOrganizationDetails,
+  adminOrganizationDetailsSchema,
+  type AdminOrganizationMember,
+  adminOrganizationMemberSchema,
+  type AdminOrganizationProject,
+  adminOrganizationProjectSchema,
+} from "./organization-details.ts"
+export { AdminOrganizationRepository } from "./organization-repository.ts"

--- a/packages/domain/admin/src/organizations/organization-details.ts
+++ b/packages/domain/admin/src/organizations/organization-details.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+/**
+ * Organization details for the backoffice org-detail page.
+ *
+ * Same flat-DTO discipline as the other admin entities. Members and
+ * projects are inlined as compact summaries — the page renders both as
+ * sections on the same screen, so a single round-trip beats two
+ * follow-up RPCs. Each summary carries only what the row component
+ * needs (no Stripe customer ids / settings / sensitive internals
+ * leaking through this surface).
+ */
+
+export const adminOrganizationMemberSchema = z.object({
+  /** Membership row id (`members.id`). */
+  membershipId: z.string(),
+  /** Per-org role. */
+  role: z.enum(["owner", "admin", "member"]),
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+    name: z.string().nullable(),
+    image: z.string().nullable(),
+    /** Global platform role — surfaced so a platform-admin lurking inside a tenant is visible at a glance. */
+    role: z.enum(["user", "admin"]),
+  }),
+})
+export type AdminOrganizationMember = z.infer<typeof adminOrganizationMemberSchema>
+
+export const adminOrganizationProjectSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  createdAt: z.date(),
+})
+export type AdminOrganizationProject = z.infer<typeof adminOrganizationProjectSchema>
+
+export const adminOrganizationDetailsSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  /** Surfaced for support — staff need to map customers to Stripe records. */
+  stripeCustomerId: z.string().nullable(),
+  members: z.array(adminOrganizationMemberSchema),
+  projects: z.array(adminOrganizationProjectSchema),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+export type AdminOrganizationDetails = z.infer<typeof adminOrganizationDetailsSchema>

--- a/packages/domain/admin/src/organizations/organization-repository.ts
+++ b/packages/domain/admin/src/organizations/organization-repository.ts
@@ -1,0 +1,28 @@
+import { type NotFoundError, type OrganizationId, type RepositoryError } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { AdminOrganizationDetails } from "./organization-details.ts"
+
+/**
+ * Cross-organization org-detail port for the backoffice.
+ *
+ * WARNING: adapters MUST run under an admin (RLS-bypassing) DB
+ * connection — see `AdminOrganizationRepositoryLive` in
+ * `@platform/db-postgres`. Only wired into handlers that have passed
+ * `adminMiddleware` in `apps/web`.
+ */
+export class AdminOrganizationRepository extends ServiceMap.Service<
+  AdminOrganizationRepository,
+  {
+    /**
+     * Fetch an organisation, its members, and its (non-deleted)
+     * projects in one call. Fails with `NotFoundError` when no org
+     * exists.
+     *
+     * Members are returned with their per-org role AND their global
+     * `users.role` (to surface platform-admins inside a tenant). Projects
+     * exclude soft-deletes — same v1 policy as the project-detail page
+     * and the search results.
+     */
+    findById(organizationId: OrganizationId): Effect.Effect<AdminOrganizationDetails, NotFoundError | RepositoryError>
+  }
+>()("@domain/admin/AdminOrganizationRepository") {}

--- a/packages/domain/admin/src/organizations/organization-repository.ts
+++ b/packages/domain/admin/src/organizations/organization-repository.ts
@@ -1,4 +1,4 @@
-import { type NotFoundError, type OrganizationId, type RepositoryError } from "@domain/shared"
+import type { NotFoundError, OrganizationId, RepositoryError } from "@domain/shared"
 import { type Effect, ServiceMap } from "effect"
 import type { AdminOrganizationDetails } from "./organization-details.ts"
 

--- a/packages/domain/admin/src/projects/get-project-details.test.ts
+++ b/packages/domain/admin/src/projects/get-project-details.test.ts
@@ -1,0 +1,48 @@
+import { NotFoundError, type ProjectId } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { getProjectDetailsUseCase } from "./get-project-details.ts"
+import type { AdminProjectDetails } from "./project-details.ts"
+import { AdminProjectRepository } from "./project-repository.ts"
+
+const TARGET = "proj-target" as ProjectId
+
+const successfulRepo = (result: AdminProjectDetails) =>
+  Layer.succeed(AdminProjectRepository, {
+    findById: () => Effect.succeed(result),
+  })
+
+const missingRepo = () =>
+  Layer.succeed(AdminProjectRepository, {
+    findById: (id) => Effect.fail(new NotFoundError({ entity: "Project", id })),
+  })
+
+const mkDetails = (overrides: Partial<AdminProjectDetails> = {}): AdminProjectDetails => ({
+  id: TARGET,
+  name: "Test Project",
+  slug: "test-project",
+  organization: { id: "org-1", name: "Org One", slug: "org-one" },
+  settings: null,
+  firstTraceAt: null,
+  lastEditedAt: new Date("2024-01-02"),
+  deletedAt: null,
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-02"),
+  ...overrides,
+})
+
+describe("getProjectDetailsUseCase", () => {
+  it("returns the project details from the repository", async () => {
+    const details = mkDetails()
+    const result = await Effect.runPromise(
+      getProjectDetailsUseCase({ projectId: TARGET }).pipe(Effect.provide(successfulRepo(details))),
+    )
+    expect(result).toBe(details)
+  })
+
+  it("propagates NotFoundError verbatim when the project does not exist", async () => {
+    await expect(
+      Effect.runPromise(getProjectDetailsUseCase({ projectId: TARGET }).pipe(Effect.provide(missingRepo()))),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Project" })
+  })
+})

--- a/packages/domain/admin/src/projects/get-project-details.ts
+++ b/packages/domain/admin/src/projects/get-project-details.ts
@@ -1,0 +1,17 @@
+import type { NotFoundError, ProjectId, RepositoryError } from "@domain/shared"
+import { Effect } from "effect"
+import type { AdminProjectDetails } from "./project-details.ts"
+import { AdminProjectRepository } from "./project-repository.ts"
+
+export interface GetProjectDetailsInput {
+  readonly projectId: ProjectId
+}
+
+export const getProjectDetailsUseCase = (
+  input: GetProjectDetailsInput,
+): Effect.Effect<AdminProjectDetails, NotFoundError | RepositoryError, AdminProjectRepository> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("admin.targetProjectId", input.projectId)
+    const repo = yield* AdminProjectRepository
+    return yield* repo.findById(input.projectId)
+  }).pipe(Effect.withSpan("admin.getProjectDetails"))

--- a/packages/domain/admin/src/projects/index.ts
+++ b/packages/domain/admin/src/projects/index.ts
@@ -1,10 +1,10 @@
 export { type GetProjectDetailsInput, getProjectDetailsUseCase } from "./get-project-details.ts"
 export {
   type AdminProjectDetails,
-  adminProjectDetailsSchema,
   type AdminProjectOrganization,
-  adminProjectOrganizationSchema,
   type AdminProjectSettings,
+  adminProjectDetailsSchema,
+  adminProjectOrganizationSchema,
   adminProjectSettingsSchema,
 } from "./project-details.ts"
 export { AdminProjectRepository } from "./project-repository.ts"

--- a/packages/domain/admin/src/projects/index.ts
+++ b/packages/domain/admin/src/projects/index.ts
@@ -1,0 +1,10 @@
+export { type GetProjectDetailsInput, getProjectDetailsUseCase } from "./get-project-details.ts"
+export {
+  type AdminProjectDetails,
+  adminProjectDetailsSchema,
+  type AdminProjectOrganization,
+  adminProjectOrganizationSchema,
+  type AdminProjectSettings,
+  adminProjectSettingsSchema,
+} from "./project-details.ts"
+export { AdminProjectRepository } from "./project-repository.ts"

--- a/packages/domain/admin/src/projects/project-details.ts
+++ b/packages/domain/admin/src/projects/project-details.ts
@@ -1,0 +1,41 @@
+import { z } from "zod"
+
+/**
+ * Project details for the backoffice project-detail page.
+ *
+ * Same flat-DTO discipline as the other admin entities — only the
+ * fields the staff UI renders, no domain-entity passthrough, so
+ * sensitive fields can't leak through this surface accidentally.
+ *
+ * `organization` is included inline because the detail page renders a
+ * link to the parent organisation as a primary affordance (same as the
+ * search-results project row). Pulling it inline saves a second
+ * round-trip and keeps the page render fully driven by the loader's
+ * single result.
+ */
+
+export const adminProjectOrganizationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+})
+export type AdminProjectOrganization = z.infer<typeof adminProjectOrganizationSchema>
+
+export const adminProjectSettingsSchema = z.object({
+  keepMonitoring: z.boolean().optional(),
+})
+export type AdminProjectSettings = z.infer<typeof adminProjectSettingsSchema>
+
+export const adminProjectDetailsSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  organization: adminProjectOrganizationSchema,
+  settings: adminProjectSettingsSchema.nullable(),
+  firstTraceAt: z.date().nullable(),
+  lastEditedAt: z.date(),
+  deletedAt: z.date().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+})
+export type AdminProjectDetails = z.infer<typeof adminProjectDetailsSchema>

--- a/packages/domain/admin/src/projects/project-repository.ts
+++ b/packages/domain/admin/src/projects/project-repository.ts
@@ -1,4 +1,4 @@
-import { type NotFoundError, type ProjectId, type RepositoryError } from "@domain/shared"
+import type { NotFoundError, ProjectId, RepositoryError } from "@domain/shared"
 import { type Effect, ServiceMap } from "effect"
 import type { AdminProjectDetails } from "./project-details.ts"
 

--- a/packages/domain/admin/src/projects/project-repository.ts
+++ b/packages/domain/admin/src/projects/project-repository.ts
@@ -1,0 +1,25 @@
+import { type NotFoundError, type ProjectId, type RepositoryError } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { AdminProjectDetails } from "./project-details.ts"
+
+/**
+ * Cross-organization project-detail port for the backoffice.
+ *
+ * WARNING: adapters MUST run under an admin (RLS-bypassing) DB
+ * connection — see `AdminProjectRepositoryLive` in
+ * `@platform/db-postgres`. Only wired into handlers that have passed
+ * `adminMiddleware` in `apps/web`.
+ */
+export class AdminProjectRepository extends ServiceMap.Service<
+  AdminProjectRepository,
+  {
+    /**
+     * Fetch a project + its parent organisation by id.
+     *
+     * Fails with `NotFoundError` when no project exists. Soft-deleted
+     * projects are excluded — the backoffice deliberately does not
+     * surface them in v1, matching the search-results filter.
+     */
+    findById(projectId: ProjectId): Effect.Effect<AdminProjectDetails, NotFoundError | RepositoryError>
+  }
+>()("@domain/admin/AdminProjectRepository") {}

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -24,6 +24,7 @@ export {
   type PollingOutboxConsumerConfig,
 } from "./outbox-consumer.ts"
 export { createOutboxWriter, OutboxEventWriterLive } from "./outbox-writer.ts"
+export { AdminProjectRepositoryLive } from "./repositories/admin-project-repository.ts"
 export { AdminUserRepositoryLive } from "./repositories/admin-user-repository.ts"
 export { AnnotationQueueItemRepositoryLive } from "./repositories/annotation-queue-item-repository.ts"
 export { AnnotationQueueRepositoryLive } from "./repositories/annotation-queue-repository.ts"

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -24,6 +24,7 @@ export {
   type PollingOutboxConsumerConfig,
 } from "./outbox-consumer.ts"
 export { createOutboxWriter, OutboxEventWriterLive } from "./outbox-writer.ts"
+export { AdminOrganizationRepositoryLive } from "./repositories/admin-organization-repository.ts"
 export { AdminProjectRepositoryLive } from "./repositories/admin-project-repository.ts"
 export { AdminUserRepositoryLive } from "./repositories/admin-user-repository.ts"
 export { AnnotationQueueItemRepositoryLive } from "./repositories/annotation-queue-item-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.test.ts
@@ -1,0 +1,124 @@
+import { AdminOrganizationRepository } from "@domain/admin"
+import { OrganizationId } from "@domain/shared"
+import { Effect } from "effect"
+import { beforeAll, describe, expect, it } from "vitest"
+import { members, organizations, users } from "../schema/better-auth.ts"
+import { projects } from "../schema/projects.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { AdminOrganizationRepositoryLive } from "./admin-organization-repository.ts"
+
+const pg = setupTestPostgres()
+
+const runWithLive = <A, E>(effect: Effect.Effect<A, E, AdminOrganizationRepository>) =>
+  Effect.runPromise(effect.pipe(withPostgres(AdminOrganizationRepositoryLive, pg.adminPostgresClient)))
+
+const makeId = (prefix: string): string => prefix.padEnd(24, "x").slice(0, 24)
+
+const ORG = makeId("org-or-target")
+const OWNER = makeId("user-or-owner")
+const ADMIN = makeId("user-or-admin")
+const PROJ_ALIVE = makeId("proj-or-alive")
+const PROJ_DELETED = makeId("proj-or-deleted")
+
+describe("AdminOrganizationRepositoryLive.findById", () => {
+  beforeAll(async () => {
+    const baseTime = new Date("2025-06-01T12:00:00.000Z")
+
+    await pg.db.insert(users).values([
+      {
+        id: OWNER,
+        email: "owner@example.com",
+        name: "Owner User",
+        emailVerified: true,
+        role: "user" as const,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+      {
+        id: ADMIN,
+        email: "platform@latitude.so",
+        name: "Platform Admin",
+        emailVerified: true,
+        role: "admin" as const,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+
+    await pg.db.insert(organizations).values([
+      {
+        id: ORG,
+        name: "Acme",
+        slug: "acme",
+        stripeCustomerId: "cus_test_123",
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+
+    await pg.db.insert(members).values([
+      { id: makeId("mem-owner"), organizationId: ORG, userId: OWNER, role: "owner" as const, createdAt: baseTime },
+      { id: makeId("mem-admin"), organizationId: ORG, userId: ADMIN, role: "member" as const, createdAt: baseTime },
+    ])
+
+    await pg.db.insert(projects).values([
+      { id: PROJ_ALIVE, organizationId: ORG, name: "live", slug: "live", createdAt: baseTime, updatedAt: baseTime },
+      {
+        id: PROJ_DELETED,
+        organizationId: ORG,
+        name: "archived",
+        slug: "archived",
+        deletedAt: baseTime,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+  })
+
+  it("returns the organisation with members and active projects", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.findById(OrganizationId(ORG))
+      }),
+    )
+
+    expect(result.id).toBe(ORG)
+    expect(result.name).toBe("Acme")
+    expect(result.stripeCustomerId).toBe("cus_test_123")
+
+    expect(result.members).toHaveLength(2)
+    const ownerMember = result.members.find((m) => m.user.id === OWNER)
+    expect(ownerMember?.role).toBe("owner")
+    expect(ownerMember?.user.email).toBe("owner@example.com")
+
+    // Surface the platform-admin user role even when their per-org role
+    // is just "member" — staff need to see "platform admin lurking in
+    // tenant" at a glance.
+    const platformAdminMember = result.members.find((m) => m.user.id === ADMIN)
+    expect(platformAdminMember?.role).toBe("member")
+    expect(platformAdminMember?.user.role).toBe("admin")
+  })
+
+  it("excludes soft-deleted projects from the projects list", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminOrganizationRepository
+        return yield* repo.findById(OrganizationId(ORG))
+      }),
+    )
+    expect(result.projects.map((p) => p.id)).toEqual([PROJ_ALIVE])
+  })
+
+  it("fails with NotFoundError for a non-existent organisation id", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminOrganizationRepository
+          return yield* repo.findById(OrganizationId(makeId("org-missing")))
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Organization" })
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
@@ -4,12 +4,7 @@ import {
   type AdminOrganizationProject,
   AdminOrganizationRepository,
 } from "@domain/admin"
-import {
-  NotFoundError,
-  type OrganizationId,
-  SqlClient,
-  type SqlClientShape,
-} from "@domain/shared"
+import { NotFoundError, type OrganizationId, SqlClient, type SqlClientShape } from "@domain/shared"
 import { and, eq, isNull } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"

--- a/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-organization-repository.ts
@@ -1,0 +1,126 @@
+import {
+  type AdminOrganizationDetails,
+  type AdminOrganizationMember,
+  type AdminOrganizationProject,
+  AdminOrganizationRepository,
+} from "@domain/admin"
+import {
+  NotFoundError,
+  type OrganizationId,
+  SqlClient,
+  type SqlClientShape,
+} from "@domain/shared"
+import { and, eq, isNull } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import type { Operator } from "../client.ts"
+import { members, organizations, users } from "../schema/better-auth.ts"
+import { projects } from "../schema/projects.ts"
+
+type MemberRoleValue = AdminOrganizationMember["role"]
+type UserRoleValue = AdminOrganizationMember["user"]["role"]
+
+/**
+ * Live layer for the backoffice org-detail port.
+ *
+ * ⚠️ SECURITY: queries run **without** an `organization_id` filter and
+ * see every org / user / project in the database. Only safe when the
+ * SqlClient was constructed with `OrganizationId("system")` (the
+ * default on `getAdminPostgresClient()`) so RLS is bypassed. Never
+ * provide this layer on the standard app-facing Postgres client.
+ *
+ * Three sequential queries: org row, members + their users, and
+ * non-deleted projects. We could collapse members + projects into
+ * parallel calls but the gain is microseconds for a backoffice page;
+ * the sequential shape is easier to reason about.
+ */
+export const AdminOrganizationRepositoryLive = Layer.effect(
+  AdminOrganizationRepository,
+  Effect.gen(function* () {
+    const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+
+    return {
+      findById: (organizationId: OrganizationId) =>
+        Effect.gen(function* () {
+          const orgRows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: organizations.id,
+                name: organizations.name,
+                slug: organizations.slug,
+                stripeCustomerId: organizations.stripeCustomerId,
+                createdAt: organizations.createdAt,
+                updatedAt: organizations.updatedAt,
+              })
+              .from(organizations)
+              .where(eq(organizations.id, organizationId))
+              .limit(1),
+          )
+          const orgRow = orgRows[0]
+          if (!orgRow) {
+            return yield* Effect.fail(new NotFoundError({ entity: "Organization", id: organizationId }))
+          }
+
+          const memberRows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                membershipId: members.id,
+                memberRole: members.role,
+                userId: users.id,
+                userEmail: users.email,
+                userName: users.name,
+                userImage: users.image,
+                userRole: users.role,
+              })
+              .from(members)
+              .innerJoin(users, eq(members.userId, users.id))
+              .where(eq(members.organizationId, organizationId))
+              .orderBy(users.email),
+          )
+
+          const projectRows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: projects.id,
+                name: projects.name,
+                slug: projects.slug,
+                createdAt: projects.createdAt,
+              })
+              .from(projects)
+              .where(and(eq(projects.organizationId, organizationId), isNull(projects.deletedAt)))
+              .orderBy(projects.name),
+          )
+
+          const memberDtos: AdminOrganizationMember[] = memberRows.map((r) => ({
+            membershipId: r.membershipId,
+            role: r.memberRole as MemberRoleValue,
+            user: {
+              id: r.userId,
+              email: r.userEmail,
+              name: r.userName ?? null,
+              image: r.userImage ?? null,
+              role: r.userRole as UserRoleValue,
+            },
+          }))
+
+          const projectDtos: AdminOrganizationProject[] = projectRows.map((r) => ({
+            id: r.id,
+            name: r.name,
+            slug: r.slug,
+            createdAt: r.createdAt,
+          }))
+
+          const details: AdminOrganizationDetails = {
+            id: orgRow.id,
+            name: orgRow.name,
+            slug: orgRow.slug,
+            stripeCustomerId: orgRow.stripeCustomerId ?? null,
+            members: memberDtos,
+            projects: projectDtos,
+            createdAt: orgRow.createdAt,
+            updatedAt: orgRow.updatedAt,
+          }
+          return details
+        }),
+    }
+  }),
+)

--- a/packages/platform/db-postgres/src/repositories/admin-project-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-project-repository.test.ts
@@ -23,9 +23,9 @@ describe("AdminProjectRepositoryLive.findById", () => {
   beforeAll(async () => {
     const baseTime = new Date("2025-06-01T12:00:00.000Z")
 
-    await pg.db.insert(organizations).values([
-      { id: ORG, name: "Project Co", slug: "project-co", createdAt: baseTime, updatedAt: baseTime },
-    ])
+    await pg.db
+      .insert(organizations)
+      .values([{ id: ORG, name: "Project Co", slug: "project-co", createdAt: baseTime, updatedAt: baseTime }])
 
     await pg.db.insert(projects).values([
       {

--- a/packages/platform/db-postgres/src/repositories/admin-project-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-project-repository.test.ts
@@ -1,0 +1,91 @@
+import { AdminProjectRepository } from "@domain/admin"
+import { ProjectId } from "@domain/shared"
+import { Effect } from "effect"
+import { beforeAll, describe, expect, it } from "vitest"
+import { organizations } from "../schema/better-auth.ts"
+import { projects } from "../schema/projects.ts"
+import { setupTestPostgres } from "../test/in-memory-postgres.ts"
+import { withPostgres } from "../with-postgres.ts"
+import { AdminProjectRepositoryLive } from "./admin-project-repository.ts"
+
+const pg = setupTestPostgres()
+
+const runWithLive = <A, E>(effect: Effect.Effect<A, E, AdminProjectRepository>) =>
+  Effect.runPromise(effect.pipe(withPostgres(AdminProjectRepositoryLive, pg.adminPostgresClient)))
+
+const makeId = (prefix: string): string => prefix.padEnd(24, "x").slice(0, 24)
+
+const ORG = makeId("org-pr-target")
+const ALIVE = makeId("proj-pr-alive")
+const DELETED = makeId("proj-pr-deleted")
+
+describe("AdminProjectRepositoryLive.findById", () => {
+  beforeAll(async () => {
+    const baseTime = new Date("2025-06-01T12:00:00.000Z")
+
+    await pg.db.insert(organizations).values([
+      { id: ORG, name: "Project Co", slug: "project-co", createdAt: baseTime, updatedAt: baseTime },
+    ])
+
+    await pg.db.insert(projects).values([
+      {
+        id: ALIVE,
+        organizationId: ORG,
+        name: "🚀 alpha",
+        slug: "alpha",
+        settings: { keepMonitoring: true },
+        createdAt: baseTime,
+        updatedAt: new Date(baseTime.getTime() + 1000),
+        firstTraceAt: new Date(baseTime.getTime() + 500),
+      },
+      {
+        id: DELETED,
+        organizationId: ORG,
+        name: "archived",
+        slug: "archived",
+        deletedAt: new Date(baseTime.getTime() + 2000),
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
+    ])
+  })
+
+  it("returns the project with its parent organisation inlined", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminProjectRepository
+        return yield* repo.findById(ProjectId(ALIVE))
+      }),
+    )
+
+    expect(result.id).toBe(ALIVE)
+    expect(result.name).toBe("🚀 alpha")
+    expect(result.slug).toBe("alpha")
+    expect(result.settings).toEqual({ keepMonitoring: true })
+    expect(result.organization).toEqual({ id: ORG, name: "Project Co", slug: "project-co" })
+    expect(result.firstTraceAt).toBeInstanceOf(Date)
+    expect(result.deletedAt).toBeNull()
+  })
+
+  it("excludes soft-deleted projects (matches the search-results filter)", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminProjectRepository
+          return yield* repo.findById(ProjectId(DELETED))
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Project" })
+  })
+
+  it("fails with NotFoundError for a non-existent project id", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminProjectRepository
+          return yield* repo.findById(ProjectId(makeId("proj-missing")))
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Project" })
+  })
+})

--- a/packages/platform/db-postgres/src/repositories/admin-project-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-project-repository.ts
@@ -1,0 +1,83 @@
+import { type AdminProjectDetails, AdminProjectRepository } from "@domain/admin"
+import {
+  NotFoundError,
+  type ProjectId,
+  type ProjectSettings,
+  SqlClient,
+  type SqlClientShape,
+} from "@domain/shared"
+import { and, eq, isNull } from "drizzle-orm"
+import { Effect, Layer } from "effect"
+import type { Operator } from "../client.ts"
+import { organizations } from "../schema/better-auth.ts"
+import { projects } from "../schema/projects.ts"
+
+/**
+ * Live layer for the backoffice project-detail port.
+ *
+ * ⚠️ SECURITY: queries run **without** an `organization_id` filter and
+ * see every project in the database. Only safe when the SqlClient was
+ * constructed with `OrganizationId("system")` (the default on
+ * `getAdminPostgresClient()`) so RLS is bypassed. Never provide this
+ * layer on the standard app-facing Postgres client.
+ *
+ * Soft-deleted projects (`deletedAt IS NOT NULL`) are excluded — the
+ * backoffice deliberately doesn't surface them in v1, matching the
+ * search-results filter. If staff need to inspect a deleted project,
+ * we'll either restore it or add an explicit toggle later.
+ */
+export const AdminProjectRepositoryLive = Layer.effect(
+  AdminProjectRepository,
+  Effect.gen(function* () {
+    const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+
+    return {
+      findById: (projectId: ProjectId) =>
+        Effect.gen(function* () {
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: projects.id,
+                name: projects.name,
+                slug: projects.slug,
+                settings: projects.settings,
+                firstTraceAt: projects.firstTraceAt,
+                lastEditedAt: projects.lastEditedAt,
+                deletedAt: projects.deletedAt,
+                createdAt: projects.createdAt,
+                updatedAt: projects.updatedAt,
+                organizationId: organizations.id,
+                organizationName: organizations.name,
+                organizationSlug: organizations.slug,
+              })
+              .from(projects)
+              .innerJoin(organizations, eq(projects.organizationId, organizations.id))
+              .where(and(eq(projects.id, projectId), isNull(projects.deletedAt)))
+              .limit(1),
+          )
+          const row = rows[0]
+          if (!row) {
+            return yield* Effect.fail(new NotFoundError({ entity: "Project", id: projectId }))
+          }
+
+          const details: AdminProjectDetails = {
+            id: row.id,
+            name: row.name,
+            slug: row.slug,
+            organization: {
+              id: row.organizationId,
+              name: row.organizationName,
+              slug: row.organizationSlug,
+            },
+            settings: (row.settings as ProjectSettings | null) ?? null,
+            firstTraceAt: row.firstTraceAt,
+            lastEditedAt: row.lastEditedAt,
+            deletedAt: row.deletedAt,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+          }
+          return details
+        }),
+    }
+  }),
+)

--- a/packages/platform/db-postgres/src/repositories/admin-project-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-project-repository.ts
@@ -1,11 +1,5 @@
 import { type AdminProjectDetails, AdminProjectRepository } from "@domain/admin"
-import {
-  NotFoundError,
-  type ProjectId,
-  type ProjectSettings,
-  SqlClient,
-  type SqlClientShape,
-} from "@domain/shared"
+import { NotFoundError, type ProjectId, type ProjectSettings, SqlClient, type SqlClientShape } from "@domain/shared"
 import { and, eq, isNull } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"

--- a/packages/ui/src/components/avatar/avatar-group.tsx
+++ b/packages/ui/src/components/avatar/avatar-group.tsx
@@ -8,6 +8,7 @@ const overflowChipClass: Record<AvatarSize, string> = {
   sm: "h-6 min-w-6 text-xs",
   md: "h-7 min-w-7 text-[10px]",
   lg: "h-8 min-w-8 text-sm",
+  xl: "h-14 min-w-14 text-xl",
 }
 
 export interface AvatarGroupItem {

--- a/packages/ui/src/components/avatar/avatar.tsx
+++ b/packages/ui/src/components/avatar/avatar.tsx
@@ -2,13 +2,17 @@ import type { CSSProperties } from "react"
 import { useHashColor } from "../../hooks/use-hash-color.ts"
 import { cn } from "../../utils/cn.ts"
 
-export type AvatarSize = "xs" | "sm" | "md" | "lg"
+export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl"
 
 const sizeClass: Record<AvatarSize, string> = {
   xs: "h-5 w-5 text-[8px]",
   sm: "h-6 w-6 text-xs",
   md: "h-7 w-7 text-[10px]",
   lg: "h-8 w-8 text-sm",
+  // Detail-page hero scale (~56 px). Used by the backoffice
+  // user / organisation dashboards so the leading visual matches
+  // the height of the title + subtitle stack.
+  xl: "h-14 w-14 text-xl",
 }
 
 export function initialsFromDisplayName(name: string): string {


### PR DESCRIPTION
## Summary

- Replaces the vertical list-of-tables layout on the three backoffice detail pages with proper dashboards: hero zone (identity + inline stat-string + primary action), side-by-side primary panels, low-weight properties strip at the bottom. Each page reuses the same shared primitives (`DashboardHero` / `DashboardSection` / `DashboardSplit` / `FactRow` / `PropertiesStrip`) but its primary panel is shaped for its data — Activity + Settings on project, Members + Projects on org, Memberships grid on user.
- Spotlight-style omnibox replaces the form-y search page: large centered input, results materialise underneath, full keyboard nav (↓/↑/Enter/Esc), real skeleton + empty states.
- Recently-viewed history (per-browser, localStorage) drives a 6-chip strip below the omnibox when the input is empty, plus a "viewed Xh ago" indicator on result rows.
- Cross-linking sweep — every user / project / organisation row now navigates to and from each of the others via typed `<Link>`s.
- Icon-led role badges across the backoffice — `MemberRoleBadge` (Crown / ShieldCheck / User glyphs on a uniform outline pill) for per-org roles, distinctly-styled `PlatformStaffBadge` (solid destructive + uppercase "Latitude staff") for the global staff identity.
- Pre-existing bug fix: the bundle-size script's allowlist regex assumed rolldown hashes never contain hyphens — they sometimes do, which was failing CI for the unchanged echarts chunk. Walk the prefix segments instead.

## Test plan

- [x] \`pnpm --filter @app/web typecheck\`, production build, bundle-size check pass locally
- [x] \`@app/web\`, \`@domain/admin\`, \`@platform/db-postgres\` test suites all green (41 + 7 + 14 tests)
- [ ] Walk the three detail pages end-to-end as \`owner@acme.com\` (or any seeded admin): each page should feel like a dashboard, not a stack of tables
- [ ] Search → click a user → impersonate from the hero action → return → confirm the user appears as a "viewed Xh ago" row on the next search
- [ ] Visit a few entities, then return to /backoffice/search with an empty input → recently-viewed chips should render under the omnibox
- [ ] Verify keyboard nav on /search: \`↓\` from input → first row, \`↑/↓\` between rows, \`Esc\` back to input, \`Enter\` opens the row