### PR TITLE
feat(issues): show affected tags on issues list and drawer

### DIFF
--- a/apps/web/src/domains/issues/issues-list-metrics.test.ts
+++ b/apps/web/src/domains/issues/issues-list-metrics.test.ts
@@ -36,6 +36,7 @@ const makeListIssuesResult = (): ListIssuesResult => ({
       escalationOccurrenceThreshold: null,
       trend: [],
       evaluations: [],
+      tags: [],
     },
     {
       id: "issue-b",
@@ -57,6 +58,7 @@ const makeListIssuesResult = (): ListIssuesResult => ({
       escalationOccurrenceThreshold: null,
       trend: [],
       evaluations: [],
+      tags: [],
     },
   ],
   totalCount: 2,

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -91,6 +91,7 @@ const toIssueRecord = (issue: IssueListItem) => ({
   escalationOccurrenceThreshold: issue.escalationOccurrenceThreshold,
   trend: issue.trend.map(toIssuesBucketRecord),
   evaluations: issue.evaluations.map(toEvaluationSummaryRecord),
+  tags: issue.tags,
 })
 
 export type IssueRecord = ReturnType<typeof toIssueRecord>
@@ -179,6 +180,7 @@ const toIssueDetailRecord = (input: {
   readonly escalationOccurrenceThreshold: number | null
   readonly trend: readonly { readonly bucket: string; readonly count: number }[]
   readonly evaluations: readonly EvaluationSummaryRecord[]
+  readonly tags: readonly string[]
   readonly keepMonitoringDefault: boolean
 }) => ({
   id: input.issue.id,
@@ -198,6 +200,7 @@ const toIssueDetailRecord = (input: {
   escalationOccurrenceThreshold: input.escalationOccurrenceThreshold,
   trend: input.trend,
   evaluations: input.evaluations,
+  tags: input.tags,
   keepMonitoringDefault: input.keepMonitoringDefault,
 })
 
@@ -364,7 +367,7 @@ export const getIssueDetail = createServerFn({ method: "GET" })
         trendFrom.setUTCHours(0, 0, 0, 0)
         const trendScaffold = buildBucketScaffold({ from: trendFrom, to: trendTo })
 
-        const [occurrences, trend, evaluationPage, settings] = yield* Effect.all([
+        const [occurrences, trend, evaluationPage, tagsAggregates, settings] = yield* Effect.all([
           scoreAnalyticsRepository.aggregateByIssues({
             organizationId: orgId,
             projectId,
@@ -383,6 +386,11 @@ export const getIssueDetail = createServerFn({ method: "GET" })
               lifecycle: "active",
               limit: 1000,
             },
+          }),
+          scoreAnalyticsRepository.aggregateTagsByIssues({
+            organizationId: orgId,
+            projectId,
+            issueIds: [issue.id],
           }),
           resolveSettings({ projectId }),
         ])
@@ -406,6 +414,7 @@ export const getIssueDetail = createServerFn({ method: "GET" })
             buckets: trend,
           }),
           evaluations: evaluationPage.items.map(toEvaluationSummaryRecord),
+          tags: tagsAggregates[0]?.tags ?? [],
           keepMonitoringDefault: settings.keepMonitoring,
         })
       }).pipe(

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
   Skeleton,
   Switch,
+  TagList,
   Text,
   Tooltip,
   useToast,
@@ -322,6 +323,7 @@ export function IssueDetailDrawer({
                 <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
               )}
             </div>
+            {!isLoading && issue?.tags && issue.tags.length > 0 ? <TagList tags={issue.tags} /> : null}
           </div>
         }
       >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -3,6 +3,7 @@ import {
   type InfiniteTableColumn,
   type InfiniteTableInfiniteScroll,
   type InfiniteTableSelection,
+  TagList,
   Text,
   Tooltip,
 } from "@repo/ui"
@@ -138,28 +139,31 @@ export function IssuesView({
       width: ISSUE_COLUMN_WIDTH,
       minWidth: ISSUE_COLUMN_MIN_WIDTH,
       render: (issue) => (
-        <div className="flex min-w-0 items-center gap-2">
-          <Text.H5 className="min-w-0 flex-1" noWrap ellipsis>
-            {issue.name}
-          </Text.H5>
-          {issue.evaluations.length > 0 ? (
-            <div className="shrink-0">
-              <IssueLifecycleStatuses
-                states={[]}
-                wrap={false}
-                extraStatuses={[
-                  {
-                    key: "monitored",
-                    label: "Monitored",
-                    variant: "success",
-                    tooltip: (
-                      <MonitoredByTooltip evaluationNames={issue.evaluations.map((evaluation) => evaluation.name)} />
-                    ),
-                  },
-                ]}
-              />
-            </div>
-          ) : null}
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <Text.H5 className="min-w-0 flex-1" noWrap ellipsis>
+              {issue.name}
+            </Text.H5>
+            {issue.evaluations.length > 0 ? (
+              <div className="shrink-0">
+                <IssueLifecycleStatuses
+                  states={[]}
+                  wrap={false}
+                  extraStatuses={[
+                    {
+                      key: "monitored",
+                      label: "Monitored",
+                      variant: "success",
+                      tooltip: (
+                        <MonitoredByTooltip evaluationNames={issue.evaluations.map((evaluation) => evaluation.name)} />
+                      ),
+                    },
+                  ]}
+                />
+              </div>
+            ) : null}
+          </div>
+          {issue.tags.length > 0 ? <TagList tags={issue.tags} /> : null}
         </div>
       ),
     },

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -21,6 +21,7 @@ import { IssueTrendBar } from "./issue-trend-bar.tsx"
 
 export const ISSUES_COLUMN_OPTIONS = [
   { id: "issue", label: "Issue", required: true },
+  { id: "tags", label: "Tags" },
   { id: "status", label: "Status" },
   { id: "trend", label: "Trend" },
   { id: "seenAt", label: "Seen at" },
@@ -139,33 +140,36 @@ export function IssuesView({
       width: ISSUE_COLUMN_WIDTH,
       minWidth: ISSUE_COLUMN_MIN_WIDTH,
       render: (issue) => (
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <div className="flex min-w-0 items-center gap-2">
-            <Text.H5 className="min-w-0 flex-1" noWrap ellipsis>
-              {issue.name}
-            </Text.H5>
-            {issue.evaluations.length > 0 ? (
-              <div className="shrink-0">
-                <IssueLifecycleStatuses
-                  states={[]}
-                  wrap={false}
-                  extraStatuses={[
-                    {
-                      key: "monitored",
-                      label: "Monitored",
-                      variant: "success",
-                      tooltip: (
-                        <MonitoredByTooltip evaluationNames={issue.evaluations.map((evaluation) => evaluation.name)} />
-                      ),
-                    },
-                  ]}
-                />
-              </div>
-            ) : null}
-          </div>
-          {issue.tags.length > 0 ? <TagList tags={issue.tags} /> : null}
+        <div className="flex min-w-0 items-center gap-2">
+          <Text.H5 className="min-w-0 flex-1" noWrap ellipsis>
+            {issue.name}
+          </Text.H5>
+          {issue.evaluations.length > 0 ? (
+            <div className="shrink-0">
+              <IssueLifecycleStatuses
+                states={[]}
+                wrap={false}
+                extraStatuses={[
+                  {
+                    key: "monitored",
+                    label: "Monitored",
+                    variant: "success",
+                    tooltip: (
+                      <MonitoredByTooltip evaluationNames={issue.evaluations.map((evaluation) => evaluation.name)} />
+                    ),
+                  },
+                ]}
+              />
+            </div>
+          ) : null}
         </div>
       ),
+    },
+    {
+      key: "tags",
+      header: "Tags",
+      width: 150,
+      render: (issue) => <TagList tags={issue.tags} />,
     },
     {
       key: "status",

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   type IssueOccurrenceAggregate,
   type IssueOccurrenceBucket,
+  type IssueTagsAggregate,
   type IssueTrendSeries,
   type IssueWindowMetric,
   ScoreAnalyticsRepository,
@@ -127,12 +128,14 @@ const createScoreAnalyticsRepository = (input: {
   readonly fullHistoryOccurrences: readonly IssueOccurrenceAggregate[]
   readonly histogramBuckets?: readonly IssueOccurrenceBucket[]
   readonly trendSeries?: readonly IssueTrendSeries[]
+  readonly tagsAggregates?: readonly IssueTagsAggregate[]
   readonly totalTraces?: number
 }) => {
   const windowMetricInputs: unknown[] = []
   const aggregateInputs: unknown[] = []
   const histogramInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
   const trendInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
+  const tagsInputs: Array<{ issueIds: readonly string[] }> = []
 
   const repository: ScoreAnalyticsRepositoryShape = {
     existsById: () => Effect.die("Unexpected existsById"),
@@ -149,7 +152,11 @@ const createScoreAnalyticsRepository = (input: {
         aggregateInputs.push(aggregateInput)
         return input.fullHistoryOccurrences.filter((occurrence) => aggregateInput.issueIds.includes(occurrence.issueId))
       }),
-    aggregateTagsByIssues: () => Effect.succeed([]),
+    aggregateTagsByIssues: ({ issueIds }) =>
+      Effect.sync(() => {
+        tagsInputs.push({ issueIds })
+        return (input.tagsAggregates ?? []).filter((entry) => issueIds.includes(entry.issueId))
+      }),
     trendByIssue: () => Effect.die("Unexpected trendByIssue"),
     listIssueWindowMetrics: (windowMetricInput) =>
       Effect.sync(() => {
@@ -178,7 +185,7 @@ const createScoreAnalyticsRepository = (input: {
     listTracesByIssue: () => Effect.die("Unexpected listTracesByIssue"),
   }
 
-  return { repository, windowMetricInputs, aggregateInputs, histogramInputs, trendInputs }
+  return { repository, windowMetricInputs, aggregateInputs, histogramInputs, trendInputs, tagsInputs }
 }
 
 const createIssueProjectionRepository = (
@@ -484,6 +491,50 @@ describe("listIssuesUseCase", () => {
     expect(trendInputs[0]?.issueIds).toEqual([activeIssue.id, regressedIssue.id])
     expect(trendInputs[0]?.from.toISOString()).toBe("2026-03-28T00:00:00.000Z")
     expect(trendInputs[0]?.to.toISOString()).toBe("2026-04-10T23:59:59.999Z")
+  })
+
+  it("attaches per-issue tag aggregates to the visible page", async () => {
+    const now = new Date("2026-04-10T00:00:00.000Z")
+    const taggedIssue = makeIssue({
+      id: IssueId("a".repeat(24)),
+      uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    })
+    const untaggedIssue = makeIssue({
+      id: IssueId("b".repeat(24)),
+      uuid: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    })
+
+    const { repository: issueRepository } = createFakeIssueRepository([taggedIssue, untaggedIssue])
+    const { repository: evaluationRepository } = createEvaluationRepository()
+    const { repository: scoreAnalyticsRepository, tagsInputs } = createScoreAnalyticsRepository({
+      windowMetrics: [
+        makeWindowMetric({ issueId: taggedIssue.id, occurrences: 1 }),
+        makeWindowMetric({ issueId: untaggedIssue.id, occurrences: 1 }),
+      ],
+      fullHistoryOccurrences: [makeOccurrence({ issueId: taggedIssue.id }), makeOccurrence({ issueId: untaggedIssue.id })],
+      tagsAggregates: [{ issueId: taggedIssue.id, tags: ["checkout", "billing"] }],
+    })
+    const { repository: issueProjectionRepository } = createIssueProjectionRepository([])
+
+    const result = await Effect.runPromise(
+      listIssuesUseCase({ organizationId, projectId, now }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(IssueRepository, issueRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+            Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+            Layer.succeed(IssueProjectionRepository, issueProjectionRepository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+          ),
+        ),
+      ),
+    )
+
+    expect(tagsInputs).toEqual([{ issueIds: [taggedIssue.id, untaggedIssue.id] }])
+    const tagsByIssueId = new Map(result.items.map((item) => [item.id, item.tags] as const))
+    expect(tagsByIssueId.get(taggedIssue.id)).toEqual(["checkout", "billing"])
+    expect(tagsByIssueId.get(untaggedIssue.id)).toEqual([])
   })
 
   describe("analytics histogram time range", () => {

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -149,6 +149,7 @@ const createScoreAnalyticsRepository = (input: {
         aggregateInputs.push(aggregateInput)
         return input.fullHistoryOccurrences.filter((occurrence) => aggregateInput.issueIds.includes(occurrence.issueId))
       }),
+    aggregateTagsByIssues: () => Effect.succeed([]),
     trendByIssue: () => Effect.die("Unexpected trendByIssue"),
     listIssueWindowMetrics: (windowMetricInput) =>
       Effect.sync(() => {

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -511,7 +511,10 @@ describe("listIssuesUseCase", () => {
         makeWindowMetric({ issueId: taggedIssue.id, occurrences: 1 }),
         makeWindowMetric({ issueId: untaggedIssue.id, occurrences: 1 }),
       ],
-      fullHistoryOccurrences: [makeOccurrence({ issueId: taggedIssue.id }), makeOccurrence({ issueId: untaggedIssue.id })],
+      fullHistoryOccurrences: [
+        makeOccurrence({ issueId: taggedIssue.id }),
+        makeOccurrence({ issueId: untaggedIssue.id }),
+      ],
       tagsAggregates: [{ issueId: taggedIssue.id, tags: ["checkout", "billing"] }],
     })
     const { repository: issueProjectionRepository } = createIssueProjectionRepository([])

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -99,6 +99,7 @@ export interface IssueListItem {
   readonly escalationOccurrenceThreshold: number | null
   readonly trend: readonly IssueOccurrenceBucket[]
   readonly evaluations: readonly Evaluation[]
+  readonly tags: readonly string[]
 }
 
 export interface ListIssuesResult {
@@ -487,7 +488,7 @@ export const listIssuesUseCase = (
     })
     const trendScaffold = buildBucketScaffold(trendTimeRange)
 
-    const [evaluationPage, trendSeries] = yield* Effect.all([
+    const [evaluationPage, trendSeries, tagsAggregates] = yield* Effect.all([
       pageIssueIds.length === 0
         ? Effect.succeed({
             items: [] as readonly Evaluation[],
@@ -511,6 +512,13 @@ export const listIssuesUseCase = (
             issueIds: pageIssueIds,
             timeRange: trendTimeRange,
           }),
+      pageIssueIds.length === 0
+        ? Effect.succeed([])
+        : scoreAnalyticsRepository.aggregateTagsByIssues({
+            organizationId: parsed.organizationId,
+            projectId: parsed.projectId,
+            issueIds: pageIssueIds,
+          }),
     ])
 
     const evaluationsByIssueId = new Map<string, Evaluation[]>()
@@ -529,6 +537,8 @@ export const listIssuesUseCase = (
         }),
       ]),
     )
+
+    const tagsByIssueId = new Map(tagsAggregates.map((entry) => [entry.issueId, entry.tags] as const))
 
     return {
       analytics: {
@@ -559,6 +569,7 @@ export const listIssuesUseCase = (
         escalationOccurrenceThreshold: candidate.escalationOccurrenceThreshold,
         trend: trendByIssueId.get(candidate.issue.id) ?? fillBuckets({ scaffold: trendScaffold, buckets: [] }),
         evaluations: evaluationsByIssueId.get(candidate.issue.id) ?? [],
+        tags: tagsByIssueId.get(candidate.issue.id) ?? [],
       })),
       totalCount: tableCandidates.length,
       hasMore: parsed.offset + parsed.limit < tableCandidates.length,

--- a/packages/domain/scores/src/index.ts
+++ b/packages/domain/scores/src/index.ts
@@ -40,6 +40,7 @@ export { isImmutableScore } from "./helpers.ts"
 export {
   type IssueOccurrenceAggregate,
   type IssueOccurrenceBucket,
+  type IssueTagsAggregate,
   type IssueTracePage,
   type IssueTraceSummary,
   type IssueTrendSeries,

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -94,6 +94,12 @@ export interface IssueWindowMetric {
   readonly lastSeenAt: Date
 }
 
+/** Per-issue rollup of tags across all traces affected by the issue. */
+export interface IssueTagsAggregate {
+  readonly issueId: IssueId
+  readonly tags: readonly string[]
+}
+
 /** Grouped issue trend result for batched chart reads. */
 export interface IssueTrendSeries {
   readonly issueId: IssueId
@@ -183,6 +189,14 @@ export interface ScoreAnalyticsRepositoryShape {
     readonly issueIds: readonly IssueId[]
     readonly options?: ScoreAnalyticsOptions
   }): Effect.Effect<readonly IssueOccurrenceAggregate[], RepositoryError, ChSqlClient>
+
+  // -- Issue tag aggregation across affected traces --------------------------
+  aggregateTagsByIssues(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly issueIds: readonly IssueId[]
+    readonly options?: ScoreAnalyticsOptions
+  }): Effect.Effect<readonly IssueTagsAggregate[], RepositoryError, ChSqlClient>
 
   // -- Issue occurrence time-series ------------------------------------------
   trendByIssue(input: {

--- a/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
+++ b/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
@@ -30,6 +30,7 @@ export const createFakeScoreAnalyticsRepository = (overrides?: Partial<ScoreAnal
     rollupByTraceIds: () => Effect.succeed([]),
     rollupBySessionIds: () => Effect.succeed([]),
     aggregateByIssues: () => Effect.succeed([]),
+    aggregateTagsByIssues: () => Effect.succeed([]),
     trendByIssue: () => Effect.succeed([]),
     listIssueWindowMetrics: () => Effect.succeed([]),
     histogramByIssues: () => Effect.succeed([]),

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -5,6 +5,7 @@ import { setupTestClickHouse } from "@platform/testkit"
 import { Effect } from "effect"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { ChSqlClientLive } from "../ch-sql-client.ts"
+import type { SpanRow } from "../seeds/spans/span-builders.ts"
 import { withClickHouse } from "../with-clickhouse.ts"
 import { ScoreAnalyticsRepositoryLive } from "./score-analytics-repository.ts"
 
@@ -41,6 +42,72 @@ function makeScoreRow(overrides: Partial<Record<string, unknown>> = {}) {
 
 async function insertScores(rows: ReturnType<typeof makeScoreRow>[]) {
   await ch.client.insert({ table: "scores", values: rows, format: "JSONEachRow" })
+}
+
+function makeSpanRow(overrides: {
+  readonly traceId: string
+  readonly spanId: string
+  readonly tags: readonly string[]
+  readonly startTime?: string
+}): SpanRow {
+  const startTime = overrides.startTime ?? "2026-03-15 12:00:00.000"
+  return {
+    organization_id: ORG_ID as string,
+    project_id: PROJECT_ID as string,
+    session_id: "",
+    user_id: "",
+    trace_id: overrides.traceId,
+    span_id: overrides.spanId,
+    parent_span_id: "",
+    api_key_id: "test-api-key",
+    simulation_id: "",
+    start_time: startTime,
+    end_time: startTime,
+    name: "test-span",
+    service_name: "test-service",
+    kind: 0,
+    status_code: 0,
+    status_message: "",
+    error_type: "",
+    tags: [...overrides.tags],
+    metadata: {},
+    operation: "",
+    provider: "",
+    model: "",
+    response_model: "",
+    tokens_input: 0,
+    tokens_output: 0,
+    tokens_cache_read: 0,
+    tokens_cache_create: 0,
+    tokens_reasoning: 0,
+    cost_input_microcents: 0,
+    cost_output_microcents: 0,
+    cost_total_microcents: 0,
+    cost_is_estimated: 0,
+    time_to_first_token_ns: 0,
+    is_streaming: 0,
+    response_id: "",
+    finish_reasons: [],
+    input_messages: "",
+    output_messages: "",
+    system_instructions: "",
+    tool_definitions: "",
+    tool_call_id: "",
+    tool_name: "",
+    tool_input: "",
+    tool_output: "",
+    attr_string: {},
+    attr_int: {},
+    attr_float: {},
+    attr_bool: {},
+    resource_string: {},
+    scope_name: "",
+    scope_version: "",
+  }
+}
+
+async function insertSpans(rows: SpanRow[]) {
+  await ch.client.insert({ table: "spans", values: rows, format: "JSONEachRow" })
 }
 
 const toClickHouseDateTime64 = (value: Date) => value.toISOString().replace("T", " ").replace("Z", "")
@@ -396,6 +463,68 @@ describe("ScoreAnalyticsRepository", () => {
         }),
       )
       expect(aggs).toHaveLength(0)
+    })
+  })
+
+  // ------------------------------------------------------------------
+  // aggregateTagsByIssues
+  // ------------------------------------------------------------------
+
+  describe("aggregateTagsByIssues", () => {
+    const issueA = "issue_tagsaaaaaaaaaaaa"
+    const issueB = "issue_tagsbbbbbbbbbbbb"
+    const traceA1 = "a".repeat(31) + "1"
+    const traceA2 = "a".repeat(31) + "2"
+    const traceB1 = "b".repeat(31) + "1"
+    const otherOrgTrace = "c".repeat(31) + "1"
+
+    beforeEach(async () => {
+      await insertSpans([
+        makeSpanRow({ traceId: traceA1, spanId: "11" + "a".repeat(14), tags: ["checkout", "billing"] }),
+        // Second span on the same trace with overlapping + new tags exercises trace-level dedup.
+        makeSpanRow({ traceId: traceA1, spanId: "12" + "a".repeat(14), tags: ["billing", "auth"] }),
+        makeSpanRow({ traceId: traceA2, spanId: "21" + "a".repeat(14), tags: ["search"] }),
+        makeSpanRow({ traceId: traceB1, spanId: "31" + "a".repeat(14), tags: ["onboarding"] }),
+        // A span in another organization that must not leak through tenancy.
+        {
+          ...makeSpanRow({ traceId: otherOrgTrace, spanId: "41" + "a".repeat(14), tags: ["leaked"] }),
+          organization_id: "other_orgggggggggggggggg",
+        },
+      ])
+
+      await insertScores([
+        makeScoreRow({ issue_id: issueA, trace_id: traceA1 }),
+        makeScoreRow({ issue_id: issueA, trace_id: traceA2 }),
+        makeScoreRow({ issue_id: issueB, trace_id: traceB1 }),
+        // Score linked to the cross-org trace under a foreign org id.
+        makeScoreRow({
+          organization_id: "other_orgggggggggggggggg",
+          issue_id: issueA,
+          trace_id: otherOrgTrace,
+        }),
+      ])
+    })
+
+    it("returns the union of trace-level tags grouped by issue, scoped to org/project", async () => {
+      const result = await runCh(
+        repo.aggregateTagsByIssues({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueIds: [IssueId(issueA), IssueId(issueB)],
+        }),
+      )
+
+      const tagsByIssue = new Map(result.map((entry) => [entry.issueId as string, [...entry.tags].sort()] as const))
+      expect(tagsByIssue.get(issueA)).toEqual(["auth", "billing", "checkout", "search"])
+      expect(tagsByIssue.get(issueB)).toEqual(["onboarding"])
+      expect(tagsByIssue.get(issueA)).not.toContain("leaked")
+    })
+
+    it("returns empty for no issue ids", async () => {
+      const result = await runCh(
+        repo.aggregateTagsByIssues({ organizationId: ORG_ID, projectId: PROJECT_ID, issueIds: [] }),
+      )
+      expect(result).toEqual([])
     })
   })
 

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -473,21 +473,21 @@ describe("ScoreAnalyticsRepository", () => {
   describe("aggregateTagsByIssues", () => {
     const issueA = "issue_tagsaaaaaaaaaaaa"
     const issueB = "issue_tagsbbbbbbbbbbbb"
-    const traceA1 = "a".repeat(31) + "1"
-    const traceA2 = "a".repeat(31) + "2"
-    const traceB1 = "b".repeat(31) + "1"
-    const otherOrgTrace = "c".repeat(31) + "1"
+    const traceA1 = `${"a".repeat(31)}1`
+    const traceA2 = `${"a".repeat(31)}2`
+    const traceB1 = `${"b".repeat(31)}1`
+    const otherOrgTrace = `${"c".repeat(31)}1`
 
     beforeEach(async () => {
       await insertSpans([
-        makeSpanRow({ traceId: traceA1, spanId: "11" + "a".repeat(14), tags: ["checkout", "billing"] }),
+        makeSpanRow({ traceId: traceA1, spanId: `11${"a".repeat(14)}`, tags: ["checkout", "billing"] }),
         // Second span on the same trace with overlapping + new tags exercises trace-level dedup.
-        makeSpanRow({ traceId: traceA1, spanId: "12" + "a".repeat(14), tags: ["billing", "auth"] }),
-        makeSpanRow({ traceId: traceA2, spanId: "21" + "a".repeat(14), tags: ["search"] }),
-        makeSpanRow({ traceId: traceB1, spanId: "31" + "a".repeat(14), tags: ["onboarding"] }),
+        makeSpanRow({ traceId: traceA1, spanId: `12${"a".repeat(14)}`, tags: ["billing", "auth"] }),
+        makeSpanRow({ traceId: traceA2, spanId: `21${"a".repeat(14)}`, tags: ["search"] }),
+        makeSpanRow({ traceId: traceB1, spanId: `31${"a".repeat(14)}`, tags: ["onboarding"] }),
         // A span in another organization that must not leak through tenancy.
         {
-          ...makeSpanRow({ traceId: otherOrgTrace, spanId: "41" + "a".repeat(14), tags: ["leaked"] }),
+          ...makeSpanRow({ traceId: otherOrgTrace, spanId: `41${"a".repeat(14)}`, tags: ["leaked"] }),
           organization_id: "other_orgggggggggggggggg",
         },
       ])

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -2,6 +2,7 @@ import type { ClickHouseClient } from "@clickhouse/client"
 import type {
   IssueOccurrenceAggregate,
   IssueOccurrenceBucket,
+  IssueTagsAggregate,
   IssueTracePage,
   IssueTraceSummary,
   IssueTrendSeries,
@@ -146,6 +147,11 @@ type IssueTrendSeriesRow = {
   count: string
 }
 
+type IssueTagsRow = {
+  issue_id: string
+  tags: string[]
+}
+
 type CountRow = {
   total: string
 }
@@ -256,6 +262,11 @@ const toIssueTrendSeries = (rows: readonly IssueTrendSeriesRow[]): readonly Issu
     buckets,
   }))
 }
+
+const toIssueTagsAggregate = (row: IssueTagsRow): IssueTagsAggregate => ({
+  issueId: toIssueId(normalizeCHString(row.issue_id)),
+  tags: row.tags.map(normalizeCHString),
+})
 
 const toIssueTraceSummary = (row: IssueTraceSummaryRow): IssueTraceSummary => ({
   traceId: toTraceId(normalizeCHString(row.trace_id)),
@@ -576,6 +587,44 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
               return result.json<IssueOccurrenceRow>()
             })
             .pipe(Effect.map((rows) => rows.map(toIssueOccurrence)))
+        }),
+
+      // -- aggregateTagsByIssues ---------------------------------------------
+      aggregateTagsByIssues: ({ organizationId, projectId, issueIds, options }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          if (issueIds.length === 0) return []
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT
+                        issue_traces.issue_id AS issue_id,
+                        arrayDistinct(arrayFlatten(groupArray(trace_tags.tags))) AS tags
+                      FROM (
+                        SELECT issue_id, trace_id
+                        FROM scores
+                        WHERE ${scopeClause(options)}
+                          AND issue_id IN ({issueIds:Array(String)})
+                          AND trace_id != ''
+                        GROUP BY issue_id, trace_id
+                      ) AS issue_traces
+                      INNER JOIN (
+                        SELECT trace_id, groupUniqArrayArray(tags) AS tags
+                        FROM traces
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                        GROUP BY trace_id
+                      ) AS trace_tags USING (trace_id)
+                      GROUP BY issue_traces.issue_id`,
+                query_params: {
+                  ...scopeParams(organizationId, projectId),
+                  issueIds: Array.from(issueIds) as string[],
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<IssueTagsRow>()
+            })
+            .pipe(Effect.map((rows) => rows.map(toIssueTagsAggregate)))
         }),
 
       // -- trendByIssue ------------------------------------------------------

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -37,6 +37,11 @@ import { SCORE_FIELD_REGISTRY } from "../registries/score-fields.ts"
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Cap on how many of an issue's most-recent traces we read when aggregating
+// tags. Tag distributions converge fast, so a sample of this size captures
+// effectively all tag variants while bounding the join cost for noisy issues.
+const ISSUE_TAG_TRACE_SAMPLE_LIMIT = 200
+
 const toClickHouseDateTime64 = (value: Date) => value.toISOString().replace("T", " ").replace("Z", "")
 
 const toAnalyticsRow = (score: Score) => ({
@@ -597,13 +602,21 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
+                // Sample the most-recent traces per issue (LIMIT N BY issue_id) so a noisy
+                // issue with tens of thousands of traces doesn't pull every trace row just
+                // to compute a tag union — tag distributions converge quickly.
                 query: `WITH issue_traces AS (
                         SELECT issue_id, trace_id
-                        FROM scores
-                        WHERE ${scopeClause(options)}
-                          AND issue_id IN ({issueIds:Array(String)})
-                          AND trace_id != ''
-                        GROUP BY issue_id, trace_id
+                        FROM (
+                          SELECT issue_id, trace_id, max(created_at) AS last_seen_at
+                          FROM scores
+                          WHERE ${scopeClause(options)}
+                            AND issue_id IN ({issueIds:Array(String)})
+                            AND trace_id != ''
+                          GROUP BY issue_id, trace_id
+                          ORDER BY issue_id, last_seen_at DESC
+                          LIMIT {tracesPerIssue:UInt32} BY issue_id
+                        )
                       ),
                       trace_tags AS (
                         SELECT trace_id, groupUniqArrayArray(tags) AS tags
@@ -622,6 +635,7 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                 query_params: {
                   ...scopeParams(organizationId, projectId),
                   issueIds: Array.from(issueIds) as string[],
+                  tracesPerIssue: ISSUE_TAG_TRACE_SAMPLE_LIMIT,
                 },
                 format: "JSONEachRow",
               })

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -265,7 +265,7 @@ const toIssueTrendSeries = (rows: readonly IssueTrendSeriesRow[]): readonly Issu
 
 const toIssueTagsAggregate = (row: IssueTagsRow): IssueTagsAggregate => ({
   issueId: toIssueId(normalizeCHString(row.issue_id)),
-  tags: row.tags.map(normalizeCHString),
+  tags: row.tags.map(normalizeCHString).filter((tag) => tag.length > 0),
 })
 
 const toIssueTraceSummary = (row: IssueTraceSummaryRow): IssueTraceSummary => ({
@@ -597,24 +597,27 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                query: `SELECT
-                        issue_traces.issue_id AS issue_id,
-                        arrayDistinct(arrayFlatten(groupArray(trace_tags.tags))) AS tags
-                      FROM (
+                query: `WITH issue_traces AS (
                         SELECT issue_id, trace_id
                         FROM scores
                         WHERE ${scopeClause(options)}
                           AND issue_id IN ({issueIds:Array(String)})
                           AND trace_id != ''
                         GROUP BY issue_id, trace_id
-                      ) AS issue_traces
-                      INNER JOIN (
+                      ),
+                      trace_tags AS (
                         SELECT trace_id, groupUniqArrayArray(tags) AS tags
                         FROM traces
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
+                          AND trace_id IN (SELECT trace_id FROM issue_traces)
                         GROUP BY trace_id
-                      ) AS trace_tags USING (trace_id)
+                      )
+                      SELECT
+                        issue_traces.issue_id AS issue_id,
+                        groupUniqArrayArray(trace_tags.tags) AS tags
+                      FROM issue_traces
+                      INNER JOIN trace_tags USING (trace_id)
                       GROUP BY issue_traces.issue_id`,
                 query_params: {
                   ...scopeParams(organizationId, projectId),


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/01adafc7-0579-4dcc-aeb8-851161a5adf4



- Aggregate tags from each issue's affected traces in ClickHouse via a new `ScoreAnalyticsRepository.aggregateTagsByIssues` (joins `scores` to `traces`, dedups via `groupUniqArrayArray`), so issues can carry tags without an N+1 fetch.
- Surface them as a dedicated `Tags` column in the Issues table (mirroring the Traces table layout) and under the title in the issue detail drawer, so the project areas an issue touches are visible without opening individual traces.

## Test plan
- [x] `pnpm -F @domain/issues -F @domain/scores -F @platform/db-clickhouse -F @app/web run typecheck`
- [x] `pnpm -F @domain/issues exec vitest run src/use-cases/list-issues.test.ts`
- [x] `pnpm -F @app/web exec vitest run src/domains/issues/issues-list-metrics.test.ts`
- [ ] Manual: open Issues page on a project with tagged traces — Tags column appears between Issue and Status, `TagList` overflow ("+N") behaves correctly when the column is narrow.
- [ ] Manual: open issue drawer — tag chips render under the description and disappear cleanly for tag-less issues.
- [ ] Manual: confirm tenancy by sanity-checking the ClickHouse query is org+project scoped (no cross-org leakage).