### PR TITLE
fix(issues): prevent monitor button flash for auto-monitored issues

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -406,6 +406,7 @@ export function IssueDetailDrawer({
               issueSource={issue?.source ?? "annotation"}
               evaluations={issue?.evaluations ?? []}
               canMonitorIssue={issue ? issue.resolvedAt === null && issue.ignoredAt === null : false}
+              isIssueLoading={isLoading}
             />
           </DetailSection>
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
@@ -102,12 +102,14 @@ export function IssueDrawerEvaluations({
   issueSource,
   evaluations,
   canMonitorIssue,
+  isIssueLoading,
 }: {
   readonly projectId: string
   readonly issueId: string
   readonly issueSource: "annotation" | "custom" | "flagger"
   readonly evaluations: readonly EvaluationSummaryRecord[]
   readonly canMonitorIssue: boolean
+  readonly isIssueLoading: boolean
 }) {
   const { toast } = useToast()
   const [tracked, setTracked] = useState<TrackedWorkflow | null>(null)
@@ -247,7 +249,7 @@ export function IssueDrawerEvaluations({
   const isPrimaryEvaluationRealigning =
     primaryEvaluation !== null && tracked?.kind === "realign" && tracked.evaluationId === primaryEvaluation.id
 
-  if (!hasAlignmentStateSynced) {
+  if (!hasAlignmentStateSynced || isIssueLoading) {
     return visibleEvaluations.length === 0 ? (
       <Skeleton className="h-20 w-full rounded-xl" />
     ) : (


### PR DESCRIPTION
Wait for both alignment state sync AND issue data loading before rendering the evaluations section. Previously the alignment state could sync before issue data loaded, causing the "Monitor" button to briefly appear for flagger issues before showing "Automatically monitored".

https://claude.ai/code/session_01AfdYHDeYPYptYd2TwsJfKv