### PR TITLE
fix(spans): scope findMessagesForTrace by project + start_time, drop FINAL

### DIFF
--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -165,18 +165,19 @@ export const mapConversationToSpans = createServerFn({ method: "GET" })
           const traceRepo = yield* TraceRepository
           const spanRepo = yield* SpanRepository
 
-          const [traceDetail, spans] = yield* Effect.all([
-            traceRepo
-              .findByTraceId({
-                organizationId: orgId,
-                projectId: ProjectId(data.projectId),
-                traceId,
-              })
-              .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null))),
-            spanRepo.findMessagesForTrace({ organizationId: orgId, traceId }),
-          ])
+          const projectId = ProjectId(data.projectId)
+          const traceDetail = yield* traceRepo
+            .findByTraceId({ organizationId: orgId, projectId, traceId })
+            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
 
           if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
+
+          const spans = yield* spanRepo.findMessagesForTrace({
+            organizationId: orgId,
+            projectId,
+            traceId,
+            startTime: traceDetail.startTime,
+          })
 
           return buildConversationSpanMaps(traceDetail.allMessages, spans)
         }).pipe(

--- a/apps/web/src/domains/spans/spans.functions.ts
+++ b/apps/web/src/domains/spans/spans.functions.ts
@@ -172,11 +172,14 @@ export const mapConversationToSpans = createServerFn({ method: "GET" })
 
           if (!traceDetail) return { messageSpanMap: {}, toolCallSpanMap: {} }
 
+          const startTimeFrom = new Date(traceDetail.startTime.getTime() - 60 * 1000)
+          const startTimeTo = new Date(traceDetail.startTime.getTime() + 24 * 60 * 60 * 1000)
           const spans = yield* spanRepo.findMessagesForTrace({
             organizationId: orgId,
             projectId,
             traceId,
-            startTime: traceDetail.startTime,
+            startTimeFrom,
+            startTimeTo,
           })
 
           return buildConversationSpanMaps(traceDetail.allMessages, spans)

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -78,12 +78,18 @@ const processRefreshTrace = (payload: RefreshTracePayload) =>
     const traceId = payload.traceId
     const startTime = new Date(payload.startTime)
 
-    // 1. Load span messages for the trace
+    // 1. Load span messages for the trace. Bound start_time to a [-1m, +1d]
+    // window around the root span so partition pruning + the
+    // (org, project, start_time) primary key on `spans` kick in — otherwise
+    // the dedupe step has to scan every monthly partition for the org.
+    const startTimeFrom = new Date(startTime.getTime() - 60 * 1000)
+    const startTimeTo = new Date(startTime.getTime() + 24 * 60 * 60 * 1000)
     const spanMessages = yield* spanRepo.findMessagesForTrace({
       organizationId: OrganizationId(organizationId),
       projectId: ProjectId(projectId),
       traceId: TraceId(traceId),
-      startTime,
+      startTimeFrom,
+      startTimeTo,
     })
 
     if (spanMessages.length === 0) {

--- a/apps/workers/src/workers/trace-search.ts
+++ b/apps/workers/src/workers/trace-search.ts
@@ -81,7 +81,9 @@ const processRefreshTrace = (payload: RefreshTracePayload) =>
     // 1. Load span messages for the trace
     const spanMessages = yield* spanRepo.findMessagesForTrace({
       organizationId: OrganizationId(organizationId),
+      projectId: ProjectId(projectId),
       traceId: TraceId(traceId),
+      startTime,
     })
 
     if (spanMessages.length === 0) {

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -50,7 +50,9 @@ export interface SpanRepositoryShape {
 
   findMessagesForTrace(input: {
     readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
     readonly traceId: TraceId
+    readonly startTime: Date
   }): Effect.Effect<readonly SpanMessagesData[], RepositoryError, ChSqlClient>
 }
 

--- a/packages/domain/spans/src/ports/span-repository.ts
+++ b/packages/domain/spans/src/ports/span-repository.ts
@@ -52,7 +52,8 @@ export interface SpanRepositoryShape {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly traceId: TraceId
-    readonly startTime: Date
+    readonly startTimeFrom: Date
+    readonly startTimeTo: Date
   }): Effect.Effect<readonly SpanMessagesData[], RepositoryError, ChSqlClient>
 }
 

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -420,15 +420,9 @@ export const SpanRepositoryLive = Layer.effect(
             )
         }),
 
-      findMessagesForTrace: ({ organizationId, projectId, traceId, startTime }) =>
+      findMessagesForTrace: ({ organizationId, projectId, traceId, startTimeFrom, startTimeTo }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
-          // Bound start_time to a [-1m, +1d] window around the root span so
-          // partition pruning + the (org, project, start_time) primary key kick
-          // in. Without this the FINAL/dedupe step has to scan every monthly
-          // partition for the org and OOMs the server on large tenants.
-          const startTimeFrom = new Date(startTime.getTime() - 60 * 1000)
-          const startTimeTo = new Date(startTime.getTime() + 24 * 60 * 60 * 1000)
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({

--- a/packages/platform/db-clickhouse/src/repositories/span-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/span-repository.ts
@@ -420,19 +420,44 @@ export const SpanRepositoryLive = Layer.effect(
             )
         }),
 
-      findMessagesForTrace: ({ organizationId, traceId }) =>
+      findMessagesForTrace: ({ organizationId, projectId, traceId, startTime }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+          // Bound start_time to a [-1m, +1d] window around the root span so
+          // partition pruning + the (org, project, start_time) primary key kick
+          // in. Without this the FINAL/dedupe step has to scan every monthly
+          // partition for the org and OOMs the server on large tenants.
+          const startTimeFrom = new Date(startTime.getTime() - 60 * 1000)
+          const startTimeTo = new Date(startTime.getTime() + 24 * 60 * 60 * 1000)
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
+                // Dedupe ReplacingMergeTree rows with `LIMIT 1 BY span_id`
+                // (newest `ingested_at` wins) instead of `FINAL`, which
+                // merges all matching parts at query time and is the
+                // dominant memory cost for traces with heavy
+                // input/output_messages payloads.
                 query: `SELECT span_id, operation, tool_call_id, input_messages, output_messages
-                      FROM spans FINAL
-                      WHERE organization_id = {organizationId:String}
-                        AND trace_id = {traceId:FixedString(32)}
-                        AND operation IN ('chat', 'text_completion', 'execute_tool')
+                      FROM (
+                        SELECT span_id, operation, tool_call_id, input_messages, output_messages, start_time
+                        FROM spans
+                        WHERE organization_id = {organizationId:String}
+                          AND project_id = {projectId:String}
+                          AND start_time >= {startTimeFrom:DateTime64(9, 'UTC')}
+                          AND start_time <= {startTimeTo:DateTime64(9, 'UTC')}
+                          AND trace_id = {traceId:FixedString(32)}
+                          AND operation IN ('chat', 'text_completion', 'execute_tool')
+                        ORDER BY span_id, ingested_at DESC
+                        LIMIT 1 BY span_id
+                      )
                       ORDER BY start_time ASC`,
-                query_params: { organizationId: organizationId as string, traceId },
+                query_params: {
+                  organizationId: organizationId as string,
+                  projectId: projectId as string,
+                  startTimeFrom: toClickhouseDateTime(startTimeFrom),
+                  startTimeTo: toClickhouseDateTime(startTimeTo),
+                  traceId,
+                },
                 format: "JSONEachRow",
               })
               return result.json<SpanMessagesRow>()


### PR DESCRIPTION
## Summary

The `trace-search` worker's `findMessagesForTrace` query was OOMing ClickHouse on large tenants — `(total) memory limit exceeded: would use 11.29 GiB ... While executing MergeTreeSelect`.

Three compounding causes in `packages/platform/db-clickhouse/src/repositories/span-repository.ts`:

- **No partition pruning.** The `spans` table is partitioned by `toYYYYMM(start_time)` and ordered by `(organization_id, project_id, start_time, …, trace_id, span_id)`. The query filtered only on `organization_id` + `trace_id`, so ClickHouse had to scan every monthly partition for the org.
- **`FINAL` on `ReplacingMergeTree`.** Forced a merge across all matching parts at query time — the dominant memory cost given the heavy `input_messages` / `output_messages` columns.
- **Heavy columns over an unbounded time range.** `input_messages` / `output_messages` are ZSTD(3) on disk but expand massively in memory.

### Changes

- Add `project_id` and a `[startTime − 1m, startTime + 1d]` window to the `WHERE` so partition pruning + the `(org, project, start_time)` primary key kick in.
- Replace `FINAL` with a `LIMIT 1 BY span_id` over `ORDER BY span_id, ingested_at DESC` subquery to dedupe ReplacingMergeTree rows without merge-on-read.
- Thread `projectId` + `startTime` through the port and both call sites:
  - Worker (`apps/workers/src/workers/trace-search.ts`) — already had both in the payload.
  - Web (`apps/web/src/domains/spans/spans.functions.ts`) — sequenced the trace fetch before the spans fetch (was running both in parallel via `Effect.all`) so `traceDetail.startTime` is available.

The 1-day upper bound assumes a single trace doesn't outlive 24h — flag if you have long-lived sessions/traces that exceed that.

## Test plan

- [x] Type-check passes across `@domain/spans`, `@platform/db-clickhouse`, `@apps/workers`, `@apps/web` (verified locally).
- [x] Spot-check `mapConversationToSpans` in the web UI for a recent trace — conversation → span attribution still resolves correctly.
- [ ] Run the trace-search worker against a known-large trace and confirm no OOM.
- [ ] Confirm `LIMIT 1 BY span_id` dedupe still produces correct messages when the same span has been ingested more than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)