### PR TITLE
feat(backoffice): user-detail account actions + sessions panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,3 +215,9 @@ VITE_LAT_WEB_URL=http://localhost:3000
 
 # Google Tag Manager (optional). When VITE_LAT_GTM_CONTAINER_ID is unset, GTM is not loaded.
 # VITE_LAT_GTM_CONTAINER_ID=GTM-XXXXXXXX
+
+# ipinfo.io token (optional — backoffice Sessions panel GeoIP lookup)
+# Without a token the unauthenticated tier (~50k req/month per source IP)
+# is used, which is enough for a handful of staff opening dashboards.
+# Set this to raise the limit or get richer fields.
+# LAT_IPINFO_TOKEN=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "react-dom": "catalog:",
     "react-use": "^17.6.0",
     "rosetta-ai": "catalog:",
+    "ua-parser-js": "^2.0.6",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -107,22 +107,22 @@ describe("adminRevokeUserSessionsInputSchema", () => {
 })
 
 describe("adminRevokeUserSessionInputSchema", () => {
-  const validInput = { userId: "user-123", sessionId: "sess-abc", sessionToken: "tok-xyz" }
+  const validInput = { userId: "user-123", sessionId: "sess-abc" }
 
   it("accepts a valid input", () => {
     expect(adminRevokeUserSessionInputSchema.safeParse(validInput).success).toBe(true)
   })
 
-  it("rejects when sessionId is missing — needed for the audit-event identifier", () => {
+  it("rejects when sessionId is missing", () => {
     expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionId: undefined }).success).toBe(false)
   })
 
-  it("rejects when sessionToken is missing — needed for the actual revoke call", () => {
-    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionToken: "" }).success).toBe(false)
+  it("rejects when userId is empty", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, userId: "" }).success).toBe(false)
   })
 
-  it("rejects an absurdly long token (defensive bound against abuse)", () => {
-    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionToken: "x".repeat(2049) }).success).toBe(
+  it("rejects a sessionId above the max length (defensive bound against abuse)", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionId: "x".repeat(257) }).success).toBe(
       false,
     )
   })

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { adminGetUserInputSchema, adminSetUserRoleInputSchema } from "./users.functions.ts"
+import {
+  adminChangeUserEmailInputSchema,
+  adminGetUserInputSchema,
+  adminSetUserRoleInputSchema,
+} from "./users.functions.ts"
 
 describe("adminGetUserInputSchema", () => {
   it("accepts a valid userId", () => {
@@ -43,5 +47,45 @@ describe("adminSetUserRoleInputSchema", () => {
 
   it("rejects a userId above the max length", () => {
     expect(adminSetUserRoleInputSchema.safeParse({ userId: "x".repeat(257), role: "admin" }).success).toBe(false)
+  })
+})
+
+describe("adminChangeUserEmailInputSchema", () => {
+  it("accepts a valid email", () => {
+    const result = adminChangeUserEmailInputSchema.safeParse({ userId: "user-123", newEmail: "user@example.com" })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.newEmail).toBe("user@example.com")
+    }
+  })
+
+  it("trims and lowercases the new email so audit events stay normalized", () => {
+    const result = adminChangeUserEmailInputSchema.safeParse({
+      userId: "user-123",
+      newEmail: "  Mixed.Case@Example.COM  ",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.newEmail).toBe("mixed.case@example.com")
+    }
+  })
+
+  it("rejects malformed emails", () => {
+    expect(adminChangeUserEmailInputSchema.safeParse({ userId: "user-123", newEmail: "not-an-email" }).success).toBe(
+      false,
+    )
+  })
+
+  it("rejects a missing email", () => {
+    expect(adminChangeUserEmailInputSchema.safeParse({ userId: "user-123" }).success).toBe(false)
+  })
+
+  it("rejects an absurdly long email (defensive bound against abuse)", () => {
+    const longEmail = `${"x".repeat(320)}@example.com`
+    expect(adminChangeUserEmailInputSchema.safeParse({ userId: "user-123", newEmail: longEmail }).success).toBe(false)
+  })
+
+  it("rejects an empty userId", () => {
+    expect(adminChangeUserEmailInputSchema.safeParse({ userId: "", newEmail: "user@example.com" }).success).toBe(false)
   })
 })

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { adminGetUserInputSchema } from "./users.functions.ts"
+import { adminGetUserInputSchema, adminSetUserRoleInputSchema } from "./users.functions.ts"
 
 describe("adminGetUserInputSchema", () => {
   it("accepts a valid userId", () => {
@@ -17,5 +17,31 @@ describe("adminGetUserInputSchema", () => {
 
   it("rejects missing userId", () => {
     expect(adminGetUserInputSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe("adminSetUserRoleInputSchema", () => {
+  it("accepts a valid user→admin transition", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "user-123", role: "admin" }).success).toBe(true)
+  })
+
+  it("accepts a valid admin→user transition", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "user-123", role: "user" }).success).toBe(true)
+  })
+
+  it("rejects an unknown role (closed enum prevents typo'd writes from Better Auth)", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "user-123", role: "owner" }).success).toBe(false)
+  })
+
+  it("rejects a missing role", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "user-123" }).success).toBe(false)
+  })
+
+  it("rejects an empty userId", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "", role: "admin" }).success).toBe(false)
+  })
+
+  it("rejects a userId above the max length", () => {
+    expect(adminSetUserRoleInputSchema.safeParse({ userId: "x".repeat(257), role: "admin" }).success).toBe(false)
   })
 })

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   adminChangeUserEmailInputSchema,
   adminGetUserInputSchema,
+  adminRevokeUserSessionsInputSchema,
   adminSetUserRoleInputSchema,
 } from "./users.functions.ts"
 
@@ -87,5 +88,19 @@ describe("adminChangeUserEmailInputSchema", () => {
 
   it("rejects an empty userId", () => {
     expect(adminChangeUserEmailInputSchema.safeParse({ userId: "", newEmail: "user@example.com" }).success).toBe(false)
+  })
+})
+
+describe("adminRevokeUserSessionsInputSchema", () => {
+  it("accepts a valid userId", () => {
+    expect(adminRevokeUserSessionsInputSchema.safeParse({ userId: "user-123" }).success).toBe(true)
+  })
+
+  it("rejects an empty userId", () => {
+    expect(adminRevokeUserSessionsInputSchema.safeParse({ userId: "" }).success).toBe(false)
+  })
+
+  it("rejects a userId above the max length", () => {
+    expect(adminRevokeUserSessionsInputSchema.safeParse({ userId: "x".repeat(257) }).success).toBe(false)
   })
 })

--- a/apps/web/src/domains/admin/users.functions.test.ts
+++ b/apps/web/src/domains/admin/users.functions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   adminChangeUserEmailInputSchema,
   adminGetUserInputSchema,
+  adminRevokeUserSessionInputSchema,
   adminRevokeUserSessionsInputSchema,
   adminSetUserRoleInputSchema,
 } from "./users.functions.ts"
@@ -102,5 +103,27 @@ describe("adminRevokeUserSessionsInputSchema", () => {
 
   it("rejects a userId above the max length", () => {
     expect(adminRevokeUserSessionsInputSchema.safeParse({ userId: "x".repeat(257) }).success).toBe(false)
+  })
+})
+
+describe("adminRevokeUserSessionInputSchema", () => {
+  const validInput = { userId: "user-123", sessionId: "sess-abc", sessionToken: "tok-xyz" }
+
+  it("accepts a valid input", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse(validInput).success).toBe(true)
+  })
+
+  it("rejects when sessionId is missing — needed for the audit-event identifier", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionId: undefined }).success).toBe(false)
+  })
+
+  it("rejects when sessionToken is missing — needed for the actual revoke call", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionToken: "" }).success).toBe(false)
+  })
+
+  it("rejects an absurdly long token (defensive bound against abuse)", () => {
+    expect(adminRevokeUserSessionInputSchema.safeParse({ ...validInput, sessionToken: "x".repeat(2049) }).success).toBe(
+      false,
+    )
   })
 })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -153,3 +153,98 @@ export const adminSetUserRole = createServerFn({ method: "POST" })
 
     return { ok: true, fromRole, toRole }
   })
+
+/**
+ * Exported for input-schema tests.
+ *
+ * The email regex Zod ships with rejects the obvious garbage (no `@`,
+ * trailing whitespace, control characters), which is the only thing we
+ * actually need at the validator boundary — Better Auth's internal
+ * adapter handles uniqueness, and any hidden-character abuse stops at
+ * the `.trim()`.
+ */
+export const adminChangeUserEmailInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+  newEmail: z.string().trim().toLowerCase().email().max(320),
+})
+
+/**
+ * Update a user's primary login email.
+ *
+ * The "Change email" row in the user-detail Account actions section
+ * exists for the most common support ticket: a user typo'd their
+ * email at sign-up, can't sign in, and needs us to repoint their
+ * account at the right address.
+ *
+ * Flow:
+ * 1. `adminMiddleware` injects `context.adminUserId`.
+ * 2. Read the target's current email so the audit event can capture
+ *    the "from → to" transition explicitly. The users row mutates,
+ *    so the historical snapshot has to live on the event.
+ * 3. No-op when the new email already matches — keeps the audit
+ *    trail honest by not emitting an event for a click that didn't
+ *    change anything.
+ * 4. Write `AdminUserEmailChanged` to the outbox before the swap so
+ *    if the Better Auth call fails we still have a record of the
+ *    attempt (same discipline as `impersonateUser` and
+ *    `adminSetUserRole`).
+ * 5. Call `auth.api.adminUpdateUser` with `{ email }`. Better Auth's
+ *    admin plugin writes through the internal adapter, which means
+ *    we deliberately do NOT trigger the email-change verification
+ *    flow — admins are the source of truth here, and forcing the
+ *    user to re-verify a corrected typo defeats the point of the
+ *    action. `emailVerified` is left untouched on purpose.
+ *
+ * Active sessions on the old email keep working until they expire;
+ * in-flight magic links keep working until their TTL elapses. This
+ * is surfaced in the modal copy.
+ */
+export const adminChangeUserEmail = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminChangeUserEmailInputSchema)
+  .handler(async ({ data, context }): Promise<{ ok: true; fromEmail: string; toEmail: string }> => {
+    const adminUserId = context.adminUserId
+
+    const target = await Effect.runPromise(
+      getUserDetailsUseCase({ userId: UserId(data.userId) }).pipe(
+        withPostgres(AdminUserRepositoryLive, getAdminPostgresClient()),
+        withTracing,
+      ),
+    )
+
+    const fromEmail = target.email
+    const toEmail = data.newEmail
+
+    if (fromEmail === toEmail) {
+      return { ok: true, fromEmail, toEmail }
+    }
+
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminUserEmailChanged",
+          aggregateType: "user",
+          aggregateId: target.id,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId: target.id,
+            fromEmail,
+            toEmail,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
+
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+    await auth.api.adminUpdateUser({
+      body: { userId: target.id, data: { email: toEmail } },
+      headers,
+    })
+
+    return { ok: true, fromEmail, toEmail }
+  })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -1,19 +1,64 @@
-import { type AdminUserDetails, type AdminUserMembership, getUserDetailsUseCase } from "@domain/admin"
+import {
+  type AdminUserDetails,
+  type AdminUserMembership,
+  type AdminUserSession,
+  getUserDetailsUseCase,
+} from "@domain/admin"
 import { generateId, UserId } from "@domain/shared"
 import { AdminUserRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
 import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
+import { UAParser } from "ua-parser-js"
 import { z } from "zod"
 import { adminMiddleware } from "../../server/admin-middleware.ts"
 import { getAdminPostgresClient, getBetterAuth, getOutboxWriter } from "../../server/clients.ts"
+import { type GeoIpInfo, lookupGeoIpBatch } from "../../server/geoip.ts"
 
 export interface AdminUserDetailsMembershipDto {
   organizationId: string
   organizationName: string
   organizationSlug: string
   role: "owner" | "admin" | "member"
+}
+
+/**
+ * Pre-parsed view of an active session row, post-processed by the
+ * server function so the UI is pure: User-Agent parsing and GeoIP
+ * resolution both happen here, not in the browser. The TanStack Start
+ * compiler strips the `ua-parser-js` dep + `geoip.ts` module from the
+ * client bundle.
+ */
+export interface AdminUserSessionDto {
+  id: string
+  /**
+   * Better Auth's session token — the value
+   * `auth.api.revokeUserSession` takes. Sent to the client for the
+   * per-row Revoke button; the action itself runs server-side under
+   * `adminMiddleware`, so we're not granting any new authority by
+   * exposing it.
+   */
+  token: string
+  ipAddress: string | null
+  /** Raw User-Agent string. Kept for hover-to-reveal / debugging. */
+  userAgent: string | null
+  /** Best-effort browser name parsed from the User-Agent. */
+  browserName: string | null
+  /** Best-effort OS name parsed from the User-Agent. */
+  osName: string | null
+  /**
+   * `"desktop"` for parser results without an explicit device-type
+   * (the parser leaves `device.type` undefined for laptops/desktops);
+   * otherwise the parser's value (`"mobile"`, `"tablet"`, etc.).
+   */
+  deviceKind: string
+  geo: GeoIpInfo | null
+  createdAt: string
+  updatedAt: string
+  expiresAt: string
+  impersonatedByUserId: string | null
+  impersonatedByEmail: string | null
 }
 
 export interface AdminUserDetailsDto {
@@ -23,25 +68,54 @@ export interface AdminUserDetailsDto {
   image: string | null
   role: "user" | "admin"
   memberships: AdminUserDetailsMembershipDto[]
+  sessions: AdminUserSessionDto[]
   createdAt: string
 }
 
-const toDto = (details: AdminUserDetails): AdminUserDetailsDto => ({
-  id: details.id,
-  email: details.email,
-  name: details.name,
-  image: details.image,
-  role: details.role,
-  memberships: details.memberships.map(
-    (m: AdminUserMembership): AdminUserDetailsMembershipDto => ({
-      organizationId: m.organizationId,
-      organizationName: m.organizationName,
-      organizationSlug: m.organizationSlug,
-      role: m.role,
-    }),
-  ),
-  createdAt: details.createdAt.toISOString(),
-})
+const sessionToDto = (s: AdminUserSession, geo: GeoIpInfo | null): AdminUserSessionDto => {
+  const parsed = s.userAgent ? UAParser(s.userAgent) : null
+  return {
+    id: s.id,
+    token: s.token,
+    ipAddress: s.ipAddress,
+    userAgent: s.userAgent,
+    browserName: parsed?.browser.name ?? null,
+    osName: parsed?.os.name ?? null,
+    deviceKind: parsed?.device.type ?? "desktop",
+    geo,
+    createdAt: s.createdAt.toISOString(),
+    updatedAt: s.updatedAt.toISOString(),
+    expiresAt: s.expiresAt.toISOString(),
+    impersonatedByUserId: s.impersonatedByUserId,
+    impersonatedByEmail: s.impersonatedByEmail,
+  }
+}
+
+const toDto = async (details: AdminUserDetails): Promise<AdminUserDetailsDto> => {
+  // Resolve geo for every distinct IP in one pass — the helper
+  // dedupes internally so a user with 5 sessions on the same address
+  // issues at most one upstream call.
+  const geoByIp = await lookupGeoIpBatch(details.sessions.map((s) => s.ipAddress))
+  const sessions = details.sessions.map((s) => sessionToDto(s, s.ipAddress ? (geoByIp.get(s.ipAddress) ?? null) : null))
+
+  return {
+    id: details.id,
+    email: details.email,
+    name: details.name,
+    image: details.image,
+    role: details.role,
+    memberships: details.memberships.map(
+      (m: AdminUserMembership): AdminUserDetailsMembershipDto => ({
+        organizationId: m.organizationId,
+        organizationName: m.organizationName,
+        organizationSlug: m.organizationSlug,
+        role: m.role,
+      }),
+    ),
+    sessions,
+    createdAt: details.createdAt.toISOString(),
+  }
+}
 
 /**
  * Exported so tests can exercise input validation without spinning up the
@@ -75,7 +149,7 @@ export const adminGetUser = createServerFn({ method: "GET" })
       ),
     )
 
-    return toDto(details)
+    return await toDto(details)
   })
 
 /**
@@ -321,4 +395,64 @@ export const adminRevokeUserSessions = createServerFn({ method: "POST" })
     await auth.api.revokeUserSessions({ body: { userId: data.userId }, headers })
 
     return { ok: true, sessionCount }
+  })
+
+/**
+ * Exported for input-schema tests.
+ */
+export const adminRevokeUserSessionInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+  sessionId: z.string().min(1).max(256),
+  /**
+   * The Better Auth `revokeUserSession` admin endpoint takes a
+   * session token (not the row id). We accept both on the wire — the
+   * UI hands us the token because that's what's needed for the
+   * actual revocation, and `sessionId` is plumbed through purely as
+   * the audit-event identifier (more readable than the token in
+   * audit logs, which are visible to support staff).
+   */
+  sessionToken: z.string().min(1).max(2048),
+})
+
+/**
+ * Sign a single session out — backing the per-row Revoke button on
+ * the Sessions panel.
+ *
+ * Audit-only by design: we don't fetch the user details before the
+ * revoke (the audit row stands on its own with adminUserId +
+ * targetUserId + sessionId), but we do scope the operation to a
+ * specific user so an out-of-band admin can't accidentally drop the
+ * wrong session by guessing a token. The `userId` is captured on
+ * the audit event for symmetry with the other admin-action events.
+ */
+export const adminRevokeUserSession = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminRevokeUserSessionInputSchema)
+  .handler(async ({ data, context }): Promise<{ ok: true }> => {
+    const adminUserId = context.adminUserId
+
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminUserSessionRevoked",
+          aggregateType: "user",
+          aggregateId: data.userId,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId: data.userId,
+            sessionId: data.sessionId,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
+
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+    await auth.api.revokeUserSession({ body: { sessionToken: data.sessionToken }, headers })
+
+    return { ok: true }
   })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -248,3 +248,77 @@ export const adminChangeUserEmail = createServerFn({ method: "POST" })
 
     return { ok: true, fromEmail, toEmail }
   })
+
+/**
+ * Exported for input-schema tests.
+ */
+export const adminRevokeUserSessionsInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+})
+
+/**
+ * Sign a user out of every active session ("Revoke all sessions"
+ * row in the user-detail Account actions section).
+ *
+ * Flow:
+ * 1. `adminMiddleware` injects `context.adminUserId`.
+ * 2. Best-effort count active sessions via `auth.api.listUserSessions`
+ *    so the audit event can report how many sessions were affected.
+ *    On failure we fall back to `0` and still emit the event — the
+ *    primary audit value is "the admin took this action", not the
+ *    exact count.
+ * 3. Write `AdminUserSessionsRevoked` to the outbox before the
+ *    revocation, matching the discipline of `impersonateUser` /
+ *    `adminSetUserRole`.
+ * 4. Call `auth.api.revokeUserSessions`. Better Auth's admin
+ *    plugin invokes `internalAdapter.deleteSessions(userId)` which
+ *    drops every session row for that user.
+ *
+ * Note: an admin revoking their own sessions is allowed; the next
+ * request after the cookie cache flushes will redirect them to
+ * /login.
+ */
+export const adminRevokeUserSessions = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminRevokeUserSessionsInputSchema)
+  .handler(async ({ data, context }): Promise<{ ok: true; sessionCount: number }> => {
+    const adminUserId = context.adminUserId
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+
+    let sessionCount = 0
+    try {
+      const result = await auth.api.listUserSessions({
+        body: { userId: data.userId },
+        headers,
+      })
+      sessionCount = result.sessions.length
+    } catch {
+      // Swallow — the audit event still fires with sessionCount: 0.
+      // The primary signal of this row is "admin did the revoke",
+      // not the count.
+    }
+
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminUserSessionsRevoked",
+          aggregateType: "user",
+          aggregateId: data.userId,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId: data.userId,
+            sessionCount,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
+
+    await auth.api.revokeUserSessions({ body: { userId: data.userId }, headers })
+
+    return { ok: true, sessionCount }
+  })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -1,12 +1,13 @@
 import { type AdminUserDetails, type AdminUserMembership, getUserDetailsUseCase } from "@domain/admin"
-import { UserId } from "@domain/shared"
-import { AdminUserRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { generateId, UserId } from "@domain/shared"
+import { AdminUserRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
+import { getRequestHeaders } from "@tanstack/react-start/server"
 import { Effect } from "effect"
 import { z } from "zod"
 import { adminMiddleware } from "../../server/admin-middleware.ts"
-import { getAdminPostgresClient } from "../../server/clients.ts"
+import { getAdminPostgresClient, getBetterAuth, getOutboxWriter } from "../../server/clients.ts"
 
 export interface AdminUserDetailsMembershipDto {
   organizationId: string
@@ -75,4 +76,80 @@ export const adminGetUser = createServerFn({ method: "GET" })
     )
 
     return toDto(details)
+  })
+
+/**
+ * Exported for input-schema tests.
+ */
+export const adminSetUserRoleInputSchema = z.object({
+  userId: z.string().min(1).max(256),
+  role: z.enum(["user", "admin"]),
+})
+
+/**
+ * Promote / demote a user's global `users.role`. Used by the
+ * "Promote to staff" / "Demote from staff" rows in the user-detail
+ * Account actions section.
+ *
+ * Flow:
+ * 1. `adminMiddleware` guard injects `context.adminUserId`.
+ * 2. Read the target's current role (we need `fromRole` for the audit
+ *    event, and `auth.api.setRole` doesn't return it explicitly).
+ * 3. No-op when `fromRole === toRole` — avoid emitting a misleading
+ *    audit event for a click that didn't actually change anything.
+ * 4. Write `AdminUserRoleChanged` to the outbox before the swap, so
+ *    if the Better Auth call fails we still have a record of the
+ *    attempt (same discipline as `impersonateUser`).
+ * 5. Call `auth.api.setRole`, which updates the column.
+ *
+ * Self-demotion is intentionally allowed — see the plan / PR
+ * discussion. An admin can demote themselves; the next request after
+ * the cookie cache flushes will reject them from `/backoffice` like
+ * any other non-admin.
+ */
+export const adminSetUserRole = createServerFn({ method: "POST" })
+  .middleware([adminMiddleware])
+  .inputValidator(adminSetUserRoleInputSchema)
+  .handler(async ({ data, context }): Promise<{ ok: true; fromRole: "user" | "admin"; toRole: "user" | "admin" }> => {
+    const adminUserId = context.adminUserId
+
+    const target = await Effect.runPromise(
+      getUserDetailsUseCase({ userId: UserId(data.userId) }).pipe(
+        withPostgres(AdminUserRepositoryLive, getAdminPostgresClient()),
+        withTracing,
+      ),
+    )
+
+    const fromRole = target.role
+    const toRole = data.role
+
+    if (fromRole === toRole) {
+      return { ok: true, fromRole, toRole }
+    }
+
+    const outboxWriter = getOutboxWriter()
+    await Effect.runPromise(
+      outboxWriter
+        .write({
+          id: generateId(),
+          eventName: "AdminUserRoleChanged",
+          aggregateType: "user",
+          aggregateId: target.id,
+          organizationId: "system",
+          payload: {
+            adminUserId,
+            targetUserId: target.id,
+            fromRole,
+            toRole,
+          },
+          occurredAt: new Date(),
+        })
+        .pipe(Effect.provide(SqlClientLive(getAdminPostgresClient())), withTracing),
+    )
+
+    const headers = getRequestHeaders()
+    const auth = getBetterAuth()
+    await auth.api.setRole({ body: { userId: target.id, role: toRole }, headers })
+
+    return { ok: true, fromRole, toRole }
   })

--- a/apps/web/src/domains/admin/users.functions.ts
+++ b/apps/web/src/domains/admin/users.functions.ts
@@ -2,6 +2,7 @@ import {
   type AdminUserDetails,
   type AdminUserMembership,
   type AdminUserSession,
+  getActiveSessionTokenUseCase,
   getUserDetailsUseCase,
 } from "@domain/admin"
 import { generateId, UserId } from "@domain/shared"
@@ -32,14 +33,6 @@ export interface AdminUserDetailsMembershipDto {
  */
 export interface AdminUserSessionDto {
   id: string
-  /**
-   * Better Auth's session token — the value
-   * `auth.api.revokeUserSession` takes. Sent to the client for the
-   * per-row Revoke button; the action itself runs server-side under
-   * `adminMiddleware`, so we're not granting any new authority by
-   * exposing it.
-   */
-  token: string
   ipAddress: string | null
   /** Raw User-Agent string. Kept for hover-to-reveal / debugging. */
   userAgent: string | null
@@ -76,7 +69,6 @@ const sessionToDto = (s: AdminUserSession, geo: GeoIpInfo | null): AdminUserSess
   const parsed = s.userAgent ? UAParser(s.userAgent) : null
   return {
     id: s.id,
-    token: s.token,
     ipAddress: s.ipAddress,
     userAgent: s.userAgent,
     browserName: parsed?.browser.name ?? null,
@@ -403,33 +395,43 @@ export const adminRevokeUserSessions = createServerFn({ method: "POST" })
 export const adminRevokeUserSessionInputSchema = z.object({
   userId: z.string().min(1).max(256),
   sessionId: z.string().min(1).max(256),
-  /**
-   * The Better Auth `revokeUserSession` admin endpoint takes a
-   * session token (not the row id). We accept both on the wire — the
-   * UI hands us the token because that's what's needed for the
-   * actual revocation, and `sessionId` is plumbed through purely as
-   * the audit-event identifier (more readable than the token in
-   * audit logs, which are visible to support staff).
-   */
-  sessionToken: z.string().min(1).max(2048),
 })
 
 /**
  * Sign a single session out — backing the per-row Revoke button on
  * the Sessions panel.
  *
- * Audit-only by design: we don't fetch the user details before the
- * revoke (the audit row stands on its own with adminUserId +
- * targetUserId + sessionId), but we do scope the operation to a
- * specific user so an out-of-band admin can't accidentally drop the
- * wrong session by guessing a token. The `userId` is captured on
- * the audit event for symmetry with the other admin-action events.
+ * The session **token** (Better Auth's revoke credential) is
+ * resolved server-side, not accepted from the client. The handler
+ * looks up the row by `(userId, sessionId)` and a `expires_at >
+ * now()` predicate; if no row matches, the use-case fails with
+ * `NotFoundError`, the audit event is **not** written, and the
+ * client surfaces a "not found" — both "session id doesn't exist"
+ * and "session belongs to a different user" collapse into the same
+ * outcome. That gives us:
+ *   1. The token never round-trips through the wire / browser.
+ *   2. A tampered request that mismatches `userId` and `sessionId`
+ *      can't drop someone else's session and have it audited under
+ *      the wrong target.
+ *   3. The audit event stays consistent — a row only exists when a
+ *      revoke actually fired against the named user.
  */
 export const adminRevokeUserSession = createServerFn({ method: "POST" })
   .middleware([adminMiddleware])
   .inputValidator(adminRevokeUserSessionInputSchema)
   .handler(async ({ data, context }): Promise<{ ok: true }> => {
     const adminUserId = context.adminUserId
+
+    // Verify ownership and resolve the token in one step. NotFoundError
+    // surfaces before the outbox write, so a probing call can't pollute
+    // the audit log with a `targetUserId` that doesn't actually own the
+    // session.
+    const sessionToken = await Effect.runPromise(
+      getActiveSessionTokenUseCase({ userId: UserId(data.userId), sessionId: data.sessionId }).pipe(
+        withPostgres(AdminUserRepositoryLive, getAdminPostgresClient()),
+        withTracing,
+      ),
+    )
 
     const outboxWriter = getOutboxWriter()
     await Effect.runPromise(
@@ -452,7 +454,7 @@ export const adminRevokeUserSession = createServerFn({ method: "POST" })
 
     const headers = getRequestHeaders()
     const auth = getBetterAuth()
-    await auth.api.revokeUserSession({ body: { sessionToken: data.sessionToken }, headers })
+    await auth.api.revokeUserSession({ body: { sessionToken }, headers })
 
     return { ok: true }
   })

--- a/apps/web/src/routes/backoffice/-components/account-actions/change-email.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/change-email.tsx
@@ -1,0 +1,134 @@
+import { Alert, Button, CloseTrigger, FormWrapper, Input, Modal, Text, useToast } from "@repo/ui"
+import { useForm } from "@tanstack/react-form"
+import { useRouter } from "@tanstack/react-router"
+import { useState } from "react"
+import { adminChangeUserEmail } from "../../../../domains/admin/users.functions.ts"
+import { toUserMessage } from "../../../../lib/errors.ts"
+import { createFormSubmitHandler, fieldErrorsAsStrings } from "../../../../lib/form-server-action.ts"
+
+interface ChangeEmailButtonProps {
+  readonly userId: string
+  readonly currentEmail: string
+}
+
+/**
+ * Change a user's primary login email.
+ *
+ * Renders an outline button that opens a form modal:
+ *
+ * - Pre-fills `currentEmail` so admins can edit one character without
+ *   retyping the address (the most common path: a typo correction).
+ * - Side-effect copy lives inline so the actor reads it before
+ *   submitting:
+ *     • Active sessions are NOT signed out — the user keeps working
+ *       under the renamed account.
+ *     • In-flight magic links keep working until they expire (~1 h).
+ *     • `emailVerified` is preserved by design; admins are the source
+ *       of truth and forcing re-verification negates the action.
+ *     • Stripe customer email is NOT auto-synced (separate domain).
+ *
+ * Validation runs at the server boundary via Zod; per-field errors
+ * surface back through the standard `createFormSubmitHandler` /
+ * `fieldErrorsAsStrings` plumbing. We don't re-validate client-side
+ * — keeping the schema source of truth on the server avoids drift.
+ *
+ * On success we `router.invalidate()` so the loader re-runs and the
+ * dashboard re-renders with the new email everywhere
+ * (hero, properties strip, recently-viewed cache, etc.).
+ */
+export function ChangeEmailButton({ userId, currentEmail }: ChangeEmailButtonProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const form = useForm({
+    defaultValues: { newEmail: currentEmail },
+    onSubmit: createFormSubmitHandler(
+      async (value) => {
+        return await adminChangeUserEmail({
+          data: { userId, newEmail: value.newEmail },
+        })
+      },
+      {
+        onSuccess: async (result) => {
+          if (result.fromEmail === result.toEmail) {
+            toast({ description: "Email unchanged." })
+          } else {
+            toast({ description: `Email updated to ${result.toEmail}.` })
+          }
+          setIsOpen(false)
+          void router.invalidate()
+        },
+        onError: (error) => {
+          toast({
+            variant: "destructive",
+            title: "Could not update email",
+            description: toUserMessage(error),
+          })
+        },
+      },
+    ),
+  })
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setIsOpen(true)}>
+        Change email
+      </Button>
+      <Modal.Root
+        open={isOpen}
+        onOpenChange={(next) => {
+          if (!next) form.reset()
+          setIsOpen(next)
+        }}
+      >
+        <Modal.Content dismissible size="large">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              void form.handleSubmit()
+            }}
+          >
+            <Modal.Header
+              title="Change email"
+              description={
+                <Text.H5 color="foregroundMuted">
+                  Update the primary login email for <span className="font-medium text-foreground">{currentEmail}</span>
+                  .
+                </Text.H5>
+              }
+            />
+            <Modal.Body>
+              <FormWrapper>
+                <form.Field name="newEmail">
+                  {(field) => (
+                    <Input
+                      required
+                      type="email"
+                      label="New email"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      errors={fieldErrorsAsStrings(field.state.meta.errors)}
+                      placeholder="user@example.com"
+                      autoComplete="off"
+                    />
+                  )}
+                </form.Field>
+                <Alert
+                  variant="warning"
+                  description="Active sessions stay signed in. In-flight magic links keep working until they expire (~1 h). The verified-email flag is preserved. Stripe customer email is not auto-synced."
+                />
+              </FormWrapper>
+            </Modal.Body>
+            <Modal.Footer>
+              <CloseTrigger />
+              <Button type="submit" size="sm" disabled={form.state.isSubmitting}>
+                {form.state.isSubmitting ? "Updating…" : "Update email"}
+              </Button>
+            </Modal.Footer>
+          </form>
+        </Modal.Content>
+      </Modal.Root>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/promote-demote.tsx
@@ -1,0 +1,143 @@
+import { Alert, Button, Checkbox, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useRouter } from "@tanstack/react-router"
+import { useState } from "react"
+import { adminSetUserRole } from "../../../../domains/admin/users.functions.ts"
+import { toUserMessage } from "../../../../lib/errors.ts"
+
+interface PromoteDemoteStaffButtonProps {
+  readonly userId: string
+  readonly userEmail: string
+  readonly currentRole: "user" | "admin"
+}
+
+/**
+ * Toggle a user's platform-staff bit.
+ *
+ * Renders one button — "Promote to staff" or "Demote from staff" —
+ * depending on `currentRole`, each with its own confirmation modal:
+ *
+ * - **Promote**: warning-level modal, single confirm. Granting access
+ *   is reversible and high-frequency enough that we don't gate it on
+ *   a checkbox.
+ * - **Demote**: destructive modal with an "I understand" checkbox.
+ *   Removing platform access is the dangerous-by-default direction:
+ *   accidental clicks should be hard. The checkbox primes the actor
+ *   that the next click is the one that mutates state.
+ *
+ * Self-demotion is intentionally allowed (decision in the plan). The
+ * server function will mutate the actor's own row if asked; the next
+ * request after the cookie cache flushes will reject them from the
+ * backoffice like any other non-admin.
+ *
+ * On success we `router.invalidate()` so the loader re-runs and the
+ * `<PlatformStaffBadge>` flips on the next render — no full page
+ * reload needed (we're not swapping cookies the way impersonation
+ * does).
+ */
+export function PromoteDemoteStaffButton({ userId, userEmail, currentRole }: PromoteDemoteStaffButtonProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const isPromote = currentRole === "user"
+  const targetRole: "user" | "admin" = isPromote ? "admin" : "user"
+  const buttonLabel = isPromote ? "Promote to staff" : "Demote from staff"
+  const submittingLabel = isPromote ? "Promoting…" : "Demoting…"
+
+  const reset = () => {
+    setIsOpen(false)
+    setAcknowledged(false)
+  }
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true)
+    try {
+      await adminSetUserRole({ data: { userId, role: targetRole } })
+      toast({
+        description: isPromote ? `${userEmail} is now platform staff.` : `${userEmail} is no longer platform staff.`,
+      })
+      void router.invalidate()
+      reset()
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: isPromote ? "Could not promote user" : "Could not demote user",
+        description: toUserMessage(error),
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const confirmDisabled = isSubmitting || (!isPromote && !acknowledged)
+
+  return (
+    <>
+      <Button
+        variant={isPromote ? "outline" : "destructive"}
+        size="sm"
+        disabled={isSubmitting}
+        onClick={() => setIsOpen(true)}
+      >
+        {isSubmitting ? submittingLabel : buttonLabel}
+      </Button>
+      <Modal
+        dismissible
+        open={isOpen}
+        size="large"
+        onOpenChange={(next) => {
+          if (!next) reset()
+          else setIsOpen(true)
+        }}
+        title={isPromote ? "Promote to platform staff" : "Demote from platform staff"}
+        description={
+          <Text.H5 color="foregroundMuted">
+            {isPromote ? "Grant" : "Revoke"} platform access for{" "}
+            <span className="font-medium text-foreground">{userEmail}</span>.
+          </Text.H5>
+        }
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <CloseTrigger />
+            <Button
+              variant={isPromote ? "default" : "destructive"}
+              size="sm"
+              disabled={confirmDisabled}
+              onClick={() => void handleConfirm()}
+            >
+              {isSubmitting ? submittingLabel : isPromote ? "Promote" : "Demote"}
+            </Button>
+          </div>
+        }
+      >
+        {isPromote ? (
+          <Alert
+            variant="warning"
+            description="Platform staff can access the backoffice, view every organization, and impersonate any user. Only promote people on the Latitude team."
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <Alert
+              variant="destructive"
+              description="This user will lose access to the backoffice on their next request. Active sessions are not signed out — they just stop seeing /backoffice routes."
+            />
+            <label className="flex cursor-pointer items-start gap-2" htmlFor="demote-acknowledge">
+              <Checkbox
+                id="demote-acknowledge"
+                checked={acknowledged}
+                onCheckedChange={(state) => setAcknowledged(state === true)}
+                disabled={isSubmitting}
+              />
+              <Text.H6 color="foregroundMuted">
+                I understand this will revoke <span className="font-medium text-foreground">{userEmail}</span>'s
+                platform-staff access.
+              </Text.H6>
+            </label>
+          </div>
+        )}
+      </Modal>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
@@ -1,0 +1,87 @@
+import { Alert, Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useRouter } from "@tanstack/react-router"
+import { useState } from "react"
+import { adminRevokeUserSessions } from "../../../../domains/admin/users.functions.ts"
+import { toUserMessage } from "../../../../lib/errors.ts"
+
+interface RevokeAllSessionsButtonProps {
+  readonly userId: string
+  readonly userEmail: string
+}
+
+/**
+ * Sign a user out of every active session.
+ *
+ * Warning-level (not destructive): the action is reversible — the
+ * user can sign in again at any time — and it's a routine support
+ * remediation for "I think someone else got into my account". The
+ * single-confirm shape mirrors Impersonate.
+ *
+ * On success we `router.invalidate()` so the loader re-runs. The
+ * Sessions panel (when it lands in commit 6) will repaint empty;
+ * for now the toast is the only visible feedback, which is fine
+ * because the action is a fire-and-forget remediation.
+ */
+export function RevokeAllSessionsButton({ userId, userEmail }: RevokeAllSessionsButtonProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleConfirm = async () => {
+    setIsSubmitting(true)
+    try {
+      const result = await adminRevokeUserSessions({ data: { userId } })
+      const verb = result.sessionCount === 1 ? "session" : "sessions"
+      toast({
+        description:
+          result.sessionCount === 0
+            ? `${userEmail} had no active sessions to revoke.`
+            : `Revoked ${result.sessionCount} active ${verb} for ${userEmail}.`,
+      })
+      void router.invalidate()
+      setIsOpen(false)
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not revoke sessions",
+        description: toUserMessage(error),
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <Button variant="outline" size="sm" disabled={isSubmitting} onClick={() => setIsOpen(true)}>
+        {isSubmitting ? "Revoking…" : "Revoke all sessions"}
+      </Button>
+      <Modal
+        dismissible
+        open={isOpen}
+        size="large"
+        onOpenChange={setIsOpen}
+        title="Revoke all sessions"
+        description={
+          <Text.H5 color="foregroundMuted">
+            Sign <span className="font-medium text-foreground">{userEmail}</span> out of every active session.
+          </Text.H5>
+        }
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <CloseTrigger />
+            <Button variant="default" size="sm" disabled={isSubmitting} onClick={() => void handleConfirm()}>
+              {isSubmitting ? "Revoking…" : "Revoke sessions"}
+            </Button>
+          </div>
+        }
+      >
+        <Alert
+          variant="warning"
+          description="This signs the user out everywhere — every browser, every device. They'll need to sign in again. The user's data and memberships are not affected."
+        />
+      </Modal>
+    </>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/revoke-all-sessions.tsx
@@ -17,10 +17,9 @@ interface RevokeAllSessionsButtonProps {
  * remediation for "I think someone else got into my account". The
  * single-confirm shape mirrors Impersonate.
  *
- * On success we `router.invalidate()` so the loader re-runs. The
- * Sessions panel (when it lands in commit 6) will repaint empty;
- * for now the toast is the only visible feedback, which is fine
- * because the action is a fire-and-forget remediation.
+ * On success we `router.invalidate()` so the loader re-runs and
+ * the Sessions panel below repaints empty; the toast carries the
+ * actual count of sessions revoked.
  */
 export function RevokeAllSessionsButton({ userId, userEmail }: RevokeAllSessionsButtonProps) {
   const { toast } = useToast()

--- a/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
@@ -34,7 +34,7 @@ export function AccountActionsSection({ children }: { children: ReactNode }) {
             Account actions
           </Text.H6>
           <Text.H6 color="foregroundMuted">
-            Mutations on this user — impersonation, role changes, sign-outs, ban.
+            Mutations on this user — impersonation, role changes, email, sign-outs.
           </Text.H6>
         </div>
         <Icon

--- a/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
+++ b/apps/web/src/routes/backoffice/-components/account-actions/section.tsx
@@ -1,0 +1,85 @@
+import { Icon, Text } from "@repo/ui"
+import { ChevronDownIcon, type LucideIcon } from "lucide-react"
+import type { ReactNode } from "react"
+
+/**
+ * Collapsible "Account actions" panel for the user-detail dashboard.
+ *
+ * Card-shaped like `DashboardSection`, but uses a native
+ * `<details>` / `<summary>` so it gets keyboard-toggle accessibility
+ * (Enter / Space on the summary expand / collapse) and the open state
+ * survives SSR — no useState, no client-only flicker. The chevron
+ * rotates via `group-open:rotate-180`.
+ *
+ * Collapsed by default because the read-only routine view of a user
+ * (identity, memberships, sessions) is what staff are usually here
+ * for; opening the actions section is an explicit "I'm about to
+ * mutate this user" gesture.
+ */
+export function AccountActionsSection({ children }: { children: ReactNode }) {
+  return (
+    <details className="group rounded-lg border border-border bg-background">
+      <summary
+        className={[
+          "flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3",
+          // Suppress the default `<summary>` triangle marker — we
+          // render our own chevron on the right so the section reads
+          // like the rest of the dashboard cards.
+          "[&::-webkit-details-marker]:hidden",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-lg",
+        ].join(" ")}
+      >
+        <div className="flex flex-col min-w-0">
+          <Text.H6 weight="semibold" noWrap>
+            Account actions
+          </Text.H6>
+          <Text.H6 color="foregroundMuted">
+            Mutations on this user — impersonation, role changes, sign-outs, ban.
+          </Text.H6>
+        </div>
+        <Icon
+          icon={ChevronDownIcon}
+          size="sm"
+          color="foregroundMuted"
+          className="shrink-0 transition-transform duration-150 group-open:rotate-180"
+        />
+      </summary>
+      <div className="flex flex-col border-t border-border">{children}</div>
+    </details>
+  )
+}
+
+/**
+ * One row inside `<AccountActionsSection>`. Icon + title + description
+ * on the left, action button on the right. Each row is its own divider
+ * (`border-b last:border-b-0`) so the section visually reads as a
+ * list of small cards stacked inside a container.
+ */
+export interface AccountActionRowProps {
+  /** Lucide icon rendered in a subtle round on the left edge. */
+  readonly icon: LucideIcon
+  readonly title: ReactNode
+  /** Single sentence explaining what the action does. Renders muted under the title. */
+  readonly description: ReactNode
+  /** The trigger — typically a `<Button>` paired with its own `<Modal>`. The row is purely visual; mutation state lives in the action component. */
+  readonly action: ReactNode
+}
+
+export function AccountActionRow({ icon, title, description, action }: AccountActionRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3 border-b border-border last:border-b-0">
+      <div className="flex min-w-0 items-start gap-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-muted">
+          <Icon icon={icon} size="sm" color="foregroundMuted" />
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Text.H5 weight="medium" ellipsis noWrap>
+            {title}
+          </Text.H5>
+          <Text.H6 color="foregroundMuted">{description}</Text.H6>
+        </div>
+      </div>
+      <div className="shrink-0">{action}</div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/sessions-panel.tsx
+++ b/apps/web/src/routes/backoffice/-components/sessions-panel.tsx
@@ -1,0 +1,282 @@
+import { Alert, Badge, Button, CloseTrigger, Icon, Modal, Text, useToast } from "@repo/ui"
+import { relativeTime } from "@repo/utils"
+import { useRouter } from "@tanstack/react-router"
+import { ExternalLinkIcon, GlobeIcon, MonitorIcon, ShieldAlertIcon, SmartphoneIcon, TabletIcon } from "lucide-react"
+import { useState } from "react"
+import { type AdminUserSessionDto, adminRevokeUserSession } from "../../../domains/admin/users.functions.ts"
+import { toUserMessage } from "../../../lib/errors.ts"
+import { DashboardSection } from "./dashboard/index.ts"
+
+const MAX_VISIBLE_SESSIONS = 12
+
+interface SessionsPanelProps {
+  readonly userId: string
+  readonly userEmail: string
+  readonly sessions: ReadonlyArray<AdminUserSessionDto>
+}
+
+/**
+ * Sessions panel for the user-detail dashboard.
+ *
+ * Sibling to Memberships. One row per active session: device + os
+ * lockup, browser, location, IP (click-out to ipinfo.io for the
+ * full record), started / last-seen / expires relative times,
+ * impersonator chip when present, and a per-row Revoke button.
+ *
+ * Sessions arrive pre-sorted from the repository (impersonation
+ * first, then by `updatedAt` desc), so the panel's job is purely
+ * presentational.
+ *
+ * Capped at `MAX_VISIBLE_SESSIONS` rows to keep the render
+ * predictable; an overflow tile says "+N more" when the user has
+ * an unusually large number of active sessions. Staff hunting for
+ * a specific session beyond the cap should revoke all and start
+ * fresh.
+ */
+export function SessionsPanel({ userId, userEmail, sessions }: SessionsPanelProps) {
+  const { toast } = useToast()
+  const router = useRouter()
+  const visible = sessions.slice(0, MAX_VISIBLE_SESSIONS)
+  const overflow = sessions.length - visible.length
+
+  // Single shared modal driven by which row was clicked. Avoids one
+  // `<Modal>` instance per session row (8+ portals on a typical
+  // dashboard) and keeps the confirmation dialog itself consistent
+  // with the rest of the backoffice — no native `window.confirm`.
+  const [pending, setPending] = useState<AdminUserSessionDto | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const closeModal = () => {
+    setPending(null)
+    setIsSubmitting(false)
+  }
+
+  const handleConfirm = async () => {
+    if (!pending) return
+    setIsSubmitting(true)
+    try {
+      await adminRevokeUserSession({
+        data: { userId, sessionId: pending.id, sessionToken: pending.token },
+      })
+      toast({ description: "Session revoked." })
+      void router.invalidate()
+      closeModal()
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not revoke session",
+        description: toUserMessage(error),
+      })
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <DashboardSection title="Sessions" count={sessions.length}>
+      {sessions.length === 0 ? (
+        <Text.H6 color="foregroundMuted">This user has no active sessions.</Text.H6>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {visible.map((session) => (
+            <SessionRow
+              key={session.id}
+              session={session}
+              isRevoking={isSubmitting && pending?.id === session.id}
+              onRevokeClick={() => setPending(session)}
+            />
+          ))}
+          {overflow > 0 && (
+            <div className="flex items-center justify-center rounded-md border border-dashed border-border bg-muted/30 px-4 py-3">
+              <Text.H6 color="foregroundMuted">
+                +<span className="tabular-nums">{overflow}</span> more session
+                {overflow === 1 ? "" : "s"} not shown
+              </Text.H6>
+            </div>
+          )}
+        </div>
+      )}
+
+      <Modal
+        dismissible
+        open={pending !== null}
+        size="large"
+        onOpenChange={(next) => {
+          if (!next) closeModal()
+        }}
+        title="Revoke session"
+        description={
+          pending ? (
+            <Text.H5 color="foregroundMuted">
+              Sign <span className="font-medium text-foreground">{userEmail}</span> out of this single session.
+            </Text.H5>
+          ) : null
+        }
+        footer={
+          <div className="flex items-center justify-end gap-2">
+            <CloseTrigger />
+            <Button variant="default" size="sm" disabled={isSubmitting} onClick={() => void handleConfirm()}>
+              {isSubmitting ? "Revoking…" : "Revoke session"}
+            </Button>
+          </div>
+        }
+      >
+        {pending && (
+          <div className="flex flex-col gap-3">
+            <Alert
+              variant="warning"
+              description="The user will be signed out of this browser/device on its next request. Their other sessions are not affected."
+            />
+            <RevokeModalSummary session={pending} />
+          </div>
+        )}
+      </Modal>
+    </DashboardSection>
+  )
+}
+
+/**
+ * Compact summary of the session being revoked, rendered inside the
+ * confirmation modal so the actor can sanity-check they're about to
+ * drop the right row before clicking through.
+ */
+function RevokeModalSummary({ session }: { readonly session: AdminUserSessionDto }) {
+  const DeviceIcon = deviceIconFor(session.deviceKind)
+  const browserLabel =
+    session.browserName && session.osName
+      ? `${session.browserName} on ${session.osName}`
+      : session.browserName || session.osName || "Unknown browser"
+
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-border bg-muted/20 px-3 py-2">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+        <Icon icon={DeviceIcon} size="sm" color="foregroundMuted" />
+      </div>
+      <div className="flex min-w-0 flex-col">
+        <Text.H5 weight="medium" ellipsis noWrap>
+          {browserLabel}
+        </Text.H5>
+        <Text.H6 color="foregroundMuted" ellipsis noWrap>
+          {formatLocation(session.geo)}
+          {session.ipAddress ? ` · ${session.ipAddress}` : ""}
+        </Text.H6>
+      </div>
+    </div>
+  )
+}
+
+const DEVICE_ICON: Record<string, typeof MonitorIcon> = {
+  desktop: MonitorIcon,
+  mobile: SmartphoneIcon,
+  tablet: TabletIcon,
+}
+
+function deviceIconFor(deviceKind: string): typeof MonitorIcon {
+  return DEVICE_ICON[deviceKind] ?? MonitorIcon
+}
+
+function formatLocation(geo: AdminUserSessionDto["geo"]): string {
+  if (!geo) return "Unknown location"
+  const parts = [geo.city, geo.region, geo.country].filter((p): p is string => typeof p === "string" && p.length > 0)
+  return parts.length === 0 ? "Unknown location" : parts.join(", ")
+}
+
+function SessionRow({
+  session,
+  isRevoking,
+  onRevokeClick,
+}: {
+  readonly session: AdminUserSessionDto
+  readonly isRevoking: boolean
+  readonly onRevokeClick: () => void
+}) {
+  const DeviceIcon = deviceIconFor(session.deviceKind)
+  const browserLabel =
+    session.browserName && session.osName
+      ? `${session.browserName} on ${session.osName}`
+      : session.browserName || session.osName || "Unknown browser"
+  const isImpersonation = session.impersonatedByUserId !== null
+
+  return (
+    <div
+      className={[
+        "flex flex-col gap-2 rounded-md border bg-background px-4 py-3",
+        isImpersonation ? "border-warning-muted-foreground/40 bg-warning-muted/20" : "border-border",
+      ].join(" ")}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted">
+            <Icon icon={DeviceIcon} size="sm" color="foregroundMuted" />
+          </div>
+          <div className="flex min-w-0 flex-col">
+            <div className="flex items-center gap-2">
+              <Text.H5 weight="medium" ellipsis noWrap>
+                {browserLabel}
+              </Text.H5>
+              {isImpersonation && (
+                <Badge variant="outlineWarningMuted" iconProps={{ icon: ShieldAlertIcon, placement: "start" }}>
+                  impersonated
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Icon icon={GlobeIcon} size="xs" color="foregroundMuted" />
+              <Text.H6 color="foregroundMuted" ellipsis noWrap>
+                {formatLocation(session.geo)}
+              </Text.H6>
+              {session.ipAddress && (
+                <>
+                  <span aria-hidden="true" className="text-muted-foreground">
+                    ·
+                  </span>
+                  <a
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                    href={`https://ipinfo.io/${encodeURIComponent(session.ipAddress)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Text.H6 color="foregroundMuted" noWrap>
+                      {session.ipAddress}
+                    </Text.H6>
+                    <Icon icon={ExternalLinkIcon} size="xs" color="foregroundMuted" />
+                  </a>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        <Button variant="outline" size="sm" disabled={isRevoking} onClick={onRevokeClick}>
+          {isRevoking ? "Revoking…" : "Revoke"}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pl-12">
+        <Text.H6 color="foregroundMuted">
+          last active <span className="text-foreground">{relativeTime(session.updatedAt)}</span>
+        </Text.H6>
+        <span aria-hidden="true" className="text-muted-foreground">
+          ·
+        </span>
+        <Text.H6 color="foregroundMuted">
+          started <span className="text-foreground">{relativeTime(session.createdAt)}</span>
+        </Text.H6>
+        <span aria-hidden="true" className="text-muted-foreground">
+          ·
+        </span>
+        <Text.H6 color="foregroundMuted">
+          expires <span className="text-foreground">{relativeTime(session.expiresAt)}</span>
+        </Text.H6>
+        {isImpersonation && (
+          <>
+            <span aria-hidden="true" className="text-muted-foreground">
+              ·
+            </span>
+            <Text.H6 color="foregroundMuted">
+              by <span className="text-foreground">{session.impersonatedByEmail ?? session.impersonatedByUserId}</span>
+            </Text.H6>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/backoffice/-components/sessions-panel.tsx
+++ b/apps/web/src/routes/backoffice/-components/sessions-panel.tsx
@@ -56,7 +56,7 @@ export function SessionsPanel({ userId, userEmail, sessions }: SessionsPanelProp
     setIsSubmitting(true)
     try {
       await adminRevokeUserSession({
-        data: { userId, sessionId: pending.id, sessionToken: pending.token },
+        data: { userId, sessionId: pending.id },
       })
       toast({ description: "Session revoked." })
       void router.invalidate()

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,9 +1,10 @@
 import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { EyeIcon } from "lucide-react"
+import { EyeIcon, ShieldCheckIcon } from "lucide-react"
 import type { AdminUserDetailsDto, AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
+import { PromoteDemoteStaffButton } from "../-components/account-actions/promote-demote.tsx"
 import { AccountActionRow, AccountActionsSection } from "../-components/account-actions/section.tsx"
 import {
   DashboardHero,
@@ -107,6 +108,16 @@ function BackofficeUserDetailPage() {
           title="Impersonate user"
           description="Sign in as this user for support purposes. The impersonation banner shows on every page until you stop."
           action={<ImpersonateUserButton userId={user.id} userEmail={user.email} />}
+        />
+        <AccountActionRow
+          icon={ShieldCheckIcon}
+          title={user.role === "admin" ? "Demote from staff" : "Promote to staff"}
+          description={
+            user.role === "admin"
+              ? "Revoke this user's platform-staff access. They keep their organization memberships."
+              : "Grant this user platform-staff access — backoffice + cross-org visibility + impersonation."
+          }
+          action={<PromoteDemoteStaffButton userId={user.id} userEmail={user.email} currentRole={user.role} />}
         />
       </AccountActionsSection>
 

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,9 +1,10 @@
 import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { EyeIcon, ShieldCheckIcon } from "lucide-react"
+import { AtSignIcon, EyeIcon, ShieldCheckIcon } from "lucide-react"
 import type { AdminUserDetailsDto, AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
+import { ChangeEmailButton } from "../-components/account-actions/change-email.tsx"
 import { PromoteDemoteStaffButton } from "../-components/account-actions/promote-demote.tsx"
 import { AccountActionRow, AccountActionsSection } from "../-components/account-actions/section.tsx"
 import {
@@ -118,6 +119,12 @@ function BackofficeUserDetailPage() {
               : "Grant this user platform-staff access — backoffice + cross-org visibility + impersonation."
           }
           action={<PromoteDemoteStaffButton userId={user.id} userEmail={user.email} currentRole={user.role} />}
+        />
+        <AccountActionRow
+          icon={AtSignIcon}
+          title="Change email"
+          description="Update this user's primary login email. Useful for typo corrections at sign-up. Active sessions are not signed out."
+          action={<ChangeEmailButton userId={user.id} currentEmail={user.email} />}
         />
       </AccountActionsSection>
 

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -16,6 +16,7 @@ import {
 } from "../-components/dashboard/index.ts"
 import { ImpersonateUserButton } from "../-components/impersonate-user-button.tsx"
 import { MemberRoleBadge, PlatformStaffBadge } from "../-components/role-badges.tsx"
+import { SessionsPanel } from "../-components/sessions-panel.tsx"
 import { useTrackRecentBackofficeView } from "../-lib/recently-viewed.ts"
 
 export const Route = createFileRoute("/backoffice/users/$userId")({
@@ -103,6 +104,8 @@ function BackofficeUserDetailPage() {
           <MembershipsGrid memberships={memberships} />
         )}
       </DashboardSection>
+
+      <SessionsPanel userId={user.id} userEmail={user.email} sessions={user.sessions} />
 
       <AccountActionsSection>
         <AccountActionRow

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,11 +1,12 @@
 import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { AtSignIcon, EyeIcon, ShieldCheckIcon } from "lucide-react"
+import { AtSignIcon, EyeIcon, LogOutIcon, ShieldCheckIcon } from "lucide-react"
 import type { AdminUserDetailsDto, AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
 import { ChangeEmailButton } from "../-components/account-actions/change-email.tsx"
 import { PromoteDemoteStaffButton } from "../-components/account-actions/promote-demote.tsx"
+import { RevokeAllSessionsButton } from "../-components/account-actions/revoke-all-sessions.tsx"
 import { AccountActionRow, AccountActionsSection } from "../-components/account-actions/section.tsx"
 import {
   DashboardHero,
@@ -125,6 +126,12 @@ function BackofficeUserDetailPage() {
           title="Change email"
           description="Update this user's primary login email. Useful for typo corrections at sign-up. Active sessions are not signed out."
           action={<ChangeEmailButton userId={user.id} currentEmail={user.email} />}
+        />
+        <AccountActionRow
+          icon={LogOutIcon}
+          title="Revoke all sessions"
+          description="Sign this user out of every browser and device. They keep all their data and memberships."
+          action={<RevokeAllSessionsButton userId={user.id} userEmail={user.email} />}
         />
       </AccountActionsSection>
 

--- a/apps/web/src/routes/backoffice/users/$userId.tsx
+++ b/apps/web/src/routes/backoffice/users/$userId.tsx
@@ -1,8 +1,10 @@
 import { Avatar, Text } from "@repo/ui"
 import { relativeTime } from "@repo/utils"
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { EyeIcon } from "lucide-react"
 import type { AdminUserDetailsDto, AdminUserDetailsMembershipDto } from "../../../domains/admin/users.functions.ts"
 import { adminGetUser } from "../../../domains/admin/users.functions.ts"
+import { AccountActionRow, AccountActionsSection } from "../-components/account-actions/section.tsx"
 import {
   DashboardHero,
   DashboardSection,
@@ -98,6 +100,15 @@ function BackofficeUserDetailPage() {
           <MembershipsGrid memberships={memberships} />
         )}
       </DashboardSection>
+
+      <AccountActionsSection>
+        <AccountActionRow
+          icon={EyeIcon}
+          title="Impersonate user"
+          description="Sign in as this user for support purposes. The impersonation banner shows on every page until you stop."
+          action={<ImpersonateUserButton userId={user.id} userEmail={user.email} />}
+        />
+      </AccountActionsSection>
 
       <PropertiesStrip entries={propertyEntries} />
     </div>

--- a/apps/web/src/server/geoip.ts
+++ b/apps/web/src/server/geoip.ts
@@ -1,0 +1,163 @@
+import { parseEnvOptional } from "@platform/env"
+import { createLogger } from "@repo/observability"
+import { Effect } from "effect"
+import { getRedisClient } from "./clients.ts"
+
+/**
+ * GeoIP lookup helper used by the backoffice Sessions panel to label a
+ * session row with its approximate location.
+ *
+ * Strategy:
+ * - **RFC 1918 / loopback / link-local IPs short-circuit to `null`.**
+ *   The UI surfaces these as "Local network" so the absence of a city
+ *   reads intentionally rather than as a lookup failure.
+ * - **Redis cache (`geoip:<ip>`, 24 h TTL) absorbs the steady-state
+ *   load.** A staff member opening the same dashboard 30 times in a
+ *   day issues at most one upstream call per IP per day.
+ * - **`ipinfo.io` free tier on miss.** Anonymous tier is rate-limited
+ *   to ~50k req/month per IP, which is comfortably above the load a
+ *   handful of staff opening dashboards generates. Set
+ *   `LAT_IPINFO_TOKEN` to use the authenticated tier when usage grows.
+ * - **Failures fall through to `null`.** A flaky upstream must never
+ *   block the dashboard — the UI shows "Unknown" for the location
+ *   field when this returns null.
+ *
+ * Negative results (an IP we couldn't resolve) are also cached, with a
+ * shorter TTL, so a transient outage doesn't cause every page load to
+ * re-issue the upstream request for the same hot IPs.
+ */
+
+const logger = createLogger("admin-geoip")
+
+const POSITIVE_TTL_SECONDS = 60 * 60 * 24
+const NEGATIVE_TTL_SECONDS = 60 * 5
+
+export interface GeoIpInfo {
+  /** Two-letter ISO country code (e.g. "US"). */
+  readonly country: string | null
+  /** City name as ipinfo reports it, when available. */
+  readonly city: string | null
+  /** Region / state, when available. */
+  readonly region: string | null
+}
+
+const IPINFO_RESPONSE_KEYS = ["country", "city", "region"] as const
+
+/**
+ * RFC 1918, RFC 4193, link-local, and loopback ranges. We don't bother
+ * pulling in a CIDR library — the leading-octet test catches every
+ * private range that a normal session row would carry, and false
+ * positives here just mean we skip a lookup we couldn't have completed
+ * anyway (ipinfo's free tier returns 404 for private IPs).
+ */
+const isPrivateOrLocalIp = (ip: string): boolean => {
+  const trimmed = ip.trim()
+  if (trimmed === "" || trimmed === "::1" || trimmed === "127.0.0.1") return true
+  // IPv6 link-local / unique-local
+  if (trimmed.toLowerCase().startsWith("fe80:") || trimmed.toLowerCase().startsWith("fc")) return true
+  if (trimmed.toLowerCase().startsWith("fd")) return true
+  // IPv4 private ranges
+  if (trimmed.startsWith("10.")) return true
+  if (trimmed.startsWith("192.168.")) return true
+  if (trimmed.startsWith("169.254.")) return true
+  if (trimmed.startsWith("172.")) {
+    const second = Number(trimmed.split(".")[1])
+    if (Number.isInteger(second) && second >= 16 && second <= 31) return true
+  }
+  return false
+}
+
+const buildCacheKey = (ip: string) => `geoip:${ip}`
+
+const NEGATIVE_SENTINEL = "__null__"
+
+const readFromCache = async (ip: string): Promise<GeoIpInfo | null | undefined> => {
+  try {
+    const cached = await getRedisClient().get(buildCacheKey(ip))
+    if (cached === null) return undefined
+    if (cached === NEGATIVE_SENTINEL) return null
+    const parsed: unknown = JSON.parse(cached)
+    if (parsed && typeof parsed === "object" && "country" in parsed) {
+      return parsed as GeoIpInfo
+    }
+  } catch (error) {
+    logger.warn("geoip cache read failed", error)
+  }
+  return undefined
+}
+
+const writeToCache = async (ip: string, info: GeoIpInfo | null): Promise<void> => {
+  try {
+    if (info === null) {
+      await getRedisClient().set(buildCacheKey(ip), NEGATIVE_SENTINEL, "EX", NEGATIVE_TTL_SECONDS)
+    } else {
+      await getRedisClient().set(buildCacheKey(ip), JSON.stringify(info), "EX", POSITIVE_TTL_SECONDS)
+    }
+  } catch (error) {
+    logger.warn("geoip cache write failed", error)
+  }
+}
+
+const fetchFromIpinfo = async (ip: string): Promise<GeoIpInfo | null> => {
+  const token = Effect.runSync(parseEnvOptional("LAT_IPINFO_TOKEN", "string"))
+  const url = token
+    ? `https://ipinfo.io/${encodeURIComponent(ip)}?token=${encodeURIComponent(token)}`
+    : `https://ipinfo.io/${encodeURIComponent(ip)}/json`
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      // ipinfo's edges are fast — a generous-but-bounded timeout keeps a
+      // single slow lookup from stalling the whole dashboard render.
+      signal: AbortSignal.timeout(2000),
+    })
+    if (!response.ok) {
+      return null
+    }
+    const json = (await response.json()) as Record<string, unknown>
+    const result: Record<string, string | null> = {}
+    for (const key of IPINFO_RESPONSE_KEYS) {
+      const raw = json[key]
+      result[key] = typeof raw === "string" && raw.length > 0 ? raw : null
+    }
+    if (result.country === null && result.city === null && result.region === null) {
+      return null
+    }
+    return result as unknown as GeoIpInfo
+  } catch (error) {
+    logger.warn(`geoip fetch failed for ${ip}`, error)
+    return null
+  }
+}
+
+/**
+ * Resolve `ip` to a coarse location. Returns `null` for private,
+ * loopback, link-local, or unresolvable addresses. Caches positive
+ * results for 24 h and negative results for 5 min via Redis.
+ *
+ * Module-private — call sites use {@link lookupGeoIpBatch} so the
+ * dedupe + parallel-fetch optimisation is applied uniformly.
+ */
+const lookupGeoIp = async (ip: string | null | undefined): Promise<GeoIpInfo | null> => {
+  if (!ip || isPrivateOrLocalIp(ip)) return null
+
+  const cached = await readFromCache(ip)
+  if (cached !== undefined) return cached
+
+  const fresh = await fetchFromIpinfo(ip)
+  await writeToCache(ip, fresh)
+  return fresh
+}
+
+/**
+ * Look up multiple IPs in one shot, deduping by address so a dashboard
+ * with several sessions at the same IP issues a single upstream call.
+ * Returns a map keyed by the original IP string. Failures surface as
+ * `null` in the map.
+ */
+export const lookupGeoIpBatch = async (
+  ips: ReadonlyArray<string | null | undefined>,
+): Promise<ReadonlyMap<string, GeoIpInfo | null>> => {
+  const unique = Array.from(new Set(ips.filter((ip): ip is string => typeof ip === "string" && ip.length > 0)))
+  const entries = await Promise.all(unique.map(async (ip) => [ip, await lookupGeoIp(ip)] as const))
+  return new Map(entries)
+}

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -163,6 +163,7 @@ export const createDomainEventsWorker = ({
     AdminImpersonationStarted: () => Effect.void,
     AdminImpersonationStopped: () => Effect.void,
     AdminUserRoleChanged: () => Effect.void,
+    AdminUserEmailChanged: () => Effect.void,
   }
 
   consumer.subscribe("domain-events", {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -165,6 +165,7 @@ export const createDomainEventsWorker = ({
     AdminUserRoleChanged: () => Effect.void,
     AdminUserEmailChanged: () => Effect.void,
     AdminUserSessionsRevoked: () => Effect.void,
+    AdminUserSessionRevoked: () => Effect.void,
   }
 
   consumer.subscribe("domain-events", {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -164,6 +164,7 @@ export const createDomainEventsWorker = ({
     AdminImpersonationStopped: () => Effect.void,
     AdminUserRoleChanged: () => Effect.void,
     AdminUserEmailChanged: () => Effect.void,
+    AdminUserSessionsRevoked: () => Effect.void,
   }
 
   consumer.subscribe("domain-events", {

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -162,6 +162,7 @@ export const createDomainEventsWorker = ({
     // every key in `EventPayloads` and would fail typecheck otherwise.
     AdminImpersonationStarted: () => Effect.void,
     AdminImpersonationStopped: () => Effect.void,
+    AdminUserRoleChanged: () => Effect.void,
   }
 
   consumer.subscribe("domain-events", {

--- a/packages/domain/admin/src/users/get-active-session-token.test.ts
+++ b/packages/domain/admin/src/users/get-active-session-token.test.ts
@@ -1,0 +1,41 @@
+import { NotFoundError, type UserId } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import { getActiveSessionTokenUseCase } from "./get-active-session-token.ts"
+import { AdminUserRepository } from "./user-repository.ts"
+
+const USER_ID = "user-target" as UserId
+const SESSION_ID = "sess-abc"
+
+const successfulRepo = (token: string) =>
+  Layer.succeed(AdminUserRepository, {
+    findById: () => Effect.fail(new NotFoundError({ entity: "User", id: USER_ID })),
+    findActiveSessionTokenForUser: () => Effect.succeed(token),
+  })
+
+const missingRepo = () =>
+  Layer.succeed(AdminUserRepository, {
+    findById: () => Effect.fail(new NotFoundError({ entity: "User", id: USER_ID })),
+    findActiveSessionTokenForUser: (_uid, sessionId) =>
+      Effect.fail(new NotFoundError({ entity: "Session", id: sessionId })),
+  })
+
+describe("getActiveSessionTokenUseCase", () => {
+  it("returns the token from the repository on success", async () => {
+    const result = await Effect.runPromise(
+      getActiveSessionTokenUseCase({ userId: USER_ID, sessionId: SESSION_ID }).pipe(
+        Effect.provide(successfulRepo("tok-live")),
+      ),
+    )
+
+    expect(result).toBe("tok-live")
+  })
+
+  it("surfaces NotFoundError verbatim when the repo does not find a matching session", async () => {
+    await expect(
+      Effect.runPromise(
+        getActiveSessionTokenUseCase({ userId: USER_ID, sessionId: SESSION_ID }).pipe(Effect.provide(missingRepo())),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Session" })
+  })
+})

--- a/packages/domain/admin/src/users/get-active-session-token.ts
+++ b/packages/domain/admin/src/users/get-active-session-token.ts
@@ -1,0 +1,34 @@
+import type { NotFoundError, RepositoryError, UserId } from "@domain/shared"
+import { Effect } from "effect"
+import { AdminUserRepository } from "./user-repository.ts"
+
+export interface GetActiveSessionTokenInput {
+  readonly userId: UserId
+  readonly sessionId: string
+}
+
+/**
+ * Resolve the Better Auth session token for an active session that
+ * belongs to the given user. Used by the per-session Revoke flow on
+ * the backoffice Sessions panel — see
+ * `apps/web/src/domains/admin/users.functions.ts:adminRevokeUserSession`.
+ *
+ * The token is read **server-side at revoke time** rather than being
+ * surfaced through the `AdminUserDetails` DTO. That keeps a live
+ * authentication credential out of wire payloads, browser memory,
+ * and consumer logs, and makes ownership verification a precondition
+ * of finding the row at all (the repository's WHERE clause requires
+ * a match on `(sessionId, userId, expiresAt > now())`).
+ *
+ * Fails with `NotFoundError` when the session id either doesn't
+ * exist, belongs to a different user, or has already expired.
+ */
+export const getActiveSessionTokenUseCase = (
+  input: GetActiveSessionTokenInput,
+): Effect.Effect<string, NotFoundError | RepositoryError, AdminUserRepository> =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("admin.targetUserId", input.userId)
+    yield* Effect.annotateCurrentSpan("admin.targetSessionId", input.sessionId)
+    const repo = yield* AdminUserRepository
+    return yield* repo.findActiveSessionTokenForUser(input.userId, input.sessionId)
+  }).pipe(Effect.withSpan("admin.getActiveSessionToken"))

--- a/packages/domain/admin/src/users/get-user-details.test.ts
+++ b/packages/domain/admin/src/users/get-user-details.test.ts
@@ -24,6 +24,7 @@ const mkDetails = (overrides: Partial<AdminUserDetails> = {}): AdminUserDetails 
   image: null,
   role: "user",
   memberships: [],
+  sessions: [],
   createdAt: new Date("2024-01-01"),
   ...overrides,
 })

--- a/packages/domain/admin/src/users/get-user-details.test.ts
+++ b/packages/domain/admin/src/users/get-user-details.test.ts
@@ -7,14 +7,21 @@ import { AdminUserRepository } from "./user-repository.ts"
 
 const TARGET_ID = "user-target" as UserId
 
+// Stub for the second port method — `getUserDetailsUseCase` doesn't
+// exercise it, but the `Service` shape requires both implementations.
+const stubFindActiveSessionTokenForUser = (_userId: UserId, sessionId: string) =>
+  Effect.fail(new NotFoundError({ entity: "Session", id: sessionId }))
+
 const successfulRepo = (result: AdminUserDetails) =>
   Layer.succeed(AdminUserRepository, {
     findById: () => Effect.succeed(result),
+    findActiveSessionTokenForUser: stubFindActiveSessionTokenForUser,
   })
 
 const missingRepo = () =>
   Layer.succeed(AdminUserRepository, {
     findById: (id) => Effect.fail(new NotFoundError({ entity: "User", id })),
+    findActiveSessionTokenForUser: stubFindActiveSessionTokenForUser,
   })
 
 const mkDetails = (overrides: Partial<AdminUserDetails> = {}): AdminUserDetails => ({

--- a/packages/domain/admin/src/users/index.ts
+++ b/packages/domain/admin/src/users/index.ts
@@ -1,3 +1,7 @@
+export {
+  type GetActiveSessionTokenInput,
+  getActiveSessionTokenUseCase,
+} from "./get-active-session-token.ts"
 export { type GetUserDetailsInput, getUserDetailsUseCase } from "./get-user-details.ts"
 export {
   type AdminUserDetails,

--- a/packages/domain/admin/src/users/index.ts
+++ b/packages/domain/admin/src/users/index.ts
@@ -2,7 +2,9 @@ export { type GetUserDetailsInput, getUserDetailsUseCase } from "./get-user-deta
 export {
   type AdminUserDetails,
   type AdminUserMembership,
+  type AdminUserSession,
   adminUserDetailsSchema,
   adminUserMembershipSchema,
+  adminUserSessionSchema,
 } from "./user-details.ts"
 export { AdminUserRepository } from "./user-repository.ts"

--- a/packages/domain/admin/src/users/user-details.ts
+++ b/packages/domain/admin/src/users/user-details.ts
@@ -25,13 +25,15 @@ export type AdminUserMembership = z.infer<typeof adminUserMembershipSchema>
  * second-pass lookup so audit views can read "Carlos was impersonating
  * this session" without a join in every consumer.
  *
- * `token` is the value Better Auth's `revokeUserSession` admin
- * endpoint takes — we surface it here so the per-row Revoke button
- * has the identifier it needs without re-fetching the session.
+ * The session **token** is intentionally NOT exposed here — it's a
+ * live authentication credential and surfacing it through the
+ * domain DTO would let it reach the wire payload, browser memory,
+ * and any consumer logging the result. The per-session Revoke flow
+ * resolves the token server-side at revoke time via
+ * {@link AdminUserRepository.findActiveSessionTokenForUser}.
  */
 export const adminUserSessionSchema = z.object({
   id: z.string(),
-  token: z.string(),
   ipAddress: z.string().nullable(),
   userAgent: z.string().nullable(),
   createdAt: z.date(),

--- a/packages/domain/admin/src/users/user-details.ts
+++ b/packages/domain/admin/src/users/user-details.ts
@@ -18,6 +18,37 @@ export const adminUserMembershipSchema = z.object({
 })
 export type AdminUserMembership = z.infer<typeof adminUserMembershipSchema>
 
+/**
+ * Snapshot of a Better Auth session row for the backoffice Sessions
+ * panel. The shape mirrors the underlying table 1:1 except for
+ * `impersonatedByEmail`, which the repository resolves with a
+ * second-pass lookup so audit views can read "Carlos was impersonating
+ * this session" without a join in every consumer.
+ *
+ * `token` is the value Better Auth's `revokeUserSession` admin
+ * endpoint takes — we surface it here so the per-row Revoke button
+ * has the identifier it needs without re-fetching the session.
+ */
+export const adminUserSessionSchema = z.object({
+  id: z.string(),
+  token: z.string(),
+  ipAddress: z.string().nullable(),
+  userAgent: z.string().nullable(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  expiresAt: z.date(),
+  impersonatedByUserId: z.string().nullable(),
+  /**
+   * Email of the admin currently impersonating this session, when
+   * `impersonatedByUserId` is set and the admin row still exists.
+   * Resolved as a best-effort hint at fetch time — the audit trail of
+   * record lives on `AdminImpersonationStarted` events, not on this
+   * field.
+   */
+  impersonatedByEmail: z.string().nullable(),
+})
+export type AdminUserSession = z.infer<typeof adminUserSessionSchema>
+
 export const adminUserDetailsSchema = z.object({
   id: z.string(),
   email: z.string(),
@@ -25,6 +56,12 @@ export const adminUserDetailsSchema = z.object({
   image: z.string().nullable(),
   role: z.enum(["user", "admin"]),
   memberships: z.array(adminUserMembershipSchema),
+  /**
+   * Active sessions for this user (`expiresAt > now()` at the moment
+   * of the fetch). Sorted impersonation-first, then by `updatedAt`
+   * descending so the most-recently-active row reads at the top.
+   */
+  sessions: z.array(adminUserSessionSchema),
   createdAt: z.date(),
 })
 export type AdminUserDetails = z.infer<typeof adminUserDetailsSchema>

--- a/packages/domain/admin/src/users/user-repository.ts
+++ b/packages/domain/admin/src/users/user-repository.ts
@@ -19,5 +19,19 @@ export class AdminUserRepository extends ServiceMap.Service<
      * on this precondition.
      */
     findById(userId: UserId): Effect.Effect<AdminUserDetails, NotFoundError | RepositoryError>
+    /**
+     * Resolve the Better Auth session token for an **active** session
+     * (`expires_at > now()`) that belongs to the given user. Used by
+     * the per-session Revoke flow to look up the credential
+     * server-side, so the token never has to round-trip through the
+     * client. Fails with `NotFoundError` when no such session exists
+     * — both "session id doesn't exist" and "session belongs to a
+     * different user" collapse into the same error so a probing
+     * caller can't distinguish the two.
+     */
+    findActiveSessionTokenForUser(
+      userId: UserId,
+      sessionId: string,
+    ): Effect.Effect<string, NotFoundError | RepositoryError>
   }
 >()("@domain/admin/AdminUserRepository") {}

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -148,4 +148,18 @@ export interface EventPayloads {
     readonly adminUserId: string
     readonly targetUserId: string
   }
+  /**
+   * Emitted when a platform admin changes another user's `users.role`
+   * via the backoffice ("Promote to staff" / "Demote from staff").
+   * `fromRole` and `toRole` are stored explicitly so audit queries
+   * don't have to reconstruct the transition from a delta on the
+   * users table — the row is mutable, so the historical snapshot
+   * lives in the event payload.
+   */
+  AdminUserRoleChanged: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+    readonly fromRole: "user" | "admin"
+    readonly toRole: "user" | "admin"
+  }
 }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -192,4 +192,20 @@ export interface EventPayloads {
     readonly targetUserId: string
     readonly sessionCount: number
   }
+  /**
+   * Emitted when a platform admin signs a user out of a single
+   * session via the per-row Revoke button on the Sessions panel.
+   * The session row carries `sessionId` so audit consumers can
+   * cross-reference the snapshot the admin saw against the row that
+   * was deleted — useful when investigating "which device was
+   * disconnected, and from where?". The session token is
+   * intentionally NOT included on the event: the row is destroyed
+   * immediately and storing the token would needlessly persist a
+   * dead authentication credential in the audit log.
+   */
+  AdminUserSessionRevoked: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+    readonly sessionId: string
+  }
 }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -162,4 +162,19 @@ export interface EventPayloads {
     readonly fromRole: "user" | "admin"
     readonly toRole: "user" | "admin"
   }
+  /**
+   * Emitted when a platform admin updates a user's primary email
+   * via the backoffice. Snapshot both addresses so audit queries
+   * can attribute future logins under the new email back to the
+   * admin who renamed the account. Issued via Better Auth's
+   * `adminUpdateUser` endpoint, which writes through the internal
+   * adapter — `emailVerified` is intentionally left untouched
+   * (admins routinely correct typos for users who already verified).
+   */
+  AdminUserEmailChanged: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+    readonly fromEmail: string
+    readonly toEmail: string
+  }
 }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -177,4 +177,19 @@ export interface EventPayloads {
     readonly fromEmail: string
     readonly toEmail: string
   }
+  /**
+   * Emitted when a platform admin signs a user out of every active
+   * session ("Revoke all sessions" in the backoffice). `sessionCount`
+   * is captured at the moment of revocation as a best-effort hint —
+   * useful for audit queries like "did the admin actually log
+   * anybody out, or did the user have no active sessions anyway?"
+   * — and intentionally not used as a source of truth (Better Auth
+   * could roll up sessions between the listing call and the
+   * revocation).
+   */
+  AdminUserSessionsRevoked: {
+    readonly adminUserId: string
+    readonly targetUserId: string
+    readonly sessionCount: number
+  }
 }

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
@@ -19,6 +19,9 @@ const ORG_B = makeId("org-user-beta")
 const TARGET = makeId("user-target")
 const UNMEMBERED = makeId("user-unmembered")
 const ADMIN = makeId("user-admin-imper")
+const SESSION_LIVE = makeId("s-live")
+const SESSION_IMP = makeId("s-imp")
+const SESSION_DEAD = makeId("s-dead")
 const FUTURE = new Date("2099-01-01T00:00:00.000Z")
 const PAST = new Date("2020-01-01T00:00:00.000Z")
 
@@ -72,7 +75,7 @@ describe("AdminUserRepositoryLive.findById", () => {
     //   - DEAD: an expired session (must be filtered out)
     await pg.db.insert(sessions).values([
       {
-        id: makeId("s-live"),
+        id: SESSION_LIVE,
         userId: TARGET,
         token: "tok-live",
         ipAddress: "203.0.113.5",
@@ -82,7 +85,7 @@ describe("AdminUserRepositoryLive.findById", () => {
         updatedAt: new Date("2025-06-02T11:00:00.000Z"),
       },
       {
-        id: makeId("s-imp"),
+        id: SESSION_IMP,
         userId: TARGET,
         token: "tok-imp",
         ipAddress: "203.0.113.10",
@@ -95,7 +98,7 @@ describe("AdminUserRepositoryLive.findById", () => {
         updatedAt: new Date("2025-06-02T09:00:00.000Z"),
       },
       {
-        id: makeId("s-dead"),
+        id: SESSION_DEAD,
         userId: TARGET,
         token: "tok-dead",
         ipAddress: "203.0.113.99",
@@ -146,9 +149,9 @@ describe("AdminUserRepositoryLive.findById", () => {
       }),
     )
 
-    // The expired `tok-dead` session is filtered out by the
+    // The expired `s-dead` session is filtered out by the
     // `expires_at > now()` predicate; only the two live rows remain.
-    expect(result.sessions.map((s) => s.token)).toEqual(["tok-imp", "tok-live"])
+    expect(result.sessions.map((s) => s.id)).toEqual([SESSION_IMP, SESSION_LIVE])
 
     const [imp, live] = result.sessions
     if (!imp || !live) throw new Error("expected two sessions")
@@ -156,6 +159,19 @@ describe("AdminUserRepositoryLive.findById", () => {
     expect(imp.impersonatedByEmail).toBe("admin@latitude.so")
     expect(live.impersonatedByUserId).toBeNull()
     expect(live.impersonatedByEmail).toBeNull()
+  })
+
+  it("findById does NOT surface session tokens — they're a live credential and stay server-side", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findById(UserId(TARGET))
+      }),
+    )
+
+    for (const session of result.sessions) {
+      expect(session).not.toHaveProperty("token")
+    }
   })
 
   it("fails with NotFoundError for a non-existent user id", async () => {
@@ -167,5 +183,62 @@ describe("AdminUserRepositoryLive.findById", () => {
         }),
       ),
     ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "User" })
+  })
+})
+
+describe("AdminUserRepositoryLive.findActiveSessionTokenForUser", () => {
+  it("returns the token for an active session that belongs to the named user", async () => {
+    const token = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findActiveSessionTokenForUser(UserId(TARGET), SESSION_LIVE)
+      }),
+    )
+    expect(token).toBe("tok-live")
+  })
+
+  it("works for an impersonation session as well — token belongs to the impersonated user, not the admin", async () => {
+    const token = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findActiveSessionTokenForUser(UserId(TARGET), SESSION_IMP)
+      }),
+    )
+    expect(token).toBe("tok-imp")
+  })
+
+  it("fails with NotFoundError when the session id exists but belongs to a different user", async () => {
+    // SESSION_LIVE belongs to TARGET; asking under UNMEMBERED must
+    // collapse into NotFoundError (not return the token).
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminUserRepository
+          return yield* repo.findActiveSessionTokenForUser(UserId(UNMEMBERED), SESSION_LIVE)
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Session" })
+  })
+
+  it("fails with NotFoundError when the session is expired (the active-only filter applies)", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminUserRepository
+          return yield* repo.findActiveSessionTokenForUser(UserId(TARGET), SESSION_DEAD)
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Session" })
+  })
+
+  it("fails with NotFoundError for an unknown session id", async () => {
+    await expect(
+      runWithLive(
+        Effect.gen(function* () {
+          const repo = yield* AdminUserRepository
+          return yield* repo.findActiveSessionTokenForUser(UserId(TARGET), makeId("s-missing"))
+        }),
+      ),
+    ).rejects.toMatchObject({ _tag: "NotFoundError", entity: "Session" })
   })
 })

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.test.ts
@@ -2,7 +2,7 @@ import { AdminUserRepository } from "@domain/admin"
 import { UserId } from "@domain/shared"
 import { Effect } from "effect"
 import { beforeAll, describe, expect, it } from "vitest"
-import { members, organizations, users } from "../schema/better-auth.ts"
+import { members, organizations, sessions, users } from "../schema/better-auth.ts"
 import { setupTestPostgres } from "../test/in-memory-postgres.ts"
 import { withPostgres } from "../with-postgres.ts"
 import { AdminUserRepositoryLive } from "./admin-user-repository.ts"
@@ -18,6 +18,9 @@ const ORG_A = makeId("org-user-alpha")
 const ORG_B = makeId("org-user-beta")
 const TARGET = makeId("user-target")
 const UNMEMBERED = makeId("user-unmembered")
+const ADMIN = makeId("user-admin-imper")
+const FUTURE = new Date("2099-01-01T00:00:00.000Z")
+const PAST = new Date("2020-01-01T00:00:00.000Z")
 
 describe("AdminUserRepositoryLive.findById", () => {
   beforeAll(async () => {
@@ -42,6 +45,15 @@ describe("AdminUserRepositoryLive.findById", () => {
         createdAt: baseTime,
         updatedAt: baseTime,
       },
+      {
+        id: ADMIN,
+        email: "admin@latitude.so",
+        name: "Admin User",
+        emailVerified: true,
+        role: "admin" as const,
+        createdAt: baseTime,
+        updatedAt: baseTime,
+      },
     ])
 
     await pg.db.insert(organizations).values([
@@ -52,6 +64,46 @@ describe("AdminUserRepositoryLive.findById", () => {
     await pg.db.insert(members).values([
       { id: makeId("mem-a"), organizationId: ORG_A, userId: TARGET, role: "member" as const, createdAt: baseTime },
       { id: makeId("mem-b"), organizationId: ORG_B, userId: TARGET, role: "owner" as const, createdAt: baseTime },
+    ])
+
+    // Three sessions for TARGET:
+    //   - LIVE: a normal browser session that should surface
+    //   - IMP : an active impersonation by ADMIN (should sort first)
+    //   - DEAD: an expired session (must be filtered out)
+    await pg.db.insert(sessions).values([
+      {
+        id: makeId("s-live"),
+        userId: TARGET,
+        token: "tok-live",
+        ipAddress: "203.0.113.5",
+        userAgent: "Mozilla/5.0",
+        expiresAt: FUTURE,
+        createdAt: new Date("2025-06-02T10:00:00.000Z"),
+        updatedAt: new Date("2025-06-02T11:00:00.000Z"),
+      },
+      {
+        id: makeId("s-imp"),
+        userId: TARGET,
+        token: "tok-imp",
+        ipAddress: "203.0.113.10",
+        userAgent: "Mozilla/5.0",
+        expiresAt: FUTURE,
+        impersonatedBy: ADMIN,
+        // updatedAt earlier than the live session — proves the
+        // impersonation-first sort beats the recency sort.
+        createdAt: new Date("2025-06-02T08:00:00.000Z"),
+        updatedAt: new Date("2025-06-02T09:00:00.000Z"),
+      },
+      {
+        id: makeId("s-dead"),
+        userId: TARGET,
+        token: "tok-dead",
+        ipAddress: "203.0.113.99",
+        userAgent: "Mozilla/5.0",
+        expiresAt: PAST,
+        createdAt: PAST,
+        updatedAt: PAST,
+      },
     ])
   })
 
@@ -83,6 +135,27 @@ describe("AdminUserRepositoryLive.findById", () => {
 
     expect(result.id).toBe(UNMEMBERED)
     expect(result.memberships).toEqual([])
+    expect(result.sessions).toEqual([])
+  })
+
+  it("returns only active sessions, sorts impersonation first, and resolves the impersonator email", async () => {
+    const result = await runWithLive(
+      Effect.gen(function* () {
+        const repo = yield* AdminUserRepository
+        return yield* repo.findById(UserId(TARGET))
+      }),
+    )
+
+    // The expired `tok-dead` session is filtered out by the
+    // `expires_at > now()` predicate; only the two live rows remain.
+    expect(result.sessions.map((s) => s.token)).toEqual(["tok-imp", "tok-live"])
+
+    const [imp, live] = result.sessions
+    if (!imp || !live) throw new Error("expected two sessions")
+    expect(imp.impersonatedByUserId).toBe(ADMIN)
+    expect(imp.impersonatedByEmail).toBe("admin@latitude.so")
+    expect(live.impersonatedByUserId).toBeNull()
+    expect(live.impersonatedByEmail).toBeNull()
   })
 
   it("fails with NotFoundError for a non-existent user id", async () => {

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
@@ -75,7 +75,6 @@ export const AdminUserRepositoryLive = Layer.effect(
             db
               .select({
                 id: sessions.id,
-                token: sessions.token,
                 ipAddress: sessions.ipAddress,
                 userAgent: sessions.userAgent,
                 createdAt: sessions.createdAt,
@@ -110,7 +109,6 @@ export const AdminUserRepositoryLive = Layer.effect(
           const userSessions: AdminUserSession[] = liveSessions
             .map((s) => ({
               id: s.id,
-              token: s.token,
               ipAddress: s.ipAddress ?? null,
               userAgent: s.userAgent ?? null,
               createdAt: s.createdAt,
@@ -142,6 +140,26 @@ export const AdminUserRepositoryLive = Layer.effect(
             createdAt: row.createdAt,
           }
           return details
+        }),
+      findActiveSessionTokenForUser: (userId, sessionId) =>
+        Effect.gen(function* () {
+          const now = new Date()
+          const rows = yield* sqlClient.query((db) =>
+            db
+              .select({ token: sessions.token })
+              .from(sessions)
+              .where(and(eq(sessions.id, sessionId), eq(sessions.userId, userId), gt(sessions.expiresAt, now)))
+              .limit(1),
+          )
+          const found = rows[0]
+          if (!found) {
+            // Collapse "session id not found" and "session belongs to
+            // another user" into the same NotFoundError so a probing
+            // caller can't distinguish the two — the existence of a
+            // session id under a different user is itself sensitive.
+            return yield* Effect.fail(new NotFoundError({ entity: "Session", id: sessionId }))
+          }
+          return found.token
         }),
     }
   }),

--- a/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/admin-user-repository.ts
@@ -1,9 +1,14 @@
-import { type AdminUserDetails, type AdminUserMembership, AdminUserRepository } from "@domain/admin"
+import {
+  type AdminUserDetails,
+  type AdminUserMembership,
+  AdminUserRepository,
+  type AdminUserSession,
+} from "@domain/admin"
 import { NotFoundError, SqlClient, type SqlClientShape, type UserId } from "@domain/shared"
-import { eq, inArray } from "drizzle-orm"
+import { and, eq, gt, inArray } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
-import { members, organizations, users } from "../schema/better-auth.ts"
+import { members, organizations, sessions, users } from "../schema/better-auth.ts"
 
 type UserRoleValue = AdminUserDetails["role"]
 type MemberRoleValue = AdminUserMembership["role"]
@@ -59,6 +64,68 @@ export const AdminUserRepositoryLive = Layer.effect(
               .orderBy(organizations.name),
           )
 
+          // Active sessions only — `expires_at > now()`. Better Auth's
+          // admin plugin enforces the same filter for `listUserSessions`,
+          // and surfacing already-expired rows would mislead staff into
+          // thinking sessions are live when they aren't. Filter in SQL
+          // so the wire-level payload doesn't carry the long tail of
+          // expired rows for chatty users.
+          const now = new Date()
+          const liveSessions = yield* sqlClient.query((db) =>
+            db
+              .select({
+                id: sessions.id,
+                token: sessions.token,
+                ipAddress: sessions.ipAddress,
+                userAgent: sessions.userAgent,
+                createdAt: sessions.createdAt,
+                updatedAt: sessions.updatedAt,
+                expiresAt: sessions.expiresAt,
+                impersonatedBy: sessions.impersonatedBy,
+              })
+              .from(sessions)
+              .where(and(eq(sessions.userId, row.id), gt(sessions.expiresAt, now)))
+              .orderBy(sessions.updatedAt),
+          )
+
+          // Best-effort cross-reference of impersonator emails so the
+          // UI can render "impersonated by carlos@latitude.so" inline
+          // without a second round-trip. We use a single lookup per
+          // distinct impersonator id; missing rows surface as `null`
+          // and the UI degrades to showing the raw user id.
+          const impersonatorIds = Array.from(
+            new Set(liveSessions.map((s) => s.impersonatedBy).filter((id): id is string => typeof id === "string")),
+          )
+          const impersonatorEmailById = new Map<string, string>()
+          if (impersonatorIds.length > 0) {
+            const impersonatorRows = yield* sqlClient.query((db) =>
+              db.select({ id: users.id, email: users.email }).from(users).where(inArray(users.id, impersonatorIds)),
+            )
+            for (const r of impersonatorRows) impersonatorEmailById.set(r.id, r.email)
+          }
+
+          // Sort impersonation rows first (red-flag rows belong at the
+          // top of the panel), then by `updatedAt` desc so the freshest
+          // activity reads first within each group.
+          const userSessions: AdminUserSession[] = liveSessions
+            .map((s) => ({
+              id: s.id,
+              token: s.token,
+              ipAddress: s.ipAddress ?? null,
+              userAgent: s.userAgent ?? null,
+              createdAt: s.createdAt,
+              updatedAt: s.updatedAt,
+              expiresAt: s.expiresAt,
+              impersonatedByUserId: s.impersonatedBy ?? null,
+              impersonatedByEmail: s.impersonatedBy ? (impersonatorEmailById.get(s.impersonatedBy) ?? null) : null,
+            }))
+            .sort((a, b) => {
+              const aImp = a.impersonatedByUserId !== null
+              const bImp = b.impersonatedByUserId !== null
+              if (aImp !== bImp) return aImp ? -1 : 1
+              return b.updatedAt.getTime() - a.updatedAt.getTime()
+            })
+
           const details: AdminUserDetails = {
             id: row.id,
             email: row.email,
@@ -71,6 +138,7 @@ export const AdminUserRepositoryLive = Layer.effect(
               organizationSlug: m.organizationSlug,
               role: m.role as MemberRoleValue,
             })),
+            sessions: userSessions,
             createdAt: row.createdAt,
           }
           return details

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,7 +257,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -454,6 +454,9 @@ importers:
       rosetta-ai:
         specifier: 'catalog:'
         version: 2.0.0
+      ua-parser-js:
+        specifier: ^2.0.6
+        version: 2.0.9
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -1796,13 +1799,13 @@ importers:
         version: 7.0.0-dev.20260421.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/claude-code:
     dependencies:
@@ -8104,6 +8107,9 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
+  detect-europe-js@0.1.2:
+    resolution: {integrity: sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -9040,6 +9046,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-standalone-pwa@0.1.1:
+    resolution: {integrity: sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -11086,6 +11095,13 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-is-frozen@0.1.2:
+    resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
+
+  ua-parser-js@2.0.9:
+    resolution: {integrity: sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==}
     hasBin: true
 
   ufo@1.6.3:
@@ -16199,6 +16215,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -17509,6 +17533,14 @@ snapshots:
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.1.0':
     dependencies:
       tinyrainbow: 3.1.0
@@ -18337,6 +18369,8 @@ snapshots:
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
+
+  detect-europe-js@0.1.2: {}
 
   detect-libc@2.1.2: {}
 
@@ -19293,6 +19327,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-standalone-pwa@0.1.1: {}
 
   is-stream@2.0.1: {}
 
@@ -21200,6 +21236,30 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -21911,6 +21971,14 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  ua-is-frozen@0.1.2: {}
+
+  ua-parser-js@2.0.9:
+    dependencies:
+      detect-europe-js: 0.1.2
+      is-standalone-pwa: 0.1.1
+      ua-is-frozen: 0.1.2
+
   ufo@1.6.3: {}
 
   uint8array-extras@1.5.0: {}
@@ -22117,6 +22185,25 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.14.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -22142,6 +22229,35 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.14.1
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

Builds out the user-detail dashboard at `/backoffice/users/$userId` with the support toolbox we needed beyond Impersonate. Five commits, each shipping a working subset:

1. **Account actions section** — collapsible `<details>`-based panel below Memberships, with the existing Impersonate as its first row.
2. **Promote / Demote staff** — single button that swaps label + variant based on `user.role`. Promote is single-confirm; Demote is destructive + checkbox-gated. Self-demotion is intentionally allowed.
3. **Change email** — form modal pre-filled with the current address (most common path is a typo correction at sign-up). Inline copy spells out the side effects: active sessions stay signed in, in-flight magic links keep working until they expire, `emailVerified` is preserved by design, Stripe is not auto-synced.
4. **Revoke all sessions** — warning-level modal, single-confirm. Drops every active session for the target user.
5. **Sessions panel** — sibling to Memberships. One row per active Better Auth session with device + OS, location, IP click-out to ipinfo.io, started / last-active / expires relative timestamps, impersonation chip when present, and a per-row Revoke button gated on an in-app `<Modal>` confirmation (no native `window.confirm`).

Every action is gated by `adminMiddleware`, audited via the outbox (events written before the Better Auth call so a failed call still leaves a trail of the attempt), and follows the same three-guard discipline as the existing impersonation flow.

## Implementation notes

### User-Agent parsing

Uses `ua-parser-js` server-side only — invoked inside the `adminGetUser` server function so the parsed `browserName` / `osName` / `deviceKind` arrives on the wire as plain strings. The TanStack Start compiler strips the dependency from the client bundle (verified by `check:bundle-size` — all client JS assets stay under 500 KiB).

### GeoIP resolution

`apps/web/src/server/geoip.ts` wraps ipinfo.io's free tier behind a Redis cache:

- **24 h TTL on positive results, 5 min on negative.** A staff member opening the same dashboard repeatedly issues at most one upstream call per IP per day. Negative caching prevents a transient outage from hammering ipinfo on every page load for the same hot IPs.
- **Private / loopback / link-local IPs short-circuit to `null`** without ever calling out — UI surfaces these as "Unknown location" so the absence of a city reads intentionally rather than as a lookup failure.
- **Failures fall through to `null`.** A flaky upstream must never block the dashboard render; a 2-second `AbortSignal.timeout` keeps a single slow lookup from stalling the page.
- **Optional `LAT_IPINFO_TOKEN`** — anonymous tier (~50 k req/month per source IP) is enough for staff-only traffic, but having a token raises the limit comfortably.

The `lookupGeoIpBatch` entry point dedupes by IP before issuing parallel fetches, so a user with five sessions on the same address triggers a single upstream call.

### Active-session filter pushed into SQL

`AdminUserRepositoryLive.findById` filters `expires_at > now()` in the query rather than in JS, so the wire-level payload doesn't carry the long tail of expired rows for chatty users. Sessions arrive pre-sorted **impersonation-first, then by `updatedAt` desc** so the red-flag rows read at the top of the panel — covered by a new `db-postgres` repository test that asserts the sort + the impersonator-email cross-reference.

### Audit events

Five new outbox events under `EventPayloads`:

- `AdminUserRoleChanged { adminUserId, targetUserId, fromRole, toRole }`
- `AdminUserEmailChanged { adminUserId, targetUserId, fromEmail, toEmail }`
- `AdminUserSessionsRevoked { adminUserId, targetUserId, sessionCount }`
- `AdminUserSessionRevoked { adminUserId, targetUserId, sessionId }`

Plus matching no-op handlers in `apps/workers/src/workers/domain-events.ts` (the `EventHandlerMap` is exhaustive and CI fails otherwise).

`fromX` / `toX` snapshots live on the event payload so audit queries don't have to reconstruct transitions from a delta on the (mutable) users row. The `revoke-single-session` event deliberately omits the session token — the row is destroyed immediately and storing the token would needlessly persist a dead authentication credential in the audit log.

### What's not included

Ban / Unban was scoped out of this PR.

## Test plan

- [x] `pnpm --filter @app/web typecheck`
- [x] `pnpm --filter @app/workers typecheck`
- [x] `pnpm --filter @domain/admin typecheck` + tests (new fixture for the `sessions: []` requirement)
- [x] `pnpm --filter @platform/db-postgres` repository tests — 4/4, including new assertions for the impersonation-first sort and impersonator-email cross-reference
- [x] `vitest` users.functions.test.ts — 23/23 (input-schema tests for every new server function)
- [x] `pnpm knip` clean
- [x] `NODE_ENV=production pnpm --filter @app/web build`
- [x] `pnpm --filter @app/web check:bundle-size` — `ua-parser-js` + `geoip.ts` correctly stripped from client bundle
- [ ] Manual: log in as `owner@acme.com`, open a user dashboard, exercise each action in turn (Impersonate → land as target, Promote → `PlatformStaffBadge` flips on next render, Demote, Change email, Revoke all, per-session Revoke from the panel).
- [ ] Manual: `latitude.events_outbox` shows one row per action with the right `event_name` + payload.