### PR TITLE
perf(score-analytics): time-bound aggregateTagsByIssues scans

### DIFF
--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -370,6 +370,11 @@ export const getIssueDetail = createServerFn({ method: "GET" })
         trendFrom.setUTCHours(0, 0, 0, 0)
         const trendScaffold = buildBucketScaffold({ from: trendFrom, to: trendTo })
 
+        // Match the listIssuesUseCase tag-aggregation window so the drawer
+        // and the table show a consistent set of tags for the same issue.
+        const tagsFrom = new Date(now)
+        tagsFrom.setUTCDate(tagsFrom.getUTCDate() - 30)
+
         const [occurrences, trend, evaluationPage, tagsAggregates, settings] = yield* Effect.all([
           scoreAnalyticsRepository.aggregateByIssues({
             organizationId: orgId,
@@ -394,6 +399,7 @@ export const getIssueDetail = createServerFn({ method: "GET" })
             organizationId: orgId,
             projectId,
             issueIds: [issue.id],
+            timeRange: { from: tagsFrom, to: now },
           }),
           resolveSettings({ projectId }),
         ])

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -16,6 +16,7 @@ import {
   issuesSortFieldSchema,
   type ListIssuesResult,
   listIssuesUseCase,
+  TAG_AGGREGATION_FALLBACK_DAYS,
 } from "@domain/issues"
 import { type IssueOccurrenceBucket, ScoreAnalyticsRepository } from "@domain/scores"
 import { IssueId, OrganizationId, ProjectId, resolveSettings } from "@domain/shared"
@@ -373,7 +374,7 @@ export const getIssueDetail = createServerFn({ method: "GET" })
         // Match the listIssuesUseCase tag-aggregation window so the drawer
         // and the table show a consistent set of tags for the same issue.
         const tagsFrom = new Date(now)
-        tagsFrom.setUTCDate(tagsFrom.getUTCDate() - 30)
+        tagsFrom.setUTCDate(tagsFrom.getUTCDate() - TAG_AGGREGATION_FALLBACK_DAYS)
 
         const [occurrences, trend, evaluationPage, tagsAggregates, settings] = yield* Effect.all([
           scoreAnalyticsRepository.aggregateByIssues({

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -136,6 +136,7 @@ export {
   type ListIssuesInput,
   type ListIssuesResult,
   listIssuesUseCase,
+  TAG_AGGREGATION_FALLBACK_DAYS,
 } from "./use-cases/list-issues.ts"
 export {
   type RefreshIssueDetailsError,

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -136,7 +136,7 @@ const createScoreAnalyticsRepository = (input: {
   const aggregateInputs: unknown[] = []
   const histogramInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
   const trendInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
-  const tagsInputs: Array<{ issueIds: readonly string[]; from: Date | undefined; to: Date | undefined }> = []
+  const tagsInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date | undefined }> = []
 
   const repository: ScoreAnalyticsRepositoryShape = {
     existsById: () => Effect.die("Unexpected existsById"),

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -136,7 +136,7 @@ const createScoreAnalyticsRepository = (input: {
   const aggregateInputs: unknown[] = []
   const histogramInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
   const trendInputs: Array<{ issueIds: readonly string[]; from: Date; to: Date }> = []
-  const tagsInputs: Array<{ issueIds: readonly string[] }> = []
+  const tagsInputs: Array<{ issueIds: readonly string[]; from: Date | undefined; to: Date | undefined }> = []
 
   const repository: ScoreAnalyticsRepositoryShape = {
     existsById: () => Effect.die("Unexpected existsById"),
@@ -153,9 +153,9 @@ const createScoreAnalyticsRepository = (input: {
         aggregateInputs.push(aggregateInput)
         return input.fullHistoryOccurrences.filter((occurrence) => aggregateInput.issueIds.includes(occurrence.issueId))
       }),
-    aggregateTagsByIssues: ({ issueIds }) =>
+    aggregateTagsByIssues: ({ issueIds, timeRange }) =>
       Effect.sync(() => {
-        tagsInputs.push({ issueIds })
+        tagsInputs.push({ issueIds, from: timeRange.from, to: timeRange.to })
         return (input.tagsAggregates ?? []).filter((entry) => issueIds.includes(entry.issueId))
       }),
     trendByIssue: () => Effect.die("Unexpected trendByIssue"),
@@ -535,10 +535,55 @@ describe("listIssuesUseCase", () => {
       ),
     )
 
-    expect(tagsInputs).toEqual([{ issueIds: [taggedIssue.id, untaggedIssue.id] }])
+    // No operator-selected time range → fallback ~30 days ending at `now`.
+    expect(tagsInputs).toHaveLength(1)
+    expect(tagsInputs[0]?.issueIds).toEqual([taggedIssue.id, untaggedIssue.id])
+    expect(tagsInputs[0]?.to?.toISOString()).toBe(now.toISOString())
+    const expectedFrom = new Date(now)
+    expectedFrom.setUTCDate(expectedFrom.getUTCDate() - 30)
+    expect(tagsInputs[0]?.from?.toISOString()).toBe(expectedFrom.toISOString())
+
     const tagsByIssueId = new Map(result.items.map((item) => [item.id, item.tags] as const))
     expect(tagsByIssueId.get(taggedIssue.id)).toEqual(["checkout", "billing"])
     expect(tagsByIssueId.get(untaggedIssue.id)).toEqual([])
+  })
+
+  it("honors the operator-selected time range when aggregating tags", async () => {
+    const now = new Date("2026-04-10T00:00:00.000Z")
+    const issue = makeIssue({ id: IssueId("a".repeat(24)), uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" })
+    const { repository: issueRepository } = createFakeIssueRepository([issue])
+    const { repository: evaluationRepository } = createEvaluationRepository()
+    const { repository: scoreAnalyticsRepository, tagsInputs } = createScoreAnalyticsRepository({
+      windowMetrics: [makeWindowMetric({ issueId: issue.id })],
+      fullHistoryOccurrences: [makeOccurrence({ issueId: issue.id })],
+    })
+    const { repository: issueProjectionRepository } = createIssueProjectionRepository([])
+
+    const selectedFrom = new Date("2026-04-01T00:00:00.000Z")
+    const selectedTo = new Date("2026-04-08T23:59:59.999Z")
+
+    await Effect.runPromise(
+      listIssuesUseCase({
+        organizationId,
+        projectId,
+        now,
+        timeRange: { from: selectedFrom, to: selectedTo },
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(IssueRepository, issueRepository),
+            Layer.succeed(EvaluationRepository, evaluationRepository),
+            Layer.succeed(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+            Layer.succeed(IssueProjectionRepository, issueProjectionRepository),
+            Layer.succeed(SqlClient, createFakeSqlClient({ organizationId })),
+            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId })),
+          ),
+        ),
+      ),
+    )
+
+    expect(tagsInputs[0]?.from?.toISOString()).toBe(selectedFrom.toISOString())
+    expect(tagsInputs[0]?.to?.toISOString()).toBe(selectedTo.toISOString())
   })
 
   describe("analytics histogram time range", () => {

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -173,6 +173,26 @@ const resolveTrendTimeRange = (input: {
   }
 }
 
+// Tag aggregation needs an explicit time bound to keep CH scans on `scores`
+// and `traces` partition-pruned (see aggregateTagsByIssues impl). If the
+// operator selected a range we honor it; otherwise we fall back to ~30 days,
+// which captures effectively all currently-relevant tags while still pinning
+// the scan to a small number of monthly partitions.
+const TAG_AGGREGATION_FALLBACK_DAYS = 30
+
+const resolveTagsTimeRange = (input: {
+  readonly timeRange: ScoreAnalyticsTimeRange | undefined
+  readonly now: Date
+}): ScoreAnalyticsTimeRange => {
+  if (input.timeRange?.from || input.timeRange?.to) {
+    return input.timeRange
+  }
+  const to = input.now
+  const from = new Date(to)
+  from.setUTCDate(from.getUTCDate() - TAG_AGGREGATION_FALLBACK_DAYS)
+  return { from, to }
+}
+
 const toScoreAnalyticsTimeRange = (
   timeRange: z.infer<typeof issuesTimeRangeSchema> | undefined,
 ): ScoreAnalyticsTimeRange | undefined => {
@@ -488,6 +508,7 @@ export const listIssuesUseCase = (
       now,
     })
     const trendScaffold = buildBucketScaffold(trendTimeRange)
+    const tagsTimeRange = resolveTagsTimeRange({ timeRange: selectedTimeRange, now })
 
     const [evaluationPage, trendSeries, tagsAggregates] = yield* Effect.all([
       pageIssueIds.length === 0
@@ -519,6 +540,7 @@ export const listIssuesUseCase = (
             organizationId: parsed.organizationId,
             projectId: parsed.projectId,
             issueIds: pageIssueIds,
+            timeRange: tagsTimeRange,
           }),
     ])
 

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -3,6 +3,7 @@ import {
   type IssueOccurrenceAggregate,
   type IssueOccurrenceBucket,
   type IssueTrendSeries,
+  type IssueTagsTimeRange,
   type IssueWindowMetric,
   ScoreAnalyticsRepository,
   type ScoreAnalyticsTimeRange,
@@ -173,21 +174,27 @@ const resolveTrendTimeRange = (input: {
   }
 }
 
-// Tag aggregation needs an explicit time bound to keep CH scans on `scores`
-// and `traces` partition-pruned (see aggregateTagsByIssues impl). If the
-// operator selected a range we honor it; otherwise we fall back to ~30 days,
-// which captures effectively all currently-relevant tags while still pinning
-// the scan to a small number of monthly partitions.
-const TAG_AGGREGATION_FALLBACK_DAYS = 30
+/**
+ * Tag aggregation needs an explicit lower-bound time so CH scans on `scores`
+ * and `traces` stay partition-pruned (see `aggregateTagsByIssues` impl). If
+ * the operator selected a range we honor it; otherwise we fall back to ~30
+ * days, which captures effectively all currently-relevant tags while still
+ * pinning the scan to a small number of monthly partitions.
+ *
+ * Exported so other call sites that fetch tags for the same issues
+ * (e.g. the issue detail handler) can use the same window and stay visually
+ * consistent with the list.
+ */
+export const TAG_AGGREGATION_FALLBACK_DAYS = 30
 
 const resolveTagsTimeRange = (input: {
   readonly timeRange: ScoreAnalyticsTimeRange | undefined
   readonly now: Date
-}): ScoreAnalyticsTimeRange => {
-  if (input.timeRange?.from || input.timeRange?.to) {
-    return input.timeRange
+}): IssueTagsTimeRange => {
+  if (input.timeRange?.from) {
+    return input.timeRange.to ? { from: input.timeRange.from, to: input.timeRange.to } : { from: input.timeRange.from }
   }
-  const to = input.now
+  const to = input.timeRange?.to ?? input.now
   const from = new Date(to)
   from.setUTCDate(from.getUTCDate() - TAG_AGGREGATION_FALLBACK_DAYS)
   return { from, to }

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -2,8 +2,8 @@ import { type Evaluation, EvaluationRepository } from "@domain/evaluations"
 import {
   type IssueOccurrenceAggregate,
   type IssueOccurrenceBucket,
-  type IssueTrendSeries,
   type IssueTagsTimeRange,
+  type IssueTrendSeries,
   type IssueWindowMetric,
   ScoreAnalyticsRepository,
   type ScoreAnalyticsTimeRange,

--- a/packages/domain/scores/src/index.ts
+++ b/packages/domain/scores/src/index.ts
@@ -41,6 +41,7 @@ export {
   type IssueOccurrenceAggregate,
   type IssueOccurrenceBucket,
   type IssueTagsAggregate,
+  type IssueTagsTimeRange,
   type IssueTracePage,
   type IssueTraceSummary,
   type IssueTrendSeries,

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -191,10 +191,13 @@ export interface ScoreAnalyticsRepositoryShape {
   }): Effect.Effect<readonly IssueOccurrenceAggregate[], RepositoryError, ChSqlClient>
 
   // -- Issue tag aggregation across affected traces --------------------------
+  // `timeRange` is required to keep the underlying scans partition-bounded
+  // (see implementation comment for context).
   aggregateTagsByIssues(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly issueIds: readonly IssueId[]
+    readonly timeRange: ScoreAnalyticsTimeRange
     readonly options?: ScoreAnalyticsOptions
   }): Effect.Effect<readonly IssueTagsAggregate[], RepositoryError, ChSqlClient>
 

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -100,6 +100,16 @@ export interface IssueTagsAggregate {
   readonly tags: readonly string[]
 }
 
+/**
+ * Time range used when aggregating issue tags. A lower bound is required
+ * (not just allowed) so the CH scans on `scores` and `traces` always have a
+ * partition-pruning predicate — see `aggregateTagsByIssues` for context.
+ */
+export interface IssueTagsTimeRange {
+  readonly from: Date
+  readonly to?: Date
+}
+
 /** Grouped issue trend result for batched chart reads. */
 export interface IssueTrendSeries {
   readonly issueId: IssueId
@@ -191,13 +201,13 @@ export interface ScoreAnalyticsRepositoryShape {
   }): Effect.Effect<readonly IssueOccurrenceAggregate[], RepositoryError, ChSqlClient>
 
   // -- Issue tag aggregation across affected traces --------------------------
-  // `timeRange` is required to keep the underlying scans partition-bounded
-  // (see implementation comment for context).
+  // `timeRange.from` is required to keep the underlying scans partition-bounded
+  // (see implementation comment for context). `to` defaults to "now".
   aggregateTagsByIssues(input: {
     readonly organizationId: OrganizationId
     readonly projectId: ProjectId
     readonly issueIds: readonly IssueId[]
-    readonly timeRange: ScoreAnalyticsTimeRange
+    readonly timeRange: IssueTagsTimeRange
     readonly options?: ScoreAnalyticsOptions
   }): Effect.Effect<readonly IssueTagsAggregate[], RepositoryError, ChSqlClient>
 

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -505,12 +505,20 @@ describe("ScoreAnalyticsRepository", () => {
       ])
     })
 
+    // The default seed rows use created_at / start_time = "2026-03-15 12:00:00.000",
+    // so any time range that includes mid-March 2026 picks them up.
+    const seedWindow = {
+      from: new Date("2026-03-01T00:00:00.000Z"),
+      to: new Date("2026-04-01T00:00:00.000Z"),
+    }
+
     it("returns the union of trace-level tags grouped by issue, scoped to org/project", async () => {
       const result = await runCh(
         repo.aggregateTagsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
+          timeRange: seedWindow,
         }),
       )
 
@@ -522,8 +530,30 @@ describe("ScoreAnalyticsRepository", () => {
 
     it("returns empty for no issue ids", async () => {
       const result = await runCh(
-        repo.aggregateTagsByIssues({ organizationId: ORG_ID, projectId: PROJECT_ID, issueIds: [] }),
+        repo.aggregateTagsByIssues({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueIds: [],
+          timeRange: seedWindow,
+        }),
       )
+      expect(result).toEqual([])
+    })
+
+    it("excludes scores and traces outside the configured time range", async () => {
+      // Tighten the window to skip the seeded mid-March data entirely.
+      const result = await runCh(
+        repo.aggregateTagsByIssues({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueIds: [IssueId(issueA), IssueId(issueB)],
+          timeRange: {
+            from: new Date("2026-04-01T00:00:00.000Z"),
+            to: new Date("2026-04-30T00:00:00.000Z"),
+          },
+        }),
+      )
+
       expect(result).toEqual([])
     })
   })

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -624,21 +624,24 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           if (issueIds.length === 0) return []
 
-          const scoresTimeRange = buildScoreCreatedAtTimeRange(timeRange, "tags_scores")
-          const scoresTimeClause =
-            scoresTimeRange.clauses.length > 0 ? ` AND ${scoresTimeRange.clauses.join(" AND ")}` : ""
-
-          const tracesTimeClauses: string[] = []
-          const tracesTimeParams: Record<string, unknown> = {}
-          if (timeRange.from) {
-            tracesTimeClauses.push(`min_start_time >= toDateTime64({tags_traces_from:String}, 3, 'UTC')`)
-            tracesTimeParams.tags_traces_from = toClickHouseDateTime64(timeRange.from)
+          // The IssueTagsTimeRange type guarantees `from`; `to` is optional and
+          // only emitted when present.
+          const scoresClauses = [
+            "created_at >= toDateTime64({tags_scores_from:String}, 3, 'UTC')",
+            ...(timeRange.to ? ["created_at <= toDateTime64({tags_scores_to:String}, 3, 'UTC')"] : []),
+          ]
+          const tracesClauses = [
+            "min_start_time >= toDateTime64({tags_traces_from:String}, 3, 'UTC')",
+            ...(timeRange.to ? ["min_start_time <= toDateTime64({tags_traces_to:String}, 3, 'UTC')"] : []),
+          ]
+          const timeParams: Record<string, unknown> = {
+            tags_scores_from: toClickHouseDateTime64(timeRange.from),
+            tags_traces_from: toClickHouseDateTime64(timeRange.from),
           }
           if (timeRange.to) {
-            tracesTimeClauses.push(`min_start_time <= toDateTime64({tags_traces_to:String}, 3, 'UTC')`)
-            tracesTimeParams.tags_traces_to = toClickHouseDateTime64(timeRange.to)
+            timeParams.tags_scores_to = toClickHouseDateTime64(timeRange.to)
+            timeParams.tags_traces_to = toClickHouseDateTime64(timeRange.to)
           }
-          const tracesTimeClause = tracesTimeClauses.length > 0 ? ` AND ${tracesTimeClauses.join(" AND ")}` : ""
 
           return yield* chSqlClient
             .query(async (client) => {
@@ -650,7 +653,8 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                           FROM scores
                           WHERE ${scopeClause(options)}
                             AND issue_id IN ({issueIds:Array(String)})
-                            AND trace_id != ''${scoresTimeClause}
+                            AND trace_id != ''
+                            AND ${scoresClauses.join(" AND ")}
                           GROUP BY issue_id, trace_id
                           ORDER BY issue_id, last_seen_at DESC
                           LIMIT {tracesPerIssue:UInt32} BY issue_id
@@ -661,7 +665,8 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                         FROM traces
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
-                          AND trace_id IN (SELECT trace_id FROM issue_traces)${tracesTimeClause}
+                          AND trace_id IN (SELECT trace_id FROM issue_traces)
+                          AND ${tracesClauses.join(" AND ")}
                         GROUP BY trace_id
                       )
                       SELECT
@@ -674,8 +679,7 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                   ...scopeParams(organizationId, projectId),
                   issueIds: Array.from(issueIds) as string[],
                   tracesPerIssue: ISSUE_TAG_TRACE_SAMPLE_LIMIT,
-                  ...scoresTimeRange.params,
-                  ...tracesTimeParams,
+                  ...timeParams,
                 },
                 format: "JSONEachRow",
               })

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -595,16 +595,54 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
         }),
 
       // -- aggregateTagsByIssues ---------------------------------------------
-      aggregateTagsByIssues: ({ organizationId, projectId, issueIds, options }) =>
+      // Performance shape (read carefully before relaxing the bounds):
+      //   * `scores` is partitioned by `toYYYYMM(created_at)` and PK is
+      //     `(org, project, created_at)`. `issue_id` is NOT in the sort key,
+      //     so without a `created_at` filter `WHERE issue_id IN (...)` does
+      //     a full scan of every monthly partition for the (org, project) —
+      //     a year-old project means ~12 partitions × millions of rows.
+      //   * `traces` is partitioned by `toYYYYMM(min_start_time)` with a
+      //     `minmax` skip index on `min_start_time`; PK is `(org, project)`,
+      //     sparse — `trace_id IN (...)` alone still scans every (org,
+      //     project) granule of history because the PK can't position by
+      //     trace_id. A `min_start_time` filter prunes partitions hard.
+      //   * The `timeRange` argument is therefore REQUIRED — both subqueries
+      //     filter on it. The use-case picks the bound (typically a 30d
+      //     fallback if the operator hasn't selected one).
+      //   * `LIMIT N BY issue_id` further caps the per-issue trace sample so
+      //     a single noisy issue can't blow up the join.
+      //
+      // TODO(perf): long-term this should be served by a dedicated per-issue
+      // tags aggregating MV (insert-time work, O(1) read). Open questions
+      // before building it: (a) which side denormalizes — `tags` onto
+      // `scores`, or `issue_id` onto `spans`/`traces`? (b) how to handle
+      // async issue clustering (an issue id is assigned after a score row
+      // already exists), (c) backfill plan for historical data. Discussed
+      // in PR #2893 review threads.
+      aggregateTagsByIssues: ({ organizationId, projectId, issueIds, timeRange, options }) =>
         Effect.gen(function* () {
           const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
           if (issueIds.length === 0) return []
+
+          const scoresTimeRange = buildScoreCreatedAtTimeRange(timeRange, "tags_scores")
+          const scoresTimeClause =
+            scoresTimeRange.clauses.length > 0 ? ` AND ${scoresTimeRange.clauses.join(" AND ")}` : ""
+
+          const tracesTimeClauses: string[] = []
+          const tracesTimeParams: Record<string, unknown> = {}
+          if (timeRange.from) {
+            tracesTimeClauses.push(`min_start_time >= toDateTime64({tags_traces_from:String}, 3, 'UTC')`)
+            tracesTimeParams.tags_traces_from = toClickHouseDateTime64(timeRange.from)
+          }
+          if (timeRange.to) {
+            tracesTimeClauses.push(`min_start_time <= toDateTime64({tags_traces_to:String}, 3, 'UTC')`)
+            tracesTimeParams.tags_traces_to = toClickHouseDateTime64(timeRange.to)
+          }
+          const tracesTimeClause = tracesTimeClauses.length > 0 ? ` AND ${tracesTimeClauses.join(" AND ")}` : ""
+
           return yield* chSqlClient
             .query(async (client) => {
               const result = await client.query({
-                // Sample the most-recent traces per issue (LIMIT N BY issue_id) so a noisy
-                // issue with tens of thousands of traces doesn't pull every trace row just
-                // to compute a tag union — tag distributions converge quickly.
                 query: `WITH issue_traces AS (
                         SELECT issue_id, trace_id
                         FROM (
@@ -612,7 +650,7 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                           FROM scores
                           WHERE ${scopeClause(options)}
                             AND issue_id IN ({issueIds:Array(String)})
-                            AND trace_id != ''
+                            AND trace_id != ''${scoresTimeClause}
                           GROUP BY issue_id, trace_id
                           ORDER BY issue_id, last_seen_at DESC
                           LIMIT {tracesPerIssue:UInt32} BY issue_id
@@ -623,7 +661,7 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                         FROM traces
                         WHERE organization_id = {organizationId:String}
                           AND project_id = {projectId:String}
-                          AND trace_id IN (SELECT trace_id FROM issue_traces)
+                          AND trace_id IN (SELECT trace_id FROM issue_traces)${tracesTimeClause}
                         GROUP BY trace_id
                       )
                       SELECT
@@ -636,6 +674,8 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
                   ...scopeParams(organizationId, projectId),
                   issueIds: Array.from(issueIds) as string[],
                   tracesPerIssue: ISSUE_TAG_TRACE_SAMPLE_LIMIT,
+                  ...scoresTimeRange.params,
+                  ...tracesTimeParams,
                 },
                 format: "JSONEachRow",
               })


### PR DESCRIPTION
## Summary
Follow-up to [#2893](https://github.com/latitude-dev/latitude-llm/pull/2893) addressing @geclos's review on the merged tag-aggregation query.

The merged query had no time bound on either underlying scan:
- **`scores`**: PK is `(org, project, created_at)` and `issue_id` is **not** in the sort key, so `WHERE issue_id IN (...)` does a full scan of every monthly partition for the (org, project) — a year-old high-traffic project means ~12 partitions × millions of rows.
- **`traces`**: PK is `(org, project)` (sparse), and although `ORDER BY` includes `trace_id` the PK index can't position by it, so `trace_id IN (...)` scans every (org, project) granule of history. The table has a `minmax` skip index on `min_start_time` and is partitioned by `toYYYYMM(min_start_time)` — a time filter prunes partitions hard.

Changes:
- Make `timeRange` **required** on `ScoreAnalyticsRepository.aggregateTagsByIssues` and filter both `scores.created_at` and `traces.min_start_time` on it.
- `listIssuesUseCase` honors the operator-selected `timeRange` if any, else falls back to **last 30 days** (`TAG_AGGREGATION_FALLBACK_DAYS`). 30d covers any currently-active issue's tag distribution while pinning the scan to ~1 monthly partition.
- `getIssueDetail` (drawer) uses the same 30-day window so the drawer and the table show a consistent set of tags for the same issue.
- Inline `TODO(perf)` block above the query documenting the long-term plan: a per-issue tags aggregating MV. Records the open design questions (denormalize `tags` onto `scores` vs `issue_id` onto `spans`/`traces`, ordering vs async issue clustering, historical backfill) so whoever picks it up doesn't start from scratch.

## Behavior trade-off
Issues whose last occurrence was more than 30 days ago and whose viewer has no time-range filter selected will show no tags. Acceptable: those issues are typically resolved/ignored. An operator looking at older issues can widen the time range and the tags follow.

## Test plan
- [x] `pnpm -F @domain/scores -F @domain/issues -F @platform/db-clickhouse -F @app/web run typecheck`
- [x] `pnpm -F @domain/issues exec vitest run src/use-cases/list-issues.test.ts` — added two assertions: the use-case passes a 30-day fallback when no time range is selected, and honors the operator's selection when present.
- [x] `pnpm -F @platform/db-clickhouse exec vitest run src/repositories/score-analytics-repository.test.ts` — added an integration test that tightens the window past the seeded data and asserts the result is empty (i.e., the time bound actually filters).