### PR TITLE
feat(traces): clickable metric cards swap the histogram series

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ At a glance: **`apps/*`** own HTTP boundaries (validation, authz, routing to use
 ## Repo-wide conventions
 
 - Organization-scoped Redis or cache keys must start with the organization prefix: `org:${organizationId}:...`. Put the org id first so tenancy is obvious and keyspaces stay consistently partitioned.
+- Never invoke `tsc` directly. Typechecking goes through `tsgo` via the package `typecheck` script — use `pnpm --filter <pkg> typecheck` for one package or `pnpm typecheck` for the whole workspace. `tsc` would diverge from CI.
 
 ## How to use this guide
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -1,6 +1,11 @@
 import type { FilterSet } from "@domain/shared"
+import { isTraceHistogramMetric, type TraceHistogramMetric } from "@domain/spans"
+import { useCallback } from "react"
+import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { GeneralAggregations } from "./general-aggregations.tsx"
 import { Histogram } from "./histogram.tsx"
+
+const DEFAULT_HISTOGRAM_METRIC: TraceHistogramMetric = "traces"
 
 interface TraceAggregationsPanelProps {
   readonly projectId: string
@@ -10,10 +15,28 @@ interface TraceAggregationsPanelProps {
 }
 
 export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }: TraceAggregationsPanelProps) {
+  // The default metric ("traces") is intentionally omitted from the URL by `useParamState` so the
+  // canonical link stays clean; only non-default selections make it into the query string.
+  const [selectedMetric, setSelectedMetric] = useParamState("histogramMetric", DEFAULT_HISTOGRAM_METRIC, {
+    validate: isTraceHistogramMetric,
+  })
+
+  const onMetricSelect = useCallback(
+    (metric: TraceHistogramMetric) => {
+      setSelectedMetric(metric)
+    },
+    [setSelectedMetric],
+  )
+
   return (
     <div className="flex flex-col rounded-lg bg-secondary p-2">
-      <GeneralAggregations projectId={projectId} filters={filters} />
-      <Histogram projectId={projectId} filters={filters} onRangeSelect={onTimeRangeSelect} />
+      <GeneralAggregations
+        projectId={projectId}
+        filters={filters}
+        selectedMetric={selectedMetric}
+        onMetricSelect={onMetricSelect}
+      />
+      <Histogram projectId={projectId} filters={filters} metric={selectedMetric} onRangeSelect={onTimeRangeSelect} />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -1,21 +1,35 @@
 import type { FilterSet } from "@domain/shared"
-import { Skeleton, Text } from "@repo/ui"
-import { formatCount, formatDuration, formatPrice } from "@repo/utils"
+import type { TraceHistogramMetric } from "@domain/spans"
+import { cn, Skeleton, Text } from "@repo/ui"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
+import { HISTOGRAM_METRIC_DEFINITIONS, type HistogramMetricDefinition } from "./histogram-metrics.ts"
 
 function AggregationItem({
   label,
   value,
   isLoading,
+  isSelected,
   skeletonWidthClassName = "w-16",
+  onClick,
 }: {
   readonly label: string
   readonly value: string
   readonly isLoading?: boolean
+  readonly isSelected: boolean
   readonly skeletonWidthClassName?: string
+  readonly onClick: () => void
 }) {
   return (
-    <div className="flex basis-[176px] min-w-[176px] shrink-0 flex-col gap-2">
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isSelected}
+      className={cn(
+        "flex basis-[176px] min-w-[176px] shrink-0 cursor-pointer flex-col gap-2 rounded-md p-2 text-left",
+        "transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isSelected && "bg-muted ring-1 ring-border",
+      )}
+    >
       <Text.H6 color="foregroundMuted">{label}</Text.H6>
       {isLoading ? (
         <Skeleton className={`h-5 ${skeletonWidthClassName}`} />
@@ -24,16 +38,24 @@ function AggregationItem({
           {value}
         </Text.H5>
       )}
-    </div>
+    </button>
   )
 }
+
+const DASH = "—"
+
+const METRIC_ORDER: readonly TraceHistogramMetric[] = ["traces", "cost", "duration", "tokens", "ttft", "spans"]
 
 export function GeneralAggregations({
   projectId,
   filters,
+  selectedMetric,
+  onMetricSelect,
 }: {
   readonly projectId: string
   readonly filters: FilterSet
+  readonly selectedMetric: TraceHistogramMetric
+  readonly onMetricSelect: (metric: TraceHistogramMetric) => void
 }) {
   const hasActiveFilters = Object.keys(filters).length > 0
   const filterOpts = hasActiveFilters ? { filters } : {}
@@ -49,33 +71,33 @@ export function GeneralAggregations({
 
   const loading = metricsLoading || countLoading
 
-  const dash = "—"
-  const traceCountStr = formatCount(totalCount)
-  const totalCostStr = traceMetrics ? formatPrice(traceMetrics.costTotalMicrocents.sum / 100_000_000) : dash
-  const medianDurationStr = traceMetrics ? formatDuration(traceMetrics.durationNs.median) : dash
-  const totalTokensStr = traceMetrics ? formatCount(traceMetrics.tokensTotal.sum) : dash
-  const totalSpansStr = traceMetrics ? formatCount(traceMetrics.spanCount.sum) : dash
+  // TTFT card is hidden when no trace in the current view recorded a first-token timestamp
+  // (`> 0`); showing it would just render "—" forever for projects that don't stream.
+  const showTtft = !!traceMetrics && traceMetrics.timeToFirstTokenNs.max > 0
 
-  const showTtftAggregations = traceMetrics && traceMetrics.timeToFirstTokenNs.max > 0
+  const visibleMetrics = METRIC_ORDER.filter((id) => id !== "ttft" || showTtft).map(
+    (id) => HISTOGRAM_METRIC_DEFINITIONS[id],
+  )
+
+  const renderValue = (def: HistogramMetricDefinition): string => {
+    if (def.id === "traces") return def.formatBucket(totalCount)
+    if (!traceMetrics) return DASH
+    return def.formatBucket(def.selectMetricsValue(traceMetrics, totalCount))
+  }
 
   return (
-    <div className="flex flex-row flex-wrap gap-3 p-4">
-      <AggregationItem label="Traces" value={traceCountStr} isLoading={loading} skeletonWidthClassName="w-16" />
-      <AggregationItem label="Total cost" value={totalCostStr} isLoading={loading} skeletonWidthClassName="w-20" />
-      <AggregationItem
-        label="Median duration"
-        value={medianDurationStr}
-        isLoading={loading}
-        skeletonWidthClassName="w-20"
-      />
-      <AggregationItem label="Total tokens" value={totalTokensStr} isLoading={loading} skeletonWidthClassName="w-20" />
-      {showTtftAggregations ? (
+    <div className="flex flex-row flex-wrap gap-1 p-2">
+      {visibleMetrics.map((def) => (
         <AggregationItem
-          label="Median time to first token"
-          value={formatDuration(traceMetrics.timeToFirstTokenNs.median)}
+          key={def.id}
+          label={def.label}
+          value={renderValue(def)}
+          isLoading={loading}
+          isSelected={selectedMetric === def.id}
+          skeletonWidthClassName={def.cardSkeletonWidthClassName}
+          onClick={() => onMetricSelect(def.id)}
         />
-      ) : null}
-      <AggregationItem label="Total spans" value={totalSpansStr} isLoading={loading} skeletonWidthClassName="w-16" />
+      ))}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram-metrics.ts
@@ -1,0 +1,80 @@
+import type { TraceHistogramMetric, TraceMetrics, TraceTimeHistogramBucket } from "@domain/spans"
+import { formatCount, formatDuration, formatPrice } from "@repo/utils"
+
+/**
+ * Single source of truth shared by the metric cards and the histogram chart. Each entry says how to
+ * label the metric, where to read its scalar value (for the cards) and its per-bucket value (for
+ * the chart), how to format both, and the noun used in tooltips ("traces", "tokens", …).
+ *
+ * Adding a new metric here is enough to expose it as both a card and a histogram series — keep this
+ * map in sync with `TRACE_HISTOGRAM_METRICS` in `@domain/spans`.
+ */
+export interface HistogramMetricDefinition {
+  readonly id: TraceHistogramMetric
+  readonly label: string
+  readonly cardSkeletonWidthClassName: string
+  readonly tooltipNoun: string
+  readonly formatBucket: (value: number) => string
+  readonly selectBucket: (bucket: TraceTimeHistogramBucket) => number
+  /** Returns the scalar value shown on the card; undefined when metrics haven't loaded yet. */
+  readonly selectMetricsValue: (metrics: TraceMetrics, totalCount: number) => number
+}
+
+const microcentsToUSD = (microcents: number): string => formatPrice(microcents / 100_000_000)
+
+export const HISTOGRAM_METRIC_DEFINITIONS: Readonly<Record<TraceHistogramMetric, HistogramMetricDefinition>> = {
+  traces: {
+    id: "traces",
+    label: "Traces",
+    cardSkeletonWidthClassName: "w-16",
+    tooltipNoun: "traces",
+    formatBucket: formatCount,
+    selectBucket: (b) => b.traceCount,
+    selectMetricsValue: (_metrics, totalCount) => totalCount,
+  },
+  cost: {
+    id: "cost",
+    label: "Total cost",
+    cardSkeletonWidthClassName: "w-20",
+    tooltipNoun: "", // Already formats value
+    formatBucket: microcentsToUSD,
+    selectBucket: (b) => b.costTotalMicrocentsSum,
+    selectMetricsValue: (m) => m.costTotalMicrocents.sum,
+  },
+  duration: {
+    id: "duration",
+    label: "Median duration",
+    cardSkeletonWidthClassName: "w-20",
+    tooltipNoun: "", // Already formats value
+    formatBucket: formatDuration,
+    selectBucket: (b) => b.durationNsMedian,
+    selectMetricsValue: (m) => m.durationNs.median,
+  },
+  tokens: {
+    id: "tokens",
+    label: "Total tokens",
+    cardSkeletonWidthClassName: "w-20",
+    tooltipNoun: "tokens",
+    formatBucket: formatCount,
+    selectBucket: (b) => b.tokensTotalSum,
+    selectMetricsValue: (m) => m.tokensTotal.sum,
+  },
+  ttft: {
+    id: "ttft",
+    label: "Median time to first token",
+    cardSkeletonWidthClassName: "w-20",
+    tooltipNoun: "", // Already formats value
+    formatBucket: formatDuration,
+    selectBucket: (b) => b.timeToFirstTokenNsMedian,
+    selectMetricsValue: (m) => m.timeToFirstTokenNs.median,
+  },
+  spans: {
+    id: "spans",
+    label: "Total spans",
+    cardSkeletonWidthClassName: "w-16",
+    tooltipNoun: "spans",
+    formatBucket: formatCount,
+    selectBucket: (b) => b.spanCountSum,
+    selectMetricsValue: (m) => m.spanCount.sum,
+  },
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/histogram.tsx
@@ -1,10 +1,10 @@
 import type { FilterSet } from "@domain/shared"
-import { denseTraceTimeHistogramBuckets } from "@domain/spans"
+import { denseTraceTimeHistogramBuckets, type TraceHistogramMetric } from "@domain/spans"
 import { BarChart, HistogramSkeleton, Text } from "@repo/ui"
-import { formatCount } from "@repo/utils"
 import { useCallback, useMemo } from "react"
 
 import { useTraceTimeHistogram } from "../../../../../../domains/traces/traces.collection.ts"
+import { HISTOGRAM_METRIC_DEFINITIONS } from "./histogram-metrics.ts"
 
 function formatBucketAxisLabel(iso: string): string {
   const d = new Date(iso)
@@ -14,11 +14,12 @@ function formatBucketAxisLabel(iso: string): string {
 interface HistogramProps {
   readonly projectId: string
   readonly filters: FilterSet
+  readonly metric: TraceHistogramMetric
   /** Called when user selects a time range via brush on the histogram. */
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }
 
-export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps) {
+export function Histogram({ projectId, filters, metric, onRangeSelect }: HistogramProps) {
   const {
     data: sparseBuckets,
     isLoading,
@@ -33,13 +34,15 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
     [sparseBuckets, rangeStartIso, rangeEndIso, bucketSeconds],
   )
 
+  const definition = HISTOGRAM_METRIC_DEFINITIONS[metric]
+
   const chartData = useMemo(
     () =>
       denseBuckets.map((b) => ({
         category: formatBucketAxisLabel(b.bucketStart),
-        value: b.traceCount,
+        value: definition.selectBucket(b),
       })),
-    [denseBuckets],
+    [denseBuckets, definition],
   )
 
   const handleSelect = useCallback(
@@ -61,8 +64,9 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
   )
 
   const formatTooltip = useCallback(
-    (category: string, value: number) => `${category}<br/><b>${formatCount(value)}</b> traces`,
-    [],
+    (category: string, value: number) =>
+      `${category}<br/><b>${definition.formatBucket(value)}</b> ${definition.tooltipNoun}`,
+    [definition],
   )
 
   if (isLoading) {
@@ -95,7 +99,7 @@ export function Histogram({ projectId, filters, onRangeSelect }: HistogramProps)
         data={chartData}
         height={160}
         showYAxis={false}
-        ariaLabel="Trace count by time bucket"
+        ariaLabel={`${definition.label} by time bucket`}
         formatTooltip={formatTooltip}
         onSelect={onRangeSelect ? handleSelect : undefined}
       />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -323,7 +323,7 @@ export function IssueDetailDrawer({
                 <Text.H5 color="foregroundMuted">{issue?.description ?? "This issue could not be loaded."}</Text.H5>
               )}
             </div>
-            {!isLoading && issue?.tags && issue.tags.length > 0 ? <TagList tags={issue.tags} /> : null}
+            {!isLoading && !!issue?.tags.length && <TagList tags={issue.tags} wrap />}
           </div>
         }
       >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
@@ -279,9 +279,7 @@ export function IssueDrawerEvaluations({
         <Icon icon={ShieldCheckIcon} size="md" color="foregroundMuted" />
         <div className="flex min-w-0 flex-col gap-1">
           <Text.H5M>Automatically monitored</Text.H5M>
-          <Text.H6 color="foregroundMuted">
-            This issue is already monitored on every trace, so a separate evaluation is not needed.
-          </Text.H6>
+          <Text.H6 color="foregroundMuted">This issue is automatically monitored by the system</Text.H6>
         </div>
       </div>
     )
@@ -403,7 +401,8 @@ export function IssueDrawerEvaluations({
         ) : null}
         {hiddenEvaluationCount > 0 ? (
           <Text.H6 className="self-center text-center" color="foregroundMuted">
-            {hiddenEvaluationCount} other evaluation{hiddenEvaluationCount === 1 ? "" : "s"} hidden from this view
+            {hiddenEvaluationCount} other evaluation
+            {hiddenEvaluationCount === 1 ? "" : "s"} hidden from this view
           </Text.H6>
         ) : null}
       </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -172,16 +172,10 @@ export function IssuesView({
       ),
     },
     {
-      key: "tags",
-      header: "Tags",
-      width: 150,
-      render: (issue) => <TagList tags={issue.tags} />,
-    },
-    {
       key: "status",
       header: "Status",
-      width: 104,
-      minWidth: 104,
+      width: 110,
+      minWidth: 110,
       sortKey: "state",
       render: (issue) => {
         const primaryState = getPrimaryLifecycleState(issue.states)
@@ -191,6 +185,12 @@ export function IssuesView({
           </div>
         )
       },
+    },
+    {
+      key: "tags",
+      header: "Tags",
+      width: 150,
+      render: (issue) => <TagList tags={issue.tags} />,
     },
     {
       key: "trend",

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -45,6 +45,7 @@ export { SpanRepository } from "./ports/span-repository.ts"
 export type {
   NumericRollup,
   TraceDistinctColumn,
+  TraceHistogramMetric,
   TraceListCursor,
   TraceListOptions,
   TraceListPage,
@@ -52,7 +53,13 @@ export type {
   TraceRepositoryShape,
   TraceTimeHistogramBucket,
 } from "./ports/trace-repository.ts"
-export { emptyTraceMetrics, TraceRepository } from "./ports/trace-repository.ts"
+export {
+  emptyTraceMetrics,
+  emptyTraceTimeHistogramBucket,
+  isTraceHistogramMetric,
+  TRACE_HISTOGRAM_METRICS,
+  TraceRepository,
+} from "./ports/trace-repository.ts"
 export {
   buildTraceCohortSummaryEntries,
   buildTraceMetricBaseline,

--- a/packages/domain/spans/src/helpers.test.ts
+++ b/packages/domain/spans/src/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   denseTraceTimeHistogramBuckets,
   pickTraceHistogramBucketSeconds,
 } from "./helpers.ts"
+import { emptyTraceTimeHistogramBucket } from "./ports/trace-repository.ts"
 
 describe("alignUnixSecondsToHistogramBucket", () => {
   it("matches ClickHouse-style intDiv(ts, bs) * bs", () => {
@@ -38,23 +39,38 @@ describe("pickTraceHistogramBucketSeconds", () => {
 })
 
 describe("denseTraceTimeHistogramBuckets", () => {
-  it("fills missing buckets with zero", () => {
+  it("fills missing buckets with zero across all metric fields", () => {
     const rangeStartIso = "2024-06-01T10:00:00.000Z"
     const rangeEndIso = "2024-06-01T12:00:00.000Z"
-    const sparse = [{ bucketStart: "2024-06-01T11:00:00.000Z", traceCount: 7 }]
-    const dense = denseTraceTimeHistogramBuckets(sparse, rangeStartIso, rangeEndIso, 3600)
+    const populated = {
+      bucketStart: "2024-06-01T11:00:00.000Z",
+      traceCount: 7,
+      costTotalMicrocentsSum: 1234,
+      durationNsMedian: 5_000_000,
+      tokensTotalSum: 200,
+      spanCountSum: 14,
+      timeToFirstTokenNsMedian: 3_000_000,
+    }
+    const dense = denseTraceTimeHistogramBuckets([populated], rangeStartIso, rangeEndIso, 3600)
     expect(dense).toHaveLength(3)
-    expect(dense[0]).toEqual({ bucketStart: "2024-06-01T10:00:00.000Z", traceCount: 0 })
-    expect(dense[1]).toEqual({ bucketStart: "2024-06-01T11:00:00.000Z", traceCount: 7 })
-    expect(dense[2]).toEqual({ bucketStart: "2024-06-01T12:00:00.000Z", traceCount: 0 })
+    expect(dense[0]).toEqual(emptyTraceTimeHistogramBucket("2024-06-01T10:00:00.000Z"))
+    expect(dense[1]).toEqual(populated)
+    expect(dense[2]).toEqual(emptyTraceTimeHistogramBucket("2024-06-01T12:00:00.000Z"))
   })
 
-  it("returns all zeros when sparse is empty", () => {
+  it("returns all-zero buckets across every metric when sparse is empty", () => {
     const rangeStartIso = "2024-06-01T00:00:00.000Z"
     const rangeEndIso = "2024-06-01T01:00:00.000Z"
     const dense = denseTraceTimeHistogramBuckets(undefined, rangeStartIso, rangeEndIso, 3600)
     expect(dense).toHaveLength(2)
-    expect(dense.every((b) => b.traceCount === 0)).toBe(true)
+    for (const bucket of dense) {
+      expect(bucket.traceCount).toBe(0)
+      expect(bucket.costTotalMicrocentsSum).toBe(0)
+      expect(bucket.durationNsMedian).toBe(0)
+      expect(bucket.tokensTotalSum).toBe(0)
+      expect(bucket.spanCountSum).toBe(0)
+      expect(bucket.timeToFirstTokenNsMedian).toBe(0)
+    }
   })
 
   it("returns empty array for invalid range", () => {
@@ -62,15 +78,43 @@ describe("denseTraceTimeHistogramBuckets", () => {
     expect(denseTraceTimeHistogramBuckets([], "not-a-date", "2024-06-01T01:00:00.000Z", 60)).toEqual([])
   })
 
-  it("sums duplicate aligned sparse rows", () => {
+  it("merges duplicate aligned sparse rows: sums additive fields, keeps max for medians", () => {
+    // ClickHouse GROUP BY guarantees one sparse row per aligned bucket, so this defensive fold
+    // is unreachable in practice. When it does fire, additive fields combine; medians can't be
+    // re-derived from two pre-computed medians, so we take the max as a safe upper bound rather
+    // than producing a meaningless sum.
     const rangeStartIso = "2024-06-01T10:00:00.000Z"
     const rangeEndIso = "2024-06-01T10:59:59.999Z"
     const sparse = [
-      { bucketStart: "2024-06-01T10:00:00.000Z", traceCount: 2 },
-      { bucketStart: "2024-06-01T10:00:00.123Z", traceCount: 3 },
+      {
+        bucketStart: "2024-06-01T10:00:00.000Z",
+        traceCount: 2,
+        costTotalMicrocentsSum: 100,
+        durationNsMedian: 1_000,
+        tokensTotalSum: 30,
+        spanCountSum: 4,
+        timeToFirstTokenNsMedian: 500,
+      },
+      {
+        bucketStart: "2024-06-01T10:00:00.123Z",
+        traceCount: 3,
+        costTotalMicrocentsSum: 200,
+        durationNsMedian: 2_000,
+        tokensTotalSum: 70,
+        spanCountSum: 6,
+        timeToFirstTokenNsMedian: 1_500,
+      },
     ]
     const dense = denseTraceTimeHistogramBuckets(sparse, rangeStartIso, rangeEndIso, 3600)
     expect(dense).toHaveLength(1)
-    expect(dense[0]?.traceCount).toBe(5)
+    expect(dense[0]).toEqual({
+      bucketStart: "2024-06-01T10:00:00.000Z",
+      traceCount: 5,
+      costTotalMicrocentsSum: 300,
+      durationNsMedian: 2_000,
+      tokensTotalSum: 100,
+      spanCountSum: 10,
+      timeToFirstTokenNsMedian: 1_500,
+    })
   })
 })

--- a/packages/domain/spans/src/helpers.ts
+++ b/packages/domain/spans/src/helpers.ts
@@ -1,6 +1,6 @@
 import type { FilterCondition, FilterSet } from "@domain/shared"
 
-import type { TraceTimeHistogramBucket } from "./ports/trace-repository.ts"
+import { emptyTraceTimeHistogramBucket, type TraceTimeHistogramBucket } from "./ports/trace-repository.ts"
 
 const DEFAULT_RANGE_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -165,20 +165,31 @@ export function denseTraceTimeHistogramBuckets(
   const first = alignUnixSecondsToHistogramBucket(startSec, bs)
   const last = alignUnixSecondsToHistogramBucket(endSec, bs)
 
-  const counts = new Map<number, number>()
+  // ClickHouse already groups by aligned `bucket_start`, so sparse rows are unique by key in
+  // practice; key-aligning here is a defensive fold against malformed input. Additive fields
+  // (count, sums) combine cleanly. Medians cannot be re-derived from two pre-computed medians,
+  // so we take the max as a safe upper bound rather than producing a meaningless sum.
+  const buckets = new Map<number, TraceTimeHistogramBucket>()
   for (const b of sparse ?? []) {
     const t = Date.parse(b.bucketStart)
     if (!Number.isFinite(t)) continue
     const key = alignUnixSecondsToHistogramBucket(Math.floor(t / 1000), bs)
-    counts.set(key, (counts.get(key) ?? 0) + b.traceCount)
+    const prev = buckets.get(key) ?? emptyTraceTimeHistogramBucket(new Date(key * 1000).toISOString())
+    buckets.set(key, {
+      bucketStart: prev.bucketStart,
+      traceCount: prev.traceCount + b.traceCount,
+      costTotalMicrocentsSum: prev.costTotalMicrocentsSum + b.costTotalMicrocentsSum,
+      durationNsMedian: Math.max(prev.durationNsMedian, b.durationNsMedian),
+      tokensTotalSum: prev.tokensTotalSum + b.tokensTotalSum,
+      spanCountSum: prev.spanCountSum + b.spanCountSum,
+      timeToFirstTokenNsMedian: Math.max(prev.timeToFirstTokenNsMedian, b.timeToFirstTokenNsMedian),
+    })
   }
 
   const out: TraceTimeHistogramBucket[] = []
   for (let u = first; u <= last; u += bs) {
-    out.push({
-      bucketStart: new Date(u * 1000).toISOString(),
-      traceCount: counts.get(u) ?? 0,
-    })
+    const iso = new Date(u * 1000).toISOString()
+    out.push(buckets.get(u) ?? emptyTraceTimeHistogramBucket(iso))
   }
   return out
 }

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -57,6 +57,7 @@ export { SpanRepository } from "./ports/span-repository.ts"
 export type {
   NumericRollup,
   TraceDistinctColumn,
+  TraceHistogramMetric,
   TraceListCursor,
   TraceListOptions,
   TraceListPage,
@@ -64,7 +65,13 @@ export type {
   TraceRepositoryShape,
   TraceTimeHistogramBucket,
 } from "./ports/trace-repository.ts"
-export { emptyTraceMetrics, TraceRepository } from "./ports/trace-repository.ts"
+export {
+  emptyTraceMetrics,
+  emptyTraceTimeHistogramBucket,
+  isTraceHistogramMetric,
+  TRACE_HISTOGRAM_METRICS,
+  TraceRepository,
+} from "./ports/trace-repository.ts"
 export type { TraceSearchBudgetShape } from "./ports/trace-search-budget.ts"
 export { TraceSearchBudget } from "./ports/trace-search-budget.ts"
 export type {

--- a/packages/domain/spans/src/ports/trace-repository.ts
+++ b/packages/domain/spans/src/ports/trace-repository.ts
@@ -150,11 +150,40 @@ export const emptyTraceMetrics = (): TraceMetrics => ({
   timeToFirstTokenNs: zeroRollup(),
 })
 
+/**
+ * Per-bucket aggregates for the traces histogram. Each bucket carries one value per supported
+ * `TraceHistogramMetric` so the frontend can swap which series it renders without refetching.
+ * Keep this in sync with `TRACE_HISTOGRAM_METRICS` and the columns selected in
+ * `TraceRepository.histogramByProjectId`.
+ */
 export interface TraceTimeHistogramBucket {
   /** Bucket start instant (UTC ISO string). */
   readonly bucketStart: string
   readonly traceCount: number
+  readonly costTotalMicrocentsSum: number
+  readonly durationNsMedian: number
+  readonly tokensTotalSum: number
+  readonly spanCountSum: number
+  readonly timeToFirstTokenNsMedian: number
 }
+
+/** Metric series the traces histogram can render. Order matches the metric cards above the chart. */
+export const TRACE_HISTOGRAM_METRICS = ["traces", "cost", "duration", "tokens", "ttft", "spans"] as const
+
+export type TraceHistogramMetric = (typeof TRACE_HISTOGRAM_METRICS)[number]
+
+export const isTraceHistogramMetric = (value: string): value is TraceHistogramMetric =>
+  (TRACE_HISTOGRAM_METRICS as readonly string[]).includes(value)
+
+export const emptyTraceTimeHistogramBucket = (bucketStart: string): TraceTimeHistogramBucket => ({
+  bucketStart,
+  traceCount: 0,
+  costTotalMicrocentsSum: 0,
+  durationNsMedian: 0,
+  tokensTotalSum: 0,
+  spanCountSum: 0,
+  timeToFirstTokenNsMedian: 0,
+})
 
 export class TraceRepository extends ServiceMap.Service<TraceRepository, TraceRepositoryShape>()(
   "@domain/spans/TraceRepository",

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.test.ts
@@ -633,10 +633,17 @@ describe("TraceRepository", () => {
       // All four agree on the same 3-trace result set (hybrid, lexical-only,
       // semantic-only — the antiparallel noise row is below the floor).
       const histogramCount = histogram.reduce((sum, bucket) => sum + bucket.traceCount, 0)
+      const histogramSpanSum = histogram.reduce((sum, bucket) => sum + bucket.spanCountSum, 0)
+      const histogramTokenSum = histogram.reduce((sum, bucket) => sum + bucket.tokensTotalSum, 0)
+      const histogramCostSum = histogram.reduce((sum, bucket) => sum + bucket.costTotalMicrocentsSum, 0)
       expect(page.items).toHaveLength(3)
       expect(count).toBe(3)
       expect(metrics.spanCount.sum).toBe(3)
       expect(histogramCount).toBe(3)
+      // Per-bucket sums collapse back to the project-wide sums computed by aggregateMetricsByProjectId.
+      expect(histogramSpanSum).toBe(metrics.spanCount.sum)
+      expect(histogramTokenSum).toBe(metrics.tokensTotal.sum)
+      expect(histogramCostSum).toBe(metrics.costTotalMicrocents.sum)
     })
   })
 })

--- a/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/trace-repository.ts
@@ -252,6 +252,29 @@ type TraceDetailRow = TraceListRow & {
   system_instructions: string
 }
 
+/**
+ * Per-bucket aggregations for the histogram, computed over the trace-deduped subquery
+ * (`SELECT ${LIST_SELECT} ... GROUP BY trace_id`). One row per bucket; columns mirror the
+ * fields exposed on `TraceTimeHistogramBucket`. Sums use plain `sum`; medians use
+ * `quantileTDigest(0.5)` (TTFT also gates on `> 0` to ignore the sentinel).
+ */
+const HISTOGRAM_BUCKET_SELECT = `count() AS trace_count,
+  sum(cost_total_microcents) AS cost_sum,
+  quantileTDigest(0.5)(duration_ns) AS duration_median,
+  sum(tokens_total) AS tokens_sum,
+  sum(span_count) AS span_sum,
+  quantileTDigestIf(0.5)(time_to_first_token_ns, time_to_first_token_ns > 0) AS ttft_median`
+
+type TraceHistogramBucketRow = {
+  bucket_start: string
+  trace_count: string
+  cost_sum: string
+  duration_median: string
+  tokens_sum: string
+  span_sum: string
+  ttft_median: string
+}
+
 const parseMessages = (json: string): GenAIMessage[] => {
   if (!json) return []
   try {
@@ -351,6 +374,17 @@ const toTtftRollup = (row: TraceMetricsRow) => ({
   avg: finiteOrZero(row.ttft_avg),
   median: finiteOrZero(row.ttft_median),
   sum: finiteOrZero(row.ttft_sum),
+})
+
+const toHistogramBucket = (row: TraceHistogramBucketRow): TraceTimeHistogramBucket => ({
+  bucketStart: parseCHDate(row.bucket_start).toISOString(),
+  traceCount: Number(row.trace_count),
+  costTotalMicrocentsSum: Number(row.cost_sum),
+  durationNsMedian: Number(row.duration_median),
+  tokensTotalSum: Number(row.tokens_sum),
+  spanCountSum: Number(row.span_sum),
+  // TTFT is gated on `> 0`, so empty buckets return `nan` from the aggregate — coerce to 0.
+  timeToFirstTokenNsMedian: finiteOrZero(row.ttft_median),
 })
 
 const toTraceMetrics = (row: TraceMetricsRow | undefined): TraceMetrics => {
@@ -1126,7 +1160,7 @@ export const TraceRepositoryLive = Layer.effect(
                             intDiv(toUnixTimestamp(start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
                             'UTC'
                           ) AS bucket_start,
-                          count() AS trace_count
+                          ${HISTOGRAM_BUCKET_SELECT}
                         FROM (
                           SELECT ${LIST_SELECT}
                           FROM traces
@@ -1148,15 +1182,10 @@ export const TraceRepositoryLive = Layer.effect(
                   },
                   format: "JSONEachRow",
                 })
-                return result.json<{ bucket_start: string; trace_count: string }>()
+                return result.json<TraceHistogramBucketRow>()
               })
               .pipe(
-                Effect.map((rows): readonly TraceTimeHistogramBucket[] =>
-                  rows.map((row) => ({
-                    bucketStart: parseCHDate(row.bucket_start).toISOString(),
-                    traceCount: Number(row.trace_count),
-                  })),
-                ),
+                Effect.map((rows): readonly TraceTimeHistogramBucket[] => rows.map(toHistogramBucket)),
                 Effect.mapError((error) => toRepositoryError(error, "histogramByProjectId")),
               )
           }
@@ -1169,7 +1198,7 @@ export const TraceRepositoryLive = Layer.effect(
                           intDiv(toUnixTimestamp(start_time), {bucketSeconds:UInt32}) * {bucketSeconds:UInt32},
                           'UTC'
                         ) AS bucket_start,
-                        count() AS trace_count
+                        ${HISTOGRAM_BUCKET_SELECT}
                       FROM (
                         SELECT ${LIST_SELECT}
                         FROM traces
@@ -1189,15 +1218,10 @@ export const TraceRepositoryLive = Layer.effect(
                 },
                 format: "JSONEachRow",
               })
-              return result.json<{ bucket_start: string; trace_count: string }>()
+              return result.json<TraceHistogramBucketRow>()
             })
             .pipe(
-              Effect.map((rows): readonly TraceTimeHistogramBucket[] =>
-                rows.map((row) => ({
-                  bucketStart: parseCHDate(row.bucket_start).toISOString(),
-                  traceCount: Number(row.trace_count),
-                })),
-              ),
+              Effect.map((rows): readonly TraceTimeHistogramBucket[] => rows.map(toHistogramBucket)),
               Effect.mapError((error) => toRepositoryError(error, "histogramByProjectId")),
             )
         }),

--- a/packages/ui/src/components/tag-badge/tag-list.tsx
+++ b/packages/ui/src/components/tag-badge/tag-list.tsx
@@ -8,21 +8,25 @@ const GAP_PX = 4
 
 export interface TagListProps {
   readonly tags: readonly string[]
+  readonly wrap?: boolean
 }
 
 /**
  * Renders a horizontal list of tag badges left-to-right.
  *
- * When the list overflows the container it truncates to the largest prefix that
- * fits alongside a "+N" overflow badge, so nothing is ever clipped or scrolled.
- * Hovering the overflow badge shows the full tag list in a tooltip.
+ * By default, when the list overflows the container it truncates to the largest
+ * prefix that fits alongside a "+N" overflow badge, so nothing is ever clipped
+ * or scrolled. Hovering the overflow badge shows the full tag list in a
+ * tooltip. When `wrap` is true, all tags are rendered and wrap onto new lines
+ * as needed instead of collapsing into "+N".
  */
-export const TagList = memo(function TagList({ tags }: TagListProps) {
+export const TagList = memo(function TagList({ tags, wrap = false }: TagListProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [visibleCount, setVisibleCount] = useState(tags.length)
   const sorted = useMemo(() => [...tags].sort(), [tags])
 
   useLayoutEffect(() => {
+    if (wrap) return
     const container = containerRef.current
     if (!container) return
 
@@ -82,9 +86,20 @@ export const TagList = memo(function TagList({ tags }: TagListProps) {
     measure()
 
     return () => observer.disconnect()
-  }, [sorted])
+  }, [sorted, wrap])
 
   if (tags.length === 0) return null
+
+  if (wrap) {
+    return (
+      <div className="flex flex-wrap items-center gap-1">
+        {sorted.map((tag) => (
+          <TagBadge key={tag} tag={tag} />
+        ))}
+      </div>
+    )
+  }
+
   const hasOverflow = visibleCount < sorted.length
   const hiddenTags = sorted.slice(visibleCount)
 


### PR DESCRIPTION
## Summary
- Metric cards above the project traces histogram are now buttons. Clicking one re-renders the chart with that metric per bucket (cost sum, median duration, token sum, median TTFT, span sum); the default "Traces" matches today's behavior.
- Selection is persisted via `?histogramMetric=<id>` for shareable links; the default `traces` is omitted so canonical URLs stay clean.
- `histogramByProjectId` now returns one value per supported metric per bucket in a single ClickHouse query, so switching metrics is instant — no refetch, no extra round-trips. Empty buckets get zeros (TTFT median is gated `> 0` and coerced from `nan`).

## Notable design choices
- Single source of truth in `apps/web/.../-components/aggregations/histogram-metrics.ts` maps each `TraceHistogramMetric` → label, card-value selector, bucket-value selector, formatter, tooltip noun. Adding a new metric is one entry there + one column in `HISTOGRAM_BUCKET_SELECT`.
- `TraceHistogramMetric` lives in `@domain/spans` next to `TRACE_HISTOGRAM_METRICS` so backend, frontend, and any future ports share the union.
- The TTFT card stays conditional (`max > 0`) so projects without streaming don't see a perpetual "—".

## Files of note
- `packages/domain/spans/src/ports/trace-repository.ts` — `TraceTimeHistogramBucket` extended; new `TraceHistogramMetric`, `TRACE_HISTOGRAM_METRICS`, `isTraceHistogramMetric`, `emptyTraceTimeHistogramBucket`
- `packages/domain/spans/src/helpers.ts` — `denseTraceTimeHistogramBuckets` fills every metric with zeros for missing buckets
- `packages/platform/db-clickhouse/src/repositories/trace-repository.ts` — `histogramByProjectId` selects all metric aggregations per bucket
- `apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/{aggregations-panel,general-aggregations,histogram,histogram-metrics}.tsx`
- `AGENTS.md` — repo-wide rule: never invoke `tsc` directly, always use `pnpm typecheck`
`