### PR TITLE
Serialize discovery and assignment with Redis locks

### DIFF
--- a/apps/workflows/src/activities/index.ts
+++ b/apps/workflows/src/activities/index.ts
@@ -21,6 +21,7 @@ export {
   hybridSearchIssues,
   rerankIssueCandidates,
   resolveMatchedIssue,
+  serializeIssueDiscovery,
   syncIssueProjections,
   syncScoreAnalytics,
 } from "./issue-discovery-activities.ts"

--- a/apps/workflows/src/activities/issue-discovery-activities.ts
+++ b/apps/workflows/src/activities/issue-discovery-activities.ts
@@ -9,12 +9,15 @@ import {
   embedScoreFeedbackUseCase,
   type HybridSearchIssuesInput,
   hybridSearchIssuesUseCase,
+  IssueDiscoveryLockUnavailableError,
   isEligibilityError,
   type RerankIssueCandidatesInput,
   type ResolveMatchedIssueInput,
   rerankIssueCandidatesUseCase,
   resolveMatchedIssueUseCase,
+  type SerializeIssueDiscoveryInput,
   type SyncIssueProjectionsInput,
+  serializeIssueDiscoveryUseCase,
   syncIssueProjectionsUseCase,
 } from "@domain/issues"
 import { type SyncScoreAnalyticsInput, syncScoreAnalyticsUseCase } from "@domain/scores"
@@ -22,6 +25,7 @@ import { OrganizationId } from "@domain/shared"
 import { withAi } from "@platform/ai"
 import { AIGenerateLive } from "@platform/ai-vercel"
 import { AIEmbedLive, AIRerankLive } from "@platform/ai-voyage"
+import { RedisIssueDiscoveryLockRepositoryLive } from "@platform/cache-redis"
 import { ScoreAnalyticsRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
 import { IssueRepositoryLive, OutboxEventWriterLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { IssueProjectionRepositoryLive, withWeaviate } from "@platform/db-weaviate"
@@ -95,8 +99,37 @@ export const createIssueFromScore = async (input: CreateIssueFromScoreInput) =>
         getPostgresClient(),
         OrganizationId(input.organizationId),
       ),
+      withWeaviate(IssueProjectionRepositoryLive, await getWeaviateClient(), OrganizationId(input.organizationId)),
       withAi(AIGenerateLive, getRedisClient()),
       withTracing,
+    ),
+  )
+
+export const serializeIssueDiscovery = async (input: SerializeIssueDiscoveryInput) =>
+  Effect.runPromise(
+    serializeIssueDiscoveryUseCase(input).pipe(
+      withPostgres(
+        Layer.mergeAll(ScoreRepositoryLive, IssueRepositoryLive, OutboxEventWriterLive),
+        getPostgresClient(),
+        OrganizationId(input.organizationId),
+      ),
+      Effect.provide(RedisIssueDiscoveryLockRepositoryLive(getRedisClient())),
+      withWeaviate(IssueProjectionRepositoryLive, await getWeaviateClient(), OrganizationId(input.organizationId)),
+      withAi(Layer.mergeAll(AIGenerateLive, AIRerankLive), getRedisClient()),
+      withTracing,
+      Effect.match({
+        onFailure: (error) => {
+          if (error instanceof IssueDiscoveryLockUnavailableError) {
+            return { status: "lock-unavailable" as const }
+          }
+
+          throw error
+        },
+        onSuccess: (result) =>
+          result.action === "skipped"
+            ? { status: "skipped" as const, reason: result.reason }
+            : { status: "serialized" as const, assignment: result },
+      }),
     ),
   )
 
@@ -108,7 +141,19 @@ export const assignScoreToIssue = async (input: AssignScoreToIssueInput) =>
         getPostgresClient(),
         OrganizationId(input.organizationId),
       ),
+      Effect.provide(RedisIssueDiscoveryLockRepositoryLive(getRedisClient())),
+      withWeaviate(IssueProjectionRepositoryLive, await getWeaviateClient(), OrganizationId(input.organizationId)),
       withTracing,
+      Effect.match({
+        onFailure: (error) => {
+          if (error instanceof IssueDiscoveryLockUnavailableError) {
+            return { status: "lock-unavailable" as const }
+          }
+
+          throw error
+        },
+        onSuccess: (assignment) => ({ status: "assigned" as const, assignment }),
+      }),
     ),
   )
 

--- a/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.test.ts
+++ b/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.test.ts
@@ -1,11 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { callOrder, mockActivities } = vi.hoisted(() => {
+const { callOrder, mockActivities, mockSleep } = vi.hoisted(() => {
   const callOrder: string[] = []
   type MockAssignmentResult = {
-    action: "assigned-existing" | "already-assigned" | "created"
+    action: "assigned" | "already-assigned" | "created"
     issueId: string
   }
+  type MockAssignResult =
+    | {
+        status: "assigned"
+        assignment: MockAssignmentResult
+      }
+    | {
+        status: "lock-unavailable"
+      }
 
   const mockActivities = {
     embedScoreFeedback: vi.fn(async () => {
@@ -16,26 +24,31 @@ const { callOrder, mockActivities } = vi.hoisted(() => {
         normalizedEmbedding: [0.6, 0.8],
       }
     }),
-    assignScoreToIssue: vi.fn(async (): Promise<MockAssignmentResult> => {
+    assignScoreToIssue: vi.fn(async (): Promise<MockAssignResult> => {
       callOrder.push("assignScoreToIssue")
       return {
-        action: "assigned-existing",
-        issueId: "issue-known",
+        status: "assigned" as const,
+        assignment: {
+          action: "assigned",
+          issueId: "issue-known",
+        },
       }
-    }),
-    syncIssueProjections: vi.fn(async () => {
-      callOrder.push("syncIssueProjections")
     }),
     syncScoreAnalytics: vi.fn(async () => {
       callOrder.push("syncScoreAnalytics")
     }),
   }
 
-  return { callOrder, mockActivities }
+  const mockSleep = vi.fn(async (durationMs: number) => {
+    callOrder.push(`sleep:${durationMs}`)
+  })
+
+  return { callOrder, mockActivities, mockSleep }
 })
 
 vi.mock("@temporalio/workflow", () => ({
   proxyActivities: () => mockActivities,
+  sleep: mockSleep,
 }))
 
 import { assignScoreToKnownIssueWorkflow } from "./assign-score-to-known-issue-workflow.ts"
@@ -55,16 +68,11 @@ describe("assignScoreToKnownIssueWorkflow", () => {
     })
 
     expect(result).toEqual({
-      action: "assigned-existing",
+      action: "assigned",
       issueId: "issue-known",
     })
 
-    expect(callOrder).toEqual([
-      "embedScoreFeedback",
-      "assignScoreToIssue",
-      "syncIssueProjections",
-      "syncScoreAnalytics",
-    ])
+    expect(callOrder).toEqual(["embedScoreFeedback", "assignScoreToIssue", "syncScoreAnalytics"])
 
     expect(mockActivities.embedScoreFeedback).toHaveBeenCalledWith({
       organizationId: "org-1",
@@ -78,13 +86,10 @@ describe("assignScoreToKnownIssueWorkflow", () => {
       issueId: "issue-known",
       normalizedEmbedding: [0.6, 0.8],
     })
-    expect(mockActivities.syncIssueProjections).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      issueId: "issue-known",
-    })
     expect(mockActivities.syncScoreAnalytics).toHaveBeenCalledWith({
       organizationId: "org-1",
       scoreId: "score-1",
     })
+    expect(mockSleep).not.toHaveBeenCalled()
   })
 })

--- a/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.ts
+++ b/apps/workflows/src/workflows/assign-score-to-known-issue-workflow.ts
@@ -1,10 +1,9 @@
 import { proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { runWithLockRetry } from "./lock-retry.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
-const { embedScoreFeedback, assignScoreToIssue, syncIssueProjections, syncScoreAnalytics } = proxyActivities<
-  typeof activities
->({
+const { embedScoreFeedback, assignScoreToIssue, syncScoreAnalytics } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
   retry: defaultActivityRetryPolicy,
 })
@@ -21,23 +20,20 @@ export const assignScoreToKnownIssueWorkflow = async (input: {
     scoreId: input.scoreId,
   })
 
-  const assignment = await assignScoreToIssue({
-    organizationId: input.organizationId,
-    projectId: input.projectId,
-    scoreId: input.scoreId,
-    issueId: input.issueId,
-    normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
-  })
-
-  await syncIssueProjections({
-    organizationId: input.organizationId,
-    issueId: assignment.issueId,
-  })
+  const result = await runWithLockRetry(() =>
+    assignScoreToIssue({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      scoreId: input.scoreId,
+      issueId: input.issueId,
+      normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
+    }),
+  )
 
   await syncScoreAnalytics({
     organizationId: input.organizationId,
     scoreId: input.scoreId,
   })
 
-  return { action: assignment.action, issueId: assignment.issueId }
+  return { action: result.assignment.action, issueId: result.assignment.issueId }
 }

--- a/apps/workflows/src/workflows/issue-discovery-workflow.test.ts
+++ b/apps/workflows/src/workflows/issue-discovery-workflow.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { callOrder, mockActivities } = vi.hoisted(() => {
+const { callOrder, mockActivities, mockSleep } = vi.hoisted(() => {
   const callOrder: string[] = []
   type MockRetrievalResult = {
     matchedIssueUuid: string | null
@@ -18,9 +18,29 @@ const { callOrder, mockActivities } = vi.hoisted(() => {
     issueId: string | null
   }
   type MockAssignmentResult = {
-    action: "created" | "assigned-existing" | "already-assigned"
+    action: "created" | "assigned" | "already-assigned"
     issueId: string
   }
+  type MockSerializeResult =
+    | {
+        status: "serialized"
+        assignment: MockAssignmentResult
+      }
+    | {
+        status: "lock-unavailable"
+      }
+    | {
+        status: "skipped"
+        reason: string
+      }
+  type MockAssignResult =
+    | {
+        status: "assigned"
+        assignment: MockAssignmentResult
+      }
+    | {
+        status: "lock-unavailable"
+      }
 
   const mockActivities = {
     checkEligibility: vi.fn<() => Promise<MockEligibilityResult>>(async () => {
@@ -56,36 +76,45 @@ const { callOrder, mockActivities } = vi.hoisted(() => {
         issueId: "issue-1",
       }
     }),
-    createIssueFromScore: vi.fn<() => Promise<MockAssignmentResult>>(async () => {
-      callOrder.push("createIssueFromScore")
+    serializeIssueDiscovery: vi.fn<() => Promise<MockSerializeResult>>(async () => {
+      callOrder.push("serializeIssueDiscovery")
       return {
-        action: "created",
-        issueId: "issue-new",
+        status: "serialized" as const,
+        assignment: {
+          action: "created",
+          issueId: "issue-new",
+        },
       }
     }),
-    assignScoreToIssue: vi.fn<() => Promise<MockAssignmentResult>>(async () => {
+    assignScoreToIssue: vi.fn<() => Promise<MockAssignResult>>(async () => {
       callOrder.push("assignScoreToIssue")
       return {
-        action: "assigned-existing",
-        issueId: "issue-1",
+        status: "assigned" as const,
+        assignment: {
+          action: "assigned",
+          issueId: "issue-1",
+        },
       }
     }),
     syncScoreAnalytics: vi.fn(async () => {
       callOrder.push("syncScoreAnalytics")
     }),
-    syncIssueProjections: vi.fn(async () => {
-      callOrder.push("syncIssueProjections")
-    }),
   }
+
+  const mockSleep = vi.fn(async (durationMs: number) => {
+    callOrder.push(`sleep:${durationMs}`)
+  })
 
   return {
     callOrder,
     mockActivities,
+    mockSleep,
   }
 })
 
 vi.mock("@temporalio/workflow", () => ({
   proxyActivities: () => mockActivities,
+  sleep: mockSleep,
 }))
 
 import { issueDiscoveryWorkflow } from "./issue-discovery-workflow.ts"
@@ -104,7 +133,7 @@ describe("issueDiscoveryWorkflow", () => {
     })
 
     expect(result).toEqual({
-      action: "assigned-existing",
+      action: "assigned",
       issueId: "issue-1",
     })
 
@@ -115,7 +144,6 @@ describe("issueDiscoveryWorkflow", () => {
       "rerankIssueCandidates",
       "resolveMatchedIssue",
       "assignScoreToIssue",
-      "syncIssueProjections",
       "syncScoreAnalytics",
     ])
 
@@ -141,14 +169,10 @@ describe("issueDiscoveryWorkflow", () => {
       issueId: "issue-1",
       normalizedEmbedding: [0.6, 0.8],
     })
-    expect(mockActivities.createIssueFromScore).not.toHaveBeenCalled()
+    expect(mockActivities.serializeIssueDiscovery).not.toHaveBeenCalled()
     expect(mockActivities.syncScoreAnalytics).toHaveBeenCalledWith({
       organizationId: "org-1",
       scoreId: "score-1",
-    })
-    expect(mockActivities.syncIssueProjections).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      issueId: "issue-1",
     })
   })
 
@@ -172,10 +196,9 @@ describe("issueDiscoveryWorkflow", () => {
     expect(mockActivities.hybridSearchIssues).not.toHaveBeenCalled()
     expect(mockActivities.rerankIssueCandidates).not.toHaveBeenCalled()
     expect(mockActivities.resolveMatchedIssue).not.toHaveBeenCalled()
-    expect(mockActivities.createIssueFromScore).not.toHaveBeenCalled()
+    expect(mockActivities.serializeIssueDiscovery).not.toHaveBeenCalled()
     expect(mockActivities.assignScoreToIssue).not.toHaveBeenCalled()
     expect(mockActivities.syncScoreAnalytics).not.toHaveBeenCalled()
-    expect(mockActivities.syncIssueProjections).not.toHaveBeenCalled()
   })
 
   it("creates a brand-new issue after resolving to no canonical match", async () => {
@@ -192,11 +215,14 @@ describe("issueDiscoveryWorkflow", () => {
         issueId: null,
       }
     })
-    mockActivities.createIssueFromScore.mockImplementationOnce(async () => {
-      callOrder.push("createIssueFromScore")
+    mockActivities.serializeIssueDiscovery.mockImplementationOnce(async () => {
+      callOrder.push("serializeIssueDiscovery")
       return {
-        action: "created",
-        issueId: "issue-new",
+        status: "serialized" as const,
+        assignment: {
+          action: "created",
+          issueId: "issue-new",
+        },
       }
     })
 
@@ -216,8 +242,7 @@ describe("issueDiscoveryWorkflow", () => {
       "hybridSearchIssues",
       "rerankIssueCandidates",
       "resolveMatchedIssue",
-      "createIssueFromScore",
-      "syncIssueProjections",
+      "serializeIssueDiscovery",
       "syncScoreAnalytics",
     ])
     expect(mockActivities.resolveMatchedIssue).toHaveBeenCalledWith({
@@ -225,10 +250,11 @@ describe("issueDiscoveryWorkflow", () => {
       projectId: "proj-1",
       matchedIssueUuid: null,
     })
-    expect(mockActivities.createIssueFromScore).toHaveBeenCalledWith({
+    expect(mockActivities.serializeIssueDiscovery).toHaveBeenCalledWith({
       organizationId: "org-1",
       projectId: "proj-1",
       scoreId: "score-1",
+      feedback: "token leakage in tool output",
       normalizedEmbedding: [0.6, 0.8],
     })
     expect(mockActivities.assignScoreToIssue).not.toHaveBeenCalled()
@@ -241,11 +267,14 @@ describe("issueDiscoveryWorkflow", () => {
         issueId: null,
       }
     })
-    mockActivities.createIssueFromScore.mockImplementationOnce(async () => {
-      callOrder.push("createIssueFromScore")
+    mockActivities.serializeIssueDiscovery.mockImplementationOnce(async () => {
+      callOrder.push("serializeIssueDiscovery")
       return {
-        action: "created",
-        issueId: "issue-new",
+        status: "serialized" as const,
+        assignment: {
+          action: "created",
+          issueId: "issue-new",
+        },
       }
     })
 
@@ -265,8 +294,7 @@ describe("issueDiscoveryWorkflow", () => {
       "hybridSearchIssues",
       "rerankIssueCandidates",
       "resolveMatchedIssue",
-      "createIssueFromScore",
-      "syncIssueProjections",
+      "serializeIssueDiscovery",
       "syncScoreAnalytics",
     ])
     expect(mockActivities.resolveMatchedIssue).toHaveBeenCalledWith({
@@ -274,12 +302,102 @@ describe("issueDiscoveryWorkflow", () => {
       projectId: "proj-1",
       matchedIssueUuid: "issue-1",
     })
-    expect(mockActivities.createIssueFromScore).toHaveBeenCalledWith({
+    expect(mockActivities.serializeIssueDiscovery).toHaveBeenCalledWith({
       organizationId: "org-1",
       projectId: "proj-1",
       scoreId: "score-1",
+      feedback: "token leakage in tool output",
       normalizedEmbedding: [0.6, 0.8],
     })
     expect(mockActivities.assignScoreToIssue).not.toHaveBeenCalled()
+  })
+
+  it("retries serialization lock contention with workflow sleeps", async () => {
+    // Pin Math.random so the jitter component of the retry delay is at its minimum (1s) and the asserted
+    // sleep durations stay deterministic. Math.random() is replay-safe inside Temporal workflows.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0)
+    try {
+      mockActivities.resolveMatchedIssue.mockImplementationOnce(async () => {
+        callOrder.push("resolveMatchedIssue")
+        return {
+          issueId: null,
+        }
+      })
+      mockActivities.serializeIssueDiscovery
+        .mockImplementationOnce(async () => {
+          callOrder.push("serializeIssueDiscovery")
+          return { status: "lock-unavailable" as const }
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push("serializeIssueDiscovery")
+          return { status: "lock-unavailable" as const }
+        })
+        .mockImplementationOnce(async () => {
+          callOrder.push("serializeIssueDiscovery")
+          return {
+            status: "serialized" as const,
+            assignment: {
+              action: "assigned" as const,
+              issueId: "issue-1",
+            },
+          }
+        })
+
+      const result = await issueDiscoveryWorkflow({
+        organizationId: "org-1",
+        projectId: "proj-1",
+        scoreId: "score-1",
+      })
+
+      expect(result).toEqual({
+        action: "assigned",
+        issueId: "issue-1",
+      })
+      expect(callOrder).toEqual([
+        "checkEligibility",
+        "embedScoreFeedback",
+        "hybridSearchIssues",
+        "rerankIssueCandidates",
+        "resolveMatchedIssue",
+        "serializeIssueDiscovery",
+        "sleep:2000",
+        "serializeIssueDiscovery",
+        "sleep:3000",
+        "serializeIssueDiscovery",
+        "syncScoreAnalytics",
+      ])
+      expect(mockSleep).toHaveBeenCalledTimes(2)
+    } finally {
+      randomSpy.mockRestore()
+    }
+  })
+
+  it("fails the workflow after exhausting lock-retry attempts", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0)
+    try {
+      mockActivities.resolveMatchedIssue.mockImplementationOnce(async () => {
+        callOrder.push("resolveMatchedIssue")
+        return { issueId: null }
+      })
+      mockActivities.serializeIssueDiscovery.mockImplementation(async () => {
+        callOrder.push("serializeIssueDiscovery")
+        return { status: "lock-unavailable" as const }
+      })
+
+      await expect(
+        issueDiscoveryWorkflow({
+          organizationId: "org-1",
+          projectId: "proj-1",
+          scoreId: "score-1",
+        }),
+      ).rejects.toThrow(/Lock remained unavailable after 18 workflow retries/)
+
+      // 18 attempts, 17 sleeps in between (no sleep after the final attempt).
+      expect(mockActivities.serializeIssueDiscovery).toHaveBeenCalledTimes(18)
+      expect(mockSleep).toHaveBeenCalledTimes(17)
+      expect(mockActivities.syncScoreAnalytics).not.toHaveBeenCalled()
+    } finally {
+      randomSpy.mockRestore()
+    }
   })
 })

--- a/apps/workflows/src/workflows/issue-discovery-workflow.ts
+++ b/apps/workflows/src/workflows/issue-discovery-workflow.ts
@@ -1,5 +1,6 @@
 import { proxyActivities } from "@temporalio/workflow"
 import type * as activities from "../activities/index.ts"
+import { runWithLockRetry } from "./lock-retry.ts"
 import { defaultActivityRetryPolicy } from "./retry-policy.ts"
 
 const {
@@ -8,9 +9,8 @@ const {
   hybridSearchIssues,
   rerankIssueCandidates,
   resolveMatchedIssue,
-  createIssueFromScore,
+  serializeIssueDiscovery,
   assignScoreToIssue,
-  syncIssueProjections,
   syncScoreAnalytics,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
@@ -47,28 +47,38 @@ export const issueDiscoveryWorkflow = async (input: {
     matchedIssueUuid: retrieval.matchedIssueUuid,
   })
 
-  const assignment =
+  const result =
     matchedIssue.issueId === null
-      ? await createIssueFromScore({
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          scoreId: input.scoreId,
-          normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
-        })
-      : await assignScoreToIssue({
-          organizationId: input.organizationId,
-          projectId: input.projectId,
-          scoreId: input.scoreId,
-          issueId: matchedIssue.issueId,
-          normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
-        })
+      ? await runWithLockRetry(() =>
+          serializeIssueDiscovery({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            scoreId: input.scoreId,
+            feedback: embeddedScoreFeedback.feedback,
+            normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
+          }),
+        )
+      : await runWithLockRetry(() =>
+          assignScoreToIssue({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            scoreId: input.scoreId,
+            issueId: matchedIssue.issueId!,
+            normalizedEmbedding: embeddedScoreFeedback.normalizedEmbedding,
+          }),
+        )
 
-  await syncIssueProjections({ organizationId: input.organizationId, issueId: assignment.issueId })
+  if (result.status === "skipped") {
+    return { action: "skipped" as const, reason: result.reason }
+  }
 
   await syncScoreAnalytics({
     organizationId: input.organizationId,
     scoreId: input.scoreId,
   })
 
-  return { action: assignment.action, issueId: assignment.issueId }
+  return {
+    action: result.assignment.action,
+    issueId: result.assignment.issueId,
+  }
 }

--- a/apps/workflows/src/workflows/lock-retry.ts
+++ b/apps/workflows/src/workflows/lock-retry.ts
@@ -1,0 +1,36 @@
+import { sleep } from "@temporalio/workflow"
+
+const LOCK_RETRY_MAX_ATTEMPTS = 18
+const LOCK_RETRY_INITIAL_DELAY_MS = 1_000
+const LOCK_RETRY_MAX_DELAY_MS = 30_000
+const LOCK_RETRY_JITTER_MIN_MS = 1_000
+const LOCK_RETRY_JITTER_MAX_MS = 100_000
+
+// Math.random() is replay-safe inside Temporal workflows (the SDK seeds it deterministically per run). Jitter
+// spreads contended waiters so they do not all wake up at the same moment and re-storm the lock.
+const getLockRetryDelayMs = (attempt: number) => {
+  const backoff = Math.min(LOCK_RETRY_INITIAL_DELAY_MS * 2 ** (attempt - 1), LOCK_RETRY_MAX_DELAY_MS)
+  const jitterRange = LOCK_RETRY_JITTER_MAX_MS - LOCK_RETRY_JITTER_MIN_MS
+  const jitter = Math.floor(Math.random() * (jitterRange + 1)) + LOCK_RETRY_JITTER_MIN_MS
+  return backoff + jitter
+}
+
+// Generic non-blocking lock retry: an activity that returns `{ status: "lock-unavailable" }` on contention is
+// retried with exponential backoff + jitter via durable workflow sleeps. Any other status is returned to the
+// caller, which discriminates the success/skipped variants itself.
+export const runWithLockRetry = async <T extends { status: string }>(
+  invoke: () => Promise<T>,
+): Promise<Exclude<T, { status: "lock-unavailable" }>> => {
+  for (let attempt = 1; attempt <= LOCK_RETRY_MAX_ATTEMPTS; attempt++) {
+    const result = await invoke()
+    if (result.status !== "lock-unavailable") {
+      return result as Exclude<T, { status: "lock-unavailable" }>
+    }
+
+    if (attempt < LOCK_RETRY_MAX_ATTEMPTS) {
+      await sleep(getLockRetryDelayMs(attempt))
+    }
+  }
+
+  throw new Error(`Lock remained unavailable after ${LOCK_RETRY_MAX_ATTEMPTS} workflow retries`)
+}

--- a/biome.json
+++ b/biome.json
@@ -50,12 +50,20 @@
       "linter": {
         "rules": {
           "style": {
+            "noNonNullAssertion": "off",
             "noRestrictedImports": {
               "level": "error",
               "options": {
                 "patterns": [
                   {
-                    "group": ["./test/*", "./testing/*", "../test/*", "../testing/*", "../../test/*", "../../testing/*"],
+                    "group": [
+                      "./test/*",
+                      "./testing/*",
+                      "../test/*",
+                      "../testing/*",
+                      "../../test/*",
+                      "../../testing/*"
+                    ],
                     "message": "Do not import test utilities in production code. Expose them via a /testing subpath export instead."
                   }
                 ]

--- a/dev-docs/issues.md
+++ b/dev-docs/issues.md
@@ -170,6 +170,7 @@ Execution rules:
 - `issues:discovery` runs first after an eligible non-draft failed non-errored score write commits
 - scores already written with `issue_id`, including direct-owned live issue-linked monitor failures, short-circuit before retrieval/rerank; retries through `issues:discovery` may still replay projection and analytics sync idempotently
 - `issue-discovery` runs only when that centralized gate still needs retrieval/rerank work
+- when initial workflow retrieval resolves to no known issue, the workflow must call the bounded locked serialization activity instead of creating an issue directly
 - `issues:refresh` runs after the configured throttle window elapses for an existing issue
 - both the workflow and the debounced task must re-check current ownership/lifecycle state before doing expensive work
 - in workflow orchestration, keep retrieval split into granular activities: feedback embedding (with normalization), hybrid Weaviate search, then reranking
@@ -177,9 +178,40 @@ Execution rules:
 - the debounced `issues:refresh` path must re-lock and re-read the canonical issue row before saving generated details so it cannot overwrite a newer centroid or lifecycle update
 - after `issues:refresh` persists changed details, it must upsert the Weaviate issue projection again; if the issue disappeared or the generated details were unchanged, it should skip the projection write
 - after rerank selects a candidate, resolve that matched issue against canonical Postgres state before choosing between the create-from-score and assign-to-issue paths
+- the no-match path is only provisional; before creating a new issue, serialization must first acquire a feedback-scoped Redis lock and re-run hybrid search, rerank, and Postgres candidate resolution
+- if the feedback-scoped re-check still finds no issue, serialization must acquire the project-scoped Redis lock and re-run retrieval again before creating
+- each Redis lock acquisition must be non-blocking; if the lock is already held, serialization returns a lock-unavailable result so the workflow sleeps durably and retries at that point instead of holding a database connection while waiting
 - both the create-from-score step and the assign-to-issue step must use a conditional `scores.issue_id` claim so only one concurrent owner wins while the canonical issue row and centroid stay transactionally consistent
 - the assign-to-issue path must lock the canonical issue row before recomputing and saving the centroid so parallel score assignments into the same issue do not lose centroid contributions
 - resolved and ignored issues are still valid discovery match candidates; this preserves regression detection and keeps future matching scores linked to intentionally ignored issues
+
+### Bounded locked serialization
+
+Weaviate is a retrieval accelerator, not the write-side source of correctness. A newly created issue can be present in Postgres before its Weaviate projection is visible to another concurrent discovery workflow. Therefore a workflow-level no-match result is not sufficient authority to create a new issue.
+
+The no-match branch must enter `serializeIssueDiscoveryUseCase`, which uses layered Redis locks. A feedback-scoped lock serializes identical feedback strings from the same score source/source id, reducing deterministic-flagger herds before external retrieval work. A project-scoped lock serializes brand-new issue creation attempts for the project, so differently worded but semantically duplicate no-match workflows do not create concurrently while Weaviate projections catch up.
+
+Inside locked serialization must:
+
+1. re-fetch the score by id
+2. acquire the feedback-scoped Redis lock
+3. re-run hybrid issue search against Weaviate using the same canonical feedback and normalized embedding
+4. re-run rerank and resolve the selected issue UUID against Postgres
+5. assign the score to the matched issue if the locked re-check now finds one
+6. otherwise acquire the project-scoped Redis lock and repeat the retrieval/rerank/Postgres resolution check
+7. assign to the project-lock match if one is found
+8. otherwise generate issue details, create one new issue, and claim `scores.issue_id`
+9. sync the issue projection before releasing the locks
+
+This intentionally moves the long external retrieval/rerank/generation section outside Postgres transactions. Lock acquisition must use Redis `SET ... NX EX`; if the key is already held, serialization exits immediately and the workflow performs an explicit sleep-and-retry loop instead of occupying a database connection as a lock waiter. Redis lock keys must be organization-prefixed (`org:${organizationId}:...`) and released with token comparison so one worker cannot release another worker's lock after TTL expiry.
+
+The correctness invariant is:
+
+- the feedback-scoped lock is acquired before the project-scoped lock to reduce deterministic-flagger herds
+- contended workers retry instead of waiting on Postgres or holding database transactions
+- project-level brand-new issue creation is serialized by the Redis project lock
+- assignment to an existing issue remains row-safe through the issue row lock and conditional score ownership claim
+- Weaviate projection lag can delay matching quality, but it must not allow duplicate issue creation from concurrent no-match workflows
 
 Concrete v1 mechanics worth carrying forward:
 

--- a/packages/domain/issues/package.json
+++ b/packages/domain/issues/package.json
@@ -23,6 +23,7 @@
     "@domain/queue": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/scores": "workspace:*",
+    "@repo/utils": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -114,3 +114,46 @@ export const ISSUE_REFRESH_THROTTLE_MS = 8 * 60 * 60 * 1000
  * becomes visible in the main Issues UI.
  */
 export const MIN_OCCURRENCES_FOR_VISIBILITY = 3
+
+// ---------------------------------------------------------------------------
+// Discovery serialization locks
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL for the outer feedback-scoped serialization lock. Wraps retrieval, AI
+ * generation, and the inner project-lock section. Sized to match the
+ * activity `startToCloseTimeout` so the lock outlives any single activity
+ * run; if a worker dies, Redis auto-deletion never strands the key.
+ */
+export const ISSUE_DISCOVERY_FEEDBACK_LOCK_TTL_SECONDS = 300
+
+/**
+ * TTL for the inner project-scoped serialization lock. Serializes brand-new
+ * issue creation per project while a prior worker is still writing the
+ * Postgres row and the Weaviate projection. Matches the activity timeout.
+ */
+export const ISSUE_DISCOVERY_PROJECT_LOCK_TTL_SECONDS = 300
+
+/** Inner project-scoped serialization lock key. */
+export const ISSUE_DISCOVERY_PROJECT_LOCK_KEY = "project"
+
+/**
+ * Outer feedback-scoped serialization lock key. Takes the SHA-256 hex digest
+ * of the canonical feedback string. Hashing serializes identical feedback
+ * across all sources without leaking the feedback into Redis keys.
+ */
+export const ISSUE_DISCOVERY_FEEDBACK_LOCK_KEY = (hash: string) => `feedback:${hash}`
+
+// ---------------------------------------------------------------------------
+// Issue update lock
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-issue serialization lock key. Wraps the assign-score-to-issue Postgres
+ * transaction (centroid recompute) and the subsequent Weaviate projection
+ * sync so concurrent writers to the same issue do not race on the projection.
+ */
+export const ISSUE_UPDATE_LOCK_KEY = (issueId: string) => `issue:${issueId}`
+
+/** TTL for the per-issue update serialization lock. Matches the activity timeout. */
+export const ISSUE_UPDATE_LOCK_TTL_SECONDS = 300

--- a/packages/domain/issues/src/errors.ts
+++ b/packages/domain/issues/src/errors.ts
@@ -85,6 +85,14 @@ export class IssueNotFoundForAssignmentError extends Data.TaggedError("IssueNotF
   readonly httpMessage = "Issue not found for assignment"
 }
 
+export class IssueDiscoveryLockUnavailableError extends Data.TaggedError("IssueDiscoveryLockUnavailableError")<{
+  readonly projectId: string
+  readonly lockKey: string
+}> {
+  readonly httpStatus = 409
+  readonly httpMessage = "Issue discovery serialization lock is currently unavailable"
+}
+
 const eligibilityErrors = [
   ScoreNotFoundForDiscoveryError,
   ScoreDiscoveryOrganizationMismatchError,

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -17,6 +17,8 @@ export {
   ISSUE_REFRESH_THROTTLE_MS,
   ISSUE_SOURCES,
   ISSUE_STATES,
+  ISSUE_UPDATE_LOCK_KEY,
+  ISSUE_UPDATE_LOCK_TTL_SECONDS,
   MIN_OCCURRENCES_FOR_VISIBILITY,
   NEW_ISSUE_AGE_DAYS,
 } from "./constants.ts"
@@ -34,6 +36,7 @@ export {
   type CheckEligibilityError,
   DraftScoreNotEligibleForDiscoveryError,
   ErroredScoreNotEligibleForDiscoveryError,
+  IssueDiscoveryLockUnavailableError,
   IssueNotFoundForAssignmentError,
   IssueNotFoundForDetailsGenerationError,
   isEligibilityError,
@@ -55,6 +58,11 @@ export {
   type UpdateIssueCentroidInput,
   updateIssueCentroid,
 } from "./helpers.ts"
+export {
+  type IssueDiscoveryLockInput,
+  IssueDiscoveryLockRepository,
+  type IssueDiscoveryLockRepositoryShape,
+} from "./ports/issue-discovery-lock-repository.ts"
 export {
   type DeleteIssueProjectionInput,
   type HybridSearchInput,
@@ -160,4 +168,10 @@ export {
   type ResolveMatchedIssueInput,
   resolveMatchedIssueUseCase,
 } from "./use-cases/resolve-matched-issue.ts"
+export {
+  type SerializeIssueDiscoveryError,
+  type SerializeIssueDiscoveryInput,
+  type SerializeIssueDiscoveryResult,
+  serializeIssueDiscoveryUseCase,
+} from "./use-cases/serialize-issue-discovery.ts"
 export { type SyncIssueProjectionsInput, syncIssueProjectionsUseCase } from "./use-cases/sync-projections.ts"

--- a/packages/domain/issues/src/ports/issue-discovery-lock-repository.ts
+++ b/packages/domain/issues/src/ports/issue-discovery-lock-repository.ts
@@ -1,0 +1,22 @@
+import type { CacheError, ProjectId } from "@domain/shared"
+import { type Effect, ServiceMap } from "effect"
+import type { IssueDiscoveryLockUnavailableError } from "../errors.ts"
+
+export interface IssueDiscoveryLockInput {
+  readonly organizationId: string
+  readonly projectId: ProjectId
+  readonly lockKey: string
+  readonly ttlSeconds: number
+}
+
+export interface IssueDiscoveryLockRepositoryShape {
+  withLock<A, E, R>(
+    input: IssueDiscoveryLockInput,
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E | IssueDiscoveryLockUnavailableError | CacheError, R>
+}
+
+export class IssueDiscoveryLockRepository extends ServiceMap.Service<
+  IssueDiscoveryLockRepository,
+  IssueDiscoveryLockRepositoryShape
+>()("@domain/issues/IssueDiscoveryLockRepository") {}

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it } from "vitest"
 import { CENTROID_EMBEDDING_DIMENSIONS } from "../constants.ts"
 import type { Issue } from "../entities/issue.ts"
 import { createIssueCentroid } from "../helpers.ts"
+import { IssueDiscoveryLockRepository } from "../ports/issue-discovery-lock-repository.ts"
+import { IssueProjectionRepository } from "../ports/issue-projection-repository.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
-import { createFakeIssueRepository } from "../testing/index.ts"
+import { createFakeIssueProjectionRepository, createFakeIssueRepository } from "../testing/index.ts"
 import { assignScoreToIssueUseCase } from "./assign-score-to-issue.ts"
 
 const organizationId = "oooooooooooooooooooooooo"
@@ -79,6 +81,10 @@ const createPassthroughSqlClient = (id: string): SqlClientShape => {
   return sqlClient
 }
 
+const passthroughLockRepository = {
+  withLock: <A, E, R>(_input: unknown, effect: Effect.Effect<A, E, R>) => effect,
+}
+
 describe("assignScoreToIssueUseCase", () => {
   it("assigns to an existing issue and requests async refresh", async () => {
     const existingIssue = makeIssue()
@@ -105,11 +111,16 @@ describe("assignScoreToIssueUseCase", () => {
             }),
         }),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
     expect(result).toEqual({
-      action: "assigned-existing",
+      action: "assigned",
       issueId: existingIssue.id,
     })
     expect(scores.get(score.id)?.issueId).toBe(existingIssue.id)
@@ -133,8 +144,9 @@ describe("assignScoreToIssueUseCase", () => {
     const existingIssue = makeIssue()
     const lockCalls: string[] = []
     const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    // findById is allowed (the post-tx projection sync legitimately uses it); we only assert that
+    // findByIdForUpdate is what gates the centroid recompute path.
     const { repository: issueRepository } = createFakeIssueRepository([existingIssue], {
-      findById: () => Effect.die("assignScoreToIssueUseCase should not use unlocked issue reads"),
       findByIdForUpdate: (id) => {
         lockCalls.push(id)
         return Effect.succeed(existingIssue)
@@ -155,6 +167,11 @@ describe("assignScoreToIssueUseCase", () => {
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
@@ -189,6 +206,11 @@ describe("assignScoreToIssueUseCase", () => {
             }),
         }),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
@@ -238,6 +260,11 @@ describe("assignScoreToIssueUseCase", () => {
             }),
         }),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
@@ -270,6 +297,11 @@ describe("assignScoreToIssueUseCase", () => {
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
         Effect.match({
           onFailure: (error) => error,
           onSuccess: () => {

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
@@ -1,13 +1,16 @@
 import { OutboxEventWriter } from "@domain/events"
 import { type Score, ScoreRepository } from "@domain/scores"
-import { IssueId, type RepositoryError, ScoreId, SqlClient } from "@domain/shared"
+import { type CacheError, IssueId, ProjectId, type RepositoryError, ScoreId, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
+import { ISSUE_UPDATE_LOCK_KEY, ISSUE_UPDATE_LOCK_TTL_SECONDS } from "../constants.ts"
 import type { Issue } from "../entities/issue.ts"
-import type { CheckEligibilityError } from "../errors.ts"
+import type { CheckEligibilityError, IssueDiscoveryLockUnavailableError } from "../errors.ts"
 import { IssueNotFoundForAssignmentError, ScoreAlreadyOwnedByIssueError } from "../errors.ts"
 import { updateIssueCentroid } from "../helpers.ts"
+import { IssueDiscoveryLockRepository } from "../ports/issue-discovery-lock-repository.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
 import { checkEligibilityUseCase } from "./check-eligibility.ts"
+import { syncIssueProjectionsUseCase } from "./sync-projections.ts"
 
 export interface AssignScoreToIssueInput {
   readonly organizationId: string
@@ -19,11 +22,13 @@ export interface AssignScoreToIssueInput {
 
 export type AssignScoreToIssueResult = {
   readonly issueId: string
-  readonly action: "assigned-existing" | "already-assigned"
+  readonly action: "assigned" | "already-assigned"
 }
 
 export type AssignScoreToIssueError =
+  | CacheError
   | CheckEligibilityError
+  | IssueDiscoveryLockUnavailableError
   | IssueNotFoundForAssignmentError
   | RepositoryError
   | ScoreAlreadyOwnedByIssueError
@@ -104,6 +109,7 @@ export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
     yield* Effect.annotateCurrentSpan("issueId", input.issueId)
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
     const sqlClient = yield* SqlClient
+    const lockRepository = yield* IssueDiscoveryLockRepository
     const scoreResult = yield* loadEligibleScoreOrCurrentOwner(input)
 
     if (scoreResult.action === "already-assigned") {
@@ -115,68 +121,87 @@ export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
 
     const score = scoreResult.score
 
-    return yield* sqlClient.transaction(
+    return yield* lockRepository.withLock(
+      {
+        organizationId: input.organizationId,
+        projectId: ProjectId(input.projectId),
+        lockKey: ISSUE_UPDATE_LOCK_KEY(input.issueId),
+        ttlSeconds: ISSUE_UPDATE_LOCK_TTL_SECONDS,
+      },
       Effect.gen(function* () {
-        const issueRepository = yield* IssueRepository
-        const outboxEventWriter = yield* OutboxEventWriter
-        const scoreRepository = yield* ScoreRepository
-        const issue = yield* issueRepository
-          .findByIdForUpdate(IssueId(input.issueId))
-          .pipe(
-            Effect.catchTag("NotFoundError", () =>
-              Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
-            ),
-          )
+        const assignment = yield* sqlClient.transaction(
+          Effect.gen(function* () {
+            const issueRepository = yield* IssueRepository
+            const outboxEventWriter = yield* OutboxEventWriter
+            const scoreRepository = yield* ScoreRepository
+            const issue = yield* issueRepository
+              .findByIdForUpdate(IssueId(input.issueId))
+              .pipe(
+                Effect.catchTag("NotFoundError", () =>
+                  Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
+                ),
+              )
 
-        if (issue.projectId !== score.projectId) {
-          return yield* new IssueNotFoundForAssignmentError({ issueId: input.issueId })
-        }
+            if (issue.projectId !== score.projectId) {
+              return yield* new IssueNotFoundForAssignmentError({ issueId: input.issueId })
+            }
 
-        const assignedAt = new Date()
-        const updatedIssue = buildIssueWithAssignedScore({
-          issue,
-          score,
-          normalizedEmbedding: input.normalizedEmbedding,
-          assignedAt,
-        })
+            const assignedAt = new Date()
+            const updatedIssue = buildIssueWithAssignedScore({
+              issue,
+              score,
+              normalizedEmbedding: input.normalizedEmbedding,
+              assignedAt,
+            })
 
-        const claimed = yield* scoreRepository.assignIssueIfUnowned({
-          scoreId: score.id,
-          issueId: issue.id,
-          updatedAt: assignedAt,
-        })
+            const claimed = yield* scoreRepository.assignIssueIfUnowned({
+              scoreId: score.id,
+              issueId: issue.id,
+              updatedAt: assignedAt,
+            })
 
-        if (!claimed) {
-          const currentScore = yield* scoreRepository
-            .findById(score.id)
-            .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
-          if (currentScore && currentScore.issueId !== null) {
+            if (!claimed) {
+              const currentScore = yield* scoreRepository
+                .findById(score.id)
+                .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)))
+              if (currentScore && currentScore.issueId !== null) {
+                return {
+                  action: "already-assigned",
+                  issueId: currentScore.issueId,
+                } satisfies AssignScoreToIssueResult
+              }
+
+              return yield* new ScoreAlreadyOwnedByIssueError({ scoreId: score.id })
+            }
+
+            yield* issueRepository.save(updatedIssue)
+            yield* outboxEventWriter.write({
+              eventName: "ScoreAssignedToIssue",
+              aggregateType: "score",
+              aggregateId: score.id,
+              organizationId: score.organizationId,
+              payload: {
+                organizationId: score.organizationId,
+                projectId: score.projectId,
+                issueId: issue.id,
+              },
+            })
+
             return {
-              action: "already-assigned",
-              issueId: currentScore.issueId,
+              action: "assigned",
+              issueId: issue.id,
             } satisfies AssignScoreToIssueResult
-          }
+          }),
+        )
 
-          return yield* new ScoreAlreadyOwnedByIssueError({ scoreId: score.id })
+        if (assignment.action === "assigned") {
+          yield* syncIssueProjectionsUseCase({
+            organizationId: input.organizationId,
+            issueId: assignment.issueId,
+          })
         }
 
-        yield* issueRepository.save(updatedIssue)
-        yield* outboxEventWriter.write({
-          eventName: "ScoreAssignedToIssue",
-          aggregateType: "score",
-          aggregateId: score.id,
-          organizationId: score.organizationId,
-          payload: {
-            organizationId: score.organizationId,
-            projectId: score.projectId,
-            issueId: issue.id,
-          },
-        })
-
-        return {
-          action: "assigned-existing",
-          issueId: issue.id,
-        } satisfies AssignScoreToIssueResult
+        return assignment
       }),
     )
   }).pipe(Effect.withSpan("issues.assignScoreToIssue")) as Effect.Effect<

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.test.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.test.ts
@@ -6,7 +6,9 @@ import { IssueId, OrganizationId, ScoreId, SqlClient, type SqlClientShape } from
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
 import { CENTROID_EMBEDDING_DIMENSIONS } from "../constants.ts"
+import { IssueProjectionRepository } from "../ports/issue-projection-repository.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
+import { createFakeIssueProjectionRepository } from "../testing/fake-issue-projection-repository.ts"
 import { createFakeIssueRepository } from "../testing/fake-issue-repository.ts"
 import { createIssueFromScoreUseCase } from "./create-issue-from-score.ts"
 
@@ -97,6 +99,10 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
@@ -129,6 +135,10 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 
@@ -176,6 +186,10 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(
+          IssueProjectionRepository,
+          createFakeIssueProjectionRepository({ organizationId }).service,
+        ),
       ),
     )
 

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.ts
@@ -9,6 +9,7 @@ import { IssueRepository } from "../ports/issue-repository.ts"
 import { checkEligibilityUseCase } from "./check-eligibility.ts"
 import type { GenerateIssueDetailsError } from "./generate-issue-details.ts"
 import { generateIssueDetailsUseCase } from "./generate-issue-details.ts"
+import { syncIssueProjectionsUseCase } from "./sync-projections.ts"
 
 export interface CreateIssueFromScoreInput {
   readonly organizationId: string
@@ -134,7 +135,7 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
 
     const sqlClient = yield* SqlClient
 
-    return yield* sqlClient.transaction(
+    const assignment = yield* sqlClient.transaction(
       Effect.gen(function* () {
         const issueRepository = yield* IssueRepository
         const scoreRepository = yield* ScoreRepository
@@ -185,6 +186,15 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
         } satisfies CreateIssueFromScoreResult
       }),
     )
+
+    if (assignment.action === "created") {
+      yield* syncIssueProjectionsUseCase({
+        organizationId: input.organizationId,
+        issueId: assignment.issueId,
+      })
+    }
+
+    return assignment
   }).pipe(Effect.withSpan("issues.createIssueFromScore")) as Effect.Effect<
     CreateIssueFromScoreResult,
     CreateIssueFromScoreError

--- a/packages/domain/issues/src/use-cases/serialize-issue-discovery.test.ts
+++ b/packages/domain/issues/src/use-cases/serialize-issue-discovery.test.ts
@@ -1,0 +1,304 @@
+import { createFakeAI } from "@domain/ai/testing"
+import { OutboxEventWriter } from "@domain/events"
+import { type Score, ScoreRepository } from "@domain/scores"
+import { createFakeScoreRepository } from "@domain/scores/testing"
+import { IssueId, OrganizationId, ScoreId, SqlClient, type SqlClientShape } from "@domain/shared"
+import { Cause, Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { CENTROID_EMBEDDING_DIMENSIONS } from "../constants.ts"
+import type { Issue } from "../entities/issue.ts"
+import { IssueDiscoveryLockUnavailableError } from "../errors.ts"
+import { createIssueCentroid } from "../helpers.ts"
+import { IssueDiscoveryLockRepository } from "../ports/issue-discovery-lock-repository.ts"
+import { IssueProjectionRepository } from "../ports/issue-projection-repository.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+import { createFakeIssueProjectionRepository, createFakeIssueRepository } from "../testing/index.ts"
+import { serializeIssueDiscoveryUseCase } from "./serialize-issue-discovery.ts"
+
+const organizationId = "oooooooooooooooooooooooo"
+const projectId = "pppppppppppppppppppppppp"
+
+const makeEmbedding = (): number[] =>
+  Array.from({ length: CENTROID_EMBEDDING_DIMENSIONS }, (_, index) => {
+    if (index === 0) return 0.6
+    if (index === 1) return 0.8
+    return 0
+  })
+
+const makeScore = (overrides: Partial<Score> = {}): Score =>
+  ({
+    id: ScoreId("ssssssssssssssssssssssss"),
+    organizationId,
+    projectId,
+    sessionId: null,
+    traceId: null,
+    spanId: null,
+    source: "annotation",
+    sourceId: "UI",
+    simulationId: null,
+    issueId: null,
+    value: 0.2,
+    passed: false,
+    feedback: "The assistant leaks API tokens in its response.",
+    metadata: {
+      rawFeedback: "The assistant leaks API tokens in its response.",
+    },
+    error: null,
+    errored: false,
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+    draftedAt: null,
+    annotatorId: null,
+    createdAt: new Date("2026-03-30T10:00:00.000Z"),
+    updatedAt: new Date("2026-03-30T10:00:00.000Z"),
+    ...overrides,
+  }) as Score
+
+const makeIssue = (overrides?: Partial<Issue>): Issue => ({
+  id: IssueId("iiiiiiiiiiiiiiiiiiiiiiii"),
+  uuid: "11111111-1111-4111-8111-111111111111",
+  organizationId,
+  projectId,
+  name: "Token leakage in responses",
+  description: "The assistant leaks API tokens in its response.",
+  source: "annotation",
+  centroid: createIssueCentroid(),
+  clusteredAt: new Date("2026-03-29T10:00:00.000Z"),
+  escalatedAt: null,
+  resolvedAt: null,
+  ignoredAt: null,
+  createdAt: new Date("2026-03-29T10:00:00.000Z"),
+  updatedAt: new Date("2026-03-29T10:00:00.000Z"),
+  ...overrides,
+})
+
+const createPassthroughSqlClient = (id: string): SqlClientShape => {
+  const sqlClient: SqlClientShape = {
+    organizationId: OrganizationId(id),
+    transaction: (effect) => effect.pipe(Effect.provideService(SqlClient, sqlClient)),
+    query: () => Effect.die("Unexpected direct SQL query in unit test"),
+  }
+
+  return sqlClient
+}
+
+describe("serializeIssueDiscoveryUseCase", () => {
+  it("re-runs retrieval under the bounded discovery lock before creating a duplicate issue", async () => {
+    const existingIssue = makeIssue()
+    const score = makeScore()
+    const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    const { repository: issueRepository, issues } = createFakeIssueRepository([existingIssue])
+    const { service: issueProjectionRepository, store } = createFakeIssueProjectionRepository({ organizationId })
+    const lockCalls: string[] = []
+    const writtenEvents: unknown[] = []
+    const fakeAi = createFakeAI({
+      rerank: () => Effect.succeed([{ index: 0, relevanceScore: 0.95 }]),
+      generate: (input) =>
+        Effect.succeed({
+          object: input.schema.parse({
+            name: "Token leakage in assistant responses",
+            description: "The assistant exposes secrets or tokens in its replies.",
+          }),
+          tokens: 10,
+          duration: 5,
+        }),
+    })
+
+    scores.set(score.id, score)
+    store.set(`${organizationId}_${projectId}::${existingIssue.uuid}`, {
+      organizationId,
+      projectId,
+      uuid: existingIssue.uuid,
+      title: existingIssue.name,
+      description: existingIssue.description,
+      vector: makeEmbedding(),
+    })
+
+    const result = await Effect.runPromise(
+      serializeIssueDiscoveryUseCase({
+        organizationId,
+        projectId,
+        scoreId: score.id,
+        feedback: score.feedback,
+        normalizedEmbedding: makeEmbedding(),
+      }).pipe(
+        Effect.provide(fakeAi.layer),
+        Effect.provideService(ScoreRepository, scoreRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(IssueProjectionRepository, issueProjectionRepository),
+        Effect.provideService(IssueDiscoveryLockRepository, {
+          withLock: (input, effect) =>
+            Effect.gen(function* () {
+              lockCalls.push(`${input.organizationId}:${input.projectId}:${input.lockKey}`)
+              return yield* effect
+            }),
+        }),
+        Effect.provideService(OutboxEventWriter, {
+          write: (event) =>
+            Effect.sync(() => {
+              writtenEvents.push(event)
+            }),
+        }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+      ),
+    )
+
+    expect(result).toEqual({ action: "assigned", issueId: existingIssue.id })
+    expect(scores.get(score.id)?.issueId).toBe(existingIssue.id)
+    expect(issues.size).toBe(1)
+    // Outer feedback lock + inner per-issue update lock around the centroid recompute and projection sync.
+    expect(lockCalls).toHaveLength(2)
+    expect(lockCalls[0]).toMatch(new RegExp(`^${organizationId}:${projectId}:feedback:[a-f0-9]{64}$`))
+    expect(lockCalls[1]).toBe(`${organizationId}:${projectId}:issue:${existingIssue.id}`)
+    expect(writtenEvents).toHaveLength(1)
+    expect(fakeAi.calls.rerank).toHaveLength(1)
+    expect(fakeAi.calls.generate).toHaveLength(0)
+  })
+
+  it("falls through to the project lock before creating a new issue", async () => {
+    const score = makeScore()
+    const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    const { repository: issueRepository, issues } = createFakeIssueRepository()
+    const { service: issueProjectionRepository } = createFakeIssueProjectionRepository({ organizationId })
+    const lockCalls: string[] = []
+    const fakeAi = createFakeAI({
+      generate: (input) =>
+        Effect.succeed({
+          object: input.schema.parse({
+            name: "Token leakage in assistant responses",
+            description: "The assistant exposes secrets or tokens in its replies.",
+          }),
+          tokens: 10,
+          duration: 5,
+        }),
+    })
+
+    scores.set(score.id, score)
+
+    const result = await Effect.runPromise(
+      serializeIssueDiscoveryUseCase({
+        organizationId,
+        projectId,
+        scoreId: score.id,
+        feedback: score.feedback,
+        normalizedEmbedding: makeEmbedding(),
+      }).pipe(
+        Effect.provide(fakeAi.layer),
+        Effect.provideService(ScoreRepository, scoreRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(IssueProjectionRepository, issueProjectionRepository),
+        Effect.provideService(IssueDiscoveryLockRepository, {
+          withLock: (input, effect) =>
+            Effect.gen(function* () {
+              lockCalls.push(`${input.organizationId}:${input.projectId}:${input.lockKey}`)
+              return yield* effect
+            }),
+        }),
+        Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+      ),
+    )
+
+    expect(result.action).toBe("created")
+    if (result.action === "skipped") expect.fail(`expected non-skipped result, got reason ${result.reason}`)
+    expect(scores.get(score.id)?.issueId).toBe(result.issueId)
+    expect(issues.size).toBe(1)
+    expect(lockCalls).toHaveLength(2)
+    expect(lockCalls[0]).toMatch(new RegExp(`^${organizationId}:${projectId}:feedback:[a-f0-9]{64}$`))
+    expect(lockCalls[1]).toBe(`${organizationId}:${projectId}:project`)
+    expect(fakeAi.calls.rerank).toHaveLength(0)
+    expect(fakeAi.calls.generate).toHaveLength(1)
+  })
+
+  it("propagates IssueDiscoveryLockUnavailableError when the feedback lock cannot be acquired", async () => {
+    const score = makeScore()
+    const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    const { repository: issueRepository, issues } = createFakeIssueRepository()
+    const { service: issueProjectionRepository } = createFakeIssueProjectionRepository({ organizationId })
+    const fakeAi = createFakeAI()
+
+    scores.set(score.id, score)
+
+    const exit = await Effect.runPromiseExit(
+      serializeIssueDiscoveryUseCase({
+        organizationId,
+        projectId,
+        scoreId: score.id,
+        feedback: score.feedback,
+        normalizedEmbedding: makeEmbedding(),
+      }).pipe(
+        Effect.provide(fakeAi.layer),
+        Effect.provideService(ScoreRepository, scoreRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(IssueProjectionRepository, issueProjectionRepository),
+        Effect.provideService(IssueDiscoveryLockRepository, {
+          withLock: (input) =>
+            Effect.fail(
+              new IssueDiscoveryLockUnavailableError({
+                projectId: input.projectId,
+                lockKey: input.lockKey,
+              }),
+            ),
+        }),
+        Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      const errOpt = Cause.findErrorOption(exit.cause)
+      expect(errOpt._tag).toBe("Some")
+      if (errOpt._tag === "Some") {
+        expect(errOpt.value).toBeInstanceOf(IssueDiscoveryLockUnavailableError)
+        expect((errOpt.value as IssueDiscoveryLockUnavailableError).lockKey).toMatch(/^feedback:[a-f0-9]{64}$/)
+      }
+    }
+    expect(issues.size).toBe(0)
+    expect(scores.get(score.id)?.issueId).toBeNull()
+    expect(fakeAi.calls.rerank).toHaveLength(0)
+    expect(fakeAi.calls.generate).toHaveLength(0)
+  })
+
+  it("returns skipped without creating an issue when the project-lock eligibility re-check fails", async () => {
+    // Score is already owned by an unrelated issue by the time we acquire the project lock — the inner
+    // eligibility check converts ScoreAlreadyOwnedByIssueError into a clean skipped result so the workflow
+    // can short-circuit without burning AI generation or activity retries.
+    const winningIssueId = IssueId("wwwwwwwwwwwwwwwwwwwwwwww")
+    const score = makeScore({ issueId: winningIssueId })
+    const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    const { repository: issueRepository, issues } = createFakeIssueRepository()
+    const { service: issueProjectionRepository } = createFakeIssueProjectionRepository({ organizationId })
+    const fakeAi = createFakeAI()
+
+    scores.set(score.id, score)
+
+    const result = await Effect.runPromise(
+      serializeIssueDiscoveryUseCase({
+        organizationId,
+        projectId,
+        scoreId: score.id,
+        feedback: score.feedback,
+        normalizedEmbedding: makeEmbedding(),
+      }).pipe(
+        Effect.provide(fakeAi.layer),
+        Effect.provideService(ScoreRepository, scoreRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(IssueProjectionRepository, issueProjectionRepository),
+        Effect.provideService(IssueDiscoveryLockRepository, {
+          withLock: (_input, effect) => effect,
+        }),
+        Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+      ),
+    )
+
+    expect(result).toEqual({
+      action: "skipped",
+      reason: "ScoreAlreadyOwnedByIssueError",
+    })
+    expect(issues.size).toBe(0)
+    expect(fakeAi.calls.generate).toHaveLength(0)
+  })
+})

--- a/packages/domain/issues/src/use-cases/serialize-issue-discovery.ts
+++ b/packages/domain/issues/src/use-cases/serialize-issue-discovery.ts
@@ -1,0 +1,137 @@
+import { type CacheError, ProjectId, type RepositoryError } from "@domain/shared"
+import { type CryptoError, hash } from "@repo/utils"
+import { Effect } from "effect"
+import {
+  ISSUE_DISCOVERY_FEEDBACK_LOCK_KEY,
+  ISSUE_DISCOVERY_FEEDBACK_LOCK_TTL_SECONDS,
+  ISSUE_DISCOVERY_PROJECT_LOCK_KEY,
+  ISSUE_DISCOVERY_PROJECT_LOCK_TTL_SECONDS,
+} from "../constants.ts"
+import { type CheckEligibilityError, type IssueDiscoveryLockUnavailableError, isEligibilityError } from "../errors.ts"
+import { IssueDiscoveryLockRepository } from "../ports/issue-discovery-lock-repository.ts"
+import type { AssignScoreToIssueError, AssignScoreToIssueResult } from "./assign-score-to-issue.ts"
+import { assignScoreToIssueUseCase } from "./assign-score-to-issue.ts"
+import { checkEligibilityUseCase } from "./check-eligibility.ts"
+import type { CreateIssueFromScoreError, CreateIssueFromScoreResult } from "./create-issue-from-score.ts"
+import { createIssueFromScoreUseCase } from "./create-issue-from-score.ts"
+import { hybridSearchIssuesUseCase } from "./hybrid-search-issues.ts"
+import { rerankIssueCandidatesUseCase } from "./rerank-issue-candidates.ts"
+import { resolveMatchedIssueUseCase } from "./resolve-matched-issue.ts"
+
+export interface SerializeIssueDiscoveryInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly scoreId: string
+  readonly feedback: string
+  readonly normalizedEmbedding: readonly number[]
+}
+
+export type SerializeIssueDiscoveryResult =
+  | AssignScoreToIssueResult
+  | CreateIssueFromScoreResult
+  | { readonly action: "skipped"; readonly reason: string }
+
+export type SerializeIssueDiscoveryError =
+  | AssignScoreToIssueError
+  | CacheError
+  | CheckEligibilityError
+  | CreateIssueFromScoreError
+  | CryptoError
+  | IssueDiscoveryLockUnavailableError
+  | RepositoryError
+
+const checkEligibility = (input: SerializeIssueDiscoveryInput) =>
+  checkEligibilityUseCase({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    scoreId: input.scoreId,
+  }).pipe(
+    Effect.map(() => ({ status: "eligible" as const })),
+    Effect.catchIf(isEligibilityError, (error) => Effect.succeed({ status: "skipped" as const, reason: error._tag })),
+  )
+
+const findMatchedIssueId = (input: SerializeIssueDiscoveryInput) =>
+  Effect.gen(function* () {
+    const hybridSearch = yield* hybridSearchIssuesUseCase({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      query: input.feedback,
+      normalizedEmbedding: input.normalizedEmbedding as number[],
+    })
+
+    const retrieval = yield* rerankIssueCandidatesUseCase({
+      query: input.feedback,
+      candidates: hybridSearch.candidates,
+    })
+
+    const matchedIssue = yield* resolveMatchedIssueUseCase({
+      organizationId: input.organizationId,
+      projectId: input.projectId,
+      matchedIssueUuid: retrieval.matchedIssueUuid,
+    })
+
+    return matchedIssue.issueId
+  })
+
+const assignToIssue = (input: SerializeIssueDiscoveryInput, issueId: string) =>
+  assignScoreToIssueUseCase({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    scoreId: input.scoreId,
+    issueId,
+    normalizedEmbedding: input.normalizedEmbedding,
+  })
+
+const createIssue = (input: SerializeIssueDiscoveryInput) =>
+  createIssueFromScoreUseCase({
+    organizationId: input.organizationId,
+    projectId: input.projectId,
+    scoreId: input.scoreId,
+    normalizedEmbedding: input.normalizedEmbedding,
+  })
+
+export const serializeIssueDiscoveryUseCase = (input: SerializeIssueDiscoveryInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
+    const lockRepository = yield* IssueDiscoveryLockRepository
+    const feedbackHash = yield* hash(input.feedback)
+
+    return yield* lockRepository.withLock(
+      {
+        organizationId: input.organizationId,
+        projectId: ProjectId(input.projectId),
+        lockKey: ISSUE_DISCOVERY_FEEDBACK_LOCK_KEY(feedbackHash),
+        ttlSeconds: ISSUE_DISCOVERY_FEEDBACK_LOCK_TTL_SECONDS,
+      },
+      Effect.gen(function* () {
+        const feedbackMatchedIssueId = yield* findMatchedIssueId(input)
+        if (feedbackMatchedIssueId !== null) {
+          return yield* assignToIssue(input, feedbackMatchedIssueId)
+        }
+
+        return yield* lockRepository.withLock(
+          {
+            organizationId: input.organizationId,
+            projectId: ProjectId(input.projectId),
+            lockKey: ISSUE_DISCOVERY_PROJECT_LOCK_KEY,
+            ttlSeconds: ISSUE_DISCOVERY_PROJECT_LOCK_TTL_SECONDS,
+          },
+          Effect.gen(function* () {
+            const eligibility = yield* checkEligibility(input)
+            if (eligibility.status === "skipped") {
+              return { action: "skipped" as const, reason: eligibility.reason }
+            }
+
+            const projectMatchedIssueId = yield* findMatchedIssueId(input)
+            if (projectMatchedIssueId !== null) {
+              return yield* assignToIssue(input, projectMatchedIssueId)
+            }
+
+            return yield* createIssue(input)
+          }),
+        )
+      }),
+    )
+  }).pipe(Effect.withSpan("issues.serializeIssueDiscovery"))

--- a/packages/platform/cache-redis/package.json
+++ b/packages/platform/cache-redis/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@domain/issues": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "@platform/env": "workspace:*",

--- a/packages/platform/cache-redis/src/index.ts
+++ b/packages/platform/cache-redis/src/index.ts
@@ -1,6 +1,7 @@
 export { CacheStore, type CacheStoreShape } from "@domain/shared"
 export { RedisCacheStoreLive } from "./ai-cache.ts"
 export { EmbedBudgetResolverLive } from "./embed-budget-resolver.ts"
+export { RedisIssueDiscoveryLockRepositoryLive } from "./issue-discovery-lock.ts"
 export { TraceSearchBudgetLive } from "./trace-search-budget.ts"
 
 import { ServiceMap } from "effect"

--- a/packages/platform/cache-redis/src/issue-discovery-lock.ts
+++ b/packages/platform/cache-redis/src/issue-discovery-lock.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto"
+import { IssueDiscoveryLockRepository, IssueDiscoveryLockUnavailableError } from "@domain/issues"
+import { CacheError } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import type { RedisClient } from "./client.ts"
+
+const releaseLockScript = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`
+
+const buildLockKey = (input: {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly lockKey: string
+}) => `org:${input.organizationId}:issues:discovery:${input.projectId}:${input.lockKey}`
+
+export const RedisIssueDiscoveryLockRepositoryLive = (redis: RedisClient) =>
+  Layer.succeed(IssueDiscoveryLockRepository, {
+    withLock: (input, effect) =>
+      Effect.gen(function* () {
+        const lockKey = buildLockKey(input)
+        const lockToken = randomUUID()
+
+        const acquired = yield* Effect.tryPromise({
+          try: () => redis.set(lockKey, lockToken, "EX", input.ttlSeconds, "NX"),
+          catch: (cause) => new CacheError({ message: `Issue discovery lock acquire failed: ${String(cause)}`, cause }),
+        })
+
+        if (acquired !== "OK") {
+          return yield* Effect.fail(
+            new IssueDiscoveryLockUnavailableError({
+              projectId: input.projectId,
+              lockKey: input.lockKey,
+            }),
+          )
+        }
+
+        return yield* effect.pipe(
+          Effect.ensuring(
+            Effect.tryPromise({
+              try: () => redis.eval(releaseLockScript, 1, lockKey, lockToken),
+              catch: (cause) =>
+                new CacheError({ message: `Issue discovery lock release failed: ${String(cause)}`, cause }),
+            }).pipe(Effect.ignore),
+          ),
+        )
+      }),
+  })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1053,6 +1053,9 @@ importers:
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../utils
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.4
@@ -1413,6 +1416,9 @@ importers:
 
   packages/platform/cache-redis:
     dependencies:
+      '@domain/issues':
+        specifier: workspace:*
+        version: link:../../domain/issues
       '@domain/shared':
         specifier: workspace:*
         version: link:../../domain/shared


### PR DESCRIPTION
## Summary
- Fixes two issue-discovery concurrency bugs: duplicate issues from racing no-match workflows (Weaviate projection lag), and stale Weaviate projections from interleaved assign-to-issue post-tx syncs.
- Adds layered Redis NX locks — feedback, project, and per-issue — covering the Postgres centroid recompute *and* the Weaviate projection sync as one critical section. `SET NX EX` is non-blocking; contention returns `lock-unavailable` immediately.
- Workflow retries `lock-unavailable` via durable Temporal `sleep` with exponential backoff (1s→30s cap) plus 1-100s jitter, so contended workers don't pin DB connections or all wake at the same instant.
- Eligibility is re-checked inside each lock; if a competing worker has already claimed the score the activity returns `{ status: "skipped", reason }` instead of failing, so it doesn't burn Temporal retry budget.
- Projection sync moved into `assignScoreToIssueUseCase` (inside the per-issue lock) and `createIssueFromScoreUseCase` (after the tx; no lock — fresh issues can't be raced). The workflow no longer calls `syncIssueProjections` itself.
- New shared workflow helper `runWithLockRetry` consolidates the retry loop; consumed by both `issueDiscoveryWorkflow` and `assignScoreToKnownIssueWorkflow`.
- Naming: `finalizeIssueDiscovery` → `serializeIssueDiscovery` (use-case, activity, file, span, status), and the assignment action `"assigned-existing"` → `"assigned"`.
- Spec doc: new "Bounded locked serialization" section in `dev-docs/issues.md`.