### PR TITLE
feat(web): add Search section with semantic trace search

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AuthenticatedProjectsProjectSlugRouteImport } from './routes/_
 import { Route as AuthenticatedProjectsProjectSlugIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/index'
 import { Route as ApiAuthProviderStartRouteImport } from './routes/api/auth/$provider/start'
 import { Route as AuthenticatedProjectsProjectSlugSettingsRouteImport } from './routes/_authenticated/projects/$projectSlug/settings'
+import { Route as AuthenticatedProjectsProjectSlugSearchIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/search/index'
 import { Route as AuthenticatedProjectsProjectSlugIssuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/issues/index'
 import { Route as AuthenticatedProjectsProjectSlugDatasetsIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/datasets/index'
 import { Route as AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRouteImport } from './routes/_authenticated/projects/$projectSlug/annotation-queues/index'
@@ -208,6 +209,12 @@ const AuthenticatedProjectsProjectSlugSettingsRoute =
     path: '/settings',
     getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
   } as any)
+const AuthenticatedProjectsProjectSlugSearchIndexRoute =
+  AuthenticatedProjectsProjectSlugSearchIndexRouteImport.update({
+    id: '/search/',
+    path: '/search/',
+    getParentRoute: () => AuthenticatedProjectsProjectSlugRoute,
+  } as any)
 const AuthenticatedProjectsProjectSlugIssuesIndexRoute =
   AuthenticatedProjectsProjectSlugIssuesIndexRouteImport.update({
     id: '/issues/',
@@ -292,6 +299,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug/annotation-queues/': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRoute
   '/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/search/': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId/': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId/items/$itemId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdItemsItemIdRoute
 }
@@ -325,6 +333,7 @@ export interface FileRoutesByTo {
   '/projects/$projectSlug/annotation-queues': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRoute
   '/projects/$projectSlug/datasets': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/projects/$projectSlug/issues': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/projects/$projectSlug/search': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdIndexRoute
   '/projects/$projectSlug/annotation-queues/$queueId/items/$itemId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdItemsItemIdRoute
 }
@@ -365,6 +374,7 @@ export interface FileRoutesById {
   '/_authenticated/projects/$projectSlug/annotation-queues/': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRoute
   '/_authenticated/projects/$projectSlug/datasets/': typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   '/_authenticated/projects/$projectSlug/issues/': typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  '/_authenticated/projects/$projectSlug/search/': typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
   '/_authenticated/projects/$projectSlug/annotation-queues/$queueId/': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdIndexRoute
   '/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId': typeof AuthenticatedProjectsProjectSlugAnnotationQueuesQueueIdItemsItemIdRoute
 }
@@ -405,6 +415,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/annotation-queues/'
     | '/projects/$projectSlug/datasets/'
     | '/projects/$projectSlug/issues/'
+    | '/projects/$projectSlug/search/'
     | '/projects/$projectSlug/annotation-queues/$queueId/'
     | '/projects/$projectSlug/annotation-queues/$queueId/items/$itemId'
   fileRoutesByTo: FileRoutesByTo
@@ -438,6 +449,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug/annotation-queues'
     | '/projects/$projectSlug/datasets'
     | '/projects/$projectSlug/issues'
+    | '/projects/$projectSlug/search'
     | '/projects/$projectSlug/annotation-queues/$queueId'
     | '/projects/$projectSlug/annotation-queues/$queueId/items/$itemId'
   id:
@@ -477,6 +489,7 @@ export interface FileRouteTypes {
     | '/_authenticated/projects/$projectSlug/annotation-queues/'
     | '/_authenticated/projects/$projectSlug/datasets/'
     | '/_authenticated/projects/$projectSlug/issues/'
+    | '/_authenticated/projects/$projectSlug/search/'
     | '/_authenticated/projects/$projectSlug/annotation-queues/$queueId/'
     | '/_authenticated/projects/$projectSlug/annotation-queues/$queueId/items/$itemId'
   fileRoutesById: FileRoutesById
@@ -708,6 +721,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSettingsRouteImport
       parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
     }
+    '/_authenticated/projects/$projectSlug/search/': {
+      id: '/_authenticated/projects/$projectSlug/search/'
+      path: '/search'
+      fullPath: '/projects/$projectSlug/search/'
+      preLoaderRoute: typeof AuthenticatedProjectsProjectSlugSearchIndexRouteImport
+      parentRoute: typeof AuthenticatedProjectsProjectSlugRoute
+    }
     '/_authenticated/projects/$projectSlug/issues/': {
       id: '/_authenticated/projects/$projectSlug/issues/'
       path: '/issues'
@@ -844,6 +864,7 @@ interface AuthenticatedProjectsProjectSlugRouteChildren {
   AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRoute: typeof AuthenticatedProjectsProjectSlugAnnotationQueuesIndexRoute
   AuthenticatedProjectsProjectSlugDatasetsIndexRoute: typeof AuthenticatedProjectsProjectSlugDatasetsIndexRoute
   AuthenticatedProjectsProjectSlugIssuesIndexRoute: typeof AuthenticatedProjectsProjectSlugIssuesIndexRoute
+  AuthenticatedProjectsProjectSlugSearchIndexRoute: typeof AuthenticatedProjectsProjectSlugSearchIndexRoute
 }
 
 const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjectSlugRouteChildren =
@@ -862,6 +883,8 @@ const AuthenticatedProjectsProjectSlugRouteChildren: AuthenticatedProjectsProjec
       AuthenticatedProjectsProjectSlugDatasetsIndexRoute,
     AuthenticatedProjectsProjectSlugIssuesIndexRoute:
       AuthenticatedProjectsProjectSlugIssuesIndexRoute,
+    AuthenticatedProjectsProjectSlugSearchIndexRoute:
+      AuthenticatedProjectsProjectSlugSearchIndexRoute,
   }
 
 const AuthenticatedProjectsProjectSlugRouteWithChildren =

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug.tsx
@@ -1,7 +1,7 @@
 import { CopyableText } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { createFileRoute, Outlet, redirect, useRouterState } from "@tanstack/react-router"
-import { DatabaseIcon, LayersIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
+import { DatabaseIcon, LayersIcon, SearchIcon, SettingsIcon, ShieldAlertIcon, TextAlignStartIcon } from "lucide-react"
 import { useProjectsCollection } from "../../../domains/projects/projects.collection.ts"
 import { getProjectBySlug, type ProjectRecord } from "../../../domains/projects/projects.functions.ts"
 import { AppSidebar, NavItem } from "../../../layouts/AppSidebar/index.tsx"
@@ -37,6 +37,7 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
     pathname === `/projects/${projectSlug}` ||
     pathname === `/projects/${projectSlug}/` ||
     pathname.startsWith(`/projects/${projectSlug}/traces`)
+  const isSearchActive = pathname.startsWith(`/projects/${projectSlug}/search`)
   const isIssuesActive = pathname.startsWith(`/projects/${projectSlug}/issues`)
   const isDatasetsActive = pathname.startsWith(`/projects/${projectSlug}/datasets`)
   const isSettingsActive = pathname.startsWith(`/projects/${projectSlug}/settings`)
@@ -58,6 +59,13 @@ function ProjectSidebar({ project, projectSlug }: { project: ProjectRecord; proj
     >
       {({ collapsed }) => (
         <>
+          <NavItem
+            icon={SearchIcon}
+            label="Search"
+            to={`/projects/${projectSlug}/search`}
+            active={isSearchActive}
+            collapsed={collapsed}
+          />
           <NavItem
             icon={TextAlignStartIcon}
             label="Traces"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -1,0 +1,79 @@
+import { type FilterSet, filterSetSchema } from "@domain/shared"
+import type { InfiniteTableSorting } from "@repo/ui"
+import type { BulkSelection, SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
+import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "./project-traces-table.tsx"
+
+export const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
+
+export const DEFAULT_TRACE_COLUMNS: TraceColumnId[] = TRACE_COLUMN_OPTIONS.map((column) => column.id)
+
+export function parseFilters(raw?: string): FilterSet {
+  if (!raw) return {}
+  try {
+    let parsed = JSON.parse(raw)
+    // TanStack Router JSON-stringifies search param values. When we store a
+    // pre-serialized JSON string (e.g. '{"startTime":...}'), it becomes
+    // '"{\"startTime\":...}"' in the URL. Unwrap the extra layer if present.
+    if (typeof parsed === "string") {
+      parsed = JSON.parse(parsed)
+    }
+    return filterSetSchema.parse(parsed)
+  } catch {
+    return {}
+  }
+}
+
+export function serializeFilters(filters: FilterSet): string | undefined {
+  const keys = Object.keys(filters)
+  return keys.length > 0 ? JSON.stringify(filters) : undefined
+}
+
+export function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): string | undefined {
+  const conds = filters.startTime
+  if (!conds) return undefined
+  const match = conds.find((c) => c.op === op)
+  return match ? String(match.value) : undefined
+}
+
+export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
+  const values = raw
+    ?.split(",")
+    .map((value) => value.trim())
+    .filter((value): value is TraceColumnId => TRACE_COLUMN_OPTIONS.some((column) => column.id === value))
+
+  if (!values || values.length === 0) {
+    return [...DEFAULT_TRACE_COLUMNS]
+  }
+
+  return values.includes("startTime") ? values : ["startTime", ...values]
+}
+
+export function serializeTraceColumnIds(columnIds: readonly TraceColumnId[]): string {
+  return Array.from(new Set(["startTime", ...columnIds])).join(",")
+}
+
+export function getSelectedCount(state: SelectionState<string>, total: number): number {
+  switch (state.mode) {
+    case "all":
+      return total - state.excludedIds.size
+    case "none":
+      return 0
+    case "partial":
+      return state.selectedIds.size
+    case "allExcept":
+      return total - state.excludedIds.size
+  }
+}
+
+export function getBulkSelection(state: SelectionState<string>): BulkSelection<string> | null {
+  switch (state.mode) {
+    case "all":
+      return { mode: "all" }
+    case "allExcept":
+      return { mode: "allExcept", rowIds: Array.from(state.excludedIds) }
+    case "partial":
+      return state.selectedIds.size > 0 ? { mode: "selected", rowIds: Array.from(state.selectedIds) } : null
+    case "none":
+      return null
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -25,6 +25,7 @@ interface TracesViewProps {
   readonly onActiveTraceChange: (traceId: string | undefined) => void
   readonly traceIdsRef: RefObject<string[]>
   readonly visibleColumnIds: readonly TraceColumnId[]
+  readonly searchQuery?: string
 }
 
 export function TracesView({
@@ -43,8 +44,10 @@ export function TracesView({
   onActiveTraceChange,
   traceIdsRef,
   visibleColumnIds,
+  searchQuery,
 }: TracesViewProps) {
   const hasActiveFilters = Object.keys(filters).length > 0
+  const hasSearchQuery = !!searchQuery && searchQuery.length > 0
 
   const {
     data: traces,
@@ -54,11 +57,13 @@ export function TracesView({
     projectId,
     sorting,
     ...(hasActiveFilters ? { filters } : {}),
+    ...(hasSearchQuery ? { searchQuery } : {}),
   })
 
   const { data: traceMetrics, isLoading: metricsLoading } = useTraceMetrics({
     projectId,
     ...(hasActiveFilters ? { filters } : {}),
+    ...(hasSearchQuery ? { searchQuery } : {}),
   })
   const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
 
@@ -136,7 +141,13 @@ export function TracesView({
           sorting={sorting}
           defaultSorting={DEFAULT_TRACE_TABLE_SORTING}
           onSortChange={onSortingChange}
-          blankSlate={hasActiveFilters ? "No traces match the current filters" : "No traces found"}
+          blankSlate={
+            hasSearchQuery
+              ? "No traces match the search query"
+              : hasActiveFilters
+                ? "No traces match the current filters"
+                : "No traces found"
+          }
           traceMetrics={traceMetrics}
           metricsLoading={metricsLoading}
         />

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -1,4 +1,4 @@
-import { type FilterSet, filterSetSchema } from "@domain/shared"
+import type { FilterSet } from "@domain/shared"
 import { Button, Icon, type InfiniteTableSorting, type SortDirection, Tabs, Tooltip, toast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import { useHotkeys } from "@tanstack/react-hotkeys"
@@ -11,7 +11,7 @@ import { useTracesCount } from "../../../../domains/traces/traces.collection.ts"
 import { enqueueTracesExport } from "../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../lib/hooks/useParamState.ts"
-import { type BulkSelection, EMPTY_SELECTION, type SelectionState } from "../../../../lib/hooks/useSelectableRows.ts"
+import { EMPTY_SELECTION, type SelectionState } from "../../../../lib/hooks/useSelectableRows.ts"
 import { TraceAggregationsPanel } from "./-components/aggregations/aggregations-panel.tsx"
 import { ColumnsSelector } from "./-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "./-components/export-confirmation-modal.tsx"
@@ -19,86 +19,22 @@ import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "./-components/project-
 import { SessionsView } from "./-components/sessions-view.tsx"
 import { TimeFilterDropdown } from "./-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
+import {
+  DEFAULT_TRACE_COLUMNS,
+  DEFAULT_TRACE_SORTING,
+  getBulkSelection,
+  getSelectedCount,
+  getTimeFilterValue,
+  parseFilters,
+  parseTraceColumnIds,
+  serializeFilters,
+  serializeTraceColumnIds,
+} from "./-components/trace-page-state.ts"
 import { TracesEmptyState } from "./-components/traces-empty-state.tsx"
 import { TracesView } from "./-components/traces-view.tsx"
 import { useRouteProject } from "./-route-data.ts"
 import { AddToQueueModal } from "./annotation-queues/-components/add-to-queue-modal.tsx"
 import { AddToDatasetModal } from "./datasets/-components/add-to-dataset-modal.tsx"
-
-const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
-
-function parseFilters(raw?: string): FilterSet {
-  if (!raw) return {}
-  try {
-    let parsed = JSON.parse(raw)
-    // TanStack Router JSON-stringifies search param values. When we store a
-    // pre-serialized JSON string (e.g. '{"startTime":...}'), it becomes
-    // '"{\"startTime\":...}"' in the URL. Unwrap the extra layer if present.
-    if (typeof parsed === "string") {
-      parsed = JSON.parse(parsed)
-    }
-    return filterSetSchema.parse(parsed)
-  } catch {
-    return {}
-  }
-}
-
-function serializeFilters(filters: FilterSet): string | undefined {
-  const keys = Object.keys(filters)
-  return keys.length > 0 ? JSON.stringify(filters) : undefined
-}
-
-function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): string | undefined {
-  const conds = filters.startTime
-  if (!conds) return undefined
-  const match = conds.find((c) => c.op === op)
-  return match ? String(match.value) : undefined
-}
-
-const DEFAULT_TRACE_COLUMNS: TraceColumnId[] = TRACE_COLUMN_OPTIONS.map((column) => column.id)
-
-function parseTraceColumnIds(raw?: string): TraceColumnId[] {
-  const values = raw
-    ?.split(",")
-    .map((value) => value.trim())
-    .filter((value): value is TraceColumnId => TRACE_COLUMN_OPTIONS.some((column) => column.id === value))
-
-  if (!values || values.length === 0) {
-    return [...DEFAULT_TRACE_COLUMNS]
-  }
-
-  return values.includes("startTime") ? values : ["startTime", ...values]
-}
-
-function serializeTraceColumnIds(columnIds: readonly TraceColumnId[]): string {
-  return Array.from(new Set(["startTime", ...columnIds])).join(",")
-}
-
-function getSelectedCount(state: SelectionState<string>, total: number): number {
-  switch (state.mode) {
-    case "all":
-      return total - state.excludedIds.size
-    case "none":
-      return 0
-    case "partial":
-      return state.selectedIds.size
-    case "allExcept":
-      return total - state.excludedIds.size
-  }
-}
-
-function getBulkSelection(state: SelectionState<string>): BulkSelection<string> | null {
-  switch (state.mode) {
-    case "all":
-      return { mode: "all" }
-    case "allExcept":
-      return { mode: "allExcept", rowIds: Array.from(state.excludedIds) }
-    case "partial":
-      return state.selectedIds.size > 0 ? { mode: "selected", rowIds: Array.from(state.selectedIds) } : null
-    case "none":
-      return null
-  }
-}
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/")({
   component: ProjectPage,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-blank-slate.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-blank-slate.tsx
@@ -1,0 +1,21 @@
+import { Icon, Text } from "@repo/ui"
+import { SparklesIcon } from "lucide-react"
+
+export function SearchBlankSlate() {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8 opacity-75">
+      <div className="max-w-lg flex flex-col items-center gap-6">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={SparklesIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>Search your traces</Text.H3>
+          <Text.H5 centered color="foregroundMuted">
+            Describe what you're looking for in plain language. Search blends keywords with meaning, so phrases like
+            "failed payments" or "long latency on signup" work as well as exact matches.
+          </Text.H5>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-empty-state.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/-components/search-empty-state.tsx
@@ -1,0 +1,21 @@
+import { Icon, Text } from "@repo/ui"
+import { SearchXIcon } from "lucide-react"
+
+export function SearchEmptyState() {
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8 opacity-75">
+      <div className="max-w-lg flex flex-col items-center gap-6">
+        <div className="h-14 w-14 rounded-xl bg-muted flex items-center justify-center">
+          <Icon icon={SearchXIcon} size="lg" color="foregroundMuted" />
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <Text.H3 centered>No traces match your search</Text.H3>
+          <Text.H5 centered color="foregroundMuted">
+            Try rewording the query or using fewer, more specific keywords. Search blends keywords and meaning, so close
+            paraphrases work too. If you're using filters or a time range, widening them can also help.
+          </Text.H5>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -1,34 +1,368 @@
-import { Input } from "@repo/ui"
+import type { FilterSet } from "@domain/shared"
+import { Button, Icon, Input, type SortDirection, Tooltip, toast } from "@repo/ui"
+import { useHotkeys } from "@tanstack/react-hotkeys"
 import { createFileRoute } from "@tanstack/react-router"
-import { SearchIcon } from "lucide-react"
-import { useState } from "react"
+import { ArrowLeftIcon, DatabaseIcon, DownloadIcon, FilterIcon, LayersIcon, SearchIcon } from "lucide-react"
+import { useRef, useState } from "react"
+import { useTracesCount } from "../../../../../domains/traces/traces.collection.ts"
+import { enqueueTracesExport } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
+import { EMPTY_SELECTION, type SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
+import { ColumnsSelector } from "../-components/columns-selector.tsx"
+import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
+import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "../-components/project-traces-table.tsx"
+import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
+import { TraceDetailDrawer } from "../-components/trace-detail-drawer.tsx"
+import {
+  DEFAULT_TRACE_COLUMNS,
+  DEFAULT_TRACE_SORTING,
+  getBulkSelection,
+  getSelectedCount,
+  getTimeFilterValue,
+  parseFilters,
+  parseTraceColumnIds,
+  serializeFilters,
+  serializeTraceColumnIds,
+} from "../-components/trace-page-state.ts"
+import { TracesView } from "../-components/traces-view.tsx"
+import { useRouteProject } from "../-route-data.ts"
+import { AddToQueueModal } from "../annotation-queues/-components/add-to-queue-modal.tsx"
+import { AddToDatasetModal } from "../datasets/-components/add-to-dataset-modal.tsx"
+
+const SEARCH_QUERY_MAX_LENGTH = 500
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/search/")({
   component: SearchPage,
 })
 
 function SearchPage() {
-  const [query, setQuery] = useState("")
+  const { projectSlug } = Route.useParams()
+  const project = useRouteProject()
+
+  const [q, setQ] = useParamState("q", "")
+  const hasSearchQuery = q.length > 0
 
   return (
     <Layout>
-      <Layout.Content>
-        <Layout.Actions>
-          <Layout.ActionsRow className="justify-stretch">
-            <div className="relative w-full">
-              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder="Search"
-                size="lg"
-                className="w-full pl-9"
-              />
-            </div>
-          </Layout.ActionsRow>
-        </Layout.Actions>
-      </Layout.Content>
+      <Layout.Actions>
+        <Layout.ActionsRow className="justify-stretch">
+          <div className="relative flex w-full items-center gap-2">
+            {hasSearchQuery ? (
+              <Tooltip
+                asChild
+                trigger={
+                  <Button variant="ghost" size="sm" onClick={() => setQ("")} aria-label="Clear search">
+                    <Icon icon={ArrowLeftIcon} size="sm" />
+                  </Button>
+                }
+              >
+                Clear search
+              </Tooltip>
+            ) : null}
+            <SearchInput key={q} initialValue={q} onSubmit={setQ} />
+          </div>
+        </Layout.ActionsRow>
+      </Layout.Actions>
+
+      {hasSearchQuery ? <SearchResults projectId={project.id} projectSlug={projectSlug} searchQuery={q} /> : null}
     </Layout>
+  )
+}
+
+function SearchInput({
+  initialValue,
+  onSubmit,
+}: {
+  readonly initialValue: string
+  readonly onSubmit: (value: string) => void
+}) {
+  const [draft, setDraft] = useState(initialValue)
+
+  return (
+    <div className="relative flex-1">
+      <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+        <Icon icon={SearchIcon} size="sm" color="foregroundMuted" />
+      </div>
+      <Input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return
+          event.preventDefault()
+          const next = draft.trim().slice(0, SEARCH_QUERY_MAX_LENGTH)
+          onSubmit(next)
+        }}
+        placeholder="Search"
+        size="lg"
+        maxLength={SEARCH_QUERY_MAX_LENGTH}
+        className="w-full pl-9"
+        autoFocus
+      />
+    </div>
+  )
+}
+
+function SearchResults({
+  projectId,
+  projectSlug,
+  searchQuery,
+}: {
+  readonly projectId: string
+  readonly projectSlug: string
+  readonly searchQuery: string
+}) {
+  const [filtersOpen, setFiltersOpen] = useParamState("filtersOpen", false)
+  const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
+  const [, setSelectedSpanId] = useParamState("spanId", "")
+  const [rawFilters, setRawFilters] = useParamState("filters", "")
+  const [sortBy, setSortBy] = useParamState("sortBy", DEFAULT_TRACE_SORTING.column)
+  const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_TRACE_SORTING.direction, {
+    validate: (v): v is SortDirection => v === "asc" || v === "desc",
+  })
+  const [rawTraceColumns, setRawTraceColumns] = useParamState(
+    "traceColumns",
+    serializeTraceColumnIds(DEFAULT_TRACE_COLUMNS),
+  )
+  const [traceDetailTab, setTraceDetailTab] = useParamState("traceDetailTab", "trace", {
+    validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
+      v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
+  })
+
+  const traceIdsRef = useRef<string[]>([])
+
+  const filters = parseFilters(rawFilters || undefined)
+  const visibleTraceColumnIds = parseTraceColumnIds(rawTraceColumns || undefined)
+  const hasActiveFilters = Object.keys(filters).length > 0
+  const timeFrom = getTimeFilterValue(filters, "gte")
+  const timeTo = getTimeFilterValue(filters, "lte")
+  const sorting = { column: sortBy, direction: sortDirection } as const
+
+  const [selectionState, setSelectionState] = useState<SelectionState<string>>(EMPTY_SELECTION)
+  const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
+  const [addToQueueOpen, setAddToQueueOpen] = useState(false)
+  const [exportModalOpen, setExportModalOpen] = useState(false)
+  const [exporting, setExporting] = useState(false)
+
+  const { totalCount: totalTraceCount } = useTracesCount({
+    projectId,
+    ...(hasActiveFilters ? { filters } : {}),
+    searchQuery,
+  })
+
+  const selectedCount = getSelectedCount(selectionState, totalTraceCount)
+  const bulkSelection = getBulkSelection(selectionState)
+
+  const onSortingChange = (next: { column: string; direction: SortDirection }) => {
+    setSortBy(next.column)
+    setSortDirection(next.direction)
+  }
+
+  const onFiltersChange = (next: FilterSet) => {
+    setFiltersOpen(true)
+    setRawFilters(serializeFilters(next) ?? "")
+  }
+
+  const clearFilters = () => {
+    setRawFilters("")
+  }
+
+  const closeTraceDrawer = () => {
+    setActiveTraceId("")
+    setSelectedSpanId("")
+    setTraceDetailTab("trace")
+  }
+
+  const onActiveTraceChange = (traceId: string | undefined) => {
+    if (!traceId) {
+      closeTraceDrawer()
+      return
+    }
+    setActiveTraceId(traceId)
+  }
+
+  const clearSelections = () => setSelectionState(EMPTY_SELECTION)
+
+  const handleExportTraces = async () => {
+    if (!bulkSelection) return
+
+    setExporting(true)
+    try {
+      await enqueueTracesExport({
+        data: {
+          projectId,
+          selection: bulkSelection,
+          ...(hasActiveFilters ? { filters } : {}),
+        },
+      })
+      toast({
+        title: "Export started",
+        description: "You'll receive an email with a download link when your export is ready.",
+      })
+      clearSelections()
+      setExportModalOpen(false)
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        description: error instanceof Error ? error.message : "Export failed",
+      })
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  const navigateTrace = (delta: 1 | -1) => {
+    const ids = traceIdsRef.current
+    if (ids.length === 0) return
+    const idx = ids.indexOf(activeTraceId)
+    const target = idx < 0 ? ids[0] : ids[idx + delta]
+    if (target) setActiveTraceId(target)
+  }
+
+  const activeTraceIndex = traceIdsRef.current.indexOf(activeTraceId)
+  const canNavigateNext =
+    traceIdsRef.current.length > 0 && (activeTraceIndex < 0 || activeTraceIndex < traceIdsRef.current.length - 1)
+  const canNavigatePrev = traceIdsRef.current.length > 0 && (activeTraceIndex < 0 || activeTraceIndex > 0)
+
+  useHotkeys([
+    { hotkey: "F", callback: () => setFiltersOpen((prev) => !prev) },
+    {
+      hotkey: "Escape",
+      callback: closeTraceDrawer,
+      options: { enabled: !!activeTraceId, ignoreInputs: true },
+    },
+  ])
+
+  return (
+    <>
+      <Layout.Actions className="pt-0">
+        <Layout.ActionsRow>
+          <Layout.ActionRowItem>
+            <TimeFilterDropdown
+              {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
+              {...(timeTo ? { startTimeTo: timeTo } : {})}
+              onChange={(from, to) => {
+                const next = { ...filters }
+                if (from || to) {
+                  const conditions = [
+                    ...(from ? [{ op: "gte" as const, value: from }] : []),
+                    ...(to ? [{ op: "lte" as const, value: to }] : []),
+                  ]
+                  next.startTime = conditions
+                } else {
+                  delete next.startTime
+                }
+                setRawFilters(serializeFilters(next) ?? "")
+              }}
+            />
+            <ColumnsSelector
+              columns={TRACE_COLUMN_OPTIONS}
+              selectedColumnIds={visibleTraceColumnIds}
+              onChange={(nextColumnIds) =>
+                setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
+              }
+            />
+            <Button variant={filtersOpen ? "outline" : "ghost"} size="sm" onClick={() => setFiltersOpen(!filtersOpen)}>
+              <Icon icon={FilterIcon} size="sm" />
+              Filters
+              {hasActiveFilters ? (
+                <span className="inline-flex items-center justify-center rounded-full bg-primary px-1.5 text-[10px] leading-4 font-medium text-primary-foreground">
+                  {Object.keys(filters).length}
+                </span>
+              ) : null}
+            </Button>
+            {hasActiveFilters ? (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                Clear all
+              </Button>
+            ) : null}
+          </Layout.ActionRowItem>
+        </Layout.ActionsRow>
+      </Layout.Actions>
+
+      {selectedCount > 0 ? (
+        <div className="flex flex-row items-center gap-2 px-6">
+          <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
+            <Icon icon={DownloadIcon} size="sm" />
+            Export Traces ({selectedCount.toLocaleString()})
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+            <Icon icon={DatabaseIcon} size="sm" />
+            Add to Dataset ({selectedCount})
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setAddToQueueOpen(true)}>
+            <Icon icon={LayersIcon} size="sm" />
+            Add to Annotation Queue ({selectedCount})
+          </Button>
+        </div>
+      ) : null}
+
+      <TracesView
+        projectId={projectId}
+        filters={filters}
+        filtersOpen={filtersOpen}
+        activeTraceId={activeTraceId || undefined}
+        activeDrawerTab={traceDetailTab}
+        sorting={sorting}
+        onSortingChange={onSortingChange}
+        selectionState={selectionState}
+        onSelectionChange={setSelectionState}
+        totalTraceCount={totalTraceCount}
+        onFiltersChange={onFiltersChange}
+        onFiltersClose={() => setFiltersOpen(false)}
+        onActiveTraceChange={onActiveTraceChange}
+        traceIdsRef={traceIdsRef}
+        visibleColumnIds={visibleTraceColumnIds}
+        searchQuery={searchQuery}
+      />
+
+      {activeTraceId ? (
+        <Layout.Aside>
+          <TraceDetailDrawer
+            key={activeTraceId}
+            traceId={activeTraceId}
+            projectId={projectId}
+            filters={filters}
+            onFiltersChange={onFiltersChange}
+            onClose={closeTraceDrawer}
+            onNextTrace={() => navigateTrace(1)}
+            onPrevTrace={() => navigateTrace(-1)}
+            canNavigateNext={canNavigateNext}
+            canNavigatePrev={canNavigatePrev}
+          />
+        </Layout.Aside>
+      ) : null}
+
+      {bulkSelection ? (
+        <>
+          <ExportConfirmationModal
+            open={exportModalOpen}
+            onOpenChange={setExportModalOpen}
+            itemLabel="trace"
+            selectedCount={selectedCount}
+            onConfirm={() => void handleExportTraces()}
+            exporting={exporting}
+          />
+          <AddToDatasetModal
+            open={addToDatasetOpen}
+            onOpenChange={setAddToDatasetOpen}
+            projectId={projectId}
+            selection={bulkSelection}
+            selectedCount={selectedCount}
+            onSuccess={clearSelections}
+          />
+          <AddToQueueModal
+            open={addToQueueOpen}
+            onOpenChange={setAddToQueueOpen}
+            projectId={projectId}
+            projectSlug={projectSlug}
+            selection={bulkSelection}
+            selectedCount={selectedCount}
+            {...(hasActiveFilters ? { filters } : {})}
+            onSuccess={clearSelections}
+          />
+        </>
+      ) : null}
+    </>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -30,7 +30,6 @@ import { useRouteProject } from "../-route-data.ts"
 import { AddToQueueModal } from "../annotation-queues/-components/add-to-queue-modal.tsx"
 import { AddToDatasetModal } from "../datasets/-components/add-to-dataset-modal.tsx"
 import { SearchBlankSlate } from "./-components/search-blank-slate.tsx"
-import { SearchEmptyState } from "./-components/search-empty-state.tsx"
 
 const SEARCH_QUERY_MAX_LENGTH = 500
 
@@ -82,16 +81,19 @@ function SearchPage() {
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  const { totalCount: totalTraceCount, isLoading: isTraceCountLoading } = useTracesCount({
+  const { totalCount: totalTraceCount } = useTracesCount({
     projectId: hasSearchQuery ? projectId : "",
     ...(hasActiveFilters ? { filters } : {}),
     searchQuery: q,
   })
 
-  const showSearchEmptyState = hasSearchQuery && !isTraceCountLoading && totalTraceCount === 0
-
   const selectedCount = getSelectedCount(selectionState, totalTraceCount)
   const bulkSelection = getBulkSelection(selectionState)
+  // Bulk actions only render for explicitly-picked rows. `mode: "all"` and
+  // `mode: "allExcept"` would resolve server-side against the unfiltered
+  // project, ignoring `searchQuery`, which would silently process more
+  // traces than the user sees in the UI.
+  const showBulkActions = bulkSelection?.mode === "selected"
 
   const onSortingChange = (next: { column: string; direction: SortDirection }) => {
     setSortBy(next.column)
@@ -250,7 +252,7 @@ function SearchPage() {
         </Layout.Actions>
       ) : null}
 
-      {hasSearchQuery && selectedCount > 0 ? (
+      {hasSearchQuery && showBulkActions ? (
         <div className="flex flex-row items-center gap-2 px-6">
           <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
             <Icon icon={DownloadIcon} size="sm" />
@@ -267,7 +269,7 @@ function SearchPage() {
         </div>
       ) : null}
 
-      {hasSearchQuery && !showSearchEmptyState ? (
+      {hasSearchQuery ? (
         <TracesView
           projectId={projectId}
           filters={filters}
@@ -288,9 +290,7 @@ function SearchPage() {
         />
       ) : null}
 
-      {showSearchEmptyState ? <SearchEmptyState /> : null}
-
-      {hasSearchQuery && !showSearchEmptyState && activeTraceId ? (
+      {hasSearchQuery && activeTraceId ? (
         <Layout.Aside>
           <TraceDetailDrawer
             key={activeTraceId}
@@ -307,7 +307,7 @@ function SearchPage() {
         </Layout.Aside>
       ) : null}
 
-      {hasSearchQuery && bulkSelection ? (
+      {hasSearchQuery && showBulkActions && bulkSelection ? (
         <ExportConfirmationModal
           open={exportModalOpen}
           onOpenChange={setExportModalOpen}
@@ -318,7 +318,7 @@ function SearchPage() {
         />
       ) : null}
 
-      {hasSearchQuery && bulkSelection ? (
+      {hasSearchQuery && showBulkActions && bulkSelection ? (
         <AddToDatasetModal
           open={addToDatasetOpen}
           onOpenChange={setAddToDatasetOpen}
@@ -329,7 +329,7 @@ function SearchPage() {
         />
       ) : null}
 
-      {hasSearchQuery && bulkSelection ? (
+      {hasSearchQuery && showBulkActions && bulkSelection ? (
         <AddToQueueModal
           open={addToQueueOpen}
           onOpenChange={setAddToQueueOpen}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -29,6 +29,7 @@ import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { AddToQueueModal } from "../annotation-queues/-components/add-to-queue-modal.tsx"
 import { AddToDatasetModal } from "../datasets/-components/add-to-dataset-modal.tsx"
+import { SearchEmptyState } from "./-components/search-empty-state.tsx"
 
 const SEARCH_QUERY_MAX_LENGTH = 500
 
@@ -80,11 +81,13 @@ function SearchPage() {
   const [exportModalOpen, setExportModalOpen] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  const { totalCount: totalTraceCount } = useTracesCount({
+  const { totalCount: totalTraceCount, isLoading: isTraceCountLoading } = useTracesCount({
     projectId: hasSearchQuery ? projectId : "",
     ...(hasActiveFilters ? { filters } : {}),
     searchQuery: q,
   })
+
+  const showSearchEmptyState = hasSearchQuery && !isTraceCountLoading && totalTraceCount === 0
 
   const selectedCount = getSelectedCount(selectionState, totalTraceCount)
   const bulkSelection = getBulkSelection(selectionState)
@@ -261,7 +264,7 @@ function SearchPage() {
         </div>
       ) : null}
 
-      {hasSearchQuery ? (
+      {hasSearchQuery && !showSearchEmptyState ? (
         <TracesView
           projectId={projectId}
           filters={filters}
@@ -282,7 +285,9 @@ function SearchPage() {
         />
       ) : null}
 
-      {hasSearchQuery && activeTraceId ? (
+      {showSearchEmptyState ? <SearchEmptyState /> : null}
+
+      {hasSearchQuery && !showSearchEmptyState && activeTraceId ? (
         <Layout.Aside>
           <TraceDetailDrawer
             key={activeTraceId}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -1,0 +1,34 @@
+import { Input } from "@repo/ui"
+import { createFileRoute } from "@tanstack/react-router"
+import { SearchIcon } from "lucide-react"
+import { useState } from "react"
+import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
+
+export const Route = createFileRoute("/_authenticated/projects/$projectSlug/search/")({
+  component: SearchPage,
+})
+
+function SearchPage() {
+  const [query, setQuery] = useState("")
+
+  return (
+    <Layout>
+      <Layout.Content>
+        <Layout.Actions>
+          <Layout.ActionsRow className="justify-stretch">
+            <div className="relative w-full">
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search"
+                size="lg"
+                className="w-full pl-9"
+              />
+            </div>
+          </Layout.ActionsRow>
+        </Layout.Actions>
+      </Layout.Content>
+    </Layout>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -1,7 +1,7 @@
 import type { FilterSet } from "@domain/shared"
 import { Button, Icon, Input, type SortDirection, Tooltip, toast } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { ArrowLeftIcon, DatabaseIcon, DownloadIcon, FilterIcon, LayersIcon, SearchIcon } from "lucide-react"
 import { useRef, useState } from "react"
 import { useTracesCount } from "../../../../../domains/traces/traces.collection.ts"
@@ -39,79 +39,15 @@ export const Route = createFileRoute("/_authenticated/projects/$projectSlug/sear
 function SearchPage() {
   const { projectSlug } = Route.useParams()
   const project = useRouteProject()
+  const projectId = project.id
 
   const [q, setQ] = useParamState("q", "")
   const hasSearchQuery = q.length > 0
 
-  return (
-    <Layout>
-      <Layout.Actions>
-        <Layout.ActionsRow className="justify-stretch">
-          <div className="relative flex w-full items-center gap-2">
-            {hasSearchQuery ? (
-              <Tooltip
-                asChild
-                trigger={
-                  <Button variant="ghost" size="sm" onClick={() => setQ("")} aria-label="Clear search">
-                    <Icon icon={ArrowLeftIcon} size="sm" />
-                  </Button>
-                }
-              >
-                Clear search
-              </Tooltip>
-            ) : null}
-            <SearchInput key={q} initialValue={q} onSubmit={setQ} />
-          </div>
-        </Layout.ActionsRow>
-      </Layout.Actions>
-
-      {hasSearchQuery ? <SearchResults projectId={project.id} projectSlug={projectSlug} searchQuery={q} /> : null}
-    </Layout>
-  )
-}
-
-function SearchInput({
-  initialValue,
-  onSubmit,
-}: {
-  readonly initialValue: string
-  readonly onSubmit: (value: string) => void
-}) {
-  const [draft, setDraft] = useState(initialValue)
-
-  return (
-    <div className="relative flex-1">
-      <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
-        <Icon icon={SearchIcon} size="sm" color="foregroundMuted" />
-      </div>
-      <Input
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key !== "Enter") return
-          event.preventDefault()
-          const next = draft.trim().slice(0, SEARCH_QUERY_MAX_LENGTH)
-          onSubmit(next)
-        }}
-        placeholder="Search"
-        size="lg"
-        maxLength={SEARCH_QUERY_MAX_LENGTH}
-        className="w-full pl-9"
-        autoFocus
-      />
-    </div>
-  )
-}
-
-function SearchResults({
-  projectId,
-  projectSlug,
-  searchQuery,
-}: {
-  readonly projectId: string
-  readonly projectSlug: string
-  readonly searchQuery: string
-}) {
+  // Results state — kept at the top level so the layout slots below
+  // (`Layout.Actions`, `Layout.Aside`, …) remain DIRECT children of `<Layout>`.
+  // `ListingLayout` discovers its panes via `Children.toArray`, which doesn't
+  // see through function components.
   const [filtersOpen, setFiltersOpen] = useParamState("filtersOpen", false)
   const [activeTraceId, setActiveTraceId] = useParamState("traceId", "")
   const [, setSelectedSpanId] = useParamState("spanId", "")
@@ -145,9 +81,9 @@ function SearchResults({
   const [exporting, setExporting] = useState(false)
 
   const { totalCount: totalTraceCount } = useTracesCount({
-    projectId,
+    projectId: hasSearchQuery ? projectId : "",
     ...(hasActiveFilters ? { filters } : {}),
-    searchQuery,
+    searchQuery: q,
   })
 
   const selectedCount = getSelectedCount(selectionState, totalTraceCount)
@@ -225,7 +161,7 @@ function SearchResults({
   const canNavigatePrev = traceIdsRef.current.length > 0 && (activeTraceIndex < 0 || activeTraceIndex > 0)
 
   useHotkeys([
-    { hotkey: "F", callback: () => setFiltersOpen((prev) => !prev) },
+    { hotkey: "F", callback: () => setFiltersOpen((prev) => !prev), options: { enabled: hasSearchQuery } },
     {
       hotkey: "Escape",
       callback: closeTraceDrawer,
@@ -234,53 +170,77 @@ function SearchResults({
   ])
 
   return (
-    <>
-      <Layout.Actions className="pt-0">
-        <Layout.ActionsRow>
-          <Layout.ActionRowItem>
-            <TimeFilterDropdown
-              {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
-              {...(timeTo ? { startTimeTo: timeTo } : {})}
-              onChange={(from, to) => {
-                const next = { ...filters }
-                if (from || to) {
-                  const conditions = [
-                    ...(from ? [{ op: "gte" as const, value: from }] : []),
-                    ...(to ? [{ op: "lte" as const, value: to }] : []),
-                  ]
-                  next.startTime = conditions
-                } else {
-                  delete next.startTime
+    <Layout>
+      <Layout.Actions>
+        <Layout.ActionsRow className="justify-stretch">
+          <div className="relative flex w-full items-center gap-2">
+            {hasSearchQuery ? (
+              <Tooltip
+                asChild
+                trigger={
+                  <Button asChild variant="ghost" size="icon">
+                    <Link to="/projects/$projectSlug/search" params={{ projectSlug }} aria-label="Clear search">
+                      <Icon icon={ArrowLeftIcon} size="sm" />
+                    </Link>
+                  </Button>
                 }
-                setRawFilters(serializeFilters(next) ?? "")
-              }}
-            />
-            <ColumnsSelector
-              columns={TRACE_COLUMN_OPTIONS}
-              selectedColumnIds={visibleTraceColumnIds}
-              onChange={(nextColumnIds) =>
-                setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
-              }
-            />
-            <Button variant={filtersOpen ? "outline" : "ghost"} size="sm" onClick={() => setFiltersOpen(!filtersOpen)}>
-              <Icon icon={FilterIcon} size="sm" />
-              Filters
-              {hasActiveFilters ? (
-                <span className="inline-flex items-center justify-center rounded-full bg-primary px-1.5 text-[10px] leading-4 font-medium text-primary-foreground">
-                  {Object.keys(filters).length}
-                </span>
-              ) : null}
-            </Button>
-            {hasActiveFilters ? (
-              <Button variant="ghost" size="sm" onClick={clearFilters}>
-                Clear all
-              </Button>
+              >
+                Clear search
+              </Tooltip>
             ) : null}
-          </Layout.ActionRowItem>
+            <SearchInput key={q} initialValue={q} onSubmit={setQ} />
+          </div>
         </Layout.ActionsRow>
       </Layout.Actions>
 
-      {selectedCount > 0 ? (
+      {hasSearchQuery ? (
+        <Layout.Actions className="pt-0">
+          <Layout.ActionsRow>
+            <Layout.ActionRowItem>
+              <TimeFilterDropdown
+                {...(timeFrom ? { startTimeFrom: timeFrom } : {})}
+                {...(timeTo ? { startTimeTo: timeTo } : {})}
+                onChange={(from, to) => {
+                  const next = { ...filters }
+                  if (from || to) {
+                    const conditions = [
+                      ...(from ? [{ op: "gte" as const, value: from }] : []),
+                      ...(to ? [{ op: "lte" as const, value: to }] : []),
+                    ]
+                    next.startTime = conditions
+                  } else {
+                    delete next.startTime
+                  }
+                  setRawFilters(serializeFilters(next) ?? "")
+                }}
+              />
+              <ColumnsSelector
+                columns={TRACE_COLUMN_OPTIONS}
+                selectedColumnIds={visibleTraceColumnIds}
+                onChange={(nextColumnIds) =>
+                  setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
+                }
+              />
+              <Button variant={filtersOpen ? "outline" : "ghost"} size="sm" onClick={() => setFiltersOpen(!filtersOpen)}>
+                <Icon icon={FilterIcon} size="sm" />
+                Filters
+                {hasActiveFilters ? (
+                  <span className="inline-flex items-center justify-center rounded-full bg-primary px-1.5 text-[10px] leading-4 font-medium text-primary-foreground">
+                    {Object.keys(filters).length}
+                  </span>
+                ) : null}
+              </Button>
+              {hasActiveFilters ? (
+                <Button variant="ghost" size="sm" onClick={clearFilters}>
+                  Clear all
+                </Button>
+              ) : null}
+            </Layout.ActionRowItem>
+          </Layout.ActionsRow>
+        </Layout.Actions>
+      ) : null}
+
+      {hasSearchQuery && selectedCount > 0 ? (
         <div className="flex flex-row items-center gap-2 px-6">
           <Button variant="outline" size="sm" onClick={() => setExportModalOpen(true)} disabled={exporting}>
             <Icon icon={DownloadIcon} size="sm" />
@@ -297,26 +257,28 @@ function SearchResults({
         </div>
       ) : null}
 
-      <TracesView
-        projectId={projectId}
-        filters={filters}
-        filtersOpen={filtersOpen}
-        activeTraceId={activeTraceId || undefined}
-        activeDrawerTab={traceDetailTab}
-        sorting={sorting}
-        onSortingChange={onSortingChange}
-        selectionState={selectionState}
-        onSelectionChange={setSelectionState}
-        totalTraceCount={totalTraceCount}
-        onFiltersChange={onFiltersChange}
-        onFiltersClose={() => setFiltersOpen(false)}
-        onActiveTraceChange={onActiveTraceChange}
-        traceIdsRef={traceIdsRef}
-        visibleColumnIds={visibleTraceColumnIds}
-        searchQuery={searchQuery}
-      />
+      {hasSearchQuery ? (
+        <TracesView
+          projectId={projectId}
+          filters={filters}
+          filtersOpen={filtersOpen}
+          activeTraceId={activeTraceId || undefined}
+          activeDrawerTab={traceDetailTab}
+          sorting={sorting}
+          onSortingChange={onSortingChange}
+          selectionState={selectionState}
+          onSelectionChange={setSelectionState}
+          totalTraceCount={totalTraceCount}
+          onFiltersChange={onFiltersChange}
+          onFiltersClose={() => setFiltersOpen(false)}
+          onActiveTraceChange={onActiveTraceChange}
+          traceIdsRef={traceIdsRef}
+          visibleColumnIds={visibleTraceColumnIds}
+          searchQuery={q}
+        />
+      ) : null}
 
-      {activeTraceId ? (
+      {hasSearchQuery && activeTraceId ? (
         <Layout.Aside>
           <TraceDetailDrawer
             key={activeTraceId}
@@ -333,36 +295,73 @@ function SearchResults({
         </Layout.Aside>
       ) : null}
 
-      {bulkSelection ? (
-        <>
-          <ExportConfirmationModal
-            open={exportModalOpen}
-            onOpenChange={setExportModalOpen}
-            itemLabel="trace"
-            selectedCount={selectedCount}
-            onConfirm={() => void handleExportTraces()}
-            exporting={exporting}
-          />
-          <AddToDatasetModal
-            open={addToDatasetOpen}
-            onOpenChange={setAddToDatasetOpen}
-            projectId={projectId}
-            selection={bulkSelection}
-            selectedCount={selectedCount}
-            onSuccess={clearSelections}
-          />
-          <AddToQueueModal
-            open={addToQueueOpen}
-            onOpenChange={setAddToQueueOpen}
-            projectId={projectId}
-            projectSlug={projectSlug}
-            selection={bulkSelection}
-            selectedCount={selectedCount}
-            {...(hasActiveFilters ? { filters } : {})}
-            onSuccess={clearSelections}
-          />
-        </>
+      {hasSearchQuery && bulkSelection ? (
+        <ExportConfirmationModal
+          open={exportModalOpen}
+          onOpenChange={setExportModalOpen}
+          itemLabel="trace"
+          selectedCount={selectedCount}
+          onConfirm={() => void handleExportTraces()}
+          exporting={exporting}
+        />
       ) : null}
-    </>
+
+      {hasSearchQuery && bulkSelection ? (
+        <AddToDatasetModal
+          open={addToDatasetOpen}
+          onOpenChange={setAddToDatasetOpen}
+          projectId={projectId}
+          selection={bulkSelection}
+          selectedCount={selectedCount}
+          onSuccess={clearSelections}
+        />
+      ) : null}
+
+      {hasSearchQuery && bulkSelection ? (
+        <AddToQueueModal
+          open={addToQueueOpen}
+          onOpenChange={setAddToQueueOpen}
+          projectId={projectId}
+          projectSlug={projectSlug}
+          selection={bulkSelection}
+          selectedCount={selectedCount}
+          {...(hasActiveFilters ? { filters } : {})}
+          onSuccess={clearSelections}
+        />
+      ) : null}
+    </Layout>
+  )
+}
+
+function SearchInput({
+  initialValue,
+  onSubmit,
+}: {
+  readonly initialValue: string
+  readonly onSubmit: (value: string) => void
+}) {
+  const [draft, setDraft] = useState(initialValue)
+
+  return (
+    <div className="relative flex-1">
+      <div className="pointer-events-none absolute inset-y-0 left-3 flex items-center">
+        <Icon icon={SearchIcon} size="sm" color="foregroundMuted" />
+      </div>
+      <Input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return
+          event.preventDefault()
+          const next = draft.trim().slice(0, SEARCH_QUERY_MAX_LENGTH)
+          onSubmit(next)
+        }}
+        placeholder="Search"
+        size="lg"
+        maxLength={SEARCH_QUERY_MAX_LENGTH}
+        className="w-full pl-9"
+        autoFocus
+      />
+    </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -221,7 +221,11 @@ function SearchPage() {
                   setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
                 }
               />
-              <Button variant={filtersOpen ? "outline" : "ghost"} size="sm" onClick={() => setFiltersOpen(!filtersOpen)}>
+              <Button
+                variant={filtersOpen ? "outline" : "ghost"}
+                size="sm"
+                onClick={() => setFiltersOpen(!filtersOpen)}
+              >
                 <Icon icon={FilterIcon} size="sm" />
                 Filters
                 {hasActiveFilters ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -29,6 +29,7 @@ import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { AddToQueueModal } from "../annotation-queues/-components/add-to-queue-modal.tsx"
 import { AddToDatasetModal } from "../datasets/-components/add-to-dataset-modal.tsx"
+import { SearchBlankSlate } from "./-components/search-blank-slate.tsx"
 import { SearchEmptyState } from "./-components/search-empty-state.tsx"
 
 const SEARCH_QUERY_MAX_LENGTH = 500
@@ -195,6 +196,8 @@ function SearchPage() {
           </div>
         </Layout.ActionsRow>
       </Layout.Actions>
+
+      {!hasSearchQuery ? <SearchBlankSlate /> : null}
 
       {hasSearchQuery ? (
         <Layout.Actions className="pt-0">


### PR DESCRIPTION
## Summary

Adds a new **Search** section to the project sidebar (the first item) that exposes the existing hybrid trace search backend (Voyage embeddings + ClickHouse lexical, weighted 0.3/0.7) as a real product feature.

- **`/projects/<slug>/search`** — empty state shows a `SparklesIcon` blank slate that nudges users toward natural-language queries.
- **`/projects/<slug>/search?q=…`** — renders the standard `TracesView` (filters sidebar, trace drawer, bulk actions, columns selector, time-range dropdown) bound to `searchQuery`.
- **`/projects/<slug>/search?q=foo`** with zero results — `TracesView` stays mounted so filter editing still works; the table's built-in blank slate ("No traces match the search query") covers the empty case.
- The search input has a back-arrow `Link` to `/projects/<slug>/search` (no params) that clears all state in one go.

### URL state

The route persists `q`, `filters`, plus the same trace-listing params used by the project home — `sortBy`, `sortDirection`, `traceColumns`, `traceId`, `spanId`, `traceDetailTab`, `filtersOpen` — so a shared link reproduces the exact view (which trace is open, current sort, visible columns, etc.). Behaviour matches `/projects/<slug>/` on purpose; nothing here is route-local in-memory state.

### Bulk action scope

Export / Add to Dataset / Add to Annotation Queue currently render **only when the user has explicitly picked rows** (`selection.mode === "selected"`). The `all` / `allExcept` selection modes resolve server-side against the unfiltered project, ignoring `searchQuery`, so allowing them on this page would silently process more traces than the visible count suggests. Extending the bulk-action server schemas to accept `searchQuery` is filed as a follow-up.

### Out of scope

- Search-input → command-palette redesign (lives on the `search-panel` branch).
- Tag autocomplete inside the search input.
- Threading `searchQuery` through bulk-action server functions.

## Test plan

- [ ] Visit `/projects/<slug>/search` — sidebar shows Search as the first item; the page renders the blank-slate hint.
- [ ] Type a query, press Enter — URL updates to `?q=…`, traces table renders with results.
- [ ] Click the back-arrow — URL drops back to `/search`, blank state returns.
- [ ] With a query that matches nothing, the table renders its blank slate; the Filters / Time / Columns toolbar still works.
- [ ] Click a trace row — drawer opens in the right pane, table stays visible.
- [ ] Apply filters via the existing Filters sidebar / `TimeFilterDropdown` — `?filters=` updates and traces narrow correctly.
- [ ] Manually pick rows and use Export / Add to Dataset / Add to Queue — actions process exactly the picked IDs.
- [ ] Use the table's "select all" checkbox — bulk-action toolbar does **not** appear (current scope; full select-all support waits on backend changes).
- [ ] Project home (`/projects/<slug>/`) is unaffected.