### PR TITLE
Improve loading state handling in SpansTab component

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab.tsx
@@ -15,7 +15,7 @@ export function SpansTab({
   readonly onSelectSpan: (spanId: string) => void
   readonly isActive: boolean
 }) {
-  const { data: spans } = useSpansByTraceCollection(traceId)
+  const { data: spans, isLoading } = useSpansByTraceCollection(traceId)
   const [isMinimized, setIsMinimized] = useState(() => selectedSpanId !== "")
   const treeContainerRef = useRef<HTMLDivElement | null>(null)
 
@@ -50,7 +50,7 @@ export function SpansTab({
     setIsMinimized((prev) => !prev)
   }
 
-  if (!spans) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-6">
         <Text.H5 color="foregroundMuted">Loading spans...</Text.H5>
@@ -58,7 +58,7 @@ export function SpansTab({
     )
   }
 
-  if (spans.length === 0) {
+  if (!spans || spans.length === 0) {
     return (
       <div className="flex items-center justify-center py-6">
         <Text.H5 color="foregroundMuted">No spans found</Text.H5>


### PR DESCRIPTION
## Summary
Updated the SpansTab component to properly distinguish between loading and empty states when fetching spans data.

## Key Changes
- Extract `isLoading` flag from `useSpansByTraceCollection` hook to explicitly track loading state
- Replace `!spans` check with `isLoading` to show loading indicator while data is being fetched
- Update empty state check to handle both loading completion and actual empty results with `!spans || spans.length === 0`

## Implementation Details
This change improves the user experience by:
- Showing a "Loading spans..." message while the data is being fetched, rather than when spans are null
- Properly handling the case where spans data has loaded but is empty (no spans found)
- Making the loading state logic more explicit and maintainable

https://claude.ai/code/session_01BAeYCX51JMyfgmtVSAxonu