### PR TITLE
feat(ui): shared CodeBlockControls with copy + expand modal

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/helpers.tsx
@@ -17,7 +17,7 @@ export function isNonEmptyJson(json: string): boolean {
 
 export function JsonBlock({ value }: { readonly value: unknown }) {
   const formatted = useMemo(() => JSON.stringify(value, null, 2), [value])
-  return <CodeBlock value={formatted} copyable className="bg-secondary" />
+  return <CodeBlock value={formatted} className="bg-secondary" />
 }
 
 export function StatusBadge({

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/spans-tab/span-detail/span-detail-content.tsx
@@ -74,7 +74,7 @@ function ErrorSection({ span }: { readonly span: SpanDetailRecord }) {
       {exception?.stacktrace && (
         <div className="flex flex-col gap-0.5">
           <Text.H6 color="destructive">Stack Trace</Text.H6>
-          <CodeBlock value={exception.stacktrace} copyable />
+          <CodeBlock value={exception.stacktrace} />
         </div>
       )}
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-detail-drawer/tabs/trace-tab.tsx
@@ -19,7 +19,7 @@ import { UsageSummary } from "./spans-tab/span-detail/usage-summary.tsx"
 
 function JsonBlock({ value }: { readonly value: unknown }) {
   const formatted = useMemo(() => JSON.stringify(value, null, 2), [value])
-  return <CodeBlock value={formatted} copyable className="bg-secondary" />
+  return <CodeBlock value={formatted} className="bg-secondary" />
 }
 
 const METRIC_FILTER_FIELD: Readonly<Record<TraceOutlierMetric, string>> = {

--- a/packages/ui/src/components/code-block/code-block-controls.tsx
+++ b/packages/ui/src/components/code-block/code-block-controls.tsx
@@ -1,0 +1,104 @@
+import { isJsonBlock, prettifyCompactJson } from "@repo/utils"
+import { Maximize2 } from "lucide-react"
+import { useMemo, useState } from "react"
+import { Button } from "../button/button.tsx"
+import { CopyButton } from "../copy-button/index.tsx"
+import { flattenHighlightedTokens, lowlight } from "../genai-conversation/parts/syntax-highlight.ts"
+import { Icon } from "../icons/icons.tsx"
+import { Modal } from "../modal/modal.tsx"
+import { Text } from "../text/text.tsx"
+import { Tooltip } from "../tooltip/tooltip.tsx"
+
+export type CodeBlockControlsProps = {
+  readonly content: string
+  readonly language?: string | undefined
+  readonly copyable?: boolean
+  readonly expandable?: boolean
+}
+
+function titleFor(language: string | undefined, isJson: boolean): string {
+  if (isJson) return "JSON"
+  if (!language) return "Code"
+  return language.charAt(0).toUpperCase() + language.slice(1)
+}
+
+function HighlightedTokens({ content, language }: { readonly content: string; readonly language: string | undefined }) {
+  const detected = useMemo(() => {
+    if (language && lowlight.registered(language)) return language
+    if (isJsonBlock(content)) return "json"
+    return null
+  }, [content, language])
+
+  const tokens = useMemo(() => {
+    if (!detected) return null
+    return flattenHighlightedTokens(lowlight.highlight(detected, content), 0)
+  }, [content, detected])
+
+  if (!tokens) return <>{content}</>
+
+  return (
+    <>
+      {tokens.map((token, i) => (
+        <span key={i} {...(token.hljsClass ? { className: token.hljsClass } : {})}>
+          {token.text}
+        </span>
+      ))}
+    </>
+  )
+}
+
+export function CodeBlockControls({
+  content,
+  language,
+  copyable = true,
+  expandable = true,
+}: CodeBlockControlsProps) {
+  const [open, setOpen] = useState(false)
+
+  const isJson = useMemo(() => language === "json" || isJsonBlock(content), [content, language])
+  const prettified = useMemo(() => (isJson ? prettifyCompactJson(content) : content), [content, isJson])
+
+  if (!copyable && !expandable) return null
+
+  return (
+    <>
+      <div className="absolute top-1 right-1 z-10 flex items-center gap-0.5">
+        {copyable ? <CopyButton value={content} tooltip="Copy" /> : null}
+        {expandable ? (
+          <Tooltip
+            asChild
+            trigger={
+              <Button type="button" variant="ghost" size="icon" onClick={() => setOpen(true)} aria-label="Expand">
+                <Icon icon={Maximize2} size="sm" color="foregroundMuted" />
+              </Button>
+            }
+          >
+            <Text.Mono size="h6">Expand</Text.Mono>
+          </Tooltip>
+        ) : null}
+      </div>
+      {expandable ? (
+        <Modal
+          open={open}
+          onOpenChange={setOpen}
+          dismissible
+          size="full"
+          height="screen"
+          scrollable={false}
+          title={titleFor(language, isJson)}
+        >
+          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-muted">
+            <div className="absolute top-1 right-1 z-10">
+              <CopyButton value={prettified} tooltip="Copy" />
+            </div>
+            <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words p-4 pr-12 text-xs">
+              <code>
+                <HighlightedTokens content={prettified} language={language} />
+              </code>
+            </pre>
+          </div>
+        </Modal>
+      ) : null}
+    </>
+  )
+}

--- a/packages/ui/src/components/code-block/code-block-controls.tsx
+++ b/packages/ui/src/components/code-block/code-block-controls.tsx
@@ -47,12 +47,7 @@ function HighlightedTokens({ content, language }: { readonly content: string; re
   )
 }
 
-export function CodeBlockControls({
-  content,
-  language,
-  copyable = true,
-  expandable = true,
-}: CodeBlockControlsProps) {
+export function CodeBlockControls({ content, language, copyable = true, expandable = true }: CodeBlockControlsProps) {
   const [open, setOpen] = useState(false)
 
   const isJson = useMemo(() => language === "json" || isJsonBlock(content), [content, language])

--- a/packages/ui/src/components/code-block/code-block.tsx
+++ b/packages/ui/src/components/code-block/code-block.tsx
@@ -1,11 +1,13 @@
 import { lazy, Suspense, useState } from "react"
 import { useMountEffect } from "../../hooks/use-mount-effect.ts"
 import { cn } from "../../utils/cn.ts"
-import { CopyButton } from "../copy-button/index.tsx"
+import { CodeBlockControls } from "./code-block-controls.tsx"
 
 export interface CodeBlockProps {
   readonly value: string
   readonly copyable?: boolean
+  readonly expandable?: boolean
+  readonly language?: string
   readonly className?: string
 }
 
@@ -21,7 +23,7 @@ function CodeBlockFallback({ className }: { readonly className?: string }) {
   )
 }
 
-export function CodeBlock({ value, copyable, className }: CodeBlockProps) {
+export function CodeBlock({ value, copyable = true, expandable = true, language, className }: CodeBlockProps) {
   const [mounted, setMounted] = useState(false)
 
   useMountEffect(() => {
@@ -37,11 +39,12 @@ export function CodeBlock({ value, copyable, className }: CodeBlockProps) {
       <Suspense fallback={<CodeBlockFallback {...(className != null && { className })} />}>
         <CodeMirrorReadonly value={value} {...(className != null && { className })} />
       </Suspense>
-      {copyable && (
-        <div className="absolute top-1 right-1">
-          <CopyButton value={value} tooltip="Copy" />
-        </div>
-      )}
+      <CodeBlockControls
+        content={value}
+        copyable={copyable}
+        expandable={expandable}
+        {...(language != null && { language })}
+      />
     </div>
   )
 }

--- a/packages/ui/src/components/genai-conversation/part.tsx
+++ b/packages/ui/src/components/genai-conversation/part.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon, FileIcon, LinkIcon, TerminalIcon, TriangleAlertIcon, XIcon } from "lucide-react"
 import type { GenAIPart } from "rosetta-ai"
 import { cn } from "../../utils/cn.ts"
+import { CodeBlockControls } from "../code-block/code-block-controls.tsx"
 import { Text } from "../text/text.tsx"
 import { Tooltip } from "../tooltip/tooltip.tsx"
 import { CollapsibleBlock } from "./parts/collapsible-block.tsx"
@@ -127,6 +128,7 @@ export function Part({
       ) : (
         <CheckIcon className="w-3.5 h-3.5 text-success" />
       )
+      const responseContent = formatJson(response)
 
       return (
         <CollapsibleBlock
@@ -135,21 +137,29 @@ export function Part({
           variant={isError ? "destructive" : "default"}
           statusIcon={statusIcon}
         >
-          <pre className={cn("overflow-auto rounded-lg p-3 text-xs", isError ? "bg-destructive-muted" : "bg-muted")}>
-            {formatJson(response)}
-          </pre>
+          <div className="relative">
+            <pre className={cn("overflow-auto rounded-lg p-3 text-xs", isError ? "bg-destructive-muted" : "bg-muted")}>
+              {responseContent}
+            </pre>
+            <CodeBlockControls content={responseContent} language="json" />
+          </div>
         </CollapsibleBlock>
       )
     }
 
-    default:
+    default: {
+      const fallbackContent = JSON.stringify(part, null, 2)
       return (
         <CollapsibleBlock
           icon={<FileIcon className="w-3.5 h-3.5" />}
           label={<Text.Mono size="h6">{part.type}</Text.Mono>}
         >
-          <pre className="overflow-auto rounded-lg bg-muted p-3 text-xs">{JSON.stringify(part, null, 2)}</pre>
+          <div className="relative">
+            <pre className="overflow-auto rounded-lg bg-muted p-3 text-xs">{fallbackContent}</pre>
+            <CodeBlockControls content={fallbackContent} language="json" />
+          </div>
         </CollapsibleBlock>
       )
+    }
   }
 }

--- a/packages/ui/src/components/genai-conversation/parts/code-block-shell.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/code-block-shell.tsx
@@ -9,17 +9,23 @@ import { cn } from "../../../utils/cn.ts"
  *
  * `not-prose` opts the block out of Tailwind Typography so the look is the
  * same whether the shell renders inside a `prose` wrapper or standalone.
+ *
+ * `controls` overlays absolutely-positioned UI (typically a `<CodeBlockControls />`)
+ * on the top-right of the block. When set, the `<pre>` is wrapped in a
+ * `relative` container so the controls anchor correctly.
  */
 export function CodeBlockShell({
   children,
   contentType,
   className,
+  controls,
 }: {
   readonly children: ReactNode
   readonly contentType?: string | undefined
   readonly className?: string | undefined
+  readonly controls?: ReactNode | undefined
 }) {
-  return (
+  const pre = (
     <pre
       {...(contentType ? { "data-content-type": contentType } : {})}
       className={cn(
@@ -29,5 +35,14 @@ export function CodeBlockShell({
     >
       {children}
     </pre>
+  )
+
+  if (!controls) return pre
+
+  return (
+    <div className="relative">
+      {pre}
+      {controls}
+    </div>
   )
 }

--- a/packages/ui/src/components/genai-conversation/parts/json-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/json-content.tsx
@@ -1,5 +1,6 @@
 import { use, useMemo } from "react"
 import { cn } from "../../../utils/cn.ts"
+import { CodeBlockControls } from "../../code-block/code-block-controls.tsx"
 import { TextSelectionContext } from "../text-selection.tsx"
 import { CodeBlockShell } from "./code-block-shell.tsx"
 import { highlightAttributes, segmentForHighlights } from "./highlight-segments.ts"
@@ -44,7 +45,7 @@ export function JsonContent({
   }, [tokens, highlights])
 
   return (
-    <CodeBlockShell contentType="json">
+    <CodeBlockShell contentType="json" controls={<CodeBlockControls content={content} language="json" />}>
       <code>
         {segments.map((segment, i) => {
           const { className: highlightClass, ...attrs } = highlightAttributes(segment.activeHighlight)

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
@@ -1,11 +1,12 @@
 import { isJsonBlock, LARGE_MARKDOWN_CONTENT_THRESHOLD, prettifyCompactJson } from "@repo/utils"
-import { use, useMemo, useState } from "react"
+import { isValidElement, type ReactNode, use, useMemo, useState } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import rehypeHighlight from "rehype-highlight"
 import remarkBreaks from "remark-breaks"
 import remarkEmoji from "remark-emoji"
 import remarkGfm from "remark-gfm"
 import { Button } from "../../button/button.tsx"
+import { CodeBlockControls } from "../../code-block/code-block-controls.tsx"
 import { Text } from "../../text/text.tsx"
 import { TextSelectionContext } from "../text-selection.tsx"
 import { CodeBlockShell } from "./code-block-shell.tsx"
@@ -25,10 +26,39 @@ const remarkPlugins = [remarkGfm, remarkEmoji, remarkBreaks] as const
 // `readonly` tuples (no covariance through `as const`).
 const rehypeHighlightPlugin: [typeof rehypeHighlight, { detect: false }] = [rehypeHighlight, { detect: false }]
 
+// rehype-highlight rewrites the text inside a code fence into nested
+// `<span>`s, so the original source string isn't a single child anymore. Walk
+// the React tree to recover it for copy/expand controls.
+function extractText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return ""
+  if (typeof node === "string" || typeof node === "number") return String(node)
+  if (Array.isArray(node)) return node.map(extractText).join("")
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode }
+    return extractText(props.children)
+  }
+  return ""
+}
+
+function extractCodeFenceLanguage(node: ReactNode): string | undefined {
+  if (!isValidElement(node)) return undefined
+  const className = (node.props as { className?: string }).className ?? ""
+  const match = /language-(\w+)/.exec(className)
+  return match?.[1]
+}
+
 // Route Markdown code fences through the same shell as JsonContent so whole-
 // part JSON and inline ```...``` blocks share one visual treatment.
 const markdownComponents: Components = {
-  pre: ({ children }) => <CodeBlockShell>{children}</CodeBlockShell>,
+  pre: ({ children }) => {
+    const content = extractText(children)
+    const language = extractCodeFenceLanguage(children)
+    return (
+      <CodeBlockShell controls={<CodeBlockControls content={content} {...(language ? { language } : {})} />}>
+        {children}
+      </CodeBlockShell>
+    )
+  },
 }
 export const LARGE_MARKDOWN_PREVIEW_LENGTH = 12_000
 

--- a/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/tool-call-block.tsx
@@ -1,7 +1,8 @@
 import { CheckIcon, ChevronDownIcon, ChevronRightIcon, ScanSearchIcon, WrenchIcon, XIcon } from "lucide-react"
-import { useId, useState } from "react"
+import { useId, useMemo, useState } from "react"
 import { cn } from "../../../utils/cn.ts"
 import { Button } from "../../button/button.tsx"
+import { CodeBlockControls } from "../../code-block/code-block-controls.tsx"
 import { CopyButton } from "../../copy-button/index.tsx"
 import { Text } from "../../text/text.tsx"
 import { Tooltip } from "../../tooltip/tooltip.tsx"
@@ -39,6 +40,9 @@ export function ToolCallBlock({
   const isError = result?.isError === true
 
   const toggleOpen = () => setOpen((prev) => !prev)
+
+  const argsContent = useMemo(() => formatJson(call.arguments), [call.arguments])
+  const resultContent = useMemo(() => (result ? formatJson(result.response) : ""), [result])
 
   return (
     <div
@@ -95,19 +99,23 @@ export function ToolCallBlock({
       </div>
 
       <div id={panelId} className={cn("flex min-w-0 flex-col", !open && "hidden")}>
-        <pre className="max-w-full overflow-auto border-y border-border bg-muted p-3 text-xs">
-          {formatJson(call.arguments)}
-        </pre>
+        <div className="relative">
+          <pre className="max-w-full overflow-auto border-y border-border bg-muted p-3 text-xs">{argsContent}</pre>
+          <CodeBlockControls content={argsContent} language="json" />
+        </div>
         {result && (
           <div className="flex min-w-0 flex-col p-3">
-            <pre
-              className={cn("max-w-full overflow-auto rounded-lg p-3 text-xs", {
-                "bg-muted": !isError,
-                "bg-destructive-muted": isError,
-              })}
-            >
-              {formatJson(result.response)}
-            </pre>
+            <div className="relative">
+              <pre
+                className={cn("max-w-full overflow-auto rounded-lg p-3 text-xs", {
+                  "bg-muted": !isError,
+                  "bg-destructive-muted": isError,
+                })}
+              >
+                {resultContent}
+              </pre>
+              <CodeBlockControls content={resultContent} language="json" />
+            </div>
           </div>
         )}
       </div>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -35,6 +35,10 @@ export { Checkbox, type CheckedState } from "./components/checkbox/checkbox.tsx"
 export { CheckboxInput, type CheckboxInputProps } from "./components/checkbox/checkbox-input.tsx"
 export { CodeBlock, type CodeBlockProps } from "./components/code-block/code-block.tsx"
 export {
+  CodeBlockControls,
+  type CodeBlockControlsProps,
+} from "./components/code-block/code-block-controls.tsx"
+export {
   Combobox,
   ComboboxChip,
   ComboboxChips,


### PR DESCRIPTION
## Summary

- New `CodeBlockControls` overlay (top-right) gives every code block in the messages UI and the standalone `CodeBlock` a consistent **Copy** + **Expand** affordance.
- Expand opens a fullscreen modal that prettifies JSON content, syntax-highlights via lowlight (JSON, JS/TS, Python, Bash, etc.), and renders read-only — no selection/annotation.
- `CodeBlock`'s `copyable` / `expandable` props default to `true`, so call sites can drop the redundant `copyable` flag.

## Changes

- **New** `packages/ui/src/components/code-block/code-block-controls.tsx` — props: `content`, `language?`, `copyable?` (default `true`), `expandable?` (default `true`).
- `CodeBlockShell` accepts an optional `controls` slot and wraps the `<pre>` in a `relative` container when set — preserves the messages UI's annotation/selection invariants since controls are a separate overlay.
- Wired into `JsonContent`, the markdown `pre` override (`MarkdownContent`), `ToolCallBlock` (both args + result panes), and the `tool_call_response` / fallback cases in `part.tsx`.
- `CodeBlock` rebuilt around `CodeBlockControls`; the inline `CopyButton` is gone.
- Cleaned up redundant `copyable` flags in `trace-tab.tsx`, `span-detail-content.tsx`, `helpers.tsx`.
- Exported `CodeBlockControls` + `CodeBlockControlsProps` from `@repo/ui`.

## Test plan

- [x] `pnpm --filter @repo/ui typecheck`
- [x] `pnpm --filter @app/web typecheck`
- [x] `pnpm --filter @repo/ui test` — 73/73 passing
- [ ] Manual: open a trace with a JSON message part, confirm copy + expand buttons in the top-right
- [ ] Manual: click expand — modal opens with prettified JSON, header copy button works, no selection/annotation popovers fire
- [ ] Manual: tool call args + result panes show controls; `tool_call_response` controls work
- [ ] Manual: standalone `CodeBlock` (trace tab JSON output, span detail stacktrace) still renders with copy + expand