### PR TITLE
fix(openclaw-telemetry): capture llm_output under both hook fire orders (0.0.7)

### DIFF
--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.test.ts
@@ -230,6 +230,27 @@ describe("resolveTokens", () => {
       })
     })
 
+    describe("gen_ai.usage.cache_creation_input_tokens (underscore variant — Anthropic-style OTel exporters, openclaw-telemetry)", () => {
+      // Two spellings exist in the wild for the cache-create token attr:
+      // the dot-separated form (`gen_ai.usage.cache_creation.input_tokens`)
+      // matches the OTEL semconv structure, and the underscore form
+      // (`gen_ai.usage.cache_creation_input_tokens`) matches what
+      // Anthropic-style OTel exporters and openclaw-telemetry emit. Both
+      // must resolve, otherwise cache-write tokens silently drop.
+      const attrs = [
+        int("gen_ai.usage.input_tokens", 10_000),
+        int("gen_ai.usage.output_tokens", 200),
+        int("gen_ai.usage.cache_read_input_tokens", 8_000),
+        int("gen_ai.usage.cache_creation_input_tokens", 1_500),
+      ]
+
+      it("resolves cache_create from the underscore-spelling key", () => {
+        const r = resolveTokens(attrs, "anthropic")
+        expect(r.cacheCreate).toBe(EXPECTED.cacheCreate)
+        expect(r.cacheRead).toBe(EXPECTED.cacheRead)
+      })
+    })
+
     describe("ai.usage.promptTokens (Vercel AI SDK v5)", () => {
       const attrs = [
         int("ai.usage.promptTokens", 10_000),

--- a/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
+++ b/packages/domain/spans/src/otlp/resolvers/usage/tokens.ts
@@ -23,6 +23,7 @@ const cacheReadCandidates = [
 
 const cacheCreateCandidates = [
   fromInt("gen_ai.usage.cache_creation.input_tokens"),
+  fromInt("gen_ai.usage.cache_creation_input_tokens"), // Anthropic-style OTel exporters (and openclaw-telemetry)
   fromInt("llm.token_count.prompt_details.cache_write"),
   fromInt("ai.usage.inputTokenDetails.cacheWriteTokens"),
   fromInt("cache_creation_tokens"), // Claude Code

--- a/packages/telemetry/openclaw/CHANGELOG.md
+++ b/packages/telemetry/openclaw/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-04-29
+
+Captures every `llm_output` event regardless of OpenClaw's hook fire order, mirrors `openclaw.session.id` onto the OTEL-standard session attrs Latitude's resolver looks for, and clears OpenClaw 2026.4.26's `potential-exfiltration` audit warning.
+
+### Fixed
+
+- **`llm_output` enrichment is no longer dropped on the `selection.runtime` path.** OpenClaw 2026.4.26+ has two hook fire orders: `cli-runner.runtime` (used by the `claude-code` agent) fires `llm_output → agent_end`, and `selection.runtime` (used by `openai-codex` / embedded ACPX agents) fires `agent_end → llm_output`. The 0.0.6 plugin finalized the run synchronously inside `agent_end`, deleting the run and shipping the OTLP batch before `selection.runtime`'s late `llm_output` could enrich the agent span. Every `llm_output`-only attribute — `gen_ai.output.messages`, `gen_ai.response.model`, `openclaw.resolved.ref`, `openclaw.harness.id`, and the entire `gen_ai.usage.*` block (input / output / cache_read / cache_creation / total tokens) — was silently lost. `onLlmOutput`'s `if (!run) return` was a clean no-op, so there was no error, no warning, no signal anything was wrong. The fix defers finalization by one microtask via `queueMicrotask`: both hook handlers in the same dispatch round write to the still-alive run, the deferred finalize runs after both, and the OTLP batch ships fully enriched. Order-agnostic — works identically for either path. Subagents go through the same `onAgentEnd` code path so they're fixed automatically.
+- **`gen_ai.usage.cache_creation_input_tokens` is now resolved by Latitude.** The resolver's `cacheCreateCandidates` only looked for the dot-separated `gen_ai.usage.cache_creation.input_tokens`; we emit the underscore form (matching what Anthropic-style OTel exporters use). Cache-write tokens silently dropped at resolve time. Resolver now picks up both spellings (`packages/domain/spans/src/otlp/resolvers/usage/tokens.ts`).
+
+### Added
+
+- **`session.id` and `gen_ai.session.id` mirrored from `openclaw.session.id` on every span.** Both are in `sessionIdCandidates` (`domain/spans/src/otlp/resolvers/identity.ts`) — `session.id` is the OpenInference / OTEL standard and the first candidate the resolver tries, `gen_ai.session.id` is the proposed OTEL GenAI semconv key. With the mirror in place, traces can be grouped by OpenClaw session in the Latitude UI without any openclaw-specific resolver path. Emitted on `agent`, `model_call`, `tool_call`, `compaction`, and `subagent` spans so child spans inherit the same grouping.
+- **Regression tests for both hook fire orders + the no-`llm_output` path + subagent ordering.** `plugin.test.ts` now exercises the cli-runner order (`llm_output` before `agent_end`), the selection.runtime order (`agent_end` before `llm_output`), the no-`llm_output` path (cli-runner skips it when `assistantText.length === 0`), and a parent-spawning-subagent flow under the selection.runtime order. The selection-path tests fire both hooks in the same sync round via a `fireSameRound` helper that mirrors how the real OpenClaw dispatcher kicks off `runAgentEnd(...).catch()` and `runLlmOutput(...).catch()` without an `await` between them.
+
+### Changed (build path)
+
+- **`SCOPE_VERSION` is baked at build time instead of read at runtime.** 0.0.6 read `package.json` via `readFileSync` to populate the OTLP `scope.version` and `service.version` attributes — that paired `node:fs` with `fetch(` in the bundled plugin and tripped OpenClaw 2026.4.26's `plugins.code_safety` scanner with a "potential-exfiltration: File read combined with network send" warning. The version is now substituted at bundle time via tsdown's `define` (`__SCOPE_VERSION__` → string literal of `package.json`'s `version`). Single source of truth (`package.json`) preserved, runtime bundle now has zero `node:fs` imports, and the audit warning is gone.
+
+### Documentation
+
+- **README pins the install spec to an exact version.** OpenClaw 2026.4.26's `openclaw security audit --deep` warns about unpinned plugin install specs for supply-chain stability. The README now uses `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7` instead of the bare package name and notes the policy.
+
 ## [0.0.6] - 2026-04-29
 
 Re-publish of the never-shipped 0.0.5 with two install-blocking fixes: the runtime no longer reads `process.env`, and the CLI is no longer in this package. Both were tripping OpenClaw 2026.4.25's `openclaw plugins install` security scan (the `env-harvesting` rule flagged the env-read + `fetch` combo in the runtime, and the `dangerous-exec` rule flagged the CLI's `child_process.spawn` call). The runtime ships clean now; the one-shot installer is moving to a separate `@latitude-data/openclaw-telemetry-cli` package and will land in a follow-up.

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -11,8 +11,10 @@ Requires OpenClaw **2026.4.25 or newer**. Get a Latitude API key + project slug 
 ### Step 1 — Install the plugin runtime
 
 ```bash
-openclaw plugins install @latitude-data/openclaw-telemetry
+openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7
 ```
+
+Pin to an exact version. OpenClaw 2026.4.26's `openclaw security audit --deep` warns about unpinned install specs (`Pin install specs to exact versions … for higher supply-chain stability`), so always include the `@<version>` suffix when installing or upgrading.
 
 OpenClaw fetches the package from npm, runs its security scan, copies files into `~/.openclaw/extensions/<id>/`, and creates a (disabled) `plugins.entries["@latitude-data/openclaw-telemetry"]` entry in `~/.openclaw/openclaw.json`. The gateway will print:
 

--- a/packages/telemetry/openclaw/openclaw.plugin.json
+++ b/packages/telemetry/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "@latitude-data/openclaw-telemetry",
   "name": "Latitude Telemetry",
   "description": "Streams every OpenClaw agent run to Latitude as OTLP traces — full prompt, message history, assistant output, tool I/O, token usage, and agent name.",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "configSchema": {
     "type": "object",
     "additionalProperties": true,

--- a/packages/telemetry/openclaw/package.json
+++ b/packages/telemetry/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/openclaw-telemetry",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "OpenClaw plugin that streams LLM calls, tool executions, and agent runs to Latitude as OTLP traces",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/openclaw/src/otlp.ts
+++ b/packages/telemetry/openclaw/src/otlp.ts
@@ -1,12 +1,32 @@
-import { readFileSync } from "node:fs"
 import { arch, hostname, platform, release } from "node:os"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
 import type { AttrValue, BuildResult, SpanRecord } from "./span-builder.ts"
 import type { OtlpExportRequest, OtlpKeyValue, OtlpResourceSpans, OtlpSpan } from "./types.ts"
 
 const SCOPE_NAME = "@latitude-data/openclaw-telemetry"
-const SCOPE_VERSION = readScopeVersion()
+
+/**
+ * Build-time-baked package version.
+ *
+ * `__SCOPE_VERSION__` is replaced at bundle time by tsdown's `define` (see
+ * `tsdown.config.ts`) with a string literal of `package.json`'s `version`,
+ * so the released bundle ships a constant — no runtime file read.
+ *
+ * Earlier versions read `package.json` at runtime via `readFileSync` to keep
+ * one source of truth for the version. That tripped OpenClaw 2026.4.26's
+ * `plugins.code_safety` scanner with a "potential-exfiltration: File read
+ * combined with network send" warning (we have `fetch(` in `client.ts`).
+ * Build-time bake preserves the single source of truth (the build reads
+ * `package.json` and inlines the value) while keeping the runtime free of
+ * `node:fs`.
+ *
+ * The `typeof` check is a runtime fallback for environments where the
+ * `define` substitution didn't run — chiefly vitest, which executes the
+ * source files directly without going through the build. `typeof` of an
+ * undeclared identifier returns `"undefined"` rather than throwing, which
+ * keeps tests working.
+ */
+declare const __SCOPE_VERSION__: string
+const SCOPE_VERSION = typeof __SCOPE_VERSION__ === "string" ? __SCOPE_VERSION__ : "0.0.0-dev"
 
 interface BuildOptions {
   /**
@@ -122,24 +142,5 @@ function safeJson(value: unknown): string {
     return JSON.stringify(value)
   } catch {
     return ""
-  }
-}
-
-/**
- * Runtime-read package version, so OTLP `scope.version` and `service.version`
- * always reflect what's actually installed. Read once at module load and
- * cached. Falls back to `"unknown"` if the read fails.
- *
- * Same import.meta.url + ../package.json pattern used by `cli.ts` for the
- * `--version` flag — single source of truth in package.json.
- */
-function readScopeVersion(): string {
-  try {
-    const here = dirname(fileURLToPath(import.meta.url))
-    const pkgPath = join(here, "..", "package.json")
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string }
-    return pkg.version ?? "unknown"
-  } catch {
-    return "unknown"
   }
 }

--- a/packages/telemetry/openclaw/src/plugin.test.ts
+++ b/packages/telemetry/openclaw/src/plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import registerLatitudePlugin, { type OpenClawPluginApiLike } from "./plugin.ts"
-import type { BuildResult } from "./span-builder.ts"
+import type { BuildResult, SpanRecord } from "./span-builder.ts"
 
 function makeApi(): {
   api: OpenClawPluginApiLike
@@ -22,6 +22,53 @@ function makeApi(): {
     return lastReturn
   }
   return { api, fire }
+}
+
+/**
+ * Drain any microtasks the plugin queued during the current sync round. The
+ * agent_end handler defers the finalize via `queueMicrotask` so that
+ * `llm_output` events arriving in the same round (selection.runtime path)
+ * still land on the run before serialization. Tests need to flush before
+ * asserting on `emitted`.
+ */
+async function flush(): Promise<void> {
+  // Two awaits is enough — first drains the queueMicrotask body, second
+  // drains anything that body queues (e.g. postTraces' Promise chain).
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+/**
+ * Fire several hook events in a single synchronous round, then await
+ * completion of all of them. This faithfully models how OpenClaw's
+ * `selection.runtime` dispatches consecutive hooks: it kicks off
+ * `runAgentEnd(...).catch(...)` and `runLlmOutput(...).catch(...)` in the
+ * same sync stack with no `await` in between, so both plugin handlers run
+ * synchronously before any microtask drains.
+ *
+ * Awaiting between fires (which is what `await fire(...); await fire(...)`
+ * does) would let the `queueMicrotask` finalize from agent_end drain BEFORE
+ * llm_output's handler runs — that's an artifact of the test harness, not
+ * how real OpenClaw behaves on this path.
+ */
+async function fireSameRound(
+  fire: (hookName: string, event: unknown, ctx: unknown) => Promise<unknown>,
+  ...hooks: ReadonlyArray<readonly [hookName: string, event: unknown, ctx: unknown]>
+): Promise<void> {
+  const promises = hooks.map(([name, event, ctx]) => fire(name, event, ctx))
+  await Promise.all(promises)
+}
+
+function agentSpan(result: BuildResult): SpanRecord {
+  const span = result.spans.find((s) => s.name === "agent")
+  if (!span) throw new Error("expected an `agent` span on the BuildResult")
+  return span
+}
+
+function firstResult(emitted: readonly BuildResult[]): BuildResult {
+  const first = emitted[0]
+  if (!first) throw new Error("expected at least one BuildResult on `emitted`")
+  return first
 }
 
 describe("registerLatitudePlugin", () => {
@@ -171,6 +218,7 @@ describe("registerLatitudePlugin", () => {
       ctx,
     )
     await fire("agent_end", { messages: [], success: true, durationMs: 200 }, ctx)
+    await flush()
 
     expect(emitted).toHaveLength(1)
     const result = emitted[0]
@@ -178,5 +226,235 @@ describe("registerLatitudePlugin", () => {
     const names = result.spans.map((s) => s.name).sort()
     expect(names).toEqual(["agent", "model_call", "model_call", "tool_call:grep"])
     // Two model_call spans, not one big llm_request.
+  })
+})
+
+// ─── Deferred finalize regression tests ───────────────────────────────────────
+//
+// OpenClaw 2026.4.26+ has two hook fire-orders depending on the runtime path:
+//
+//   selection.runtime (codex / embedded ACPX):
+//     llm_input → ...model_calls / tool_calls... → agent_end → llm_output
+//
+//   cli-runner.runtime (claude-code):
+//     llm_input → llm_output (only when assistantText.length > 0) → agent_end
+//
+// Synchronous finalize on agent_end would silently drop every `llm_output`
+// field (output messages, response model, resolved ref, harness id, full
+// `gen_ai.usage.*` block) on the selection path — `onLlmOutput` arrives after
+// the run was deleted, hits `if (!run) return`, no error, no warn, just gone.
+// Deferring the finalize via `queueMicrotask` lets both event handlers in the
+// same sync round write to the still-alive run before serialization.
+
+describe("deferred finalize: llm_output enrichment under both fire orders", () => {
+  function makePlugin(): {
+    fire: ReturnType<typeof makeApi>["fire"]
+    emitted: BuildResult[]
+  } {
+    const { api, fire } = makeApi()
+    const emitted: BuildResult[] = []
+    registerLatitudePlugin(api, {
+      config: {
+        apiKey: "x",
+        project: "p",
+        baseUrl: "http://localhost:0",
+        enabled: true,
+        debug: false,
+        allowConversationAccess: true,
+      },
+      onEmit: (r) => emitted.push(r),
+    })
+    return { fire, emitted }
+  }
+
+  const llmOutputEvt = {
+    runId: "r-1",
+    sessionId: "s-1",
+    provider: "openai",
+    model: "gpt-5",
+    resolvedRef: "openai/gpt-5",
+    harnessId: "harness-7",
+    assistantTexts: ["all done"],
+    lastAssistant: { role: "assistant", content: "all done" },
+    usage: { input: 12, output: 5, cacheRead: 4, cacheWrite: 0, total: 21 },
+  }
+
+  function expectFullyEnriched(result: BuildResult): void {
+    const agent = agentSpan(result)
+    // The `llm_output` fields the selection-path bug used to drop:
+    expect(agent.attrs["gen_ai.response.model"]).toBe("gpt-5")
+    expect(agent.attrs["openclaw.resolved.ref"]).toBe("openai/gpt-5")
+    expect(agent.attrs["openclaw.harness.id"]).toBe("harness-7")
+    expect(agent.attrs["gen_ai.usage.input_tokens"]).toBe(12)
+    expect(agent.attrs["gen_ai.usage.output_tokens"]).toBe(5)
+    expect(agent.attrs["gen_ai.usage.total_tokens"]).toBe(21)
+    expect(agent.attrs["gen_ai.usage.cache_read_input_tokens"]).toBe(4)
+    expect(agent.attrs["gen_ai.output.messages:gated"]).toBeDefined()
+    // The `agent_end` field that always lands:
+    expect(agent.attrs["openclaw.run.success"]).toBe(true)
+  }
+
+  it("cli-runner order: llm_output BEFORE agent_end → output captured", async () => {
+    const { fire, emitted } = makePlugin()
+    const ctx = { runId: "r-1", sessionId: "s-1", agentId: "router" }
+
+    await fire("before_agent_start", { prompt: "do thing" }, ctx)
+    await fire(
+      "llm_input",
+      {
+        runId: "r-1",
+        sessionId: "s-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "do thing",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      ctx,
+    )
+    await fire("llm_output", llmOutputEvt, ctx)
+    await fire("agent_end", { messages: [], success: true, durationMs: 200 }, ctx)
+    await flush()
+
+    expect(emitted).toHaveLength(1)
+    expectFullyEnriched(firstResult(emitted))
+  })
+
+  it("selection.runtime order: agent_end BEFORE llm_output → output STILL captured", async () => {
+    const { fire, emitted } = makePlugin()
+    const ctx = { runId: "r-1", sessionId: "s-1", agentId: "router" }
+
+    await fire("before_agent_start", { prompt: "do thing" }, ctx)
+    await fire(
+      "llm_input",
+      {
+        runId: "r-1",
+        sessionId: "s-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "do thing",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      ctx,
+    )
+    // agent_end fires FIRST (selection.runtime). With synchronous finalize,
+    // the run would be deleted before llm_output arrives and every
+    // llm_output-only field would be silently dropped. Both hooks fire in
+    // the SAME sync round (no `await` between them) — that's what the real
+    // OpenClaw `selection.runtime` dispatcher does. See `fireSameRound`.
+    await fireSameRound(
+      fire,
+      ["agent_end", { messages: [], success: true, durationMs: 200 }, ctx],
+      ["llm_output", llmOutputEvt, ctx],
+    )
+    await flush()
+
+    expect(emitted).toHaveLength(1)
+    expectFullyEnriched(firstResult(emitted))
+  })
+
+  it("no llm_output (cli path with empty assistantText): finalize still ships", async () => {
+    const { fire, emitted } = makePlugin()
+    const ctx = { runId: "r-1", sessionId: "s-1", agentId: "router" }
+
+    await fire("before_agent_start", { prompt: "do thing" }, ctx)
+    await fire(
+      "llm_input",
+      {
+        runId: "r-1",
+        sessionId: "s-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "do thing",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      ctx,
+    )
+    // No llm_output (cli-runner skips it when assistantText.length === 0).
+    await fire("agent_end", { messages: [], success: true, durationMs: 200 }, ctx)
+    await flush()
+
+    expect(emitted).toHaveLength(1)
+    const agent = agentSpan(firstResult(emitted))
+    // agent_end fields are present:
+    expect(agent.attrs["openclaw.run.success"]).toBe(true)
+    // llm_output-only fields are NOT present, but the run still emitted:
+    expect(agent.attrs["gen_ai.response.model"]).toBeUndefined()
+    expect(agent.attrs["gen_ai.usage.input_tokens"]).toBeUndefined()
+  })
+
+  it("subagents: same fix applies — child agent_end + llm_output captured under selection order", async () => {
+    const { fire, emitted } = makePlugin()
+    const parentCtx = { runId: "parent", sessionId: "s-parent", agentId: "router" }
+    const childCtx = { runId: "child", sessionId: "s-child", agentId: "code-agent" }
+
+    // Parent run
+    await fire("before_agent_start", { prompt: "outer task" }, parentCtx)
+    await fire(
+      "llm_input",
+      {
+        runId: "parent",
+        sessionId: "s-parent",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "outer task",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      parentCtx,
+    )
+
+    // Parent spawns a subagent — child runId is registered with parent's
+    // traceId so the child's spans nest under the parent's `subagent` span.
+    await fire(
+      "subagent_spawned",
+      { runId: "parent", childSessionKey: "child", agentId: "code-agent", label: "code", mode: "run" },
+      parentCtx,
+    )
+
+    // ─── Child agent runs through the SAME `onAgentEnd` path as a top-level
+    // ─── agent. Selection-runtime order applies: child's `agent_end` fires
+    // ─── before child's `llm_output`. Without deferred finalize, child's
+    // ─── llm_output enrichment would be silently dropped — same bug, just
+    // ─── one level deep.
+    await fire("before_agent_start", { prompt: "inner task" }, childCtx)
+    await fire(
+      "llm_input",
+      {
+        runId: "child",
+        sessionId: "s-child",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "inner task",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      childCtx,
+    )
+    await fireSameRound(
+      fire,
+      ["agent_end", { messages: [], success: true, durationMs: 50 }, childCtx],
+      ["llm_output", { ...llmOutputEvt, runId: "child" }, childCtx],
+    )
+    await flush()
+
+    // Then the parent finalizes. subagent_ended fires before parent's own
+    // agent_end (parent's view of the child completing). agent_end and
+    // llm_output fire in the same selection.runtime round.
+    await fire("subagent_ended", { runId: "parent", childSessionKey: "child", outcome: "completed" }, parentCtx)
+    await fireSameRound(
+      fire,
+      ["agent_end", { messages: [], success: true, durationMs: 200 }, parentCtx],
+      ["llm_output", { ...llmOutputEvt, runId: "parent" }, parentCtx],
+    )
+    await flush()
+
+    expect(emitted).toHaveLength(2)
+    // Both parent and child should have full output enrichment:
+    for (const result of emitted) {
+      expectFullyEnriched(result)
+    }
   })
 })

--- a/packages/telemetry/openclaw/src/plugin.test.ts
+++ b/packages/telemetry/openclaw/src/plugin.test.ts
@@ -32,8 +32,12 @@ function makeApi(): {
  * asserting on `emitted`.
  */
 async function flush(): Promise<void> {
-  // Two awaits is enough — first drains the queueMicrotask body, second
-  // drains anything that body queues (e.g. postTraces' Promise chain).
+  // Two awaits is enough here: the first lets the queueMicrotask-scheduled
+  // finalize run, and the second lets any additional microtasks queued by
+  // that finalize run before assertions. This does not wait for unrelated
+  // async work that resumes only after timers, I/O, or fetch resolve —
+  // postTraces awaits fetch, so its completion is not guaranteed by this
+  // helper, and tests must not depend on it.
   await Promise.resolve()
   await Promise.resolve()
 }

--- a/packages/telemetry/openclaw/src/plugin.ts
+++ b/packages/telemetry/openclaw/src/plugin.ts
@@ -179,23 +179,60 @@ export default function registerLatitudePlugin(api: OpenClawPluginApiLike, opts:
   )
 
   // ─── Trace flush ────────────────────────────────────────────────────────
-
+  //
+  // Why we defer the finalize by one microtask tick instead of finalizing
+  // synchronously inside the agent_end handler: OpenClaw 2026.4.26+ has TWO
+  // hook fire-orders depending on which runtime the agent uses, and the
+  // selection.runtime path (used by the codex / embedded ACPX agents) fires
+  // events in this order:
+  //
+  //     llm_input → ...model_calls / tool_calls... → agent_end → llm_output
+  //
+  // The cli-runner.runtime path (used by the claude-code agent) fires the
+  // reverse — `llm_output` BEFORE `agent_end` — and only when the assistant
+  // emitted a non-empty text part.
+  //
+  // If we finalize on agent_end synchronously, the run is deleted and the OTLP
+  // batch is shipped before `llm_output` (under selection.runtime) gets a
+  // chance to enrich the agent span with `gen_ai.output.messages`,
+  // `gen_ai.response.model`, `openclaw.resolved.ref`, `openclaw.harness.id`,
+  // and the entire `gen_ai.usage.*` block. The `onLlmOutput` handler then
+  // bails on `if (!run) return` cleanly (no error, no warning), and every
+  // attribute that lives on the `llm_output` event is silently dropped.
+  //
+  // Deferring with `queueMicrotask` is order-agnostic: in either path, both
+  // hook handlers run synchronously in the current microtask round and write
+  // to the still-alive run; the queued finalize fires after both have
+  // completed and serializes a fully-enriched batch. Subagents go through
+  // exactly the same `onAgentEnd` path so they benefit automatically.
+  //
+  // We don't use `setTimeout(0)` because the +1 macrotask of latency isn't
+  // meaningful here, and `queueMicrotask` is more reliable on process exit
+  // (microtasks drain before exit; macrotasks may not). If a future OpenClaw
+  // ever introduces an `await` between `agent_end` dispatch and `llm_output`
+  // dispatch, we'll need to switch to `setTimeout(0)`.
   api.on(
     "agent_end",
     wrap<OpenClawAgentEndEvent>("agent_end", (evt, ctx) => {
-      const result = builder.onAgentEnd(evt, ctx)
-      if (!result) {
-        logger.debug("agent_end fired without a matching run in flight")
-        return
-      }
-      opts.onEmit?.(result)
-      const payload = buildOtlpRequest(result, { allowConversationAccess: config.allowConversationAccess })
-      void postTraces({
-        baseUrl: config.baseUrl,
-        apiKey: config.apiKey,
-        project: config.project,
-        payload,
-        logger,
+      queueMicrotask(() => {
+        try {
+          const result = builder.onAgentEnd(evt, ctx)
+          if (!result) {
+            logger.debug("agent_end fired without a matching run in flight")
+            return
+          }
+          opts.onEmit?.(result)
+          const payload = buildOtlpRequest(result, { allowConversationAccess: config.allowConversationAccess })
+          void postTraces({
+            baseUrl: config.baseUrl,
+            apiKey: config.apiKey,
+            project: config.project,
+            payload,
+            logger,
+          })
+        } catch (err) {
+          logger.warn(`agent_end finalize failed: ${String(err)}`)
+        }
       })
     }),
   )

--- a/packages/telemetry/openclaw/src/span-builder.test.ts
+++ b/packages/telemetry/openclaw/src/span-builder.test.ts
@@ -177,6 +177,46 @@ describe("SpanBuilder latitude.tags and latitude.metadata", () => {
       expect((span.attrs["latitude.metadata"] as Record<string, string>)["openclaw.agent.id"]).toBe("personal")
     }
   })
+
+  it("mirrors openclaw.session.id to session.id and gen_ai.session.id on every span", () => {
+    // session.id and gen_ai.session.id are in `sessionIdCandidates`
+    // (domain/spans/src/otlp/resolvers/identity.ts). Mirroring lets Latitude's
+    // resolver pick up the OpenClaw session for grouping without an
+    // openclaw-specific code path.
+    const b = new SpanBuilder()
+    const fullCtx = ctx({ agentId: "personal", trigger: "user" })
+    b.onBeforeAgentStart({}, fullCtx)
+    b.onModelCallStarted({ runId: "run-1", callId: "A", provider: "openai", model: "gpt-5" }, fullCtx)
+    b.onModelCallEnded(
+      { runId: "run-1", callId: "A", provider: "openai", model: "gpt-5", outcome: "completed" },
+      fullCtx,
+    )
+    b.onBeforeToolCall({ toolName: "grep", params: { q: "x" }, runId: "run-1", toolCallId: "tc-1" }, fullCtx)
+    b.onAfterToolCall(
+      { toolName: "grep", params: { q: "x" }, runId: "run-1", toolCallId: "tc-1", result: "match" },
+      fullCtx,
+    )
+    const result = b.onAgentEnd({ messages: [], success: true }, fullCtx)
+
+    for (const span of result?.spans ?? []) {
+      expect(span.attrs["session.id"]).toBe("s-1")
+      expect(span.attrs["gen_ai.session.id"]).toBe("s-1")
+      // The openclaw-namespaced original is still emitted (kept for any
+      // existing tooling that filtered on it).
+      if (span.name === "agent") {
+        expect(span.attrs["openclaw.session.id"]).toBe("s-1")
+      }
+    }
+  })
+
+  it("omits session.id mirrors when ctx has no sessionId", () => {
+    const b = new SpanBuilder()
+    b.onBeforeAgentStart({}, { runId: "run-1", agentId: "x" })
+    const result = b.onAgentEnd({ messages: [], success: true }, { runId: "run-1" })
+    const agent = findSpan(result, "agent")
+    expect(agent?.attrs["session.id"]).toBeUndefined()
+    expect(agent?.attrs["gen_ai.session.id"]).toBeUndefined()
+  })
 })
 
 describe("SpanBuilder.onAgentEnd", () => {

--- a/packages/telemetry/openclaw/src/span-builder.ts
+++ b/packages/telemetry/openclaw/src/span-builder.ts
@@ -164,6 +164,7 @@ export class SpanBuilder {
       attrs: {
         ...flattenCtx(ctx),
         ...latitudeAttrs(ctx),
+        ...sessionAttrs(ctx),
         "openclaw.run.id": runId,
         // before_agent_start payload — gated content fields go via `gated.*`
         // attribute keys so the OTLP layer can scrub them without a parallel
@@ -248,6 +249,7 @@ export class SpanBuilder {
       endMs: undefined,
       attrs: {
         ...latitudeAttrs(ctx),
+        ...sessionAttrs(ctx),
         "openclaw.run.id": evt.runId,
         "openclaw.call.id": evt.callId,
         "gen_ai.system": evt.provider,
@@ -310,6 +312,7 @@ export class SpanBuilder {
       endMs: undefined,
       attrs: {
         ...latitudeAttrs(ctx),
+        ...sessionAttrs(ctx),
         "openclaw.run.id": evt.runId,
         "gen_ai.tool.name": evt.toolName,
         "gen_ai.tool.call.id": toolCallId,
@@ -381,6 +384,7 @@ export class SpanBuilder {
       endMs: undefined,
       attrs: {
         ...latitudeAttrs(ctx),
+        ...sessionAttrs(ctx),
         "openclaw.run.id": runId,
         "openclaw.compaction.message_count.before": evt.messageCount,
         "openclaw.compaction.session_file": evt.sessionFile,
@@ -431,6 +435,7 @@ export class SpanBuilder {
         // (opened later by the child run's before_agent_start) carries
         // its OWN ctx.
         ...latitudeAttrs(ctx),
+        ...sessionAttrs(ctx),
         "openclaw.parent.run.id": parentRunId,
         "openclaw.run.id": evt.runId,
         "openclaw.subagent.child_session_key": evt.childSessionKey,
@@ -615,6 +620,22 @@ function flattenCtx(ctx: OpenClawAgentContext): AttrInput {
     "openclaw.cron.job.id": ctx.jobId,
     "openclaw.model.provider.id": ctx.modelProviderId,
     "openclaw.model.id": ctx.modelId,
+  }
+}
+
+/**
+ * Mirror OpenClaw's session id onto the OTEL-standard keys Latitude's
+ * resolver looks for. `gen_ai.session.id` and `session.id` are both in
+ * `sessionIdCandidates` (domain/spans/src/otlp/resolvers/identity.ts), so
+ * traces can be grouped by session in the Latitude UI without an
+ * openclaw-specific code path. Emitted on every span, not just `agent`,
+ * so child spans (model_call / tool_call / etc.) inherit the same grouping.
+ */
+function sessionAttrs(ctx: OpenClawAgentContext): AttrInput {
+  if (!ctx.sessionId) return {}
+  return {
+    "session.id": ctx.sessionId,
+    "gen_ai.session.id": ctx.sessionId,
   }
 }
 

--- a/packages/telemetry/openclaw/tsdown.config.ts
+++ b/packages/telemetry/openclaw/tsdown.config.ts
@@ -1,4 +1,17 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "tsdown"
+
+// Read the version at build time and bake it into the bundle as
+// `__SCOPE_VERSION__`. Reading `package.json` at runtime via `readFileSync`
+// (the pre-0.0.7 approach) tripped OpenClaw 2026.4.26's `plugins.code_safety`
+// scanner with a "potential-exfiltration: File read combined with network
+// send" warning, because the bundle paired `node:fs.readFileSync` with the
+// `fetch` call in `client.ts`. Reading at build time keeps `package.json` as
+// the single source of truth for the version while shipping a runtime
+// bundle that has zero `node:fs` imports.
+const pkgJsonPath = fileURLToPath(new URL("./package.json", import.meta.url))
+const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as { version: string }
 
 export default defineConfig({
   entry: ["src/plugin.ts"],
@@ -8,4 +21,7 @@ export default defineConfig({
   clean: true,
   target: "node20",
   fixedExtension: false,
+  define: {
+    __SCOPE_VERSION__: JSON.stringify(pkg.version),
+  },
 })


### PR DESCRIPTION
## Summary

Fixes silently-dropped `llm_output` enrichment on OpenClaw 2026.4.26's `selection.runtime` path (codex / embedded ACPX agents), plus three smaller wins.

### The bug

OpenClaw 2026.4.26+ has two hook fire orders:
- **`cli-runner.runtime`** (claude-code): `llm_input → llm_output → agent_end`
- **`selection.runtime`** (codex / embedded ACPX): `llm_input → agent_end → llm_output`

The 0.0.6 plugin finalized synchronously inside `agent_end` — deleted the run and shipped the OTLP batch before `selection.runtime`'s late `llm_output` could enrich the agent span. Every `llm_output`-only attribute disappeared: `gen_ai.output.messages`, `gen_ai.response.model`, `openclaw.resolved.ref`, `openclaw.harness.id`, and the **entire `gen_ai.usage.*` block** (input / output / cache_read / cache_creation / total tokens). `onLlmOutput`'s `if (!run) return` was a clean no-op so nothing showed in stderr.

Diagnosed against OpenClaw's `selection-D9uTvvsw.js` source (textual fire order at lines 7511 / 7789 / 7851) by another agent who confirmed stderr had zero `llm_output handler failed` lines, ruling out my earlier `assistantTexts: undefined` theory.

### The fix

Defer finalization by one microtask via `queueMicrotask` in `plugin.ts`:

```ts
api.on("agent_end", wrap("agent_end", (evt, ctx) => {
  queueMicrotask(() => {
    const result = builder.onAgentEnd(evt, ctx)
    // ...postTraces with the now-fully-enriched payload
  })
}))
```

Both hook handlers in the same dispatch round write to the still-alive run; the deferred finalize runs after both. Order-agnostic — works identically for either fire order. **Subagents go through the same `onAgentEnd` code path, so they're fixed automatically.**

### Other changes (0.0.7)

- **Mirror `openclaw.session.id` → `session.id` + `gen_ai.session.id` on every span.** Both are in Latitude's resolver `sessionIdCandidates` (`domain/spans/src/otlp/resolvers/identity.ts`). Traces can now be grouped by OpenClaw session in the Latitude UI without an openclaw-specific resolver path.
- **Add `gen_ai.usage.cache_creation_input_tokens` to Latitude's resolver candidates.** We emit this underscore form (matching Anthropic-style OTel exporters); the resolver previously only knew the dot-separated `cache_creation.input_tokens` form, so cache-write tokens silently dropped at resolve time. One-line fix in `tokens.ts` plus a focused unit test.
- **Bake `SCOPE_VERSION` at build time via tsdown's `define`.** 0.0.6 read `package.json` via `readFileSync` for the OTLP `scope.version` / `service.version` attrs — that paired with `fetch(` in `client.ts` and tripped OpenClaw 2026.4.26's `plugins.code_safety` scanner with a `potential-exfiltration: File read combined with network send` warning. Bundle now has zero `node:fs` imports.
- **Pin install spec in README to `@0.0.7`.** OpenClaw `security audit --deep` warns about unpinned plugin install specs for supply-chain stability.

## Test plan

- [x] `pnpm --filter @latitude-data/openclaw-telemetry typecheck` — passes
- [x] `pnpm --filter @latitude-data/openclaw-telemetry test` — 72 passed (was 66; +4 deferred-finalize regression tests, +2 session.id mirror tests)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry check` — biome clean
- [x] `pnpm --filter @latitude-data/openclaw-telemetry build` — produces `dist/plugin.js` with version `"0.0.7"` baked
- [x] `pnpm --filter @domain/spans test` — 415 passed (existing + new cache_creation_input_tokens underscore-spelling test)
- [x] `grep -cE 'readFileSync|node:fs|fileURLToPath|process\.env' dist/plugin.js` — `0` matches across all four
- [ ] After publish: re-run install on a real OpenClaw 2026.4.26+ box. Expected: `openclaw security audit --deep` no longer reports `potential-exfiltration` for `dist/plugin.js`. Expected: traces now carry `gen_ai.usage.input_tokens` / `output_tokens` / `total_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` plus `gen_ai.output.messages` and `gen_ai.response.model` on the agent span, regardless of whether the agent runs through `cli-runner.runtime` or `selection.runtime`.

### Regression test coverage for the deferred finalize

`plugin.test.ts` now exercises:

- `cli-runner` order (`llm_output` before `agent_end`) → output captured
- `selection.runtime` order (`agent_end` before `llm_output`) → output **STILL** captured (this is the bug fix)
- No `llm_output` (cli-runner skips it when assistantText is empty) → finalize still ships, agent span has no output attrs but everything else is intact
- Parent + subagent under selection.runtime order → both batches carry full `gen_ai.usage.*` and `gen_ai.output.messages`

Selection-path tests use a `fireSameRound` helper that fires both hooks in the same sync round (via `Promise.all`) without an `await` between them, faithfully modeling how OpenClaw's real dispatcher kicks off `runAgentEnd(...).catch()` and `runLlmOutput(...).catch()`. Awaiting between fires (which the test harness would normally do) drains microtasks and would let the queued finalize fire before `llm_output` — that's a test-harness artifact, not how real OpenClaw behaves on this path.