### PR TITLE
fix(evaluations): tolerate traces without a root span when writing scores

### DIFF
--- a/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
+++ b/packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts
@@ -238,7 +238,7 @@ export const runLiveEvaluationUseCase = (input: RunLiveEvaluationInput) =>
         sourceId: evaluation.id,
         sessionId: traceDetail.sessionId ?? null,
         traceId: traceDetail.traceId,
-        spanId: traceDetail.rootSpanId,
+        spanId: traceDetail.rootSpanId || null,
         simulationId: traceDetail.simulationId || null,
         issueId: persistedIssueId,
         value: execution.kind === "completed" ? execution.result.value : 0,

--- a/packages/domain/spans/src/entities/trace.ts
+++ b/packages/domain/spans/src/entities/trace.ts
@@ -49,7 +49,7 @@ export const traceSchema = z.object({
   providers: z.array(z.string()).readonly(),
   serviceNames: z.array(z.string()).readonly(),
 
-  rootSpanId: spanIdSchema,
+  rootSpanId: z.union([z.literal(""), spanIdSchema]), // root span id, empty string when no root span has been ingested
   rootSpanName: z.string(),
 })
 


### PR DESCRIPTION
## Summary

- Fixes `BadRequestError: Too small: expected string to have >=16 characters` raised from `writeScoreUseCase` during live evaluation runs.
- Models `Trace.rootSpanId` as `"" | SpanId` (mirroring how `simulationId` is modeled) and treats the empty value as "no root span" at the consumer.

## Root cause

ClickHouse's trace aggregation uses `argMinIfMerge(root_span_id)` (`packages/platform/db-clickhouse/src/repositories/trace-repository.ts:206`). When a trace has no row qualifying as a root span (orphan/child-only spans, or root not yet ingested), the merged value falls back to the column default — an empty string.

The repository brand-casts that value without validating (`SpanId(normalizeCHString(row.root_span_id))` at line 324), so the empty string slipped past the entity schema and into `runLiveEvaluationUseCase`, which forwarded it as `spanId` to `writeScoreUseCase`. The score schema's `spanId: spanIdSchema.nullable()` requires `null` or exactly 16 chars, hence the Zod error.

## Changes

- `packages/domain/spans/src/entities/trace.ts`: `rootSpanId` is now `z.union([z.literal(""), spanIdSchema])`, mirroring `simulationId` (line 45).
- `packages/domain/evaluations/src/use-cases/live/run-live-evaluation.ts`: pass `traceDetail.rootSpanId || null` so the absent case becomes `null` for the score.

## Reviewer notes

- The web detail drawer already guards on an empty `rootSpanId` (`apps/web/src/routes/.../trace-tab.tsx:246`), confirming the empty case is real in production data.
- The CSV export at `packages/domain/spans/src/use-cases/build-traces-export.ts:48` stringifies `rootSpanId` directly and continues to work with the union.
- Tests use full 16-char fixtures (`SpanId("r".repeat(16))`) and remain valid under the union.

## Test plan

- [ ] Trigger a live evaluation against a trace with no root span (or simulate by inserting a trace whose only spans have parents) and confirm the score is written with `spanId = null` instead of erroring.
- [ ] Existing live evaluation paths (with a real root span) still write the score with the 16-char span id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)