### PR TITLE
Fix missing output for Vercel AI SDK streamObject/generateObject

### DIFF
--- a/packages/domain/spans/src/otlp/content/vercel.ts
+++ b/packages/domain/spans/src/otlp/content/vercel.ts
@@ -92,10 +92,12 @@ function parseInputFromCallLevel(attrs: readonly OtlpKeyValue[]): {
 
 function parseOutput(attrs: readonly OtlpKeyValue[]): GenAIMessage[] {
   const text = rawStringAttr(attrs, "ai.response.text")
+  const objectJson = rawStringAttr(attrs, "ai.response.object")
   const toolCallsJson = rawStringAttr(attrs, "ai.response.toolCalls")
 
   const contentParts: object[] = []
   if (text) contentParts.push({ type: "text", text })
+  else if (objectJson) contentParts.push({ type: "text", text: objectJson })
   if (toolCallsJson) {
     const toolCalls = parseJsonSafe(toolCallsJson)
     if (Array.isArray(toolCalls)) {

--- a/packages/domain/spans/src/otlp/content/vercel.ts
+++ b/packages/domain/spans/src/otlp/content/vercel.ts
@@ -4,6 +4,7 @@
  * Top-level spans:
  *   ai.prompt           — JSON object with { system?: string, messages: [...] }
  *   ai.response.text    — plain text string (assistant output)
+ *   ai.response.object  — JSON string of a structured object (generateObject output)
  *   ai.response.toolCalls — JSON string of tool call objects
  *
  * Call-level spans:

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -949,6 +949,58 @@ describe("Vercel AI SDK duplicate usage normalization", () => {
   })
 })
 
+describe("Vercel AI SDK streamObject / generateObject output", () => {
+  function buildObjectSpan(operationId: string, responseObject: object): OtlpExportTraceServiceRequest {
+    return {
+      resourceSpans: [
+        {
+          resource: { attributes: [str("service.name", SERVICE_NAME)] },
+          scopeSpans: [
+            {
+              scope: { name: SCOPE_NAME, version: SCOPE_VERSION },
+              spans: [
+                {
+                  traceId: TRACE_ID,
+                  spanId: "f0f0f0f0f0f00001",
+                  name: operationId,
+                  kind: 1,
+                  startTimeUnixNano: "1710590500000000000",
+                  endTimeUnixNano: "1710590501000000000",
+                  attributes: [
+                    str("ai.operationId", operationId),
+                    str("ai.prompt", JSON.stringify({
+                      messages: [{ role: "user", content: [{ type: "text", text: "Describe the weather." }] }],
+                    })),
+                    str("ai.response.object", JSON.stringify(responseObject)),
+                  ],
+                  status: { code: 1 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  it.each([
+    ["ai.streamObject"],
+    ["ai.generateObject"],
+  ])("%s surfaces ai.response.object as assistant output", (operationId) => {
+    const obj = { city: "Barcelona", temperature: 22 }
+    const spans = transformOtlpToSpans(buildObjectSpan(operationId, obj), CONTEXT)
+    const span = spans[0]!
+
+    expect(span.outputMessages).toHaveLength(1)
+    const assistant = span.outputMessages[0]!
+    expect(assistant.role).toBe("assistant")
+    const parts = (assistant as { parts: { type: string; content?: string }[] }).parts
+    const textPart = parts.find((p) => p.type === "text")
+    expect(textPart).toBeDefined()
+    expect((textPart as { content: string }).content).toContain("Barcelona")
+  })
+})
+
 describe("Vercel AI SDK top-level prompt fallback", () => {
   it("treats ai.prompt.prompt as a user input message when ai.prompt.messages is absent", () => {
     const spans = transformOtlpToSpans(

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -968,9 +968,12 @@ describe("Vercel AI SDK streamObject / generateObject output", () => {
                   endTimeUnixNano: "1710590501000000000",
                   attributes: [
                     str("ai.operationId", operationId),
-                    str("ai.prompt", JSON.stringify({
-                      messages: [{ role: "user", content: [{ type: "text", text: "Describe the weather." }] }],
-                    })),
+                    str(
+                      "ai.prompt",
+                      JSON.stringify({
+                        messages: [{ role: "user", content: [{ type: "text", text: "Describe the weather." }] }],
+                      }),
+                    ),
                     str("ai.response.object", JSON.stringify(responseObject)),
                   ],
                   status: { code: 1 },
@@ -989,11 +992,13 @@ describe("Vercel AI SDK streamObject / generateObject output", () => {
   ])("%s surfaces ai.response.object as assistant output", (operationId) => {
     const obj = { city: "Barcelona", temperature: 22 }
     const spans = transformOtlpToSpans(buildObjectSpan(operationId, obj), CONTEXT)
-    const span = spans[0]!
+    const span = spans[0]
+    expect(span).toBeDefined()
 
-    expect(span.outputMessages).toHaveLength(1)
-    const assistant = span.outputMessages[0]!
-    expect(assistant.role).toBe("assistant")
+    expect(span?.outputMessages).toHaveLength(1)
+    const assistant = span?.outputMessages[0]
+    expect(assistant).toBeDefined()
+    expect(assistant?.role).toBe("assistant")
     const parts = (assistant as { parts: { type: string; content?: string }[] }).parts
     const textPart = parts.find((p) => p.type === "text")
     expect(textPart).toBeDefined()


### PR DESCRIPTION
## Summary
- Vercel AI SDK's `streamObject` and `generateObject` emit structured output under `ai.response.object`, but the Vercel content parser only checked `ai.response.text` and `ai.response.toolCalls` — silently dropping all structured-object outputs
- Added `ai.response.object` as a fallback in `parseOutput` when `ai.response.text` is absent, surfacing it as a text content part in the assistant message

## Test plan
- [x] Added `it.each` test covering both `ai.streamObject` and `ai.generateObject` confirming `ai.response.object` is surfaced as assistant output
- [x] All existing Vercel transform tests continue to pass