### PR TITLE
feat(openclaw-telemetry-cli): one-shot installer in a separate npm package (0.0.7)

### DIFF
--- a/.github/workflows/publish-openclaw-telemetry-cli.yml
+++ b/.github/workflows/publish-openclaw-telemetry-cli.yml
@@ -1,0 +1,101 @@
+name: Publish OpenClaw Telemetry CLI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - packages/telemetry/openclaw-cli/**
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 25
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Get package version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./packages/telemetry/openclaw-cli/package.json').version")
+          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check version on npm
+        id: check_version
+        run: |
+          NPM_VERSION=$(npm view @latitude-data/openclaw-telemetry-cli version 2>/dev/null || echo "0.0.0")
+          if [ "${{ steps.get_version.outputs.version }}" != "$NPM_VERSION" ]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install dependencies
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry-cli build
+
+      - name: Typecheck
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry-cli typecheck
+
+      - name: Lint
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry-cli check
+
+      - name: Test
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm --filter @latitude-data/openclaw-telemetry-cli test
+
+      - name: Publish to npm
+        if: steps.check_version.outputs.should_publish == 'true'
+        run: pnpm publish --access public --filter @latitude-data/openclaw-telemetry-cli --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Extract changelog
+        if: steps.check_version.outputs.should_publish == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          if [ -f packages/telemetry/openclaw-cli/CHANGELOG.md ]; then
+            awk -v ver="$VERSION" '
+              /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) { found=1; next } }
+              found { print }
+            ' packages/telemetry/openclaw-cli/CHANGELOG.md > release_notes.md
+          fi
+          if [ ! -s release_notes.md ]; then
+            echo "Package updates and improvements" > release_notes.md
+          fi
+          {
+            echo "body<<EOF"
+            cat release_notes.md
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check_version.outputs.should_publish == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: openclaw-telemetry-cli-${{ steps.get_version.outputs.version }}
+          name: OpenClaw Telemetry CLI v${{ steps.get_version.outputs.version }}
+          body: ${{ steps.changelog.outputs.body }}
+          draft: false
+          prerelease: ${{ contains(steps.get_version.outputs.version, 'alpha') || contains(steps.get_version.outputs.version, 'beta') || contains(steps.get_version.outputs.version, 'rc') }}

--- a/packages/telemetry/openclaw-cli/CHANGELOG.md
+++ b/packages/telemetry/openclaw-cli/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to the `@latitude-data/openclaw-telemetry-cli` installer will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.7] - 2026-04-29
+
+Initial release of the standalone installer CLI. The runtime split that landed in `@latitude-data/openclaw-telemetry` 0.0.6 ([PR #2920](https://github.com/latitude-dev/latitude-llm/pull/2920)) deleted the bundled CLI from the runtime package so that runtime would pass OpenClaw 2026.4.25+'s install-time `dangerous-exec` security scan. The 0.0.6 manual install flow asked operators to run six `openclaw config set` commands plus a hand-edited `plugins.allow` array; this package brings the one-shot `npx -y` UX back. By living in a separate npm package, this CLI is installed via `npx`/`npm install -g` rather than `openclaw plugins install`, so it never goes through OpenClaw's install-time scanner.
+
+### Added
+
+- `latitude-openclaw install` — one-shot install: version check, npm-spec install, `plugins.entries[id]` config + hooks layering, `plugins.allow` add, post-write `openclaw config validate --json` check (with backup-restore on failure), TTY-or-flag-driven gateway restart prompt.
+- `latitude-openclaw uninstall` — plan-builder confirmation, backup before changes, `openclaw plugins uninstall ... --force`, defensive cleanup of our state from `openclaw.json` (idempotent against partial installs), gateway restart prompt.
+- `--openclaw-dir <path>` flag plus `OPENCLAW_HOME` env var plus `./openclaw.json` cwd auto-detection plus `~/.openclaw` default. `OPENCLAW_HOME=<resolved>` is passed to every spawned `openclaw` subprocess; the post-install validate step catches the case where OpenClaw doesn't honor the env var and writes its install record to a different dir from where we wrote the entry (restores backup + aborts with both paths in the error).
+- `--dry-run` — render the proposed JSON diff against `openclaw.json` and the exact `openclaw plugins install` command, exit 0 without spawning subprocesses or writing files.
+- `--restart` / `--no-restart` — control gateway restart behavior. Default on TTY: prompt; default non-TTY: skip with manual instructions.
+- Lockstep version refusal — CLI hardcodes `RUNTIME_VERSION = "0.0.7"` and queries the npm registry to verify that exact runtime version exists; aborts with an upgrade-the-CLI message on 404 (half-published releases).
+- Atomic settings writes — `openclaw.json` is written via `<file>.tmp.<pid>` then `rename`'d, so a SIGTERM mid-write can't leave a half-serialized file. Combined with the `.latitude-bak` backup, recovery is always possible.
+- Upgrade-detection UX — reads `<configDir>/plugins/installs.json` to render `Upgrading 0.0.6 → 0.0.7` (or `Re-applying 0.0.7 (idempotent)`) before any subprocess spawn.
+
+### Carried forward (from the deleted runtime CLI)
+
+- Interactive vs flag-driven dispatch (`--api-key`, `--project`, `--staging`, `--dev`, `--no-content`, `--allow-conversation`, `--no-trust`, `--yes` / `--no-prompt`).
+- `MIN_OPENCLAW_VERSION = "2026.4.25"` version check via `openclaw --version` parser.
+- `setPluginEntry` tristate merge logic — `apiKey` / `project` always overwritten, `baseUrl` / `enabled` / `debug` / `allowConversationAccess` preserved when undefined; `allowConversationAccess` mirrored into both `config.*` (payload-content gate) and `hooks.*` (dispatch gate).
+- `migrateLegacyEntries` 0.0.1-era top-level `env.LATITUDE_*` sweep.
+- `openclaw plugins uninstall ... --force` defensive cleanup pattern.
+
+### Lockstep with the runtime
+
+`RUNTIME_VERSION = "0.0.7"` is hardcoded in `src/setup.ts`. Every CLI release is paired with a runtime release of the same version number — bumping the runtime requires bumping the CLI in the same commit and re-publishing both packages. The `npm view`-style registry check at install start refuses to proceed if the pinned runtime version isn't on npm, so half-published releases fail loudly.

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -82,7 +82,7 @@ Output includes the resolved config dir, the exact `openclaw plugins install` co
 
 The CLI resolves the OpenClaw config directory in this order, stopping at the first match:
 
-1. **`--openclaw-dir <path>`** flag (absolute, or relative to cwd).
+1. **`--openclaw-dir=<path>`** flag (absolute, or relative to cwd; the space-separated form `--openclaw-dir <path>` works too).
 2. **`OPENCLAW_HOME`** env var (absolute, or relative to cwd).
 3. **`./openclaw.json`** in the current working directory → use cwd.
 4. **`~/.openclaw`** (default).

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -1,46 +1,25 @@
 # @latitude-data/openclaw-telemetry-cli
 
-One-shot installer for the [`@latitude-data/openclaw-telemetry`](https://www.npmjs.com/package/@latitude-data/openclaw-telemetry) OpenClaw plugin. Wraps the manual `openclaw plugins install` + `openclaw config set` flow into a single `npx -y` invocation, with prompts on TTY and flags for CI.
+One-shot installer for the [`@latitude-data/openclaw-telemetry`](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme) OpenClaw plugin. Wraps `openclaw plugins install` + the manual `openclaw config set` flow into a single `npx -y` command, with TTY prompts, CI flags, dry-run, custom config dir, upgrade detection, and the gateway restart.
+
+For details on the plugin runtime itself — what it sends, the span tree, and the manual install flow — see the [runtime README](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw#readme).
+
+## Requirements
+
+- **OpenClaw 2026.4.25 or newer** on PATH.
+- A **Latitude API key** and **project slug** — both from [console.latitude.so/settings/api-keys](https://console.latitude.so/settings/api-keys).
 
 ## Install
 
-Requires OpenClaw **2026.4.25 or newer**. Get a Latitude API key + project slug from `https://console.latitude.so/settings/api-keys` first.
+Interactive (recommended for first-time setup):
 
 ```bash
 npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install
 ```
 
-The CLI will:
+The CLI prompts for your API key and project slug, installs the plugin, writes the config, validates it, and offers to restart the gateway.
 
-1. Verify your OpenClaw version (`openclaw --version` ≥ 2026.4.25); abort with an upgrade message otherwise.
-2. Verify the runtime contract — that `@latitude-data/openclaw-telemetry@0.0.7` exists on npm. (Half-published releases abort here.)
-3. Detect any prior install via `<configDir>/plugins/installs.json` and render `Upgrading 0.0.6 → 0.0.7` UX.
-4. Prompt for your API key and project slug (interactive only).
-5. Back up `~/.openclaw/openclaw.json` to `openclaw.json.latitude-bak` before any change.
-6. Run `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7 --force` (npm fetch + security scan + extension placement + install record + disabled `plugins.entries[id]`).
-7. Layer your config + hooks on top of the entry: `apiKey`, `project`, `baseUrl` (only when `--staging` / `--dev` set), `config.allowConversationAccess` AND `hooks.allowConversationAccess` (always coupled — both are `true` by default).
-8. Add the plugin id to `plugins.allow` (silences the "untracked code" warning at every gateway start). Pass `--no-trust` to opt out.
-9. Run `openclaw config validate --json` to confirm the result; restore the backup and abort if validation fails.
-10. On TTY, prompt to restart the gateway; non-TTY skips by default. `--restart` / `--no-restart` override.
-
-## Flag matrix
-
-| Flag | Effect |
-| --- | --- |
-| `--api-key=<key>` | Pass the API key non-interactively. |
-| `--project=<slug>` | Pass the project slug non-interactively. |
-| `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
-| `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
-| `--no-content` | Disable conversation capture (still emits structural-only telemetry — timing, tokens, ids). Mirrored into both `config.allowConversationAccess` and `hooks.allowConversationAccess`. |
-| `--allow-conversation` | Force conversation capture on. |
-| `--no-trust` | Skip auto-adding the plugin id to `plugins.allow`. The "untracked code" warning will keep showing until you add it manually. |
-| `--openclaw-dir=<path>` | Override the OpenClaw config directory. See [Config dir resolution](#config-dir-resolution). |
-| `--dry-run` | Render the proposed JSON diff against `openclaw.json` and the install spec we'd run; exit 0 without writing or spawning anything. |
-| `--restart` | Always restart the gateway after install, even non-TTY (CI escape hatch for "do everything"). |
-| `--no-restart` | Never restart the gateway, even on TTY. Always wins over `--restart`. |
-| `--yes` / `--no-prompt` | Skip all prompts. Required when `--api-key` and `--project` are not on a TTY. |
-
-## CI install
+Non-interactive / CI:
 
 ```bash
 npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install \
@@ -50,9 +29,56 @@ npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install \
   --no-restart
 ```
 
-`--no-restart` keeps the gateway running while you finish other config; restart yourself when ready.
+`--yes` skips all prompts (required when you can't type into a TTY); `--no-restart` keeps the gateway running so you can finish other config first.
 
-## Config dir resolution
+## What the CLI does
+
+In order, on every install:
+
+1. **Verifies your OpenClaw version** (`openclaw --version` ≥ 2026.4.25). Aborts with an upgrade message on older versions.
+2. **Verifies the runtime contract** — that `@latitude-data/openclaw-telemetry@0.0.7` exists on npm. (Catches half-published releases.)
+3. **Detects any prior install** via `<configDir>/plugins/installs.json`. Renders `Upgrading 0.0.6 → 0.0.7` (or `Re-applying 0.0.7 (idempotent)`) if found.
+4. **Prompts for your API key and project slug** — interactive only; flags / `--yes` skip the prompts.
+5. **Backs up `openclaw.json`** to `openclaw.json.latitude-bak` before any change.
+6. **Runs `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7 --force`** — npm fetch, security scan, extension placement, install record, disabled `plugins.entries[id]`.
+7. **Writes the plugin config** atomically (temp + rename): `apiKey`, `project`, `baseUrl` (only if `--staging` / `--dev`), `config.allowConversationAccess` AND `hooks.allowConversationAccess` (always coupled — both `true` by default; `--no-content` to emit structural-only telemetry).
+8. **Adds the plugin id to `plugins.allow`** to silence OpenClaw's "untracked code" warning. Pass `--no-trust` to opt out.
+9. **Validates** the result with `openclaw config validate --json`. If it fails, restores the backup and aborts with the validator's message.
+10. **Restarts the gateway**. Default: prompts on TTY, skips non-TTY (with manual instructions). `--restart` always restarts; `--no-restart` always skips.
+
+## Flags
+
+| Flag | Effect |
+| --- | --- |
+| `--api-key=<key>` | Pass the API key non-interactively. |
+| `--project=<slug>` | Pass the project slug non-interactively. |
+| `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
+| `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
+| `--no-content` | Disable conversation capture (still emits structural-only telemetry — timing, tokens, ids). Mirrored into both `config.allowConversationAccess` and `hooks.allowConversationAccess`. |
+| `--allow-conversation` | Force conversation capture on (overrides existing config). |
+| `--no-trust` | Skip auto-adding the plugin id to `plugins.allow`. |
+| `--openclaw-dir=<path>` | Override the OpenClaw config directory. See [Custom config directory](#custom-config-directory). |
+| `--dry-run` | Preview every change without touching the filesystem or spawning subprocesses. See [Dry run](#dry-run). |
+| `--restart` | Always restart the gateway, even non-TTY. CI escape hatch for "do everything". |
+| `--no-restart` | Never restart the gateway, even on TTY. Always wins over `--restart`. |
+| `--yes` / `--no-prompt` | Skip all prompts. Required when running non-TTY without supplying `--api-key` / `--project`. |
+| `--version`, `-v` | Print the CLI version and exit. |
+| `--help`, `-h` | Print usage. |
+
+## Modes
+
+### Dry run
+
+Preview every change without touching the filesystem or spawning subprocesses:
+
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dry-run \
+  --api-key=lat_xxx --project=my-project
+```
+
+Output includes the resolved config dir, the exact `openclaw plugins install` command we'd spawn, and a unified-ish JSON diff between the current `openclaw.json` and the proposed result. Useful for reviewing changes before applying them, or for verifying flag behaviour in CI.
+
+### Custom config directory
 
 The CLI resolves the OpenClaw config directory in this order, stopping at the first match:
 
@@ -61,20 +87,32 @@ The CLI resolves the OpenClaw config directory in this order, stopping at the fi
 3. **`./openclaw.json`** in the current working directory → use cwd.
 4. **`~/.openclaw`** (default).
 
-The resolved path is printed at install start so it's visible. The CLI passes `OPENCLAW_HOME=<resolved>` to every spawned `openclaw` subprocess so the runtime side resolves to the same dir.
+The resolved path is printed at install start. The CLI passes `OPENCLAW_HOME=<resolved>` to every spawned `openclaw` subprocess, so the runtime side picks up the same dir.
 
-> **Caveat.** OpenClaw's CLI may not honor `OPENCLAW_HOME` directly (we don't see it advertised in upstream docs). When that happens, the runtime side may still write the install record into `~/.openclaw/`, while we wrote `openclaw.json` to the custom dir. The post-install `openclaw config validate --json` step (built into the install flow) catches this — validate fails because the entry is in a different file from the install record, the backup is restored, and we abort with both paths in the error. **No silent two-place writes.**
+> **Caveat.** OpenClaw's CLI may not honor `OPENCLAW_HOME` directly. When that happens, the runtime side may write the install record into `~/.openclaw/`, while we write `openclaw.json` to the custom dir. The post-install `openclaw config validate --json` step catches this — validation fails because the entry is in a different file from the install record, the backup is restored, and the CLI aborts with both paths in the error. **No silent two-place writes.**
 
-## Dry run
-
-Use `--dry-run` to preview every change without touching the filesystem or spawning subprocesses:
+### Structural-only telemetry
 
 ```bash
-npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dry-run \
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --no-content \
   --api-key=lat_xxx --project=my-project
 ```
 
-Output includes the resolved config dir, the exact `openclaw plugins install` command we'd spawn, and a unified-ish JSON diff between the current `openclaw.json` and the proposed result. Useful for review-before-commit when openclaw.json is checked into a config repo.
+The plugin still emits the full span tree — timings, token usage, model name, agent name, ids — just with content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, tool args/results) scrubbed. Each span carries `latitude.captured.content: false` so the gate state is visible in the Latitude UI.
+
+### Targeting staging or local dev
+
+```bash
+# Staging
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --staging --yes \
+  --api-key=lat_xxx --project=my-project
+
+# Local dev
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dev --yes \
+  --api-key=lat_xxx --project=my-project
+```
+
+`--staging` writes `baseUrl: https://staging-ingest.latitude.so`; `--dev` writes `baseUrl: http://localhost:3002`. Without either flag, the runtime defaults to production (`https://ingest.latitude.so`).
 
 ## Uninstall
 
@@ -85,26 +123,27 @@ npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall
 The uninstall flow:
 
 1. Confirms with the operator (TTY only — pass `--yes` to skip).
-2. Backs up `~/.openclaw/openclaw.json` to `openclaw.json.latitude-bak`.
-3. Runs `openclaw plugins uninstall @latitude-data/openclaw-telemetry --force` (removes extension files, the install record, and `plugins.entries[id]`, plus auto-cleans `plugins.allow` / `plugins.deny` / `plugins.load.paths` entries).
-4. Defensive cleanup of our state from `openclaw.json` (idempotent — safe to re-run).
+2. Backs up `openclaw.json` to `openclaw.json.latitude-bak`.
+3. Runs `openclaw plugins uninstall @latitude-data/openclaw-telemetry --force`. OpenClaw removes the extension files, the install record, `plugins.entries[id]`, and the `plugins.allow` entry.
+4. Defensive cleanup of any lingering state in `openclaw.json` (idempotent — safe to re-run).
 5. Restart prompt (same TTY-vs-CI logic as install; `--restart` / `--no-restart` override).
 
-Backup at `~/.openclaw/openclaw.json.latitude-bak` is kept after uninstall — delete it manually if you don't need it.
+The backup at `openclaw.json.latitude-bak` is kept after uninstall — delete it manually when you don't need it anymore.
 
 ## Lockstep policy
 
-This CLI installs **exactly** `@latitude-data/openclaw-telemetry@0.0.7` (pinned in source as `RUNTIME_VERSION`). Every CLI release is paired with a runtime release of the same version number. Bumping the runtime requires bumping the CLI in the same commit and re-publishing both.
-
-Why pinning matters:
-
-- **Supply-chain audit.** OpenClaw's `security audit --deep` warns about unpinned plugin install specs. Hardcoding the version satisfies the audit automatically.
-- **CLI ↔ runtime contract.** The CLI knows exactly which runtime contract it's installing (config keys, hook names, dispatch gates). Floating tags would let half-released runtimes ship with mismatched CLIs.
+This CLI installs **exactly** `@latitude-data/openclaw-telemetry@0.0.7` (pinned in source as `RUNTIME_VERSION`). Every CLI release is paired with a runtime release of the same version number; bumping the runtime requires bumping the CLI in the same commit and re-publishing both.
 
 If npm doesn't have the exact pinned version (half-published release), the CLI aborts with `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest`.
 
+Pinning to an exact version also satisfies OpenClaw's `Pin install specs to exact versions` supply-chain audit warning automatically.
+
 ## Why this is a separate package
 
-OpenClaw 2026.4.25+ runs an install-time security scan on `openclaw plugins install` (`plugins.code_safety` checks for `dangerous-exec` / `env-harvesting` patterns). This CLI uses `child_process.spawn` to invoke OpenClaw — that's a `dangerous-exec` flag. By keeping the CLI in a **separate npm package** that's installed via `npx`/`npm install -g` rather than `openclaw plugins install`, the CLI never goes through OpenClaw's scanner. The runtime plugin (`@latitude-data/openclaw-telemetry`) is installed by this CLI on the operator's behalf and is itself scanner-clean (no `child_process`, no `node:fs` runtime reads).
+OpenClaw 2026.4.25+ runs an install-time security scan on `openclaw plugins install` (`plugins.code_safety`, looking for `dangerous-exec` / `env-harvesting` patterns). This CLI uses `child_process.spawn` to invoke OpenClaw — a `dangerous-exec` flag. Keeping the CLI in a **separate npm package** that's installed via `npx` / `npm install -g` rather than `openclaw plugins install` means the CLI never goes through OpenClaw's scanner. The runtime plugin ([`@latitude-data/openclaw-telemetry`](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw)) is installed by this CLI on the operator's behalf and is itself scanner-clean (no `child_process`, no `node:fs` runtime reads).
 
-See the [v0.0.7 changelog of the runtime](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/openclaw/CHANGELOG.md) for the wider history of the split.
+See the [runtime CHANGELOG](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/openclaw/CHANGELOG.md) for the wider history of the split.
+
+## License
+
+MIT

--- a/packages/telemetry/openclaw-cli/README.md
+++ b/packages/telemetry/openclaw-cli/README.md
@@ -1,0 +1,110 @@
+# @latitude-data/openclaw-telemetry-cli
+
+One-shot installer for the [`@latitude-data/openclaw-telemetry`](https://www.npmjs.com/package/@latitude-data/openclaw-telemetry) OpenClaw plugin. Wraps the manual `openclaw plugins install` + `openclaw config set` flow into a single `npx -y` invocation, with prompts on TTY and flags for CI.
+
+## Install
+
+Requires OpenClaw **2026.4.25 or newer**. Get a Latitude API key + project slug from `https://console.latitude.so/settings/api-keys` first.
+
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install
+```
+
+The CLI will:
+
+1. Verify your OpenClaw version (`openclaw --version` ≥ 2026.4.25); abort with an upgrade message otherwise.
+2. Verify the runtime contract — that `@latitude-data/openclaw-telemetry@0.0.7` exists on npm. (Half-published releases abort here.)
+3. Detect any prior install via `<configDir>/plugins/installs.json` and render `Upgrading 0.0.6 → 0.0.7` UX.
+4. Prompt for your API key and project slug (interactive only).
+5. Back up `~/.openclaw/openclaw.json` to `openclaw.json.latitude-bak` before any change.
+6. Run `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7 --force` (npm fetch + security scan + extension placement + install record + disabled `plugins.entries[id]`).
+7. Layer your config + hooks on top of the entry: `apiKey`, `project`, `baseUrl` (only when `--staging` / `--dev` set), `config.allowConversationAccess` AND `hooks.allowConversationAccess` (always coupled — both are `true` by default).
+8. Add the plugin id to `plugins.allow` (silences the "untracked code" warning at every gateway start). Pass `--no-trust` to opt out.
+9. Run `openclaw config validate --json` to confirm the result; restore the backup and abort if validation fails.
+10. On TTY, prompt to restart the gateway; non-TTY skips by default. `--restart` / `--no-restart` override.
+
+## Flag matrix
+
+| Flag | Effect |
+| --- | --- |
+| `--api-key=<key>` | Pass the API key non-interactively. |
+| `--project=<slug>` | Pass the project slug non-interactively. |
+| `--staging` | Target `https://staging.latitude.so` / `https://staging-ingest.latitude.so`. |
+| `--dev` | Target `http://localhost:3000` / `http://localhost:3002`. |
+| `--no-content` | Disable conversation capture (still emits structural-only telemetry — timing, tokens, ids). Mirrored into both `config.allowConversationAccess` and `hooks.allowConversationAccess`. |
+| `--allow-conversation` | Force conversation capture on. |
+| `--no-trust` | Skip auto-adding the plugin id to `plugins.allow`. The "untracked code" warning will keep showing until you add it manually. |
+| `--openclaw-dir=<path>` | Override the OpenClaw config directory. See [Config dir resolution](#config-dir-resolution). |
+| `--dry-run` | Render the proposed JSON diff against `openclaw.json` and the install spec we'd run; exit 0 without writing or spawning anything. |
+| `--restart` | Always restart the gateway after install, even non-TTY (CI escape hatch for "do everything"). |
+| `--no-restart` | Never restart the gateway, even on TTY. Always wins over `--restart`. |
+| `--yes` / `--no-prompt` | Skip all prompts. Required when `--api-key` and `--project` are not on a TTY. |
+
+## CI install
+
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install \
+  --api-key="$LATITUDE_API_KEY" \
+  --project=my-project \
+  --yes \
+  --no-restart
+```
+
+`--no-restart` keeps the gateway running while you finish other config; restart yourself when ready.
+
+## Config dir resolution
+
+The CLI resolves the OpenClaw config directory in this order, stopping at the first match:
+
+1. **`--openclaw-dir <path>`** flag (absolute, or relative to cwd).
+2. **`OPENCLAW_HOME`** env var (absolute, or relative to cwd).
+3. **`./openclaw.json`** in the current working directory → use cwd.
+4. **`~/.openclaw`** (default).
+
+The resolved path is printed at install start so it's visible. The CLI passes `OPENCLAW_HOME=<resolved>` to every spawned `openclaw` subprocess so the runtime side resolves to the same dir.
+
+> **Caveat.** OpenClaw's CLI may not honor `OPENCLAW_HOME` directly (we don't see it advertised in upstream docs). When that happens, the runtime side may still write the install record into `~/.openclaw/`, while we wrote `openclaw.json` to the custom dir. The post-install `openclaw config validate --json` step (built into the install flow) catches this — validate fails because the entry is in a different file from the install record, the backup is restored, and we abort with both paths in the error. **No silent two-place writes.**
+
+## Dry run
+
+Use `--dry-run` to preview every change without touching the filesystem or spawning subprocesses:
+
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --dry-run \
+  --api-key=lat_xxx --project=my-project
+```
+
+Output includes the resolved config dir, the exact `openclaw plugins install` command we'd spawn, and a unified-ish JSON diff between the current `openclaw.json` and the proposed result. Useful for review-before-commit when openclaw.json is checked into a config repo.
+
+## Uninstall
+
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall
+```
+
+The uninstall flow:
+
+1. Confirms with the operator (TTY only — pass `--yes` to skip).
+2. Backs up `~/.openclaw/openclaw.json` to `openclaw.json.latitude-bak`.
+3. Runs `openclaw plugins uninstall @latitude-data/openclaw-telemetry --force` (removes extension files, the install record, and `plugins.entries[id]`, plus auto-cleans `plugins.allow` / `plugins.deny` / `plugins.load.paths` entries).
+4. Defensive cleanup of our state from `openclaw.json` (idempotent — safe to re-run).
+5. Restart prompt (same TTY-vs-CI logic as install; `--restart` / `--no-restart` override).
+
+Backup at `~/.openclaw/openclaw.json.latitude-bak` is kept after uninstall — delete it manually if you don't need it.
+
+## Lockstep policy
+
+This CLI installs **exactly** `@latitude-data/openclaw-telemetry@0.0.7` (pinned in source as `RUNTIME_VERSION`). Every CLI release is paired with a runtime release of the same version number. Bumping the runtime requires bumping the CLI in the same commit and re-publishing both.
+
+Why pinning matters:
+
+- **Supply-chain audit.** OpenClaw's `security audit --deep` warns about unpinned plugin install specs. Hardcoding the version satisfies the audit automatically.
+- **CLI ↔ runtime contract.** The CLI knows exactly which runtime contract it's installing (config keys, hook names, dispatch gates). Floating tags would let half-released runtimes ship with mismatched CLIs.
+
+If npm doesn't have the exact pinned version (half-published release), the CLI aborts with `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest`.
+
+## Why this is a separate package
+
+OpenClaw 2026.4.25+ runs an install-time security scan on `openclaw plugins install` (`plugins.code_safety` checks for `dangerous-exec` / `env-harvesting` patterns). This CLI uses `child_process.spawn` to invoke OpenClaw — that's a `dangerous-exec` flag. By keeping the CLI in a **separate npm package** that's installed via `npx`/`npm install -g` rather than `openclaw plugins install`, the CLI never goes through OpenClaw's scanner. The runtime plugin (`@latitude-data/openclaw-telemetry`) is installed by this CLI on the operator's behalf and is itself scanner-clean (no `child_process`, no `node:fs` runtime reads).
+
+See the [v0.0.7 changelog of the runtime](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/openclaw/CHANGELOG.md) for the wider history of the split.

--- a/packages/telemetry/openclaw-cli/package.json
+++ b/packages/telemetry/openclaw-cli/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@latitude-data/openclaw-telemetry-cli",
+  "version": "0.0.7",
+  "description": "One-shot installer for the @latitude-data/openclaw-telemetry OpenClaw plugin. Configures credentials, plugins.allow, and the gateway-restart prompt against ~/.openclaw/openclaw.json.",
+  "author": "Latitude Data SL <hello@latitude.so>",
+  "license": "MIT",
+  "keywords": [
+    "openclaw",
+    "telemetry",
+    "installer",
+    "cli",
+    "latitude"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw-cli"
+  },
+  "homepage": "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw-cli#readme",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "bin": {
+    "latitude-openclaw": "./dist/cli.js"
+  },
+  "main": "./dist/cli.js",
+  "types": "./dist/cli.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/cli.d.ts",
+      "default": "./dist/cli.js"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --pool=forks --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@clack/prompts": "^1.2.0",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/telemetry/openclaw-cli/src/cli.test.ts
+++ b/packages/telemetry/openclaw-cli/src/cli.test.ts
@@ -21,6 +21,48 @@ describe("parseFlags", () => {
     const { flags } = parseFlags(["install", "extra-arg", "--yes"])
     expect(flags.yes).toBe(true)
   })
+
+  it("supports `--key value` (space-separated) for known value-taking flags", () => {
+    // Standard CLI convention — operators expect `--api-key lat_xxx`,
+    // `--openclaw-dir /tmp/x`, and `--project foo` to work alongside the
+    // `--key=value` form. Boolean flags are never consumed as values.
+    const cases: Array<[string[], Record<string, unknown>]> = [
+      [["install", "--api-key", "lat_xxx"], { "api-key": "lat_xxx" }],
+      [["install", "--project", "my-proj"], { project: "my-proj" }],
+      [["install", "--openclaw-dir", "/tmp/x"], { "openclaw-dir": "/tmp/x" }],
+    ]
+    for (const [argv, expected] of cases) {
+      const { flags } = parseFlags(argv)
+      for (const [k, v] of Object.entries(expected)) {
+        expect(flags[k]).toBe(v)
+      }
+    }
+  })
+
+  it("doesn't consume an adjacent flag as a value (--no-content --yes stays two booleans)", () => {
+    const { flags } = parseFlags(["install", "--no-content", "--yes"])
+    expect(flags["no-content"]).toBe(true)
+    expect(flags.yes).toBe(true)
+  })
+
+  it("treats a value-flag at end-of-argv (no following token) as boolean true", () => {
+    // Defensive: if someone runs `--api-key` with no following value, we
+    // don't crash trying to read undefined as the value — we just treat
+    // it as a flag. Downstream `normalizeInstallFlags` then drops it
+    // (boolean → not a string).
+    const { flags } = parseFlags(["install", "--api-key"])
+    expect(flags["api-key"]).toBe(true)
+  })
+
+  it("doesn't consume the next flag as the value of a value-taking flag (--api-key --project)", () => {
+    // Edge case: `--api-key --project foo` should NOT bind --api-key to
+    // "--project" as a literal string. The parser sees `--project` next
+    // and treats `--api-key` as boolean true; `--project foo` then binds
+    // normally.
+    const { flags } = parseFlags(["install", "--api-key", "--project", "foo"])
+    expect(flags["api-key"]).toBe(true)
+    expect(flags.project).toBe("foo")
+  })
 })
 
 describe("normalizeInstallFlags", () => {

--- a/packages/telemetry/openclaw-cli/src/cli.test.ts
+++ b/packages/telemetry/openclaw-cli/src/cli.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { normalizeInstallFlags, normalizeUninstallFlags, parseFlags } from "./setup.ts"
+
+describe("parseFlags", () => {
+  it("returns the subcommand and a flat key/value map of --flags", () => {
+    const { subcommand, flags } = parseFlags(["install", "--api-key=lat_xxx", "--yes"])
+    expect(subcommand).toBe("install")
+    expect(flags["api-key"]).toBe("lat_xxx")
+    expect(flags.yes).toBe(true)
+  })
+
+  it("treats bare `--flag` as boolean true", () => {
+    const { flags } = parseFlags(["install", "--no-content", "--no-trust", "--dry-run", "--restart"])
+    expect(flags["no-content"]).toBe(true)
+    expect(flags["no-trust"]).toBe(true)
+    expect(flags["dry-run"]).toBe(true)
+    expect(flags.restart).toBe(true)
+  })
+
+  it("ignores positional args after the subcommand", () => {
+    const { flags } = parseFlags(["install", "extra-arg", "--yes"])
+    expect(flags.yes).toBe(true)
+  })
+})
+
+describe("normalizeInstallFlags", () => {
+  it("maps --staging to the staging environment", () => {
+    const norm = normalizeInstallFlags({ staging: true })
+    expect(norm.environment?.name).toBe("staging")
+  })
+
+  it("maps --dev to the local-dev environment", () => {
+    const norm = normalizeInstallFlags({ dev: true })
+    expect(norm.environment?.name).toBe("dev")
+  })
+
+  it("rejects --staging + --dev together", () => {
+    expect(() => normalizeInstallFlags({ staging: true, dev: true })).toThrow(/mutually exclusive/)
+  })
+
+  it("derives allowConversationAccess tristate from --no-content / --allow-conversation", () => {
+    expect(normalizeInstallFlags({ "no-content": true }).allowConversationAccess).toBe(false)
+    expect(normalizeInstallFlags({ "allow-conversation": true }).allowConversationAccess).toBe(true)
+    expect(normalizeInstallFlags({}).allowConversationAccess).toBeUndefined()
+  })
+
+  it("collapses --yes / --no-prompt into noPrompt", () => {
+    expect(normalizeInstallFlags({ yes: true }).noPrompt).toBe(true)
+    expect(normalizeInstallFlags({ "no-prompt": true }).noPrompt).toBe(true)
+  })
+
+  it("captures --openclaw-dir path", () => {
+    expect(normalizeInstallFlags({ "openclaw-dir": "/tmp/x" }).openclawDir).toBe("/tmp/x")
+  })
+
+  it("derives restart mode from --restart / --no-restart with mutually-exclusive guard", () => {
+    expect(normalizeInstallFlags({}).restart).toBe("auto")
+    expect(normalizeInstallFlags({ restart: true }).restart).toBe("force")
+    expect(normalizeInstallFlags({ "no-restart": true }).restart).toBe("never")
+    expect(() => normalizeInstallFlags({ restart: true, "no-restart": true })).toThrow(/mutually exclusive/)
+  })
+
+  it("captures --dry-run as a boolean", () => {
+    expect(normalizeInstallFlags({ "dry-run": true }).dryRun).toBe(true)
+    expect(normalizeInstallFlags({}).dryRun).toBeFalsy()
+  })
+})
+
+describe("normalizeUninstallFlags", () => {
+  it("collapses --yes / --no-prompt into noPrompt", () => {
+    expect(normalizeUninstallFlags({ yes: true }).noPrompt).toBe(true)
+    expect(normalizeUninstallFlags({ "no-prompt": true }).noPrompt).toBe(true)
+  })
+
+  it("captures --openclaw-dir + --restart / --no-restart", () => {
+    const f = normalizeUninstallFlags({ "openclaw-dir": "/tmp/x", "no-restart": true })
+    expect(f.openclawDir).toBe("/tmp/x")
+    expect(f.restart).toBe("never")
+  })
+
+  it("rejects --restart + --no-restart together", () => {
+    expect(() => normalizeUninstallFlags({ restart: true, "no-restart": true })).toThrow(/mutually exclusive/)
+  })
+})

--- a/packages/telemetry/openclaw-cli/src/cli.ts
+++ b/packages/telemetry/openclaw-cli/src/cli.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
 import { normalizeInstallFlags, normalizeUninstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
+import { readCliVersion } from "./version.ts"
 
 const USAGE = `usage: latitude-openclaw <command> [options]
 
@@ -34,24 +32,12 @@ uninstall options:
   --yes / --no-prompt   Skip the confirmation prompt
 `
 
-function readVersion(): string {
-  // dist/cli.js → ../package.json
-  const here = dirname(fileURLToPath(import.meta.url))
-  const pkgPath = join(here, "..", "package.json")
-  try {
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string }
-    return pkg.version ?? "unknown"
-  } catch {
-    return "unknown"
-  }
-}
-
 async function main(): Promise<void> {
   const argv = process.argv.slice(2)
   // Top-level --version / --help are handled before parseFlags so users can
   // type them as the first arg without hitting the "unknown subcommand" path.
   if (argv[0] === "--version" || argv[0] === "-v") {
-    process.stdout.write(`${readVersion()}\n`)
+    process.stdout.write(`${readCliVersion()}\n`)
     return
   }
   if (argv[0] === "--help" || argv[0] === "-h") {

--- a/packages/telemetry/openclaw-cli/src/cli.ts
+++ b/packages/telemetry/openclaw-cli/src/cli.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { normalizeInstallFlags, normalizeUninstallFlags, parseFlags, runInstall, runUninstall } from "./setup.ts"
+
+const USAGE = `usage: latitude-openclaw <command> [options]
+
+commands:
+  install               Install the plugin (interactive when stdin is a TTY)
+  uninstall             Remove the plugin entry and files
+  --version, -v         Print the package version
+  --help, -h            Print this message
+
+install options:
+  --api-key=<key>       Pass the API key non-interactively
+  --project=<slug>      Pass the project slug non-interactively
+  --staging             Target https://staging.latitude.so / staging-ingest
+  --dev                 Target http://localhost:3000 / 3002
+  --no-content          Skip raw prompt/response/tool I/O capture
+  --allow-conversation  Force conversation capture on (overrides existing config)
+  --no-trust            Skip adding plugin id to plugins.allow
+  --openclaw-dir=<path> Override OpenClaw config dir (default: $OPENCLAW_HOME, ./openclaw.json,
+                        or ~/.openclaw — see resolution order in README)
+  --dry-run             Show the diff against current openclaw.json and exit (no writes)
+  --restart             Always restart the gateway, even non-TTY
+  --no-restart          Never restart the gateway, even on TTY
+  --yes / --no-prompt   Skip all prompts (required for non-TTY / CI)
+
+uninstall options:
+  --openclaw-dir=<path> Override OpenClaw config dir (same precedence as install)
+  --restart             Always restart the gateway, even non-TTY
+  --no-restart          Never restart the gateway, even on TTY
+  --yes / --no-prompt   Skip the confirmation prompt
+`
+
+function readVersion(): string {
+  // dist/cli.js → ../package.json
+  const here = dirname(fileURLToPath(import.meta.url))
+  const pkgPath = join(here, "..", "package.json")
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string }
+    return pkg.version ?? "unknown"
+  } catch {
+    return "unknown"
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  // Top-level --version / --help are handled before parseFlags so users can
+  // type them as the first arg without hitting the "unknown subcommand" path.
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    process.stdout.write(`${readVersion()}\n`)
+    return
+  }
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    process.stdout.write(USAGE)
+    return
+  }
+
+  const { subcommand, flags } = parseFlags(argv)
+  if (subcommand === "install" || subcommand === undefined) {
+    await runInstall(normalizeInstallFlags(flags))
+    return
+  }
+  if (subcommand === "uninstall") {
+    await runUninstall(normalizeUninstallFlags(flags))
+    return
+  }
+  process.stderr.write(`unknown subcommand: ${subcommand}\n`)
+  process.stderr.write(USAGE)
+  process.exit(1)
+}
+
+main().catch((err) => {
+  process.stderr.write(`${String(err)}\n`)
+  process.exit(1)
+})

--- a/packages/telemetry/openclaw-cli/src/config-dir.test.ts
+++ b/packages/telemetry/openclaw-cli/src/config-dir.test.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { pathsFor, resolveConfigDir } from "./config-dir.ts"
+
+describe("resolveConfigDir", () => {
+  let tmpRoot: string
+  let cwd: string
+  let home: string
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "openclaw-cli-cfgdir-"))
+    cwd = join(tmpRoot, "cwd")
+    home = join(tmpRoot, "home")
+    mkdirSync(cwd, { recursive: true })
+    mkdirSync(home, { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it("uses --openclaw-dir flag first when provided", () => {
+    const explicit = join(tmpRoot, "explicit")
+    mkdirSync(explicit)
+    // Even with cwd having an openclaw.json, the flag wins.
+    writeFileSync(join(cwd, "openclaw.json"), "{}")
+    const r = resolveConfigDir({ flag: explicit, env: "/env-set", cwd, home })
+    expect(r.dir).toBe(explicit)
+    expect(r.source).toBe("flag")
+  })
+
+  it("resolves --openclaw-dir relative paths against cwd", () => {
+    const r = resolveConfigDir({ flag: "./relative", cwd, home })
+    expect(r.dir).toBe(join(cwd, "relative"))
+    expect(r.source).toBe("flag")
+  })
+
+  it("falls back to OPENCLAW_HOME env when no flag", () => {
+    const envDir = join(tmpRoot, "env-home")
+    const r = resolveConfigDir({ env: envDir, cwd, home })
+    expect(r.dir).toBe(envDir)
+    expect(r.source).toBe("env")
+  })
+
+  it("auto-detects ./openclaw.json in cwd when no flag/env", () => {
+    writeFileSync(join(cwd, "openclaw.json"), "{}")
+    const r = resolveConfigDir({ env: "", cwd, home })
+    expect(r.dir).toBe(cwd)
+    expect(r.source).toBe("cwd")
+  })
+
+  it("falls back to ~/.openclaw when nothing else matches", () => {
+    const r = resolveConfigDir({ env: "", cwd, home })
+    expect(r.dir).toBe(join(home, ".openclaw"))
+    expect(r.source).toBe("default")
+  })
+
+  it("treats empty-string flag as absent (so it doesn't shadow env/cwd/home)", () => {
+    const envDir = join(tmpRoot, "env-home")
+    const r = resolveConfigDir({ flag: "", env: envDir, cwd, home })
+    expect(r.source).toBe("env")
+  })
+})
+
+describe("pathsFor", () => {
+  it("derives all four well-known paths from a config dir", () => {
+    const p = pathsFor("/foo/bar")
+    expect(p.configDir).toBe("/foo/bar")
+    expect(p.settingsPath).toBe("/foo/bar/openclaw.json")
+    expect(p.settingsBackupPath).toBe("/foo/bar/openclaw.json.latitude-bak")
+    // installs.json sits under <configDir>/plugins/, not the root.
+    expect(p.installsPath).toBe("/foo/bar/plugins/installs.json")
+  })
+})

--- a/packages/telemetry/openclaw-cli/src/config-dir.ts
+++ b/packages/telemetry/openclaw-cli/src/config-dir.ts
@@ -1,0 +1,80 @@
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve as resolvePath } from "node:path"
+
+/**
+ * Resolution order for the OpenClaw config directory (the parent of
+ * `openclaw.json`):
+ *
+ *   1. `--openclaw-dir <path>` flag (most explicit; absolute or cwd-relative).
+ *   2. `OPENCLAW_HOME` env var (next-most explicit; absolute or cwd-relative).
+ *   3. `./openclaw.json` exists in the current working directory → use cwd
+ *      (matches `cd into a project that has its own openclaw.json` UX).
+ *   4. `~/.openclaw` (default; matches OpenClaw's hardcoded default).
+ *
+ * The CLI passes `OPENCLAW_HOME=<resolved>` to every spawned `openclaw`
+ * subprocess so the runtime side resolves to the same dir we're writing to.
+ *
+ * Caveat — at the time of writing, OpenClaw's CLI does not advertise
+ * `OPENCLAW_HOME` support; the runtime side may still resolve `~/.openclaw`
+ * regardless of what we set. The post-install `openclaw config validate
+ * --json` step (in `setup.ts`) catches this and restores the backup if the
+ * runtime fell back to the wrong dir. Don't trust the resolved path alone —
+ * trust the validation result.
+ */
+export interface ResolvedConfigDir {
+  /** Absolute path to the chosen config directory. */
+  readonly dir: string
+  /** Where the value came from, for logging / debug. */
+  readonly source: "flag" | "env" | "cwd" | "default"
+}
+
+interface ResolveOptions {
+  /** Value of the `--openclaw-dir` flag, if set. */
+  readonly flag?: string | undefined
+  /** Override `OPENCLAW_HOME` env var (defaults to `process.env.OPENCLAW_HOME`). */
+  readonly env?: string | undefined
+  /** Override cwd (for tests). Defaults to `process.cwd()`. */
+  readonly cwd?: string | undefined
+  /** Override home dir (for tests). Defaults to `os.homedir()`. */
+  readonly home?: string | undefined
+}
+
+export function resolveConfigDir(opts: ResolveOptions = {}): ResolvedConfigDir {
+  const cwd = opts.cwd ?? process.cwd()
+  const home = opts.home ?? homedir()
+
+  if (typeof opts.flag === "string" && opts.flag.length > 0) {
+    return { dir: absolutize(opts.flag, cwd), source: "flag" }
+  }
+  const envValue = opts.env !== undefined ? opts.env : process.env.OPENCLAW_HOME
+  if (typeof envValue === "string" && envValue.length > 0) {
+    return { dir: absolutize(envValue, cwd), source: "env" }
+  }
+  if (existsSync(join(cwd, "openclaw.json"))) {
+    return { dir: cwd, source: "cwd" }
+  }
+  return { dir: join(home, ".openclaw"), source: "default" }
+}
+
+function absolutize(p: string, cwd: string): string {
+  return isAbsolute(p) ? p : resolvePath(cwd, p)
+}
+
+/** Settings paths derived from a config dir. */
+export interface SettingsPaths {
+  readonly configDir: string
+  readonly settingsPath: string
+  readonly settingsBackupPath: string
+  /** OpenClaw's plugins install record — read-only, used for upgrade-detection. */
+  readonly installsPath: string
+}
+
+export function pathsFor(configDir: string): SettingsPaths {
+  return {
+    configDir,
+    settingsPath: join(configDir, "openclaw.json"),
+    settingsBackupPath: join(configDir, "openclaw.json.latitude-bak"),
+    installsPath: join(configDir, "plugins", "installs.json"),
+  }
+}

--- a/packages/telemetry/openclaw-cli/src/diff.test.ts
+++ b/packages/telemetry/openclaw-cli/src/diff.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { jsonDiff } from "./diff.ts"
+
+describe("jsonDiff", () => {
+  it("returns empty string when before and after are deeply equal", () => {
+    expect(jsonDiff({ a: 1, b: [2, 3] }, { a: 1, b: [2, 3] })).toBe("")
+  })
+
+  it("renders a hunk with --- / +++ headers and +/- markers", () => {
+    const before = { plugins: { entries: { foo: { enabled: false } } } }
+    const after = { plugins: { entries: { foo: { enabled: true } } } }
+    const out = jsonDiff(before, after)
+    expect(out).toContain("--- current")
+    expect(out).toContain("+++ proposed")
+    // Line is `<marker><space><JSON-line>` where the JSON line itself has
+    // 8 spaces of indent (`"enabled"` is at depth 4 with 2-space JSON.stringify).
+    expect(out).toMatch(/^- {9}"enabled": false$/m)
+    expect(out).toMatch(/^\+ {9}"enabled": true$/m)
+  })
+
+  it("respects fromLabel / toLabel options", () => {
+    const out = jsonDiff({ x: 1 }, { x: 2 }, { fromLabel: "live", toLabel: "next" })
+    expect(out).toContain("--- live")
+    expect(out).toContain("+++ next")
+  })
+
+  it("renders pure additions (no `before` value)", () => {
+    const out = jsonDiff({}, { foo: "bar" })
+    expect(out).toContain('+   "foo": "bar"')
+    // Should not have a `- "foo": "bar"` line for an empty `before`.
+    expect(out).not.toMatch(/^- {2}"foo":/m)
+  })
+
+  it("renders pure removals", () => {
+    const out = jsonDiff({ foo: "bar" }, {})
+    expect(out).toContain('-   "foo": "bar"')
+  })
+})

--- a/packages/telemetry/openclaw-cli/src/diff.ts
+++ b/packages/telemetry/openclaw-cli/src/diff.ts
@@ -1,0 +1,131 @@
+/**
+ * Tiny purpose-built JSON line-diff for `--dry-run` output. Renders changes
+ * to `openclaw.json` in a human-readable unified-diff-ish format without
+ * pulling in a real diff library (zero new deps).
+ *
+ * The shape of `openclaw.json` is small (a few hundred lines tops, with
+ * stable key ordering after our edits), so the naive line-by-line approach
+ * produces a perfectly readable output. We mark added lines with `+ ` and
+ * removed lines with `- `, with a few lines of context around each change.
+ */
+const CONTEXT_LINES = 3
+
+interface DiffOptions {
+  /** Header label for the "before" side (default: `current`). */
+  fromLabel?: string
+  /** Header label for the "after" side (default: `proposed`). */
+  toLabel?: string
+}
+
+/**
+ * Render a unified-ish diff between two unknown JSON values. Returns an
+ * empty string if they're identical after normalization.
+ */
+export function jsonDiff(before: unknown, after: unknown, opts: DiffOptions = {}): string {
+  const fromLabel = opts.fromLabel ?? "current"
+  const toLabel = opts.toLabel ?? "proposed"
+
+  const beforeJson = `${JSON.stringify(before ?? {}, null, 2)}\n`
+  const afterJson = `${JSON.stringify(after ?? {}, null, 2)}\n`
+
+  if (beforeJson === afterJson) return ""
+
+  const beforeLines = beforeJson.split("\n")
+  const afterLines = afterJson.split("\n")
+
+  // Compute LCS-driven minimal edit script. For files of this size the
+  // O(n*m) DP is fine — `openclaw.json` rarely exceeds a few hundred lines.
+  const ops = lcsDiff(beforeLines, afterLines)
+
+  const out: string[] = []
+  out.push(`--- ${fromLabel}`)
+  out.push(`+++ ${toLabel}`)
+
+  // Render hunks (groups of contiguous changes + their context).
+  let i = 0
+  while (i < ops.length) {
+    if (ops[i]?.kind === "eq") {
+      i++
+      continue
+    }
+    // Found a change — collect the surrounding hunk.
+    const hunkStart = Math.max(0, i - CONTEXT_LINES)
+    let hunkEnd = i
+    while (hunkEnd < ops.length) {
+      if (ops[hunkEnd]?.kind === "eq") {
+        // Stop the hunk after CONTEXT_LINES of equality, unless the very
+        // next non-equal op is within CONTEXT_LINES * 2 (then we collapse
+        // adjacent change blocks into one hunk).
+        let runOfEq = 0
+        let k = hunkEnd
+        while (k < ops.length && ops[k]?.kind === "eq" && runOfEq < CONTEXT_LINES * 2) {
+          runOfEq++
+          k++
+        }
+        if (k >= ops.length || ops[k]?.kind === "eq") {
+          hunkEnd = Math.min(hunkEnd + CONTEXT_LINES, ops.length)
+          break
+        }
+        hunkEnd = k
+        continue
+      }
+      hunkEnd++
+    }
+
+    for (let j = hunkStart; j < hunkEnd && j < ops.length; j++) {
+      const op = ops[j]
+      if (!op) continue
+      if (op.kind === "eq") out.push(`  ${op.line}`)
+      else if (op.kind === "add") out.push(`+ ${op.line}`)
+      else if (op.kind === "del") out.push(`- ${op.line}`)
+    }
+    i = hunkEnd
+  }
+
+  return out.join("\n")
+}
+
+type Op = { kind: "eq"; line: string } | { kind: "add"; line: string } | { kind: "del"; line: string }
+
+function lcsDiff(a: readonly string[], b: readonly string[]): Op[] {
+  const n = a.length
+  const m = b.length
+  // dp[i][j] = LCS length of a[0..i) and b[0..j)
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0))
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i]![j] = (dp[i - 1]?.[j - 1] ?? 0) + 1
+      } else {
+        dp[i]![j] = Math.max(dp[i - 1]?.[j] ?? 0, dp[i]?.[j - 1] ?? 0)
+      }
+    }
+  }
+  // Walk back to produce the edit script.
+  const ops: Op[] = []
+  let i = n
+  let j = m
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      ops.push({ kind: "eq", line: a[i - 1] as string })
+      i--
+      j--
+    } else if ((dp[i - 1]?.[j] ?? 0) >= (dp[i]?.[j - 1] ?? 0)) {
+      ops.push({ kind: "del", line: a[i - 1] as string })
+      i--
+    } else {
+      ops.push({ kind: "add", line: b[j - 1] as string })
+      j--
+    }
+  }
+  while (i > 0) {
+    ops.push({ kind: "del", line: a[i - 1] as string })
+    i--
+  }
+  while (j > 0) {
+    ops.push({ kind: "add", line: b[j - 1] as string })
+    j--
+  }
+  ops.reverse()
+  return ops
+}

--- a/packages/telemetry/openclaw-cli/src/openclaw-cli.test.ts
+++ b/packages/telemetry/openclaw-cli/src/openclaw-cli.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { compareCalver } from "./openclaw-cli.ts"
+
+describe("compareCalver", () => {
+  it("returns 0 for equal versions", () => {
+    expect(compareCalver("2026.4.25", "2026.4.25")).toBe(0)
+  })
+
+  it("orders by year first", () => {
+    expect(compareCalver("2025.12.99", "2026.1.0")).toBe(-1)
+    expect(compareCalver("2026.1.0", "2025.12.99")).toBe(1)
+  })
+
+  it("orders by minor next", () => {
+    expect(compareCalver("2026.4.25", "2026.5.0")).toBe(-1)
+    expect(compareCalver("2026.5.0", "2026.4.25")).toBe(1)
+  })
+
+  it("orders by patch last (numeric, not lexicographic)", () => {
+    // Lexicographic would put "21" > "5", numeric correctly puts "21" > "5".
+    expect(compareCalver("2026.4.21", "2026.4.5")).toBe(1)
+    expect(compareCalver("2026.4.5", "2026.4.21")).toBe(-1)
+  })
+
+  it("treats missing components as 0 (defensive against truncated versions)", () => {
+    expect(compareCalver("2026.4", "2026.4.0")).toBe(0)
+    expect(compareCalver("2026.4.1", "2026.4")).toBe(1)
+  })
+
+  it("matches the minimum-version comparison the installer uses", () => {
+    // Anchor for the actual production check.
+    const MIN = "2026.4.25"
+    expect(compareCalver("2026.4.21", MIN)).toBe(-1) // reporter's old version → blocked
+    expect(compareCalver("2026.4.25", MIN)).toBe(0) // exact match → allowed
+    expect(compareCalver("2026.4.27", MIN)).toBe(1) // newer → allowed
+    expect(compareCalver("2027.1.0", MIN)).toBe(1) // future year → allowed
+  })
+
+  it("doesn't crash on non-numeric suffixes (defensive)", () => {
+    // OpenClaw's CalVer is bare numbers — pre-release tags like `-alpha`
+    // shouldn't appear. If one does, we fall back to a per-component
+    // string comparison rather than blowing up. We don't claim correct
+    // semver-style ordering for these; just no crash.
+    expect(() => compareCalver("2026.4.25-rc1", "2026.4.25")).not.toThrow()
+  })
+})

--- a/packages/telemetry/openclaw-cli/src/openclaw-cli.ts
+++ b/packages/telemetry/openclaw-cli/src/openclaw-cli.ts
@@ -1,0 +1,147 @@
+import { type SpawnSyncReturns, spawnSync } from "node:child_process"
+
+/**
+ * Lowest OpenClaw version we support. The reporter verified hook-dispatch
+ * gating works correctly here; older versions either reject
+ * `hooks.allowConversationAccess` outright (≤ 2026.4.21) or have unverified
+ * gating behaviour (2026.4.22 – 2026.4.24). Refusing to install on older
+ * versions is intentional — we'd rather fail loudly than ship a
+ * config the gateway will quarantine or hooks the dispatcher will block.
+ */
+export const MIN_OPENCLAW_VERSION = "2026.4.25"
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+type RunResult =
+  | { ok: true; stdout: string; stderr: string; code: 0 }
+  | { ok: false; reason: "enoent"; stdout: ""; stderr: ""; code: null }
+  | { ok: false; reason: "timeout"; stdout: string; stderr: string; code: null }
+  | { ok: false; reason: "exit"; stdout: string; stderr: string; code: number }
+
+/**
+ * Spawn `openclaw <args>` synchronously. Reports failure modes structurally so
+ * callers can decide how to degrade (missing binary vs. timed out vs. exited
+ * non-zero). Never throws; ENOENT becomes `{ reason: "enoent" }`.
+ *
+ * `opts.env` lets callers overlay environment variables on top of `process.env`
+ * — used by the install flow to inject `OPENCLAW_HOME` so `openclaw plugins
+ * install`, `openclaw config validate`, and `openclaw gateway restart` all
+ * resolve the same config dir as our settings-file edits. The overlay is
+ * additive: the caller passes only the keys to override and we merge them on
+ * top of `process.env`.
+ */
+export function runOpenclaw(
+  args: string[],
+  opts: { timeoutMs?: number; stdin?: string; env?: NodeJS.ProcessEnv } = {},
+): RunResult {
+  const env = opts.env ? { ...process.env, ...opts.env } : undefined
+  const result: SpawnSyncReturns<string> = spawnSync("openclaw", args, {
+    encoding: "utf-8",
+    timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    input: opts.stdin,
+    // Inherit env so the user's PATH and any LATITUDE_* / OPENCLAW_* vars
+    // reach the child process. When opts.env is set, it's merged on top
+    // (e.g. OPENCLAW_HOME from --openclaw-dir).
+    ...(env ? { env } : {}),
+    stdio: ["pipe", "pipe", "pipe"],
+  })
+
+  // spawnSync surfaces I/O errors through `result.error` rather than a thrown
+  // exception when called this way. Order matters: a timeout shows up as
+  // `error.code === "ETIMEDOUT"` AND/OR `signal === "SIGTERM"|"SIGKILL"`
+  // depending on platform — classify it before the generic `if (err)`
+  // catch-all so callers reliably get `reason: "timeout"` (and the
+  // timeout-specific error messages in setup.ts aren't dead code).
+  const err = result.error as (NodeJS.ErrnoException & { code?: string }) | undefined
+  if (err?.code === "ENOENT") {
+    return { ok: false, reason: "enoent", stdout: "", stderr: "", code: null }
+  }
+  if (err?.code === "ETIMEDOUT" || result.signal === "SIGTERM" || result.signal === "SIGKILL") {
+    return {
+      ok: false,
+      reason: "timeout",
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      code: null,
+    }
+  }
+  if (err) {
+    // Treat any other spawn error as an unparseable exit failure.
+    return {
+      ok: false,
+      reason: "exit",
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? String(err),
+      code: typeof result.status === "number" ? result.status : 1,
+    }
+  }
+
+  if (result.status === 0) {
+    return { ok: true, stdout: result.stdout ?? "", stderr: result.stderr ?? "", code: 0 }
+  }
+
+  return {
+    ok: false,
+    reason: "exit",
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    code: typeof result.status === "number" ? result.status : 1,
+  }
+}
+
+type VersionLookup =
+  | { ok: true; version: string; raw: string }
+  | { ok: false; error: "missing" | "unparseable"; raw?: string | undefined }
+
+/**
+ * Run `openclaw --version` and parse out the version string.
+ *
+ * Banner format (per OpenClaw `src/cli/banner.ts` `formatCliBannerLine`):
+ *   `🦞 OpenClaw <version> (<commit-sha>)`
+ *
+ * The banner is normally suppressed when `--version` is the flag, but the
+ * version itself still goes to stdout. We accept either layout (with or
+ * without the lobster + commit sha) so we don't break if OpenClaw later
+ * prints just the bare version string.
+ */
+export function getOpenclawVersion(): VersionLookup {
+  const result = runOpenclaw(["--version"], { timeoutMs: 5_000 })
+  if (!result.ok) {
+    if (result.reason === "enoent") return { ok: false, error: "missing" }
+    return { ok: false, error: "unparseable", raw: result.stdout || result.stderr }
+  }
+
+  const raw = result.stdout.trim()
+  // Match a CalVer triple anywhere in the output. Be liberal — banner
+  // decorations (emoji, "OpenClaw" prefix, trailing "(sha)") all just
+  // surround a single `YYYY.M.PATCH` somewhere.
+  const match = raw.match(/(\d{4}\.\d+\.\d+)/)
+  if (!match) return { ok: false, error: "unparseable", raw }
+  return { ok: true, version: match[1] as string, raw }
+}
+
+/**
+ * Compare two CalVer strings (`YYYY.M.PATCH`). Returns -1 if `a` < `b`,
+ * 0 if equal, 1 if `a` > `b`. Strings with extra components or non-numeric
+ * pieces fall back to a per-component string comparison so unexpected
+ * formats don't crash the installer.
+ */
+export function compareCalver(a: string, b: string): -1 | 0 | 1 {
+  const ap = a.split(".")
+  const bp = b.split(".")
+  const len = Math.max(ap.length, bp.length)
+  for (let i = 0; i < len; i++) {
+    const ai = ap[i] ?? "0"
+    const bi = bp[i] ?? "0"
+    const an = Number(ai)
+    const bn = Number(bi)
+    if (Number.isFinite(an) && Number.isFinite(bn)) {
+      if (an < bn) return -1
+      if (an > bn) return 1
+      continue
+    }
+    if (ai < bi) return -1
+    if (ai > bi) return 1
+  }
+  return 0
+}

--- a/packages/telemetry/openclaw-cli/src/settings-file.test.ts
+++ b/packages/telemetry/openclaw-cli/src/settings-file.test.ts
@@ -1,0 +1,412 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  addToPluginsAllow,
+  backupSettings,
+  migrateLegacyEntries,
+  type OpenClawSettings,
+  PLUGIN_ID,
+  readInstalledRuntimeVersion,
+  readSettings,
+  removeFromPluginsAllow,
+  removePluginEntry,
+  restoreBackup,
+  setPluginEntry,
+  writeSettings,
+} from "./settings-file.ts"
+
+describe("setPluginEntry", () => {
+  it("writes credentials under .config and dispatch gate under .hooks (mirrored)", () => {
+    const settings: OpenClawSettings = {}
+    setPluginEntry(settings, {
+      apiKey: "k",
+      project: "p",
+      baseUrl: "https://staging-ingest.latitude.so",
+      allowConversationAccess: true,
+      debug: false,
+    })
+
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    expect(entry?.enabled).toBe(true)
+    expect(entry?.config?.apiKey).toBe("k")
+    expect(entry?.config?.project).toBe("p")
+    expect(entry?.config?.baseUrl).toBe("https://staging-ingest.latitude.so")
+    expect(entry?.config?.allowConversationAccess).toBe(true)
+    // Hooks block must mirror config — that's what gates dispatch on
+    // OpenClaw 2026.4.25+.
+    expect(entry?.hooks?.allowConversationAccess).toBe(true)
+    // We don't write to top-level `env` (root schema rejects arbitrary keys).
+    expect((settings as { env?: unknown }).env).toBeUndefined()
+  })
+
+  it("mirrors allowConversationAccess: false into both config and hooks", () => {
+    const settings: OpenClawSettings = {}
+    setPluginEntry(settings, {
+      apiKey: "k",
+      project: "p",
+      baseUrl: undefined,
+      allowConversationAccess: false,
+    })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    expect(entry?.config?.allowConversationAccess).toBe(false)
+    expect(entry?.hooks?.allowConversationAccess).toBe(false)
+  })
+
+  it("clears baseUrl when undefined (production install after a staging install)", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            config: { apiKey: "old-k", project: "old-p", baseUrl: "https://staging-ingest.latitude.so" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "new-k", project: "new-p", baseUrl: undefined })
+    const config = settings.plugins?.entries?.[PLUGIN_ID]?.config
+    expect(config?.baseUrl).toBeUndefined()
+    expect(config?.apiKey).toBe("new-k")
+  })
+
+  it("preserves unrelated fields on the existing plugin entry", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            subagent: { allowModelOverride: true },
+            config: { customField: "keep me" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID] as {
+      subagent?: { allowModelOverride?: boolean }
+      config?: Record<string, unknown>
+    }
+    expect(entry.subagent?.allowModelOverride).toBe(true)
+    expect(entry.config?.customField).toBe("keep me")
+    expect(entry.config?.apiKey).toBe("k")
+  })
+
+  it("preserves an existing hooks.allowPromptInjection alongside the new allowConversationAccess", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            hooks: { allowPromptInjection: true },
+            config: { apiKey: "old", project: "old" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "new", project: "new", baseUrl: undefined })
+    const hooks = settings.plugins?.entries?.[PLUGIN_ID]?.hooks
+    expect(hooks?.allowPromptInjection).toBe(true)
+    expect(hooks?.allowConversationAccess).toBe(true)
+  })
+
+  it("preserves a hand-edited `enabled: false` across re-installs", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: false,
+            config: { apiKey: "old", project: "old" },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "new", project: "new", baseUrl: undefined })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    // Paused plugin stays paused — operator's intent wins.
+    expect(entry?.enabled).toBe(false)
+    expect((entry?.config as Record<string, unknown>)?.apiKey).toBe("new")
+  })
+
+  it("defaults to enabled=true for a fresh install (no existing entry)", () => {
+    const settings: OpenClawSettings = {}
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined })
+    expect(settings.plugins?.entries?.[PLUGIN_ID]?.enabled).toBe(true)
+  })
+
+  it("explicitly setting enabled overrides existing", () => {
+    const settings: OpenClawSettings = {
+      plugins: { entries: { [PLUGIN_ID]: { enabled: false } } },
+    }
+    setPluginEntry(settings, { apiKey: "k", project: "p", baseUrl: undefined, enabled: true })
+    expect(settings.plugins?.entries?.[PLUGIN_ID]?.enabled).toBe(true)
+  })
+
+  it("preserves existing debug when not overridden", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: { [PLUGIN_ID]: { config: { apiKey: "x", project: "y", debug: true } } },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "x", project: "y", baseUrl: undefined })
+    const config = settings.plugins?.entries?.[PLUGIN_ID]?.config as Record<string, unknown>
+    expect(config.debug).toBe(true)
+  })
+
+  it("preserves existing allowConversationAccess when not overridden — and mirrors into hooks", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: { config: { apiKey: "x", project: "y", allowConversationAccess: false } },
+        },
+      },
+    }
+    setPluginEntry(settings, { apiKey: "x", project: "y", baseUrl: undefined })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    expect(entry?.config?.allowConversationAccess).toBe(false)
+    expect(entry?.hooks?.allowConversationAccess).toBe(false)
+  })
+
+  it("explicit allowConversationAccess in patch overrides existing — both config and hooks update", () => {
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            hooks: { allowConversationAccess: false },
+            config: { apiKey: "x", project: "y", allowConversationAccess: false },
+          },
+        },
+      },
+    }
+    setPluginEntry(settings, {
+      apiKey: "x",
+      project: "y",
+      baseUrl: undefined,
+      allowConversationAccess: true,
+    })
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    expect(entry?.config?.allowConversationAccess).toBe(true)
+    expect(entry?.hooks?.allowConversationAccess).toBe(true)
+  })
+})
+
+describe("addToPluginsAllow", () => {
+  it("adds the plugin id when missing", () => {
+    const settings: OpenClawSettings = {}
+    expect(addToPluginsAllow(settings)).toBe(true)
+    expect(settings.plugins?.allow).toEqual([PLUGIN_ID])
+  })
+
+  it("is idempotent when the id is already present", () => {
+    const settings: OpenClawSettings = { plugins: { allow: [PLUGIN_ID, "other"] } }
+    expect(addToPluginsAllow(settings)).toBe(false)
+    expect(settings.plugins?.allow).toEqual([PLUGIN_ID, "other"])
+  })
+
+  it("preserves other entries already in the allow list", () => {
+    const settings: OpenClawSettings = { plugins: { allow: ["foo", "bar"] } }
+    addToPluginsAllow(settings)
+    expect(settings.plugins?.allow).toEqual(["foo", "bar", PLUGIN_ID])
+  })
+
+  it("treats a hand-edited non-array allow as empty (defensive)", () => {
+    // openclaw.json is user-editable; if someone wrote `"allow": "foo"`
+    // instead of `"allow": ["foo"]`, we must not spread the string into
+    // characters. Replace the bad value with a clean single-element array.
+    const settings = { plugins: { allow: "wrong" as unknown as string[] } } as OpenClawSettings
+    expect(addToPluginsAllow(settings)).toBe(true)
+    expect(settings.plugins?.allow).toEqual([PLUGIN_ID])
+  })
+})
+
+describe("removeFromPluginsAllow", () => {
+  it("removes only our id", () => {
+    const settings: OpenClawSettings = { plugins: { allow: ["foo", PLUGIN_ID, "bar"] } }
+    expect(removeFromPluginsAllow(settings)).toBe(true)
+    expect(settings.plugins?.allow).toEqual(["foo", "bar"])
+  })
+
+  it("returns false when nothing changes", () => {
+    const settings: OpenClawSettings = { plugins: { allow: ["foo"] } }
+    expect(removeFromPluginsAllow(settings)).toBe(false)
+    expect(settings.plugins?.allow).toEqual(["foo"])
+  })
+
+  it("returns false when allow is missing entirely", () => {
+    const settings: OpenClawSettings = {}
+    expect(removeFromPluginsAllow(settings)).toBe(false)
+  })
+})
+
+describe("migrateLegacyEntries", () => {
+  it("does NOT strip hooks.allowConversationAccess (it's load-bearing on 2026.4.25+)", () => {
+    // Regression guard: 0.0.2 used to strip this key here. On current OpenClaw
+    // versions the key is required, so the strip would break dispatch.
+    // setPluginEntry overwrites it with the right value anyway; the
+    // migration's only job now is the env sweep.
+    const settings: OpenClawSettings = {
+      plugins: {
+        entries: {
+          [PLUGIN_ID]: {
+            enabled: true,
+            hooks: { allowConversationAccess: true },
+          },
+        },
+      },
+    }
+    migrateLegacyEntries(settings)
+    const entry = settings.plugins?.entries?.[PLUGIN_ID]
+    expect(entry?.hooks?.allowConversationAccess).toBe(true)
+  })
+
+  it("strips top-level env.LATITUDE_* keys our 0.0.1 installer leaked", () => {
+    const settings = {
+      env: {
+        LATITUDE_API_KEY: "old",
+        LATITUDE_PROJECT: "old",
+        LATITUDE_BASE_URL: "https://staging-ingest.latitude.so",
+      },
+    }
+    const { changed } = migrateLegacyEntries(settings)
+    expect(changed).toBe(true)
+    expect(settings.env).toBeUndefined()
+  })
+
+  it("leaves a real OpenClaw env block alone (shellEnv + vars)", () => {
+    const settings = {
+      env: {
+        shellEnv: { enabled: true },
+        vars: { CUSTOM_VAR: "value" },
+      },
+    }
+    migrateLegacyEntries(settings)
+    expect(settings.env).toBeDefined()
+    expect(settings.env.shellEnv.enabled).toBe(true)
+    expect(settings.env.vars.CUSTOM_VAR).toBe("value")
+  })
+})
+
+describe("removePluginEntry", () => {
+  it("removes the plugin entry and reports whether it changed anything", () => {
+    const settings: OpenClawSettings = {
+      plugins: { entries: { [PLUGIN_ID]: { enabled: true }, "other-plugin": { enabled: true } } },
+    }
+    expect(removePluginEntry(settings)).toBe(true)
+    expect(PLUGIN_ID in (settings.plugins?.entries ?? {})).toBe(false)
+    expect("other-plugin" in (settings.plugins?.entries ?? {})).toBe(true)
+    expect(removePluginEntry(settings)).toBe(false)
+  })
+})
+
+// ─── File-system-touching tests (write/read/backup/restore/installs.json) ───
+
+describe("settings-file: read / write / backup / restore", () => {
+  let tmpRoot: string
+  let settingsPath: string
+  let backupPath: string
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "openclaw-cli-settings-"))
+    settingsPath = join(tmpRoot, "openclaw.json")
+    backupPath = join(tmpRoot, "openclaw.json.latitude-bak")
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it("writeSettings produces a parseable file with trailing newline", () => {
+    writeSettings(settingsPath, { plugins: { entries: { [PLUGIN_ID]: { enabled: true } } } })
+    const raw = readFileSync(settingsPath, "utf-8")
+    expect(raw.endsWith("\n")).toBe(true)
+    const parsed = JSON.parse(raw)
+    expect(parsed.plugins.entries[PLUGIN_ID].enabled).toBe(true)
+  })
+
+  it("writeSettings is atomic: no .tmp.* sibling left behind on success", () => {
+    // Atomic write goes through `<file>.tmp.<pid>` then renames over the
+    // target. After a successful write the tmp must not be readable as a
+    // stale sibling — that would mean either the rename failed or we left
+    // a partial file.
+    writeSettings(settingsPath, { foo: "bar" } as OpenClawSettings)
+    const siblings = readdirSync(tmpRoot)
+    expect(siblings).toContain("openclaw.json")
+    expect(siblings.filter((f) => f.startsWith("openclaw.json.tmp."))).toEqual([])
+  })
+
+  it("readSettings returns {} on missing file", () => {
+    expect(readSettings(settingsPath)).toEqual({})
+  })
+
+  it("readSettings returns {} on parse error (defensive)", () => {
+    writeFileSync(settingsPath, "not-valid-json")
+    expect(readSettings(settingsPath)).toEqual({})
+  })
+
+  it("backupSettings copies the live file to the backup path", () => {
+    writeSettings(settingsPath, { foo: "bar" } as OpenClawSettings)
+    backupSettings(settingsPath, backupPath)
+    expect(readFileSync(backupPath, "utf-8")).toBe(readFileSync(settingsPath, "utf-8"))
+  })
+
+  it("backupSettings is a no-op when the live file is missing", () => {
+    backupSettings(settingsPath, backupPath)
+    // Backup must not be created from thin air — if there's nothing live,
+    // there's nothing to back up.
+    expect(() => readFileSync(backupPath, "utf-8")).toThrow()
+  })
+
+  it("restoreBackup overwrites the live file with the backup", () => {
+    writeSettings(settingsPath, { foo: "bar" } as OpenClawSettings)
+    backupSettings(settingsPath, backupPath)
+    writeSettings(settingsPath, { foo: "changed" } as OpenClawSettings)
+    expect(restoreBackup(settingsPath, backupPath)).toBe(true)
+    expect(JSON.parse(readFileSync(settingsPath, "utf-8")).foo).toBe("bar")
+  })
+
+  it("restoreBackup returns false when no backup exists", () => {
+    expect(restoreBackup(settingsPath, backupPath)).toBe(false)
+  })
+})
+
+describe("readInstalledRuntimeVersion", () => {
+  let tmpRoot: string
+  let installsPath: string
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "openclaw-cli-installs-"))
+    mkdirSync(join(tmpRoot, "plugins"))
+    installsPath = join(tmpRoot, "plugins", "installs.json")
+  })
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it("returns undefined when installs.json is missing", () => {
+    expect(readInstalledRuntimeVersion(installsPath)).toBeUndefined()
+  })
+
+  it("returns the recorded version when present", () => {
+    writeFileSync(
+      installsPath,
+      JSON.stringify({ entries: { [PLUGIN_ID]: { version: "0.0.6" }, "other-plugin": { version: "1.0.0" } } }),
+    )
+    expect(readInstalledRuntimeVersion(installsPath)).toBe("0.0.6")
+  })
+
+  it("returns undefined when our id isn't in the record", () => {
+    writeFileSync(installsPath, JSON.stringify({ entries: { "other-plugin": { version: "1.0.0" } } }))
+    expect(readInstalledRuntimeVersion(installsPath)).toBeUndefined()
+  })
+
+  it("returns undefined on parse error", () => {
+    writeFileSync(installsPath, "not-valid-json")
+    expect(readInstalledRuntimeVersion(installsPath)).toBeUndefined()
+  })
+
+  it("returns undefined on schemas we don't recognize (e.g. version is not a string)", () => {
+    writeFileSync(installsPath, JSON.stringify({ entries: { [PLUGIN_ID]: { version: 42 } } }))
+    expect(readInstalledRuntimeVersion(installsPath)).toBeUndefined()
+  })
+})

--- a/packages/telemetry/openclaw-cli/src/settings-file.ts
+++ b/packages/telemetry/openclaw-cli/src/settings-file.ts
@@ -1,0 +1,325 @@
+import { copyFileSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+
+/** Plugin id used both as the npm package name and as the OpenClaw plugin id. */
+export const PLUGIN_ID = "@latitude-data/openclaw-telemetry"
+
+/**
+ * The shape OpenClaw's strict zod schema accepts for a single
+ * `plugins.entries[id]` block. We keep this minimal — only the fields we
+ * actually write — so we don't drop anything when round-tripping an entry
+ * with fields we don't know about.
+ */
+interface OpenClawPluginEntry {
+  enabled?: boolean
+  /**
+   * Strict zod object on OpenClaw 2026.4.25+: only `allowPromptInjection` and
+   * `allowConversationAccess` are accepted. We populate the latter — it's the
+   * dispatch gate the OpenClaw runtime checks before forwarding LLM/tool/agent
+   * events to non-bundled plugins. Without it, the gateway logs
+   * `[plugins] typed hook "..." blocked because non-bundled plugins must set
+   * plugins.entries.<id>.hooks.allowConversationAccess=true` and the plugin's
+   * handlers never fire.
+   */
+  hooks?: {
+    allowPromptInjection?: boolean
+    allowConversationAccess?: boolean
+    [key: string]: unknown
+  }
+  /**
+   * Free-form bucket OpenClaw passes to the plugin at activation
+   * (`api.pluginConfig`). Our credentials and feature flags live here.
+   */
+  config?: Record<string, unknown>
+  // Pass through anything else that may already be there — `subagent`, etc.
+  [key: string]: unknown
+}
+
+export interface OpenClawSettings {
+  plugins?: {
+    enabled?: boolean
+    entries?: Record<string, OpenClawPluginEntry>
+    /**
+     * Operator-managed allowlist of plugin ids that may auto-load. OpenClaw
+     * warns at every gateway start when a non-bundled plugin loads without
+     * provenance via `plugins.allow` or an install record.
+     */
+    allow?: string[]
+    load?: { paths?: string[] }
+    [key: string]: unknown
+  }
+  [key: string]: unknown
+}
+
+export interface LatitudePluginConfig {
+  apiKey: string
+  project: string
+  baseUrl?: string | undefined
+  allowConversationAccess?: boolean | undefined
+  debug?: boolean | undefined
+}
+
+export function readSettings(settingsPath: string): OpenClawSettings {
+  if (!existsSync(settingsPath)) return {}
+  try {
+    const raw = readFileSync(settingsPath, "utf-8")
+    const parsed = JSON.parse(raw) as OpenClawSettings
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Write `openclaw.json` atomically: serialize to a sibling tempfile, then
+ * rename over the target. `rename` is atomic on POSIX and effectively atomic
+ * on Windows for our case — a crash mid-serialization can no longer leave a
+ * truncated `openclaw.json` (combined with `.latitude-bak`, recovery is
+ * always possible).
+ *
+ * Earlier versions used `writeFileSync` directly; that left a corruption
+ * window where SIGTERM between `open()` and the final `write()` would leave
+ * a partial JSON file the gateway couldn't parse.
+ */
+export function writeSettings(settingsPath: string, settings: OpenClawSettings): void {
+  const tmp = `${settingsPath}.tmp.${process.pid}`
+  writeFileSync(tmp, `${JSON.stringify(settings, null, 2)}\n`, "utf-8")
+  renameSync(tmp, settingsPath)
+}
+
+export function backupSettings(settingsPath: string, backupPath: string): void {
+  if (existsSync(settingsPath)) copyFileSync(settingsPath, backupPath)
+}
+
+/**
+ * Restore the backup over the live settings file. Used when a post-write
+ * step (e.g. `openclaw config validate --json`) reports the new file is
+ * invalid — better to roll back to a known-good state than leave a broken
+ * config that'll fail at gateway-restart time.
+ */
+export function restoreBackup(settingsPath: string, backupPath: string): boolean {
+  if (!existsSync(backupPath)) return false
+  copyFileSync(backupPath, settingsPath)
+  return true
+}
+
+interface SetPluginEntryPatch {
+  /** New API key. Always overwrites — comes from the install prompt. */
+  apiKey: string
+  /** New project slug. Always overwrites — comes from the install prompt. */
+  project: string
+  /**
+   * New `baseUrl`. `undefined` clears any existing override (used when
+   * installing back to production). Anything else overwrites.
+   */
+  baseUrl: string | undefined
+  /**
+   * `true`/`false` overwrites both `config.allowConversationAccess` AND
+   * `hooks.allowConversationAccess` (always coupled — see `setPluginEntry`).
+   * `undefined` preserves the existing value, or defaults to `true` for a
+   * fresh install.
+   */
+  allowConversationAccess?: boolean | undefined
+  /**
+   * `true`/`false` overwrites; `undefined` preserves the existing value (the
+   * installer doesn't pass `debug` — it's a hand-edit affordance).
+   */
+  debug?: boolean | undefined
+  /**
+   * `true`/`false` overwrites; `undefined` preserves existing, defaulting to
+   * `true` for a fresh install. This keeps a paused plugin (`enabled: false`
+   * hand-edited in openclaw.json) paused across re-installs.
+   */
+  enabled?: boolean | undefined
+}
+
+/**
+ * Set the `plugins.entries[id]` block for our plugin.
+ *
+ * Two places in the entry get written:
+ *
+ *   - `.config` (free-form `record(string, unknown)`): credentials, baseUrl,
+ *     and our copy of `allowConversationAccess`. This is what the plugin
+ *     runtime reads via `api.pluginConfig`.
+ *   - `.hooks.allowConversationAccess`: controls whether OpenClaw's hook
+ *     dispatcher actually forwards `llm_input` / `llm_output` / tool /
+ *     `agent_end` events to our handlers. Without it set to `true` on
+ *     OpenClaw 2026.4.25+, every typed hook is blocked at the dispatcher
+ *     and the plugin's handlers never fire.
+ *
+ * The two flags mean different things — `hooks.*` is the dispatch gate,
+ * `config.*` is the payload-content gate — but for THIS plugin we always
+ * couple them: dispatch off + payload on is useless (no payloads to gate),
+ * and dispatch on + payload off is a legitimate "structural-only telemetry"
+ * mode (timing, tokens, ids, agent name; no message bodies). Always writing
+ * both from the same source keeps the operator's mental model simple.
+ *
+ * Re-install idempotency: only `apiKey` / `project` / `baseUrl` always
+ * overwrite (these come from install prompts). `enabled`, `debug`, and
+ * `allowConversationAccess` are preserved when not provided in the patch.
+ */
+export function setPluginEntry(settings: OpenClawSettings, patch: SetPluginEntryPatch): void {
+  const plugins = settings.plugins ?? {}
+  const entries = plugins.entries ?? {}
+  const existing = entries[PLUGIN_ID] ?? {}
+  const existingConfig = (existing.config ?? {}) as Record<string, unknown>
+  const existingHooks = existing.hooks ?? {}
+
+  const nextConfig: Record<string, unknown> = {
+    ...existingConfig,
+    apiKey: patch.apiKey,
+    project: patch.project,
+  }
+  if (patch.baseUrl !== undefined) {
+    nextConfig.baseUrl = patch.baseUrl
+  } else {
+    delete nextConfig.baseUrl
+  }
+  if (patch.allowConversationAccess !== undefined) {
+    nextConfig.allowConversationAccess = patch.allowConversationAccess
+  }
+  if (patch.debug !== undefined) {
+    nextConfig.debug = patch.debug
+  }
+
+  // Resolve the effective allowConversationAccess for the hooks block.
+  // We mirror whatever ended up in nextConfig.allowConversationAccess (just
+  // computed above) so the two flags always agree. If neither the patch nor
+  // the existing config sets it, fall back to the existing hooks value, then
+  // to `true` (matches the README's first-install promise).
+  const effectiveAccess =
+    typeof nextConfig.allowConversationAccess === "boolean"
+      ? nextConfig.allowConversationAccess
+      : typeof existingHooks.allowConversationAccess === "boolean"
+        ? existingHooks.allowConversationAccess
+        : true
+
+  const nextHooks: OpenClawPluginEntry["hooks"] = {
+    ...existingHooks,
+    allowConversationAccess: effectiveAccess,
+  }
+
+  // Preserve a hand-edited `enabled: false` across re-installs. Fresh install
+  // (no existing entry, no explicit patch) defaults to true.
+  const nextEnabled = patch.enabled ?? existing.enabled ?? true
+
+  entries[PLUGIN_ID] = {
+    ...existing,
+    enabled: nextEnabled,
+    hooks: nextHooks,
+    config: nextConfig,
+  }
+  plugins.entries = entries
+  settings.plugins = plugins
+}
+
+/** Remove the plugin entry entirely. Used by uninstall as defense-in-depth. */
+export function removePluginEntry(settings: OpenClawSettings): boolean {
+  const plugins = settings.plugins
+  if (!plugins?.entries) return false
+  if (!(PLUGIN_ID in plugins.entries)) return false
+  delete plugins.entries[PLUGIN_ID]
+  return true
+}
+
+/**
+ * Add the plugin id to `plugins.allow`. Idempotent — returns `true` only when
+ * the array changed. OpenClaw warns at every gateway start when a non-bundled
+ * plugin auto-loads without provenance via `plugins.allow` or an install
+ * record. We get one warning cleared by going through `openclaw plugins
+ * install` (provenance) and the other by adding ourselves to allow.
+ *
+ * Defensive against hand-edited non-array values: if `plugins.allow` is
+ * present but not an array (e.g. someone wrote a string), we replace it
+ * with a single-element array rather than spreading the bad value.
+ */
+export function addToPluginsAllow(settings: OpenClawSettings): boolean {
+  const plugins = settings.plugins ?? {}
+  const existing = plugins.allow
+  const allow = Array.isArray(existing) ? existing : []
+  if (allow.includes(PLUGIN_ID)) return false
+  plugins.allow = [...allow, PLUGIN_ID]
+  settings.plugins = plugins
+  return true
+}
+
+/**
+ * Inverse of `addToPluginsAllow`. Defense-in-depth — `openclaw plugins
+ * uninstall` already strips the entry, but the install path can be skipped
+ * (e.g. the user removed the plugin manually) and we want re-install/uninstall
+ * round-trips to be tidy regardless.
+ */
+export function removeFromPluginsAllow(settings: OpenClawSettings): boolean {
+  const allow = settings.plugins?.allow
+  if (!Array.isArray(allow) || !allow.includes(PLUGIN_ID)) return false
+  if (settings.plugins) {
+    settings.plugins.allow = allow.filter((id) => id !== PLUGIN_ID)
+  }
+  return true
+}
+
+export function hasLatitudePlugin(settings: OpenClawSettings): boolean {
+  return Boolean(settings.plugins?.entries && PLUGIN_ID in settings.plugins.entries)
+}
+
+/**
+ * Strip leftover keys from older installers that the strict zod schema
+ * rejects on current OpenClaw versions.
+ *
+ * 0.0.1 wrote `LATITUDE_*` keys directly under `settings.env`. OpenClaw's
+ * root schema is strict; the `env` block accepts only `{shellEnv, vars}`,
+ * so those keys cause the gateway to quarantine the config as
+ * `clobbered.<ts>` and roll back. We sweep them on every install.
+ *
+ * Note: 0.0.1 also wrote `hooks.allowConversationAccess` (when that key was
+ * not yet in the schema). We deliberately do NOT strip it anymore — on
+ * OpenClaw 2026.4.25+ the key IS in the schema and IS load-bearing for
+ * dispatch. `setPluginEntry` overwrites it on every install with the right
+ * value, so any 0.0.1 leftover is reconciled there.
+ */
+export function migrateLegacyEntries(settings: OpenClawSettings): { changed: boolean } {
+  let changed = false
+
+  const env = settings.env
+  if (env && typeof env === "object" && !Array.isArray(env)) {
+    const envObj = env as Record<string, unknown>
+    for (const key of ["LATITUDE_API_KEY", "LATITUDE_PROJECT", "LATITUDE_BASE_URL"]) {
+      if (key in envObj) {
+        delete envObj[key]
+        changed = true
+      }
+    }
+    // Drop the env object only if it's now empty; don't touch a real
+    // OpenClaw env block (`{shellEnv, vars}`) that already had those keys.
+    if (Object.keys(envObj).length === 0) {
+      delete settings.env
+    }
+  }
+
+  return { changed }
+}
+
+/**
+ * Read OpenClaw's plugins install record (`<configDir>/plugins/installs.json`)
+ * and return the version recorded for our plugin id, if any. Used by the
+ * install flow to render `Upgrading 0.0.6 → 0.0.7` UX.
+ *
+ * Best-effort: returns undefined on any read/parse error, on missing file,
+ * on schemas we don't recognize. Callers must handle the undefined case
+ * (typically by rendering a "fresh install" path).
+ */
+export function readInstalledRuntimeVersion(installsPath: string): string | undefined {
+  if (!existsSync(installsPath)) return undefined
+  try {
+    const raw = readFileSync(installsPath, "utf-8")
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined
+    const entries = (parsed as { entries?: Record<string, unknown> }).entries
+    if (!entries || typeof entries !== "object") return undefined
+    const ours = entries[PLUGIN_ID]
+    if (!ours || typeof ours !== "object") return undefined
+    const version = (ours as { version?: unknown }).version
+    return typeof version === "string" ? version : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/telemetry/openclaw-cli/src/setup.ts
+++ b/packages/telemetry/openclaw-cli/src/setup.ts
@@ -21,6 +21,7 @@ import {
   setPluginEntry,
   writeSettings,
 } from "./settings-file.ts"
+import { readCliVersion } from "./version.ts"
 
 /**
  * The runtime version this CLI installs. Lockstep with the runtime — bump
@@ -101,19 +102,40 @@ interface InstallFlags {
   yes?: boolean
 }
 
+/**
+ * Flags that take a value (either `--key=value` or `--key value`). Bare
+ * `--key` is reserved for booleans and shouldn't consume the next argv
+ * token as its value — operators expect `--no-content` next to `--yes`
+ * to mean two booleans, not "no-content takes the value `--yes`".
+ */
+const VALUE_FLAGS = new Set(["api-key", "project", "openclaw-dir"])
+
 export function parseFlags(argv: string[]): {
   subcommand: string | undefined
   flags: Record<string, string | boolean>
 } {
   const [subcommand, ...rest] = argv
   const flags: Record<string, string | boolean> = {}
-  for (const arg of rest) {
-    if (!arg.startsWith("--")) continue
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]
+    if (!arg || !arg.startsWith("--")) continue
     const eq = arg.indexOf("=")
     if (eq >= 0) {
       flags[arg.slice(2, eq)] = arg.slice(eq + 1)
+      continue
+    }
+    const key = arg.slice(2)
+    const next = rest[i + 1]
+    // Space-separated form (`--key value`): only consume the next token
+    // when the key is in VALUE_FLAGS and the next token isn't itself a
+    // flag. This matches the standard convention everyone expects from
+    // CLIs, while keeping bare boolean flags from accidentally swallowing
+    // adjacent flags as values.
+    if (VALUE_FLAGS.has(key) && next !== undefined && !next.startsWith("--")) {
+      flags[key] = next
+      i += 1
     } else {
-      flags[arg.slice(2)] = true
+      flags[key] = true
     }
   }
   return { subcommand, flags }
@@ -391,6 +413,17 @@ async function applyChanges({
   //    entry OpenClaw just created. Atomic write — temp + rename — combined
   //    with the .latitude-bak backup means a SIGTERM mid-write can never
   //    leave openclaw.json in a half-serialized state.
+  //
+  // Snapshot the post-`openclaw plugins install` state for rollback. The
+  // pre-install backup at `.latitude-bak` covers the typical case where
+  // openclaw.json existed before our flow, but `backupSettings` is a no-op
+  // when there's no source file to copy — that's fresh installs (no prior
+  // openclaw.json). For those, the post-install state captured here is the
+  // valid rollback target: it reflects exactly what `openclaw plugins
+  // install` produced, which is always schema-valid (a disabled
+  // plugins.entries[id] block + whatever else OpenClaw bootstrapped).
+  const postInstallSnapshot = readSettings(paths.settingsPath)
+
   const settingsSpinner = spinner()
   settingsSpinner.start("Updating openclaw.json")
   const settings = readSettings(paths.settingsPath)
@@ -428,19 +461,53 @@ async function applyChanges({
   })
   if (!validateResult.ok || isInvalidConfigPayload(validateResult.stdout)) {
     validateSpinner.stop("openclaw config validate failed")
-    const restored = restoreBackup(paths.settingsPath, paths.settingsBackupPath)
+    const rollback = rollbackSettings(paths, postInstallSnapshot)
     const detail =
       validateResult.ok === false
         ? validateResult.stderr.trim() || validateResult.stdout.trim() || `exit code ${validateResult.code}`
         : validateResult.stdout.trim() || "config validate reported invalid config"
-    throw new Error(
-      `openclaw config validate reported a problem after our changes:\n  ${detail}\n` +
-        (restored
-          ? `Backup restored from ${paths.settingsBackupPath} — your config is back to the pre-install state.`
-          : `Backup at ${paths.settingsBackupPath} could not be restored automatically; restore it manually.`),
-    )
+    throw new Error(`openclaw config validate reported a problem after our changes:\n  ${detail}\n${rollback}`)
   }
   validateSpinner.stop("Config valid")
+}
+
+/**
+ * Two-tier rollback for validation failures:
+ *
+ *   1. If `.latitude-bak` exists (typical case — operator had openclaw.json
+ *      before this flow), restore from it. That's the user's true
+ *      pre-install state.
+ *   2. If `.latitude-bak` doesn't exist (fresh install — no openclaw.json
+ *      pre-flow, so `backupSettings` no-op'd), write `postInstallSnapshot`
+ *      back. That's the state immediately after `openclaw plugins install`
+ *      and before any of our config layering — schema-valid, just a
+ *      disabled plugin entry. Operator can re-run install or run
+ *      `openclaw plugins uninstall` to fully revert OpenClaw's bookkeeping.
+ *
+ * Returns the human-readable recovery line to append to the thrown error.
+ */
+function rollbackSettings(paths: SettingsPaths, postInstallSnapshot: OpenClawSettings): string {
+  if (existsSync(paths.settingsBackupPath)) {
+    const restored = restoreBackup(paths.settingsPath, paths.settingsBackupPath)
+    return restored
+      ? `Backup restored from ${paths.settingsBackupPath} — your config is back to the pre-install state.`
+      : `Backup at ${paths.settingsBackupPath} could not be restored automatically; restore it manually.`
+  }
+  // Fresh-install path: write the post-install snapshot back. Atomic, same
+  // as the install write.
+  try {
+    writeSettings(paths.settingsPath, postInstallSnapshot)
+    return (
+      `${paths.settingsPath} rolled back to the post-\`openclaw plugins install\` state ` +
+      `(plugin entry exists but disabled). Run \`openclaw plugins uninstall ${PLUGIN_ID} --force\` ` +
+      "to fully revert if you don't intend to retry."
+    )
+  } catch (err) {
+    return (
+      `Couldn't roll back ${paths.settingsPath} (${String(err)}). ` +
+      `Run \`openclaw plugins uninstall ${PLUGIN_ID} --force\` and inspect the file manually.`
+    )
+  }
 }
 
 /** Best-effort detection of `{"valid": false, ...}` in the validate output. */
@@ -505,8 +572,7 @@ async function ensureRuntimeOnNpm(): Promise<void> {
     const res = await fetch(url, { method: "GET", signal: AbortSignal.timeout(5_000) })
     if (res.status === 404) {
       cancel(
-        `CLI ${process.env.npm_package_version ?? "(this version)"} expects ` +
-          `${RUNTIME_PACKAGE_NAME}@${RUNTIME_VERSION} but npm doesn't have that exact version. ` +
+        `CLI ${readCliVersion()} expects ${RUNTIME_PACKAGE_NAME}@${RUNTIME_VERSION} but npm doesn't have that exact version. ` +
           `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest`,
       )
       process.exit(1)
@@ -624,7 +690,18 @@ export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
   ]
   note(plan.join("\n"), "Plan")
 
-  if (!flags.noPrompt && process.stdin.isTTY === true) {
+  if (!flags.noPrompt) {
+    if (process.stdin.isTTY !== true) {
+      // Symmetric with `runFlagDrivenInstall` requiring --api-key/--project
+      // when non-TTY: there's no way for the operator to confirm a
+      // destructive uninstall in a piped/CI invocation, so we refuse rather
+      // than silently going ahead. `npx -y ...-cli uninstall` accidentally
+      // landing inside a CI script otherwise wipes the plugin without any
+      // confirming signal.
+      throw new Error(
+        "Non-interactive uninstall requires --yes / --no-prompt to confirm. Re-run with --yes to bypass the prompt explicitly.",
+      )
+    }
     const ok = await confirm({ message: "Proceed?", initialValue: true })
     if (isCancel(ok) || ok !== true) return onCancel()
   }

--- a/packages/telemetry/openclaw-cli/src/setup.ts
+++ b/packages/telemetry/openclaw-cli/src/setup.ts
@@ -1,0 +1,678 @@
+import { existsSync, mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+import { cancel, confirm, intro, isCancel, log, note, outro, password, spinner, text } from "@clack/prompts"
+import pc from "picocolors"
+import { pathsFor, type ResolvedConfigDir, resolveConfigDir, type SettingsPaths } from "./config-dir.ts"
+import { jsonDiff } from "./diff.ts"
+import { compareCalver, getOpenclawVersion, MIN_OPENCLAW_VERSION, runOpenclaw } from "./openclaw-cli.ts"
+import {
+  addToPluginsAllow,
+  backupSettings,
+  hasLatitudePlugin,
+  type LatitudePluginConfig,
+  migrateLegacyEntries,
+  type OpenClawSettings,
+  PLUGIN_ID,
+  readInstalledRuntimeVersion,
+  readSettings,
+  removeFromPluginsAllow,
+  removePluginEntry,
+  restoreBackup,
+  setPluginEntry,
+  writeSettings,
+} from "./settings-file.ts"
+
+/**
+ * The runtime version this CLI installs. Lockstep with the runtime — bump
+ * both packages in the same commit. The CLI's npm-spec install is pinned to
+ * this exact version (not a floating tag), so we never accidentally install
+ * a runtime that doesn't match the contract this CLI was built against.
+ *
+ * Pinning also satisfies OpenClaw's `Pin install specs to exact versions`
+ * supply-chain audit warning automatically.
+ */
+const RUNTIME_PACKAGE_NAME = "@latitude-data/openclaw-telemetry"
+const RUNTIME_VERSION = "0.0.7"
+
+const DOCS_URL = "https://docs.latitude.so/openclaw-telemetry"
+
+interface EnvironmentConfig {
+  name: "production" | "staging" | "dev"
+  label: string
+  app: string
+  ingest: string
+}
+
+const PRODUCTION_ENV: EnvironmentConfig = {
+  name: "production",
+  label: "production",
+  app: "https://console.latitude.so",
+  ingest: "https://ingest.latitude.so",
+}
+const STAGING_ENV: EnvironmentConfig = {
+  name: "staging",
+  label: "staging",
+  app: "https://staging.latitude.so",
+  ingest: "https://staging-ingest.latitude.so",
+}
+const DEV_ENV: EnvironmentConfig = {
+  name: "dev",
+  label: "local dev",
+  app: "http://localhost:3000",
+  ingest: "http://localhost:3002",
+}
+
+function urlsFor(env: EnvironmentConfig): {
+  apiKeys: string
+  projects: string
+  projectView: (slug: string) => string
+} {
+  return {
+    apiKeys: `${env.app}/settings/api-keys`,
+    projects: env.app,
+    projectView: (slug: string) => `${env.app}/projects/${slug}`,
+  }
+}
+
+interface InstallFlags {
+  apiKey?: string | undefined
+  project?: string | undefined
+  environment?: EnvironmentConfig | undefined
+  /**
+   * Tristate: `true` = capture (`--allow-conversation`), `false` = scrub
+   * (`--no-content`), `undefined` = preserve existing or first-install
+   * default. Tristate keeps re-install idempotent for hand-edited values.
+   */
+  allowConversationAccess?: boolean | undefined
+  /** When true, skip adding the plugin id to `plugins.allow`. */
+  noTrust?: boolean
+  /** Override for the OpenClaw config directory. */
+  openclawDir?: string | undefined
+  /** When true, render the diff and the install spec without making any changes. */
+  dryRun?: boolean
+  /**
+   * Restart-the-gateway behaviour:
+   *   - `"force"`   (--restart): always restart, even non-TTY.
+   *   - `"never"`   (--no-restart): never restart, even on TTY.
+   *   - `"auto"`    (default): prompt on TTY, skip otherwise.
+   */
+  restart?: "force" | "never" | "auto"
+  noPrompt?: boolean
+  yes?: boolean
+}
+
+export function parseFlags(argv: string[]): {
+  subcommand: string | undefined
+  flags: Record<string, string | boolean>
+} {
+  const [subcommand, ...rest] = argv
+  const flags: Record<string, string | boolean> = {}
+  for (const arg of rest) {
+    if (!arg.startsWith("--")) continue
+    const eq = arg.indexOf("=")
+    if (eq >= 0) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1)
+    } else {
+      flags[arg.slice(2)] = true
+    }
+  }
+  return { subcommand, flags }
+}
+
+export function normalizeInstallFlags(flags: Record<string, string | boolean>): InstallFlags {
+  let environment: EnvironmentConfig | undefined
+  if (flags.staging === true) environment = STAGING_ENV
+  if (flags.dev === true) {
+    if (environment) throw new Error("--staging and --dev are mutually exclusive")
+    environment = DEV_ENV
+  }
+  // Tristate: leave undefined unless the user explicitly asked one way or the
+  // other. Re-install then preserves whatever's already in openclaw.json.
+  let allowConversationAccess: boolean | undefined
+  if (flags["no-content"] === true || flags["no-conversation"] === true) allowConversationAccess = false
+  if (flags["allow-conversation"] === true) allowConversationAccess = true
+
+  let restart: "force" | "never" | "auto" = "auto"
+  if (flags["no-restart"] === true) restart = "never"
+  if (flags.restart === true) {
+    if (flags["no-restart"] === true) throw new Error("--restart and --no-restart are mutually exclusive")
+    restart = "force"
+  }
+
+  return {
+    apiKey: typeof flags["api-key"] === "string" ? flags["api-key"] : undefined,
+    project: typeof flags.project === "string" ? flags.project : undefined,
+    environment,
+    allowConversationAccess,
+    noTrust: flags["no-trust"] === true,
+    openclawDir: typeof flags["openclaw-dir"] === "string" ? flags["openclaw-dir"] : undefined,
+    dryRun: flags["dry-run"] === true,
+    restart,
+    noPrompt: flags["no-prompt"] === true || flags.yes === true,
+    yes: flags.yes === true,
+  }
+}
+
+// ─── Install ────────────────────────────────────────────────────────────────
+
+export async function runInstall(flags: InstallFlags = {}): Promise<void> {
+  const canPrompt = !flags.noPrompt && process.stdin.isTTY === true
+  if (!canPrompt) return runFlagDrivenInstall(flags)
+  await runInteractiveInstall(flags)
+}
+
+function resolvePaths(flags: InstallFlags): { resolved: ResolvedConfigDir; paths: SettingsPaths } {
+  const resolved = resolveConfigDir({ flag: flags.openclawDir })
+  return { resolved, paths: pathsFor(resolved.dir) }
+}
+
+function envForSubprocess(paths: SettingsPaths): NodeJS.ProcessEnv {
+  // Pass OPENCLAW_HOME to the subprocess so its own resolution lines up
+  // with ours. Caveat documented in config-dir.ts — at the time of writing
+  // OpenClaw's CLI doesn't advertise OPENCLAW_HOME support; the post-write
+  // `openclaw config validate --json` step catches a config-dir mismatch.
+  return { OPENCLAW_HOME: paths.configDir }
+}
+
+async function runInteractiveInstall(flags: InstallFlags): Promise<void> {
+  intro(pc.bgCyan(pc.black(" Latitude · OpenClaw telemetry ")))
+
+  // Bail before any prompts if the host OpenClaw is too old. We'd rather
+  // tell the user to upgrade than walk them through a config we can't make
+  // work on their version.
+  ensureOpenclawIsCompatible()
+
+  const { resolved, paths } = resolvePaths(flags)
+  log.info(`Using config dir: ${pc.dim(paths.configDir)} ${pc.dim(`(source: ${resolved.source})`)}`)
+
+  // Lockstep contract check. If the runtime version we're built against
+  // isn't on npm yet (half-published release), abort with a clear upgrade
+  // path before we waste any of the operator's time on prompts.
+  await ensureRuntimeOnNpm()
+
+  // Render the upgrade UX before any spawn. Reads OpenClaw's own install
+  // record so the version is what's *actually* running, not what was last
+  // hand-edited into openclaw.json.
+  const installedVersion = readInstalledRuntimeVersion(paths.installsPath)
+  if (installedVersion !== undefined) {
+    if (installedVersion === RUNTIME_VERSION) {
+      log.info(`${PLUGIN_ID} ${pc.dim(installedVersion)} already installed — re-applying (idempotent).`)
+    } else {
+      log.info(`Upgrading ${PLUGIN_ID} from ${pc.dim(installedVersion)} → ${pc.cyan(RUNTIME_VERSION)}`)
+    }
+  }
+
+  const existing = readSettings(paths.settingsPath)
+  const existingConfig =
+    (existing.plugins?.entries?.[PLUGIN_ID]?.config as LatitudePluginConfig | undefined) ?? undefined
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  const urls = urlsFor(envConfig)
+
+  const aboutLines = [
+    "Captures every OpenClaw agent run and ships it to Latitude as",
+    "OpenTelemetry traces — full system prompt, tool I/O, messages,",
+    "token usage, and agent name on every span.",
+    "",
+    `${pc.dim("Docs")}   ${pc.cyan(DOCS_URL)}`,
+  ]
+  if (envConfig.name !== "production") {
+    aboutLines.push("", pc.yellow(`Using ${envConfig.label} environment (${envConfig.ingest})`))
+  }
+  note(aboutLines.join("\n"), "About")
+
+  log.info(`Get an API key at ${pc.cyan(urls.apiKeys)}`)
+  log.info(`Create a project at ${pc.cyan(urls.projects)}`)
+
+  const apiKey = await promptApiKey(existingConfig?.apiKey, flags.apiKey)
+  const project = await promptProject(existingConfig?.project, flags.project)
+
+  await applyChanges({
+    apiKey,
+    project,
+    envConfig,
+    allowConversationAccess: flags.allowConversationAccess,
+    noTrust: flags.noTrust === true,
+    paths,
+    dryRun: flags.dryRun === true,
+  })
+
+  if (!flags.dryRun) {
+    await maybeRestartGateway(flags.restart ?? "auto", paths)
+  }
+
+  note(
+    [
+      flags.dryRun ? "Dry-run only — nothing was written." : "Plugin installed and configured.",
+      `View your traces at  ${pc.cyan(urls.projectView(project))}`,
+    ].join("\n"),
+    "Next step",
+  )
+  outro(flags.dryRun ? pc.dim("(dry-run)") : pc.green("✓ Installed"))
+}
+
+async function runFlagDrivenInstall(flags: InstallFlags): Promise<void> {
+  ensureOpenclawIsCompatible()
+  const { resolved, paths } = resolvePaths(flags)
+  process.stdout.write(`Using config dir: ${paths.configDir} (source: ${resolved.source})\n`)
+  await ensureRuntimeOnNpm()
+
+  const apiKey = flags.apiKey
+  const project = flags.project
+  if (!apiKey || !project) {
+    throw new Error("Non-interactive install requires --api-key=... and --project=... (or run in a TTY).")
+  }
+  const envConfig = flags.environment ?? PRODUCTION_ENV
+  await applyChanges({
+    apiKey,
+    project,
+    envConfig,
+    allowConversationAccess: flags.allowConversationAccess,
+    noTrust: flags.noTrust === true,
+    paths,
+    dryRun: flags.dryRun === true,
+  })
+  if (flags.dryRun) {
+    process.stdout.write("Dry-run only — nothing was written.\n")
+    return
+  }
+  await maybeRestartGateway(flags.restart ?? "auto", paths)
+  process.stdout.write(`Installed Latitude plugin in ${paths.settingsPath}\n`)
+}
+
+async function promptApiKey(_existing: string | undefined, flag: string | undefined): Promise<string> {
+  if (flag) return flag
+  const result = await password({
+    message: "Latitude API key",
+    mask: "•",
+    validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+  })
+  if (isCancel(result)) return onCancel()
+  return result
+}
+
+async function promptProject(existing: string | undefined, flag: string | undefined): Promise<string> {
+  if (flag) return flag
+  const result = await text({
+    message: "Latitude project slug",
+    placeholder: existing ?? "my-openclaw-project",
+    ...(existing ? { initialValue: existing } : {}),
+    validate: (v) => (v && v.length > 0 ? undefined : "Required"),
+  })
+  if (isCancel(result)) return onCancel()
+  return result
+}
+
+function onCancel(): never {
+  cancel("Cancelled — nothing was changed")
+  process.exit(1)
+}
+
+interface ApplyParams {
+  apiKey: string
+  project: string
+  envConfig: EnvironmentConfig
+  /** Tristate — see `InstallFlags.allowConversationAccess`. */
+  allowConversationAccess: boolean | undefined
+  noTrust: boolean
+  paths: SettingsPaths
+  dryRun: boolean
+}
+
+async function applyChanges({
+  apiKey,
+  project,
+  envConfig,
+  allowConversationAccess,
+  noTrust,
+  paths,
+  dryRun,
+}: ApplyParams): Promise<void> {
+  const installSpec = `${RUNTIME_PACKAGE_NAME}@${RUNTIME_VERSION}`
+
+  // Build the proposed post-install settings without writing them. The
+  // dry-run path uses this directly; the real path writes the same value.
+  const before = readSettings(paths.settingsPath)
+  const after = structuredClone(before) as OpenClawSettings
+  migrateLegacyEntries(after)
+  setPluginEntry(after, {
+    apiKey,
+    project,
+    baseUrl: envConfig.name === "production" ? undefined : envConfig.ingest,
+    allowConversationAccess,
+  })
+  if (!noTrust) addToPluginsAllow(after)
+
+  if (dryRun) {
+    log.info(`Would run: ${pc.dim(`openclaw plugins install ${installSpec} --force`)}`)
+    const diff = jsonDiff(before, after, { fromLabel: paths.settingsPath, toLabel: `${paths.settingsPath} (proposed)` })
+    if (diff.length > 0) {
+      process.stdout.write(`${diff}\n`)
+    } else {
+      log.info(`No openclaw.json changes — current config already matches.`)
+    }
+    return
+  }
+
+  // 1. Take the backup BEFORE openclaw plugins install touches openclaw.json
+  //    so it represents the user's true pre-install state. `openclaw plugins
+  //    install` creates plugins.entries[id], so backing up after would lose
+  //    the original "no entry" state and make recovery harder if any later
+  //    step fails.
+  ensureSettingsDir(paths)
+  backupSettings(paths.settingsPath, paths.settingsBackupPath)
+
+  // 2. Hand placement off to OpenClaw via the npm-spec form. OpenClaw fetches
+  //    the package from npm, runs its install-time security scan, copies
+  //    files into <configDir>/extensions/<encoded-id>/, writes the install
+  //    record into <configDir>/plugins/installs.json, and creates a (disabled,
+  //    configless) plugins.entries[id] in openclaw.json. We layer config +
+  //    hooks + allow on top in step 3. --force lets us overwrite an existing
+  //    install (e.g. when re-running on top of a previous version).
+  const installSpinner = spinner()
+  installSpinner.start(`Installing plugin via openclaw plugins install ${installSpec}`)
+  const installResult = runOpenclaw(["plugins", "install", installSpec, "--force"], {
+    timeoutMs: 60_000,
+    env: envForSubprocess(paths),
+  })
+  if (!installResult.ok) {
+    installSpinner.stop("openclaw plugins install failed")
+    if (installResult.reason === "enoent") {
+      throw new Error("`openclaw` not found on PATH. Install OpenClaw first (https://openclaw.ai/install) and re-run.")
+    }
+    if (installResult.reason === "timeout") {
+      throw new Error("openclaw plugins install timed out after 60s. Try running it manually to see what's stuck.")
+    }
+    const detail = installResult.stderr.trim() || installResult.stdout.trim() || `exit code ${installResult.code}`
+    throw new Error(`openclaw plugins install failed: ${detail}`)
+  }
+  installSpinner.stop("Plugin registered with OpenClaw")
+
+  // 3. Layer our config, hooks, and (optionally) plugins.allow on top of the
+  //    entry OpenClaw just created. Atomic write — temp + rename — combined
+  //    with the .latitude-bak backup means a SIGTERM mid-write can never
+  //    leave openclaw.json in a half-serialized state.
+  const settingsSpinner = spinner()
+  settingsSpinner.start("Updating openclaw.json")
+  const settings = readSettings(paths.settingsPath)
+  migrateLegacyEntries(settings)
+  setPluginEntry(settings, {
+    apiKey,
+    project,
+    baseUrl: envConfig.name === "production" ? undefined : envConfig.ingest,
+    allowConversationAccess,
+    // `debug` intentionally not passed — `setPluginEntry` preserves
+    // hand-edited values; fresh installs leave the key absent (runtime
+    // default is `false`).
+  })
+  if (!noTrust) {
+    addToPluginsAllow(settings)
+  }
+  writeSettings(paths.settingsPath, settings)
+  settingsSpinner.stop(`Updated ${paths.settingsPath}`)
+  if (existsSync(paths.settingsBackupPath)) log.info(`Backup saved at ${pc.dim(paths.settingsBackupPath)}`)
+  if (noTrust) {
+    log.warning(
+      `--no-trust set; OpenClaw will warn at every gateway start that ${PLUGIN_ID} is untrusted. Add it to plugins.allow yourself when you're ready.`,
+    )
+  }
+
+  // 4. Validate. Catches schema regressions and config-dir mismatch (where
+  //    OpenClaw didn't pick up our OPENCLAW_HOME and wrote the install
+  //    record to a different file from where we wrote the entry) before the
+  //    operator restarts the gateway and finds out the hard way.
+  const validateSpinner = spinner()
+  validateSpinner.start("Validating openclaw.json")
+  const validateResult = runOpenclaw(["config", "validate", "--json"], {
+    timeoutMs: 10_000,
+    env: envForSubprocess(paths),
+  })
+  if (!validateResult.ok || isInvalidConfigPayload(validateResult.stdout)) {
+    validateSpinner.stop("openclaw config validate failed")
+    const restored = restoreBackup(paths.settingsPath, paths.settingsBackupPath)
+    const detail =
+      validateResult.ok === false
+        ? validateResult.stderr.trim() || validateResult.stdout.trim() || `exit code ${validateResult.code}`
+        : validateResult.stdout.trim() || "config validate reported invalid config"
+    throw new Error(
+      `openclaw config validate reported a problem after our changes:\n  ${detail}\n` +
+        (restored
+          ? `Backup restored from ${paths.settingsBackupPath} — your config is back to the pre-install state.`
+          : `Backup at ${paths.settingsBackupPath} could not be restored automatically; restore it manually.`),
+    )
+  }
+  validateSpinner.stop("Config valid")
+}
+
+/** Best-effort detection of `{"valid": false, ...}` in the validate output. */
+function isInvalidConfigPayload(stdout: string): boolean {
+  const trimmed = stdout.trim()
+  if (!trimmed) return false
+  try {
+    const parsed = JSON.parse(trimmed) as { valid?: unknown }
+    return parsed.valid === false
+  } catch {
+    // Validator may print non-JSON banners — if exit code was 0, treat as valid.
+    return false
+  }
+}
+
+function ensureSettingsDir(paths: SettingsPaths): void {
+  const dir = dirname(paths.settingsPath)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+}
+
+/**
+ * Verify `openclaw` is on PATH AND its version is >= MIN_OPENCLAW_VERSION.
+ * Aborts with a clear upgrade message otherwise. Called before any user
+ * prompts so we don't waste their time collecting credentials we can't
+ * use.
+ */
+function ensureOpenclawIsCompatible(): void {
+  const v = getOpenclawVersion()
+  if (!v.ok) {
+    if (v.error === "missing") {
+      cancel("OpenClaw CLI not found on PATH. Install or update via `npm install -g openclaw@latest` and re-run.")
+      process.exit(1)
+    }
+    cancel(
+      `Couldn't parse OpenClaw version output${v.raw ? ` (got: ${pc.dim(v.raw)})` : ""}. Run \`openclaw --version\` and report the output.`,
+    )
+    process.exit(1)
+  }
+  if (compareCalver(v.version, MIN_OPENCLAW_VERSION) < 0) {
+    cancel(
+      `OpenClaw ${v.version} is older than the minimum supported version (${MIN_OPENCLAW_VERSION}). Run \`npm install -g openclaw@latest\` and re-run install.`,
+    )
+    process.exit(1)
+  }
+  log.info(`OpenClaw ${pc.dim(v.version)} (>= ${MIN_OPENCLAW_VERSION})`)
+}
+
+/**
+ * Lockstep contract check. The CLI installs a pinned `RUNTIME_VERSION`; if
+ * that version isn't published yet (half-released release pipeline), abort
+ * with a clear upgrade path so the operator's gateway doesn't end up with a
+ * runtime that doesn't match this CLI's expectations.
+ *
+ * Best-effort — uses the npm registry's HTTP API rather than spawning
+ * `npm view` so we don't require npm to be on PATH. Network failure
+ * (offline) → warn-and-continue; the install spawn would fail visibly
+ * anyway if the package wasn't there.
+ */
+async function ensureRuntimeOnNpm(): Promise<void> {
+  const url = `https://registry.npmjs.org/${encodeURIComponent(RUNTIME_PACKAGE_NAME)}/${encodeURIComponent(RUNTIME_VERSION)}`
+  try {
+    const res = await fetch(url, { method: "GET", signal: AbortSignal.timeout(5_000) })
+    if (res.status === 404) {
+      cancel(
+        `CLI ${process.env.npm_package_version ?? "(this version)"} expects ` +
+          `${RUNTIME_PACKAGE_NAME}@${RUNTIME_VERSION} but npm doesn't have that exact version. ` +
+          `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest`,
+      )
+      process.exit(1)
+    }
+    if (!res.ok) {
+      log.warning(`npm registry check returned HTTP ${res.status}; continuing.`)
+    }
+  } catch (err) {
+    // Offline / DNS / timeout — the install spawn will surface any real
+    // problem.
+    log.warning(`Couldn't reach npm registry to verify ${RUNTIME_PACKAGE_NAME}@${RUNTIME_VERSION}: ${String(err)}`)
+  }
+}
+
+/**
+ * Restart the OpenClaw gateway, prompting on TTY by default. The behaviour
+ * is governed by `flags.restart`:
+ *
+ *   - `"force"` (--restart): always restart, even non-TTY. CI escape hatch.
+ *   - `"never"` (--no-restart): never restart, even on TTY.
+ *   - `"auto"` (default): prompt on TTY ("Restart now? [Y/n]"); skip
+ *     non-TTY (and print the manual command). Hybrid that keeps interactive
+ *     UX safe while CI defaults to leaving the operator in control.
+ */
+async function maybeRestartGateway(mode: "force" | "never" | "auto", paths: SettingsPaths): Promise<void> {
+  if (mode === "never") {
+    log.info(`Skipping gateway restart (--no-restart). Run \`openclaw gateway restart\` when ready.`)
+    return
+  }
+
+  let shouldRestart: boolean
+  if (mode === "force") {
+    shouldRestart = true
+  } else {
+    // "auto": prompt on TTY, skip non-TTY.
+    if (process.stdin.isTTY !== true) {
+      log.info(`Run \`openclaw gateway restart\` to load the plugin.`)
+      return
+    }
+    const confirmed = await confirm({
+      message: "Restart the OpenClaw gateway now to load the plugin?",
+      initialValue: true,
+    })
+    if (isCancel(confirmed) || confirmed !== true) {
+      log.info(`Run \`openclaw gateway restart\` when ready.`)
+      return
+    }
+    shouldRestart = true
+  }
+
+  if (!shouldRestart) return
+
+  log.warning("Restarting gateway. In-flight runs may be interrupted.")
+  const restartSpinner = spinner()
+  restartSpinner.start("openclaw gateway restart")
+  const restartResult = runOpenclaw(["gateway", "restart"], {
+    timeoutMs: 60_000,
+    env: envForSubprocess(paths),
+  })
+  if (!restartResult.ok) {
+    restartSpinner.stop("Gateway restart failed")
+    const detail = restartResult.stderr.trim() || restartResult.stdout.trim() || `exit code ${restartResult.code}`
+    log.warning(`openclaw gateway restart failed: ${detail}. Restart it yourself when ready.`)
+    return
+  }
+  restartSpinner.stop("Gateway restarted")
+}
+
+// ─── Uninstall ──────────────────────────────────────────────────────────────
+
+interface UninstallFlags {
+  noPrompt?: boolean
+  openclawDir?: string | undefined
+  restart?: "force" | "never" | "auto"
+}
+
+export function normalizeUninstallFlags(flags: Record<string, string | boolean>): UninstallFlags {
+  let restart: "force" | "never" | "auto" = "auto"
+  if (flags["no-restart"] === true) restart = "never"
+  if (flags.restart === true) {
+    if (flags["no-restart"] === true) throw new Error("--restart and --no-restart are mutually exclusive")
+    restart = "force"
+  }
+  return {
+    noPrompt: flags["no-prompt"] === true || flags.yes === true,
+    openclawDir: typeof flags["openclaw-dir"] === "string" ? flags["openclaw-dir"] : undefined,
+    restart,
+  }
+}
+
+export async function runUninstall(flags: UninstallFlags = {}): Promise<void> {
+  intro(pc.bgYellow(pc.black(" Latitude · OpenClaw telemetry — uninstall ")))
+
+  const resolved = resolveConfigDir({ flag: flags.openclawDir })
+  const paths = pathsFor(resolved.dir)
+  log.info(`Using config dir: ${pc.dim(paths.configDir)} ${pc.dim(`(source: ${resolved.source})`)}`)
+
+  const settings = readSettings(paths.settingsPath)
+  const hasEntry = hasLatitudePlugin(settings)
+
+  // Without an entry, there's nothing for `openclaw plugins uninstall` to
+  // remove either — short-circuit cleanly. If the user wants to uninstall
+  // even when our entry is gone (e.g. we crashed mid-install), they can
+  // run `openclaw plugins uninstall` themselves.
+  if (!hasEntry) {
+    note("No Latitude plugin entry found — nothing to remove.", "Status")
+    outro(pc.dim("Nothing changed"))
+    return
+  }
+
+  const plan = [
+    `Run \`openclaw plugins uninstall ${PLUGIN_ID} --force\` (removes files, install record, and plugin entry)`,
+    `Sweep any leftover LATITUDE_* keys from settings.env`,
+    `Backup of openclaw.json saved at ${paths.settingsBackupPath}`,
+  ]
+  note(plan.join("\n"), "Plan")
+
+  if (!flags.noPrompt && process.stdin.isTTY === true) {
+    const ok = await confirm({ message: "Proceed?", initialValue: true })
+    if (isCancel(ok) || ok !== true) return onCancel()
+  }
+
+  // 1. Take the backup BEFORE openclaw plugins uninstall touches
+  //    openclaw.json so it represents the user's true pre-uninstall state
+  //    (entry + config + plugins.allow). Backing up after would capture
+  //    the already-stripped state, defeating the point of the backup.
+  backupSettings(paths.settingsPath, paths.settingsBackupPath)
+
+  // 2. Hand uninstall to OpenClaw. It removes files, the install record,
+  //    plugins.entries[id], plugins.allow, plugins.deny, plugins.load.paths
+  //    — see src/plugins/uninstall.ts.
+  const s = spinner()
+  s.start("Reverting via openclaw plugins uninstall")
+  const uninstallResult = runOpenclaw(["plugins", "uninstall", PLUGIN_ID, "--force"], {
+    timeoutMs: 60_000,
+    env: envForSubprocess(paths),
+  })
+  if (!uninstallResult.ok) {
+    s.stop("openclaw plugins uninstall failed")
+    if (uninstallResult.reason === "enoent") {
+      log.warning(
+        "`openclaw` not found on PATH. Falling back to local cleanup — files at <configDir>/extensions/ may remain.",
+      )
+    } else {
+      const detail =
+        uninstallResult.stderr.trim() || uninstallResult.stdout.trim() || `exit code ${uninstallResult.code}`
+      log.warning(`openclaw plugins uninstall reported: ${detail}. Continuing with local cleanup.`)
+    }
+  } else {
+    s.stop("Plugin removed by OpenClaw")
+  }
+
+  // 3. Defensive cleanup — `openclaw plugins uninstall` already strips the
+  //    entry and plugins.allow on success, but if it failed above (enoent
+  //    / non-zero) we still want our state out of openclaw.json. These
+  //    are all idempotent.
+  const cleanupSpinner = spinner()
+  cleanupSpinner.start("Reverting openclaw.json")
+  const post = readSettings(paths.settingsPath)
+  removePluginEntry(post)
+  removeFromPluginsAllow(post)
+  migrateLegacyEntries(post)
+  writeSettings(paths.settingsPath, post)
+  cleanupSpinner.stop("Done")
+
+  await maybeRestartGateway(flags.restart ?? "auto", paths)
+
+  outro(pc.green("✓ Uninstalled"))
+}

--- a/packages/telemetry/openclaw-cli/src/version.ts
+++ b/packages/telemetry/openclaw-cli/src/version.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/**
+ * Read this CLI's own version from its `package.json`. Used by:
+ *   - `cli.ts` for `--version`
+ *   - `setup.ts` in the npm-registry-404 abort message, so the upgrade
+ *     instruction shows the version the user is actually running. Earlier
+ *     versions read `process.env.npm_package_version`, but that env var
+ *     is only set by `npm run` — not by `npx`, not by globally-installed
+ *     bins. The vast majority of `latitude-openclaw` invocations come
+ *     through one of those, so the env-var approach printed
+ *     `(this version)` instead of the real version every time.
+ */
+export function readCliVersion(): string {
+  // dist/cli.js → ../package.json (after bundling); src/version.ts →
+  // ../package.json under vitest's source-mode runner. Both shapes have
+  // the package.json one directory up from the entry file.
+  const here = dirname(fileURLToPath(import.meta.url))
+  const pkgPath = join(here, "..", "package.json")
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string }
+    return pkg.version ?? "unknown"
+  } catch {
+    return "unknown"
+  }
+}

--- a/packages/telemetry/openclaw-cli/tsconfig.json
+++ b/packages/telemetry/openclaw-cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "incremental": false,
+    "composite": false
+  }
+}

--- a/packages/telemetry/openclaw-cli/tsdown.config.ts
+++ b/packages/telemetry/openclaw-cli/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown"
+
+// CLI entry only — this package never gets loaded as an OpenClaw plugin
+// (no `openclaw` extensions field in package.json), so there's no scope
+// version to bake. The runtime package handles its own SCOPE_VERSION.
+export default defineConfig({
+  entry: ["src/cli.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "node20",
+  fixedExtension: false,
+})

--- a/packages/telemetry/openclaw/README.md
+++ b/packages/telemetry/openclaw/README.md
@@ -1,30 +1,41 @@
 # @latitude-data/openclaw-telemetry
 
-OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) as OTLP traces. Full fidelity — exact system prompt, message history, assistant output, token usage, tool I/O, and the running agent's name on every span.
+OpenClaw plugin that streams every agent run to [Latitude](https://latitude.so) as OTLP traces — full system prompt, message history, assistant output, token usage, tool I/O, and the running agent's name on every span.
+
+## Requirements
+
+- **OpenClaw 2026.4.25 or newer** on PATH.
+- A **Latitude API key** and **project slug** — both from [console.latitude.so/settings/api-keys](https://console.latitude.so/settings/api-keys).
 
 ## Install
 
-Requires OpenClaw **2026.4.25 or newer**. Get a Latitude API key + project slug from `https://console.latitude.so/settings/api-keys` first.
+### Recommended — one-shot CLI
 
-> **One-shot installer coming soon.** A separate `@latitude-data/openclaw-telemetry-cli` package is in flight that will collapse the steps below into `npx -y @latitude-data/openclaw-telemetry-cli install`. For now, the manual flow below is the supported path.
+The companion CLI handles every step (install, config, validate, restart) in one command:
 
-### Step 1 — Install the plugin runtime
+```bash
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install
+```
+
+It prompts for your API key and project slug, runs `openclaw plugins install` for you, writes the plugin entry into `openclaw.json`, adds the plugin to `plugins.allow`, validates the result, and (on TTY) offers to restart the gateway. See the [CLI README](https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/openclaw-cli#readme) for the full flag matrix, dry-run mode, custom config dir, and CI usage.
+
+### Manual install
+
+If you'd rather not use the CLI, do exactly what it does, in four steps:
+
+#### 1. Install the runtime
 
 ```bash
 openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7
 ```
 
-Pin to an exact version. OpenClaw 2026.4.26's `openclaw security audit --deep` warns about unpinned install specs (`Pin install specs to exact versions … for higher supply-chain stability`), so always include the `@<version>` suffix when installing or upgrading.
+Pin to an exact version. OpenClaw's `security audit --deep` warns about unpinned install specs, so always include the `@<version>` suffix.
 
-OpenClaw fetches the package from npm, runs its security scan, copies files into `~/.openclaw/extensions/<id>/`, and creates a (disabled) `plugins.entries["@latitude-data/openclaw-telemetry"]` entry in `~/.openclaw/openclaw.json`. The gateway will print:
+OpenClaw fetches from npm, runs its security scan, copies files into `~/.openclaw/extensions/<id>/`, and creates a (disabled) `plugins.entries["@latitude-data/openclaw-telemetry"]` entry in `~/.openclaw/openclaw.json`.
 
-> Plugin installed but disabled. Configure it, then run `openclaw plugins enable @latitude-data/openclaw-telemetry`.
+#### 2. Configure and enable
 
-That's expected — the next step does the configure-and-enable.
-
-### Step 2 — Configure and enable
-
-Run these `openclaw config set` commands (use bracket notation so the scoped package name parses correctly). Substitute your real API key and project slug in the first two:
+Run these `openclaw config set` commands (use bracket notation so the scoped package name parses correctly). Substitute your real API key and project slug:
 
 ```bash
 openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.apiKey' "lat_xxx"
@@ -34,19 +45,19 @@ openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].hooks.
 openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].enabled' true
 ```
 
-Why two `allowConversationAccess` writes? They mean different things — `hooks.*` is OpenClaw's dispatch gate (without it the plugin's hook handlers never fire), `config.*` is the plugin's payload-content gate (without it the plugin emits structural-only spans). For full content capture they must both be `true`. See [The two flags](#the-two-flags) for details.
+Both `allowConversationAccess` writes are required — see [The two flags](#the-two-flags).
 
-### Step 3 — Add to `plugins.allow` (optional but loud)
+#### 3. Add to `plugins.allow` (optional but recommended)
 
-OpenClaw warns at every gateway restart about non-bundled plugins that auto-load without provenance via `plugins.allow`. Silence the warning by adding the id:
+OpenClaw warns at every gateway restart about non-bundled plugins that auto-load without provenance via `plugins.allow`. Silence the warning:
 
 ```bash
-# `config set` can't append to arrays — set the whole list. If you already have
-# entries in `plugins.allow`, include them here too:
+# `config set` can't append to arrays — set the whole list. Include any other
+# plugins you already have in `plugins.allow`.
 openclaw config set 'plugins.allow' '["@latitude-data/openclaw-telemetry"]'
 ```
 
-### Step 4 — Restart the gateway
+#### 4. Restart the gateway
 
 ```bash
 openclaw gateway restart
@@ -63,11 +74,11 @@ grep -E "blocked|plugin not found|latitude" /tmp/openclaw/openclaw-*.log | tail
 # → no "blocked", no "plugin not found"
 ```
 
-Send a message to one of your OpenClaw agents — within a few seconds, traces appear at `https://console.latitude.so/projects/<your-slug>`.
+Send a message to one of your OpenClaw agents — within seconds, traces appear at `https://console.latitude.so/projects/<your-slug>`.
 
-### Alternative: hand-edit `~/.openclaw/openclaw.json`
+#### Or: hand-edit `~/.openclaw/openclaw.json`
 
-If you'd rather paste a JSON block than run six commands, the equivalent edit is:
+Equivalent to steps 2 + 3 in one paste:
 
 ```jsonc
 {
@@ -90,42 +101,53 @@ If you'd rather paste a JSON block than run six commands, the equivalent edit is
 }
 ```
 
-Merge this with whatever else is in `openclaw.json`. Then `openclaw config validate` and `openclaw gateway restart` as above.
+Merge with whatever else is in `openclaw.json`. Then run `openclaw config validate` and `openclaw gateway restart`.
 
-### Targeting a different environment
+## Uninstall
 
-For staging or local-dev, also set `baseUrl`:
+If you installed via the CLI:
 
 ```bash
-# Staging:
-openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.baseUrl' "https://staging-ingest.latitude.so"
-
-# Local dev:
-openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.baseUrl' "http://localhost:3002"
+npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall
 ```
 
-### Structural-only telemetry (no content capture)
+Manual uninstall:
 
-If you want trace metadata (timings, token usage, model name, agent name, ids) without the prompt/response content, keep `hooks.allowConversationAccess` at `true` (so OpenClaw still dispatches events to us) and set only `config.allowConversationAccess` to `false`:
+```bash
+openclaw plugins uninstall @latitude-data/openclaw-telemetry --force
+openclaw gateway restart
+```
+
+OpenClaw removes the extension files, install record, plugin entry, and the `plugins.allow` entry.
+
+## Targeting staging or local dev
+
+By default the plugin sends to production (`https://ingest.latitude.so`). Override `baseUrl` to point elsewhere:
+
+```bash
+# Staging
+openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.baseUrl' \
+  "https://staging-ingest.latitude.so"
+
+# Local dev
+openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.baseUrl' \
+  "http://localhost:3002"
+```
+
+The CLI handles this with `--staging` / `--dev` flags.
+
+## Structural-only telemetry (no content capture)
+
+To get trace metadata (timings, token usage, model name, agent name, ids) without prompt/response content, keep `hooks.allowConversationAccess` at `true` so events still dispatch, and set only `config.allowConversationAccess` to `false`:
 
 ```bash
 openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].config.allowConversationAccess' false
 openclaw config set 'plugins.entries["@latitude-data/openclaw-telemetry"].hooks.allowConversationAccess' true
 ```
 
-Setting `hooks.allowConversationAccess=false` would block dispatch entirely — see [The two flags](#the-two-flags). The plugin still emits the full span tree; just the content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, tool args/results) are scrubbed. Each span carries a `latitude.captured.content: false` boolean so the gate state is visible in the Latitude UI.
+Setting `hooks.allowConversationAccess=false` would block dispatch entirely — see [The two flags](#the-two-flags). With this config the plugin still emits the full span tree, just with content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, tool args/results) scrubbed. Each span carries `latitude.captured.content: false` so the gate state is visible in the Latitude UI.
 
-## Uninstall
-
-```bash
-openclaw plugins uninstall @latitude-data/openclaw-telemetry --force
-```
-
-OpenClaw removes the files, install record, plugin entry, and the `plugins.allow` entry. After that, restart the gateway:
-
-```bash
-openclaw gateway restart
-```
+The CLI handles this with `--no-content`.
 
 ## What gets sent
 
@@ -147,15 +169,13 @@ agent (root, traceId = hash(runId))
 
 Five span kinds:
 
-- **`agent`** — root of the run. Carries `openclaw.session.key`, `openclaw.agent.id`, `openclaw.agent.name`, aggregated token usage across all generations, run duration, success/error status, the first user prompt, and the full final message list. This is where attempt-aggregate `gen_ai.*` lands.
-- **`model_call`** — one per actual provider API call inside the run. Carries provider, request/response model, `openclaw.api`, `openclaw.transport`, per-call duration, outcome, error category, time-to-first-byte, request payload bytes, response stream bytes, upstream request id hash, and `gen_ai.input.messages` snapshotted at the moment that generation started. Per-call output messages and per-call token usage aren't surfaced by OpenClaw today (attempt-aggregate only); those stay on `agent`.
+- **`agent`** — root of the run. Carries `openclaw.session.key`, `openclaw.agent.id`, `openclaw.agent.name`, aggregated token usage across all generations, run duration, success/error status, the first user prompt, and the full final message list. Attempt-aggregate `gen_ai.*` lands here.
+- **`model_call`** — one per provider API call inside the run. Carries provider, request/response model, `openclaw.api`, `openclaw.transport`, per-call duration, outcome, error category, time-to-first-byte, request payload bytes, response stream bytes, upstream request id hash, and `gen_ai.input.messages` snapshotted at the moment that generation started. Per-call output messages and per-call token usage aren't surfaced by OpenClaw today (attempt-aggregate only); those stay on `agent`.
 - **`tool_call:<name>`** — one per tool invocation. Canonical `gen_ai.tool.*` attributes: `name`, `call.id`, `call.arguments`, `call.result`. Sibling of `agent`, NOT child of `model_call` — tools run between generations, not during them.
 - **`compaction`** — rare; fires when OpenClaw hits the message budget mid-run. Records before/after message counts and the compacted-out count.
 - **`subagent`** — one per child run spawned by this agent. The child's entire `agent` subtree (its own `model_call`s, `tool_call`s, even further-nested `subagent`s) parents itself underneath via cross-runId trace propagation, so a spawn tree is one waterfall in one trace.
 
-Every span carries `openclaw.agent.id` and `openclaw.agent.name`. Multi-agent setups produce spans tagged with the invoking agent's id, letting you filter and group by agent in the Latitude UI.
-
-All spans share the same `traceId` so they group as one trace per agent run (and one trace per spawn tree, by virtue of the subagent linkage).
+Every span carries `openclaw.agent.id` and `openclaw.agent.name` — multi-agent setups produce spans tagged with the invoking agent's id, letting you filter and group by agent in the Latitude UI. All spans share the same `traceId`, so they group as one trace per agent run (and one trace per spawn tree, by virtue of the subagent linkage).
 
 ### Backend caveat: Codex / Claude-Code-style providers
 
@@ -175,13 +195,13 @@ We subscribe to OpenClaw's typed plugin hooks (`src/plugins/hook-types.ts` upstr
 
 Two more hooks (`llm_input`, `llm_output`) are subscribed to for **content only** — they don't open or close spans, they just enrich the `agent` span with attempt-aggregate data and seed the rolling history snapshot used by per-call `model_call.gen_ai.input.messages`.
 
-The hook system runs handlers fire-and-forget (see [`src/plugins/hooks.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/hooks.ts) upstream), so nothing we do here can slow the agent loop. The one exception is `before_tool_call`, which is a `runModifyingHook` — our handler returns `undefined` so OpenClaw dispatches the tool normally. Returning anything else (e.g. `{block: true}`) would block every tool call.
+The hook system runs handlers fire-and-forget, so nothing we do here can slow the agent loop. The one exception is `before_tool_call`, which is a `runModifyingHook` — our handler returns `undefined` so OpenClaw dispatches the tool normally. Returning anything else (e.g. `{block: true}`) would block every tool call.
 
-**No runtime wrapping.** Unlike third-party OpenClaw observability plugins that try to monkey-patch `@mariozechner/pi-ai` (and run into jiti's CJS/ESM module isolation), we stay inside the supported plugin API. The hooks give us everything, at lower risk of breaking on OpenClaw updates.
+**No runtime wrapping.** We stay inside the supported plugin API rather than monkey-patching `@mariozechner/pi-ai`. The hooks give us everything, at lower risk of breaking on OpenClaw updates.
 
 ## Configuration reference
 
-The installer writes two blocks to `plugins.entries["@latitude-data/openclaw-telemetry"]`:
+Two blocks live under `plugins.entries["@latitude-data/openclaw-telemetry"]`:
 
 ### `.config` — read by the plugin's runtime
 
@@ -189,8 +209,8 @@ The installer writes two blocks to `plugins.entries["@latitude-data/openclaw-tel
 | --- | --- | --- | --- |
 | `apiKey` | yes | — | Bearer token for Latitude ingestion. |
 | `project` | yes | — | Slug of the project to route traces into. |
-| `baseUrl` | no | `https://ingest.latitude.so` | Override OTLP ingest origin. Installer sets this only when you pass `--staging` or `--dev`. |
-| `allowConversationAccess` | no | `false` | When `true`, attach raw prompts, assistant responses, system instructions, and tool I/O to spans. When `false`, emit only timing, token usage, model name, agent id, and structural ids — same span tree, scrubbed payloads. **Must match `hooks.allowConversationAccess` below — see "the two flags".** |
+| `baseUrl` | no | `https://ingest.latitude.so` | Override OTLP ingest origin. The CLI sets this only when `--staging` or `--dev` is passed. |
+| `allowConversationAccess` | no | `false` | When `true`, attach raw prompts, assistant responses, system instructions, and tool I/O to spans. When `false`, emit only timing, token usage, model name, agent id, and structural ids — same span tree, scrubbed payloads. **Must match `hooks.allowConversationAccess` below — see [The two flags](#the-two-flags).** |
 | `enabled` | no | `true` | Set to `false` to pause emission without uninstalling. |
 | `debug` | no | `false` | Log diagnostic lines to stderr (visible in the gateway log). |
 
@@ -207,66 +227,31 @@ The installer writes two blocks to `plugins.entries["@latitude-data/openclaw-tel
 - **`hooks.*`** is the **dispatch gate**. `false` → OpenClaw never forwards events to us. No traces.
 - **`config.*`** is the **payload-content gate**. `false` → we emit spans normally but scrub message content from them. Structural-only telemetry.
 
-For *this* plugin, we always couple them — the installer writes both from the same source. If you hand-edit, set them to the same value:
+For *this* plugin we always couple them — the CLI writes both from the same source. If you hand-edit:
 
 - **Both `true`**: full content capture (the default).
-- **Both `false`**: structural-only telemetry (set via `--no-content`).
-- Anything else is incoherent: `hooks: false + config: true` means dispatch is off and content gating is moot; `hooks: true + config: false` works but is what you'd get with both `false` plus extra ceremony.
+- `hooks: true` + `config: false`: structural-only telemetry (set via `--no-content`).
+- `hooks: false` + anything: no traces. Don't.
 
-### Environment variable fallbacks
+### Environment-variable fallbacks
 
-If a `config.*` key isn't set, the runtime falls back to env vars on the gateway process: `LATITUDE_API_KEY`, `LATITUDE_PROJECT`, `LATITUDE_BASE_URL`, `LATITUDE_DEBUG`, `LATITUDE_OPENCLAW_ENABLED`. The installer doesn't set them — pluginConfig is the canonical surface — but they're useful for flipping `debug` without editing `openclaw.json`.
-
-### Manual installation
-
-If you can't run the installer, do exactly what it does:
-
-1. **Hand placement to OpenClaw** with `openclaw plugins install <path-to-extracted-package> --force`. This is what populates `~/.openclaw/extensions/`, writes the install record, and creates the (initially empty) `plugins.entries[id]` block. Don't hand-place files into the extensions directory — the persisted plugin index won't see them.
-2. **Add the config + hooks block** to `~/.openclaw/openclaw.json`:
-
-```jsonc
-{
-  "plugins": {
-    "allow": ["@latitude-data/openclaw-telemetry"],
-    "entries": {
-      "@latitude-data/openclaw-telemetry": {
-        "enabled": true,
-        "hooks": {
-          "allowConversationAccess": true
-        },
-        "config": {
-          "apiKey": "lat_xxx",
-          "project": "my-openclaw-project",
-          "allowConversationAccess": true
-        }
-      }
-    }
-  }
-}
-```
-
-Run `openclaw config validate` — should print `valid: true`. Then `openclaw gateway restart`.
+If a `config.*` key isn't set, the runtime falls back to env vars on the gateway process: `LATITUDE_API_KEY`, `LATITUDE_PROJECT`, `LATITUDE_BASE_URL`, `LATITUDE_DEBUG`, `LATITUDE_OPENCLAW_ENABLED`. Useful for flipping `debug` without editing `openclaw.json`.
 
 ## Privacy
 
-There are two defaults at play — keep them straight:
+The CLI's first-install default writes `allowConversationAccess: true` to both blocks → full content capture. Pass `--no-content` for structural-only telemetry.
 
-- **Installer default**: when you run `npx -y @latitude-data/openclaw-telemetry install` without `--no-content`, the installer writes `allowConversationAccess: true` to both the `hooks` and `config` blocks. **You get full content capture** — prompts, assistant responses, system instructions, tool I/O — shipped to Latitude alongside structural telemetry.
-- **Runtime default for absent keys**: if you hand-write `openclaw.json` and leave `allowConversationAccess` out entirely, `config.allowConversationAccess` falls back to `false` at the plugin's runtime (privacy-preserving) and `hooks.allowConversationAccess` falls back to OpenClaw's default (also `false`, which means dispatch is blocked and you get nothing). **Manual installs without those keys produce no traces, not "structural-only traces".**
+For hand-edited configs, leaving `allowConversationAccess` out entirely produces **no traces** (not "structural-only traces") because `hooks.allowConversationAccess` defaults to `false` at OpenClaw's level and dispatch is blocked. Always set both keys explicitly.
 
-The installer always writes both keys to the same value, so the installer-driven path is unambiguous. The runtime-default trap only matters for hand-rolled configs.
-
-When you pass `--no-content` (or hand-edit both flags to `false`), we emit the same span tree but scrub the content attributes (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool.call.arguments`/`result`, the interaction's `user_prompt`). Timings, token usage, model name, agent name, ids, and the `latitude.captured.content: false` boolean still flow.
-
-To pause emission entirely without uninstalling, set `LATITUDE_OPENCLAW_ENABLED=0` in the gateway environment, or set `enabled: false` on the plugin entry in `openclaw.json`.
+To pause emission without uninstalling, set `enabled: false` on the plugin entry, or `LATITUDE_OPENCLAW_ENABLED=0` in the gateway environment.
 
 ## Supported OpenClaw versions
 
-Requires OpenClaw **2026.4.25 or newer**. The installer detects the version up-front via `openclaw --version` and aborts with an upgrade message on older versions — supporting the full range with portability shims would mean shipping known-broken behaviour (≤ 2026.4.21 reject `hooks.allowConversationAccess` outright; 2026.4.22 – 2026.4.24 have unverified dispatch gating). Run `npm install -g openclaw@latest` to upgrade.
+Requires **2026.4.25 or newer**. Earlier versions either reject `hooks.allowConversationAccess` outright (≤ 2026.4.21) or have unverified dispatch gating (2026.4.22 – 2026.4.24). The CLI's version check aborts on older versions; manual installs run into validation errors. Run `npm install -g openclaw@latest` to upgrade.
 
 ## How it fails
 
-Fail-open by design. If the API is unreachable, your key is wrong, or a hook payload is malformed, the plugin logs to stderr (when `LATITUDE_DEBUG=1`) and the agent run continues unaffected.
+Fail-open by design. If the API is unreachable, your key is wrong, or a hook payload is malformed, the plugin logs to stderr (when `debug: true`) and the agent run continues unaffected.
 
 ## License
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,7 +257,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -1891,6 +1891,34 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/telemetry/openclaw-cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.4.6
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.14.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260421.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/typescript:
     dependencies:
@@ -16027,6 +16055,14 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -17336,6 +17372,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -21005,6 +21049,30 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -21930,6 +21998,25 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.14.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -21955,6 +22042,35 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.14.1
+      jsdom: 29.0.2(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

Brings back the `npx -y @latitude-data/openclaw-telemetry-cli install` one-shot UX that PR #2920 removed when it deleted the bundled CLI from the runtime package. Living in a **separate** npm package means this CLI is installed via `npx` / `npm install -g` rather than `openclaw plugins install` — so it never goes through OpenClaw's install-time security scanner. The runtime side stays clean (no `child_process`, no `node:fs` runtime reads); the operator side stays a one-shot.

The CLI carries the deleted CLI's core forward (cli.ts, setup.ts, settings-file.ts, openclaw-cli.ts + tests) and adds the new behaviour from the planning conversation:

- **Configurable config dir.** `--openclaw-dir <path>` > `OPENCLAW_HOME` env > `./openclaw.json` in cwd > `~/.openclaw` default. Passed through as `OPENCLAW_HOME` to every spawned `openclaw` subprocess; the post-write `openclaw config validate --json` step catches the case where OpenClaw doesn't honor the env var (restores backup + aborts loudly with both paths in the error rather than silently writing to two places).
- **npm-spec install.** `applyChanges` spawns `openclaw plugins install @latitude-data/openclaw-telemetry@0.0.7 --force` (pinned, lockstep with the runtime) instead of installing from a local package root. Pinning also satisfies OpenClaw's `Pin install specs to exact versions` supply-chain audit warning automatically.
- **Atomic settings writes.** `writeSettings` goes through `<file>.tmp.<pid>` + `renameSync`. Combined with the `.latitude-bak` backup, mid-write crashes can no longer corrupt `openclaw.json`.
- **Post-write `openclaw config validate --json`.** Catches schema regressions and config-dir mismatch *immediately* — before the operator restarts the gateway and finds out the hard way. Restores the backup and aborts with the validator's message on failure.
- **Upgrade-detection UX.** Reads `<configDir>/plugins/installs.json` to render `Upgrading 0.0.6 → 0.0.7` (or `Re-applying 0.0.7 (idempotent)`) before any subprocess spawn.
- **`--dry-run`.** Resolves config dir, prints the exact `openclaw plugins install` command, prints a unified-ish JSON diff between the current `openclaw.json` and the proposed result. Zero subprocess calls, zero writes.
- **Gateway restart prompt.** Default: prompt on TTY (`Restart the OpenClaw gateway now to load the plugin? [Y/n]`), skip non-TTY with manual instructions. `--restart` always restarts (CI escape hatch), `--no-restart` always skips (always wins).
- **Lockstep version refusal.** CLI hardcodes `RUNTIME_VERSION = "0.0.7"` and queries the npm registry to verify that exact runtime version exists before installing. Aborts with `Upgrade the CLI: npm install -g @latitude-data/openclaw-telemetry-cli@latest` on 404. Network failure → warn and continue (the install spawn would fail visibly anyway).

A standalone publish workflow at `.github/workflows/publish-openclaw-telemetry-cli.yml` mirrors `publish-claude-code-telemetry.yml`: path filter on `packages/telemetry/openclaw-cli/**`, npm version-bump check, GitHub release with extracted CHANGELOG section, reuses the existing `NPM_TOKEN` secret.

## Lockstep policy

CLI 0.0.7 installs runtime 0.0.7 (PR #2925). Bumping the runtime requires bumping `RUNTIME_VERSION` in `src/setup.ts` and re-publishing both packages in the same release. The README documents this. The npm-registry pre-flight check enforces it at install time (the CLI refuses to install a runtime version that's not on npm).

## Test plan

- [x] `pnpm --filter @latitude-data/openclaw-telemetry-cli typecheck` — passes
- [x] `pnpm --filter @latitude-data/openclaw-telemetry-cli test` — 68 passed (carryover settings-file 13 + openclaw-cli 6 + new config-dir 7 + diff 5 + cli flag-parsing 11 + settings-file FS-touching 11 + installs.json reader 5)
- [x] `pnpm --filter @latitude-data/openclaw-telemetry-cli check` — biome clean
- [x] `pnpm --filter @latitude-data/openclaw-telemetry-cli build` — produces `dist/cli.js` with shebang + exec bit + `RUNTIME_VERSION = "0.0.7"` baked
- [ ] **After publish, fresh install:** `npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install` → prompts for apiKey + project, spawns the npm-spec install, writes `plugins.entries[id]`, adds to `plugins.allow`, runs validate, prompts to restart gateway. Expected: traces flow within seconds of the restart.
- [ ] **Re-install (upgrade UX):** running on top of an existing 0.0.7 → `Re-applying 0.0.7 (idempotent)`. Existing hand-edited `debug: true` preserved.
- [ ] **CI install:** `npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --api-key=lat_xxx --project=my-project --yes --no-restart` → zero prompts, exits 0, gateway not restarted.
- [ ] **Dry-run:** `--dry-run --api-key=k --project=p` → prints resolved dir + install spec + JSON diff, exits 0, `openclaw.json` unchanged.
- [ ] **Custom config dir:** `OPENCLAW_HOME=/tmp/test npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 install --yes --api-key=k --project=p` → writes to `/tmp/test/openclaw.json`; on validate failure (OpenClaw didn't honor the env), restores backup and prints both paths in the error.
- [ ] **Uninstall:** `npx -y @latitude-data/openclaw-telemetry-cli@0.0.7 uninstall --yes` → spawns `openclaw plugins uninstall ... --force`, removes entry, removes from `plugins.allow`, sweeps legacy env keys, gateway-restart prompt per `--yes`/`--no-restart`.
- [ ] **Audit clean:** `openclaw security audit --deep` → zero warnings about `@latitude-data/openclaw-telemetry-cli` (was never `openclaw plugins install`'d).