### PR TITLE
fix(models): alias openai-codex to openai for pricing lookup

### DIFF
--- a/packages/domain/models/src/browser.ts
+++ b/packages/domain/models/src/browser.ts
@@ -31,3 +31,4 @@ export {
   modelPricingSchema,
   modelSchema,
 } from "./entities/model.ts"
+export { PROVIDER_ALIASES, resolveProviderName } from "./provider-aliases.ts"

--- a/packages/domain/models/src/index.ts
+++ b/packages/domain/models/src/index.ts
@@ -33,6 +33,7 @@ export {
   parseModelsDevData,
 } from "./entities/model.ts"
 
+export { PROVIDER_ALIASES, resolveProviderName } from "./provider-aliases.ts"
 export {
   costBreakdownKey,
   estimateCost,

--- a/packages/domain/models/src/provider-aliases.ts
+++ b/packages/domain/models/src/provider-aliases.ts
@@ -1,0 +1,30 @@
+/**
+ * Provider name resolution shared by the model registry (pricing lookups)
+ * and consumers that need the canonical models.dev provider id (e.g.
+ * picking a provider icon in the UI).
+ *
+ * Browser-safe: this module has no runtime dependencies and does not
+ * import the bundled models.dev JSON.
+ */
+
+/**
+ * Maps well-known provider identifiers to their models.dev equivalents.
+ *
+ * Providers whose internal names differ from the models.dev convention
+ * are mapped here. Unknown providers pass through unchanged.
+ */
+export const PROVIDER_ALIASES: Record<string, string> = {
+  amazon_bedrock: "amazon-bedrock",
+  google_vertex: "google-vertex",
+  anthropic_vertex: "anthropic-vertex",
+  "openai-codex": "openai",
+}
+
+// Vercel AI SDK appends transport-style suffixes like `.responses` and `.chat`
+// to provider ids. Strip them so lookups resolve to the base provider.
+const VERCEL_PROVIDER_SUFFIX = /\.(chat|messages|responses|generative-ai|embed)$/
+
+export function resolveProviderName(provider: string): string {
+  const stripped = provider.replace(VERCEL_PROVIDER_SUFFIX, "")
+  return PROVIDER_ALIASES[stripped] ?? stripped
+}

--- a/packages/domain/models/src/registry.test.ts
+++ b/packages/domain/models/src/registry.test.ts
@@ -186,6 +186,13 @@ describe("getCostSpec", () => {
     const result = getCostSpec("unknown-provider", "model")
     expect(result.costImplemented).toBe(false)
   })
+
+  it("resolves openai-codex provider to openai for pricing lookup", () => {
+    const codex = getCostSpec("openai-codex", "gpt-5-codex")
+    const openai = getCostSpec("openai", "gpt-5-codex")
+    expect(codex.costImplemented).toBe(true)
+    expect(codex).toEqual(openai)
+  })
 })
 
 describe("estimateCost", () => {

--- a/packages/domain/models/src/registry.ts
+++ b/packages/domain/models/src/registry.ts
@@ -11,30 +11,9 @@ import type { CostBreakdown, CostLookupResult, TokenUsage } from "./entities/cos
 import { computeCostBreakdown, estimateTotalCost } from "./entities/cost.ts"
 import type { Model, ModelPricing } from "./entities/model.ts"
 import { parseModelsDevData } from "./entities/model.ts"
+import { resolveProviderName } from "./provider-aliases.ts"
 
 let cachedModels: Model[] | null = null
-
-/**
- * Maps well-known provider identifiers to their models.dev equivalents.
- *
- * Providers whose internal names differ from the models.dev convention
- * are mapped here. Unknown providers pass through unchanged.
- */
-const PROVIDER_ALIASES: Record<string, string> = {
-  amazon_bedrock: "amazon-bedrock",
-  google_vertex: "google-vertex",
-  anthropic_vertex: "anthropic-vertex",
-  "openai-codex": "openai",
-}
-
-// Vercel AI SDK appends transport-style suffixes like `.responses` and `.chat`
-// to provider ids. Strip them so pricing lookup resolves to the base provider.
-const VERCEL_PROVIDER_SUFFIX = /\.(chat|messages|responses|generative-ai|embed)$/
-
-function resolveProviderName(provider: string): string {
-  const stripped = provider.replace(VERCEL_PROVIDER_SUFFIX, "")
-  return PROVIDER_ALIASES[stripped] ?? stripped
-}
 
 /**
  * Bedrock regional inference profiles prepend a geography prefix

--- a/packages/domain/models/src/registry.ts
+++ b/packages/domain/models/src/registry.ts
@@ -24,6 +24,7 @@ const PROVIDER_ALIASES: Record<string, string> = {
   amazon_bedrock: "amazon-bedrock",
   google_vertex: "google-vertex",
   anthropic_vertex: "anthropic-vertex",
+  "openai-codex": "openai",
 }
 
 // Vercel AI SDK appends transport-style suffixes like `.responses` and `.chat`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@domain/models": "workspace:*",
     "@repo/utils": "workspace:*",
     "@tanstack/react-virtual": "^3.13.23",
     "class-variance-authority": "^0.7.1",

--- a/packages/ui/src/components/icons/custom-icons/providers/provider-icon.tsx
+++ b/packages/ui/src/components/icons/custom-icons/providers/provider-icon.tsx
@@ -1,3 +1,4 @@
+import { resolveProviderName } from "@domain/models"
 import { BotIcon } from "lucide-react"
 import { Icon, type IconProps } from "../../icons.tsx"
 import { PROVIDER_ICON_MAP } from "./provider-map.ts"
@@ -7,7 +8,8 @@ export interface ProviderIconProps extends Omit<IconProps, "icon"> {
 }
 
 export function ProviderIcon({ provider, ...props }: ProviderIconProps) {
-  const supportedIcon = PROVIDER_ICON_MAP[provider.toLowerCase()]
+  const resolved = resolveProviderName(provider).toLowerCase()
+  const supportedIcon = PROVIDER_ICON_MAP[resolved]
   const IconComponent = supportedIcon ?? BotIcon
   return <Icon icon={IconComponent} {...props} />
 }

--- a/packages/ui/src/components/icons/custom-icons/providers/provider-map.ts
+++ b/packages/ui/src/components/icons/custom-icons/providers/provider-map.ts
@@ -63,7 +63,6 @@ export const PROVIDER_ICON_MAP: Record<string, ProviderIconComponent> = {
   nvidia: NvidiaIcon,
   "ollama-cloud": OllamaIcon,
   openai: OpenaiIcon,
-  "openai-codex": OpenaiIcon,
   opencode: OpencodeIcon,
   "opencode-go": OpencodeIcon,
   openrouter: OpenrouterIcon,

--- a/packages/ui/src/components/icons/custom-icons/providers/provider-map.ts
+++ b/packages/ui/src/components/icons/custom-icons/providers/provider-map.ts
@@ -63,6 +63,7 @@ export const PROVIDER_ICON_MAP: Record<string, ProviderIconComponent> = {
   nvidia: NvidiaIcon,
   "ollama-cloud": OllamaIcon,
   openai: OpenaiIcon,
+  "openai-codex": OpenaiIcon,
   opencode: OpencodeIcon,
   "opencode-go": OpencodeIcon,
   openrouter: OpenrouterIcon,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2017,6 +2017,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.40.0
         version: 6.41.1
+      '@domain/models':
+        specifier: workspace:*
+        version: link:../domain/models
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

- `openai-codex` is a real provider value that shows up in telemetry (Codex CLI / OpenAI Codex tooling), but it is not a top-level provider in `models.dev.json` — codex models live under the `openai` provider. Without an alias, `getCostSpec("openai-codex", …)` returned `costImplemented: false` and we lost pricing for those spans.
- Add `"openai-codex": "openai"` to `PROVIDER_ALIASES` in `packages/domain/models/src/registry.ts`. The alias is intentionally placed in the registry (lookup-only) rather than in `packages/domain/spans/src/otlp/resolvers/identity.ts` (ingestion-time), so the original provider string is preserved on persisted spans while cost lookups transparently fall back to OpenAI's pricing.
- We don't control `models.dev.json` — it's regenerated from upstream, so adding an `openai-codex` entry there would be clobbered on the next refresh.

## Test plan

- [x] `pnpm --filter @domain/models exec vitest run src/registry.test.ts` — 35 tests pass, including the new `resolves openai-codex provider to openai for pricing lookup` regression test.
- [x] `pnpm typecheck` at workspace root — 59/59 tasks pass.
- [ ] End-to-end (post-merge): an OTLP span ingested with `gen_ai.provider.name = "openai-codex"` and a known codex model id (e.g. `gpt-5-codex`) lands in storage with `provider = "openai-codex"` (unchanged) **and** non-zero estimated cost.