### PR TITLE
fix(core): invalidate getData cache on commit publish

### DIFF
--- a/packages/core/src/events/handlers/clearDocumentGetDataCache.test.ts
+++ b/packages/core/src/events/handlers/clearDocumentGetDataCache.test.ts
@@ -1,0 +1,195 @@
+import { HEAD_COMMIT, ModifiedDocumentType } from '@latitude-data/constants'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import type { Cache } from '../../cache'
+import { cache } from '../../cache'
+import { getDataCacheKey } from '../../services/documents/getDataCacheKey'
+import {
+  CommitPublishedEvent,
+  DocumentCreatedEvent,
+  DocumentsDeletedEvent,
+} from '../events'
+import { clearDocumentGetDataCache } from './clearDocumentGetDataCache'
+
+describe('clearDocumentGetDataCache', () => {
+  let redis: Cache
+  let workspaceId: number
+  let projectId: number
+  let testCounter = Math.floor(Date.now() / 100)
+  const testKeys = new Set<string>()
+
+  const trackKey = (key: string) => {
+    testKeys.add(key)
+    return key
+  }
+
+  beforeAll(async () => {
+    redis = await cache()
+    process.setMaxListeners(20)
+  })
+
+  beforeEach(() => {
+    workspaceId = testCounter++
+    projectId = testCounter++
+    testKeys.clear()
+  })
+
+  afterEach(async () => {
+    for (const key of testKeys) {
+      await redis.del(key)
+    }
+    testKeys.clear()
+  })
+
+  it('clears the cache for a documentCreated event', async () => {
+    const commitUuid = 'commit-uuid-create'
+    const path = 'docs/created'
+    const key = trackKey(
+      getDataCacheKey({
+        workspaceId,
+        projectId,
+        commitUuid,
+        documentPath: path,
+      }),
+    )
+    await redis.set(key, 'cached')
+
+    const event: DocumentCreatedEvent = {
+      type: 'documentCreated',
+      data: {
+        workspaceId,
+        projectId,
+        commitUuid,
+        document: {
+          path,
+        } as DocumentCreatedEvent['data']['document'],
+      },
+    }
+
+    await clearDocumentGetDataCache({ data: event })
+
+    expect(await redis.get(key)).toBeNull()
+  })
+
+  it('clears the cache for every path on documentsDeleted', async () => {
+    const commitUuid = 'commit-uuid-delete'
+    const paths = ['docs/a', 'docs/b']
+    const keys = paths.map((path) =>
+      trackKey(
+        getDataCacheKey({
+          workspaceId,
+          projectId,
+          commitUuid,
+          documentPath: path,
+        }),
+      ),
+    )
+    await Promise.all(keys.map((key) => redis.set(key, 'cached')))
+
+    const event: DocumentsDeletedEvent = {
+      type: 'documentsDeleted',
+      data: {
+        workspaceId,
+        projectId,
+        commitUuid,
+        documentUuids: ['uuid-a', 'uuid-b'],
+        documentPaths: paths,
+        softDeletedDocumentUuids: [],
+        hardDeletedDocumentUuids: [],
+      },
+    }
+
+    await clearDocumentGetDataCache({ data: event })
+
+    for (const key of keys) {
+      expect(await redis.get(key)).toBeNull()
+    }
+  })
+
+  it('clears both the live and merged-commit cache keys for every changed path on commitPublished', async () => {
+    const commitUuid = 'commit-uuid-publish'
+    const otherCommitUuid = 'commit-uuid-untouched'
+    const changedPath = 'prompts/changed'
+    const otherPath = 'prompts/untouched'
+
+    const liveKey = trackKey(
+      getDataCacheKey({
+        workspaceId,
+        projectId,
+        commitUuid: HEAD_COMMIT,
+        documentPath: changedPath,
+      }),
+    )
+    const mergedKey = trackKey(
+      getDataCacheKey({
+        workspaceId,
+        projectId,
+        commitUuid,
+        documentPath: changedPath,
+      }),
+    )
+    const unrelatedLiveKey = trackKey(
+      getDataCacheKey({
+        workspaceId,
+        projectId,
+        commitUuid: HEAD_COMMIT,
+        documentPath: otherPath,
+      }),
+    )
+    const unrelatedCommitKey = trackKey(
+      getDataCacheKey({
+        workspaceId,
+        projectId,
+        commitUuid: otherCommitUuid,
+        documentPath: changedPath,
+      }),
+    )
+
+    await Promise.all([
+      redis.set(liveKey, 'stale'),
+      redis.set(mergedKey, 'stale'),
+      redis.set(unrelatedLiveKey, 'fresh'),
+      redis.set(unrelatedCommitKey, 'fresh'),
+    ])
+
+    const event: CommitPublishedEvent = {
+      type: 'commitPublished',
+      data: {
+        workspaceId,
+        userEmail: 'test@example.com',
+        commit: {
+          uuid: commitUuid,
+          projectId,
+        } as CommitPublishedEvent['data']['commit'],
+        changedDocuments: [
+          { path: changedPath, changeType: ModifiedDocumentType.Updated },
+        ],
+      },
+    }
+
+    await clearDocumentGetDataCache({ data: event })
+
+    expect(await redis.get(liveKey)).toBeNull()
+    expect(await redis.get(mergedKey)).toBeNull()
+    expect(await redis.get(unrelatedLiveKey)).toBe('fresh')
+    expect(await redis.get(unrelatedCommitKey)).toBe('fresh')
+  })
+
+  it('does nothing when commitPublished has no changed documents', async () => {
+    const event: CommitPublishedEvent = {
+      type: 'commitPublished',
+      data: {
+        workspaceId,
+        userEmail: 'test@example.com',
+        commit: {
+          uuid: 'commit-uuid-empty',
+          projectId,
+        } as CommitPublishedEvent['data']['commit'],
+        changedDocuments: [],
+      },
+    }
+
+    await expect(
+      clearDocumentGetDataCache({ data: event }),
+    ).resolves.not.toThrow()
+  })
+})

--- a/packages/core/src/events/handlers/clearDocumentGetDataCache.ts
+++ b/packages/core/src/events/handlers/clearDocumentGetDataCache.ts
@@ -1,13 +1,15 @@
+import { HEAD_COMMIT } from '@latitude-data/constants'
 import { cache } from '../../cache'
 import { getDataCacheKey } from '../../services/documents/getDataCacheKey'
 import {
+  CommitPublishedEvent,
   DocumentCreatedEvent,
   DocumentsDeletedEvent,
   EventHandler,
 } from '../events'
 
 export const clearDocumentGetDataCache: EventHandler<
-  DocumentCreatedEvent | DocumentsDeletedEvent
+  DocumentCreatedEvent | DocumentsDeletedEvent | CommitPublishedEvent
 > = async ({ data: event }) => {
   try {
     const cacheClient = await cache()
@@ -29,6 +31,23 @@ export const clearDocumentGetDataCache: EventHandler<
           documentPath: path,
         }),
       )
+      if (keys.length > 0) await cacheClient.del(...keys)
+    } else if (event.type === 'commitPublished') {
+      const { workspaceId, commit, changedDocuments } = event.data
+      const keys = changedDocuments.flatMap((doc) => [
+        getDataCacheKey({
+          workspaceId,
+          projectId: commit.projectId,
+          commitUuid: HEAD_COMMIT,
+          documentPath: doc.path,
+        }),
+        getDataCacheKey({
+          workspaceId,
+          projectId: commit.projectId,
+          commitUuid: commit.uuid,
+          documentPath: doc.path,
+        }),
+      ])
       if (keys.length > 0) await cacheClient.del(...keys)
     }
   } catch (_error) {

--- a/packages/core/src/events/handlers/index.ts
+++ b/packages/core/src/events/handlers/index.ts
@@ -39,7 +39,7 @@ import { unassignIssuesOnDocumentsDeleted } from './unassignIssuesOnDocumentsDel
 export const EventHandlers: IEventsHandlers = {
   claimReferralInvitations: [createClaimInvitationReferralJob],
   commitCreated: [],
-  commitPublished: [],
+  commitPublished: [clearDocumentGetDataCache],
   datasetCreated: [],
   datasetUploaded: [createDatasetRowsJob],
   documentCreated: [clearDocumentGetDataCache],


### PR DESCRIPTION
## Summary

- The gateway `getData` Redis cache (1h TTL, set in `apps/gateway/src/common/documents/getData.ts:223`) was only being invalidated on document writes inside drafts (`documentCreated`, `documentsDeleted`, `updateDocumentContent`), never on publish.
- Production API callers use `versionUuid='live'` (the SDK default for production runs), whose cache key (`workspace:W:project:P:version:live:document:X`) differs from the draft commit's. Publishing a draft updated the head commit in DB but left the `'live'` cache entries untouched, so prompt changes stayed stale for up to 1 hour.
- The `commitPublished` event was registered with an empty handler array in `packages/core/src/events/handlers/index.ts:42` — the regression entered with `b328d7039` (Feb 25), where the cache was added but only wired to document-write events. This bug has been live on `latitude-v1` since then and matches a customer-reported "delay applying prompt changes" bug (~30 min stale prompts via the public API).

## Fix

Extend `clearDocumentGetDataCache` to handle `CommitPublishedEvent` and wire it to the `commitPublished` handler array. For every changed document path in the published commit, we delete both:

- `getDataCacheKey({ ..., commitUuid: 'live', documentPath })` — the critical key for production callers
- `getDataCacheKey({ ..., commitUuid: <merged commit uuid>, documentPath })` — defensive, in case anyone cached via the explicit commit UUID pre-publish

The `commitPublished` event already carries `changedDocuments`, so no event-shape changes are needed.

### Known limitation

For renamed paths (`ModifiedDocumentType.UpdatedPath`), only the new path is invalidated — the old path's cache entry will still serve the previous document for up to 1 hour. The event payload doesn't carry the previous path; can be added as a follow-up if it bites in practice. Renames are rare and the symptom is "old document at a path that no longer exists" rather than "wrong content at a live path".

## Test plan

- [x] `pnpm test src/events/handlers/clearDocumentGetDataCache.test.ts` (4 tests, including the publish path that asserts both `live` and merged keys are deleted while unrelated keys are preserved)
- [x] `pnpm test src/services/commits/merge` — existing merge tests still pass
- [x] `pnpm test src/common/documents/getData.test.ts` (gateway) — getData test still passes
- [x] `pnpm tc` for `packages/core`
- [x] `pnpm lint` clean for changed files
- [ ] Manual smoke after deploy: edit and publish a prompt, hit the API with `versionUuid=live`, confirm new content within seconds (not after the 1h TTL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)