### PR TITLE
fix(core): surface real prompt-reference errors when running documents

### DIFF
--- a/packages/core/src/services/commits/runDocumentAtCommit.test.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.test.ts
@@ -5,7 +5,12 @@ import { ChainError, RunErrorCodes } from '@latitude-data/constants/errors'
 import { Providers } from '@latitude-data/constants'
 import { LogSources, StreamEventTypes } from '../../constants'
 import { publisher } from '../../events/publisher'
-import { createProject, createTelemetryContext } from '../../tests/factories'
+import {
+  createDocumentVersion,
+  createDraft,
+  createProject,
+  createTelemetryContext,
+} from '../../tests/factories'
 import { testConsumeStream } from '../../tests/helpers'
 import { Result } from './../../lib/Result'
 import { runDocumentAtCommit } from './index'
@@ -301,6 +306,48 @@ model: gpt-4o
 
       // Restore the spy
       streamAIResponseSpy.mockRestore()
+    })
+  })
+
+  describe('with unresolved prompt references', () => {
+    it('returns the underlying compile error instead of "missing reference function"', async () => {
+      const { workspace, project, user } = await createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: { placeholder: dummyDoc1Content },
+      })
+      const { commit } = await createDraft({ project, user })
+      const { documentVersion: document } = await createDocumentVersion({
+        workspace,
+        user,
+        commit,
+        path: 'main-prompt',
+        content: `---
+provider: openai
+model: gpt-4o
+---
+
+<prompt path="prompts/missing-doc" />
+`,
+      })
+      const context = createTelemetryContext({ workspace })
+
+      const result = await runDocumentAtCommit({
+        context,
+        workspace,
+        document,
+        commit,
+        parameters: {},
+        source: LogSources.API,
+      })
+
+      expect(result.error).toBeInstanceOf(ChainError)
+      const error = result.error as ChainError<RunErrorCodes.ChainCompileError>
+      expect(error.errorCode).toBe(RunErrorCodes.ChainCompileError)
+      expect(error.message).toContain('reference-not-found')
+      expect(error.message).toContain('path: prompts/missing-doc')
+      expect(error.message).not.toContain(
+        'A reference function was not provided',
+      )
     })
   })
 

--- a/packages/core/src/services/commits/runDocumentAtCommit.ts
+++ b/packages/core/src/services/commits/runDocumentAtCommit.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@latitude-data/constants'
+import { ChainError, RunErrorCodes } from '@latitude-data/constants/errors'
 import type { SimulationSettings } from '@latitude-data/constants/simulation'
-import { LogSources } from '../../constants'
+import { ErrorableEntity, LogSources } from '../../constants'
 import { generateUUIDIdentifier } from '../../lib/generateUUID'
 import { isRetryableError } from '../../lib/isRetryableError'
 import { Result } from '../../lib/Result'
@@ -17,6 +18,7 @@ import { runChain } from '../chains/run'
 import { getResolvedContent } from '../documents'
 import { ToolHandler } from '../documents/tools/clientTools/handlers'
 import { buildProvidersMap } from '../providerApiKeys/buildMap'
+import { createRunError } from '../runErrors/create'
 import { RunDocumentChecker } from './RunDocumentChecker'
 
 export type RunDocumentAtCommitArgs = {
@@ -87,21 +89,38 @@ export async function runDocumentAtCommit(
   const providersMap = await buildProvidersMap({
     workspaceId: workspace.id,
   })
-  const result = await getResolvedContent({
-    document,
-    commit,
-    customPrompt,
-  })
-  if (result.error) return result
 
   const $prompt = telemetry.span.prompt(
     {
       name: document.path.split('/').at(-1),
       parameters: parameters,
-      template: result.value,
+      template: customPrompt ?? document.content,
     },
     ctxWithAttributes,
   )
+
+  const result = await getResolvedContent({
+    document,
+    commit,
+    customPrompt,
+  })
+  if (result.error) {
+    const compileError = new ChainError({
+      code: RunErrorCodes.ChainCompileError,
+      message: `Error compiling prompt for document uuid: ${document.documentUuid} - ${result.error.message}`,
+    })
+    await createRunError({
+      data: {
+        errorableUuid,
+        errorableType: ErrorableEntity.DocumentLog,
+        code: compileError.errorCode,
+        message: compileError.message,
+        details: compileError.details,
+      },
+    }).then((r) => r.unwrap())
+    $prompt.fail(compileError)
+    return Result.error(compileError)
+  }
 
   const checker = new RunDocumentChecker({
     document,

--- a/packages/core/src/services/documents/getResolvedContent.ts
+++ b/packages/core/src/services/documents/getResolvedContent.ts
@@ -1,8 +1,35 @@
+import { type CompileError } from 'promptl-ai'
 import { type Commit } from '../../schema/models/types/Commit'
 import { type DocumentVersion } from '../../schema/models/types/DocumentVersion'
 import { LatitudeError } from '../../lib/errors'
 import { Result, TypedResult } from '../../lib/Result'
 import { scanDocumentContent } from './scan'
+
+// Promptl `code` values for compile errors emitted on reference (<prompt path="..." />) tags.
+// Sourced from promptl's `errors` map in node_modules/promptl-ai/dist/index.js.
+// Used as a guard so we only try to extract a `path` attribute from the offending
+// source range when the error is actually about a reference tag.
+const REFERENCE_ERROR_CODES = new Set([
+  'reference-not-found',
+  'circular-reference',
+  'reference-missing-parameter',
+  'reference-error',
+  'reference-depth-limit',
+  'invalid-reference-path',
+  'reference-tag-without-prompt',
+  'missing-reference-function',
+])
+
+function formatScanError(content: string, error: CompileError): string {
+  const base = `${error.code}: ${error.message}`
+  if (!REFERENCE_ERROR_CODES.has(error.code)) return base
+
+  const snippet = content.slice(error.startIndex, error.endIndex)
+  const match = snippet.match(/path\s*=\s*['"]([^'"]+)['"]/)
+  if (!match) return base
+
+  return `${base} (path: ${match[1]})`
+}
 
 export async function getResolvedContent({
   commit,
@@ -21,15 +48,26 @@ export async function getResolvedContent({
     return Result.ok(document.resolvedContent!)
   }
 
+  const content = customPrompt ?? document.content
   const metadataResult = await scanDocumentContent({
     document: {
       ...document,
-      content: customPrompt ?? document.content,
+      content,
     },
     commit,
   })
 
   if (metadataResult.error) return metadataResult
 
-  return Result.ok(metadataResult.unwrap().resolvedPrompt)
+  const metadata = metadataResult.unwrap()
+
+  if (metadata.errors.length > 0) {
+    const message = metadata.errors
+      .map((error) => formatScanError(content, error))
+      .join('\n')
+
+    return Result.error(new LatitudeError(message))
+  }
+
+  return Result.ok(metadata.resolvedPrompt)
 }


### PR DESCRIPTION
## Summary
- When a prompt contains `<prompt path="..." />` and the referenced doc can't be resolved, promptl logs the cause on `metadata.errors` but leaves the unresolved tag in `resolvedPrompt`. The downstream scan in `RunDocumentChecker` then throws `missingReferenceFunction`, surfacing the misleading "A reference function was not provided" instead of the real reason.
- `getResolvedContent` now propagates `metadata.errors` so the actual cause (e.g. `reference-not-found`, `circular-reference`) reaches the caller.
- `runDocumentAtCommit` opens the prompt span before resolution so a resolution failure still goes through `$prompt.fail` + `createRunError`, preserving trace and document-log visibility.

## Why this happens
1. Customer prompt has a `<prompt path="prompts/foo" />` whose target is missing in the current draft.
2. promptl `scan()` records `referenceNotFound` on `metadata.errors` and leaves the original tag in `resolvedPrompt`.
3. The caller did not inspect `metadata.errors`, so the unresolved prompt continued downstream.
4. `RunDocumentChecker.createChain()` re-scans without a `referenceFn`, hits the still-present `<prompt>` node, throws `missingReferenceFunction`.

## Test plan
- [x] New test: a draft document with `<prompt path="prompts/missing-doc" />` returns a `ChainError(ChainCompileError)` whose message contains `reference-not-found` and not the misleading "A reference function was not provided".
- [x] `pnpm test src/services/commits/runDocumentAtCommit.test.ts` (9/9 pass)
- [x] `pnpm test src/services/commits/RunDocumentChecker` (existing suite, 6/6 pass)
- [x] `pnpm tc` for `@latitude-data/core`
- [x] `pnpm lint` (no new warnings/errors in touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)