### PR TITLE
Show trace annotation indicators

### DIFF
--- a/apps/web/src/domains/annotations/annotations.collection.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.ts
@@ -86,7 +86,7 @@ export function useAnnotationCountsByTraceIds({
   readonly enabled?: boolean
 }) {
   const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
-  const uniqueTraceIds = useMemo(() => [...new Set(traceIds)], [traceIds])
+  const uniqueTraceIds = useMemo(() => [...new Set(traceIds)].sort(), [traceIds])
   const chunks = useMemo(() => chunkTraceIds(uniqueTraceIds), [uniqueTraceIds])
 
   const queries = useQueries({
@@ -111,8 +111,20 @@ export function useAnnotationCountsByTraceIds({
     return countsByTraceId
   }, [queries])
 
+  const pendingTraceIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const [index, query] of queries.entries()) {
+      if (!query.isLoading) continue
+      for (const traceId of chunks[index] ?? []) {
+        ids.add(traceId)
+      }
+    }
+    return ids
+  }, [chunks, queries])
+
   return {
     data,
+    pendingTraceIds,
     isLoading: queries.some((query) => query.isLoading),
     isFetching: queries.some((query) => query.isFetching),
   }

--- a/apps/web/src/domains/annotations/annotations.collection.ts
+++ b/apps/web/src/domains/annotations/annotations.collection.ts
@@ -3,13 +3,16 @@
 // inserts would need to fake those locally and reconcile — fragile given how isDraftAnnotation
 // drives read-only vs editable state. Annotations are also scoped per trace, not a single global
 // list, so a collection instance cache would add complexity with no reactive benefit.
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMemo } from "react"
 import {
   approveSystemAnnotation,
   createAnnotation,
   deleteAnnotation,
+  listAnnotationCountsByTraceIds,
   listAnnotationsByTrace,
   rejectSystemAnnotation,
+  type TraceAnnotationCountsRecord,
   updateAnnotation,
 } from "./annotations.functions.ts"
 
@@ -27,6 +30,22 @@ const annotationsByTraceQueryKey = (
   offset?: number,
   draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
 ) => ["annotations", "trace", projectId, traceId, limit, offset, draftMode] as const
+
+const annotationCountsByTraceIdsQueryKey = (
+  projectId: string,
+  traceIds: readonly string[],
+  draftMode: "exclude" | "include" | "only" = DEFAULT_TRACE_DRAFT_MODE,
+) => ["annotations", "trace-counts", projectId, traceIds, draftMode] as const
+
+const TRACE_COUNT_BATCH_SIZE = 50
+
+const chunkTraceIds = (traceIds: readonly string[]): readonly string[][] => {
+  const chunks: string[][] = []
+  for (let i = 0; i < traceIds.length; i += TRACE_COUNT_BATCH_SIZE) {
+    chunks.push(traceIds.slice(i, i + TRACE_COUNT_BATCH_SIZE))
+  }
+  return chunks
+}
 
 export function useAnnotationsByTrace({
   projectId,
@@ -53,6 +72,50 @@ export function useAnnotationsByTrace({
       }),
     enabled,
   })
+}
+
+export function useAnnotationCountsByTraceIds({
+  projectId,
+  traceIds,
+  draftMode,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly traceIds: readonly string[]
+  readonly draftMode?: "exclude" | "include" | "only"
+  readonly enabled?: boolean
+}) {
+  const effectiveDraftMode = draftMode ?? DEFAULT_TRACE_DRAFT_MODE
+  const uniqueTraceIds = useMemo(() => [...new Set(traceIds)], [traceIds])
+  const chunks = useMemo(() => chunkTraceIds(uniqueTraceIds), [uniqueTraceIds])
+
+  const queries = useQueries({
+    queries: chunks.map((chunk) => ({
+      queryKey: annotationCountsByTraceIdsQueryKey(projectId, chunk, effectiveDraftMode),
+      queryFn: () =>
+        listAnnotationCountsByTraceIds({
+          data: { projectId, traceIds: chunk, draftMode: effectiveDraftMode },
+        }),
+      enabled: enabled && projectId.length > 0 && chunk.length > 0,
+      staleTime: 30_000,
+    })),
+  })
+
+  const data = useMemo(() => {
+    const countsByTraceId = new Map<string, TraceAnnotationCountsRecord>()
+    for (const query of queries) {
+      for (const counts of query.data ?? []) {
+        countsByTraceId.set(counts.traceId, counts)
+      }
+    }
+    return countsByTraceId
+  }, [queries])
+
+  return {
+    data,
+    isLoading: queries.some((query) => query.isLoading),
+    isFetching: queries.some((query) => query.isFetching),
+  }
 }
 
 export function useCreateAnnotation() {
@@ -127,6 +190,9 @@ export function useApproveSystemAnnotation() {
         }
       }
     },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["annotations"] })
+    },
   })
 }
 
@@ -162,6 +228,9 @@ export function useRejectSystemAnnotation() {
           queryClient.setQueryData(queryKey, data)
         }
       }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ["annotations"] })
     },
   })
 }

--- a/apps/web/src/domains/annotations/annotations.functions.ts
+++ b/apps/web/src/domains/annotations/annotations.functions.ts
@@ -7,8 +7,8 @@ import {
 import { writeDraftAnnotationUseCase } from "@domain/annotations/src/use-cases/write-draft-annotation.ts"
 import { WorkflowStarter } from "@domain/queue"
 import type { AnnotationScore, ScoreListPage } from "@domain/scores"
-import { annotationAnchorSchema, scoreDraftModeSchema } from "@domain/scores"
-import { ProjectId, ScoreId } from "@domain/shared"
+import { annotationAnchorSchema, ScoreRepository, scoreDraftModeSchema } from "@domain/scores"
+import { ProjectId, ScoreId, TraceId } from "@domain/shared"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
 import {
@@ -71,6 +71,18 @@ const toListResult = (page: ScoreListPage) => ({
 })
 
 type AnnotationListResult = ReturnType<typeof toListResult>
+
+const toCountsRecord = (counts: {
+  readonly traceId: TraceId
+  readonly positiveCount: number
+  readonly negativeCount: number
+}) => ({
+  traceId: counts.traceId as string,
+  positiveCount: counts.positiveCount,
+  negativeCount: counts.negativeCount,
+})
+
+export type TraceAnnotationCountsRecord = ReturnType<typeof toCountsRecord>
 
 /** Annotations created from a queue must pass queue.id as sourceId; otherwise defaults to "UI". */
 const getSourceId = (queueId: string | undefined) => queueId ?? "UI"
@@ -214,6 +226,34 @@ export const listAnnotationsByTrace = createServerFn({ method: "GET" })
     )
 
     return toListResult(result)
+  })
+
+export const listAnnotationCountsByTraceIds = createServerFn({ method: "GET" })
+  .inputValidator(
+    z.object({
+      projectId: z.string(),
+      traceIds: z.array(z.string().length(32)).max(100),
+      draftMode: scoreDraftModeSchema.optional(),
+    }),
+  )
+  .handler(async ({ data }): Promise<readonly TraceAnnotationCountsRecord[]> => {
+    if (data.traceIds.length === 0) return []
+
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ScoreRepository
+        return yield* repo.countAnnotationsByTraceIds({
+          projectId: ProjectId(data.projectId),
+          traceIds: data.traceIds.map(TraceId),
+          options: { draftMode: data.draftMode ?? "include" },
+        })
+      }).pipe(withPostgres(ScoreRepositoryLive, client, organizationId), withTracing),
+    )
+
+    return result.map(toCountsRecord)
   })
 
 export const approveSystemAnnotation = createServerFn({ method: "POST" })

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -103,8 +103,8 @@ export function ProjectTracesTable({
       {
         key: "indicators",
         header: "",
-        width: 96,
-        minWidth: 96,
+        width: 88,
+        minWidth: 80,
         resizable: false,
         ellipsis: false,
         cellClassName: "px-0",
@@ -371,6 +371,7 @@ function TraceIndicatorsCell({
   const positiveCount = annotationCounts?.positiveCount ?? 0
   const negativeCount = annotationCounts?.negativeCount ?? 0
   const hasBadges = positiveCount > 0 || negativeCount > 0 || errorCount > 0
+  const showIconOnly = positiveCount > 0 && negativeCount > 0 && errorCount > 0
 
   return (
     <span className="flex items-center justify-start gap-1">
@@ -381,7 +382,9 @@ function TraceIndicatorsCell({
             <Status
               variant="success"
               indicator={<Icon icon={ThumbsUpIcon} size="xs" />}
-              label={formatCount(positiveCount)}
+              label={showIconOnly ? "" : formatCount(positiveCount)}
+              className={showIconOnly ? "gap-0 px-1.5" : undefined}
+              aria-label={`${positiveCount} positive ${positiveCount === 1 ? "annotation" : "annotations"}`}
             />
           }
         >
@@ -395,7 +398,9 @@ function TraceIndicatorsCell({
             <Status
               variant="destructive"
               indicator={<Icon icon={ThumbsDownIcon} size="xs" />}
-              label={formatCount(negativeCount)}
+              label={showIconOnly ? "" : formatCount(negativeCount)}
+              className={showIconOnly ? "gap-0 px-1.5" : undefined}
+              aria-label={`${negativeCount} negative ${negativeCount === 1 ? "annotation" : "annotations"}`}
             />
           }
         >
@@ -409,7 +414,9 @@ function TraceIndicatorsCell({
             <Status
               variant="warning"
               indicator={<Icon icon={TriangleAlertIcon} size="xs" />}
-              label={formatCount(errorCount)}
+              label={showIconOnly ? "" : formatCount(errorCount)}
+              className={showIconOnly ? "gap-0 px-1.5" : undefined}
+              aria-label={`${errorCount} ${errorCount === 1 ? "error" : "errors"} in this trace`}
             />
           }
         >

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -1,17 +1,20 @@
 import type { TraceMetrics } from "@domain/spans"
 import {
+  Icon,
   InfiniteTable,
   type InfiniteTableColumn,
   type InfiniteTableInfiniteScroll,
   type InfiniteTableSelection,
   type InfiniteTableSorting,
   ProviderIcon,
+  Skeleton,
   Status,
   TagList,
   Tooltip,
 } from "@repo/ui"
 import { formatCount, formatDuration, formatPrice, relativeTime } from "@repo/utils"
 import { Link } from "@tanstack/react-router"
+import { ThumbsDownIcon, ThumbsUpIcon, TriangleAlertIcon } from "lucide-react"
 import { type ReactNode, useCallback, useMemo } from "react"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { TableMetricSubheader } from "./table/metric-subheader.tsx"
@@ -20,6 +23,7 @@ import { TraceOutlierBadge } from "./trace-outlier-badge.tsx"
 export const DEFAULT_TRACE_TABLE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
 
 export const TRACE_COLUMN_OPTIONS = [
+  { id: "indicators", label: "Indicators", required: true },
   { id: "startTime", label: "Start Time", required: true },
   { id: "name", label: "Name" },
   { id: "tags", label: "Tags" },
@@ -33,6 +37,11 @@ export const TRACE_COLUMN_OPTIONS = [
 ] as const
 
 export type TraceColumnId = (typeof TRACE_COLUMN_OPTIONS)[number]["id"]
+
+export interface TraceAnnotationCounts {
+  readonly positiveCount: number
+  readonly negativeCount: number
+}
 
 interface ProjectTracesTableProps {
   readonly projectId: string
@@ -56,6 +65,8 @@ interface ProjectTracesTableProps {
   readonly linkTarget?: "_self" | "_blank"
   readonly traceMetrics?: TraceMetrics | null | undefined
   readonly metricsLoading?: boolean | undefined
+  readonly annotationCounts?: ReadonlyMap<string, TraceAnnotationCounts> | undefined
+  readonly annotationCountsLoading?: boolean | undefined
   readonly scrollAreaLayout?: "fill" | "intrinsic"
   readonly scrollContainerClassName?: string
 }
@@ -80,6 +91,8 @@ export function ProjectTracesTable({
   linkTarget,
   traceMetrics,
   metricsLoading,
+  annotationCounts,
+  annotationCountsLoading,
   scrollAreaLayout,
   scrollContainerClassName,
 }: ProjectTracesTableProps) {
@@ -88,31 +101,30 @@ export function ProjectTracesTable({
   const allColumns = useMemo((): InfiniteTableColumn<TraceRecord>[] => {
     return [
       {
+        key: "indicators",
+        header: "",
+        width: 96,
+        minWidth: 96,
+        resizable: false,
+        ellipsis: false,
+        cellClassName: "px-0",
+        render: (trace) => (
+          <TraceIndicatorsCell
+            errorCount={trace.errorCount}
+            annotationCounts={annotationCounts?.get(trace.traceId)}
+            annotationCountsLoading={annotationCountsLoading === true}
+          />
+        ),
+      },
+      {
         key: "startTime",
         header: "Start Time",
         sortKey: "startTime",
         width: 210,
         render: (trace) => (
-          <span className="flex items-center justify-start gap-x-1.5">
-            <Tooltip asChild trigger={<span className="truncate">{relativeTime(new Date(trace.startTime))}</span>}>
-              {new Date(trace.startTime).toLocaleString()}
-            </Tooltip>
-            {trace.errorCount > 0 && (
-              <Tooltip
-                asChild
-                trigger={
-                  <Status
-                    variant="destructive"
-                    indicator={false}
-                    label={formatCount(trace.errorCount)}
-                    className="!rounded-md"
-                  />
-                }
-              >
-                {trace.errorCount} {trace.errorCount === 1 ? "error" : "errors"} in this trace
-              </Tooltip>
-            )}
-          </span>
+          <Tooltip asChild trigger={<span className="truncate">{relativeTime(new Date(trace.startTime))}</span>}>
+            {new Date(trace.startTime).toLocaleString()}
+          </Tooltip>
         ),
       },
       {
@@ -273,12 +285,7 @@ export function ProjectTracesTable({
         align: "end",
         sortKey: "spans",
         width: 110,
-        render: (trace) => (
-          <>
-            {formatCount(trace.spanCount)}
-            {trace.errorCount > 0 ? <span className="text-destructive"> ({trace.errorCount} err)</span> : null}
-          </>
-        ),
+        render: (trace) => formatCount(trace.spanCount),
         ...(showMetricSubheaders
           ? {
               renderSubheader: () => (
@@ -292,7 +299,16 @@ export function ProjectTracesTable({
           : {}),
       },
     ]
-  }, [showMetricSubheaders, traceMetrics, metricsLoading, projectId, getTraceHref, linkTarget])
+  }, [
+    showMetricSubheaders,
+    traceMetrics,
+    metricsLoading,
+    projectId,
+    getTraceHref,
+    linkTarget,
+    annotationCounts,
+    annotationCountsLoading,
+  ])
 
   const columns = useMemo(
     () => allColumns.filter((column) => visibleColumnIds.includes(column.key as TraceColumnId)),
@@ -340,5 +356,67 @@ export function ProjectTracesTable({
       {...(onSortChange ? { onSortChange } : {})}
       {...(blankSlate !== undefined ? { blankSlate } : {})}
     />
+  )
+}
+
+function TraceIndicatorsCell({
+  errorCount,
+  annotationCounts,
+  annotationCountsLoading,
+}: {
+  readonly errorCount: number
+  readonly annotationCounts: TraceAnnotationCounts | undefined
+  readonly annotationCountsLoading: boolean
+}) {
+  const positiveCount = annotationCounts?.positiveCount ?? 0
+  const negativeCount = annotationCounts?.negativeCount ?? 0
+  const hasBadges = positiveCount > 0 || negativeCount > 0 || errorCount > 0
+
+  return (
+    <span className="flex items-center justify-start gap-1">
+      {positiveCount > 0 ? (
+        <Tooltip
+          asChild
+          trigger={
+            <Status
+              variant="success"
+              indicator={<Icon icon={ThumbsUpIcon} size="xs" />}
+              label={formatCount(positiveCount)}
+            />
+          }
+        >
+          {positiveCount} positive {positiveCount === 1 ? "annotation" : "annotations"}
+        </Tooltip>
+      ) : null}
+      {negativeCount > 0 ? (
+        <Tooltip
+          asChild
+          trigger={
+            <Status
+              variant="destructive"
+              indicator={<Icon icon={ThumbsDownIcon} size="xs" />}
+              label={formatCount(negativeCount)}
+            />
+          }
+        >
+          {negativeCount} negative {negativeCount === 1 ? "annotation" : "annotations"}
+        </Tooltip>
+      ) : null}
+      {errorCount > 0 ? (
+        <Tooltip
+          asChild
+          trigger={
+            <Status
+              variant="warning"
+              indicator={<Icon icon={TriangleAlertIcon} size="xs" />}
+              label={formatCount(errorCount)}
+            />
+          }
+        >
+          {errorCount} {errorCount === 1 ? "error" : "errors"} in this trace
+        </Tooltip>
+      ) : null}
+      {!hasBadges && annotationCountsLoading ? <Skeleton className="h-5 w-20" /> : null}
+    </span>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -66,7 +66,7 @@ interface ProjectTracesTableProps {
   readonly traceMetrics?: TraceMetrics | null | undefined
   readonly metricsLoading?: boolean | undefined
   readonly annotationCounts?: ReadonlyMap<string, TraceAnnotationCounts> | undefined
-  readonly annotationCountsLoading?: boolean | undefined
+  readonly annotationCountsPendingTraceIds?: ReadonlySet<string> | undefined
   readonly scrollAreaLayout?: "fill" | "intrinsic"
   readonly scrollContainerClassName?: string
 }
@@ -92,7 +92,7 @@ export function ProjectTracesTable({
   traceMetrics,
   metricsLoading,
   annotationCounts,
-  annotationCountsLoading,
+  annotationCountsPendingTraceIds,
   scrollAreaLayout,
   scrollContainerClassName,
 }: ProjectTracesTableProps) {
@@ -112,7 +112,7 @@ export function ProjectTracesTable({
           <TraceIndicatorsCell
             errorCount={trace.errorCount}
             annotationCounts={annotationCounts?.get(trace.traceId)}
-            annotationCountsLoading={annotationCountsLoading === true}
+            annotationCountsPending={annotationCountsPendingTraceIds?.has(trace.traceId) === true}
           />
         ),
       },
@@ -307,7 +307,7 @@ export function ProjectTracesTable({
     getTraceHref,
     linkTarget,
     annotationCounts,
-    annotationCountsLoading,
+    annotationCountsPendingTraceIds,
   ])
 
   const columns = useMemo(
@@ -362,11 +362,11 @@ export function ProjectTracesTable({
 function TraceIndicatorsCell({
   errorCount,
   annotationCounts,
-  annotationCountsLoading,
+  annotationCountsPending,
 }: {
   readonly errorCount: number
   readonly annotationCounts: TraceAnnotationCounts | undefined
-  readonly annotationCountsLoading: boolean
+  readonly annotationCountsPending: boolean
 }) {
   const positiveCount = annotationCounts?.positiveCount ?? 0
   const negativeCount = annotationCounts?.negativeCount ?? 0
@@ -423,7 +423,7 @@ function TraceIndicatorsCell({
           {errorCount} {errorCount === 1 ? "error" : "errors"} in this trace
         </Tooltip>
       ) : null}
-      {!hasBadges && annotationCountsLoading ? <Skeleton className="h-5 w-20" /> : null}
+      {!hasBadges && annotationCountsPending ? <Skeleton className="h-5 w-20" /> : null}
     </span>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -36,6 +36,7 @@ export function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): strin
 }
 
 export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
+  const requiredColumnIds = TRACE_COLUMN_OPTIONS.filter((column) => column.required === true).map((column) => column.id)
   const values = raw
     ?.split(",")
     .map((value) => value.trim())
@@ -45,7 +46,7 @@ export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
     return [...DEFAULT_TRACE_COLUMNS]
   }
 
-  return values.includes("startTime") ? values : ["startTime", ...values]
+  return Array.from(new Set([...requiredColumnIds, ...values]))
 }
 
 export function serializeTraceColumnIds(columnIds: readonly TraceColumnId[]): string {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -7,6 +7,9 @@ export const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime"
 
 export const DEFAULT_TRACE_COLUMNS: TraceColumnId[] = TRACE_COLUMN_OPTIONS.map((column) => column.id)
 
+const getRequiredTraceColumnIds = (): TraceColumnId[] =>
+  TRACE_COLUMN_OPTIONS.filter((column) => column.required === true).map((column) => column.id)
+
 export function parseFilters(raw?: string): FilterSet {
   if (!raw) return {}
   try {
@@ -36,7 +39,7 @@ export function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): strin
 }
 
 export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
-  const requiredColumnIds = TRACE_COLUMN_OPTIONS.filter((column) => column.required === true).map((column) => column.id)
+  const requiredColumnIds = getRequiredTraceColumnIds()
   const values = raw
     ?.split(",")
     .map((value) => value.trim())
@@ -50,7 +53,7 @@ export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
 }
 
 export function serializeTraceColumnIds(columnIds: readonly TraceColumnId[]): string {
-  return Array.from(new Set(["startTime", ...columnIds])).join(",")
+  return Array.from(new Set([...getRequiredTraceColumnIds(), ...columnIds])).join(",")
 }
 
 export function getSelectedCount(state: SelectionState<string>, total: number): number {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -8,7 +8,7 @@ export const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime"
 export const DEFAULT_TRACE_COLUMNS: TraceColumnId[] = TRACE_COLUMN_OPTIONS.map((column) => column.id)
 
 const getRequiredTraceColumnIds = (): TraceColumnId[] =>
-  TRACE_COLUMN_OPTIONS.filter((column) => column.required === true).map((column) => column.id)
+  TRACE_COLUMN_OPTIONS.filter((column) => "required" in column && column.required === true).map((column) => column.id)
 
 export function parseFilters(raw?: string): FilterSet {
   if (!raw) return {}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -2,6 +2,7 @@ import type { FilterSet } from "@domain/shared"
 import type { InfiniteTableSorting } from "@repo/ui"
 import { useHotkeys } from "@tanstack/react-hotkeys"
 import { type RefObject, useCallback, useMemo } from "react"
+import { useAnnotationCountsByTraceIds } from "../../../../../domains/annotations/annotations.collection.ts"
 import { useTraceMetrics, useTracesInfiniteScroll } from "../../../../../domains/traces/traces.collection.ts"
 import type { TraceRecord } from "../../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout, listingLayoutIntrinsicScroll } from "../../../../../layouts/ListingLayout/index.tsx"
@@ -66,6 +67,11 @@ export function TracesView({
     ...(hasSearchQuery ? { searchQuery } : {}),
   })
   const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
+  const { data: annotationCounts, isLoading: annotationCountsLoading } = useAnnotationCountsByTraceIds({
+    projectId,
+    traceIds,
+    enabled: traceIds.length > 0,
+  })
 
   // Write trace IDs into the shared ref during render so the parent can navigate next/prev without a callback effect
   traceIdsRef.current = traceIds
@@ -150,6 +156,8 @@ export function TracesView({
           }
           traceMetrics={traceMetrics}
           metricsLoading={metricsLoading}
+          annotationCounts={annotationCounts}
+          annotationCountsLoading={annotationCountsLoading}
         />
       </Layout.List>
     </Layout.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/traces-view.tsx
@@ -67,7 +67,7 @@ export function TracesView({
     ...(hasSearchQuery ? { searchQuery } : {}),
   })
   const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
-  const { data: annotationCounts, isLoading: annotationCountsLoading } = useAnnotationCountsByTraceIds({
+  const { data: annotationCounts, pendingTraceIds: annotationCountsPendingTraceIds } = useAnnotationCountsByTraceIds({
     projectId,
     traceIds,
     enabled: traceIds.length > 0,
@@ -157,7 +157,7 @@ export function TracesView({
           traceMetrics={traceMetrics}
           metricsLoading={metricsLoading}
           annotationCounts={annotationCounts}
-          annotationCountsLoading={annotationCountsLoading}
+          annotationCountsPendingTraceIds={annotationCountsPendingTraceIds}
         />
       </Layout.List>
     </Layout.Body>

--- a/packages/domain/scores/src/index.ts
+++ b/packages/domain/scores/src/index.ts
@@ -62,6 +62,7 @@ export {
   ScoreRepository,
   type ScoreRepositoryShape,
   scoreDraftModeSchema,
+  type TraceAnnotationCounts,
 } from "./ports/score-repository.ts"
 export { deleteScoreAnalyticsUseCase } from "./use-cases/delete-score-analytics.ts"
 export {

--- a/packages/domain/scores/src/ports/score-repository.ts
+++ b/packages/domain/scores/src/ports/score-repository.ts
@@ -29,6 +29,12 @@ export interface ScoreListPage {
   readonly offset: number
 }
 
+export interface TraceAnnotationCounts {
+  readonly traceId: TraceId
+  readonly positiveCount: number
+  readonly negativeCount: number
+}
+
 export interface ScoreRepositoryShape {
   findById(id: ScoreId): Effect.Effect<Score, NotFoundError | RepositoryError, SqlClient>
   save(score: Score): Effect.Effect<void, RepositoryError, SqlClient>
@@ -75,6 +81,11 @@ export interface ScoreRepositoryShape {
     readonly source?: ScoreSource
     readonly options?: ScoreListOptions
   }): Effect.Effect<ScoreListPage, RepositoryError, SqlClient>
+  countAnnotationsByTraceIds(input: {
+    readonly projectId: ProjectId
+    readonly traceIds: readonly TraceId[]
+    readonly options?: Pick<ScoreListOptions, "draftMode">
+  }): Effect.Effect<readonly TraceAnnotationCounts[], RepositoryError, SqlClient>
   listBySessionId(input: {
     readonly projectId: ProjectId
     readonly sessionId: SessionId

--- a/packages/domain/scores/src/testing/fake-score-repository.ts
+++ b/packages/domain/scores/src/testing/fake-score-repository.ts
@@ -63,6 +63,7 @@ export const createFakeScoreRepository = (overrides?: Partial<ScoreRepositorySha
     listByProjectId: () => Effect.succeed(EMPTY_PAGE),
     listBySourceId: () => Effect.succeed(EMPTY_PAGE),
     listByTraceId: () => Effect.succeed(EMPTY_PAGE),
+    countAnnotationsByTraceIds: () => Effect.succeed([]),
     listBySessionId: () => Effect.succeed(EMPTY_PAGE),
     listBySpanId: () => Effect.succeed(EMPTY_PAGE),
     listByIssueId: () => Effect.succeed(EMPTY_PAGE),

--- a/packages/platform/db-postgres/src/repositories/score-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.test.ts
@@ -624,6 +624,82 @@ describe("ScoreRepositoryLive + score use cases", () => {
     expect(customSourcePage.items[0]?.sourceId).toBe("api-source")
   })
 
+  it("counts annotation scores by trace and sentiment", async () => {
+    const organizationId = "cccccccccccccccccccccccc"
+    const positiveTraceId = TraceId("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    const mixedTraceId = TraceId("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        source: "annotation",
+        sourceId: "UI",
+        traceId: positiveTraceId,
+        value: 0.9,
+        passed: true,
+        feedback: "Looks good",
+        metadata: { rawFeedback: "Looks good" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        source: "annotation",
+        sourceId: "UI",
+        traceId: mixedTraceId,
+        value: 0.1,
+        passed: false,
+        feedback: "Bad answer",
+        metadata: { rawFeedback: "Bad answer" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        source: "annotation",
+        sourceId: "UI",
+        traceId: mixedTraceId,
+        value: 0.8,
+        passed: true,
+        feedback: "Draft positive",
+        metadata: { rawFeedback: "Draft positive" },
+        draftedAt: new Date("2026-03-24T15:00:00.000Z"),
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    await Effect.runPromise(
+      writeScoreUseCase({
+        projectId: annotationProjectId,
+        source: "custom",
+        sourceId: "api-source",
+        traceId: mixedTraceId,
+        value: 0.99,
+        passed: true,
+        feedback: "Custom score",
+        metadata: { channel: "api" },
+      }).pipe(createWriteProvider(database, organizationId)),
+    )
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* ScoreRepository
+        return yield* repository.countAnnotationsByTraceIds({
+          projectId: annotationProjectId,
+          traceIds: [positiveTraceId, mixedTraceId, TraceId("cccccccccccccccccccccccccccccccc")],
+          options: { draftMode: "include" },
+        })
+      }).pipe(withPostgres(ScoreRepositoryLive, database.appPostgresClient, OrganizationId(organizationId))),
+    )
+
+    const countsByTraceId = new Map(counts.map((count) => [count.traceId, count]))
+
+    expect(countsByTraceId.get(positiveTraceId)).toMatchObject({ positiveCount: 1, negativeCount: 0 })
+    expect(countsByTraceId.get(mixedTraceId)).toMatchObject({ positiveCount: 1, negativeCount: 1 })
+    expect(countsByTraceId.has(TraceId("cccccccccccccccccccccccccccccccc"))).toBe(false)
+  })
+
   it("findPublishedSystemAnnotationByTraceAndFeedback finds existing system annotation score", async () => {
     const organizationId = "qqqqqqqqqqqqqqqqqqqqqqqq"
     const traceId = TraceId("tttttttttttttttttttttttttttttttt")

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -375,10 +375,11 @@ export const ScoreRepositoryLive = Layer.effect(
 
           const sqlClient = yield* resolveSqlClient()
           const draftClause = applyDraftMode(options)
+          const traceIdValues = traceIds.map((traceId) => String(traceId))
           const baseWhere = and(
             eq(scores.projectId, projectId),
             eq(scores.source, "annotation"),
-            inArray(scores.traceId, [...traceIds] as string[]),
+            inArray(scores.traceId, traceIdValues),
           )
           const whereClause = draftClause
             ? and(eq(scores.organizationId, sqlClient.organizationId), baseWhere, draftClause)

--- a/packages/platform/db-postgres/src/repositories/score-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/score-repository.ts
@@ -1,4 +1,4 @@
-import type { Score, ScoreListOptions, ScoreSource } from "@domain/scores"
+import type { Score, ScoreListOptions, ScoreSource, TraceAnnotationCounts } from "@domain/scores"
 import { ScoreRepository, scoreSchema } from "@domain/scores"
 import {
   type IssueId,
@@ -12,7 +12,7 @@ import {
   type TraceId,
 } from "@domain/shared"
 import { createLogger } from "@repo/observability"
-import { and, desc, eq, isNotNull, isNull, type SQL, sql } from "drizzle-orm"
+import { and, desc, eq, inArray, isNotNull, isNull, type SQL, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { scores } from "../schema/scores.ts"
@@ -368,6 +368,50 @@ export const ScoreRepositoryLive = Layer.effect(
           options,
         })
       },
+
+      countAnnotationsByTraceIds: ({ projectId, traceIds, options }) =>
+        Effect.gen(function* () {
+          if (traceIds.length === 0) return []
+
+          const sqlClient = yield* resolveSqlClient()
+          const draftClause = applyDraftMode(options)
+          const baseWhere = and(
+            eq(scores.projectId, projectId),
+            eq(scores.source, "annotation"),
+            inArray(scores.traceId, [...traceIds] as string[]),
+          )
+          const whereClause = draftClause
+            ? and(eq(scores.organizationId, sqlClient.organizationId), baseWhere, draftClause)
+            : and(eq(scores.organizationId, sqlClient.organizationId), baseWhere)
+
+          return yield* sqlClient
+            .query((db) =>
+              db
+                .select({
+                  traceId: scores.traceId,
+                  positiveCount: sql<number>`count(*) filter (where ${scores.passed} = true and ${scores.errored} = false)::int`,
+                  negativeCount: sql<number>`count(*) filter (where ${scores.passed} = false and ${scores.errored} = false)::int`,
+                })
+                .from(scores)
+                .where(whereClause)
+                .groupBy(scores.traceId),
+            )
+            .pipe(
+              Effect.map((rows): readonly TraceAnnotationCounts[] =>
+                rows.flatMap((row) =>
+                  row.traceId
+                    ? [
+                        {
+                          traceId: row.traceId as TraceId,
+                          positiveCount: row.positiveCount,
+                          negativeCount: row.negativeCount,
+                        },
+                      ]
+                    : [],
+                ),
+              ),
+            )
+        }),
 
       listBySessionId: ({
         projectId,

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -128,6 +128,7 @@ function DataRowInner<T>({
               "align-middle text-sm leading-5 font-normal",
               { "max-w-0 whitespace-nowrap text-ellipsis": useEllipsis },
               { "text-right": col.align === "end" },
+              col.cellClassName,
             )}
           >
             {typeof content === "string" ? (

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -18,6 +18,8 @@ export interface InfiniteTableColumn<T> {
   renderSubheader?: (column: InfiniteTableColumn<T>, columnIndex: number) => ReactNode
   /** Whether to apply text ellipsis overflow on the cell. Defaults to `true`. */
   ellipsis?: boolean
+  /** Optional className applied to each body cell for this column. */
+  cellClassName?: string
 }
 
 export interface InfiniteTableSelection {


### PR DESCRIPTION
## Summary
- Adds positive and negative annotation indicators to the traces table so annotated traces are visible directly in the list.
- Loads annotation counts in batches for the traces currently present in the table, keeping the ClickHouse trace query separate from the Postgres annotation data and avoiding per-row requests.
- Moves trace health indicators into a compact leading column that combines annotation and error badges, including an icon-only layout when all indicators are present.

<img width="329" height="341" alt="image" src="https://github.com/user-attachments/assets/c6008ffa-3ab0-446a-b23a-18287b007a43" />

## How it works
Traces continue to load from the existing trace source. Once a page of traces is available, the UI asks for annotation counts for those trace IDs in bounded batches. The server resolves those batches with one grouped Postgres query per batch, counting positive and negative annotation scores by trace. This keeps the request count tied to visible table pages rather than total trace volume, and avoids joining across the ClickHouse/Postgres boundary.

The table receives the resulting count map and renders only the indicators that are present for each trace. One or two indicators show an icon plus count. When positive annotations, negative annotations, and errors are all present, the badges collapse to icons only to keep the column narrow while preserving the exact counts in accessible labels and tooltips.

## Test plan
- Ran `pnpm format`.
- Ran `pnpm knip`.
- Checked IDE lints for the touched table component.
- Ran `git diff --check` for the PR diff.