### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,32 +44,12 @@ Detailed policies, command examples, and code samples live under **`.agents/skil
 
 ## Cursor Cloud specific instructions
 
-### Environment prerequisites
+The update script runs `scripts/cloud-install.sh` and `scripts/cloud-start.sh` on every session start — dependencies are installed, Docker infra is started, and all databases are migrated and seeded automatically.
 
-The VM snapshot includes Docker, mise (with Node 25), pnpm 10.33.0, and goose. The update script runs `scripts/cloud-install.sh` (env files + `pnpm install`) and `scripts/cloud-start.sh` (Docker infra + migrations + seeds) on every session start, so all databases are migrated and seeded automatically.
+For services, ports, health checks, Docker Compose, dev servers, and Mailpit auth flow, see [toolchain-commands skill](.agents/skills/toolchain-commands/SKILL.md). Seeded users include `owner@acme.com`, `admin@acme.com`, etc., all in the "Acme Inc." organization.
 
-### Services overview
-
-| Service | Port | Health / verify |
-|---------|------|----------------|
-| Web (TanStack Start) | 3000 | `curl -sI http://localhost:3000` → 307 redirect to `/login` |
-| API (Hono) | 3001 | `curl -s http://localhost:3001/health` |
-| Ingest (Hono) | 3002 | `curl -s http://localhost:3002/health` |
-| Workers (BullMQ) | 9090 | `curl -s http://localhost:9090/health` |
-| Workflows (Temporal) | 9091 | `curl -s http://localhost:9091/health` |
-| Mailpit UI | 8025 | `curl -s http://localhost:8025` |
-| Temporal UI | 8233 | `curl -s http://localhost:8233` |
-
-Start dev servers per `.cursor/environment.json` terminals, or individually: `pnpm --filter @app/<name> dev`.
-
-### Authentication in local dev
-
-Auth uses Better Auth with **magic links** (no passwords by default). After entering an email at `/login`, retrieve the magic link from Mailpit at `http://localhost:8025`. Seeded users include `owner@acme.com`, `admin@acme.com`, etc., all in the "Acme Inc." organization.
-
-### Gotchas
+**Cloud-only gotchas:**
 
 - `pnpm build` must complete before `pnpm db:up` — migration scripts depend on compiled platform packages.
 - The `pnpm install` output may warn about unapproved build scripts (`@swc/core`, `sharp`, etc.). These are non-blocking — pre-built binaries are used.
 - The Docker daemon in cloud VMs needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles this.
-- Typechecking uses `tsgo` (native TS preview) via `pnpm typecheck` — never invoke `tsc` directly.
-- For standard commands (lint, test, build, dev, typecheck), see [toolchain-commands skill](.agents/skills/toolchain-commands/SKILL.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,35 @@ Detailed policies, command examples, and code samples live under **`.agents/skil
 | **Testing** | [.agents/skills/testing/SKILL.md](.agents/skills/testing/SKILL.md) | Vitest layers, PGlite/chdb testkit, **`/testing` package exports**, avoiding `vi.mock` for repositories |
 | **Toolchain and commands** | [.agents/skills/toolchain-commands/SKILL.md](.agents/skills/toolchain-commands/SKILL.md) | Node/pnpm/Turbo/Vitest/Biome, scripts, filters, CI, `.env.*` setup, **Docker Compose, dev servers, Mailpit** |
 | **Web frontend** | [.agents/skills/web-frontend/SKILL.md](.agents/skills/web-frontend/SKILL.md) | `apps/web` UI, TanStack Start, collections, `@repo/ui`, layout, **`-components/`**, legacy UI reference, **`useMountEffect` policy**, **`useForm` + `createFormSubmitHandler` + `fieldErrorsAsStrings`** for Zod field errors on forms |
+
+## Cursor Cloud specific instructions
+
+### Environment prerequisites
+
+The VM snapshot includes Docker, mise (with Node 25), pnpm 10.33.0, and goose. The update script runs `scripts/cloud-install.sh` (env files + `pnpm install`) and `scripts/cloud-start.sh` (Docker infra + migrations + seeds) on every session start, so all databases are migrated and seeded automatically.
+
+### Services overview
+
+| Service | Port | Health / verify |
+|---------|------|----------------|
+| Web (TanStack Start) | 3000 | `curl -sI http://localhost:3000` → 307 redirect to `/login` |
+| API (Hono) | 3001 | `curl -s http://localhost:3001/health` |
+| Ingest (Hono) | 3002 | `curl -s http://localhost:3002/health` |
+| Workers (BullMQ) | 9090 | `curl -s http://localhost:9090/health` |
+| Workflows (Temporal) | 9091 | `curl -s http://localhost:9091/health` |
+| Mailpit UI | 8025 | `curl -s http://localhost:8025` |
+| Temporal UI | 8233 | `curl -s http://localhost:8233` |
+
+Start dev servers per `.cursor/environment.json` terminals, or individually: `pnpm --filter @app/<name> dev`.
+
+### Authentication in local dev
+
+Auth uses Better Auth with **magic links** (no passwords by default). After entering an email at `/login`, retrieve the magic link from Mailpit at `http://localhost:8025`. Seeded users include `owner@acme.com`, `admin@acme.com`, etc., all in the "Acme Inc." organization.
+
+### Gotchas
+
+- `pnpm build` must complete before `pnpm db:up` — migration scripts depend on compiled platform packages.
+- The `pnpm install` output may warn about unapproved build scripts (`@swc/core`, `sharp`, etc.). These are non-blocking — pre-built binaries are used.
+- The Docker daemon in cloud VMs needs `fuse-overlayfs` storage driver and `iptables-legacy`. The update script handles this.
+- Typechecking uses `tsgo` (native TS preview) via `pnpm typecheck` — never invoke `tsc` directly.
+- For standard commands (lint, test, build, dev, typecheck), see [toolchain-commands skill](.agents/skills/toolchain-commands/SKILL.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with cloud-only gotchas, referencing the existing toolchain-commands skill for services, ports, health checks, Docker Compose, and Mailpit auth flow — no duplication.

**Cloud-only content added:**
- Update script runs `scripts/cloud-install.sh` + `scripts/cloud-start.sh` (auto deps, infra, migrations, seeds)
- Build-before-migrate ordering gotcha
- Unapproved build script warnings are non-blocking
- Docker fuse-overlayfs/iptables-legacy requirement for cloud VMs
- Seeded users reference (`owner@acme.com`, etc.)

### Environment setup verified

All services start and pass health checks:

| Service | Status |
|---------|--------|
| Web (3000) | 307 redirect to /login |
| API (3001) | `{"service":"api","status":"ok"}` |
| Ingest (3002) | `{"service":"ingest","status":"ok"}` |
| Workers (9090) | `{"status":"ok"}` |
| Workflows (9091) | `{"status":"ok"}` |

### Testing

- **Lint**: 57/57 tasks passed (`pnpm check`)
- **Tests**: 57/57 tasks passed (`pnpm test`)
- **Hello world**: Signed in via magic link, explored traces, sessions, and issues in the seeded Acme Inc. org

[latitude_hello_world_demo.mp4](https://cursor.com/agents/bc-dd86e450-10e9-4047-9fcc-5ea0e44f0bcb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flatitude_hello_world_demo.mp4)

[Dashboard logged in state](https://cursor.com/agents/bc-dd86e450-10e9-4047-9fcc-5ea0e44f0bcb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_logged_in.webp)
[Traces view with metrics](https://cursor.com/agents/bc-dd86e450-10e9-4047-9fcc-5ea0e44f0bcb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraces_view.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd86e450-10e9-4047-9fcc-5ea0e44f0bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd86e450-10e9-4047-9fcc-5ea0e44f0bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

