### PR TITLE
fix(LAT-547): Align annotation span with tool selections

### DIFF
--- a/packages/domain/annotations/src/helpers/resolve-write-annotation-trace-context.ts
+++ b/packages/domain/annotations/src/helpers/resolve-write-annotation-trace-context.ts
@@ -7,13 +7,13 @@ import {
   type RepositoryError,
   type TraceId,
 } from "@domain/shared"
-import { resolveLastLlmCompletionSpanId, SpanRepository, TraceRepository } from "@domain/spans"
+import { resolveAnnotationSpanIdForWrite, SpanRepository, TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import { resolveAnnotationAnchorText } from "./resolve-annotation-anchor-text.ts"
 
 /**
  * Loads trace (and optionally spans) for annotation writes: anchor validation, session/span resolution.
- * Fails if the trace is missing when required, or if span resolution is required but no LLM span exists.
+ * Fails if the trace is missing when required.
  */
 export const resolveWriteAnnotationTraceContext = (input: {
   readonly organizationId: OrganizationId
@@ -69,11 +69,25 @@ export const resolveWriteAnnotationTraceContext = (input: {
 
     if (needsSpanResolution) {
       const spanRepository = yield* SpanRepository
-      const spans = yield* spanRepository.listByTraceId({
+      const llmSpans = yield* spanRepository.listByTraceId({
         organizationId: input.organizationId,
         traceId: input.traceId,
       })
-      const resolvedSpanId = resolveLastLlmCompletionSpanId(spans)
+      const startTimeFrom = new Date(detail.startTime.getTime() - 60 * 1000)
+      const startTimeTo = new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000)
+      const spanMessages = yield* spanRepository.findMessagesForTrace({
+        organizationId: input.organizationId,
+        projectId: input.projectId,
+        traceId: input.traceId,
+        startTimeFrom,
+        startTimeTo,
+      })
+      const resolvedSpanId = resolveAnnotationSpanIdForWrite({
+        allMessages: detail.allMessages,
+        spanMessages,
+        llmSpans,
+        anchor: input.anchor,
+      })
       if (resolvedSpanId) spanId = resolvedSpanId
     }
 

--- a/packages/domain/annotations/src/helpers/resolve-write-annotation-trace-context.ts
+++ b/packages/domain/annotations/src/helpers/resolve-write-annotation-trace-context.ts
@@ -7,7 +7,12 @@ import {
   type RepositoryError,
   type TraceId,
 } from "@domain/shared"
-import { resolveAnnotationSpanIdForWrite, SpanRepository, TraceRepository } from "@domain/spans"
+import {
+  annotationAnchorTargetsToolPart,
+  resolveAnnotationSpanIdForWrite,
+  SpanRepository,
+  TraceRepository,
+} from "@domain/spans"
 import { Effect } from "effect"
 import { resolveAnnotationAnchorText } from "./resolve-annotation-anchor-text.ts"
 
@@ -73,15 +78,16 @@ export const resolveWriteAnnotationTraceContext = (input: {
         organizationId: input.organizationId,
         traceId: input.traceId,
       })
-      const startTimeFrom = new Date(detail.startTime.getTime() - 60 * 1000)
-      const startTimeTo = new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000)
-      const spanMessages = yield* spanRepository.findMessagesForTrace({
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        traceId: input.traceId,
-        startTimeFrom,
-        startTimeTo,
-      })
+      const needsToolSpanMessages = annotationAnchorTargetsToolPart(detail.allMessages, input.anchor)
+      const spanMessages = needsToolSpanMessages
+        ? yield* spanRepository.findMessagesForTrace({
+            organizationId: input.organizationId,
+            projectId: input.projectId,
+            traceId: input.traceId,
+            startTimeFrom: new Date(detail.startTime.getTime() - 60 * 1000),
+            startTimeTo: new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000),
+          })
+        : []
       const resolvedSpanId = resolveAnnotationSpanIdForWrite({
         allMessages: detail.allMessages,
         spanMessages,

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -16,7 +16,7 @@ import {
   type ScoreId,
   TraceId,
 } from "@domain/shared"
-import { resolveLastLlmCompletionSpanId, SpanRepository, TraceRepository } from "@domain/spans"
+import { resolveAnnotationSpanIdForWrite, SpanRepository, TraceRepository } from "@domain/spans"
 import { Effect } from "effect"
 import type { GenAIMessage } from "rosetta-ai"
 import { z } from "zod"
@@ -155,11 +155,26 @@ export const enrichAnnotationForPublicationUseCase = Effect.fn("annotations.enri
       }
       if (resolvedSpanId === null) {
         const spanRepository = yield* SpanRepository
-        const spans = yield* spanRepository.listByTraceId({
+        const llmSpans = yield* spanRepository.listByTraceId({
           organizationId: OrganizationId(annotationScore.organizationId),
           traceId: TraceId(annotationScore.traceId),
         })
-        resolvedSpanId = resolveLastLlmCompletionSpanId(spans) ?? null
+        const startTimeFrom = new Date(detail.startTime.getTime() - 60 * 1000)
+        const startTimeTo = new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000)
+        const spanMessages = yield* spanRepository.findMessagesForTrace({
+          organizationId: OrganizationId(annotationScore.organizationId),
+          projectId: ProjectId(annotationScore.projectId),
+          traceId: TraceId(annotationScore.traceId),
+          startTimeFrom,
+          startTimeTo,
+        })
+        resolvedSpanId =
+          resolveAnnotationSpanIdForWrite({
+            allMessages: detail.allMessages,
+            spanMessages,
+            llmSpans,
+            anchor: metadata,
+          }) ?? null
       }
 
       if (detail.allMessages.length > 0) {

--- a/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
+++ b/packages/domain/annotations/src/use-cases/enrich-annotation-for-publication.ts
@@ -16,7 +16,12 @@ import {
   type ScoreId,
   TraceId,
 } from "@domain/shared"
-import { resolveAnnotationSpanIdForWrite, SpanRepository, TraceRepository } from "@domain/spans"
+import {
+  annotationAnchorTargetsToolPart,
+  resolveAnnotationSpanIdForWrite,
+  SpanRepository,
+  TraceRepository,
+} from "@domain/spans"
 import { Effect } from "effect"
 import type { GenAIMessage } from "rosetta-ai"
 import { z } from "zod"
@@ -159,15 +164,16 @@ export const enrichAnnotationForPublicationUseCase = Effect.fn("annotations.enri
           organizationId: OrganizationId(annotationScore.organizationId),
           traceId: TraceId(annotationScore.traceId),
         })
-        const startTimeFrom = new Date(detail.startTime.getTime() - 60 * 1000)
-        const startTimeTo = new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000)
-        const spanMessages = yield* spanRepository.findMessagesForTrace({
-          organizationId: OrganizationId(annotationScore.organizationId),
-          projectId: ProjectId(annotationScore.projectId),
-          traceId: TraceId(annotationScore.traceId),
-          startTimeFrom,
-          startTimeTo,
-        })
+        const needsToolSpanMessages = annotationAnchorTargetsToolPart(detail.allMessages, metadata)
+        const spanMessages = needsToolSpanMessages
+          ? yield* spanRepository.findMessagesForTrace({
+              organizationId: OrganizationId(annotationScore.organizationId),
+              projectId: ProjectId(annotationScore.projectId),
+              traceId: TraceId(annotationScore.traceId),
+              startTimeFrom: new Date(detail.startTime.getTime() - 60 * 1000),
+              startTimeTo: new Date(detail.startTime.getTime() + 24 * 60 * 60 * 1000),
+            })
+          : []
         resolvedSpanId =
           resolveAnnotationSpanIdForWrite({
             allMessages: detail.allMessages,

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -20,6 +20,10 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
+  type AnnotationWriteSpanAnchor,
+  resolveAnnotationSpanIdForWrite,
+} from "./helpers/resolve-annotation-span-id-for-write.ts"
+export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -20,6 +20,7 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
+  annotationAnchorTargetsToolPart,
   type AnnotationWriteSpanAnchor,
   resolveAnnotationSpanIdForWrite,
 } from "./helpers/resolve-annotation-span-id-for-write.ts"

--- a/packages/domain/spans/src/browser.ts
+++ b/packages/domain/spans/src/browser.ts
@@ -20,8 +20,8 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
-  annotationAnchorTargetsToolPart,
   type AnnotationWriteSpanAnchor,
+  annotationAnchorTargetsToolPart,
   resolveAnnotationSpanIdForWrite,
 } from "./helpers/resolve-annotation-span-id-for-write.ts"
 export {

--- a/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
+++ b/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
@@ -56,9 +56,7 @@ describe("resolveAnnotationSpanIdForWrite", () => {
     }
     const messages: GenAIMessage[] = [textMsg("user", "open file"), assistantWithTool]
     const toolSpanId = "t".repeat(16)
-    const spanMessages = [
-      makeSpanMessages(toolSpanId, textMsg("assistant", "tool output"), [], toolCallId),
-    ]
+    const spanMessages = [makeSpanMessages(toolSpanId, textMsg("assistant", "tool output"), [], toolCallId)]
 
     const resolved = resolveAnnotationSpanIdForWrite({
       allMessages: messages,

--- a/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
+++ b/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
@@ -3,7 +3,10 @@ import type { GenAIMessage } from "rosetta-ai"
 import { describe, expect, it } from "vitest"
 import type { SpanMessagesData } from "../ports/span-repository.ts"
 import { stubListSpan } from "../testing/stub-list-span.ts"
-import { resolveAnnotationSpanIdForWrite } from "./resolve-annotation-span-id-for-write.ts"
+import {
+  annotationAnchorTargetsToolPart,
+  resolveAnnotationSpanIdForWrite,
+} from "./resolve-annotation-span-id-for-write.ts"
 
 const orgId = OrganizationId("o".repeat(24))
 const projectId = ProjectId("p".repeat(24))
@@ -38,6 +41,26 @@ const chatSpan = stubListSpan({
   operation: "chat",
   startTime: new Date("2026-01-02T00:00:00.000Z"),
   endTime: new Date("2026-01-02T00:01:00.000Z"),
+})
+
+describe("annotationAnchorTargetsToolPart", () => {
+  it("is false for text selections", () => {
+    const messages: GenAIMessage[] = [textMsg("assistant", "Hello")]
+    expect(annotationAnchorTargetsToolPart(messages, { messageIndex: 0, partIndex: 0 })).toBe(false)
+  })
+
+  it("is true for tool_call_response anchor", () => {
+    const messages: GenAIMessage[] = [
+      {
+        role: "assistant",
+        parts: [
+          { type: "tool_call", name: "Read", id: "tc1", arguments: {} },
+          { type: "tool_call_response", id: "tc1", response: {} },
+        ],
+      },
+    ]
+    expect(annotationAnchorTargetsToolPart(messages, { messageIndex: 0, partIndex: 1 })).toBe(true)
+  })
 })
 
 describe("resolveAnnotationSpanIdForWrite", () => {

--- a/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
+++ b/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.test.ts
@@ -1,0 +1,126 @@
+import { OrganizationId, ProjectId, SessionId, SpanId, TraceId } from "@domain/shared"
+import type { GenAIMessage } from "rosetta-ai"
+import { describe, expect, it } from "vitest"
+import type { SpanMessagesData } from "../ports/span-repository.ts"
+import { stubListSpan } from "../testing/stub-list-span.ts"
+import { resolveAnnotationSpanIdForWrite } from "./resolve-annotation-span-id-for-write.ts"
+
+const orgId = OrganizationId("o".repeat(24))
+const projectId = ProjectId("p".repeat(24))
+const traceId = TraceId("t".repeat(32))
+const sessionId = SessionId("s".repeat(24))
+
+function textMsg(role: "user" | "assistant", content: string): GenAIMessage {
+  return { role, parts: [{ type: "text", content }] }
+}
+
+function makeSpanMessages(
+  spanId: string,
+  output: GenAIMessage,
+  inputs: readonly GenAIMessage[] = [],
+  toolCallId = "",
+): SpanMessagesData {
+  return {
+    spanId: SpanId(spanId),
+    operation: "execute_tool",
+    toolCallId,
+    inputMessages: inputs,
+    outputMessages: [output],
+  }
+}
+
+const chatSpan = stubListSpan({
+  organizationId: orgId,
+  projectId,
+  traceId,
+  sessionId,
+  spanId: SpanId("c".repeat(16)),
+  operation: "chat",
+  startTime: new Date("2026-01-02T00:00:00.000Z"),
+  endTime: new Date("2026-01-02T00:01:00.000Z"),
+})
+
+describe("resolveAnnotationSpanIdForWrite", () => {
+  it("returns execute_tool span when anchor selects tool_call_response with matching id", () => {
+    const toolCallId = "call-read-1"
+    const assistantWithTool: GenAIMessage = {
+      role: "assistant",
+      parts: [
+        { type: "tool_call", name: "Read", id: toolCallId, arguments: {} },
+        {
+          type: "tool_call_response",
+          id: toolCallId,
+          response: { error: "failed" },
+        },
+      ],
+    }
+    const messages: GenAIMessage[] = [textMsg("user", "open file"), assistantWithTool]
+    const toolSpanId = "t".repeat(16)
+    const spanMessages = [
+      makeSpanMessages(toolSpanId, textMsg("assistant", "tool output"), [], toolCallId),
+    ]
+
+    const resolved = resolveAnnotationSpanIdForWrite({
+      allMessages: messages,
+      spanMessages,
+      llmSpans: [chatSpan],
+      anchor: { messageIndex: 1, partIndex: 1 },
+    })
+
+    expect(resolved).toEqual(SpanId(toolSpanId))
+  })
+
+  it("returns execute_tool span when anchor selects tool_call part", () => {
+    const toolCallId = "tc-99"
+    const assistantWithTool: GenAIMessage = {
+      role: "assistant",
+      parts: [{ type: "tool_call", name: "Bash", id: toolCallId, arguments: { cmd: "ls" } }],
+    }
+    const messages: GenAIMessage[] = [assistantWithTool]
+    const toolSpanId = "u".repeat(16)
+    const spanMessages = [makeSpanMessages(toolSpanId, textMsg("assistant", "out"), [], toolCallId)]
+
+    const resolved = resolveAnnotationSpanIdForWrite({
+      allMessages: messages,
+      spanMessages,
+      llmSpans: [chatSpan],
+      anchor: { messageIndex: 0, partIndex: 0 },
+    })
+
+    expect(resolved).toEqual(SpanId(toolSpanId))
+  })
+
+  it("falls back to last LLM completion when anchor is plain text", () => {
+    const messages: GenAIMessage[] = [textMsg("assistant", "Hello")]
+    const laterChat = stubListSpan({
+      organizationId: orgId,
+      projectId,
+      traceId,
+      sessionId,
+      spanId: SpanId("d".repeat(16)),
+      operation: "chat",
+      startTime: new Date("2026-01-02T00:00:30.000Z"),
+      endTime: new Date("2026-01-02T00:02:00.000Z"),
+    })
+
+    const resolved = resolveAnnotationSpanIdForWrite({
+      allMessages: messages,
+      spanMessages: [],
+      llmSpans: [chatSpan, laterChat],
+      anchor: { messageIndex: 0, partIndex: 0 },
+    })
+
+    expect(resolved).toEqual(laterChat.spanId)
+  })
+
+  it("falls back to last LLM completion when anchor is omitted", () => {
+    const resolved = resolveAnnotationSpanIdForWrite({
+      allMessages: [],
+      spanMessages: [],
+      llmSpans: [chatSpan],
+      anchor: undefined,
+    })
+
+    expect(resolved).toEqual(chatSpan.spanId)
+  })
+})

--- a/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.ts
+++ b/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.ts
@@ -10,6 +10,17 @@ export type AnnotationWriteSpanAnchor = {
   readonly partIndex?: number | undefined
 }
 
+/** True when the anchor selects a tool_call or tool_call_response part (needs execute_tool span mapping). */
+export function annotationAnchorTargetsToolPart(
+  allMessages: readonly GenAIMessage[],
+  anchor: AnnotationWriteSpanAnchor | undefined,
+): boolean {
+  const { messageIndex, partIndex } = anchor ?? {}
+  if (messageIndex === undefined || partIndex === undefined) return false
+  const part = allMessages[messageIndex]?.parts[partIndex]
+  return part?.type === "tool_call" || part?.type === "tool_call_response"
+}
+
 /**
  * Resolves which span an annotation should attach to when the client did not send `spanId`.
  *

--- a/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.ts
+++ b/packages/domain/spans/src/helpers/resolve-annotation-span-id-for-write.ts
@@ -1,0 +1,41 @@
+import { SpanId, type SpanId as SpanIdBrand } from "@domain/shared"
+import type { GenAIMessage } from "rosetta-ai"
+import type { Span } from "../entities/span.ts"
+import type { SpanMessagesData } from "../ports/span-repository.ts"
+import { buildConversationSpanMaps } from "../use-cases/map-conversation-to-spans.ts"
+import { resolveLastLlmCompletionSpanId } from "./resolve-last-llm-completion-span.ts"
+
+export type AnnotationWriteSpanAnchor = {
+  readonly messageIndex?: number | undefined
+  readonly partIndex?: number | undefined
+}
+
+/**
+ * Resolves which span an annotation should attach to when the client did not send `spanId`.
+ *
+ * Text selections on tool call / tool result parts must use the `execute_tool` span (via
+ * `toolCallSpanMap`), not the latest LLM completion — otherwise the annotation appears on the wrong
+ * span in the trace UI (LAT-547).
+ */
+export function resolveAnnotationSpanIdForWrite(input: {
+  readonly allMessages: readonly GenAIMessage[]
+  readonly spanMessages: readonly SpanMessagesData[]
+  readonly llmSpans: readonly Span[]
+  readonly anchor: AnnotationWriteSpanAnchor | undefined
+}): SpanIdBrand | undefined {
+  const { messageIndex, partIndex } = input.anchor ?? {}
+  if (messageIndex !== undefined && partIndex !== undefined) {
+    const { toolCallSpanMap } = buildConversationSpanMaps(input.allMessages, input.spanMessages)
+    const msg = input.allMessages[messageIndex]
+    const part = msg?.parts[partIndex]
+    if (part?.type === "tool_call") {
+      const id = typeof (part as { id?: unknown }).id === "string" ? (part as { id: string }).id.trim() : ""
+      if (id && toolCallSpanMap[id]) return SpanId(toolCallSpanMap[id])
+    }
+    if (part?.type === "tool_call_response") {
+      const id = typeof (part as { id?: unknown }).id === "string" ? (part as { id: string }).id.trim() : ""
+      if (id && toolCallSpanMap[id]) return SpanId(toolCallSpanMap[id])
+    }
+  }
+  return resolveLastLlmCompletionSpanId(input.llmSpans)
+}

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -36,6 +36,10 @@ export {
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
 export {
+  resolveAnnotationSpanIdForWrite,
+  type AnnotationWriteSpanAnchor,
+} from "./helpers/resolve-annotation-span-id-for-write.ts"
+export {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,
   mergeTraceHistogramTimeFilters,

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -32,8 +32,8 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
-  annotationAnchorTargetsToolPart,
   type AnnotationWriteSpanAnchor,
+  annotationAnchorTargetsToolPart,
   resolveAnnotationSpanIdForWrite,
 } from "./helpers/resolve-annotation-span-id-for-write.ts"
 export {

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -32,13 +32,13 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
+  type AnnotationWriteSpanAnchor,
+  resolveAnnotationSpanIdForWrite,
+} from "./helpers/resolve-annotation-span-id-for-write.ts"
+export {
   isLlmCompletionOperation,
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
-export {
-  resolveAnnotationSpanIdForWrite,
-  type AnnotationWriteSpanAnchor,
-} from "./helpers/resolve-annotation-span-id-for-write.ts"
 export {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -32,6 +32,7 @@ export type { Trace, TraceDetail } from "./entities/trace.ts"
 export { traceDetailSchema, traceSchema } from "./entities/trace.ts"
 export { SpanDecodingError } from "./errors.ts"
 export {
+  annotationAnchorTargetsToolPart,
   type AnnotationWriteSpanAnchor,
   resolveAnnotationSpanIdForWrite,
 } from "./helpers/resolve-annotation-span-id-for-write.ts"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Annotations created from text selections on tool call or tool result content were stored with `spanId` resolved to the **latest LLM completion** span whenever the client omitted `spanId` (or when enrichment re-resolved a null `spanId`). That made the annotation badge appear on the wrong span in the trace UI relative to the tool error the user actually selected.

## Changes

- Add `resolveAnnotationSpanIdForWrite` in `@domain/spans`: when the anchor points at a `tool_call` or `tool_call_response` part with a non-empty `id`, map it through the same `toolCallSpanMap` logic as `buildConversationSpanMaps`; otherwise keep the existing fallback to `resolveLastLlmCompletionSpanId`.
- Add `annotationAnchorTargetsToolPart`: only call `findMessagesForTrace` when that predicate is true (tool-span mapping). Plain text / message-level anchors skip the extra CH query and match pre-change behavior for API paths.
- Use the above in `resolveWriteAnnotationTraceContext` and `enrichAnnotationForPublicationUseCase`.
- Unit tests; export from `index.ts` and `browser.ts` for Vite.

## Verification

- Biome: barrel export order + formatting.
- API tests: avoiding unconditional `findMessagesForTrace` fixes 500s on `annotations.test.ts` where CH message-query behavior differs in test.

Run locally: `pnpm --filter @domain/spans check && pnpm --filter @domain/spans test`, `pnpm --filter @app/api test`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LAT-547](https://linear.app/latitude/issue/LAT-547/tool-error-annotations-are-not-working-as-expected)

<div><a href="https://cursor.com/agents/bc-20461371-ca7f-4e68-94ba-181b28be8ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20461371-ca7f-4e68-94ba-181b28be8ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

