### PR TITLE
feat(flaggers): add message-level annotation anchors

### DIFF
--- a/apps/workflows/src/activities/flagger-activities.ts
+++ b/apps/workflows/src/activities/flagger-activities.ts
@@ -53,6 +53,7 @@ interface DraftAnnotateOutput {
   readonly sessionId: string | null
   readonly simulationId: string | null
   readonly scoreId: string
+  readonly messageIndex?: number | undefined
 }
 
 export const draftAnnotate = async (input: {
@@ -95,6 +96,7 @@ export const saveAnnotation = async (input: {
   readonly sessionId?: string | null
   readonly simulationId?: string | null
   readonly scoreId: string
+  readonly messageIndex?: number | undefined
 }): Promise<FlaggerAnnotateOutput> =>
   Effect.runPromise(
     saveFlaggerAnnotationUseCase(input).pipe(

--- a/apps/workflows/src/workflows/flagger-workflow.test.ts
+++ b/apps/workflows/src/workflows/flagger-workflow.test.ts
@@ -5,12 +5,20 @@ const TEST_TRACE_CREATED_AT = "2024-01-15T10:00:00.000Z"
 const { mockActivities } = vi.hoisted(() => {
   const mockActivities = {
     runFlagger: vi.fn(async (): Promise<{ matched: boolean }> => ({ matched: false })),
-    draftAnnotate: vi.fn(async () => ({
-      traceId: "trace-1",
-      feedback: "Test feedback",
-      traceCreatedAt: "2024-01-15T10:00:00.000Z",
-      scoreId: "score-default",
-    })),
+    draftAnnotate: vi.fn(
+      async (): Promise<{
+        traceId: string
+        feedback: string
+        traceCreatedAt: string
+        scoreId: string
+        messageIndex?: number | undefined
+      }> => ({
+        traceId: "trace-1",
+        feedback: "Test feedback",
+        traceCreatedAt: "2024-01-15T10:00:00.000Z",
+        scoreId: "score-default",
+      }),
+    ),
     saveAnnotation: vi.fn(async () => ({
       flaggerId: "flagger-1",
       traceId: "trace-1",
@@ -124,6 +132,37 @@ describe("flaggerWorkflow", () => {
       traceCreatedAt: TEST_TRACE_CREATED_AT,
       scoreId: "score-from-draft",
     })
+  })
+
+  it("passes messageIndex from draftAnnotate through to saveAnnotation when present", async () => {
+    mockActivities.runFlagger.mockResolvedValueOnce({ matched: true })
+    mockActivities.draftAnnotate.mockResolvedValueOnce({
+      traceId: "trace-1",
+      feedback: "Generated feedback",
+      traceCreatedAt: TEST_TRACE_CREATED_AT,
+      scoreId: "score-msg-idx",
+      messageIndex: 5,
+    })
+    mockActivities.saveAnnotation.mockResolvedValueOnce({
+      flaggerId: FLAGGER_ID,
+      traceId: "trace-1",
+      draftAnnotationId: "draft-789",
+    })
+
+    await flaggerWorkflow({
+      organizationId: "org-1",
+      projectId: "proj-1",
+      traceId: "trace-1",
+      flaggerId: FLAGGER_ID,
+      flaggerSlug: "jailbreaking",
+    })
+
+    expect(mockActivities.saveAnnotation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageIndex: 5,
+        scoreId: "score-msg-idx",
+      }),
+    )
   })
 
   it("propagates draftAnnotate errors for Temporal retry", async () => {

--- a/apps/workflows/src/workflows/flagger-workflow.ts
+++ b/apps/workflows/src/workflows/flagger-workflow.ts
@@ -68,6 +68,7 @@ export const flaggerWorkflow = async (input: {
       feedback: draftResult.feedback,
       traceCreatedAt: draftResult.traceCreatedAt,
       scoreId: draftResult.scoreId,
+      messageIndex: draftResult.messageIndex,
     })
 
     log.info("Flagger save annotation completed", {

--- a/packages/domain/flaggers/src/constants.ts
+++ b/packages/domain/flaggers/src/constants.ts
@@ -32,5 +32,4 @@ export const FLAGGER_ANNOTATOR_MAX_TOKENS = 2048
 export const FLAGGER_DRAFT_DEFAULTS = {
   passed: false,
   value: 0,
-  hasAnchor: false,
 } as const

--- a/packages/domain/flaggers/src/flagger-strategies/empty-response.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/empty-response.ts
@@ -19,6 +19,8 @@ export const emptyResponseStrategy: FlaggerStrategy = {
 
   detectDeterministically(trace: TraceDetail): DetectionResult {
     const result = detectEmptyResponseFlagger(trace)
-    return result.matched ? { kind: "matched", feedback: result.feedback } : { kind: "no-match" }
+    return result.matched
+      ? { kind: "matched", feedback: result.feedback, messageIndex: result.messageIndex }
+      : { kind: "no-match" }
   },
 }

--- a/packages/domain/flaggers/src/flagger-strategies/output-schema-validation.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/output-schema-validation.ts
@@ -19,6 +19,8 @@ export const outputSchemaValidationStrategy: FlaggerStrategy = {
 
   detectDeterministically(trace: TraceDetail): DetectionResult {
     const result = detectOutputSchemaValidationFlagger(trace)
-    return result.matched ? { kind: "matched", feedback: result.feedback } : { kind: "no-match" }
+    return result.matched
+      ? { kind: "matched", feedback: result.feedback, messageIndex: result.messageIndex }
+      : { kind: "no-match" }
   },
 }

--- a/packages/domain/flaggers/src/flagger-strategies/tool-call-errors.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/tool-call-errors.ts
@@ -19,6 +19,8 @@ export const toolCallErrorsStrategy: FlaggerStrategy = {
 
   detectDeterministically(trace: TraceDetail): DetectionResult {
     const result = detectToolCallErrorsFlagger(trace)
-    return result.matched ? { kind: "matched", feedback: result.feedback } : { kind: "no-match" }
+    return result.matched
+      ? { kind: "matched", feedback: result.feedback, messageIndex: result.messageIndex }
+      : { kind: "no-match" }
   },
 }

--- a/packages/domain/flaggers/src/flagger-strategies/types.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/types.ts
@@ -16,7 +16,7 @@ export const FLAGGER_STRATEGY_SLUGS = [
 export type FlaggerSlug = (typeof FLAGGER_STRATEGY_SLUGS)[number]
 
 export type DetectionResult =
-  | { readonly kind: "matched"; readonly feedback: string }
+  | { readonly kind: "matched"; readonly feedback: string; readonly messageIndex?: number | undefined }
   | { readonly kind: "no-match" }
   | { readonly kind: "ambiguous" }
 

--- a/packages/domain/flaggers/src/helpers.test.ts
+++ b/packages/domain/flaggers/src/helpers.test.ts
@@ -22,8 +22,8 @@ function toolResponse(id: string, response: unknown): TraceMessage {
   }
 }
 
-function makeOutputTrace(outputMessages: TraceDetail["outputMessages"]): TraceDetail {
-  return { outputMessages } as TraceDetail
+function makeAssistantTrace(allMessages: TraceDetail["allMessages"]): TraceDetail {
+  return { allMessages } as TraceDetail
 }
 
 function assistantText(content: string): TraceDetail["outputMessages"][number] {
@@ -34,21 +34,26 @@ function assistantText(content: string): TraceDetail["outputMessages"][number] {
 }
 
 describe("detectToolCallErrorsFlagger", () => {
-  it("matches failed tool result payloads and includes the tool name + error snippet", () => {
+  it("matches failed tool result payloads and includes the tool name + error snippet + messageIndex", () => {
     const result = detectToolCallErrorsFlagger(
       makeTrace([assistantToolCall("call-weather"), toolResponse("call-weather", { ok: false, error: "timeout" })]),
     )
 
-    expect(result).toEqual({ matched: true, feedback: 'Tool "get_weather" returned error: timeout' })
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe('Tool "get_weather" returned error: timeout')
+      expect(result.messageIndex).toBe(1)
+    }
   })
 
-  it("matches malformed tool interactions with empty tool_call id", () => {
+  it("matches malformed tool interactions with empty tool_call id and returns messageIndex 0", () => {
     const result = detectToolCallErrorsFlagger(makeTrace([assistantToolCall("")]))
 
     expect(result.matched).toBe(true)
     if (result.matched) {
       expect(result.feedback).toContain("Malformed tool call")
       expect(result.feedback).toContain("get_weather")
+      expect(result.messageIndex).toBe(0)
     }
   })
 
@@ -235,52 +240,53 @@ describe("detectToolCallErrorsFlagger", () => {
 
 describe("detectOutputSchemaValidationFlagger", () => {
   it("does not match when the assistant output is valid JSON", () => {
-    const result = detectOutputSchemaValidationFlagger(makeOutputTrace([assistantText('{"a": 1, "b": 2}')]))
+    const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText('{"a": 1, "b": 2}')]))
 
     expect(result).toEqual({ matched: false })
   })
 
   it("does not match when the assistant output is not JSON-looking", () => {
-    const result = detectOutputSchemaValidationFlagger(makeOutputTrace([assistantText("Hello! The answer is 42.")]))
+    const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText("Hello! The answer is 42.")]))
 
     expect(result).toEqual({ matched: false })
   })
 
   it("matches with the trailing-comma message when JSON is truncated after a comma", () => {
-    // Order matters: the trailing-comma heuristic runs before JSON.parse so its
-    // specific clustering message takes precedence over the generic parse-failure one.
-    const result = detectOutputSchemaValidationFlagger(makeOutputTrace([assistantText('{"a": 1,')]))
+    const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText('{"a": 1,')]))
 
-    expect(result).toEqual({
-      matched: true,
-      feedback: "Assistant output ended with a trailing comma, suggesting truncated JSON",
-    })
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe("Assistant output ended with a trailing comma, suggesting truncated JSON")
+      expect(result.messageIndex).toBe(0)
+    }
   })
 
   it("matches with the unclosed-string message when JSON is truncated mid-string", () => {
-    const result = detectOutputSchemaValidationFlagger(makeOutputTrace([assistantText('{"msg": "hello')]))
+    const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText('{"msg": "hello')]))
 
-    expect(result).toEqual({
-      matched: true,
-      feedback: "Assistant output contains an unclosed JSON string, suggesting truncated output",
-    })
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe("Assistant output contains an unclosed JSON string, suggesting truncated output")
+      expect(result.messageIndex).toBe(0)
+    }
   })
 
   it("ignores escaped quotes when detecting unclosed strings", () => {
     // The outer string is properly closed — the \" inside should not flip the balance.
     const result = detectOutputSchemaValidationFlagger(
-      makeOutputTrace([assistantText('{"msg": "quoted \\"ok\\" value"}')]),
+      makeAssistantTrace([assistantText('{"msg": "quoted \\"ok\\" value"}')]),
     )
 
     expect(result).toEqual({ matched: false })
   })
 
   it("falls back to the generic parse-failure message when JSON is malformed but not a truncation pattern", () => {
-    const result = detectOutputSchemaValidationFlagger(makeOutputTrace([assistantText("{not valid json}")]))
+    const result = detectOutputSchemaValidationFlagger(makeAssistantTrace([assistantText("{not valid json}")]))
 
-    expect(result).toEqual({
-      matched: true,
-      feedback: "Assistant output failed JSON parse (malformed or truncated structured output)",
-    })
+    expect(result.matched).toBe(true)
+    if (result.matched) {
+      expect(result.feedback).toBe("Assistant output failed JSON parse (malformed or truncated structured output)")
+      expect(result.messageIndex).toBe(0)
+    }
   })
 })

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -9,16 +9,21 @@ const EXPECTED_TOOL_HTTP_STATUS_MAX = 499
 const ERROR_SNIPPET_MAX_LENGTH = 160
 
 export type DeterministicFlaggerMatch =
-  | { readonly matched: true; readonly feedback: string }
+  | { readonly matched: true; readonly feedback: string; readonly messageIndex?: number | undefined }
   | { readonly matched: false }
 
 const NO_MATCH: DeterministicFlaggerMatch = { matched: false }
-const match = (feedback: string): DeterministicFlaggerMatch => ({ matched: true, feedback })
+const match = (feedback: string, messageIndex?: number): DeterministicFlaggerMatch => ({
+  matched: true,
+  feedback,
+  ...(messageIndex !== undefined ? { messageIndex } : {}),
+})
 
 export function detectToolCallErrorsFlagger(trace: TraceMessagesOnly): DeterministicFlaggerMatch {
   const toolNameById = new Map<string, string>()
 
-  for (const message of trace.allMessages) {
+  for (let msgIdx = 0; msgIdx < trace.allMessages.length; msgIdx++) {
+    const message = trace.allMessages[msgIdx]!
     for (const part of message.parts) {
       if (part.type === "tool_call") {
         const toolCallId = typeof part.id === "string" ? part.id.trim() : ""
@@ -26,11 +31,11 @@ export function detectToolCallErrorsFlagger(trace: TraceMessagesOnly): Determini
 
         if (!toolCallId || !toolName) {
           const label = toolName ? `tool "${toolName}"` : "an unnamed tool"
-          return match(`Malformed tool call: ${label} with missing or empty tool_call id`)
+          return match(`Malformed tool call: ${label} with missing or empty tool_call id`, msgIdx)
         }
 
         if (toolNameById.has(toolCallId)) {
-          return match(`Duplicate tool_call id emitted for tool "${toolName}"`)
+          return match(`Duplicate tool_call id emitted for tool "${toolName}"`, msgIdx)
         }
 
         toolNameById.set(toolCallId, toolName)
@@ -41,13 +46,16 @@ export function detectToolCallErrorsFlagger(trace: TraceMessagesOnly): Determini
 
       const toolCallId = typeof part.id === "string" ? part.id.trim() : ""
       if (!toolCallId || !toolNameById.has(toolCallId)) {
-        return match(`Tool response references an unknown tool_call id "${toolCallId || "<empty>"}"`)
+        return match(`Tool response references an unknown tool_call id "${toolCallId || "<empty>"}"`, msgIdx)
       }
 
       if (responseIndicatesFailure(part.response)) {
         const toolName = toolNameById.get(toolCallId) ?? "<unknown>"
         const snippet = extractErrorSnippet(part.response)
-        return match(snippet ? `Tool "${toolName}" returned error: ${snippet}` : `Tool "${toolName}" returned an error`)
+        return match(
+          snippet ? `Tool "${toolName}" returned error: ${snippet}` : `Tool "${toolName}" returned an error`,
+          msgIdx,
+        )
       }
     }
   }
@@ -166,14 +174,16 @@ function responseIndicatesFailure(response: unknown): boolean {
 }
 
 export function detectOutputSchemaValidationFlagger(trace: TraceDetail): DeterministicFlaggerMatch {
-  for (const message of trace.outputMessages) {
+  for (let msgIdx = 0; msgIdx < trace.allMessages.length; msgIdx++) {
+    const message = trace.allMessages[msgIdx]!
     if (message.role !== "assistant") continue
     for (const part of message.parts) {
       if (part.type !== "text") continue
       const content = typeof part.content === "string" ? part.content.trim() : ""
       if (!content || (!content.startsWith("{") && !content.startsWith("["))) continue
 
-      if (content.endsWith(",")) return match("Assistant output ended with a trailing comma, suggesting truncated JSON")
+      if (content.endsWith(","))
+        return match("Assistant output ended with a trailing comma, suggesting truncated JSON", msgIdx)
 
       let inString = false
       let escaped = false
@@ -189,12 +199,13 @@ export function detectOutputSchemaValidationFlagger(trace: TraceDetail): Determi
         }
         if (char === '"') inString = !inString
       }
-      if (inString) return match("Assistant output contains an unclosed JSON string, suggesting truncated output")
+      if (inString)
+        return match("Assistant output contains an unclosed JSON string, suggesting truncated output", msgIdx)
 
       try {
         JSON.parse(content)
       } catch {
-        return match("Assistant output failed JSON parse (malformed or truncated structured output)")
+        return match("Assistant output failed JSON parse (malformed or truncated structured output)", msgIdx)
       }
     }
   }
@@ -203,7 +214,8 @@ export function detectOutputSchemaValidationFlagger(trace: TraceDetail): Determi
 }
 
 export function detectEmptyResponseFlagger(trace: TraceDetail): DeterministicFlaggerMatch {
-  for (const message of trace.outputMessages) {
+  for (let msgIdx = 0; msgIdx < trace.allMessages.length; msgIdx++) {
+    const message = trace.allMessages[msgIdx]!
     if (message.role !== "assistant") continue
 
     let hasToolCall = false
@@ -224,9 +236,9 @@ export function detectEmptyResponseFlagger(trace: TraceDetail): DeterministicFla
 
     if (hasToolCall && !hasText) continue
     const accumulatedText = textParts.join("").trim()
-    if (accumulatedText === "") return match("Assistant response was empty or whitespace only")
+    if (accumulatedText === "") return match("Assistant response was empty or whitespace only", msgIdx)
     if (accumulatedText.length >= 3 && new Set(accumulatedText).size === 1) {
-      return match(`Assistant response was degenerate: only the character "${accumulatedText[0]}" repeated`)
+      return match(`Assistant response was degenerate: only the character "${accumulatedText[0]}" repeated`, msgIdx)
     }
   }
 

--- a/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.test.ts
+++ b/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.test.ts
@@ -57,14 +57,14 @@ const makeTraceDetail = (): TraceDetail => ({
 })
 
 describe("draftFlaggerAnnotationUseCase", () => {
-  it("generates a scoreId, returns it in the output, and forwards it to the annotator's telemetry", async () => {
+  it("generates a scoreId, returns messageIndex and other fields in the output, and forwards them to the annotator's telemetry", async () => {
     const { repository: traceRepo } = createFakeTraceRepository({
       findByTraceId: () => Effect.succeed(makeTraceDetail()),
     })
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { feedback: "Draft feedback" } as T,
+          object: { feedback: "Draft feedback", messageIndex: 0 } as T,
           tokens: 10,
           duration: 100,
         }),
@@ -94,6 +94,7 @@ describe("draftFlaggerAnnotationUseCase", () => {
     expect(result.traceId).toBe(TRACE_ID)
     expect(result.sessionId).toBe("session")
     expect(result.simulationId).toBeNull()
+    expect(result.messageIndex).toBe(0)
 
     expect(calls.generate).toHaveLength(1)
     expect(calls.generate[0].telemetry).toMatchObject({

--- a/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.ts
+++ b/packages/domain/flaggers/src/use-cases/draft-flagger-annotation.ts
@@ -28,6 +28,7 @@ export interface DraftFlaggerAnnotationOutput {
   readonly sessionId: string | null
   readonly simulationId: string | null
   readonly scoreId: ScoreId
+  readonly messageIndex?: number | undefined
 }
 
 interface DraftFlaggerAnnotationInput {
@@ -70,5 +71,6 @@ export const draftFlaggerAnnotationUseCase = Effect.fn("flaggers.draftFlaggerAnn
     sessionId: annotatorResult.sessionId,
     simulationId: annotatorResult.simulationId,
     scoreId,
+    messageIndex: annotatorResult.messageIndex,
   } as DraftFlaggerAnnotationOutput
 })

--- a/packages/domain/flaggers/src/use-cases/flagger-annotator-contracts.test.ts
+++ b/packages/domain/flaggers/src/use-cases/flagger-annotator-contracts.test.ts
@@ -214,6 +214,36 @@ describe("flaggerAnnotatorOutputSchema", () => {
     expect(result.success).toBe(true)
   })
 
+  it("accepts feedback with optional messageIndex", () => {
+    const output = {
+      feedback: "This response contains a jailbreak attempt.",
+      messageIndex: 3,
+    }
+    const result = flaggerAnnotatorOutputSchema.safeParse(output)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.messageIndex).toBe(3)
+    }
+  })
+
+  it("rejects negative messageIndex", () => {
+    const output = {
+      feedback: "valid feedback",
+      messageIndex: -1,
+    }
+    const result = flaggerAnnotatorOutputSchema.safeParse(output)
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects non-integer messageIndex", () => {
+    const output = {
+      feedback: "valid feedback",
+      messageIndex: 1.5,
+    }
+    const result = flaggerAnnotatorOutputSchema.safeParse(output)
+    expect(result.success).toBe(false)
+  })
+
   it("rejects missing feedback", () => {
     const output = {}
     const result = flaggerAnnotatorOutputSchema.safeParse(output)

--- a/packages/domain/flaggers/src/use-cases/flagger-annotator-contracts.ts
+++ b/packages/domain/flaggers/src/use-cases/flagger-annotator-contracts.ts
@@ -23,6 +23,7 @@ export type FlaggerAnnotateOutput = z.infer<typeof flaggerAnnotateOutputSchema>
 
 export const flaggerAnnotatorOutputSchema = z.object({
   feedback: z.string().min(1),
+  messageIndex: z.number().int().nonnegative().optional(),
 })
 
 export type FlaggerAnnotatorOutput = z.infer<typeof flaggerAnnotatorOutputSchema>

--- a/packages/domain/flaggers/src/use-cases/process-flaggers.ts
+++ b/packages/domain/flaggers/src/use-cases/process-flaggers.ts
@@ -207,7 +207,7 @@ const processOneStrategy = (input: ProcessOneStrategyInput) =>
 
     switch (result.kind) {
       case "matched":
-        return yield* handleMatched(input, result.feedback)
+        return yield* handleMatched(input, result.feedback, result.messageIndex)
       case "no-match":
         return yield* handleNoMatch(input, flagger, strategy)
       case "ambiguous":
@@ -215,7 +215,7 @@ const processOneStrategy = (input: ProcessOneStrategyInput) =>
     }
   })
 
-const handleMatched = (input: ProcessOneStrategyInput, feedback: string) =>
+const handleMatched = (input: ProcessOneStrategyInput, feedback: string, messageIndex?: number) =>
   Effect.gen(function* () {
     const simulationId = input.trace.simulationId === "" ? null : input.trace.simulationId
 
@@ -225,6 +225,7 @@ const handleMatched = (input: ProcessOneStrategyInput, feedback: string) =>
       sessionId: input.trace.sessionId,
       simulationId,
       feedback,
+      messageIndex,
     })
 
     return { slug: input.slug, action: "matched-issue" } satisfies StrategyDecision

--- a/packages/domain/flaggers/src/use-cases/run-flagger-annotator.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger-annotator.test.ts
@@ -63,9 +63,10 @@ function makeTraceDetail(allMessages: TraceDetail["allMessages"]): TraceDetail {
 }
 
 describe("runFlaggerAnnotatorUseCase", () => {
-  it("returns structured feedback from AI generation", async () => {
+  it("returns structured feedback from AI generation including optional messageIndex", async () => {
     const expectedFeedback =
       "This conversation shows a clear jailbreaking attempt where the user tries to bypass safety constraints."
+    const expectedMessageIndex = 0
 
     const { repository: traceRepo } = createFakeTraceRepository({
       findByTraceId: () =>
@@ -86,7 +87,7 @@ describe("runFlaggerAnnotatorUseCase", () => {
     const { calls, layer: aiLayer } = createFakeAI({
       generate: <T>() =>
         Effect.succeed({
-          object: { feedback: expectedFeedback } as T,
+          object: { feedback: expectedFeedback, messageIndex: expectedMessageIndex } as T,
           tokens: 150,
           duration: 500_000_000,
         }),
@@ -109,6 +110,7 @@ describe("runFlaggerAnnotatorUseCase", () => {
       traceCreatedAt: "2026-01-01T00:00:00.000Z",
       sessionId: "session",
       simulationId: null,
+      messageIndex: expectedMessageIndex,
     })
     expect(calls.generate).toHaveLength(1)
 
@@ -118,6 +120,7 @@ describe("runFlaggerAnnotatorUseCase", () => {
     expect(generateCall.maxTokens).toBe(2048)
     expect(generateCall.provider).toBe("amazon-bedrock")
     expect(generateCall.system).toContain("Jailbreaking")
+    expect(generateCall.system).toContain("messageIndex")
     expect(generateCall.telemetry).toMatchObject({
       spanName: "flagger.draft",
       tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerDraft],
@@ -210,12 +213,12 @@ describe("runFlaggerAnnotatorUseCase", () => {
       "Write about the underlying issue in plain language, not about the transcript formatting or what was omitted.",
     )
     expect(generateCall.prompt).toContain(
-      "[system]: You are Acme Support Bot. Help with orders and shipping. Be concise. Use tools when needed....",
+      "[m0 system]: You are Acme Support Bot. Help with orders and shipping. Be concise. Use tools when needed....",
     )
-    expect(generateCall.prompt).toContain("[user]: Where is order 12345?")
-    expect(generateCall.prompt).toContain("[assistant]: Let me check that for you.")
-    expect(generateCall.prompt).toContain("[toolcall]: lookup_order")
-    expect(generateCall.prompt).toContain("[toolresult]: error")
+    expect(generateCall.prompt).toContain("[m1 user]: Where is order 12345?")
+    expect(generateCall.prompt).toContain("[m2 assistant]: Let me check that for you.")
+    expect(generateCall.prompt).toContain("[m2 toolcall]: lookup_order")
+    expect(generateCall.prompt).toContain("[m3 toolresult]: error")
     expect(generateCall.prompt).not.toContain('"orderId":"12345"')
     expect(generateCall.prompt).not.toContain("timeout while looking up order 12345")
     expect(generateCall.prompt).not.toContain("sensitive payload")

--- a/packages/domain/flaggers/src/use-cases/run-flagger-annotator.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger-annotator.ts
@@ -26,6 +26,7 @@ export interface RunFlaggerAnnotatorResult {
   readonly traceCreatedAt: string
   readonly sessionId: string | null
   readonly simulationId: string | null
+  readonly messageIndex?: number | undefined
 }
 
 export type RunFlaggerAnnotatorError = RepositoryError | AIError | AICredentialError
@@ -70,7 +71,7 @@ Grounding rules:
 
 Use the simplest wording that still carries the full meaning. Prefer short, everyday words over formal or technical synonyms when both fit, and keep the feedback only as long as it needs to be — no padding, no restatement, no meta-commentary. The original context and nuance must still come through; simpler wording is the goal, not less information.
 
-Respond with structured data containing a single "feedback" field with your annotation text.
+Respond with structured data containing a "feedback" field with your annotation text, and an optional "messageIndex" field (integer) pointing to the specific transcript line where the issue is most evident. Each transcript line is prefixed with its message index like \`[m12 assistant]:\`. Only specify messageIndex when you can confidently identify the line — it is better to omit it than to guess. When the transcript shows a toolcall or toolresult line that is the direct evidence, prefer its index.
 `.trim()
 
 const SYSTEM_PROMPT_PREVIEW_MAX_LINES = 4
@@ -164,7 +165,8 @@ function responseIndicatesFailure(response: unknown): boolean {
 const formatConversationForAnnotator = (messages: readonly { role: string; parts: unknown[] }[]): string => {
   const lines: string[] = []
 
-  for (const message of messages) {
+  for (let msgIdx = 0; msgIdx < messages.length; msgIdx++) {
+    const message = messages[msgIdx]!
     if (message.role === "system") {
       const systemText = message.parts
         .flatMap((part) => {
@@ -175,7 +177,7 @@ const formatConversationForAnnotator = (messages: readonly { role: string; parts
         .join("\n")
 
       const preview = cropSystemPromptPreview(systemText)
-      if (preview) lines.push(`[system]: ${preview}`)
+      if (preview) lines.push(`[m${msgIdx} system]: ${preview}`)
       continue
     }
 
@@ -185,7 +187,7 @@ const formatConversationForAnnotator = (messages: readonly { role: string; parts
       if (message.role !== "user" && message.role !== "assistant") return
 
       const body = textParts.join("\n").trim()
-      if (body) lines.push(`[${message.role}]: ${body}`)
+      if (body) lines.push(`[m${msgIdx} ${message.role}]: ${body}`)
       textParts.length = 0
     }
 
@@ -202,14 +204,18 @@ const formatConversationForAnnotator = (messages: readonly { role: string; parts
 
       if (part.type === "tool_call" || part.type === "tool-call") {
         flushText()
-        lines.push(`[toolcall]: ${toNonEmptyString(part.name) ?? toNonEmptyString(part.toolName) ?? "<unknown tool>"}`)
+        const toolName = toNonEmptyString(part.name) ?? toNonEmptyString(part.toolName) ?? "<unknown tool>"
+        lines.push(`[m${msgIdx} toolcall]: ${toolName}`)
         continue
       }
 
       if (part.type === "tool_call_response" || part.type === "tool-result") {
         flushText()
         const response = "response" in part ? part.response : part.result
-        lines.push(`[toolresult]: ${responseIndicatesFailure(response) ? "error" : "ok"}`)
+        const status = responseIndicatesFailure(response) ? "error" : "ok"
+        if (message.role === "tool" || message.role === "function") {
+          lines.push(`[m${msgIdx} toolresult]: ${status}`)
+        }
       }
     }
 
@@ -290,6 +296,7 @@ Return structured data with a single "feedback" field per the system instruction
     traceCreatedAt: input.trace.startTime.toISOString(),
     sessionId: input.trace.sessionId,
     simulationId: input.trace.simulationId === "" ? null : input.trace.simulationId,
+    messageIndex: result.object.messageIndex,
   }
 })
 

--- a/packages/domain/flaggers/src/use-cases/save-flagger-annotation.ts
+++ b/packages/domain/flaggers/src/use-cases/save-flagger-annotation.ts
@@ -24,6 +24,7 @@ const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, message: str
 export interface SaveFlaggerAnnotationInput extends FlaggerAnnotateInput {
   readonly feedback: string
   readonly traceCreatedAt: string
+  readonly messageIndex?: number | undefined
 }
 
 export type SaveFlaggerAnnotationError =
@@ -51,6 +52,7 @@ export const saveFlaggerAnnotationUseCase = Effect.fn("flaggers.saveFlaggerAnnot
     sessionId: parsedInput.sessionId ?? null,
     simulationId: parsedInput.simulationId ?? null,
     feedback: input.feedback,
+    messageIndex: input.messageIndex,
   })
 
   return flaggerAnnotateOutputSchema.parse({

--- a/packages/domain/flaggers/src/use-cases/upsert-flagger-annotation-score.ts
+++ b/packages/domain/flaggers/src/use-cases/upsert-flagger-annotation-score.ts
@@ -10,6 +10,7 @@ interface UpsertFlaggerAnnotationScoreInput {
   readonly sessionId: string | null
   readonly simulationId: string | null
   readonly feedback: string
+  readonly messageIndex?: number | undefined
 }
 
 type UpsertFlaggerAnnotationScoreResult =
@@ -50,7 +51,10 @@ export const upsertFlaggerAnnotationScore = (input: UpsertFlaggerAnnotationScore
       value: FLAGGER_DRAFT_DEFAULTS.value,
       passed: FLAGGER_DRAFT_DEFAULTS.passed,
       feedback: input.feedback,
-      metadata: { rawFeedback: input.feedback },
+      metadata: {
+        rawFeedback: input.feedback,
+        ...(input.messageIndex !== undefined ? { messageIndex: input.messageIndex } : {}),
+      },
       error: null,
       draftedAt: null,
     })


### PR DESCRIPTION
## Summary
- Adds optional `messageIndex` anchor to flagger-authored annotations so trace conversations show which message an issue refers to
- LLM annotator transcripts are now prefixed with `[m{idx}]` labels; the model returns an optional `messageIndex` alongside feedback
- Deterministic flaggers (`tool-call-errors`, `output-schema-validation`, `empty-response`) return the offending message index on match
- `messageIndex` flows through the full draft/save/upsert pipeline and is persisted in annotation score metadata
- No UI changes needed — the existing `messageIndex`→highlight/navigation wiring already works

## Files changed
19 files, +185/-69 across `@domain/flaggers` and `@app/workflows`

## Tested
- All `@domain/flaggers` tests (151) and `@app/workflows` tests (57) pass
- Full workspace `turbo format` + `knip` pass