### PR TITLE
fix(onboarding): activate org before welcome redirect

### DIFF
--- a/apps/web/src/routes/welcome/index.tsx
+++ b/apps/web/src/routes/welcome/index.tsx
@@ -119,6 +119,7 @@ function WelcomePage() {
       await setActiveOrganization({
         data: { organizationId: organization.id, organizationSlug: organization.slug },
       })
+      // Full navigation ensures project onboarding reads the freshly-updated auth session.
       window.location.href = `/projects/${organization.defaultProject.slug}/onboarding`
     } catch (err) {
       setError(toUserMessage(err))

--- a/apps/web/src/routes/welcome/index.tsx
+++ b/apps/web/src/routes/welcome/index.tsx
@@ -116,10 +116,10 @@ function WelcomePage() {
     try {
       await updateUser({ data: { name: userName } })
       const organization = await createOrganization({ data: { name: organizationName } })
-      await router.navigate({
-        to: "/projects/$projectSlug/onboarding",
-        params: { projectSlug: organization.defaultProject.slug },
+      await setActiveOrganization({
+        data: { organizationId: organization.id, organizationSlug: organization.slug },
       })
+      window.location.href = `/projects/${organization.defaultProject.slug}/onboarding`
     } catch (err) {
       setError(toUserMessage(err))
       setIsSubmitting(false)


### PR DESCRIPTION
## Summary
- set the newly created organization active before leaving `/welcome`
- use a hard navigation to project onboarding so the next request reads a fresh session cookie
- prevent new signups from hitting project-scoped onboarding with no `activeOrganizationId` and bouncing away from onboarding

## Verification
- `pnpm --filter @latitude-data/telemetry build`
- `pnpm --filter @app/web typecheck`
- `pnpm exec biome check \"apps/web/src/routes/welcome/index.tsx\"`