### PR TITLE
Fix PH sessions

### DIFF
--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -88,9 +88,11 @@ export const identifyOrganization = async (input: IdentifyOrganizationInput): Pr
 }
 
 /**
- * Clear the current identity. Call before identifying a new user (handled
- * automatically in the authenticated layout effect) and at explicit logout so
- * the previous user's session events don't bleed into the next one.
+ * Clear the current identity and session. Call on explicit logout only — do
+ * not call from the authenticated layout on mount: `posthog.reset()` starts a
+ * fresh recording session, and layout remounts (including React Strict Mode in
+ * dev) would fragment recordings. `identifyUser` in `PostHogIdentity` is enough
+ * to attribute the same browser session to the signed-in user.
  */
 export const resetPostHog = async (): Promise<void> => {
   const posthog = await loadInstance()

--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -27,6 +27,22 @@ const readEnv = (): PostHogEnv | null => {
 // underlying window object.
 let instancePromise: Promise<PostHog | null> | null = null
 
+const LAST_IDENTIFIED_KEY = "ph_last_identified_user"
+
+const getLastIdentifiedUserId = (): string | null => {
+  if (typeof window === "undefined") return null
+  return sessionStorage.getItem(LAST_IDENTIFIED_KEY)
+}
+
+const setLastIdentifiedUserId = (id: string | null) => {
+  if (typeof window === "undefined") return
+  if (id) {
+    sessionStorage.setItem(LAST_IDENTIFIED_KEY, id)
+  } else {
+    sessionStorage.removeItem(LAST_IDENTIFIED_KEY)
+  }
+}
+
 const loadInstance = (): Promise<PostHog | null> => {
   if (typeof window === "undefined") return Promise.resolve(null)
   const env = readEnv()
@@ -68,8 +84,18 @@ interface IdentifyUserInput {
 }
 
 export const identifyUser = async (input: IdentifyUserInput): Promise<void> => {
+  const previousUserId = getLastIdentifiedUserId()
+  const userChanged = !!(previousUserId && previousUserId !== input.id)
+
+  setLastIdentifiedUserId(input.id)
+
   const posthog = await loadInstance()
   if (!posthog) return
+
+  if (userChanged) {
+    posthog.reset()
+  }
+
   posthog.identify(input.id, {
     email: input.email,
     ...(input.name ? { name: input.name } : {}),
@@ -88,14 +114,16 @@ export const identifyOrganization = async (input: IdentifyOrganizationInput): Pr
 }
 
 /**
- * Clear the current identity and session. Call on explicit logout only — do
- * not call from the authenticated layout on mount: `posthog.reset()` starts a
- * fresh recording session, and layout remounts (including React Strict Mode in
- * dev) would fragment recordings. `identifyUser` in `PostHogIdentity` is enough
- * to attribute the same browser session to the signed-in user.
+ * Clear the current identity and session. Called on explicit logout and
+ * automatically by {@link identifyUser} when the user id changes (i.e. impersonation)
+ *
+ * Do not call from the authenticated layout on mount: `posthog.reset()`
+ * starts a fresh recording session, and layout remounts (including React
+ * Strict Mode in dev) would fragment recordings.
  */
 export const resetPostHog = async (): Promise<void> => {
   const posthog = await loadInstance()
   if (!posthog) return
+  setLastIdentifiedUserId(null)
   posthog.reset()
 }

--- a/apps/web/src/lib/posthog/posthog-provider.tsx
+++ b/apps/web/src/lib/posthog/posthog-provider.tsx
@@ -1,6 +1,6 @@
 import { useMountEffect } from "@repo/ui"
 import { useEffect } from "react"
-import { identifyOrganization, identifyUser, initPostHog, resetPostHog } from "./posthog-client.ts"
+import { identifyOrganization, identifyUser, initPostHog } from "./posthog-client.ts"
 
 export function PostHogProvider() {
   useMountEffect(() => {
@@ -25,14 +25,11 @@ export function PostHogIdentity({
   organizationName,
 }: PostHogIdentityProps) {
   useMountEffect(() => {
-    void (async () => {
-      await resetPostHog()
-      await identifyUser({
-        id: userId,
-        email: userEmail,
-        ...(userName != null ? { name: userName } : {}),
-      })
-    })()
+    void identifyUser({
+      id: userId,
+      email: userEmail,
+      ...(userName != null ? { name: userName } : {}),
+    })
   })
 
   useEffect(() => {


### PR DESCRIPTION
- **Problem**: PostHog session replays appeared fragmented (short segments, buffering). PostHog support flagged erroneous posthog.reset() calls as a common cause.
- **Root cause**: reset() was called whenever the authenticated layout's PostHogIdentity mounted (before identify()). Any remount starts a new PostHog session.
- **Fix — logout-only reset**: Removed the reset() from the mount path. On sign-in / app shell load, only identify() and the existing org group logic run — no reset.
- **Fix — identity-swap guard**: Added a sessionStorage-backed guard in identifyUser that detects when the user id changes (e.g. admin impersonation swaps the session cookie without logout). When a different user id is identified, posthog.reset() is called automatically before re-identifying, preventing PostHog from aliasing/merging distinct users.
- **Why sessionStorage**: Impersonation triggers a full page reload (window.location.href = "/"), which destroys module-level state. sessionStorage survives reloads within the same tab but clears on tab close — the right lifetime for this guard.
- **No-op for same user**: Normal page reloads, React Strict Mode double-mounts, and SPA navigations all see the same user id and skip the reset — recordings stay continuous.