### PR TITLE
Persist and reorder table columns

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/columns-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/columns-selector.tsx
@@ -1,14 +1,16 @@
 import {
   Button,
-  DropdownMenuCheckboxItem,
+  cn,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRoot,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Icon,
 } from "@repo/ui"
-import { ChevronDown, Columns2Icon } from "lucide-react"
+import { ChevronDown, Columns2Icon, EyeIcon, EyeOffIcon, GripVerticalIcon, LockIcon } from "lucide-react"
+import { type DragEvent, useState } from "react"
 
 export interface TableColumnOption {
   readonly id: string
@@ -20,13 +22,57 @@ export function ColumnsSelector({
   columns,
   selectedColumnIds,
   onChange,
+  onOrderChange,
   disabled = false,
 }: {
   readonly columns: readonly TableColumnOption[]
   readonly selectedColumnIds: readonly string[]
   readonly onChange: (nextColumnIds: string[]) => void
+  readonly onOrderChange?: (nextColumnIds: string[]) => void
   readonly disabled?: boolean
 }) {
+  const [draggedColumnId, setDraggedColumnId] = useState<string | null>(null)
+  const [dragTargetColumnId, setDragTargetColumnId] = useState<string | null>(null)
+
+  function handleDragStart(event: DragEvent, columnId: string) {
+    if (!onOrderChange) return
+    event.dataTransfer.effectAllowed = "move"
+    event.dataTransfer.setData("text/plain", columnId)
+    setDraggedColumnId(columnId)
+  }
+
+  function handleDragOver(event: DragEvent, columnId: string) {
+    if (!draggedColumnId || draggedColumnId === columnId) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "move"
+    setDragTargetColumnId(columnId)
+  }
+
+  function handleDrop(event: DragEvent, columnId: string) {
+    if (!onOrderChange) return
+    event.preventDefault()
+    const sourceColumnId = draggedColumnId ?? event.dataTransfer.getData("text/plain")
+    if (!sourceColumnId || sourceColumnId === columnId) return
+
+    const orderedColumnIds = columns.map((column) => column.id)
+    const sourceIndex = orderedColumnIds.indexOf(sourceColumnId)
+    const targetIndex = orderedColumnIds.indexOf(columnId)
+    if (sourceIndex < 0 || targetIndex < 0) return
+
+    const nextColumnIds = [...orderedColumnIds]
+    const [movedColumnId] = nextColumnIds.splice(sourceIndex, 1)
+    if (!movedColumnId) return
+    nextColumnIds.splice(targetIndex, 0, movedColumnId)
+    onOrderChange(nextColumnIds)
+    setDraggedColumnId(null)
+    setDragTargetColumnId(null)
+  }
+
+  function handleDragEnd() {
+    setDraggedColumnId(null)
+    setDragTargetColumnId(null)
+  }
+
   return (
     <DropdownMenuRoot>
       <DropdownMenuTrigger asChild>
@@ -41,22 +87,60 @@ export function ColumnsSelector({
         <DropdownMenuSeparator />
         {columns.map((column) => {
           const checked = selectedColumnIds.includes(column.id)
-          return (
-            <DropdownMenuCheckboxItem
-              key={column.id}
-              checked={checked}
-              disabled={column.required === true}
-              onCheckedChange={(nextChecked) => {
-                if (nextChecked) {
-                  onChange([...selectedColumnIds, column.id])
-                  return
-                }
+          const required = column.required === true
 
-                onChange(selectedColumnIds.filter((selectedColumnId) => selectedColumnId !== column.id))
-              }}
+          function toggleColumn() {
+            if (required) return
+            const nextSelectedColumnIds = new Set(selectedColumnIds)
+            if (checked) {
+              nextSelectedColumnIds.delete(column.id)
+            } else {
+              nextSelectedColumnIds.add(column.id)
+            }
+            onChange(columns.map((option) => option.id).filter((columnId) => nextSelectedColumnIds.has(columnId)))
+          }
+
+          return (
+            <DropdownMenuItem
+              key={column.id}
+              onSelect={(event) => event.preventDefault()}
+              onDragOver={(event) => handleDragOver(event, column.id)}
+              onDragLeave={() => setDragTargetColumnId(null)}
+              onDrop={(event) => handleDrop(event, column.id)}
+              onClick={toggleColumn}
+              className={cn("group cursor-pointer gap-2", {
+                "bg-accent": dragTargetColumnId === column.id,
+                "opacity-50": draggedColumnId === column.id,
+              })}
             >
-              {column.label}
-            </DropdownMenuCheckboxItem>
+              <button
+                type="button"
+                tabIndex={-1}
+                aria-label={`Drag ${column.label} column`}
+                draggable={Boolean(onOrderChange)}
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+                onDragStart={(event) => handleDragStart(event, column.id)}
+                onDragEnd={handleDragEnd}
+                className="flex cursor-grab items-center text-muted-foreground active:cursor-grabbing"
+              >
+                <Icon icon={GripVerticalIcon} size="sm" />
+              </button>
+              <span className="min-w-0 flex-1 truncate">{column.label}</span>
+              {required ? (
+                <span className="flex items-center text-muted-foreground">
+                  <Icon icon={LockIcon} size="sm" />
+                </span>
+              ) : checked ? (
+                <span className="flex items-center text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
+                  <Icon icon={EyeIcon} size="sm" />
+                </span>
+              ) : (
+                <span className="flex items-center text-muted-foreground">
+                  <Icon icon={EyeOffIcon} size="sm" />
+                </span>
+              )}
+            </DropdownMenuItem>
           )
         })}
       </DropdownMenuContent>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/columns-selector.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/columns-selector.tsx
@@ -10,7 +10,7 @@ import {
   Icon,
 } from "@repo/ui"
 import { ChevronDown, Columns2Icon, EyeIcon, EyeOffIcon, GripVerticalIcon, LockIcon } from "lucide-react"
-import { type DragEvent, useState } from "react"
+import { type DragEvent, type KeyboardEvent, useState } from "react"
 
 export interface TableColumnOption {
   readonly id: string
@@ -73,6 +73,21 @@ export function ColumnsSelector({
     setDragTargetColumnId(null)
   }
 
+  function moveColumn(columnId: string, direction: -1 | 1) {
+    if (!onOrderChange) return
+
+    const orderedColumnIds = columns.map((column) => column.id)
+    const sourceIndex = orderedColumnIds.indexOf(columnId)
+    const targetIndex = sourceIndex + direction
+    if (sourceIndex < 0 || targetIndex < 0 || targetIndex >= orderedColumnIds.length) return
+
+    const nextColumnIds = [...orderedColumnIds]
+    const [movedColumnId] = nextColumnIds.splice(sourceIndex, 1)
+    if (!movedColumnId) return
+    nextColumnIds.splice(targetIndex, 0, movedColumnId)
+    onOrderChange(nextColumnIds)
+  }
+
   return (
     <DropdownMenuRoot>
       <DropdownMenuTrigger asChild>
@@ -100,14 +115,34 @@ export function ColumnsSelector({
             onChange(columns.map((option) => option.id).filter((columnId) => nextSelectedColumnIds.has(columnId)))
           }
 
+          function handleKeyDown(event: KeyboardEvent) {
+            if (!event.shiftKey) return
+            if (event.key === "ArrowUp") {
+              event.preventDefault()
+              event.stopPropagation()
+              moveColumn(column.id, -1)
+            } else if (event.key === "ArrowDown") {
+              event.preventDefault()
+              event.stopPropagation()
+              moveColumn(column.id, 1)
+            }
+          }
+
           return (
             <DropdownMenuItem
               key={column.id}
-              onSelect={(event) => event.preventDefault()}
+              role="menuitemcheckbox"
+              aria-checked={checked}
+              aria-label={required ? `${column.label}, always visible` : undefined}
+              aria-keyshortcuts={onOrderChange ? "Shift+ArrowUp Shift+ArrowDown" : undefined}
+              onSelect={(event) => {
+                event.preventDefault()
+                toggleColumn()
+              }}
+              onKeyDown={handleKeyDown}
               onDragOver={(event) => handleDragOver(event, column.id)}
               onDragLeave={() => setDragTargetColumnId(null)}
               onDrop={(event) => handleDrop(event, column.id)}
-              onClick={toggleColumn}
               className={cn("group cursor-pointer gap-2", {
                 "bg-accent": dragTargetColumnId === column.id,
                 "opacity-50": draggedColumnId === column.id,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/project-traces-table.tsx
@@ -23,7 +23,7 @@ import { TraceOutlierBadge } from "./trace-outlier-badge.tsx"
 export const DEFAULT_TRACE_TABLE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
 
 export const TRACE_COLUMN_OPTIONS = [
-  { id: "indicators", label: "Indicators", required: true },
+  { id: "indicators", label: "Indicators" },
   { id: "startTime", label: "Start Time", required: true },
   { id: "name", label: "Name" },
   { id: "tags", label: "Tags" },
@@ -102,9 +102,10 @@ export function ProjectTracesTable({
     return [
       {
         key: "indicators",
-        header: "",
+        header: "Indicators",
         width: 88,
-        minWidth: 80,
+        minWidth: 88,
+        maxWidth: 88,
         resizable: false,
         ellipsis: false,
         cellClassName: "px-0",
@@ -310,10 +311,13 @@ export function ProjectTracesTable({
     annotationCountsPendingTraceIds,
   ])
 
-  const columns = useMemo(
-    () => allColumns.filter((column) => visibleColumnIds.includes(column.key as TraceColumnId)),
-    [allColumns, visibleColumnIds],
-  )
+  const columns = useMemo(() => {
+    const columnsById = new Map(allColumns.map((column) => [column.key, column]))
+    return visibleColumnIds.flatMap((columnId) => {
+      const column = columnsById.get(columnId)
+      return column ? [column] : []
+    })
+  }, [allColumns, visibleColumnIds])
 
   const handleTraceClick = useCallback(
     (trace: TraceRecord) => {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/sessions-view.tsx
@@ -36,6 +36,21 @@ const DEFAULT_SORTING: InfiniteTableSorting = { column: "startTime", direction: 
 
 const SESSION_TRACES_LIMIT = 25
 
+export const SESSION_COLUMN_OPTIONS = [
+  { id: "startTime", label: "Start Time", required: true },
+  { id: "name", label: "Name" },
+  { id: "tags", label: "Tags" },
+  { id: "duration", label: "Duration" },
+  { id: "ttft", label: "Time To First Token" },
+  { id: "cost", label: "Cost" },
+  { id: "sessionId", label: "Session ID" },
+  { id: "userId", label: "User ID" },
+  { id: "models", label: "Models" },
+  { id: "spans", label: "Spans" },
+] as const
+
+export type SessionColumnId = (typeof SESSION_COLUMN_OPTIONS)[number]["id"]
+
 function useExpandedSessionTraces(
   projectId: string,
   expandedIds: ReadonlySet<string>,
@@ -173,6 +188,7 @@ interface SessionsViewProps {
   readonly onFiltersClose: () => void
   readonly onActiveTraceChange: (traceId: string | undefined) => void
   readonly traceIdsRef: RefObject<string[]>
+  readonly visibleColumnIds: readonly SessionColumnId[]
 }
 
 export function SessionsView({
@@ -188,6 +204,7 @@ export function SessionsView({
   onFiltersClose,
   onActiveTraceChange,
   traceIdsRef,
+  visibleColumnIds,
 }: SessionsViewProps) {
   const [sorting, setSorting] = useState<InfiniteTableSorting>(DEFAULT_SORTING)
   const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(new Set())
@@ -209,7 +226,7 @@ export function SessionsView({
     ...(hasActiveFilters ? { filters } : {}),
   })
 
-  const columns = useMemo((): InfiniteTableColumn<SessionTableRow>[] => {
+  const allColumns = useMemo((): InfiniteTableColumn<SessionTableRow>[] => {
     return [
       {
         key: "startTime",
@@ -355,6 +372,14 @@ export function SessionsView({
       },
     ]
   }, [sessionMetrics, sessionMetricsLoading])
+
+  const columns = useMemo(() => {
+    const columnsById = new Map(allColumns.map((column) => [column.key, column]))
+    return visibleColumnIds.flatMap((columnId) => {
+      const column = columnsById.get(columnId)
+      return column ? [column] : []
+    })
+  }, [allColumns, visibleColumnIds])
 
   const traceMap = useExpandedSessionTraces(projectId, expandedIds, sessions, sorting)
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table-column-settings.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/table-column-settings.ts
@@ -1,0 +1,101 @@
+import { useLocalStorage } from "@repo/ui"
+import { useMemo } from "react"
+
+import type { TableColumnOption } from "./columns-selector.tsx"
+
+interface TableColumnSettings<ColumnId extends string> {
+  readonly columnIds: readonly ColumnId[]
+  readonly visibleColumnIds: readonly ColumnId[]
+}
+
+function uniqueKnownColumnIds<ColumnId extends string>({
+  columnIds,
+  knownColumnIds,
+}: {
+  readonly columnIds: readonly string[] | undefined
+  readonly knownColumnIds: ReadonlySet<ColumnId>
+}): ColumnId[] {
+  const nextColumnIds: ColumnId[] = []
+  for (const columnId of columnIds ?? []) {
+    if (knownColumnIds.has(columnId as ColumnId) && !nextColumnIds.includes(columnId as ColumnId)) {
+      nextColumnIds.push(columnId as ColumnId)
+    }
+  }
+  return nextColumnIds
+}
+
+function reconcileColumnSettings<ColumnId extends string>({
+  settings,
+  columns,
+}: {
+  readonly settings: TableColumnSettings<ColumnId> | null
+  readonly columns: readonly TableColumnOption[]
+}): TableColumnSettings<ColumnId> {
+  const defaultColumnIds = columns.map((column) => column.id as ColumnId)
+  const knownColumnIds = new Set(defaultColumnIds)
+  const requiredColumnIds = columns.filter((column) => column.required === true).map((column) => column.id as ColumnId)
+
+  const storedColumnIds = uniqueKnownColumnIds({ columnIds: settings?.columnIds, knownColumnIds })
+  const columnIds = [...storedColumnIds, ...defaultColumnIds.filter((columnId) => !storedColumnIds.includes(columnId))]
+
+  const storedVisibleColumnIds = uniqueKnownColumnIds({ columnIds: settings?.visibleColumnIds, knownColumnIds })
+  const visibleColumnIds =
+    storedVisibleColumnIds.length > 0
+      ? [...storedVisibleColumnIds, ...defaultColumnIds.filter((columnId) => !storedColumnIds.includes(columnId))]
+      : [...defaultColumnIds]
+
+  const requiredVisibleColumnIds = requiredColumnIds.filter((columnId) => !visibleColumnIds.includes(columnId))
+  const nextVisibleColumnIds = [...requiredVisibleColumnIds, ...visibleColumnIds].sort(
+    (leftColumnId, rightColumnId) => columnIds.indexOf(leftColumnId) - columnIds.indexOf(rightColumnId),
+  )
+
+  return { columnIds, visibleColumnIds: nextVisibleColumnIds }
+}
+
+export function useTableColumnSettings<ColumnId extends string>({
+  storageKey,
+  columns,
+}: {
+  readonly storageKey: string
+  readonly columns: readonly TableColumnOption[]
+}) {
+  const { value: storedSettings, setValue: setStoredSettings } = useLocalStorage<TableColumnSettings<ColumnId> | null>({
+    key: storageKey,
+    defaultValue: null,
+  })
+
+  const settings = useMemo(
+    () => reconcileColumnSettings({ settings: storedSettings, columns }),
+    [storedSettings, columns],
+  )
+
+  const orderedColumns = useMemo(() => {
+    const columnsById = new Map(columns.map((column) => [column.id, column]))
+    return settings.columnIds.flatMap((columnId) => {
+      const column = columnsById.get(columnId)
+      return column ? [column] : []
+    })
+  }, [columns, settings.columnIds])
+
+  return {
+    columns: orderedColumns,
+    visibleColumnIds: settings.visibleColumnIds,
+    setVisibleColumnIds: (visibleColumnIds: readonly ColumnId[]) => {
+      setStoredSettings((previousSettings) => ({
+        ...reconcileColumnSettings({ settings: previousSettings, columns }),
+        visibleColumnIds,
+      }))
+    },
+    setColumnIds: (columnIds: readonly ColumnId[]) => {
+      setStoredSettings((previousSettings) =>
+        reconcileColumnSettings({
+          settings: {
+            ...reconcileColumnSettings({ settings: previousSettings, columns }),
+            columnIds,
+          },
+          columns,
+        }),
+      )
+    },
+  }
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -1,14 +1,8 @@
 import { type FilterSet, filterSetSchema } from "@domain/shared"
 import type { InfiniteTableSorting } from "@repo/ui"
 import type { BulkSelection, SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
-import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "./project-traces-table.tsx"
 
 export const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
-
-export const DEFAULT_TRACE_COLUMNS: TraceColumnId[] = TRACE_COLUMN_OPTIONS.map((column) => column.id)
-
-const getRequiredTraceColumnIds = (): TraceColumnId[] =>
-  TRACE_COLUMN_OPTIONS.filter((column) => "required" in column && column.required === true).map((column) => column.id)
 
 export function parseFilters(raw?: string): FilterSet {
   if (!raw) return {}
@@ -36,24 +30,6 @@ export function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): strin
   if (!conds) return undefined
   const match = conds.find((c) => c.op === op)
   return match ? String(match.value) : undefined
-}
-
-export function parseTraceColumnIds(raw?: string): TraceColumnId[] {
-  const requiredColumnIds = getRequiredTraceColumnIds()
-  const values = raw
-    ?.split(",")
-    .map((value) => value.trim())
-    .filter((value): value is TraceColumnId => TRACE_COLUMN_OPTIONS.some((column) => column.id === value))
-
-  if (!values || values.length === 0) {
-    return [...DEFAULT_TRACE_COLUMNS]
-  }
-
-  return Array.from(new Set([...requiredColumnIds, ...values]))
-}
-
-export function serializeTraceColumnIds(columnIds: readonly TraceColumnId[]): string {
-  return Array.from(new Set([...getRequiredTraceColumnIds(), ...columnIds])).join(",")
 }
 
 export function getSelectedCount(state: SelectionState<string>, total: number): number {

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -16,19 +16,17 @@ import { TraceAggregationsPanel } from "./-components/aggregations/aggregations-
 import { ColumnsSelector } from "./-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "./-components/export-confirmation-modal.tsx"
 import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "./-components/project-traces-table.tsx"
-import { SessionsView } from "./-components/sessions-view.tsx"
+import { SESSION_COLUMN_OPTIONS, type SessionColumnId, SessionsView } from "./-components/sessions-view.tsx"
+import { useTableColumnSettings } from "./-components/table-column-settings.ts"
 import { TimeFilterDropdown } from "./-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
 import {
-  DEFAULT_TRACE_COLUMNS,
   DEFAULT_TRACE_SORTING,
   getBulkSelection,
   getSelectedCount,
   getTimeFilterValue,
   parseFilters,
-  parseTraceColumnIds,
   serializeFilters,
-  serializeTraceColumnIds,
 } from "./-components/trace-page-state.ts"
 import { TracesEmptyState } from "./-components/traces-empty-state.tsx"
 import { TracesView } from "./-components/traces-view.tsx"
@@ -58,11 +56,6 @@ function ProjectPage() {
   const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_TRACE_SORTING.direction, {
     validate: (v): v is SortDirection => v === "asc" || v === "desc",
   })
-  const [rawTraceColumns, setRawTraceColumns] = useParamState(
-    "traceColumns",
-    serializeTraceColumnIds(DEFAULT_TRACE_COLUMNS),
-  )
-
   const [traceDetailTab, setTraceDetailTab] = useParamState("traceDetailTab", "trace", {
     validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
       v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
@@ -72,7 +65,14 @@ function ProjectPage() {
   const traceIdsRef = useRef<string[]>([])
 
   const filters = useMemo(() => parseFilters(rawFilters || undefined), [rawFilters])
-  const visibleTraceColumnIds = parseTraceColumnIds(rawTraceColumns || undefined)
+  const traceColumnSettings = useTableColumnSettings<TraceColumnId>({
+    storageKey: "projects.traces.columns.v1",
+    columns: TRACE_COLUMN_OPTIONS,
+  })
+  const sessionColumnSettings = useTableColumnSettings<SessionColumnId>({
+    storageKey: "projects.sessions.columns.v1",
+    columns: SESSION_COLUMN_OPTIONS,
+  })
   const hasActiveFilters = Object.keys(filters).length > 0
   const timeFrom = getTimeFilterValue(filters, "gte")
   const timeTo = getTimeFilterValue(filters, "lte")
@@ -254,14 +254,6 @@ function ProjectPage() {
                 setRawFilters(serializeFilters(next) ?? "")
               }}
             />
-            <ColumnsSelector
-              columns={TRACE_COLUMN_OPTIONS}
-              selectedColumnIds={visibleTraceColumnIds}
-              onChange={(nextColumnIds) =>
-                setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
-              }
-              disabled={activeTab !== "traces"}
-            />
             <Tooltip
               asChild
               trigger={
@@ -289,6 +281,25 @@ function ProjectPage() {
             )}
           </Layout.ActionRowItem>
           <Layout.ActionRowItem>
+            {activeTab === "sessions" ? (
+              <ColumnsSelector
+                columns={sessionColumnSettings.columns}
+                selectedColumnIds={sessionColumnSettings.visibleColumnIds}
+                onChange={(nextColumnIds) =>
+                  sessionColumnSettings.setVisibleColumnIds(nextColumnIds as SessionColumnId[])
+                }
+                onOrderChange={(nextColumnIds) =>
+                  sessionColumnSettings.setColumnIds(nextColumnIds as SessionColumnId[])
+                }
+              />
+            ) : (
+              <ColumnsSelector
+                columns={traceColumnSettings.columns}
+                selectedColumnIds={traceColumnSettings.visibleColumnIds}
+                onChange={(nextColumnIds) => traceColumnSettings.setVisibleColumnIds(nextColumnIds as TraceColumnId[])}
+                onOrderChange={(nextColumnIds) => traceColumnSettings.setColumnIds(nextColumnIds as TraceColumnId[])}
+              />
+            )}
             <Tabs
               variant="bordered"
               size="sm"
@@ -331,9 +342,9 @@ function ProjectPage() {
       </div>
 
       {activeTab === "traces" ? (
-        <TracesView {...sharedViewProps} visibleColumnIds={visibleTraceColumnIds} />
+        <TracesView {...sharedViewProps} visibleColumnIds={traceColumnSettings.visibleColumnIds} />
       ) : (
-        <SessionsView {...sharedViewProps} />
+        <SessionsView {...sharedViewProps} visibleColumnIds={sessionColumnSettings.visibleColumnIds} />
       )}
 
       {activeTraceId ? (

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-view.tsx
@@ -247,7 +247,11 @@ export function IssuesView({
     },
   ]
 
-  const columns = allColumns.filter((column) => visibleColumnIds.includes(column.key as IssuesColumnId))
+  const columnsById = new Map(allColumns.map((column) => [column.key, column]))
+  const columns = visibleColumnIds.flatMap((columnId) => {
+    const column = columnsById.get(columnId)
+    return column ? [column] : []
+  })
 
   return (
     <Layout.Body>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/index.tsx
@@ -27,6 +27,7 @@ import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
 import { EMPTY_SELECTION, type SelectionState, useSelectableRows } from "../../../../../lib/hooks/useSelectableRows.ts"
 import { ColumnsSelector } from "../-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
+import { useTableColumnSettings } from "../-components/table-column-settings.ts"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { useRouteProject } from "../-route-data.ts"
 import { IssueDetailDrawer } from "./-components/issue-detail-drawer.tsx"
@@ -40,29 +41,11 @@ import {
 } from "./-components/issues-view.tsx"
 
 const DEFAULT_SORTING: IssuesTableSorting = { column: "lastSeen", direction: "desc" }
-const DEFAULT_COLUMNS: IssuesColumnId[] = ISSUES_COLUMN_OPTIONS.map((column) => column.id)
 const ISSUE_SEARCH_DEBOUNCE_MS = 300
 const SORT_COLUMNS = ["lastSeen", "occurrences", "state"] as const satisfies readonly IssuesTableSorting["column"][]
 const SORT_DIRECTIONS = ["asc", "desc"] as const satisfies readonly IssuesTableSorting["direction"][]
 const SORT_PARAM_PATTERN = /^(lastSeen|occurrences|state):(asc|desc)$/
 const EMPTY_ISSUES: readonly IssueRecord[] = []
-
-function parseColumnIds(raw?: string): IssuesColumnId[] {
-  const values = raw
-    ?.split(",")
-    .map((value) => value.trim())
-    .filter((value): value is IssuesColumnId => ISSUES_COLUMN_OPTIONS.some((column) => column.id === value))
-
-  if (!values || values.length === 0) {
-    return [...DEFAULT_COLUMNS]
-  }
-
-  return values.includes("issue") ? values : ["issue", ...values]
-}
-
-function serializeColumnIds(columnIds: readonly IssuesColumnId[]): string {
-  return Array.from(new Set(["issue", ...columnIds])).join(",")
-}
 
 function serializeSorting(sorting: IssuesTableSorting): string {
   return `${sorting.column}:${sorting.direction}`
@@ -93,7 +76,6 @@ function IssuesPage() {
   const [lifecycleGroup, setLifecycleGroup] = useParamState("issuesLifecycle", "active", {
     validate: (value): value is "active" | "archived" => value === "active" || value === "archived",
   })
-  const [rawColumns, setRawColumns] = useParamState("issuesColumns", serializeColumnIds(DEFAULT_COLUMNS))
   const [timeFrom, setTimeFrom] = useParamState("issuesTimeFrom", "")
   const [timeTo, setTimeTo] = useParamState("issuesTimeTo", "")
   const [searchQuery, setSearchQuery] = useParamState("issuesSearch", "")
@@ -123,7 +105,10 @@ function IssuesPage() {
     [searchInput, searchQuery, setSearchQuery],
   )
 
-  const visibleColumnIds = parseColumnIds(rawColumns || undefined)
+  const columnSettings = useTableColumnSettings<IssuesColumnId>({
+    storageKey: "projects.issues.columns.v1",
+    columns: ISSUES_COLUMN_OPTIONS,
+  })
   const timeRange =
     timeFrom || timeTo
       ? {
@@ -321,11 +306,6 @@ function IssuesPage() {
                   setTimeTo(to ?? "")
                 }}
               />
-              <ColumnsSelector
-                columns={ISSUES_COLUMN_OPTIONS}
-                selectedColumnIds={visibleColumnIds}
-                onChange={(nextColumnIds) => setRawColumns(serializeColumnIds(nextColumnIds as IssuesColumnId[]))}
-              />
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
               <Tabs
@@ -356,6 +336,12 @@ function IssuesPage() {
                 />
                 <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               </div>
+              <ColumnsSelector
+                columns={columnSettings.columns}
+                selectedColumnIds={columnSettings.visibleColumnIds}
+                onChange={(nextColumnIds) => columnSettings.setVisibleColumnIds(nextColumnIds as IssuesColumnId[])}
+                onOrderChange={(nextColumnIds) => columnSettings.setColumnIds(nextColumnIds as IssuesColumnId[])}
+              />
             </Layout.ActionRowItem>
           </Layout.ActionsRow>
         </Layout.Actions>
@@ -404,7 +390,7 @@ function IssuesPage() {
           infiniteScroll={infiniteScroll}
           sorting={sorting}
           occurrencesSum={occurrencesSum}
-          visibleColumnIds={visibleColumnIds}
+          visibleColumnIds={columnSettings.visibleColumnIds}
           activeIssueId={activeIssueId || undefined}
           selection={selection}
           onSortChange={setSorting}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -17,18 +17,16 @@ import { EMPTY_SELECTION, type SelectionState } from "../../../../../lib/hooks/u
 import { ColumnsSelector } from "../-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
 import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "../-components/project-traces-table.tsx"
+import { useTableColumnSettings } from "../-components/table-column-settings.ts"
 import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "../-components/trace-detail-drawer.tsx"
 import {
-  DEFAULT_TRACE_COLUMNS,
   DEFAULT_TRACE_SORTING,
   getBulkSelection,
   getSelectedCount,
   getTimeFilterValue,
   parseFilters,
-  parseTraceColumnIds,
   serializeFilters,
-  serializeTraceColumnIds,
 } from "../-components/trace-page-state.ts"
 import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
@@ -63,10 +61,6 @@ function SearchPage() {
   const [sortDirection, setSortDirection] = useParamState("sortDirection", DEFAULT_TRACE_SORTING.direction, {
     validate: (v): v is SortDirection => v === "asc" || v === "desc",
   })
-  const [rawTraceColumns, setRawTraceColumns] = useParamState(
-    "traceColumns",
-    serializeTraceColumnIds(DEFAULT_TRACE_COLUMNS),
-  )
   const [traceDetailTab, setTraceDetailTab] = useParamState("traceDetailTab", "trace", {
     validate: (v): v is "trace" | "conversation" | "spans" | "annotations" =>
       v === "trace" || v === "conversation" || v === "spans" || v === "annotations",
@@ -75,7 +69,10 @@ function SearchPage() {
   const traceIdsRef = useRef<string[]>([])
 
   const filters = parseFilters(rawFilters || undefined)
-  const visibleTraceColumnIds = parseTraceColumnIds(rawTraceColumns || undefined)
+  const traceColumnSettings = useTableColumnSettings<TraceColumnId>({
+    storageKey: "projects.search.traces.columns.v1",
+    columns: TRACE_COLUMN_OPTIONS,
+  })
   const hasSearchQuery = q.length > 0
   const hasActiveFilters = Object.keys(filters).length > 0
   const hasContent = hasSearchQuery || hasActiveFilters
@@ -242,13 +239,6 @@ function SearchPage() {
                   setRawFilters(serializeFilters(next) ?? "")
                 }}
               />
-              <ColumnsSelector
-                columns={TRACE_COLUMN_OPTIONS}
-                selectedColumnIds={visibleTraceColumnIds}
-                onChange={(nextColumnIds) =>
-                  setRawTraceColumns(serializeTraceColumnIds(nextColumnIds as TraceColumnId[]))
-                }
-              />
               <Button
                 variant={filtersOpen ? "outline" : "ghost"}
                 size="sm"
@@ -269,6 +259,12 @@ function SearchPage() {
               ) : null}
             </Layout.ActionRowItem>
             <Layout.ActionRowItem>
+              <ColumnsSelector
+                columns={traceColumnSettings.columns}
+                selectedColumnIds={traceColumnSettings.visibleColumnIds}
+                onChange={(nextColumnIds) => traceColumnSettings.setVisibleColumnIds(nextColumnIds as TraceColumnId[])}
+                onOrderChange={(nextColumnIds) => traceColumnSettings.setColumnIds(nextColumnIds as TraceColumnId[])}
+              />
               {loadedSavedSearch ? (
                 <SplitButton
                   variant="outline"
@@ -342,7 +338,7 @@ function SearchPage() {
           onFiltersClose={() => setFiltersOpen(false)}
           onActiveTraceChange={onActiveTraceChange}
           traceIdsRef={traceIdsRef}
-          visibleColumnIds={visibleTraceColumnIds}
+          visibleColumnIds={traceColumnSettings.visibleColumnIds}
           searchQuery={q}
         />
       ) : null}

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -122,6 +122,7 @@ function DataRowInner<T>({
         return (
           <td
             key={col.key}
+            {...(col.maxWidth !== undefined ? { style: { maxWidth: col.maxWidth } } : {})}
             className={cn(
               "px-4 py-2",
               "first:rounded-l-lg last:rounded-r-lg overflow-hidden",

--- a/packages/ui/src/components/infinite-table/data-row.tsx
+++ b/packages/ui/src/components/infinite-table/data-row.tsx
@@ -5,6 +5,8 @@ import { Checkbox, type CheckedState } from "../checkbox/checkbox.tsx"
 import { Text } from "../text/text.tsx"
 import type { InfiniteTableColumn } from "./types.ts"
 
+const SELECTION_COLUMN_WIDTH = 48
+
 interface DataRowProps<T> {
   row: T
   rowKey: string
@@ -101,6 +103,7 @@ function DataRowInner<T>({
       )}
       {hasSelection && (
         <td
+          style={{ width: SELECTION_COLUMN_WIDTH, minWidth: SELECTION_COLUMN_WIDTH, maxWidth: SELECTION_COLUMN_WIDTH }}
           className={cn(
             "px-4 py-2",
             "first:rounded-l-lg last:rounded-r-lg overflow-hidden",

--- a/packages/ui/src/components/infinite-table/headers/header-cell.tsx
+++ b/packages/ui/src/components/infinite-table/headers/header-cell.tsx
@@ -29,6 +29,7 @@ export function HeaderCell({
   resizable = true,
   minWidth = 60,
   width: preferredWidth,
+  maxWidth,
   className,
   sortable,
   sortDirection,
@@ -42,6 +43,8 @@ export function HeaderCell({
   minWidth?: number
   /** Preferred starting width (px); the first layout lock keeps at least this width. */
   width?: number
+  /** Maximum width (px); when set equal to `width`, the column stays fixed. */
+  maxWidth?: number
   className?: string
   sortable?: boolean
   sortDirection?: SortDirection | null
@@ -83,10 +86,13 @@ export function HeaderCell({
       ? ({
           width: preferredWidth,
           ...(minWidth > 60 ? { minWidth } : {}),
+          ...(maxWidth !== undefined ? { maxWidth } : {}),
         } as const)
       : minWidth > 60
-        ? ({ minWidth } as const)
-        : undefined
+        ? ({ minWidth, ...(maxWidth !== undefined ? { maxWidth } : {}) } as const)
+        : maxWidth !== undefined
+          ? ({ maxWidth } as const)
+          : undefined
 
   const headerBody = (
     <div className="flex min-h-0 w-full min-w-0 flex-col gap-0">

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -12,6 +12,7 @@ import { useHeaderLayoutLock } from "./use-header-layout-lock.ts"
 const ROW_HEIGHT = 40
 const SKELETON_ROW_COUNT = 8
 const EXPANDED_SKELETON_COUNT = 3
+const SELECTION_COLUMN_WIDTH = 48
 
 function nextSortDirection(current: SortDirection | null): SortDirection | null {
   if (current === null) return "desc"
@@ -161,7 +162,13 @@ export function InfiniteTable<T>({
               <tr>
                 {hasExpansion && <HeaderCell resizable={false} className="w-8" showSubheaderSlot={hasSubheaderRow} />}
                 {selection && (
-                  <HeaderCell resizable={false} className="w-10" showSubheaderSlot={hasSubheaderRow}>
+                  <HeaderCell
+                    resizable={false}
+                    width={SELECTION_COLUMN_WIDTH}
+                    minWidth={SELECTION_COLUMN_WIDTH}
+                    maxWidth={SELECTION_COLUMN_WIDTH}
+                    showSubheaderSlot={hasSubheaderRow}
+                  >
                     <Checkbox checked={selection.headerState} onCheckedChange={() => selection.toggleAll()} />
                   </HeaderCell>
                 )}

--- a/packages/ui/src/components/infinite-table/infinite-table.tsx
+++ b/packages/ui/src/components/infinite-table/infinite-table.tsx
@@ -181,6 +181,7 @@ export function InfiniteTable<T>({
                       resizable={col.resizable !== false && i < columns.length - 1}
                       {...(col.minWidth !== undefined ? { minWidth: col.minWidth } : {})}
                       {...(col.width !== undefined ? { width: col.width } : {})}
+                      {...(col.maxWidth !== undefined ? { maxWidth: col.maxWidth } : {})}
                       showSubheaderSlot={hasSubheaderRow}
                       {...(hasSubheaderRow ? { subheader: col.renderSubheader?.(col, i) } : {})}
                       {...(sortDir ? { sortDirection: sortDir } : {})}

--- a/packages/ui/src/components/infinite-table/types.ts
+++ b/packages/ui/src/components/infinite-table/types.ts
@@ -13,6 +13,8 @@ export interface InfiniteTableColumn<T> {
   minWidth?: number
   /** Preferred starting width (px) for the first layout lock; the column can later be resized smaller. */
   width?: number
+  /** Maximum width (px); when set equal to `width`, the column stays fixed. */
+  maxWidth?: number
   sortKey?: string
   /** Optional second header row cell; use for summaries. Keep controls `stopPropagation` if the column is sortable. */
   renderSubheader?: (column: InfiniteTableColumn<T>, columnIndex: number) => ReactNode

--- a/packages/ui/src/components/infinite-table/use-header-layout-lock.ts
+++ b/packages/ui/src/components/infinite-table/use-header-layout-lock.ts
@@ -28,7 +28,8 @@ export function resolveLockedHeaderLayout<T>({
 }: ResolveLockedHeaderLayoutParams<T>) {
   const lockedHeaderWidths = headerCells.map((headerCell, headerIndex) => {
     const column = columns[headerIndex - leadingColumnCount]
-    return Math.max(headerCell.offsetWidth, column?.width ?? 0)
+    const measuredWidth = Math.max(headerCell.offsetWidth, column?.width ?? 0)
+    return column?.maxWidth !== undefined ? Math.min(measuredWidth, column.maxWidth) : measuredWidth
   })
 
   return {
@@ -59,6 +60,7 @@ export function useHeaderLayoutLock<T>({
           col.align ?? "",
           col.minWidth ?? "",
           col.width ?? "",
+          col.maxWidth ?? "",
           col.resizable ?? "",
           col.sortKey ?? "",
           col.renderSubheader ? "1" : "0",


### PR DESCRIPTION
## Summary
- Keep the Columns menu open while toggling visibility, with clearer visible/hidden/locked states.
- Let users drag column options to reorder trace, session, search, and issue tables, and persist those choices in localStorage.
- Move column controls to the display-focused side of each toolbar and keep the trace Indicators column fixed-width, labeled, hideable, and reorderable.

<img width="275" height="463" alt="image" src="https://github.com/user-attachments/assets/6ec4567e-324f-4ef2-a1c6-d0b2a194c43a" />


## Test plan
- Ran `pnpm format` and `pnpm knip` from the repo root before committing.
- Ran `pnpm test` in `apps/web`.
- Earlier validation also included `pnpm typecheck` in `apps/web` and `packages/ui`.