### PR TITLE
Disable PH for latitude users

### DIFF
--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -66,6 +66,8 @@ const loadInstance = (): Promise<PostHog | null> => {
         capture_pageview: true,
         autocapture: true,
         disable_session_recording: false,
+        // Start silent — syncPostHogSession opts in for real customers once the authenticated layout mounts
+        opt_out_capturing_by_default: true,
       })
       return posthog
     })
@@ -148,13 +150,13 @@ export const syncPostHogSession = async (input: SyncSessionInput): Promise<void>
 /**
  * Clear the current identity and session. Called on explicit logout.
  *
- * Re-enables capturing after reset so the next login starts from a neutral
- * baseline — `syncPostHogSession` will opt out again if the new user is staff.
+ * Does NOT re-enable capturing — `opt_out_capturing_by_default: true` in the
+ * init config keeps unauthenticated routes silent. The next authenticated
+ * mount will call `syncPostHogSession`, which opts in for real customers.
  */
 export const resetPostHog = async (): Promise<void> => {
   const posthog = await loadInstance()
   if (!posthog) return
   setLastIdentifiedUserId(null)
   posthog.reset()
-  posthog.opt_in_capturing()
 }

--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -9,6 +9,7 @@
 import type { PostHog } from "posthog-js"
 
 const POSTHOG_DEFAULT_HOST = "https://eu.i.posthog.com"
+const INTERNAL_EMAIL_DOMAIN = "latitude.so"
 
 interface PostHogEnv {
   readonly apiKey: string
@@ -20,6 +21,11 @@ const readEnv = (): PostHogEnv | null => {
   if (!apiKey) return null
   const host = import.meta.env.VITE_LAT_POSTHOG_HOST ?? POSTHOG_DEFAULT_HOST
   return { apiKey, host }
+}
+
+export const isLatitudeStaffEmail = (email: string): boolean => {
+  const host = email.trim().split("@").pop()?.toLowerCase()
+  return host === INTERNAL_EMAIL_DOMAIN
 }
 
 // Module-level singletons. These are re-created across HMR module reloads,
@@ -77,17 +83,48 @@ export const initPostHog = async (): Promise<void> => {
   await loadInstance()
 }
 
+const setPostHogCaptureEnabled = async (enabled: boolean): Promise<void> => {
+  const posthog = await loadInstance()
+  if (!posthog) return
+  if (enabled) {
+    posthog.opt_in_capturing()
+  } else {
+    posthog.opt_out_capturing()
+  }
+}
+
 interface IdentifyUserInput {
   readonly id: string
   readonly email: string
   readonly name?: string | null
 }
 
-export const identifyUser = async (input: IdentifyUserInput): Promise<void> => {
-  const previousUserId = getLastIdentifiedUserId()
-  const userChanged = !!(previousUserId && previousUserId !== input.id)
+interface SyncSessionInput {
+  readonly user: IdentifyUserInput
+  readonly organizationId: string
+  readonly organizationName?: string | null | undefined
+  readonly excludeFromAnalytics: boolean
+}
 
-  setLastIdentifiedUserId(input.id)
+/**
+ * Single entry-point for the authenticated layout to sync PostHog state.
+ *
+ * When the session is internal (staff email or impersonation), opt out of
+ * capturing so no events, recordings, or person records are created. When
+ * it's a real customer session, opt in, handle user-change resets, and
+ * call identify + group.
+ */
+export const syncPostHogSession = async (input: SyncSessionInput): Promise<void> => {
+  if (input.excludeFromAnalytics) {
+    await setPostHogCaptureEnabled(false)
+    return
+  }
+
+  await setPostHogCaptureEnabled(true)
+
+  const previousUserId = getLastIdentifiedUserId()
+  const userChanged = !!(previousUserId && previousUserId !== input.user.id)
+  setLastIdentifiedUserId(input.user.id)
 
   const posthog = await loadInstance()
   if (!posthog) return
@@ -96,34 +133,28 @@ export const identifyUser = async (input: IdentifyUserInput): Promise<void> => {
     posthog.reset()
   }
 
-  posthog.identify(input.id, {
-    email: input.email,
-    ...(input.name ? { name: input.name } : {}),
+  posthog.identify(input.user.id, {
+    email: input.user.email,
+    ...(input.user.name ? { name: input.user.name } : {}),
   })
-}
 
-interface IdentifyOrganizationInput {
-  readonly id: string
-  readonly name?: string | null
-}
-
-export const identifyOrganization = async (input: IdentifyOrganizationInput): Promise<void> => {
-  const posthog = await loadInstance()
-  if (!posthog) return
-  posthog.group("organization", input.id, input.name ? { name: input.name } : undefined)
+  posthog.group(
+    "organization",
+    input.organizationId,
+    input.organizationName ? { name: input.organizationName } : undefined,
+  )
 }
 
 /**
- * Clear the current identity and session. Called on explicit logout and
- * automatically by {@link identifyUser} when the user id changes (i.e. impersonation)
+ * Clear the current identity and session. Called on explicit logout.
  *
- * Do not call from the authenticated layout on mount: `posthog.reset()`
- * starts a fresh recording session, and layout remounts (including React
- * Strict Mode in dev) would fragment recordings.
+ * Re-enables capturing after reset so the next login starts from a neutral
+ * baseline — `syncPostHogSession` will opt out again if the new user is staff.
  */
 export const resetPostHog = async (): Promise<void> => {
   const posthog = await loadInstance()
   if (!posthog) return
   setLastIdentifiedUserId(null)
   posthog.reset()
+  posthog.opt_in_capturing()
 }

--- a/apps/web/src/lib/posthog/posthog-provider.tsx
+++ b/apps/web/src/lib/posthog/posthog-provider.tsx
@@ -1,6 +1,6 @@
 import { useMountEffect } from "@repo/ui"
 import { useEffect } from "react"
-import { identifyOrganization, identifyUser, initPostHog } from "./posthog-client.ts"
+import { initPostHog, syncPostHogSession } from "./posthog-client.ts"
 
 export function PostHogProvider() {
   useMountEffect(() => {
@@ -15,6 +15,7 @@ interface PostHogIdentityProps {
   readonly userName?: string | null | undefined
   readonly organizationId: string
   readonly organizationName?: string | null | undefined
+  readonly excludeFromAnalytics: boolean
 }
 
 export function PostHogIdentity({
@@ -23,19 +24,20 @@ export function PostHogIdentity({
   userName,
   organizationId,
   organizationName,
+  excludeFromAnalytics,
 }: PostHogIdentityProps) {
-  useMountEffect(() => {
-    void identifyUser({
-      id: userId,
-      email: userEmail,
-      ...(userName != null ? { name: userName } : {}),
-    })
-  })
-
   useEffect(() => {
-    if (!organizationName) return
-    void identifyOrganization({ id: organizationId, name: organizationName })
-  }, [organizationId, organizationName])
+    void syncPostHogSession({
+      user: {
+        id: userId,
+        email: userEmail,
+        ...(userName != null ? { name: userName } : {}),
+      },
+      organizationId,
+      organizationName,
+      excludeFromAnalytics,
+    })
+  }, [userId, userEmail, userName, organizationId, organizationName, excludeFromAnalytics])
 
   return null
 }

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -8,7 +8,7 @@ import { getSession } from "../domains/sessions/session.functions.ts"
 import { getSupportUserIdentity } from "../domains/support/support.functions.ts"
 import { authClient } from "../lib/auth-client.ts"
 import { IntercomProvider } from "../lib/intercom/intercom-provider.tsx"
-import { resetPostHog } from "../lib/posthog/posthog-client.ts"
+import { isLatitudeStaffEmail, resetPostHog } from "../lib/posthog/posthog-client.ts"
 import { PostHogIdentity } from "../lib/posthog/posthog-provider.tsx"
 import { useThemePreference } from "../lib/theme.ts"
 import { BreadcrumbTrail } from "./_authenticated/-components/breadcrumb-trail.tsx"
@@ -250,6 +250,7 @@ function AuthenticatedLayout() {
           userName={user.name}
           organizationId={organizationId}
           organizationName={org?.name}
+          excludeFromAnalytics={isLatitudeStaffEmail(user.email) || impersonatedBy != null}
         />
         {impersonatedBy && <ImpersonationBanner impersonatedUserEmail={user.email} />}
         {isProjectOnboarding ? null : <NavHeader />}


### PR DESCRIPTION
- **Problem**: Internal @latitude.so team usage floods PostHog with staff events, recordings, and person records — polluting product analytics with non-customer data.
- **Fix**: @latitude.so emails and impersonation sessions now call posthog.opt_out_capturing(), which suppresses all events, recordings, and person creation for those sessions.
- **Customer sessions unchanged**: Non-staff users get opt_in_capturing() before identify + group, same as before.
- **Logout safety**: resetPostHog re-enables capturing after reset(), so the next login starts from a clean baseline — if a customer logs in after staff on the same browser, analytics work normally.
- **Single syncPostHogSession entry-point**: Replaces separate identifyUser + identifyOrganization calls with one function that handles opt-out, user-change detection, identify, and group in the correct order.