### PR TITLE
feat(datasets): add traces of an issue to a dataset [LAT-545]

### DIFF
--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -14,6 +14,7 @@ import {
   listRows,
   parseDatasetCsv,
   type TraceSelection,
+  type TraceSource,
   updateDatasetDetails,
   updateRow,
 } from "@domain/datasets"
@@ -21,6 +22,7 @@ import {
   DatasetId,
   DatasetRowId,
   DatasetVersionId,
+  IssueId,
   isValidId,
   OrganizationId,
   ProjectId,
@@ -31,7 +33,12 @@ import {
 } from "@domain/shared"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
-import { DatasetRowRepositoryLive, TraceRepositoryLive, withClickHouse } from "@platform/db-clickhouse"
+import {
+  DatasetRowRepositoryLive,
+  ScoreAnalyticsRepositoryLive,
+  TraceRepositoryLive,
+  withClickHouse,
+} from "@platform/db-clickhouse"
 import { DatasetRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -594,11 +601,16 @@ function toTraceSelection(sel: z.infer<typeof rowSelectionSchema>): TraceSelecti
   return { mode: sel.mode, traceIds: sel.rowIds.map(TraceId) }
 }
 
+function toTraceSource(issueId: string | undefined): TraceSource {
+  return issueId ? { kind: "issue", issueId: IssueId(issueId) } : { kind: "project" }
+}
+
 export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
   .inputValidator(
     z.object({
       projectId: z.string(),
       datasetId: z.string(),
+      issueId: z.string().optional(),
       selection: rowSelectionSchema,
     }),
   )
@@ -611,11 +623,13 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
       addTracesToDataset({
         projectId: ProjectId(data.projectId),
         datasetId: DatasetId(data.datasetId),
+        source: toTraceSource(data.issueId),
         selection: toTraceSelection(data.selection),
       }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
         withClickHouse(TraceRepositoryLive, chClient, orgId),
+        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
@@ -640,6 +654,7 @@ export const createDatasetFromTracesFunction = createServerFn({
           message: "Invalid dataset id",
         }),
       projectId: z.string(),
+      issueId: z.string().optional(),
       name: z.string().min(1),
       selection: rowSelectionSchema,
     }),
@@ -663,11 +678,13 @@ export const createDatasetFromTracesFunction = createServerFn({
           ...(data.datasetId ? { datasetId: DatasetId(data.datasetId) } : {}),
           projectId: ProjectId(data.projectId),
           name: data.name,
+          source: toTraceSource(data.issueId),
           selection: toTraceSelection(data.selection),
         }).pipe(
           withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), pgClient, orgId),
           withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
           withClickHouse(TraceRepositoryLive, chClient, orgId),
+          withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId),
           withAi(AIEmbedLive, getRedisClient()),
           withTracing,
         ),

--- a/apps/web/src/domains/issues/issues.collection.ts
+++ b/apps/web/src/domains/issues/issues.collection.ts
@@ -10,7 +10,7 @@ import type {
   IssueTracePageRecord,
   IssueTraceRecord,
 } from "./issues.functions.ts"
-import { getIssue, getIssueDetail, listIssues, listIssueTraces } from "./issues.functions.ts"
+import { countIssueTraces, getIssue, getIssueDetail, listIssues, listIssueTraces } from "./issues.functions.ts"
 
 const queryClient = getQueryClient()
 const DEFAULT_ISSUES_BATCH_SIZE = 50
@@ -76,6 +76,9 @@ const getIssueTracesQueryKey = (projectId: string, issueId: string) => ["issue-t
 
 const getIssueTracesPageKey = (projectId: string, issueId: string, offset: number) =>
   ["issue-traces-page", projectId, issueId, offset] as const
+
+const getIssueTracesCountQueryKey = (projectId: string, issueId: string) =>
+  ["issue-traces-count", projectId, issueId] as const
 
 const buildListIssuesRequest = (input: IssuesKeyInput, offset: number) => ({
   projectId: input.projectId,
@@ -303,12 +306,32 @@ export function useIssueTracesInfiniteScroll({
   return { data, isLoading, infiniteScroll }
 }
 
+export function useIssueTracesCount({
+  projectId,
+  issueId,
+  enabled = true,
+}: {
+  readonly projectId: string
+  readonly issueId: string
+  readonly enabled?: boolean
+}) {
+  const { data } = useQuery({
+    queryKey: getIssueTracesCountQueryKey(projectId, issueId),
+    queryFn: () => countIssueTraces({ data: { projectId, issueId } }),
+    enabled: enabled && projectId.length > 0 && issueId.length > 0,
+    staleTime: ISSUES_QUERY_STALE_TIME_MS,
+  })
+
+  return data?.total ?? 0
+}
+
 const invalidateIssueDetailQueries = (projectId: string, issueId: string) =>
   Promise.all([
     queryClient.invalidateQueries({ queryKey: getIssueQueryKey(projectId, issueId) }),
     queryClient.invalidateQueries({ queryKey: getIssueDetailQueryKey(projectId, issueId) }),
     queryClient.invalidateQueries({ queryKey: getIssueTracesQueryKey(projectId, issueId) }),
     queryClient.invalidateQueries({ queryKey: ["issue-traces-page", projectId, issueId] }),
+    queryClient.invalidateQueries({ queryKey: getIssueTracesCountQueryKey(projectId, issueId) }),
   ])
 
 export const invalidateIssueQueries = (projectId: string, issueId?: string) =>

--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -147,6 +147,11 @@ const issueTracesInputSchema = z.object({
   offset: z.number().int().min(0).optional(),
 })
 
+const issueTracesCountInputSchema = z.object({
+  projectId: z.string(),
+  issueId: z.string(),
+})
+
 const toUtcDayEnd = (value: Date): Date =>
   new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate(), 23, 59, 59, 999))
 
@@ -500,6 +505,28 @@ export const listIssueTraces = createServerFn({ method: "GET" })
         withAi(AIEmbedLive, getRedisClient()),
         withTracing,
       ),
+    )
+  })
+
+export const countIssueTraces = createServerFn({ method: "GET" })
+  .inputValidator(issueTracesCountInputSchema)
+  .handler(async ({ data }): Promise<{ readonly total: number }> => {
+    const { organizationId } = await requireSession()
+    const orgId = OrganizationId(organizationId)
+    const chClient = getClickhouseClient()
+    const projectId = ProjectId(data.projectId)
+    const issueId = IssueId(data.issueId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+        const total = yield* scoreAnalyticsRepository.countTracesByIssue({
+          organizationId: orgId,
+          projectId,
+          issueId,
+        })
+        return { total }
+      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, chClient, orgId), withTracing),
     )
   })
 

--- a/apps/web/src/lib/hooks/useSelectableRows.ts
+++ b/apps/web/src/lib/hooks/useSelectableRows.ts
@@ -20,6 +20,32 @@ export const EMPTY_SELECTION: SelectionState<string> = {
   excludedIds: new Set(),
 }
 
+export function getSelectedCount<T extends string | number>(state: SelectionState<T>, total: number): number {
+  switch (state.mode) {
+    case "all":
+      return total - state.excludedIds.size
+    case "none":
+      return 0
+    case "partial":
+      return state.selectedIds.size
+    case "allExcept":
+      return total - state.excludedIds.size
+  }
+}
+
+export function getBulkSelection<T extends string | number>(state: SelectionState<T>): BulkSelection<T> | null {
+  switch (state.mode) {
+    case "all":
+      return { mode: "all" }
+    case "allExcept":
+      return { mode: "allExcept", rowIds: Array.from(state.excludedIds) }
+    case "partial":
+      return state.selectedIds.size > 0 ? { mode: "selected", rowIds: Array.from(state.selectedIds) } : null
+    case "none":
+      return null
+  }
+}
+
 export function useSelectableRows<T extends string | number>({
   rowIds,
   initialSelection = [],

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
@@ -3,20 +3,25 @@ import { Alert, Button, CloseTrigger, Input, Modal, Select, type SelectOption, T
 import { useNavigate } from "@tanstack/react-router"
 import { Plus } from "lucide-react"
 import { useCallback, useMemo, useState } from "react"
-import { useDatasetsList } from "../../../../../../domains/datasets/datasets.collection.ts"
-import type { DatasetRecord } from "../../../../../../domains/datasets/datasets.functions.ts"
+import { useDatasetsList } from "../../../../../domains/datasets/datasets.collection.ts"
+import type { DatasetRecord } from "../../../../../domains/datasets/datasets.functions.ts"
 import {
   addTracesToDatasetFunction,
   createDatasetFromTracesFunction,
-} from "../../../../../../domains/datasets/datasets.functions.ts"
-import { getQueryClient } from "../../../../../../lib/data/query-client.tsx"
-import { toUserMessage } from "../../../../../../lib/errors.ts"
-import type { BulkSelection } from "../../../../../../lib/hooks/useSelectableRows.ts"
+} from "../../../../../domains/datasets/datasets.functions.ts"
+import { getQueryClient } from "../../../../../lib/data/query-client.tsx"
+import { toUserMessage } from "../../../../../lib/errors.ts"
+import type { BulkSelection } from "../../../../../lib/hooks/useSelectableRows.ts"
 
 interface AddToDatasetModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   projectId: string
+  /**
+   * When set, "all" / "allExcept" selections resolve only against traces linked
+   * to this issue (via score analytics). Omit on the project-wide traces page.
+   */
+  issueId?: string
   selection: BulkSelection<string>
   selectedCount: number
   onSuccess: () => void
@@ -26,6 +31,7 @@ export function AddToDatasetModal({
   open,
   onOpenChange,
   projectId,
+  issueId,
   selection,
   selectedCount,
   onSuccess,
@@ -64,6 +70,7 @@ export function AddToDatasetModal({
             projectId,
             name: newDatasetName.trim(),
             selection,
+            ...(issueId ? { issueId } : {}),
           },
         })
         toast({
@@ -80,7 +87,12 @@ export function AddToDatasetModal({
       } else {
         if (!selectedDatasetId) return
         const result = await addTracesToDatasetFunction({
-          data: { projectId, datasetId: selectedDatasetId, selection },
+          data: {
+            projectId,
+            datasetId: selectedDatasetId,
+            selection,
+            ...(issueId ? { issueId } : {}),
+          },
         })
         toast({
           title: "Traces added to dataset",
@@ -106,6 +118,7 @@ export function AddToDatasetModal({
     selectedDatasetId,
     newDatasetName,
     projectId,
+    issueId,
     selection,
     selectedCount,
     toast,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/trace-page-state.ts
@@ -1,6 +1,5 @@
 import { type FilterSet, filterSetSchema } from "@domain/shared"
 import type { InfiniteTableSorting } from "@repo/ui"
-import type { BulkSelection, SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
 
 export const DEFAULT_TRACE_SORTING: InfiniteTableSorting = { column: "startTime", direction: "desc" }
 
@@ -30,30 +29,4 @@ export function getTimeFilterValue(filters: FilterSet, op: "gte" | "lte"): strin
   if (!conds) return undefined
   const match = conds.find((c) => c.op === op)
   return match ? String(match.value) : undefined
-}
-
-export function getSelectedCount(state: SelectionState<string>, total: number): number {
-  switch (state.mode) {
-    case "all":
-      return total - state.excludedIds.size
-    case "none":
-      return 0
-    case "partial":
-      return state.selectedIds.size
-    case "allExcept":
-      return total - state.excludedIds.size
-  }
-}
-
-export function getBulkSelection(state: SelectionState<string>): BulkSelection<string> | null {
-  switch (state.mode) {
-    case "all":
-      return { mode: "all" }
-    case "allExcept":
-      return { mode: "allExcept", rowIds: Array.from(state.excludedIds) }
-    case "partial":
-      return state.selectedIds.size > 0 ? { mode: "selected", rowIds: Array.from(state.selectedIds) } : null
-    case "none":
-      return null
-  }
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -11,7 +11,13 @@ import { useTracesCount } from "../../../../domains/traces/traces.collection.ts"
 import { enqueueTracesExport } from "../../../../domains/traces/traces.functions.ts"
 import { ListingLayout as Layout } from "../../../../layouts/ListingLayout/index.tsx"
 import { useParamState } from "../../../../lib/hooks/useParamState.ts"
-import { EMPTY_SELECTION, type SelectionState } from "../../../../lib/hooks/useSelectableRows.ts"
+import {
+  EMPTY_SELECTION,
+  getBulkSelection,
+  getSelectedCount,
+  type SelectionState,
+} from "../../../../lib/hooks/useSelectableRows.ts"
+import { AddToDatasetModal } from "./-components/add-to-dataset-modal.tsx"
 import { TraceAggregationsPanel } from "./-components/aggregations/aggregations-panel.tsx"
 import { ColumnsSelector } from "./-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "./-components/export-confirmation-modal.tsx"
@@ -22,8 +28,6 @@ import { TimeFilterDropdown } from "./-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "./-components/trace-detail-drawer.tsx"
 import {
   DEFAULT_TRACE_SORTING,
-  getBulkSelection,
-  getSelectedCount,
   getTimeFilterValue,
   parseFilters,
   serializeFilters,
@@ -31,7 +35,6 @@ import {
 import { TracesEmptyState } from "./-components/traces-empty-state.tsx"
 import { TracesView } from "./-components/traces-view.tsx"
 import { useRouteProject } from "./-route-data.ts"
-import { AddToDatasetModal } from "./datasets/-components/add-to-dataset-modal.tsx"
 
 export const Route = createFileRoute("/_authenticated/projects/$projectSlug/")({
   component: ProjectPage,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-detail-drawer.tsx
@@ -20,20 +20,24 @@ import {
   ArrowDownRightIcon,
   ArrowUpIcon,
   CheckIcon,
+  DatabaseIcon,
   PauseIcon,
   PlayIcon,
   TextAlignStartIcon,
   XIcon,
 } from "lucide-react"
-import { type ReactNode, useState } from "react"
+import { type ReactNode, useMemo, useState } from "react"
 import { HotkeyBadge } from "../../../../../../components/hotkey-badge.tsx"
 import {
   invalidateIssueQueries,
   useIssueDetail,
+  useIssueTracesCount,
   useIssueTracesInfiniteScroll,
 } from "../../../../../../domains/issues/issues.collection.ts"
 import { applyIssueLifecycleAction } from "../../../../../../domains/issues/issues.functions.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
+import { useSelectableRows } from "../../../../../../lib/hooks/useSelectableRows.ts"
+import { AddToDatasetModal } from "../../-components/add-to-dataset-modal.tsx"
 import {
   DEFAULT_TRACE_TABLE_SORTING,
   ProjectTracesTable,
@@ -170,6 +174,12 @@ export function IssueDetailDrawer({
   const [lifecycleConfirmAction, setLifecycleConfirmAction] = useState<LifecycleConfirmationAction | null>(null)
   const [keepMonitoring, setKeepMonitoring] = useState(true)
   const [isLifecycleLoading, setIsLifecycleLoading] = useState(false)
+  const [addToDatasetOpen, setAddToDatasetOpen] = useState(false)
+
+  const traceIds = useMemo(() => traces.map((t) => t.traceId), [traces])
+  const totalTraceCount = useIssueTracesCount({ projectId, issueId, enabled: issue !== null })
+  const traceSelection = useSelectableRows({ rowIds: traceIds, totalRowCount: totalTraceCount })
+  const { selectedCount, bulkSelection, clearSelections } = traceSelection
   const hasActiveLinkedEvaluations =
     issue?.evaluations.some((evaluation) => evaluation.archivedAt === null && evaluation.deletedAt === null) ?? false
   const lifecycleConfirmation = lifecycleConfirmAction ? getLifecycleConfirmation(lifecycleConfirmAction) : null
@@ -419,6 +429,14 @@ export function IssueDetailDrawer({
             className="gap-1"
             contentClassName="pl-0 pt-0 max-h-none overflow-hidden flex flex-col"
           >
+            {selectedCount > 0 && (
+              <div className="flex items-center gap-2 pb-2">
+                <Button variant="outline" size="sm" onClick={() => setAddToDatasetOpen(true)}>
+                  <Icon icon={DatabaseIcon} size="sm" />
+                  Add to Dataset ({selectedCount})
+                </Button>
+              </div>
+            )}
             <ProjectTracesTable
               projectId={projectId}
               data={traces}
@@ -430,6 +448,7 @@ export function IssueDetailDrawer({
               getTraceHref={getTraceHref}
               linkTarget="_blank"
               rowInteractionRole="link"
+              selection={traceSelection}
               infiniteScroll={infiniteScroll}
               blankSlate="This issue has not been seen on any traces yet."
               scrollAreaLayout="intrinsic"
@@ -438,6 +457,18 @@ export function IssueDetailDrawer({
           </DetailSection>
         </div>
       </DetailDrawer>
+
+      {bulkSelection && (
+        <AddToDatasetModal
+          open={addToDatasetOpen}
+          onOpenChange={setAddToDatasetOpen}
+          projectId={projectId}
+          issueId={issueId}
+          selection={bulkSelection}
+          selectedCount={selectedCount}
+          onSuccess={clearSelections}
+        />
+      )}
 
       <Modal.Root open={resolveModalOpen} onOpenChange={setResolveModalOpen}>
         <Modal.Content dismissible>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -13,7 +13,13 @@ import { enqueueTracesExport } from "../../../../../domains/traces/traces.functi
 import { ListingLayout as Layout } from "../../../../../layouts/ListingLayout/index.tsx"
 import { toUserMessage } from "../../../../../lib/errors.ts"
 import { useParamState } from "../../../../../lib/hooks/useParamState.ts"
-import { EMPTY_SELECTION, type SelectionState } from "../../../../../lib/hooks/useSelectableRows.ts"
+import {
+  EMPTY_SELECTION,
+  getBulkSelection,
+  getSelectedCount,
+  type SelectionState,
+} from "../../../../../lib/hooks/useSelectableRows.ts"
+import { AddToDatasetModal } from "../-components/add-to-dataset-modal.tsx"
 import { ColumnsSelector } from "../-components/columns-selector.tsx"
 import { ExportConfirmationModal } from "../-components/export-confirmation-modal.tsx"
 import { TRACE_COLUMN_OPTIONS, type TraceColumnId } from "../-components/project-traces-table.tsx"
@@ -22,15 +28,12 @@ import { TimeFilterDropdown } from "../-components/time-filter-dropdown.tsx"
 import { TraceDetailDrawer } from "../-components/trace-detail-drawer.tsx"
 import {
   DEFAULT_TRACE_SORTING,
-  getBulkSelection,
-  getSelectedCount,
   getTimeFilterValue,
   parseFilters,
   serializeFilters,
 } from "../-components/trace-page-state.ts"
 import { TracesView } from "../-components/traces-view.tsx"
 import { useRouteProject } from "../-route-data.ts"
-import { AddToDatasetModal } from "../datasets/-components/add-to-dataset-modal.tsx"
 import { SaveSearchModal } from "./-components/save-search-modal.tsx"
 import { SavedSearchesList } from "./-components/saved-searches-list.tsx"
 

--- a/packages/domain/datasets/package.json
+++ b/packages/domain/datasets/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@domain/exports": "workspace:*",
     "@domain/events": "workspace:*",
+    "@domain/scores": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",
     "effect": "catalog:",

--- a/packages/domain/datasets/src/index.ts
+++ b/packages/domain/datasets/src/index.ts
@@ -31,6 +31,7 @@ export {
   addTracesToDataset,
   createDatasetFromTraces,
   type TraceSelection,
+  type TraceSource,
 } from "./use-cases/add-traces-to-dataset.ts"
 export {
   type BuildDatasetExportInput,

--- a/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
@@ -1,4 +1,5 @@
-import type { DatasetId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import type { DatasetId, IssueId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { ChSqlClient } from "@domain/shared"
 import type { TraceDetail, TraceListCursor } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
@@ -14,6 +15,8 @@ export type TraceSelection =
   | { readonly mode: "selected"; readonly traceIds: readonly TraceId[] }
   | { readonly mode: "all" }
   | { readonly mode: "allExcept"; readonly traceIds: readonly TraceId[] }
+
+export type TraceSource = { readonly kind: "project" } | { readonly kind: "issue"; readonly issueId: IssueId }
 
 function mapTraceToRow(t: TraceDetail) {
   return {
@@ -40,8 +43,9 @@ function mapTraceToRow(t: TraceDetail) {
 }
 
 const PAGE_SIZE = 1_000
+const ISSUE_TRACE_PAGE_SIZE = 1_000
 
-function collectAllTraceIds(args: { readonly organizationId: OrganizationId; readonly projectId: ProjectId }) {
+function collectAllProjectTraceIds(args: { readonly organizationId: OrganizationId; readonly projectId: ProjectId }) {
   return Effect.gen(function* () {
     const repo = yield* TraceRepository
     const ids: TraceId[] = []
@@ -65,9 +69,55 @@ function collectAllTraceIds(args: { readonly organizationId: OrganizationId; rea
   })
 }
 
+function collectAllIssueTraceIds(args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly issueId: IssueId
+}) {
+  return Effect.gen(function* () {
+    const repo = yield* ScoreAnalyticsRepository
+    const ids: TraceId[] = []
+    let offset = 0
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const page = yield* repo.listTracesByIssue({
+        organizationId: args.organizationId,
+        projectId: args.projectId,
+        issueId: args.issueId,
+        limit: ISSUE_TRACE_PAGE_SIZE,
+        offset,
+      })
+      for (const item of page.items) {
+        ids.push(item.traceId)
+      }
+      if (!page.hasMore) break
+      offset += page.limit
+    }
+
+    return ids
+  })
+}
+
+function collectAllTraceIds(args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly source: TraceSource
+}) {
+  if (args.source.kind === "issue") {
+    return collectAllIssueTraceIds({
+      organizationId: args.organizationId,
+      projectId: args.projectId,
+      issueId: args.source.issueId,
+    })
+  }
+  return collectAllProjectTraceIds({ organizationId: args.organizationId, projectId: args.projectId })
+}
+
 function resolveTraceIds(args: {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
+  readonly source: TraceSource
   readonly selection: TraceSelection
 }) {
   return Effect.gen(function* () {
@@ -76,6 +126,7 @@ function resolveTraceIds(args: {
     const allIds = yield* collectAllTraceIds({
       organizationId: args.organizationId,
       projectId: args.projectId,
+      source: args.source,
     })
 
     if (args.selection.mode === "all") return allIds
@@ -101,6 +152,7 @@ const EMPTY_RESULT = { versionId: "" as const, version: 0, rowIds: [] as string[
 export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(function* (args: {
   readonly projectId: ProjectId
   readonly datasetId: DatasetId
+  readonly source: TraceSource
   readonly selection: TraceSelection
 }) {
   yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
@@ -112,6 +164,7 @@ export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(funct
   const traceIds = yield* resolveTraceIds({
     organizationId: chSqlClient.organizationId,
     projectId: args.projectId,
+    source: args.source,
     selection: args.selection,
   })
   if (traceIds.length === 0) return EMPTY_RESULT
@@ -145,6 +198,7 @@ export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(funct
 export const createDatasetFromTraces = Effect.fn("datasets.createDatasetFromTraces")(function* (args: {
   readonly projectId: ProjectId
   readonly name: string
+  readonly source: TraceSource
   readonly selection: TraceSelection
 }) {
   yield* Effect.annotateCurrentSpan("projectId", args.projectId)
@@ -161,6 +215,7 @@ export const createDatasetFromTraces = Effect.fn("datasets.createDatasetFromTrac
     const traceIds = yield* resolveTraceIds({
       organizationId: chSqlClient.organizationId,
       projectId: args.projectId,
+      source: args.source,
       selection: args.selection,
     })
     if (traceIds.length === 0) {

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -184,6 +184,7 @@ const createScoreAnalyticsRepository = (input: {
       }),
     countDistinctTracesByTimeRange: () => Effect.succeed(input.totalTraces ?? 0),
     listTracesByIssue: () => Effect.die("Unexpected listTracesByIssue"),
+    countTracesByIssue: () => Effect.die("Unexpected countTracesByIssue"),
   }
 
   return { repository, windowMetricInputs, aggregateInputs, histogramInputs, trendInputs, tagsInputs }

--- a/packages/domain/scores/src/ports/score-analytics-repository.ts
+++ b/packages/domain/scores/src/ports/score-analytics-repository.ts
@@ -257,6 +257,12 @@ export interface ScoreAnalyticsRepositoryShape {
     readonly offset?: number
     readonly options?: ScoreAnalyticsOptions
   }): Effect.Effect<IssueTracePage, RepositoryError, ChSqlClient>
+  countTracesByIssue(input: {
+    readonly organizationId: OrganizationId
+    readonly projectId: ProjectId
+    readonly issueId: IssueId
+    readonly options?: ScoreAnalyticsOptions
+  }): Effect.Effect<number, RepositoryError, ChSqlClient>
 }
 
 export class ScoreAnalyticsRepository extends Context.Service<

--- a/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
+++ b/packages/domain/scores/src/testing/fake-score-analytics-repository.ts
@@ -43,6 +43,7 @@ export const createFakeScoreAnalyticsRepository = (overrides?: Partial<ScoreAnal
         limit: 25,
         offset: 0,
       }),
+    countTracesByIssue: () => Effect.succeed(0),
     delete: (id) =>
       Effect.sync(() => {
         const index = inserted.indexOf(id)

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -727,6 +727,18 @@ describe("ScoreAnalyticsRepository", () => {
       expect(page.limit).toBe(1)
       expect(page.offset).toBe(0)
     })
+
+    it("counts distinct traces linked to one issue", async () => {
+      const total = await runCh(
+        repo.countTracesByIssue({
+          organizationId: ORG_ID,
+          projectId: PROJECT_ID,
+          issueId: IssueId(issueA),
+        }),
+      )
+
+      expect(total).toBe(1)
+    })
   })
 
   // ------------------------------------------------------------------

--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.ts
@@ -889,6 +889,31 @@ export const ScoreAnalyticsRepositoryLive = Layer.effect(
               Effect.mapError((error) => toRepositoryError(error, "listTracesByIssue")),
             )
         }),
+      countTracesByIssue: ({ organizationId, projectId, issueId, options }) =>
+        Effect.gen(function* () {
+          const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
+
+          return yield* chSqlClient
+            .query(async (client) => {
+              const result = await client.query({
+                query: `SELECT uniqExact(trace_id) AS total
+                      FROM scores
+                      WHERE ${scopeClause(options)}
+                        AND issue_id = {issueId:FixedString(24)}
+                        AND trace_id != ''`,
+                query_params: {
+                  ...scopeParams(organizationId, projectId),
+                  issueId: issueId as string,
+                },
+                format: "JSONEachRow",
+              })
+              return result.json<CountRow>()
+            })
+            .pipe(
+              Effect.map((rows) => Number(rows[0]?.total ?? 0)),
+              Effect.mapError((error) => toRepositoryError(error, "countTracesByIssue")),
+            )
+        }),
       // Lightweight DELETE (row mask); omits deleted rows from subsequent SELECTs without full part rewrite.
       delete: deleteScore,
     }

--- a/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
+++ b/packages/platform/db-clickhouse/src/use-cases/add-traces-to-dataset.test.ts
@@ -9,12 +9,15 @@ import {
 } from "@domain/datasets"
 import { createFakeDatasetRepository } from "@domain/datasets/testing"
 import { OutboxEventWriter } from "@domain/events"
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository } from "@domain/scores/testing"
 import { SqlClient, type SqlClientShape } from "@domain/shared"
 import {
   bootstrapSeedScope,
   type ChSqlClient,
   DatasetId,
   ExternalUserId,
+  IssueId,
   OrganizationId,
   ProjectId,
   RepositoryError,
@@ -97,17 +100,27 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
     )
   })
 
+  const defaultScoreAnalyticsRepo = createFakeScoreAnalyticsRepository().repository
+
   const runWithLive = <A, E>(
     effect: Effect.Effect<
       A,
       E,
-      DatasetRepository | DatasetRowRepository | TraceRepository | ChSqlClient | OutboxEventWriter | SqlClient
+      | DatasetRepository
+      | DatasetRowRepository
+      | TraceRepository
+      | ScoreAnalyticsRepository
+      | ChSqlClient
+      | OutboxEventWriter
+      | SqlClient
     >,
+    scoreAnalyticsRepo: (typeof ScoreAnalyticsRepository)["Service"] = defaultScoreAnalyticsRepo,
   ) =>
     Effect.runPromise(
       effect.pipe(
         Effect.provideService(DatasetRepository, datasetRepo),
         Effect.provideService(DatasetRowRepository, rowRepo),
+        Effect.provideService(ScoreAnalyticsRepository, scoreAnalyticsRepo),
         Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
         Effect.provideService(SqlClient, inertSqlClient),
         withClickHouse(TraceRepositoryLive.pipe(Layer.provideMerge(mockAILayer)), ch.client, ORG_ID),
@@ -119,7 +132,13 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
     effect: Effect.Effect<
       A,
       E,
-      DatasetRepository | DatasetRowRepository | TraceRepository | ChSqlClient | OutboxEventWriter | SqlClient
+      | DatasetRepository
+      | DatasetRowRepository
+      | TraceRepository
+      | ScoreAnalyticsRepository
+      | ChSqlClient
+      | OutboxEventWriter
+      | SqlClient
     >,
     services: {
       datasetRepo: (typeof DatasetRepository)["Service"]
@@ -132,6 +151,7 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
         Effect.provideService(DatasetRepository, services.datasetRepo),
         Effect.provideService(DatasetRowRepository, services.rowRepo),
         Effect.provideService(TraceRepository, services.traceRepo),
+        Effect.provideService(ScoreAnalyticsRepository, defaultScoreAnalyticsRepo),
         Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
         Effect.provideService(SqlClient, inertSqlClient),
         Effect.provide(ChSqlClientLive(ch.client, ORG_ID)),
@@ -146,6 +166,7 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
       addTracesToDataset({
         projectId: PROJECT_ID,
         datasetId: DATASET_ID,
+        source: { kind: "project" },
         selection: { mode: "selected", traceIds: [traceId] },
       }),
     )
@@ -170,6 +191,7 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
       createDatasetFromTraces({
         projectId: PROJECT_ID,
         name: "from-traces-dataset",
+        source: { kind: "project" },
         selection: { mode: "selected", traceIds },
       }),
     )
@@ -235,6 +257,7 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
       addTracesToDataset({
         projectId: PROJECT_ID,
         datasetId: DATASET_ID,
+        source: { kind: "project" },
         selection: { mode: "selected", traceIds: [TraceId("trace-meta-1")] },
       }),
       { datasetRepo, rowRepo, traceRepo: fakeTraceRepo },
@@ -319,6 +342,7 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
         createDatasetFromTraces({
           projectId: PROJECT_ID,
           name: "rollback-on-fail",
+          source: { kind: "project" },
           selection: { mode: "selected", traceIds: [TraceId("trace-fail-1")] },
         }),
         {
@@ -336,5 +360,80 @@ describe("addTracesToDataset and createDatasetFromTraces", () => {
     await expect(
       Effect.runPromise(capturingDatasetRepo.findById(id).pipe(Effect.provideService(SqlClient, inertSqlClient))),
     ).rejects.toBeInstanceOf(DatasetNotFoundError)
+  })
+
+  it("addTracesToDataset resolves traces from issue source via listTracesByIssue", async () => {
+    expect(seededTraceIds.length).toBeGreaterThanOrEqual(1)
+    const issueId = IssueId("issue-link-all")
+
+    const issueScoreRepo = createFakeScoreAnalyticsRepository({
+      listTracesByIssue: ({ limit = 25, offset = 0 }) =>
+        Effect.succeed({
+          items: seededTraceIds.map((traceId) => ({ traceId, lastSeenAt: new Date() })),
+          hasMore: false,
+          limit,
+          offset,
+        }),
+    }).repository
+
+    const result = await runWithLive(
+      addTracesToDataset({
+        projectId: PROJECT_ID,
+        datasetId: DATASET_ID,
+        source: { kind: "issue", issueId },
+        selection: { mode: "all" },
+      }),
+      issueScoreRepo,
+    )
+
+    expect(result.rowIds.length).toBe(seededTraceIds.length)
+
+    const { rows } = await Effect.runPromise(
+      rowRepo.list({ datasetId: DATASET_ID }).pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))),
+    )
+    expect(rows.length).toBe(seededTraceIds.length)
+    const rowTraceIds = new Set(rows.map((r) => (r.metadata as Record<string, unknown>).traceId))
+    for (const traceId of seededTraceIds) {
+      expect(rowTraceIds.has(traceId)).toBe(true)
+    }
+  })
+
+  // Excludes a synthetic trace id rather than a seeded one so the assertion holds
+  // even when the seed deduper produces a single distinct trace.
+  it("addTracesToDataset honors allExcept when source is an issue", async () => {
+    expect(seededTraceIds.length).toBeGreaterThanOrEqual(1)
+    const issueId = IssueId("issue-link-except")
+    const fabricatedExcluded = TraceId("fabricated-excluded-trace")
+
+    const issueScoreRepo = createFakeScoreAnalyticsRepository({
+      listTracesByIssue: ({ limit = 25, offset = 0 }) =>
+        Effect.succeed({
+          items: [
+            ...seededTraceIds.map((traceId) => ({ traceId, lastSeenAt: new Date() })),
+            { traceId: fabricatedExcluded, lastSeenAt: new Date() },
+          ],
+          hasMore: false,
+          limit,
+          offset,
+        }),
+    }).repository
+
+    const result = await runWithLive(
+      addTracesToDataset({
+        projectId: PROJECT_ID,
+        datasetId: DATASET_ID,
+        source: { kind: "issue", issueId },
+        selection: { mode: "allExcept", traceIds: [fabricatedExcluded] },
+      }),
+      issueScoreRepo,
+    )
+
+    expect(result.rowIds.length).toBe(seededTraceIds.length)
+
+    const { rows } = await Effect.runPromise(
+      rowRepo.list({ datasetId: DATASET_ID }).pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))),
+    )
+    const rowTraceIds = rows.map((r) => (r.metadata as Record<string, unknown>).traceId)
+    expect(rowTraceIds).not.toContain(fabricatedExcluded)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -913,6 +913,9 @@ importers:
       '@domain/exports':
         specifier: workspace:*
         version: link:../exports
+      '@domain/scores':
+        specifier: workspace:*
+        version: link:../scores
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

Mirror the main traces page's selection + add-to-dataset flow inside the issue detail drawer so users can pull every trace linked to an issue into a regression dataset without leaving the drawer.

- **Domain** — `addTracesToDataset` / `createDatasetFromTraces` now take a `TraceSource = { kind: "project" } | { kind: "issue"; issueId }`. For the issue branch, `resolveTraceIds` enumerates via `ScoreAnalyticsRepository.listTracesByIssue`.
- **Repo** — added `countTracesByIssue` (`uniqExact(trace_id)`) so the drawer's selection label is accurate before the user has scrolled all pages.
- **Web** — optional `issueId` on the dataset server fns; `AddToDatasetModal` moved to `projects/$projectSlug/-components/` so both the main traces page and the issue drawer share it; `getSelectedCount` / `getBulkSelection` moved next to `useSelectableRows`.

Linear: https://linear.app/latitude/issue/LAT-545

## Test plan

- [x] Open an issue with several linked traces; in the drawer select rows, click **Add to Dataset (N)**, pick an existing dataset → rows added match the linked-trace count.
- [x] Same as above but **Create new dataset** instead of picking one.
- [x] Use the header checkbox to select all → button shows the full linked-trace count from `countTracesByIssue`, not just the loaded page.
- [x] Main traces page still works end-to-end (regression check on the moved modal + helpers).
- [x] CI: typecheck (61/61), `@platform/db-clickhouse` (110/110), `@domain/datasets` (6/6), `@app/web` (236/236).

🤖 Generated with [Claude Code](https://claude.com/claude-code)