### PR TITLE
feat(alerts): add alert_incidents data layer

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: create-pr
+description: Patterns and conventions for creating a good PR
+---
+
+# PR Description Guidelines
+
+The work is done. Now, create a new PR for the current changes. If you're not on a new branch yet, create one first. Then, create the PR.
+Treat the changes as a real deliverable. The description is the first thing anyone reading this work will see, and most readers will not read the diff line by line.
+
+## Audience
+
+Write for someone who:
+- Is a developer on this team
+- Already knows this repository and its existing architecture
+- Has not seen this work before
+
+You don't need to explain the codebase, the framework, or how things generally work in this system. You do need to explain everything *new* that this PR introduces — concepts, entities, flows, behaviors — clearly enough that the reader understands the change without opening the diff.
+
+Cover only what's in *this* PR. If it's part of a larger effort (MVP, migration, refactor), one short line of framing is enough. Don't restate the whole project.
+
+## Title
+
+The title is a one-line summary of the change. Specific, declarative, imperative mood.
+
+- Good: `Add alert incident lifecycle and worker pipeline`
+- Bad: `Alert work` / `Various improvements` / `Updates to alerts module`
+
+If the repo uses a prefix convention (`feat:`, `fix:`, scoping like `[backend]`), match it.
+
+## What the description must convey
+
+Every PR description, regardless of size, has to answer:
+
+1. **What this PR does** — the actual change, in plain language
+2. **Why it exists** — the problem, motivation, or unblock (skip only if the title makes it self-evident)
+
+Beyond those two, include whatever else the reader needs to actually understand the change:
+
+- New domain concepts introduced (entities, events, jobs, statuses, etc.): what they are, when they're created, who produces and consumes them
+- Non-obvious decisions: trade-offs, why an alternative was rejected, schema or concurrency choices that aren't visible from the diff
+- Deliberate scope cuts and known follow-ups
+- Anything a reviewer would otherwise have to reverse-engineer from the code
+- How the change was tested or validated, when relevant
+
+If something is only interesting at the code level — naming, file moves, mechanical refactors — leave it in the diff.
+
+## Structure
+
+Don't follow a fixed template. The right structure depends entirely on what this PR contains.
+
+Decide the structure by asking: *what does the reader need to know, and in what order?* Then group that information into coherent sections with headers that describe their actual content. A small bug fix might be three sentences with no headers at all. A PR introducing a new subsystem might have five sections. Both are correct when they match the change.
+
+Order matters: start with whatever orients the reader fastest (usually a summary), put context next, push edge cases, caveats, and follow-ups toward the end.
+
+## Linking
+
+If related issues or PRs exist, link them. Use GitHub's keyword syntax (`Closes #123`, `Refs #456`) where appropriate.
+
+## Style
+
+The description should read like a senior engineer wrote it for a colleague — direct, specific, no filler. The following phrasings mark text as AI-generated and must be avoided:
+
+- **Marketing adjectives**: "comprehensive," "robust," "seamless," "powerful," "elegant," "sophisticated," "production-ready," "first-class"
+- **Hedging verbs**: "aims to," "seeks to," "strives to" — just say what it does
+- **Filler verbs**: "leverages" / "utilizes" → "uses". "ensures that X" → just state X. "facilitates" → describe the actual mechanism
+- **Throat-clearing openers**: "It's worth noting that," "Importantly,", "In essence,", "It should be mentioned that"
+- **Closing summaries**: "In summary," "Overall," "Ultimately," — stop when you're done
+- **Vague abstractions**: "provides functionality for X" → say what it does. "handles the logic of Y" → say how
+- **Artificial parallelism**: "fast, clean, and reliable" — pick the one that matters
+- **"Not just X but Y" construction**
+- **"In order to"** → "to"
+- **Restating the prompt or the section header in the first sentence of a section**
+
+Write declaratively. "Adds X. X is created when Y happens." Not "This PR aims to introduce X, which would help with Y."
+
+Use prose where bullets would fragment a thought. Use bullets where prose would become a wall. Don't enumerate every file changed.
+
+Use lowercase headings unless the repo's existing PRs use a different convention.
+
+## Output
+
+Return the title and description as raw markdown in separate code blocks I can paste into GitHub directly. No preamble, no commentary after the blocks.
+
+If this PR includes noticeable UI work — new views, new sections, visual changes — remind me at the end to attach screenshots or a short screen recording to the PR for reviewer context.

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -18,6 +18,7 @@
     "@hono/node-server": "catalog:",
     "hono": "catalog:",
     "@domain/ai": "workspace:*",
+    "@domain/alerts": "workspace:*",
     "@domain/annotation-queues": "workspace:*",
     "@domain/annotations": "workspace:*",
     "@domain/api-keys": "workspace:*",

--- a/apps/workers/src/server.ts
+++ b/apps/workers/src/server.ts
@@ -29,6 +29,7 @@ import { createAnnotationQueuesWorker } from "./workers/annotation-queues.ts"
 import { createAnnotationScoresWorker } from "./workers/annotation-scores.ts"
 import { createApiKeysWorker } from "./workers/api-keys.ts"
 import { createDeterministicFlaggersWorker } from "./workers/deterministic-flaggers.ts"
+import { createAlertIncidentsWorker } from "./workers/domain-events/alert-incidents.ts"
 import { createInvitationEmailWorker } from "./workers/domain-events/invitation-email.ts"
 import { createMagicLinkEmailWorker } from "./workers/domain-events/magic-link-email.ts"
 import { createMarketingContactsWorker } from "./workers/domain-events/marketing-contacts.ts"
@@ -153,6 +154,7 @@ const bootstrap = async () => {
     createInvitationEmailWorker(ctx)
     createUserDeletionWorker(ctx)
     createMarketingContactsWorker(ctx)
+    createAlertIncidentsWorker(ctx)
     createApiKeysWorker(ctx)
     createSpanIngestionWorker(ctx)
     createExportsWorker(ctx)

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -105,6 +105,20 @@ export const createDomainEventsWorker = ({
         throttleMs: ISSUE_REFRESH_THROTTLE_MS,
       }),
 
+    IssueCreated: (event) =>
+      pub.publish("alert-incidents", "issue-created", event.payload, {
+        dedupeKey: `alert-incidents:issue.new:${event.payload.issueId}`,
+      }),
+
+    IssueRegressed: (event) =>
+      pub.publish("alert-incidents", "issue-regressed", event.payload, {
+        dedupeKey: `alert-incidents:issue.regressed:${event.payload.issueId}:${event.payload.triggerScoreId}`,
+      }),
+
+    // PR 1 has no consumer for IncidentCreated. PR 2 (email channel) and
+    // PR 3 (in-app feed) will replace this no-op with channel fan-out.
+    IncidentCreated: () => Effect.void,
+
     AnnotationDeleted: (event) => {
       const { organizationId, projectId, scoreId, issueId, draftedAt, feedback, source, createdAt } = event.payload
 

--- a/apps/workers/src/workers/domain-events/alert-incidents.ts
+++ b/apps/workers/src/workers/domain-events/alert-incidents.ts
@@ -1,0 +1,67 @@
+import { type AlertIncidentKind, createAlertIncidentFromIssueEventUseCase } from "@domain/alerts"
+import type { QueueConsumer } from "@domain/queue"
+import { OrganizationId } from "@domain/shared"
+import { AlertIncidentRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
+import { createLogger, withTracing } from "@repo/observability"
+import { Effect, Layer } from "effect"
+import { getPostgresClient } from "../../clients.ts"
+
+const logger = createLogger("alert-incidents")
+
+interface AlertIncidentsDeps {
+  consumer: QueueConsumer
+}
+
+const repoLayer = Layer.mergeAll(AlertIncidentRepositoryLive, OutboxEventWriterLive)
+
+const createIncidentFor = (
+  kind: AlertIncidentKind,
+  payload: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly issueId: string
+    readonly occurredAt: Date
+  },
+) => {
+  const pgClient = getPostgresClient()
+
+  return createAlertIncidentFromIssueEventUseCase({
+    kind,
+    organizationId: payload.organizationId,
+    projectId: payload.projectId,
+    issueId: payload.issueId,
+    occurredAt: payload.occurredAt,
+  }).pipe(
+    withPostgres(repoLayer, pgClient, OrganizationId(payload.organizationId)),
+    Effect.tap((incident) =>
+      Effect.sync(() =>
+        logger.info(`alert_incident created kind=${incident.kind} issueId=${payload.issueId} id=${incident.id}`),
+      ),
+    ),
+    Effect.tapError((error) =>
+      Effect.sync(() => logger.error(`alert_incident creation failed kind=${kind} issueId=${payload.issueId}`, error)),
+    ),
+    Effect.asVoid,
+    withTracing,
+  )
+}
+
+export const createAlertIncidentsWorker = ({ consumer }: AlertIncidentsDeps) => {
+  consumer.subscribe("alert-incidents", {
+    "issue-created": (payload) =>
+      createIncidentFor("issue.new", {
+        organizationId: payload.organizationId,
+        projectId: payload.projectId,
+        issueId: payload.issueId,
+        occurredAt: new Date(payload.createdAt),
+      }),
+
+    "issue-regressed": (payload) =>
+      createIncidentFor("issue.regressed", {
+        organizationId: payload.organizationId,
+        projectId: payload.projectId,
+        issueId: payload.issueId,
+        occurredAt: new Date(payload.regressedAt),
+      }),
+  })
+}

--- a/packages/domain/alerts/package.json
+++ b/packages/domain/alerts/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@domain/alerts",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@domain/events": "workspace:*",
+    "@domain/shared": "workspace:*",
+    "effect": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
+  }
+}

--- a/packages/domain/alerts/src/entities/alert-incident.ts
+++ b/packages/domain/alerts/src/entities/alert-incident.ts
@@ -1,0 +1,46 @@
+import { alertIncidentIdSchema, cuidSchema, organizationIdSchema, projectIdSchema } from "@domain/shared"
+import { z } from "zod"
+
+/**
+ * Discriminator for the entity that produced an alert. Polymorphic source pointer:
+ * `(sourceType, sourceId)` together identify the subject of the incident.
+ */
+export const ALERT_INCIDENT_SOURCE_TYPES = ["issue"] as const
+export const alertIncidentSourceTypeSchema = z.enum(ALERT_INCIDENT_SOURCE_TYPES)
+export type AlertIncidentSourceType = z.infer<typeof alertIncidentSourceTypeSchema>
+
+/**
+ * Namespaced kind. The prefix matches `sourceType` so kinds remain unambiguous
+ * even when future source types add their own variants (e.g. `saved_search.threshold`).
+ */
+export const ALERT_INCIDENT_KINDS = ["issue.new", "issue.regressed"] as const
+export const alertIncidentKindSchema = z.enum(ALERT_INCIDENT_KINDS)
+export type AlertIncidentKind = z.infer<typeof alertIncidentKindSchema>
+
+export const ALERT_SEVERITIES = ["medium", "high"] as const
+export const alertSeveritySchema = z.enum(ALERT_SEVERITIES)
+export type AlertSeverity = z.infer<typeof alertSeveritySchema>
+
+/**
+ * Hardcoded severity per kind for V1. Stored on the row so future configurable
+ * severity can land without a migration.
+ */
+export const SEVERITY_FOR_KIND: Record<AlertIncidentKind, AlertSeverity> = {
+  "issue.new": "medium",
+  "issue.regressed": "high",
+}
+
+export const alertIncidentSchema = z.object({
+  id: alertIncidentIdSchema,
+  organizationId: organizationIdSchema,
+  projectId: projectIdSchema,
+  sourceType: alertIncidentSourceTypeSchema,
+  sourceId: cuidSchema, // V1 sources are issues; widen if future sources need other id shapes
+  kind: alertIncidentKindSchema,
+  severity: alertSeveritySchema,
+  startedAt: z.date(),
+  endedAt: z.date().nullable(),
+  createdAt: z.date(),
+})
+
+export type AlertIncident = z.infer<typeof alertIncidentSchema>

--- a/packages/domain/alerts/src/index.ts
+++ b/packages/domain/alerts/src/index.ts
@@ -1,0 +1,23 @@
+export type {
+  AlertIncident,
+  AlertIncidentKind,
+  AlertIncidentSourceType,
+  AlertSeverity,
+} from "./entities/alert-incident.ts"
+export {
+  ALERT_INCIDENT_KINDS,
+  ALERT_INCIDENT_SOURCE_TYPES,
+  ALERT_SEVERITIES,
+  alertIncidentKindSchema,
+  alertIncidentSchema,
+  alertIncidentSourceTypeSchema,
+  alertSeveritySchema,
+  SEVERITY_FOR_KIND,
+} from "./entities/alert-incident.ts"
+export type { AlertIncidentRepositoryShape } from "./ports/alert-incident-repository.ts"
+export { AlertIncidentRepository } from "./ports/alert-incident-repository.ts"
+export type {
+  CreateAlertIncidentFromIssueEventError,
+  CreateAlertIncidentFromIssueEventInput,
+} from "./use-cases/create-alert-incident-from-issue-event.ts"
+export { createAlertIncidentFromIssueEventUseCase } from "./use-cases/create-alert-incident-from-issue-event.ts"

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -1,0 +1,11 @@
+import type { RepositoryError, SqlClient } from "@domain/shared"
+import { Context, type Effect } from "effect"
+import type { AlertIncident } from "../entities/alert-incident.ts"
+
+export interface AlertIncidentRepositoryShape {
+  insert(incident: AlertIncident): Effect.Effect<void, RepositoryError, SqlClient>
+}
+
+export class AlertIncidentRepository extends Context.Service<AlertIncidentRepository, AlertIncidentRepositoryShape>()(
+  "@domain/alerts/AlertIncidentRepository",
+) {}

--- a/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
@@ -1,0 +1,103 @@
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { OrganizationId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { AlertIncident } from "../entities/alert-incident.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+import { createAlertIncidentFromIssueEventUseCase } from "./create-alert-incident-from-issue-event.ts"
+
+const cuid = (seed: string) => seed.padEnd(24, "0")
+
+function createTestLayers() {
+  const events: OutboxWriteEvent[] = []
+  const inserted: AlertIncident[] = []
+
+  const AlertIncidentRepositoryTest = Layer.succeed(
+    AlertIncidentRepository,
+    AlertIncidentRepository.of({
+      insert: (incident) =>
+        Effect.sync(() => {
+          inserted.push(incident)
+        }),
+    }),
+  )
+
+  const OutboxEventWriterTest = Layer.succeed(
+    OutboxEventWriter,
+    OutboxEventWriter.of({
+      write: (event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+    }),
+  )
+
+  const SqlClientTest = Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(cuid("o")) }))
+
+  return {
+    events,
+    inserted,
+    layer: Layer.mergeAll(AlertIncidentRepositoryTest, OutboxEventWriterTest, SqlClientTest),
+  }
+}
+
+describe("createAlertIncidentFromIssueEventUseCase", () => {
+  it("inserts an alert_incidents row and writes IncidentCreated when kind is issue.new", async () => {
+    const { events, inserted, layer } = createTestLayers()
+    const occurredAt = new Date("2026-05-06T10:00:00Z")
+
+    const incident = await Effect.runPromise(
+      createAlertIncidentFromIssueEventUseCase({
+        kind: "issue.new",
+        organizationId: cuid("o"),
+        projectId: cuid("p"),
+        issueId: cuid("i"),
+        occurredAt,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(inserted).toHaveLength(1)
+    expect(inserted[0]).toMatchObject({
+      kind: "issue.new",
+      severity: "medium",
+      sourceType: "issue",
+      sourceId: cuid("i"),
+      startedAt: occurredAt,
+      endedAt: null,
+    })
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IncidentCreated",
+      aggregateType: "alert_incident",
+      aggregateId: incident.id,
+      organizationId: cuid("o"),
+      payload: {
+        organizationId: cuid("o"),
+        projectId: cuid("p"),
+        alertIncidentId: incident.id,
+        kind: "issue.new",
+        sourceType: "issue",
+        sourceId: cuid("i"),
+      },
+    })
+  })
+
+  it("uses high severity for issue.regressed", async () => {
+    const { inserted, layer } = createTestLayers()
+
+    await Effect.runPromise(
+      createAlertIncidentFromIssueEventUseCase({
+        kind: "issue.regressed",
+        organizationId: cuid("o"),
+        projectId: cuid("p"),
+        issueId: cuid("i"),
+        occurredAt: new Date(),
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(inserted[0]?.severity).toBe("high")
+    expect(inserted[0]?.kind).toBe("issue.regressed")
+  })
+})

--- a/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.ts
+++ b/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.ts
@@ -1,0 +1,68 @@
+import { OutboxEventWriter } from "@domain/events"
+import { AlertIncidentId, generateId, OrganizationId, ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { type AlertIncident, type AlertIncidentKind, SEVERITY_FOR_KIND } from "../entities/alert-incident.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+
+export interface CreateAlertIncidentFromIssueEventInput {
+  readonly kind: AlertIncidentKind
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+  readonly occurredAt: Date
+}
+
+export type CreateAlertIncidentFromIssueEventError = RepositoryError
+
+export const createAlertIncidentFromIssueEventUseCase = (input: CreateAlertIncidentFromIssueEventInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("alertIncident.kind", input.kind)
+    yield* Effect.annotateCurrentSpan("alertIncident.issueId", input.issueId)
+    yield* Effect.annotateCurrentSpan("alertIncident.projectId", input.projectId)
+
+    const sqlClient = yield* SqlClient
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const alertIncidentRepository = yield* AlertIncidentRepository
+        const outboxEventWriter = yield* OutboxEventWriter
+
+        const now = new Date()
+        const incident: AlertIncident = {
+          id: AlertIncidentId(generateId()),
+          organizationId: OrganizationId(input.organizationId),
+          projectId: ProjectId(input.projectId),
+          sourceType: "issue",
+          sourceId: input.issueId,
+          kind: input.kind,
+          severity: SEVERITY_FOR_KIND[input.kind],
+          startedAt: input.occurredAt,
+          endedAt: null,
+          createdAt: now,
+        }
+
+        yield* alertIncidentRepository.insert(incident)
+
+        yield* outboxEventWriter.write({
+          eventName: "IncidentCreated",
+          aggregateType: "alert_incident",
+          aggregateId: incident.id,
+          organizationId: incident.organizationId,
+          payload: {
+            organizationId: incident.organizationId,
+            projectId: incident.projectId,
+            alertIncidentId: incident.id,
+            kind: incident.kind,
+            sourceType: incident.sourceType,
+            sourceId: incident.sourceId,
+          },
+        })
+
+        return incident
+      }),
+    )
+  }).pipe(Effect.withSpan("alerts.createAlertIncidentFromIssueEvent")) as Effect.Effect<
+    AlertIncident,
+    CreateAlertIncidentFromIssueEventError,
+    SqlClient | AlertIncidentRepository | OutboxEventWriter
+  >

--- a/packages/domain/alerts/tsconfig.json
+++ b/packages/domain/alerts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -40,6 +40,45 @@ export interface EventPayloads {
     readonly projectId: string
     readonly issueId: string
   }
+  /**
+   * Emitted by `createIssueFromScoreUseCase` after the issue row is saved.
+   * Drives the alert pipeline's `issue.new` incident creation.
+   */
+  IssueCreated: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly issueId: string
+    readonly createdAt: string
+  }
+  /**
+   * Emitted by `assignScoreToIssueUseCase` when assigning a score whose
+   * `lastSeenAt` is later than the issue's `resolvedAt`. The use case clears
+   * `resolvedAt` on the same transaction (reifying the regression as a stored
+   * fact); idempotency on subsequent regression-causing scores is enforced by
+   * the cleared field, so a second event will not be emitted in the same cycle.
+   * `triggerScoreId` discriminates per regression cycle so a future regression
+   * after re-resolution is a distinct event.
+   */
+  IssueRegressed: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly issueId: string
+    readonly regressedAt: string
+    readonly triggerScoreId: string
+  }
+  /**
+   * Emitted by the alert-incidents worker after an `alert_incidents` row is
+   * inserted. PR 1 has no consumer (the dispatcher routes it to a no-op);
+   * PR 2 (email) and PR 3 (in-app) will subscribe.
+   */
+  IncidentCreated: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly alertIncidentId: string
+    readonly kind: "issue.new" | "issue.regressed"
+    readonly sourceType: "issue"
+    readonly sourceId: string
+  }
   AnnotationDeleted: {
     readonly organizationId: string
     readonly projectId: string

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.test.ts
@@ -315,4 +315,132 @@ describe("assignScoreToIssueUseCase", () => {
     expect(scores.get(score.id)?.issueId).toBeNull()
     expect(issues.get(foreignIssue.id)?.centroid.mass).toBe(0)
   })
+
+  describe("regression detection", () => {
+    it("clears resolvedAt and emits IssueRegressed when score is newer than the issue's resolution", async () => {
+      const resolvedAt = new Date("2026-04-01T00:00:00.000Z")
+      const existingIssue = makeIssue({ resolvedAt })
+      const { repository: scoreRepository, scores } = createFakeScoreRepository()
+      const { repository: issueRepository, issues } = createFakeIssueRepository([existingIssue])
+      const score = makeScore({ createdAt: new Date("2026-04-15T10:00:00.000Z") })
+      scores.set(score.id, score)
+      const writtenEvents: unknown[] = []
+
+      await Effect.runPromise(
+        assignScoreToIssueUseCase({
+          organizationId,
+          projectId,
+          scoreId: score.id,
+          issueId: existingIssue.id,
+          normalizedEmbedding: makeEmbedding(),
+        }).pipe(
+          Effect.provideService(ScoreRepository, scoreRepository),
+          Effect.provideService(IssueRepository, issueRepository),
+          Effect.provideService(OutboxEventWriter, {
+            write: (event) =>
+              Effect.sync(() => {
+                writtenEvents.push(event)
+              }),
+          }),
+          Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+          Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+          Effect.provideService(
+            IssueProjectionRepository,
+            createFakeIssueProjectionRepository({ organizationId }).service,
+          ),
+        ),
+      )
+
+      expect(issues.get(existingIssue.id)?.resolvedAt).toBeNull()
+      expect(writtenEvents).toContainEqual(
+        expect.objectContaining({
+          eventName: "IssueRegressed",
+          aggregateType: "issue",
+          aggregateId: existingIssue.id,
+          organizationId,
+          payload: expect.objectContaining({
+            organizationId,
+            projectId,
+            issueId: existingIssue.id,
+            triggerScoreId: score.id,
+            regressedAt: score.createdAt.toISOString(),
+          }),
+        }),
+      )
+    })
+
+    it("does not emit IssueRegressed and preserves resolvedAt when score predates resolution", async () => {
+      const resolvedAt = new Date("2026-04-15T00:00:00.000Z")
+      const existingIssue = makeIssue({ resolvedAt })
+      const { repository: scoreRepository, scores } = createFakeScoreRepository()
+      const { repository: issueRepository, issues } = createFakeIssueRepository([existingIssue])
+      const score = makeScore({ createdAt: new Date("2026-04-01T10:00:00.000Z") })
+      scores.set(score.id, score)
+      const writtenEvents: unknown[] = []
+
+      await Effect.runPromise(
+        assignScoreToIssueUseCase({
+          organizationId,
+          projectId,
+          scoreId: score.id,
+          issueId: existingIssue.id,
+          normalizedEmbedding: makeEmbedding(),
+        }).pipe(
+          Effect.provideService(ScoreRepository, scoreRepository),
+          Effect.provideService(IssueRepository, issueRepository),
+          Effect.provideService(OutboxEventWriter, {
+            write: (event) =>
+              Effect.sync(() => {
+                writtenEvents.push(event)
+              }),
+          }),
+          Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+          Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+          Effect.provideService(
+            IssueProjectionRepository,
+            createFakeIssueProjectionRepository({ organizationId }).service,
+          ),
+        ),
+      )
+
+      expect(issues.get(existingIssue.id)?.resolvedAt?.getTime()).toBe(resolvedAt.getTime())
+      expect(writtenEvents.find((e) => (e as { eventName?: string }).eventName === "IssueRegressed")).toBeUndefined()
+    })
+
+    it("does not emit IssueRegressed when the issue is not resolved", async () => {
+      const existingIssue = makeIssue({ resolvedAt: null })
+      const { repository: scoreRepository, scores } = createFakeScoreRepository()
+      const { repository: issueRepository } = createFakeIssueRepository([existingIssue])
+      const score = makeScore({ createdAt: new Date("2026-05-01T10:00:00.000Z") })
+      scores.set(score.id, score)
+      const writtenEvents: unknown[] = []
+
+      await Effect.runPromise(
+        assignScoreToIssueUseCase({
+          organizationId,
+          projectId,
+          scoreId: score.id,
+          issueId: existingIssue.id,
+          normalizedEmbedding: makeEmbedding(),
+        }).pipe(
+          Effect.provideService(ScoreRepository, scoreRepository),
+          Effect.provideService(IssueRepository, issueRepository),
+          Effect.provideService(OutboxEventWriter, {
+            write: (event) =>
+              Effect.sync(() => {
+                writtenEvents.push(event)
+              }),
+          }),
+          Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+          Effect.provideService(IssueDiscoveryLockRepository, passthroughLockRepository),
+          Effect.provideService(
+            IssueProjectionRepository,
+            createFakeIssueProjectionRepository({ organizationId }).service,
+          ),
+        ),
+      )
+
+      expect(writtenEvents.find((e) => (e as { eventName?: string }).eventName === "IssueRegressed")).toBeUndefined()
+    })
+  })
 })

--- a/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
+++ b/packages/domain/issues/src/use-cases/assign-score-to-issue.ts
@@ -80,7 +80,7 @@ const buildIssueWithAssignedScore = ({
   readonly score: Score
   readonly normalizedEmbedding: readonly number[]
   readonly assignedAt: Date
-}): Issue => {
+}): { readonly updatedIssue: Issue; readonly isRegression: boolean } => {
   const centroid = updateIssueCentroid({
     centroid: {
       ...issue.centroid,
@@ -95,11 +95,22 @@ const buildIssueWithAssignedScore = ({
     timestamp: assignedAt,
   })
 
+  // Reify regression at write time: a score newer than the issue's resolution
+  // means the issue is no longer resolved. Clearing `resolvedAt` here makes
+  // "is the issue regressed" a stored fact (and gives the regression event
+  // idempotency for free — a subsequent score in the same cycle won't see
+  // resolvedAt != null and won't re-emit).
+  const isRegression = issue.resolvedAt !== null && score.createdAt.getTime() > issue.resolvedAt.getTime()
+
   return {
-    ...issue,
-    centroid,
-    clusteredAt: centroid.clusteredAt,
-    updatedAt: assignedAt,
+    updatedIssue: {
+      ...issue,
+      centroid,
+      clusteredAt: centroid.clusteredAt,
+      resolvedAt: isRegression ? null : issue.resolvedAt,
+      updatedAt: assignedAt,
+    },
+    isRegression,
   }
 }
 
@@ -147,7 +158,7 @@ export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
             }
 
             const assignedAt = new Date()
-            const updatedIssue = buildIssueWithAssignedScore({
+            const { updatedIssue, isRegression } = buildIssueWithAssignedScore({
               issue,
               score,
               normalizedEmbedding: input.normalizedEmbedding,
@@ -186,6 +197,22 @@ export const assignScoreToIssueUseCase = (input: AssignScoreToIssueInput) =>
                 issueId: issue.id,
               },
             })
+
+            if (isRegression) {
+              yield* outboxEventWriter.write({
+                eventName: "IssueRegressed",
+                aggregateType: "issue",
+                aggregateId: updatedIssue.id,
+                organizationId: updatedIssue.organizationId,
+                payload: {
+                  organizationId: updatedIssue.organizationId,
+                  projectId: updatedIssue.projectId,
+                  issueId: updatedIssue.id,
+                  regressedAt: score.createdAt.toISOString(),
+                  triggerScoreId: score.id,
+                },
+              })
+            }
 
             return {
               action: "assigned",

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.test.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.test.ts
@@ -1,5 +1,6 @@
 import type { GenerateInput, GenerateResult } from "@domain/ai"
 import { createFakeAI } from "@domain/ai/testing"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
 import { type AnnotationScore, type Score, ScoreRepository } from "@domain/scores"
 import { createFakeScoreRepository } from "@domain/scores/testing"
 import { IssueId, OrganizationId, ScoreId, SqlClient, type SqlClientShape } from "@domain/shared"
@@ -11,6 +12,17 @@ import { IssueRepository } from "../ports/issue-repository.ts"
 import { createFakeIssueProjectionRepository } from "../testing/fake-issue-projection-repository.ts"
 import { createFakeIssueRepository } from "../testing/fake-issue-repository.ts"
 import { createIssueFromScoreUseCase } from "./create-issue-from-score.ts"
+
+const createFakeOutboxEventWriter = () => {
+  const events: OutboxWriteEvent[] = []
+  const service = OutboxEventWriter.of({
+    write: (event) =>
+      Effect.sync(() => {
+        events.push(event)
+      }),
+  })
+  return { events, service }
+}
 
 const organizationId = "oooooooooooooooooooooooo"
 const projectId = "pppppppppppppppppppppppp"
@@ -87,6 +99,7 @@ describe("createIssueFromScoreUseCase", () => {
     const { repository: issueRepository, issues } = createFakeIssueRepository()
     const score = makeScore()
     scores.set(score.id, score)
+    const outbox = createFakeOutboxEventWriter()
 
     const result = await Effect.runPromise(
       createIssueFromScoreUseCase({
@@ -99,6 +112,7 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(OutboxEventWriter, outbox.service),
         Effect.provideService(
           IssueProjectionRepository,
           createFakeIssueProjectionRepository({ organizationId }).service,
@@ -113,6 +127,15 @@ describe("createIssueFromScoreUseCase", () => {
     expect(issues.get(result.issueId)?.description).toBe("The assistant exposes secrets or tokens in its replies.")
     expect(issues.get(result.issueId)?.centroid.mass).toBeGreaterThan(0)
     expect(calls.generate).toHaveLength(1)
+
+    expect(outbox.events).toHaveLength(1)
+    expect(outbox.events[0]).toMatchObject({
+      eventName: "IssueCreated",
+      aggregateType: "issue",
+      aggregateId: result.issueId,
+      organizationId,
+      payload: { organizationId, projectId, issueId: result.issueId },
+    })
   })
 
   it("returns already-assigned before generation when the score already belongs to an issue", async () => {
@@ -135,6 +158,7 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(OutboxEventWriter, createFakeOutboxEventWriter().service),
         Effect.provideService(
           IssueProjectionRepository,
           createFakeIssueProjectionRepository({ organizationId }).service,
@@ -186,6 +210,7 @@ describe("createIssueFromScoreUseCase", () => {
         Effect.provideService(ScoreRepository, scoreRepository),
         Effect.provideService(IssueRepository, issueRepository),
         Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(OutboxEventWriter, createFakeOutboxEventWriter().service),
         Effect.provideService(
           IssueProjectionRepository,
           createFakeIssueProjectionRepository({ organizationId }).service,
@@ -248,6 +273,7 @@ describe("createIssueFromScoreUseCase", () => {
             Effect.provideService(ScoreRepository, scoreRepository),
             Effect.provideService(IssueRepository, issueRepository),
             Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+            Effect.provideService(OutboxEventWriter, createFakeOutboxEventWriter().service),
             Effect.provideService(
               IssueProjectionRepository,
               createFakeIssueProjectionRepository({ organizationId }).service,

--- a/packages/domain/issues/src/use-cases/create-issue-from-score.ts
+++ b/packages/domain/issues/src/use-cases/create-issue-from-score.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import { type Score, ScoreRepository } from "@domain/scores"
 import { generateId, type RepositoryError, ScoreId, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
@@ -139,6 +140,7 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
       Effect.gen(function* () {
         const issueRepository = yield* IssueRepository
         const scoreRepository = yield* ScoreRepository
+        const outboxEventWriter = yield* OutboxEventWriter
 
         const scoreResult = yield* loadEligibleScoreOrCurrentOwner(input)
         if (scoreResult.action === "already-assigned") {
@@ -179,6 +181,19 @@ export const createIssueFromScoreUseCase = (input: CreateIssueFromScoreInput) =>
         }
 
         yield* issueRepository.save(issue)
+
+        yield* outboxEventWriter.write({
+          eventName: "IssueCreated",
+          aggregateType: "issue",
+          aggregateId: issue.id,
+          organizationId: issue.organizationId,
+          payload: {
+            organizationId: issue.organizationId,
+            projectId: issue.projectId,
+            issueId: issue.id,
+            createdAt: issue.createdAt.toISOString(),
+          },
+        })
 
         return {
           action: "created",

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -84,6 +84,22 @@ const _registry = {
     }
   }>(),
 
+  "alert-incidents": payloads<{
+    "issue-created": {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly issueId: string
+      readonly createdAt: string
+    }
+    "issue-regressed": {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly issueId: string
+      readonly regressedAt: string
+      readonly triggerScoreId: string
+    }
+  }>(),
+
   issues: payloads<{
     discovery: {
       readonly organizationId: string

--- a/packages/domain/shared/src/id.ts
+++ b/packages/domain/shared/src/id.ts
@@ -54,6 +54,7 @@ export type AnnotationQueueId = Id<"AnnotationQueueId">
 export type AnnotationQueueItemId = Id<"AnnotationQueueItemId">
 export type FlaggerId = Id<"FlaggerId">
 export type SavedSearchId = Id<"SavedSearchId">
+export type AlertIncidentId = Id<"AlertIncidentId">
 
 // Telemetry-related IDs
 export type TraceId = Id<"TraceId">
@@ -80,6 +81,7 @@ export const AnnotationQueueId = (value: string): AnnotationQueueId => value as 
 export const AnnotationQueueItemId = (value: string): AnnotationQueueItemId => value as AnnotationQueueItemId
 export const FlaggerId = (value: string): FlaggerId => value as FlaggerId
 export const SavedSearchId = (value: string): SavedSearchId => value as SavedSearchId
+export const AlertIncidentId = (value: string): AlertIncidentId => value as AlertIncidentId
 export const TraceId = (value: string): TraceId => value as TraceId
 export const SpanId = (value: string): SpanId => value as SpanId
 export const DatasetId = (value: string): DatasetId => value as DatasetId
@@ -106,6 +108,7 @@ export const annotationQueueItemIdSchema = cuidSchema.transform(AnnotationQueueI
 export const flaggerIdSchema = cuidSchema.transform(FlaggerId)
 export const simulationIdSchema = cuidSchema.transform(SimulationId)
 export const savedSearchIdSchema = cuidSchema.transform(SavedSearchId)
+export const alertIncidentIdSchema = cuidSchema.transform(AlertIncidentId)
 
 // The telemetry-related IDs have custom length constraints
 export const SESSION_ID_LENGTH = 128

--- a/packages/platform/db-postgres/drizzle/.migration-lock
+++ b/packages/platform/db-postgres/drizzle/.migration-lock
@@ -4,6 +4,6 @@
 # create migrations in parallel, preventing incompatible
 # migrations from being merged without conflict resolution.
 #
-# Generated: 2026-05-06T09:49:20.595Z
-# Hash: 0f5c85c4-f6cf-42df-b6b7-f565f2deda5f
+# Generated: 2026-05-06T15:43:19.462Z
+# Hash: f2ae216b-4eff-4229-9f08-803a1bdfcd72
 # Do not manually edit this file.

--- a/packages/platform/db-postgres/drizzle/20260506154119_alert-incidents-table/migration.sql
+++ b/packages/platform/db-postgres/drizzle/20260506154119_alert-incidents-table/migration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "latitude"."alert_incidents" (
+	"id" varchar(24) PRIMARY KEY,
+	"organization_id" varchar(24) NOT NULL,
+	"project_id" varchar(24) NOT NULL,
+	"source_type" varchar(32) NOT NULL,
+	"source_id" varchar(24) NOT NULL,
+	"kind" varchar(64) NOT NULL,
+	"severity" varchar(16) NOT NULL,
+	"started_at" timestamp with time zone NOT NULL,
+	"ended_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "latitude"."alert_incidents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE INDEX "alert_incidents_project_started_at_idx" ON "latitude"."alert_incidents" ("organization_id","project_id","started_at");--> statement-breakpoint
+CREATE INDEX "alert_incidents_source_idx" ON "latitude"."alert_incidents" ("source_type","source_id","started_at");--> statement-breakpoint
+CREATE POLICY "alert_incidents_organization_policy" ON "latitude"."alert_incidents" AS PERMISSIVE FOR ALL TO public USING (organization_id = get_current_organization_id()) WITH CHECK (organization_id = get_current_organization_id());

--- a/packages/platform/db-postgres/drizzle/20260506154119_alert-incidents-table/snapshot.json
+++ b/packages/platform/db-postgres/drizzle/20260506154119_alert-incidents-table/snapshot.json
@@ -1,0 +1,5681 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "eb6fd297-7d6b-4190-a6f3-224f39c5bc0a",
+  "prevIds": [
+    "33a6070f-077f-4f52-8b85-abfcd35406c2"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": true,
+      "name": "alert_incidents",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queue_items",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "annotation_queues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "api_keys",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "accounts",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "invitations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "members",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "organizations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "sessions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "subscriptions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "verifications",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "datasets",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "dataset_versions",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "evaluations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "organization_feature_flags",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "flaggers",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "issues",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "outbox_events",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "projects",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "saved_searches",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "scores",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "isRlsEnabled": true,
+      "name": "simulations",
+      "entityType": "tables",
+      "schema": "latitude"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "kind",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "severity",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "queue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "completed_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "review_started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "system",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(140)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "instructions",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assignees",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "total_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "completed_items",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token_hash",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "last_used_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "scope",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "password",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'pending'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "inviter_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'member'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "logo",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organizations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "token",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "active_organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "impersonated_by",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "plan",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_subscription_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "'incomplete'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_start",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trial_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at_period_end",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cancel_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "canceled_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ended_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "seats",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "billing_interval",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_schedule_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "email",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "image",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(50)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'user'",
+      "generated": null,
+      "identity": null,
+      "name": "role",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "banned",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_reason",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ban_expires",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "job_title",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "users"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "current_version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "version",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_inserted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_updated",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "rows_deleted",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'api'",
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "script",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trigger",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "alignment",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aligned_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "enabled_for_all",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "archived_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "feature_flag_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "enabled_by_admin_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "true",
+      "generated": null,
+      "identity": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "10",
+      "generated": null,
+      "identity": null,
+      "name": "sampling",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "uuid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "description",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "centroid",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "clustered_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "escalated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "resolved_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "ignored_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "event_name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "''",
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_type",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "aggregate_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "payload",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "published",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "published_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "occurred_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "settings",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "first_trace_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "last_edited_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(80)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "query",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "filter_set",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "assigned_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "deleted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "trace_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "span_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "simulation_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "double precision",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "value",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "feedback",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "duration",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "tokens",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "bigint",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "0",
+      "generated": null,
+      "identity": null,
+      "name": "cost",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "drafted_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "annotator_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "organization_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(24)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataset",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 1,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "evaluations",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "passed",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "errored",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "error",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_incidents_project_started_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "source_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "started_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "alert_incidents_source_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "queue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "completed_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queue_items_queue_progress_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "annotation_queues_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "api_keys_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "accounts_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_email_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "inviter_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "invitations_inviterId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_organizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "members_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_userId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "active_organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "sessions_activeOrganizationId_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "verifications_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "verifications"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "datasets_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "dataset_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "version",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "dataset_versions_dataset_id_version_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "archived_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "evaluations_issue_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "feature_flags_identifier_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "feature_flag_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "organization_feature_flags_feature_flag_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "flaggers_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "ignored_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "resolved_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "issues_project_lifecycle_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_workspace_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "aggregate_type",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "outbox_events_aggregate_type_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "outbox_events"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "projects_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_project_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "assigned_user_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "deleted_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "saved_searches_assigned_user_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_organization_id_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_project_list_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_source_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "source_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": true,
+      "where": "\"source\" = 'evaluation' AND \"drafted_at\" IS NULL AND \"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_canonical_evaluation_trace_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "issue_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"issue_id\" IS NOT NULL AND \"drafted_at\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_issue_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "trace_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"trace_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_trace_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "session_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"session_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_session_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "span_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"span_id\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_span_lookup_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NULL AND \"errored\" = false AND \"passed\" = false AND \"issue_id\" IS NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_issue_discovery_work_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "updated_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"drafted_at\" IS NOT NULL",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "scores_draft_finalization_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "organization_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "project_id",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "created_at",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "simulations_project_created_at_idx",
+      "entityType": "indexes",
+      "schema": "latitude",
+      "table": "simulations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "accounts_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "inviter_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "invitations_inviter_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "organization_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "organizations",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_organization_id_organizations_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "members_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "user_id"
+      ],
+      "schemaTo": "latitude",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "name": "sessions_user_id_users_id_fkey",
+      "entityType": "fks",
+      "schema": "latitude",
+      "table": "sessions"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "alert_incidents_pkey",
+      "schema": "latitude",
+      "table": "alert_incidents",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queue_items_pkey",
+      "schema": "latitude",
+      "table": "annotation_queue_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "annotation_queues_pkey",
+      "schema": "latitude",
+      "table": "annotation_queues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "api_keys_pkey",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "accounts_pkey",
+      "schema": "latitude",
+      "table": "accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "invitations_pkey",
+      "schema": "latitude",
+      "table": "invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "members_pkey",
+      "schema": "latitude",
+      "table": "members",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organizations_pkey",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "sessions_pkey",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "subscriptions_pkey",
+      "schema": "latitude",
+      "table": "subscriptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "verifications_pkey",
+      "schema": "latitude",
+      "table": "verifications",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "datasets_pkey",
+      "schema": "latitude",
+      "table": "datasets",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dataset_versions_pkey",
+      "schema": "latitude",
+      "table": "dataset_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "evaluations_pkey",
+      "schema": "latitude",
+      "table": "evaluations",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "feature_flags_pkey",
+      "schema": "latitude",
+      "table": "feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "organization_feature_flags_pkey",
+      "schema": "latitude",
+      "table": "organization_feature_flags",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "flaggers_pkey",
+      "schema": "latitude",
+      "table": "flaggers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issues_pkey",
+      "schema": "latitude",
+      "table": "issues",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "outbox_events_pkey",
+      "schema": "latitude",
+      "table": "outbox_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pkey",
+      "schema": "latitude",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "saved_searches_pkey",
+      "schema": "latitude",
+      "table": "saved_searches",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "scores_pkey",
+      "schema": "latitude",
+      "table": "scores",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "simulations_pkey",
+      "schema": "latitude",
+      "table": "simulations",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "queue_id",
+        "trace_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "annotation_queue_items_unique_trace_per_queue_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "annotation_queues_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "datasets_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "name",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "evaluations_unique_name_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "feature_flag_id"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organization_feature_flags_unique_org_flag_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug"
+      ],
+      "nullsNotDistinct": true,
+      "name": "flaggers_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "organization_id",
+        "project_id",
+        "slug",
+        "deleted_at"
+      ],
+      "nullsNotDistinct": true,
+      "name": "saved_searches_unique_slug_per_project_idx",
+      "entityType": "uniques",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token_hash"
+      ],
+      "nullsNotDistinct": false,
+      "name": "api_keys_token_hash_key",
+      "schema": "latitude",
+      "table": "api_keys",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "organizations_slug_key",
+      "schema": "latitude",
+      "table": "organizations",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "token"
+      ],
+      "nullsNotDistinct": false,
+      "name": "sessions_token_key",
+      "schema": "latitude",
+      "table": "sessions",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "email"
+      ],
+      "nullsNotDistinct": false,
+      "name": "users_email_key",
+      "schema": "latitude",
+      "table": "users",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "identifier"
+      ],
+      "nullsNotDistinct": false,
+      "name": "feature_flags_identifier_key",
+      "schema": "latitude",
+      "table": "feature_flags",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "uuid"
+      ],
+      "nullsNotDistinct": false,
+      "name": "issues_uuid_key",
+      "schema": "latitude",
+      "table": "issues",
+      "entityType": "uniques"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "alert_incidents_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "alert_incidents"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queue_items_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queue_items"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "annotation_queues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "annotation_queues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "api_keys_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "api_keys"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "invitations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "invitations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "members_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "members"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "reference_id = get_current_organization_id()",
+      "withCheck": "reference_id = get_current_organization_id()",
+      "name": "subscriptions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "subscriptions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "datasets_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "datasets"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "dataset_versions_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "dataset_versions"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "evaluations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "evaluations"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "organization_feature_flags_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "organization_feature_flags"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "flaggers_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "flaggers"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "issues_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "issues"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "projects_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "projects"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "saved_searches_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "saved_searches"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "scores_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "scores"
+    },
+    {
+      "as": "PERMISSIVE",
+      "for": "ALL",
+      "roles": [
+        "public"
+      ],
+      "using": "organization_id = get_current_organization_id()",
+      "withCheck": "organization_id = get_current_organization_id()",
+      "name": "simulations_organization_policy",
+      "entityType": "policies",
+      "schema": "latitude",
+      "table": "simulations"
+    }
+  ],
+  "renames": []
+}

--- a/packages/platform/db-postgres/package.json
+++ b/packages/platform/db-postgres/package.json
@@ -30,6 +30,7 @@
     "@better-auth/core": "1.5.6",
     "@better-auth/stripe": "1.5.6",
     "@domain/admin": "workspace:*",
+    "@domain/alerts": "workspace:*",
     "@domain/annotation-queues": "workspace:*",
     "@domain/api-keys": "workspace:*",
     "@domain/evaluations": "workspace:*",

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -28,6 +28,7 @@ export { AdminFeatureFlagRepositoryLive } from "./repositories/admin-feature-fla
 export { AdminOrganizationRepositoryLive } from "./repositories/admin-organization-repository.ts"
 export { AdminProjectRepositoryLive } from "./repositories/admin-project-repository.ts"
 export { AdminUserRepositoryLive } from "./repositories/admin-user-repository.ts"
+export { AlertIncidentRepositoryLive } from "./repositories/alert-incident-repository.ts"
 export { AnnotationQueueItemRepositoryLive } from "./repositories/annotation-queue-item-repository.ts"
 export { AnnotationQueueRepositoryLive } from "./repositories/annotation-queue-repository.ts"
 export { ApiKeyRepositoryLive } from "./repositories/api-key-repository.ts"

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -1,0 +1,32 @@
+import { type AlertIncident, AlertIncidentRepository } from "@domain/alerts"
+import { SqlClient, type SqlClientShape } from "@domain/shared"
+import { Effect, Layer } from "effect"
+import type { Operator } from "../client.ts"
+import { alertIncidents } from "../schema/alert-incidents.ts"
+
+const toInsertRow = (incident: AlertIncident): typeof alertIncidents.$inferInsert => ({
+  id: incident.id,
+  organizationId: incident.organizationId,
+  projectId: incident.projectId,
+  sourceType: incident.sourceType,
+  sourceId: incident.sourceId,
+  kind: incident.kind,
+  severity: incident.severity,
+  startedAt: incident.startedAt,
+  endedAt: incident.endedAt,
+  createdAt: incident.createdAt,
+})
+
+export const AlertIncidentRepositoryLive = Layer.effect(
+  AlertIncidentRepository,
+  Effect.succeed(
+    AlertIncidentRepository.of({
+      insert: (incident) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          const row = toInsertRow(incident)
+          yield* sqlClient.query((db) => db.insert(alertIncidents).values(row))
+        }),
+    }),
+  ),
+)

--- a/packages/platform/db-postgres/src/schema/alert-incidents.ts
+++ b/packages/platform/db-postgres/src/schema/alert-incidents.ts
@@ -1,0 +1,24 @@
+import type { AlertIncidentKind, AlertIncidentSourceType, AlertSeverity } from "@domain/alerts"
+import { index, varchar } from "drizzle-orm/pg-core"
+import { cuid, latitudeSchema, organizationRLSPolicy, tzTimestamp } from "../schemaHelpers.ts"
+
+export const alertIncidents = latitudeSchema.table(
+  "alert_incidents",
+  {
+    id: cuid("id").primaryKey(),
+    organizationId: cuid("organization_id").notNull(),
+    projectId: cuid("project_id").notNull(),
+    sourceType: varchar("source_type", { length: 32 }).$type<AlertIncidentSourceType>().notNull(),
+    sourceId: varchar("source_id", { length: 24 }).notNull(),
+    kind: varchar("kind", { length: 64 }).$type<AlertIncidentKind>().notNull(),
+    severity: varchar("severity", { length: 16 }).$type<AlertSeverity>().notNull(),
+    startedAt: tzTimestamp("started_at").notNull(),
+    endedAt: tzTimestamp("ended_at"),
+    createdAt: tzTimestamp("created_at").defaultNow().notNull(),
+  },
+  (t) => [
+    organizationRLSPolicy("alert_incidents"),
+    index("alert_incidents_project_started_at_idx").on(t.organizationId, t.projectId, t.startedAt),
+    index("alert_incidents_source_idx").on(t.sourceType, t.sourceId, t.startedAt),
+  ],
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       '@domain/ai':
         specifier: workspace:*
         version: link:../../packages/domain/ai
+      '@domain/alerts':
+        specifier: workspace:*
+        version: link:../../packages/domain/alerts
       '@domain/annotation-queues':
         specifier: workspace:*
         version: link:../../packages/domain/annotation-queues
@@ -840,6 +843,25 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.3.6
+
+  packages/domain/alerts:
+    dependencies:
+      '@domain/events':
+        specifier: workspace:*
+        version: link:../events
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../shared
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.57
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/domain/annotation-queues:
     dependencies:
@@ -1581,6 +1603,9 @@ importers:
       '@domain/admin':
         specifier: workspace:*
         version: link:../../domain/admin
+      '@domain/alerts':
+        specifier: workspace:*
+        version: link:../../domain/alerts
       '@domain/annotation-queues':
         specifier: workspace:*
         version: link:../../domain/annotation-queues

--- a/specs/alerts.md
+++ b/specs/alerts.md
@@ -1,0 +1,980 @@
+# Alerts
+
+> **Documentation**: `dev-docs/reliability.md`, `dev-docs/issues.md`, `dev-docs/spans.md`
+
+## Purpose
+
+This document captures the product and architecture discussion around Alerts.
+
+It describes the long-term shape of the Alerts product, the MVP carved out of that vision, how the system relates to existing Latitude features, how user-facing configuration works, and which design questions remain open.
+
+The MVP-specific sections (**MVP Scope**, **MVP Data Model**, **MVP Architecture and Flow**, **Notification System**, **Implementation Plan**) are the source of truth for what is being built first. The broader sections describe the eventual product.
+
+## Problem
+
+Notification delivery is not a new infrastructure problem; Latitude already sends transactional email. The alerts system owns a different question:
+
+> When and why should Latitude create a notification-worthy signal?
+
+The core product problem is to let users express "tell me when something meaningful happens" without forcing them to learn a generic monitoring query language.
+
+## Current Product Context
+
+Trace ingestion is already implemented end-to-end:
+
+- `apps/ingest` accepts trace payloads.
+- span ingestion workers decode OTLP payloads and persist spans into ClickHouse.
+- `SpanIngested` fans out to trace-end processing.
+
+Issue discovery and tracking are also already wired:
+
+- scores are the canonical issue-discovery signal.
+- eligible failed scores create or match issues through the issue-discovery pipeline.
+- evaluation failures for issue-linked evaluations are written with `issueId`, which lets them track existing issues directly.
+- issues already have lifecycle concepts such as `new`, `escalating`, `resolved`, `regressed`, and `ignored`.
+- issue states are **derived at read time** in `packages/domain/issues/src/helpers.ts` (`deriveIssueLifecycleStates`); only `resolvedAt` and `ignoredAt` are stored. `escalatedAt` exists on the schema but is not currently written.
+
+Saved Searches are implemented as stored trace search scopes:
+
+- a saved search stores `query` plus `filterSet`.
+- the search page can list, open, update, rename, assign, and delete saved searches.
+- the trace repository already exposes count, last-match, annotated count, metric aggregate, histogram, and single-trace filter matching primitives that can support alert evaluation.
+
+Alerts should build on these existing concepts instead of inventing a separate monitoring query model from scratch.
+
+## MVP Scope
+
+V1 ships project-scoped, event-driven alerts only. Two alert kinds — `issue.new` and `issue.regressed` — are persisted as `alert_incidents` rows in PR 1, with email and in-app channels added in PR 2 and PR 3 respectively. Every other alert category in this document is deferred.
+
+**In scope for V1:**
+
+- Two alert kinds: New Issue Discovered, Issue Regressed
+- `alert_incidents` table as the system-of-record for fired alerts (PR 1)
+- Email delivery to organization members (PR 2)
+- Distinct email templates per alert kind (PR 2)
+- In-app notification feed with read state (PR 3)
+- Per-project channel toggles (PR 2): which kinds get emailed
+- Per-user channel toggles (PR 2): opt out of email entirely
+- Org-level `alerts` feature flag introduced in PR 2 for staged rollout
+
+**Deferred:**
+
+- `issue.escalating` alert kind — escalation is a derived state computed from occurrence analytics; reifying it at write time requires loading the aggregate on every score assignment. Defer until a periodic recomputation worker exists or the cost is justified.
+- Issue-scoped alerts (per-issue subscriptions, volume spike, stops receiving matches)
+- Saved Search alerts of any kind
+- Threshold and anomaly detection
+- Trace-match and scheduled-check trigger engines
+- Slack and other custom channels
+- Incident lifecycle (acknowledge, resolve, sustained-condition tracking)
+- Email delivery audit log
+- Per-(user, organization) membership settings — V1 user settings are global per user
+- Per-project subscriber model — V1 notifies all org members
+- Digest or batching strategies
+- Org-level default preferences
+
+**Why this cut:**
+
+- Issue lifecycle changes for `new` and `regressed` are cheap to reify at write time. Both are already on the score-assignment / issue-creation paths and require no new infrastructure for detection.
+- `issue.escalating` requires the issue's occurrence aggregate at write time, which is expensive on the hot score-assignment path. Deferring keeps PR 1 lean.
+- Splitting incident creation (PR 1) from each delivery channel (PR 2 email, PR 3 in-app) bounds the blast radius of each PR. Channels can ship and roll back independently of the data layer.
+
+## Conceptual Model
+
+The conceptual model below describes the eventual product. The MVP exercises a subset of these concepts.
+
+### Alert Rule
+
+An alert rule is user configuration. It answers:
+
+- what scope is being watched
+- what condition is being evaluated
+- how severe a firing should be
+- whether the rule is enabled
+- how repeated firings are deduped or cooled down
+
+Conceptual shape:
+
+```typescript
+type AlertSeverity = "critical" | "high" | "medium" | "low"
+
+type AlertRuleConcept = {
+  id: string
+  projectId: string
+  name: string
+  enabled: boolean
+  severity: AlertSeverity
+  scope: AlertScope
+  trigger: AlertTrigger
+  cooldownMinutes?: number
+}
+```
+
+Severity belongs on each alert rule, not only on the parent scope. This supports multiple rules for the same saved search or issue with different priority:
+
+```text
+(High)     total monthly cost > $20
+(Critical) total monthly cost > $40
+```
+
+Severity should later drive notification routing and escalation policy. It should not initially imply a different detector algorithm unless there is a strong product reason.
+
+**V1 does not introduce an `AlertRule` entity.** The two project alert kinds are unconditional in PR 1 (every emission produces an incident). PR 2 introduces channel-level gating via per-project and per-user settings stored as jsonb on `projects` and `users`. Severity is hardcoded per kind. A rules table only earns its keep when alerts grow beyond one-per-kind-per-project — saved-search alerts will be that second instance.
+
+### Alert Event
+
+An alert event is a single firing of a rule. It answers:
+
+- which rule fired
+- when it fired
+- what observed value caused it
+- what threshold or dynamic bound was crossed
+- what trace, issue, saved search, or window the event refers to
+
+Alert events should exist before notification delivery exists so the system is auditable and testable.
+
+**In V1, alert events are realized as `alert_incidents` rows introduced in PR 1.** PR 1 ships only the data layer; PR 2 and PR 3 add the email and in-app channels as consumers of `IncidentCreated`.
+
+### Incident
+
+An incident is a longer-lived active state caused by one or more alert events. Incidents are useful for threshold and anomaly rules because the condition can remain active across many evaluations.
+
+**V1 incidents have no lifecycle.** The `alert_incidents` table is introduced in PR 1, but the rows are simple dispatch records: one row per firing, no `status`, `acknowledged_at`, or `resolved_at`. Lifecycle columns can be added later without migration risk.
+
+The conceptual separation that should outlive V1:
+
+- **Alert Rule**: user configuration
+- **Alert Event**: a single firing caused by a rule
+- **Incident**: optional future active state that groups one or more firings
+
+In V1, Rule is replaced by per-channel settings, Event is the same row as Incident, and lifecycle is absent. The full separation appears as more alert categories are added.
+
+## Alert Scopes
+
+Alerts should be scoped to one of three product surfaces.
+
+### Project Scope
+
+Project alerts are project-wide and mostly watch issue lifecycle or discovery events.
+
+Typical use cases:
+
+- notify when a new issue is discovered in the project
+- notify when any issue regresses
+- notify when any issue becomes escalating
+
+**V1 implements only project scope.**
+
+### Issue Scope
+
+Issue alerts are configured for one specific issue.
+
+Typical use cases:
+
+- notify when a new trace/score matches this issue
+- notify when this issue's match volume spikes
+- optionally notify when this issue stops receiving matches
+
+**Deferred.**
+
+### Saved Search Scope
+
+Saved Search alerts are configured for one saved trace search. The saved search query and `filterSet` define the monitored population of traces.
+
+Typical use cases:
+
+- notify when a new trace matches the saved search
+- notify when matching trace volume spikes
+- notify when the saved search stops matching traces
+- notify when matching trace metrics cross static thresholds
+- notify when matching trace metrics become anomalously high
+
+Alert rules should reference the saved search by id, not copy its filters by default. Editing the saved search should update what its alerts monitor. A later product decision can add "snapshot filters" if users need rules that do not follow saved-search edits.
+
+**Deferred.**
+
+## Trigger Engines
+
+Alert scopes describe what is watched. Trigger engines describe how evaluation runs.
+
+### Event Alerts
+
+Event alerts fire from domain events or lifecycle transitions.
+
+Examples:
+
+- project: new issue discovered
+- project: issue regressed
+- project: issue became escalating
+- issue: issue resolved or ignored, if needed later
+
+Event alerts are evaluated by a dedicated alerts worker that consumes domain events. The event carries ids only; the alert evaluator re-fetches current state before firing user-visible alert events.
+
+**V1 implements only the event trigger engine.**
+
+### Trace Match Alerts
+
+Trace match alerts run when a trace finishes or when a score is assigned to an issue.
+
+Examples:
+
+- saved search: a new trace matches this saved search
+- saved search: any matching trace has cost over `$0.20`
+- issue: a new trace/score matched this issue
+
+For saved searches, trace matching can reuse the existing filter matching concept: evaluate the new trace against saved-search filter sets and optional per-trace metric predicates.
+
+For issue alerts, a new match is driven by score assignment to the issue, not by the raw trace alone. The alert should fire when the issue gains a new owned score/occurrence.
+
+**Deferred.**
+
+### Scheduled Checks
+
+Scheduled checks periodically evaluate aggregate conditions over windows.
+
+Examples:
+
+- saved search: total cost this month is over `$20`
+- saved search: average duration over the last hour is over `5s`
+- saved search: matching trace volume is anomalously high
+- issue: match volume is anomalously high
+
+Scheduled checks conceptually evaluate persisted alert rules, compute current values from trace/score analytics, apply dedupe/cooldown rules, and create alert events when rules fire.
+
+**Deferred.**
+
+## Project Alerts
+
+Project alerts are configured once per project.
+
+### New Issue Discovered
+
+**V1.** Configured per project in PR 2 (`alerts.notifyOnNewIssue`).
+
+User-facing configuration:
+
+```text
+[x] Notify when a new issue is discovered
+```
+
+Internal shape:
+
+- scope: project
+- trigger: event — `IssueCreated`
+- emission point: `createIssueFromScoreUseCase` in `packages/domain/issues`, after `issueRepository.save(issue)`
+- severity: hardcoded `medium`
+- dedupe: `issue.new:${issueId}` (an issue can only be new once)
+
+### Issue Regressed
+
+**V1.** Configured per project in PR 2 (`alerts.notifyOnRegression`).
+
+User-facing configuration:
+
+```text
+[x] Notify when an issue regresses
+```
+
+Internal shape:
+
+- scope: project
+- trigger: event — `IssueRegressed`
+- emission point: `assign-score-to-issue.ts` in `packages/domain/issues`. When `issue.resolvedAt != null && score.lastSeenAt > issue.resolvedAt`, clear `resolvedAt` on the issue (reifying the transition) and emit `IssueRegressed` after save.
+- severity: hardcoded `high`
+- dedupe: `issue.regressed:${issueId}:${triggerScoreId}` — the regressing score id discriminates per-cycle so a future regression after resolution is a distinct incident
+
+The clearing of `resolvedAt` is the source of idempotency: a second score arriving in the same regression window will not see `resolvedAt != null` and will not re-emit.
+
+### Issue Became Escalating
+
+**Deferred from V1.** Future direction documented for design continuity.
+
+User-facing configuration:
+
+```text
+[x] Notify when an issue starts escalating
+```
+
+Internal shape:
+
+- scope: project
+- trigger: event — `IssueEscalated` (not yet emitted)
+- detection: requires the issue's occurrence aggregate (`recentOccurrences` vs `baselineAvgOccurrences`) which lives in analytics. Detecting the transition either requires loading the aggregate on every score assignment (expensive on the hot path) or a periodic recomputation worker that compares previous-derived-state to current and emits transition events.
+- severity: hardcoded `high`
+- dedupe: would need a per-cycle discriminator analogous to the regression `triggerScoreId`
+
+The existing issue state definition says an issue is escalating when recent occurrences exceed its baseline by a configured factor and minimum count. Alerting will reuse the lifecycle state rather than implement a second independent escalation definition.
+
+V1 does not attempt to track "still escalating" reminders. A transition is a one-shot signal.
+
+## Issue Alerts
+
+**Deferred from V1.** Future direction documented for design continuity.
+
+### New Match
+
+User-facing configuration:
+
+```text
+[x] (High v) Notify when a new trace matches this issue
+```
+
+Internal shape:
+
+- scope: issue
+- trigger: trace match
+- source signal: score assignment to the issue
+- configurable fields: enabled, severity, optional cooldown
+- dedupe: rule id plus score id or trace id
+
+### Volume Spike
+
+User-facing configuration:
+
+```text
+[x] (High v) Notify when match volume spikes
+```
+
+Internal shape:
+
+- scope: issue
+- trigger: scheduled anomaly
+- metric: issue occurrence count
+- aggregation: count per fixed evaluation window
+- configurable fields: enabled, severity
+- non-configurable defaults: evaluation cadence, baseline window, minimum occurrence count, cooldown
+
+The user should not configure multipliers, percentiles, baseline windows, or sensitivity in the first UI. Latitude should compute dynamic bounds from historical occurrence counts.
+
+This overlaps significantly with the existing escalation lifecycle and may be cut entirely in favor of escalation alerts.
+
+### Stops Receiving Matches
+
+This is optional and likely not in early scope unless a concrete user need appears.
+
+User-facing configuration:
+
+```text
+[ ] (Low v) Notify when this issue stops receiving matches
+```
+
+Internal shape:
+
+- scope: issue
+- trigger: scheduled check
+- condition: no occurrences in current window after a historically active baseline
+- configurable fields: enabled, severity
+
+This overlaps with automatic resolution and may not need a separate alert.
+
+## Saved Search Alerts
+
+**Deferred from V1.** Future direction documented for design continuity. This is the first detailed UI target after V1.
+
+A saved search defines the trace population. Alert UI should not expose a generic query builder. It should expose simple alert rows that compile to alert rules internally.
+
+### Suggested UI Shape
+
+The alerts control should live inside a Saved Search, likely behind an "Alerts" button. It can open a popover or modal containing a list of alert rows.
+
+```text
+Alerts for "Failed payments"
+
+Default alerts
+[ ] (Medium v) Notify when a new trace matches
+[x] (High v) Notify when matching trace volume spikes
+[ ] (Medium v) Notify when this search stops matching traces
+
+Anomalies
+[x] (High v) Notify when [cost v] anomalies happen
+[ ] (Medium v) Notify when [duration v] anomalies happen
++ Add anomaly
+
+Metric alerts
+[x] (High v) Notify when [total v] [cost v] is [over v] [$20] during [this month v]
+[x] (Critical v) Notify when [any v] [cost v] is [over v] [$0.20]
++ Add metric alert
+```
+
+There should be no separate advanced panel. Anything that is not in this UI is not user-configurable.
+
+### New Trace Match
+
+User-facing configuration:
+
+```text
+[ ] (Medium v) Notify when a new trace matches
+```
+
+Internal shape:
+
+- scope: saved search
+- trigger: trace match
+- conditions: none
+- configurable fields: enabled, severity, cooldown
+- dedupe: rule id plus trace id
+
+### Stops Matching Traces
+
+User-facing configuration:
+
+```text
+[ ] (Medium v) Notify when this search stops matching traces
+```
+
+Internal shape:
+
+- scope: saved search
+- trigger: scheduled check
+- condition: current window has zero matching traces after the saved search was historically active
+- configurable fields: enabled, severity
+- non-configurable defaults: activity baseline, evaluation cadence, cooldown
+
+This must be carefully defined to avoid noisy alerts for searches that naturally match rarely.
+
+### Volume Spike
+
+User-facing configuration:
+
+```text
+[x] (High v) Notify when matching trace volume spikes
+```
+
+Internal shape:
+
+- scope: saved search
+- trigger: scheduled anomaly
+- metric: matching trace count
+- aggregation: count per evaluation window
+- configurable fields: enabled, severity
+- non-configurable defaults: evaluation cadence, baseline window, minimum count, cooldown
+
+### Metric Threshold Alerts
+
+Metric threshold alerts are user-configured static conditions.
+
+User-facing row format:
+
+```text
+[x] (High v) Notify when [aggregation v] [metric v] is [operator v] [value] during [window v]
+```
+
+If aggregation is `any`, the row describes a per-trace condition and does not need a window:
+
+```text
+[x] (Critical v) Notify when [any v] [cost v] is [over v] [$0.20]
+```
+
+Supported aggregations:
+
+- `any`: any matching trace crosses the threshold; evaluated as a trace-match alert
+- `count`: count of matching traces in a window
+- `total`: sum of the metric in a window
+- `average`: average value in a window
+- `max`: maximum value in a window
+- `p95`: p95 value in a window
+
+Supported metrics:
+
+- trace count
+- cost
+- duration
+- TTFT
+- token usage
+
+Supported operators:
+
+- `over` for first iteration
+
+Supported windows:
+
+- last 15 minutes
+- last hour
+- last day
+- last 7 days
+- this month
+
+Internal mapping:
+
+- `any` aggregation maps to the trace-match trigger engine.
+- all windowed aggregations map to the scheduled-check trigger engine.
+
+### Anomaly Alerts
+
+Anomaly alerts are scheduled, dynamic checks. They are not per-trace outlier detection. Single-trace threshold behavior belongs to metric threshold alerts using `any`.
+
+User-facing configuration:
+
+```text
+[x] (High v) Notify when [cost v] anomalies happen
+[ ] (Medium v) Notify when [duration v] anomalies happen
++ Add anomaly
+```
+
+Supported anomaly metrics:
+
+- volume
+- cost
+- duration
+- TTFT
+- token usage
+
+All anomaly metrics are "higher is worse". Lower-bound anomalies are not part of the first design except for the separate "stops matching traces" alert.
+
+The user should not configure:
+
+- p50/p95/p99
+- MAD multiplier
+- baseline window
+- current window
+- sensitivity
+- seasonal strategy
+- comparison threshold
+
+Severity remains configurable, but severity is for priority/routing, not detector tuning.
+
+## Anomaly Definition
+
+**Deferred from V1.**
+
+For Saved Searches and Issue volume spikes, an anomaly means:
+
+> The current aggregate value is unusually high compared with the historical behavior of this same scope, and there is enough historical data to trust that comparison.
+
+There is no universal anomaly detector that works for all metrics and all data shapes. The preferred initial product direction is a robust statistical detector rather than a machine-learning black box.
+
+### Proposed Initial Definition
+
+Use a percentile/MAD-style dynamic upper band.
+
+For each anomaly rule:
+
+1. evaluate on a fixed cadence, probably hourly
+2. compute the current window value
+3. compute historical comparable window values for the same scope and metric
+4. compute the historical median
+5. compute `MAD = median(abs(value - median))`
+6. compute `scaledMAD = MAD * 1.4826`
+7. compute `upperBound = median + k * scaledMAD`
+8. fire if current value is above `upperBound`, minimum sample/volume requirements are met, and cooldown is not active
+
+This works better than a fixed multiplier because stable searches get narrow bounds while noisy searches get wider bounds.
+
+Example:
+
+- a saved search whose p95 duration is normally between `4s` and `4.5s` should alert when recent p95 duration becomes `8s`
+- a saved search whose p95 duration naturally ranges from `20s` to `5m` should not alert for ordinary values inside that broad range
+
+The exact `k`, current window, baseline window, minimum historical buckets, minimum current value, consecutive breach requirement, and cooldown are product/architecture constants to settle before this becomes a build plan. They are not UI settings.
+
+Potential conservative defaults:
+
+- evaluation cadence: hourly
+- current window: last hour
+- baseline: previous 14 days of hourly buckets
+- minimum historical buckets: 48
+- minimum current count for volume anomaly: 10 matching traces
+- consecutive breaches: 1 or 2, still undecided
+- cooldown: 24h per alert rule
+
+When there is not enough history, the rule should not fire. The UI can show "Learning normal behavior" or similar status if needed.
+
+## MVP Data Model
+
+V1 introduces no `alert_rules` table. PR 1 ships the `alert_incidents` table as the system-of-record. PR 2 adds per-project and per-user channel settings as jsonb on existing `projects` and `users` rows. PR 3 adds the in-app `notifications` table.
+
+### Alert incident (PR 1)
+
+```typescript
+type AlertIncident = {
+  id: string
+  organization_id: string
+  project_id: string
+  source_type: 'issue'                    // polymorphic for future sources
+  source_id: string                        // issue id
+  kind: 'issue.new' | 'issue.regressed'    // namespaced; future: issue.escalating, saved_search.*
+  severity: 'medium' | 'high'              // hardcoded per kind in V1, stored for forward compatibility
+  started_at: Date                         // when the underlying transition occurred
+  ended_at: Date | null                    // nullable; always NULL in V1 (all V1 kinds are one-off)
+  dedupe_key: string                       // unique idempotency token, see below
+}
+```
+
+Stored as `alert_incidents`.
+
+**Naming**: `alert_incidents` is preferred over `incidents` to avoid the PagerDuty-style "incident with ack/resolve lifecycle" connotation, and over `alerts` to avoid overloading with rule/configuration language. The `alert_` prefix matches repo style (e.g., `feature_flags`, `organization_feature_flags`).
+
+**Polymorphic source pointer**: `(source_type, source_id)` is the standard cross-system pattern (GitHub, Sentry, Linear). It loses DB-level FK integrity on `source_id`, which is acceptable for an audit-style table where applications validate the reference. The alternative — one nullable FK per source type with a CHECK constraint — gets ugly fast as source types grow.
+
+**Kind**: a namespaced string. PR 1 supports `issue.new` and `issue.regressed`. The namespace prefix prevents collisions across source types (`issue.new` ≠ `saved_search.new`) and keeps the column self-documenting. Layered on top with a Zod enum in domain code for type safety.
+
+**started_at and ended_at**: `started_at` is the timestamp from the underlying domain transition (carried on the event), not the wall-clock at insert time. `ended_at` is nullable and **always NULL in V1** because both V1 kinds are one-off events with no notion of resolution. The column is included now to accommodate sustained conditions (thresholds, anomalies) without a future migration; the precise semantics for "still active" vs "one-off" will be decided when the first sustained kind ships.
+
+**Severity placement**: stored at write time, not derived. The mapping is hardcoded today, but storing the value forward-compatibly lets configurable severity land without a migration.
+
+**Dedupe key**: per-kind deterministic token, unique across the table. Avoids a composite unique constraint that would change shape per kind.
+
+- `issue.new`: `issue.new:${issueId}`
+- `issue.regressed`: `issue.regressed:${issueId}:${triggerScoreId}`
+
+Recommended indexes:
+
+- unique on `dedupe_key`
+- `(organization_id, project_id, started_at desc)` for project-scoped feeds
+- `(source_type, source_id, started_at desc)` for "what alerts fired for this issue"
+
+### Project alert settings (PR 2)
+
+```typescript
+type ProjectAlertSettings = {
+  notifyOnNewIssue: boolean       // default: true
+  notifyOnRegression: boolean     // default: true
+}
+```
+
+Stored under `alerts` in the existing `projects.settings` jsonb column. Validated with a Zod schema on read and write. Reads merge with defaults so existing rows or partial blobs return a fully populated object.
+
+**These settings gate the email channel, not incident creation.** Incidents in `alert_incidents` are written unconditionally for every emission. The toggles control whether the email worker sends mail for an incident of that kind.
+
+PR 2 does not include `notifyOnEscalation` because `issue.escalating` is deferred from V1 entirely.
+
+### User notification settings (PR 2)
+
+```typescript
+type UserNotificationSettings = {
+  emailEnabled: boolean           // default: true
+}
+```
+
+Stored as a new `users.settings: jsonb` column (no existing column today). Same Zod-validation and default-merge pattern as project settings. Settings are global per user, not per (user, organization) membership.
+
+### Notification (PR 3)
+
+```typescript
+type Notification = {
+  id: string
+  recipient_user_id: string
+  alert_incident_id: string
+  created_at: Date
+  seen_at: Date | null
+}
+```
+
+In-app feed entries only. No email log table — emails are fire-and-forget in V1. Content is rendered on read from the linked incident plus its source.
+
+## MVP Architecture and Flow
+
+### Event emission (PR 1)
+
+Two domain events are added to `packages/domain/events`:
+
+- `IssueCreated` — emitted in `createIssueFromScoreUseCase` after `issueRepository.save(issue)`. Payload: `{ organizationId, projectId, issueId, createdAt }`.
+- `IssueRegressed` — emitted in `assign-score-to-issue.ts` after the score is assigned, when `issue.resolvedAt != null && score.lastSeenAt > issue.resolvedAt`. The use case clears `resolvedAt` on the saved issue (reifying the regression) and writes the event. Payload: `{ organizationId, projectId, issueId, regressedAt, triggerScoreId }`.
+
+Per-direction policy: V1 emits only the events it consumes. Lifecycle commands (`IssueResolved`, `IssueIgnored`, etc.) are not emitted until a consumer needs them.
+
+### Alerts worker (PR 1)
+
+```text
+[issue domain] emits IssueCreated or IssueRegressed
+   ↓
+[alerts worker subscribes]
+   - re-fetch the issue and project to confirm current state
+   - compute dedupe_key and severity from kind
+   - INSERT alert_incidents row, ON CONFLICT (dedupe_key) DO NOTHING
+   - if a row was actually inserted, emit IncidentCreated { incidentId }
+```
+
+PR 1 has no feature flag, no settings checks, and no delivery. Incident creation is unconditional for every consumed event. The worker is a pure producer of `alert_incidents` rows and `IncidentCreated` events.
+
+### Email worker (PR 2)
+
+```text
+[IncidentCreated]
+   ↓
+[email worker subscribes]
+   - feature flag: alerts enabled for org? if not, drop
+   - load project.settings.alerts; if the kind toggle is off, drop
+   - load org members
+   - for each member, read users.settings.notifications.emailEnabled; if off, skip
+   - render per-kind template, enqueue email job
+   - email job idempotency key: emails:alert:${incidentId}:${recipientUserId}
+```
+
+Email sending uses the existing `@domain/email` + `@platform/email-transport` pipeline (Mailgun prod, Mailpit dev), the same path that already handles login and invite emails.
+
+### Notifications worker (PR 3)
+
+```text
+[IncidentCreated]
+   ↓
+[notifications worker subscribes]
+   - load incident, org members
+   - for each member, INSERT notifications row, ON CONFLICT (incident_id, recipient_user_id) DO NOTHING
+   - in-app fan-out is unconditional in V1; per-user in_app_enabled is a future addition
+```
+
+### Idempotency
+
+- `alert_incidents` (PR 1): unique constraint on `dedupe_key`. The worker writes idempotently and only emits `IncidentCreated` when the row was actually inserted (not on conflict).
+- Email job (PR 2): BullMQ job id derived from `(incidentId, recipientUserId)`.
+- `notifications` (PR 3): unique constraint on `(incident_id, recipient_user_id)`.
+
+### Recipient resolution
+
+V1 broadcasts to all organization members. This is a conscious simplification. Per-project subscribers and per-issue watchers are deferred until customer feedback justifies the extra surface.
+
+### Severity placement
+
+Severity is stored on the incident row at write time, not derived at read time. The mapping is hardcoded today (`issue.new` → `medium`, `issue.regressed` → `high`), but storing the value forward-compatibly lets future configurable severity land without a migration.
+
+## Notification System
+
+V1 supports two channels: email (PR 2, outbound, fire-and-forget) and in-app (PR 3, persisted for read state). Slack and other custom channels are designed-around but not implemented.
+
+### Channel separation
+
+In-app notifications are persisted with read state. They render content on read by joining to the linked incident and its source. They live forever in the user's feed.
+
+Emails are write-once, frozen at send time, and not persisted as a delivery log in V1. The user receives the email; that is the artifact. Bounce handling, retry logic, and provider message ids are handled by the existing email infrastructure; alerts reuse that pipeline rather than introducing new sender plumbing.
+
+### Forward compatibility
+
+The `notifications` table introduced in PR 3 keeps room for future delivery channels:
+
+- additional channels (Slack, push) can land as sibling delivery tables joined by `alert_incident_id` rather than overloading the in-app feed table
+- new source types (announcements, saved-search alerts, system messages) are accommodated by the polymorphic `source_type` already on `alert_incidents`
+- a renderer registry keyed on `(source_type, kind)` produces the title/body/action for each surface
+
+The `users.settings` jsonb shape allows future channel toggles without a schema change. New keys can be added with sensible defaults.
+
+### Out of scope for V1
+
+- Email log table for audit and bounce reconciliation
+- Per-channel preference granularity in user settings
+- Per-event-kind preference granularity in user settings
+- Slack integration
+- Digest or batching strategies
+- Org-level default preferences
+- Migrating login and invite emails through the alerts pipeline
+
+## Architecture Shape
+
+The broader architecture (beyond V1) recognizes three distinct paths.
+
+### Domain Event Path
+
+Domain event alerts are conceptually downstream of existing domain events and lifecycle transitions. They should not redefine issue lifecycle rules. For example, a regressed issue alert should depend on the Issue system deciding that the issue regressed.
+
+The key architecture idea is that event alerts react to facts that the domain already knows.
+
+**V1 implements only this path.**
+
+### Trace Match Path
+
+Trace match alerts are conceptually tied to trace-end processing and issue score assignment.
+
+For Saved Searches, a trace match alert asks whether a newly completed trace belongs to the saved search population. For Issue alerts, a new match is not raw trace matching; it is score ownership: a score/occurrence has been assigned to that issue.
+
+Per-trace metric threshold alerts also belong to this path when their aggregation is `any`, for example:
+
+```text
+Notify when [any] [cost] is [over] [$0.20]
+```
+
+### Scheduled Check Path
+
+Scheduled checks are conceptually periodic evaluations over a window. They cover aggregate thresholds and anomaly checks.
+
+These alerts need historical metric data, a current evaluation window, and enough state to avoid repeatedly firing the same condition too often.
+
+The important architecture idea is that scheduled alerts compare populations over time, while trace match alerts evaluate one new trace or occurrence.
+
+## Relationship To Other Features
+
+### Trace Ingestion
+
+Trace ingestion provides the raw telemetry and materialized traces. Saved Search alerts depend on this data because a saved search is a named population of traces.
+
+Trace-end processing is the natural conceptual moment for "new trace match" alerts and `any` per-trace metric alerts.
+
+### Issues
+
+Issues provide semantic failure grouping and lifecycle state. Project and Issue alerts should reuse issue lifecycle semantics instead of duplicating them.
+
+Relevant existing issue states:
+
+- `new`
+- `escalating`
+- `resolved`
+- `regressed`
+- `ignored`
+
+Issue states are derived at read time today. V1 reifies the regression transition by clearing `resolvedAt` at the moment of regression so the derive helper continues to work and idempotency is robust. Future `issue.escalating` will likely require a similar reification (writing `escalatedAt`) once a write-time detector exists.
+
+Issue-scoped alerts (deferred) should use score assignment as the match signal because issues are backed by scores, not raw traces alone.
+
+### Evaluations
+
+Evaluations can track specific issues because failed live evaluations are written as scores linked to the evaluation's issue. This means issue alerts can capture evaluation-driven matches as ordinary issue occurrences.
+
+Evaluation notification routing is not part of the current discussion, but issue-linked evaluation failures are one source of alert-worthy matches.
+
+### Saved Searches
+
+Saved Searches are the clearest initial product surface for alert configuration after V1. They already store the trace population as `query` plus `filterSet`.
+
+Saved Search alerts should be configured inside the Saved Search surface. Users should not have to create a new independent query in the alerting UI.
+
+## Alternatives Considered
+
+### Generic Monitor Builder
+
+One option is to expose a generic monitoring/query builder like Datadog or Grafana. This would make the system powerful but probably too complex for the initial Latitude UX.
+
+Rejected: Saved Search alerts should feel like simple alert rows attached to a saved search, not a full query language.
+
+### Metric-Grouped UI
+
+One option is to organize the UI by metric groups:
+
+```text
+Duration
+Cost
+Token usage
+```
+
+This may work for browsing, but it becomes bulky once users add multiple alerts. The preferred direction is a row-based sentence UI where each alert reads naturally.
+
+### Single-Trace Anomaly Alerts
+
+One option is to let "anomaly" include single-trace outlier detection.
+
+Rejected: per-trace outliers are covered by static metric alerts using `any`, such as:
+
+```text
+Notify when [any] [cost] is [over] [$0.20]
+```
+
+Anomaly alerts should be scheduled/window-based only.
+
+### User-Configurable Anomaly Parameters
+
+One option is to expose p50/p95, baseline windows, MAD multipliers, and sensitivity.
+
+Rejected: there is no advanced panel. If a setting is not in the main UI, it is not configurable. Anomaly alerts should let users choose the metric and severity, while Latitude owns the dynamic threshold behavior.
+
+### Alert Rules Table from Day One
+
+One option is to introduce a normalized `alert_rules` table for V1 even though only two project-wide kinds exist.
+
+Rejected: two boolean fields per project do not justify the entity. Per-project channel toggles fit comfortably under the existing `projects.settings` jsonb column. The rules table earns its keep when alerts grow beyond one-per-kind-per-project, which is when saved-search alerts ship.
+
+### Per-(User, Organization) Membership Settings
+
+One option is to scope user notification settings to each membership so a user in multiple organizations can receive different alerts per org.
+
+Rejected for V1: most users today belong to one organization. Global per-user settings are simpler in UI and storage. Migration to per-membership is a one-time chore if customer feedback justifies it later. The decision is reversible, but the cost of getting it wrong now is low.
+
+### Single Table for In-App and Outbound Notifications
+
+One option is to record every channel (in-app, email, future Slack) in one `notifications` table with a `channel` column.
+
+Rejected: in-app and email have fundamentally different lifecycles. In-app is stateful (read state), reactive to source changes, and lives forever in a feed. Email is write-once, frozen at send, and audited via provider message ids. Unifying produces a table where most columns are nullable per channel. V1 keeps in-app in `notifications` and treats email as a fire-and-forget channel through the existing email infrastructure.
+
+### Migrate Login and Invite Emails Through the Alerts Pipeline
+
+One option is to route all user-facing emails (login codes, invites, billing receipts, alerts) through the same alerts/notification pipeline.
+
+Rejected: transactional emails are not preference-gated and have a different deliverability profile (must always send). Mixing them with preference-gated alerts invites confusion. The alerts pipeline is shaped to allow a future migration if it ever makes sense, but V1 does not pursue it.
+
+### Incident Lifecycle in V1
+
+One option is to ship `alert_incidents` with `status`, `acknowledged_at`, and `resolved_at` from the start.
+
+Rejected: V1 alerts are discrete event-driven transitions on issues. The issue lifecycle is the persistent state; an `alert_incidents` row is a record of "this transition happened". Lifecycle columns earn their keep when sustained conditions appear (thresholds, anomalies). They can be added later without migration risk.
+
+### Settings Gating Incident Creation Instead of Channels
+
+One option is for `project.alerts.notifyOnRegression = false` to prevent the `alert_incidents` row from being created at all.
+
+Rejected: incident records are useful audit data even when no channel is fired. Decoupling creation from delivery means future analytics ("how many regressions did we silently observe?") are answerable from the table alone, and adding a new channel later does not require revisiting the gating semantics. PR 1 creates incidents unconditionally; channel workers do their own gating.
+
+### `incidents` or `alerts` as the Table Name
+
+Considered `incidents` (clean but carries PagerDuty connotation) and `alerts` (overloaded with rule/config language).
+
+Rejected in favor of `alert_incidents`: the `alert_` prefix avoids both connotations, matches repo style (`feature_flags`, `organization_feature_flags`), and stays room-temperature about lifecycle semantics.
+
+### `is_sustained` Discriminator from Day One
+
+One option is to add a column distinguishing one-off incidents from sustained conditions immediately, so `ended_at` semantics are unambiguous.
+
+Rejected: V1 has no sustained kinds. Any choice now is speculative until a real sustained kind arrives. `ended_at` is included as nullable; when the first threshold or anomaly kind ships, the discriminator (or other approach) can be added against concrete behavior.
+
+### Feature Flag in PR 1
+
+One option is to gate `alert_incidents` creation behind an org-level FF from PR 1.
+
+Rejected: PR 1 has no user-visible behavior — incidents are silent records. The FF earns its keep in PR 2 when emails actually reach users. Adding it in PR 1 is defensive but unnecessary noise. The `alerts` FF is introduced in PR 2 and reused by PR 3.
+
+## Implementation Plan
+
+### PR 1: Alert Incidents
+
+**Goal:** Issue lifecycle transitions for `new` and `regressed` produce `alert_incidents` rows. No user-visible delivery.
+
+- Add `alert_incidents` table with the schema above; generate migration via `pnpm pg:generate`
+- Add Zod contracts and a repository in `packages/domain/alerts` (or the closest existing home)
+- Add domain events `IssueCreated` and `IssueRegressed` to `packages/domain/events`
+- Emit `IssueCreated` in `packages/domain/issues/src/use-cases/create-issue-from-score.ts` after `issueRepository.save(issue)`
+- In `packages/domain/issues/src/use-cases/assign-score-to-issue.ts`: detect regression (`issue.resolvedAt != null && score.lastSeenAt > issue.resolvedAt`), clear `resolvedAt` on the saved issue, emit `IssueRegressed` with `triggerScoreId`
+- Register an `alert-incidents` queue topic in `packages/domain/queue`
+- In `apps/workers/src/workers/domain-events.ts`, fan out `IssueCreated` and `IssueRegressed` to the alert-incidents worker
+- Create `apps/workers/src/workers/domain-events/alert-incidents.ts`: subscribes, computes dedupe key + severity, inserts row idempotently, emits `IncidentCreated`
+- Tests: regression detection clears `resolvedAt`, second regression-causing score after the first does not re-emit, repeated event delivery does not produce duplicate rows
+
+### PR 2: Email Channel
+
+**Goal:** Project members receive a designed, per-kind email when an `alert_incidents` row is created, gated by per-project and per-user settings.
+
+- Extend `projectSettingsSchema` in `packages/domain/shared/src/settings.ts` with `alerts: { notifyOnNewIssue, notifyOnRegression }`
+- Add `users.settings: jsonb` column with new `userSettingsSchema` carrying `notifications: { emailEnabled }`; generate migration
+- Add the `alerts` org-level feature flag
+- Create the email worker subscribed to `IncidentCreated` (in `apps/workers/src/workers/domain-events/alert-emails.ts`): FF check → project setting check → org members → per-user setting check → render template → enqueue email job
+- Create per-kind email templates in `packages/domain/email/src/templates/issue-alert/{new,regressed}/index.tsx`, following the magic-link pattern
+- Add the project-settings UI section ("Alerts") and the account-settings UI section ("Notifications")
+- Tests: end-to-end against Mailpit for both kinds, with FF/project/user gating combinations
+
+### PR 3: In-app Notifications
+
+**Goal:** Users see a feed of alerts in the app with read state.
+
+- Add `notifications` table with `(id, recipient_user_id, alert_incident_id, created_at, seen_at)` and a unique index on `(alert_incident_id, recipient_user_id)`
+- Create the notifications worker subscribed to `IncidentCreated` (in `apps/workers/src/workers/domain-events/alert-notifications.ts`): inserts feed entries for each org member; in-app fan-out is unconditional in V1
+- In-app notification feed UI with `seen_at` tracking; renders content on read by joining to `alert_incidents` and the source issue
+- Tests: feed entry created per member, idempotent on retry, read state persists
+
+## Open Questions
+
+Resolved during V1 scoping:
+
+- Project-level "new issue discovered" fires at `createIssueFromScoreUseCase` save time, not on first row insertion of any candidate
+- V1 notifies all organization members; per-project subscribers deferred
+- V1 user settings are global per user, not per (user, organization) membership
+- V1 stores no email audit log
+- V1 incidents have no lifecycle columns
+- V1 anomaly checks, saved-search alerts, and issue-scoped alerts are deferred entirely
+- `issue.escalating` is deferred from V1 (requires occurrence analytics on the hot write path)
+- Severity is stored on `alert_incidents` (hardcoded per kind in V1) rather than derived on read
+- `alert_incidents` creation is unconditional in PR 1; channel gating lives in PR 2 (project + user settings) and PR 3 (none)
+- Table name is `alert_incidents` (not `incidents`, not `alerts`)
+- `ended_at` is nullable and always NULL in V1; sustained-condition semantics decided when the first sustained kind ships
+- No feature flag in PR 1; the `alerts` FF is introduced in PR 2
+
+Still open:
+
+- Should V1 send email when the user who triggered a state change is the same recipient? Issue lifecycle transitions are typically system-detected, so this should rarely matter, but worth confirming
+- Should V1 expose a separate `inAppEnabled` toggle in `users.settings.notifications`, or is in-app fan-out unconditional for org members? V1 leans unconditional; if disabled in-app is needed later, the jsonb shape accommodates it without a migration
+- Should the email and notification workers write a small audit row when they drop a delivery (FF off, settings off), or is silent dropping acceptable? V1 leans silent; `alert_incidents` already records that the alert fired
+- Should the saved-search alerts effort that follows V1 reuse the same `alert_incidents` table and `IncidentCreated` event, or introduce its own? Default direction is reuse — same pipeline, more source types
+- Which alert surfaces need MCP/API access in the initial product, besides web UI?


### PR DESCRIPTION
This is the first PR of the Alerts MVP (see [`specs/alerts.md`](./specs/alerts.md) for the full design). It introduces the data layer that PR 2 (email channel) and PR 3 (in-app feed) will both build on.

There is **nothing user-facing in this PR** — no emails, no UI, no settings, no feature flag. The only externally observable side effect is rows appearing in `alert_incidents` and an `IncidentCreated` domain event landing in the outbox so downstream channels can subscribe.

## What is an alert incident?

An alert incident is a persisted record that something alert-worthy happened. The new `alert_incidents` table is the system-of-record: every notification a user eventually receives in PR 2 or PR 3 will trace back to a row here.

Each row captures:

- **What it's about** — a polymorphic `source_type` + `source_id` pointer. V1 always uses `'issue'`; the schema accommodates future sources like saved searches without migration.
- **What kind of event** — a namespaced `kind`, currently `issue.new` or `issue.regressed`.
- **How serious** — a hardcoded `severity` (`medium` for new, `high` for regressed), stored on the row so future configurable severity won't need a migration.
- **When it happened** — `started_at` is the underlying domain transition's timestamp.
- **`ended_at`** is reserved for future sustained conditions (thresholds, anomalies). Always `NULL` in V1.

## How incidents get created

```
[issue domain]            emits IssueCreated / IssueRegressed via outbox
        ↓
[domain-events worker]    fans out to the alert-incidents topic
        ↓
[alert-incidents worker]  runs createAlertIncidentFromIssueEvent in a tx
                          → inserts alert_incidents row
                          → emits IncidentCreated to the outbox
```

`IncidentCreated` is wired as a no-op in the dispatcher for now. PR 2 and PR 3 replace that no-op with the email and in-app fan-outs respectively.

## Issue domain changes

Two events are added:

- `IssueCreated` — emitted in `createIssueFromScoreUseCase` after the new issue is saved.
- `IssueRegressed` — emitted in `assignScoreToIssueUseCase` when an incoming score's `createdAt` is later than the issue's `resolvedAt`.

The regression case includes **one behavioral change worth highlighting**: when regression is detected, `assignScoreToIssueUseCase` clears `resolvedAt` on the saved issue. This turns a previously derived state ("the issue is regressed if any score is newer than its resolution") into a stored fact.

The benefit: idempotency comes for free. A second regression-causing score in the same cycle sees `resolvedAt = null` and the regression check is false, so no duplicate event is emitted. `triggerScoreId` rides the event payload so a future regression after re-resolution is a distinct cycle.

The existing derive helper already handles `resolvedAt = null`, so read paths are unaffected.

## Why `issue.escalating` isn't here

The MVP spec lists three project alerts (`new`, `regressed`, `escalating`); only the first two are wired in this PR. Escalation is a derived state computed from occurrence analytics — reifying it at write time would require loading the occurrence aggregate on every score assignment, which is too costly on that hot path. It will land in a follow-up alongside a periodic recomputation worker.

## Idempotency

There is no DB unique constraint on `alert_incidents`. Two upstream layers prevent duplicates:

1. The reified `resolvedAt` blocks the issue domain from re-emitting `IssueRegressed` in the same cycle.
2. The dispatcher fan-out uses deterministic BullMQ dedupe keys (e.g., `alert-incidents:issue.new:${issueId}`), collapsing retried jobs.

If both layers ever slip through, the consequence is one extra row — recoverable, not catastrophic. A unique constraint can be added later if duplicates ever appear in practice.

## Test plan

- [x] Unit tests in `@domain/alerts` for the use case (insert, emit `IncidentCreated`, severity per kind)
- [x] Unit tests in `@domain/issues` for regression detection (clears `resolvedAt`, no double-emit on subsequent score, doesn't fire when issue is not resolved) and `IssueCreated` emission shape
- [x] Typecheck and biome clean across `@domain/alerts`, `@domain/issues`, `@domain/events`, `@domain/queue`, `@domain/shared`, `@platform/db-postgres`, `@app/workers`
- [x] Migration applies cleanly to dev DB
- [ ] Manual: trigger issue creation in dev → row appears in `alert_incidents`, `IncidentCreated` in the outbox
- [ ] Manual: resolve an issue, ingest a later score → `issues.resolved_at` cleared, regression row appears, `IncidentCreated` in the outbox