### PR TITLE
(QA) Fix metrics component's responsiveness [LAT-520]

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -53,12 +53,7 @@ export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }
           onMetricSelect={onMetricSelect}
           onCollapse={() => setCollapsed(true)}
         />
-        <Histogram
-          projectId={projectId}
-          filters={filters}
-          metric={selectedMetric}
-          onRangeSelect={onTimeRangeSelect}
-        />
+        <Histogram projectId={projectId} filters={filters} metric={selectedMetric} onRangeSelect={onTimeRangeSelect} />
       </div>
     </div>
   )

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -1,7 +1,7 @@
 import type { FilterSet } from "@domain/shared"
 import { isTraceHistogramMetric, type TraceHistogramMetric } from "@domain/spans"
 import { Button, Icon, Text } from "@repo/ui"
-import { BarChart2, ChevronDown, ChevronUp } from "lucide-react"
+import { BarChart2, ChevronDown } from "lucide-react"
 import { useCallback, useState } from "react"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { GeneralAggregations } from "./general-aggregations.tsx"
@@ -25,38 +25,41 @@ export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }
     validate: isTraceHistogramMetric,
   })
 
-  const onMetricSelect = useCallback(
-    (metric: TraceHistogramMetric) => setSelectedMetric(metric),
-    [setSelectedMetric],
-  )
+  const onMetricSelect = useCallback((metric: TraceHistogramMetric) => setSelectedMetric(metric), [setSelectedMetric])
+
+  if (collapsed) {
+    return (
+      <div className="flex flex-col rounded-lg bg-secondary">
+        <div className="flex items-center justify-between px-4 py-2">
+          <div className="flex items-center gap-1.5">
+            <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
+            <Text.H6 color="foregroundMuted">Traces statistics</Text.H6>
+          </div>
+          <Button variant="ghost" size="icon" onClick={() => setCollapsed(false)} aria-label="Expand statistics">
+            <Icon icon={ChevronDown} size="sm" />
+          </Button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col rounded-lg bg-secondary">
-      <div className="flex items-center justify-between px-4 py-2">
-        <div className="flex items-center gap-1.5">
-          <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
-          <Text.H6 color="foregroundMuted">Traces statistics</Text.H6>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setCollapsed((c) => !c)}
-          aria-label={collapsed ? "Expand statistics" : "Collapse statistics"}
-        >
-          <Icon icon={collapsed ? ChevronDown : ChevronUp} size="sm" />
-        </Button>
+      <div className="p-2">
+        <GeneralAggregations
+          projectId={projectId}
+          filters={filters}
+          selectedMetric={selectedMetric}
+          onMetricSelect={onMetricSelect}
+          onCollapse={() => setCollapsed(true)}
+        />
+        <Histogram
+          projectId={projectId}
+          filters={filters}
+          metric={selectedMetric}
+          onRangeSelect={onTimeRangeSelect}
+        />
       </div>
-      {!collapsed && (
-        <div className="p-2">
-          <GeneralAggregations
-            projectId={projectId}
-            filters={filters}
-            selectedMetric={selectedMetric}
-            onMetricSelect={onMetricSelect}
-          />
-          <Histogram projectId={projectId} filters={filters} metric={selectedMetric} onRangeSelect={onTimeRangeSelect} />
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/aggregations-panel.tsx
@@ -1,6 +1,8 @@
 import type { FilterSet } from "@domain/shared"
 import { isTraceHistogramMetric, type TraceHistogramMetric } from "@domain/spans"
-import { useCallback } from "react"
+import { Button, Icon, Text } from "@repo/ui"
+import { BarChart2, ChevronDown, ChevronUp } from "lucide-react"
+import { useCallback, useState } from "react"
 import { useParamState } from "../../../../../../lib/hooks/useParamState.ts"
 import { GeneralAggregations } from "./general-aggregations.tsx"
 import { Histogram } from "./histogram.tsx"
@@ -15,6 +17,8 @@ interface TraceAggregationsPanelProps {
 }
 
 export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }: TraceAggregationsPanelProps) {
+  const [collapsed, setCollapsed] = useState(false)
+
   // The default metric ("traces") is intentionally omitted from the URL by `useParamState` so the
   // canonical link stays clean; only non-default selections make it into the query string.
   const [selectedMetric, setSelectedMetric] = useParamState("histogramMetric", DEFAULT_HISTOGRAM_METRIC, {
@@ -22,21 +26,37 @@ export function TraceAggregationsPanel({ projectId, filters, onTimeRangeSelect }
   })
 
   const onMetricSelect = useCallback(
-    (metric: TraceHistogramMetric) => {
-      setSelectedMetric(metric)
-    },
+    (metric: TraceHistogramMetric) => setSelectedMetric(metric),
     [setSelectedMetric],
   )
 
   return (
-    <div className="flex flex-col rounded-lg bg-secondary p-2">
-      <GeneralAggregations
-        projectId={projectId}
-        filters={filters}
-        selectedMetric={selectedMetric}
-        onMetricSelect={onMetricSelect}
-      />
-      <Histogram projectId={projectId} filters={filters} metric={selectedMetric} onRangeSelect={onTimeRangeSelect} />
+    <div className="flex flex-col rounded-lg bg-secondary">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-1.5">
+          <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
+          <Text.H6 color="foregroundMuted">Traces statistics</Text.H6>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? "Expand statistics" : "Collapse statistics"}
+        >
+          <Icon icon={collapsed ? ChevronDown : ChevronUp} size="sm" />
+        </Button>
+      </div>
+      {!collapsed && (
+        <div className="p-2">
+          <GeneralAggregations
+            projectId={projectId}
+            filters={filters}
+            selectedMetric={selectedMetric}
+            onMetricSelect={onMetricSelect}
+          />
+          <Histogram projectId={projectId} filters={filters} metric={selectedMetric} onRangeSelect={onTimeRangeSelect} />
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -1,6 +1,7 @@
 import type { FilterSet } from "@domain/shared"
 import type { TraceHistogramMetric } from "@domain/spans"
-import { cn, Skeleton, Text } from "@repo/ui"
+import { Button, Icon, cn, Skeleton, Text } from "@repo/ui"
+import { ChevronUp } from "lucide-react"
 import { useState } from "react"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
 import { HISTOGRAM_METRIC_DEFINITIONS, type HistogramMetricDefinition } from "./histogram-metrics.ts"
@@ -52,11 +53,13 @@ export function GeneralAggregations({
   filters,
   selectedMetric,
   onMetricSelect,
+  onCollapse,
 }: {
   readonly projectId: string
   readonly filters: FilterSet
   readonly selectedMetric: TraceHistogramMetric
   readonly onMetricSelect: (metric: TraceHistogramMetric) => void
+  readonly onCollapse: () => void
 }) {
   const hasActiveFilters = Object.keys(filters).length > 0
   const filterOpts = hasActiveFilters ? { filters } : {}
@@ -89,27 +92,38 @@ export function GeneralAggregations({
   }
 
   return (
-    <div className="relative">
-      <div
-        className="flex flex-row gap-1 overflow-x-auto p-2 pr-10"
-        onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
-      >
-        {visibleMetrics.map((def) => (
-          <AggregationItem
-            key={def.id}
-            label={def.label}
-            value={renderValue(def)}
-            isLoading={loading}
-            isSelected={selectedMetric === def.id}
-            skeletonWidthClassName={def.cardSkeletonWidthClassName}
-            onClick={() => onMetricSelect(def.id)}
-          />
-        ))}
+    <div className="flex items-start gap-1 pr-2">
+      <div className="relative min-w-0 flex-1">
+        <div
+          className="flex flex-row gap-1 overflow-x-auto p-2"
+          onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
+        >
+          {visibleMetrics.map((def) => (
+            <AggregationItem
+              key={def.id}
+              label={def.label}
+              value={renderValue(def)}
+              isLoading={loading}
+              isSelected={selectedMetric === def.id}
+              skeletonWidthClassName={def.cardSkeletonWidthClassName}
+              onClick={() => onMetricSelect(def.id)}
+            />
+          ))}
+        </div>
+        {showLeftFade && (
+          <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-secondary to-transparent" />
+        )}
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
       </div>
-      {showLeftFade && (
-        <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-secondary to-transparent" />
-      )}
-      <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onCollapse}
+        aria-label="Collapse statistics"
+        className="shrink-0"
+      >
+        <Icon icon={ChevronUp} size="sm" />
+      </Button>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -1,6 +1,7 @@
 import type { FilterSet } from "@domain/shared"
 import type { TraceHistogramMetric } from "@domain/spans"
 import { cn, Skeleton, Text } from "@repo/ui"
+import { useState } from "react"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
 import { HISTOGRAM_METRIC_DEFINITIONS, type HistogramMetricDefinition } from "./histogram-metrics.ts"
 
@@ -79,6 +80,8 @@ export function GeneralAggregations({
     (id) => HISTOGRAM_METRIC_DEFINITIONS[id],
   )
 
+  const [showLeftFade, setShowLeftFade] = useState(false)
+
   const renderValue = (def: HistogramMetricDefinition): string => {
     if (def.id === "traces") return def.formatBucket(totalCount)
     if (!traceMetrics) return DASH
@@ -86,18 +89,27 @@ export function GeneralAggregations({
   }
 
   return (
-    <div className="flex flex-row flex-wrap gap-1 p-2">
-      {visibleMetrics.map((def) => (
-        <AggregationItem
-          key={def.id}
-          label={def.label}
-          value={renderValue(def)}
-          isLoading={loading}
-          isSelected={selectedMetric === def.id}
-          skeletonWidthClassName={def.cardSkeletonWidthClassName}
-          onClick={() => onMetricSelect(def.id)}
-        />
-      ))}
+    <div className="relative">
+      <div
+        className="flex flex-row gap-1 overflow-x-auto p-2 pr-10"
+        onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
+      >
+        {visibleMetrics.map((def) => (
+          <AggregationItem
+            key={def.id}
+            label={def.label}
+            value={renderValue(def)}
+            isLoading={loading}
+            isSelected={selectedMetric === def.id}
+            skeletonWidthClassName={def.cardSkeletonWidthClassName}
+            onClick={() => onMetricSelect(def.id)}
+          />
+        ))}
+      </div>
+      {showLeftFade && (
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-secondary to-transparent" />
+      )}
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/aggregations/general-aggregations.tsx
@@ -1,6 +1,6 @@
 import type { FilterSet } from "@domain/shared"
 import type { TraceHistogramMetric } from "@domain/spans"
-import { Button, Icon, cn, Skeleton, Text } from "@repo/ui"
+import { Button, cn, Icon, Skeleton, Text } from "@repo/ui"
 import { ChevronUp } from "lucide-react"
 import { useState } from "react"
 import { useTraceMetrics, useTracesCount } from "../../../../../../domains/traces/traces.collection.ts"
@@ -115,13 +115,7 @@ export function GeneralAggregations({
         )}
         <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
       </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={onCollapse}
-        aria-label="Collapse statistics"
-        className="shrink-0"
-      >
+      <Button variant="ghost" size="icon" onClick={onCollapse} aria-label="Collapse statistics" className="shrink-0">
         <Icon icon={ChevronUp} size="sm" />
       </Button>
     </div>

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -88,27 +88,29 @@ export function IssuesAnalyticsPanel({
     [analytics.histogram, onRangeSelect],
   )
 
+  if (collapsed) {
+    return (
+      <div className="flex flex-col rounded-lg bg-secondary">
+        <div className="flex items-center justify-between px-4 py-2">
+          <div className="flex items-center gap-1.5">
+            <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
+            <Text.H6 color="foregroundMuted">Issues statistics</Text.H6>
+          </div>
+          <Button variant="ghost" size="icon" onClick={() => setCollapsed(false)} aria-label="Expand statistics">
+            <Icon icon={ChevronDown} size="sm" />
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col rounded-lg bg-secondary">
-      <div className="flex items-center justify-between px-4 py-2">
-        <div className="flex items-center gap-1.5">
-          <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
-          <Text.H6 color="foregroundMuted">Issues statistics</Text.H6>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setCollapsed((c) => !c)}
-          aria-label={collapsed ? "Expand statistics" : "Collapse statistics"}
-        >
-          <Icon icon={collapsed ? ChevronDown : ChevronUp} size="sm" />
-        </Button>
-      </div>
-      {!collapsed && (
-        <div className="p-2">
-          <div className="relative">
+      <div className="p-2">
+        <div className="flex items-start gap-1 pr-2">
+          <div className="relative min-w-0 flex-1">
             <div
-              className="flex flex-row gap-3 overflow-x-auto p-4 pr-14"
+              className="flex flex-row gap-3 overflow-x-auto p-4"
               onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
             >
               {COUNT_CARDS.map((card) => (
@@ -126,30 +128,39 @@ export function IssuesAnalyticsPanel({
             )}
             <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
           </div>
-
-          {isLoading ? (
-            <div className="px-4 py-3">
-              <HistogramSkeleton height={160} />
-            </div>
-          ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
-            <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
-              <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
-            </div>
-          ) : (
-            <div className="px-4 py-3">
-              <BarChart
-                data={histogramBarChartData}
-                height={160}
-                showYAxis={false}
-                xAxisLabelFontSize={10}
-                ariaLabel="Issue occurrences by day"
-                formatTooltip={formatHistogramTooltip}
-                onSelect={onRangeSelect ? handleSelect : undefined}
-              />
-            </div>
-          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setCollapsed(true)}
+            aria-label="Collapse statistics"
+            className="shrink-0"
+          >
+            <Icon icon={ChevronUp} size="sm" />
+          </Button>
         </div>
-      )}
+
+        {isLoading ? (
+          <div className="px-4 py-3">
+            <HistogramSkeleton height={160} />
+          </div>
+        ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
+          <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
+            <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
+          </div>
+        ) : (
+          <div className="px-4 py-3">
+            <BarChart
+              data={histogramBarChartData}
+              height={160}
+              showYAxis={false}
+              xAxisLabelFontSize={10}
+              ariaLabel="Issue occurrences by day"
+              formatTooltip={formatHistogramTooltip}
+              onSelect={onRangeSelect ? handleSelect : undefined}
+            />
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issues-analytics-panel.tsx
@@ -1,6 +1,7 @@
-import { BarChart, HistogramSkeleton, Skeleton, Text } from "@repo/ui"
+import { BarChart, Button, HistogramSkeleton, Icon, Skeleton, Text } from "@repo/ui"
 import { formatCount } from "@repo/utils"
-import { useCallback, useMemo } from "react"
+import { BarChart2, ChevronDown, ChevronUp } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
 import type { IssuesListResultRecord } from "../../../../../../domains/issues/issues.functions.ts"
 import { formatDayBucketLabel, formatDayBucketTooltipLabel } from "./issue-formatters.ts"
 
@@ -48,6 +49,9 @@ export function IssuesAnalyticsPanel({
   readonly isLoading: boolean
   readonly onRangeSelect?: ((range: { from: string; to: string } | null) => void) | undefined
 }) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [showLeftFade, setShowLeftFade] = useState(false)
+
   const histogramBarChartData = useMemo(
     () =>
       analytics.histogram.map((bucket) => ({
@@ -85,38 +89,65 @@ export function IssuesAnalyticsPanel({
   )
 
   return (
-    <div className="flex flex-col rounded-lg bg-secondary p-2">
-      <div className="flex flex-row flex-wrap gap-3 p-4">
-        {COUNT_CARDS.map((card) => (
-          <AggregationItem
-            key={card.key}
-            label={card.label}
-            value={formatCount(analytics.counts[card.key])}
-            isLoading={isLoading}
-            skeletonWidthClassName={card.key === "seenOccurrences" ? "w-20" : "w-16"}
-          />
-        ))}
+    <div className="flex flex-col rounded-lg bg-secondary">
+      <div className="flex items-center justify-between px-4 py-2">
+        <div className="flex items-center gap-1.5">
+          <Icon icon={BarChart2} size="sm" color="foregroundMuted" />
+          <Text.H6 color="foregroundMuted">Issues statistics</Text.H6>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? "Expand statistics" : "Collapse statistics"}
+        >
+          <Icon icon={collapsed ? ChevronDown : ChevronUp} size="sm" />
+        </Button>
       </div>
+      {!collapsed && (
+        <div className="p-2">
+          <div className="relative">
+            <div
+              className="flex flex-row gap-3 overflow-x-auto p-4 pr-14"
+              onScroll={(e) => setShowLeftFade(e.currentTarget.scrollLeft > 0)}
+            >
+              {COUNT_CARDS.map((card) => (
+                <AggregationItem
+                  key={card.key}
+                  label={card.label}
+                  value={formatCount(analytics.counts[card.key])}
+                  isLoading={isLoading}
+                  skeletonWidthClassName={card.key === "seenOccurrences" ? "w-20" : "w-16"}
+                />
+              ))}
+            </div>
+            {showLeftFade && (
+              <div className="pointer-events-none absolute inset-y-0 left-0 w-10 bg-gradient-to-r from-secondary to-transparent" />
+            )}
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-secondary to-transparent" />
+          </div>
 
-      {isLoading ? (
-        <div className="px-4 py-3">
-          <HistogramSkeleton height={160} />
-        </div>
-      ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
-        <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
-          <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
-        </div>
-      ) : (
-        <div className="px-4 py-3">
-          <BarChart
-            data={histogramBarChartData}
-            height={160}
-            showYAxis={false}
-            xAxisLabelFontSize={10}
-            ariaLabel="Issue occurrences by day"
-            formatTooltip={formatHistogramTooltip}
-            onSelect={onRangeSelect ? handleSelect : undefined}
-          />
+          {isLoading ? (
+            <div className="px-4 py-3">
+              <HistogramSkeleton height={160} />
+            </div>
+          ) : analytics.histogram.length === 0 || analytics.histogram.every((bucket) => bucket.count === 0) ? (
+            <div className="flex w-full min-h-[80px] items-center justify-center px-4 py-3">
+              <Text.H6 color="foregroundMuted">No issue occurrences in this time window</Text.H6>
+            </div>
+          ) : (
+            <div className="px-4 py-3">
+              <BarChart
+                data={histogramBarChartData}
+                height={160}
+                showYAxis={false}
+                xAxisLabelFontSize={10}
+                ariaLabel="Issue occurrences by day"
+                formatTooltip={formatHistogramTooltip}
+                onSelect={onRangeSelect ? handleSelect : undefined}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
This skinny PR fixes an issue declared in [LAT-520](https://linear.app/latitude/issue/LAT-520/fix-trace-chart-component-overflow-width) regarding the bad responsiveness of the metrics flex-box in case of metrics not fitting in the width of the parent frame.

Changes:
- If all metrics don't fit the frame width `overflow:scroll` is applied for optimal vertical space management
- Entire metrics tab is now collapsible for the sake of a more flexible and customizable layout

<img width="872" height="480" alt="LAT-520" src="https://github.com/user-attachments/assets/03142c46-8c38-4eeb-b8db-d965a49f8c14" />
