### PR TITLE
Stop recording PH events of latitude team

### DIFF
--- a/apps/web/src/lib/posthog/posthog-client.ts
+++ b/apps/web/src/lib/posthog/posthog-client.ts
@@ -61,13 +61,15 @@ const loadInstance = (): Promise<PostHog | null> => {
       const posthog = mod.posthog
       posthog.init(env.apiKey, {
         api_host: env.host,
-        // Per product decision: session recordings + autocapture + pageview.
-        // Masking uses PostHog defaults (passwords + [data-ph-mask]).
         capture_pageview: true,
         autocapture: true,
-        disable_session_recording: false,
-        // Start silent — syncPostHogSession opts in for real customers once the authenticated layout mounts
+        disable_session_recording: true,
         opt_out_capturing_by_default: true,
+        // Force opt-out on every init regardless of persisted cookie state.
+        // syncPostHogSession will explicitly opt in for non-staff users.
+        loaded: (ph) => {
+          ph.opt_out_capturing()
+        },
       })
       return posthog
     })
@@ -90,7 +92,9 @@ const setPostHogCaptureEnabled = async (enabled: boolean): Promise<void> => {
   if (!posthog) return
   if (enabled) {
     posthog.opt_in_capturing()
+    posthog.startSessionRecording()
   } else {
+    posthog.stopSessionRecording()
     posthog.opt_out_capturing()
   }
 }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
+import type { JobTitle } from "@domain/users"
 import { Button, Checkbox, CodeBlock, CopyButton, ProviderIcon, Tabs, Text, useMountEffect, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import type { LucideIcon } from "lucide-react"

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -94,13 +94,13 @@ const STACK_CHOICE_OPTIONS: ReadonlyArray<{
   {
     id: "coding-agent-machine",
     title: "Coding agent",
-    description: "Receive traces and monitor issues in your Claude Code or OpenClaw agent",
+    description: "Monitor your Claude Code or OpenClaw agent",
     leading: { type: "logo", src: ONBOARDING_CLAUDE_CODE_LOGO_SRC },
   },
   {
     id: "production-agent",
-    title: "Production agent traces",
-    description: "Set up Latitude directly in your project running on any available provider",
+    title: "Production app or agent",
+    description: "Track and debug LLM-powered features running in your own application",
     leading: { type: "icon", Icon: SquareDashedBottomCode },
   },
 ]

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -1,5 +1,4 @@
 import { DEFAULT_API_KEY_NAME } from "@domain/api-keys"
-import type { JobTitle } from "@domain/users"
 import { Button, Checkbox, CodeBlock, CopyButton, ProviderIcon, Tabs, Text, useMountEffect, useToast } from "@repo/ui"
 import { eq } from "@tanstack/react-db"
 import type { LucideIcon } from "lucide-react"
@@ -584,8 +583,10 @@ export function OnboardingFlow({
                   <img src="/favicon.svg" alt="Latitude" className="h-8 w-8" />
                 </div>
                 <div className="flex flex-col gap-2">
-                  <Text.H2 weight="medium">Select your stack</Text.H2>
-                  <Text.H4 color="foregroundMuted">What do you want to monitor with Latitude?</Text.H4>
+                  <Text.H2 weight="medium">What do you want to monitor?</Text.H2>
+                  <Text.H4 color="foregroundMuted">
+                    Choose the type of AI system you want to observe with Latitude.
+                  </Text.H4>
                 </div>
               </div>
               <div className="flex flex-col gap-3">


### PR DESCRIPTION
The first hypothesis didnt work, this should fix it.

Root cause: PostHog persists opt-in state in a cookie. If a staff user was ever opted in (before the exclusion logic existed), PostHog restores that state on next page load and starts capturing immediately — before syncPostHogSession can call opt_out_capturing().
Fix 1 — loaded callback: Added loaded: (ph) => { ph.opt_out_capturing() } to the PostHog init config. This forces opt-out on every single page load, regardless of what the cookie says. No events can fire until syncPostHogSession explicitly opts in.
Fix 2 — Session recording disabled at init: Changed disable_session_recording: true so no recording starts until startSessionRecording() is explicitly called for non-staff users.
Fix 3 — Explicit recording lifecycle: setPostHogCaptureEnabled(true) now calls startSessionRecording(); setPostHogCaptureEnabled(false) calls stopSessionRecording().