### PR TITLE
docs(telemetry): add agentic install path and fix Python shutdown [LAT-558]

### DIFF
--- a/docs/telemetry/overview.mdx
+++ b/docs/telemetry/overview.mdx
@@ -7,7 +7,33 @@ Latitude Telemetry instruments your AI application and sends traces to Latitude.
 
 Once connected, every LLM execution becomes a trace in Latitude that you can inspect in the **Traces** view, enrich with **scores and annotations**, and evaluate with [Evaluations](../evaluations/overview).
 
-## Quick Start
+## Agentic installation
+
+The fastest way to add Latitude is to let your coding agent (Claude Code, Cursor, Windsurf, etc.) install it for you. The [Latitude skill](https://github.com/latitude-dev/skills) guides the agent through codebase discovery (existing OpenTelemetry, conflicting LLM-observability vendors, which LLM SDKs are in use, where LLM calls actually happen), picks the right install path, places initialization correctly, and verifies that traces land in your project.
+
+### Ask your coding agent
+
+Paste this prompt into your agent:
+
+> Install the Latitude AI skill from github.com/latitude-dev/skills and use it to add tracing to this application with Latitude following best practices.
+
+The agent will fetch the skill, read your codebase, ask only the questions it can't answer from the code, and produce a working install.
+
+### Install the skill manually
+
+If you prefer to install the skill ahead of time (no global setup needed — `npx` runs it directly):
+
+```bash
+npx skills add latitude-dev/skills --skill "latitude-telemetry"
+```
+
+Then in your agent:
+
+> Add tracing to this application with Latitude following best practices.
+
+The skill covers TypeScript and Python, the providers and frameworks listed in [Supported Integrations](#supported-integrations), and audits existing OpenTelemetry setups for compatibility.
+
+## Manual installation
 
 One function sets up everything: auto-instrumentation, the Latitude exporter, and async context propagation:
 
@@ -59,7 +85,7 @@ One function sets up everything: auto-instrumentation, the Latitude exporter, an
         messages=[{"role": "user", "content": "Hello"}],
     )
 
-    latitude.shutdown()
+    latitude["shutdown"]()
     ```
   </Tab>
 </Tabs>
@@ -127,7 +153,7 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
         },
     )
 
-    latitude.shutdown()
+    latitude["shutdown"]()
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- Adds an **Agentic installation** section to `docs/telemetry/overview.mdx`, featured ahead of manual setup. It surfaces the Latitude skill (`latitude-dev/skills`) with a copy-pasteable prompt for the user's coding agent and the `npx skills add latitude-dev/skills --skill "latitude-telemetry"` command. Mirrors the structure of [Langfuse's get-started](https://langfuse.com/docs/observability/get-started).
- Renames the existing manual section from **Quick Start** to **Manual installation** so the two paths are clearly parallel.
- Fixes two `latitude.shutdown()` calls in the Python tabs to `latitude["shutdown"]()`. `init_latitude` returns a `TypedDict` (a real `dict` at runtime), so attribute access fails with `AttributeError`. The example test files in `packages/telemetry/python/examples/` use the item-access form. This is exactly the kind of "looks fine, breaks at runtime" guidance that triggered LAT-558 in the first place.

The skill itself was reorganized in `latitude-dev/skills@939d80b` to drive codebase discovery (existing OTel, conflicting LLM-observability vendors, which LLM SDKs are in use, where LLM calls actually happen) before writing any code. This PR points users at it.

Linear: [LAT-558](https://linear.app/latitude/issue/LAT-558/improve-telemetry-installation)

## Test plan

- [ ] Render `docs/telemetry/overview.mdx` locally and confirm the new **Agentic installation** section renders correctly with the prompt blockquote and `npx skills add` command block.
- [ ] Confirm the renamed **Manual installation** section still has both TS and Python tabs working as before.
- [ ] Click through the in-page anchor link `#supported-integrations` from the new section and confirm it scrolls to the table.
- [ ] Run the Python `latitude["shutdown"]()` snippet against a local `init_latitude` to confirm it works (item access, not attribute access).
- [ ] Try the agentic prompt end-to-end on a sample app (e.g. one of `~/code/latitude/sample-*`) and confirm traces land in Latitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)