### PR TITLE
feat(alerts): track escalating issues as sustained incidents

### DIFF
--- a/apps/web/src/domains/issues/issues.functions.ts
+++ b/apps/web/src/domains/issues/issues.functions.ts
@@ -416,7 +416,8 @@ export const getIssueDetail = createServerFn({ method: "GET" })
           issue,
           states: deriveIssueLifecycleStates({
             issue,
-            occurrence,
+            isEscalating: issue.lifecycle.isEscalating,
+            isRegressed: issue.lifecycle.isRegressed,
             now,
           }),
           firstSeenAt: occurrence?.firstSeenAt ?? issue.createdAt,

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -1,5 +1,5 @@
 import type { EventEnvelope } from "@domain/events"
-import { ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
+import { ESCALATION_CHECK_THROTTLE_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
 import { SCORE_PUBLICATION_DEBOUNCE } from "@domain/scores"
 import { TRACE_END_DEBOUNCE_MS } from "@domain/spans"
@@ -168,7 +168,7 @@ describe("domain-events dispatcher", () => {
     }
   })
 
-  it("routes ScoreAssignedToIssue to issues:refresh with dedupe and debounce", async () => {
+  it("fans ScoreAssignedToIssue out to issues:refresh and issues:checkEscalation", async () => {
     const { consumer, published } = setupDispatcher()
 
     const envelope = makeEnvelope("ScoreAssignedToIssue", {
@@ -179,17 +179,28 @@ describe("domain-events dispatcher", () => {
 
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
-    expect(published).toHaveLength(1)
-    expect(published[0]?.queue).toBe("issues")
-    expect(published[0]?.task).toBe("refresh")
-    expect(published[0]?.payload).toEqual({
+    expect(published).toHaveLength(2)
+
+    const refresh = published.find((p) => p.task === "refresh")
+    expect(refresh?.queue).toBe("issues")
+    expect(refresh?.payload).toEqual({
       organizationId: "org-1",
       projectId: "proj-1",
       issueId: "issue-42",
     })
-    expect(published[0]?.options?.dedupeKey).toBe("issues:refresh:issue-42")
-    expect(published[0]?.options?.throttleMs).toBe(ISSUE_REFRESH_THROTTLE_MS)
-    expect(published[0]?.options?.debounceMs).toBeUndefined()
+    expect(refresh?.options?.dedupeKey).toBe("issues:refresh:issue-42")
+    expect(refresh?.options?.throttleMs).toBe(ISSUE_REFRESH_THROTTLE_MS)
+    expect(refresh?.options?.debounceMs).toBeUndefined()
+
+    const checkEscalation = published.find((p) => p.task === "checkEscalation")
+    expect(checkEscalation?.queue).toBe("issues")
+    expect(checkEscalation?.payload).toEqual({
+      organizationId: "org-1",
+      projectId: "proj-1",
+      issueId: "issue-42",
+    })
+    expect(checkEscalation?.options?.dedupeKey).toBe("issues:check-escalation:issue-42")
+    expect(checkEscalation?.options?.throttleMs).toBe(ESCALATION_CHECK_THROTTLE_MS)
   })
 
   it("fans out whitelisted events to posthog-analytics:track in addition to the primary handler", async () => {

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -1,5 +1,5 @@
 import type { EventEnvelope } from "@domain/events"
-import { ESCALATION_CHECK_THROTTLE_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
+import { ESCALATION_CHECK_THROTTLE_MS, ESCALATION_RECHECK_DELAY_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
 import { SCORE_PUBLICATION_DEBOUNCE } from "@domain/scores"
 import { TRACE_END_DEBOUNCE_MS } from "@domain/spans"
@@ -168,7 +168,7 @@ describe("domain-events dispatcher", () => {
     }
   })
 
-  it("fans ScoreAssignedToIssue out to issues:refresh and issues:checkEscalation", async () => {
+  it("fans ScoreAssignedToIssue out to refresh + throttled and debounced escalation checks", async () => {
     const { consumer, published } = setupDispatcher()
 
     const envelope = makeEnvelope("ScoreAssignedToIssue", {
@@ -179,7 +179,7 @@ describe("domain-events dispatcher", () => {
 
     await consumer.dispatchTask("domain-events", "dispatch", envelopeToDispatchPayload(envelope))
 
-    expect(published).toHaveLength(2)
+    expect(published).toHaveLength(3)
 
     const refresh = published.find((p) => p.task === "refresh")
     expect(refresh?.queue).toBe("issues")
@@ -192,15 +192,18 @@ describe("domain-events dispatcher", () => {
     expect(refresh?.options?.throttleMs).toBe(ISSUE_REFRESH_THROTTLE_MS)
     expect(refresh?.options?.debounceMs).toBeUndefined()
 
-    const checkEscalation = published.find((p) => p.task === "checkEscalation")
-    expect(checkEscalation?.queue).toBe("issues")
-    expect(checkEscalation?.payload).toEqual({
-      organizationId: "org-1",
-      projectId: "proj-1",
-      issueId: "issue-42",
-    })
-    expect(checkEscalation?.options?.dedupeKey).toBe("issues:check-escalation:issue-42")
-    expect(checkEscalation?.options?.throttleMs).toBe(ESCALATION_CHECK_THROTTLE_MS)
+    const escalationChecks = published.filter((p) => p.task === "checkEscalation")
+    expect(escalationChecks).toHaveLength(2)
+
+    const throttled = escalationChecks.find((p) => p.options?.dedupeKey === "issues:check-escalation:issue-42")
+    expect(throttled?.options?.throttleMs).toBe(ESCALATION_CHECK_THROTTLE_MS)
+    expect(throttled?.options?.debounceMs).toBeUndefined()
+
+    const debounced = escalationChecks.find(
+      (p) => p.options?.dedupeKey === "issues:check-escalation-recheck:issue-42",
+    )
+    expect(debounced?.options?.debounceMs).toBe(ESCALATION_RECHECK_DELAY_MS)
+    expect(debounced?.options?.throttleMs).toBeUndefined()
   })
 
   it("fans out whitelisted events to posthog-analytics:track in addition to the primary handler", async () => {

--- a/apps/workers/src/workers/domain-events.test.ts
+++ b/apps/workers/src/workers/domain-events.test.ts
@@ -199,9 +199,7 @@ describe("domain-events dispatcher", () => {
     expect(throttled?.options?.throttleMs).toBe(ESCALATION_CHECK_THROTTLE_MS)
     expect(throttled?.options?.debounceMs).toBeUndefined()
 
-    const debounced = escalationChecks.find(
-      (p) => p.options?.dedupeKey === "issues:check-escalation-recheck:issue-42",
-    )
+    const debounced = escalationChecks.find((p) => p.options?.dedupeKey === "issues:check-escalation-recheck:issue-42")
     expect(debounced?.options?.debounceMs).toBe(ESCALATION_RECHECK_DELAY_MS)
     expect(debounced?.options?.throttleMs).toBeUndefined()
   })

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -1,5 +1,5 @@
 import type { DomainEvent, EventEnvelope, EventPayloads } from "@domain/events"
-import { ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
+import { ESCALATION_CHECK_THROTTLE_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { SCORE_PUBLICATION_DEBOUNCE } from "@domain/scores"
 import { TRACE_END_DEBOUNCE_MS } from "@domain/spans"
@@ -98,12 +98,23 @@ export const createDomainEventsWorker = ({
 
     // Throttled: the first assignment schedules the refresh for `now + 8h`,
     // and subsequent assignments within the window are dropped so a constant
-    // annotation stream cannot starve the refresh.
+    // annotation stream cannot starve the refresh. The escalation check runs
+    // alongside on a much tighter throttle (15min) — it's cheap (single CH
+    // aggregate + maybe one Postgres update) and detection latency matters.
     ScoreAssignedToIssue: (event) =>
-      pub.publish("issues", "refresh", event.payload, {
-        dedupeKey: `issues:refresh:${event.payload.issueId}`,
-        throttleMs: ISSUE_REFRESH_THROTTLE_MS,
-      }),
+      Effect.all(
+        [
+          pub.publish("issues", "refresh", event.payload, {
+            dedupeKey: `issues:refresh:${event.payload.issueId}`,
+            throttleMs: ISSUE_REFRESH_THROTTLE_MS,
+          }),
+          pub.publish("issues", "checkEscalation", event.payload, {
+            dedupeKey: `issues:check-escalation:${event.payload.issueId}`,
+            throttleMs: ESCALATION_CHECK_THROTTLE_MS,
+          }),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.asVoid),
 
     IssueCreated: (event) =>
       pub.publish("alert-incidents", "issue-created", event.payload, {
@@ -113,6 +124,16 @@ export const createDomainEventsWorker = ({
     IssueRegressed: (event) =>
       pub.publish("alert-incidents", "issue-regressed", event.payload, {
         dedupeKey: `alert-incidents:issue.regressed:${event.payload.issueId}:${event.payload.triggerScoreId}`,
+      }),
+
+    IssueEscalated: (event) =>
+      pub.publish("alert-incidents", "issue-escalated", event.payload, {
+        dedupeKey: `alert-incidents:issue.escalating:${event.payload.issueId}:${event.payload.escalatedAt}`,
+      }),
+
+    IssueEscalationEnded: (event) =>
+      pub.publish("alert-incidents", "issue-escalation-ended", event.payload, {
+        dedupeKey: `alert-incidents:issue.escalation-ended:${event.payload.issueId}:${event.payload.endedAt}`,
       }),
 
     // PR 1 has no consumer for IncidentCreated. PR 2 (email channel) and

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -1,5 +1,5 @@
 import type { DomainEvent, EventEnvelope, EventPayloads } from "@domain/events"
-import { ESCALATION_CHECK_THROTTLE_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
+import { ESCALATION_CHECK_THROTTLE_MS, ESCALATION_RECHECK_DELAY_MS, ISSUE_REFRESH_THROTTLE_MS } from "@domain/issues"
 import type { QueueConsumer, QueuePublisherShape } from "@domain/queue"
 import { SCORE_PUBLICATION_DEBOUNCE } from "@domain/scores"
 import { TRACE_END_DEBOUNCE_MS } from "@domain/spans"
@@ -98,9 +98,13 @@ export const createDomainEventsWorker = ({
 
     // Throttled: the first assignment schedules the refresh for `now + 8h`,
     // and subsequent assignments within the window are dropped so a constant
-    // annotation stream cannot starve the refresh. The escalation check runs
-    // alongside on a much tighter throttle (15min) — it's cheap (single CH
-    // aggregate + maybe one Postgres update) and detection latency matters.
+    // annotation stream cannot starve the refresh. The escalation check fans
+    // out twice in tandem: a 15-min throttled push (catches escalation
+    // STARTS quickly while activity is high) and a debounced recheck that
+    // only fires after `ESCALATION_RECHECK_DELAY_MS` of quiet on the same
+    // issue (catches escalation ENDS once scoring stops — the recent
+    // occurrence count organically drops below the exit threshold). Different
+    // dedupeKeys so the throttle and the debounce don't collide.
     ScoreAssignedToIssue: (event) =>
       Effect.all(
         [
@@ -111,6 +115,10 @@ export const createDomainEventsWorker = ({
           pub.publish("issues", "checkEscalation", event.payload, {
             dedupeKey: `issues:check-escalation:${event.payload.issueId}`,
             throttleMs: ESCALATION_CHECK_THROTTLE_MS,
+          }),
+          pub.publish("issues", "checkEscalation", event.payload, {
+            dedupeKey: `issues:check-escalation-recheck:${event.payload.issueId}`,
+            debounceMs: ESCALATION_RECHECK_DELAY_MS,
           }),
         ],
         { concurrency: "unbounded" },

--- a/apps/workers/src/workers/domain-events/alert-incidents.ts
+++ b/apps/workers/src/workers/domain-events/alert-incidents.ts
@@ -1,4 +1,8 @@
-import { type AlertIncidentKind, createAlertIncidentFromIssueEventUseCase } from "@domain/alerts"
+import {
+  type AlertIncidentKind,
+  closeAlertIncidentFromIssueEventUseCase,
+  createAlertIncidentFromIssueEventUseCase,
+} from "@domain/alerts"
 import type { QueueConsumer } from "@domain/queue"
 import { OrganizationId } from "@domain/shared"
 import { AlertIncidentRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
@@ -46,6 +50,31 @@ const createIncidentFor = (
   )
 }
 
+const closeIncidentFor = (
+  kind: AlertIncidentKind,
+  payload: {
+    readonly organizationId: string
+    readonly issueId: string
+    readonly endedAt: Date
+  },
+) => {
+  const pgClient = getPostgresClient()
+
+  return closeAlertIncidentFromIssueEventUseCase({
+    kind,
+    issueId: payload.issueId,
+    endedAt: payload.endedAt,
+  }).pipe(
+    withPostgres(repoLayer, pgClient, OrganizationId(payload.organizationId)),
+    Effect.tap(() => Effect.sync(() => logger.info(`alert_incident closed kind=${kind} issueId=${payload.issueId}`))),
+    Effect.tapError((error) =>
+      Effect.sync(() => logger.error(`alert_incident close failed kind=${kind} issueId=${payload.issueId}`, error)),
+    ),
+    Effect.asVoid,
+    withTracing,
+  )
+}
+
 export const createAlertIncidentsWorker = ({ consumer }: AlertIncidentsDeps) => {
   consumer.subscribe("alert-incidents", {
     "issue-created": (payload) =>
@@ -62,6 +91,21 @@ export const createAlertIncidentsWorker = ({ consumer }: AlertIncidentsDeps) => 
         projectId: payload.projectId,
         issueId: payload.issueId,
         occurredAt: new Date(payload.regressedAt),
+      }),
+
+    "issue-escalated": (payload) =>
+      createIncidentFor("issue.escalating", {
+        organizationId: payload.organizationId,
+        projectId: payload.projectId,
+        issueId: payload.issueId,
+        occurredAt: new Date(payload.escalatedAt),
+      }),
+
+    "issue-escalation-ended": (payload) =>
+      closeIncidentFor("issue.escalating", {
+        organizationId: payload.organizationId,
+        issueId: payload.issueId,
+        endedAt: new Date(payload.endedAt),
       }),
   })
 }

--- a/apps/workers/src/workers/issues.ts
+++ b/apps/workers/src/workers/issues.ts
@@ -1,4 +1,10 @@
-import { discoverIssueUseCase, refreshIssueDetailsUseCase, removeScoreFromIssueUseCase } from "@domain/issues"
+import {
+  checkIssueEscalationUseCase,
+  discoverIssueUseCase,
+  ESCALATION_RECHECK_DELAY_MS,
+  refreshIssueDetailsUseCase,
+  removeScoreFromIssueUseCase,
+} from "@domain/issues"
 import {
   type QueueConsumer,
   QueuePublisher,
@@ -97,6 +103,45 @@ export const createIssuesWorker = async ({
         Effect.tapError((error) =>
           Effect.sync(() => logger.error(`Issue refresh failed for ${payload.projectId}/${payload.issueId}`, error)),
         ),
+        Effect.asVoid,
+      ),
+    // Reify the (otherwise read-time-derived) escalating state on the issue
+    // and emit transition events. While the issue is currently escalating,
+    // schedule a delayed self-recheck so escalation EXITS still get detected
+    // when scoring activity stops (no more push triggers, recent count
+    // organically drops below the exit threshold).
+    checkEscalation: (payload) =>
+      checkIssueEscalationUseCase(payload).pipe(
+        withPostgres(
+          Layer.mergeAll(IssueRepositoryLive, OutboxEventWriterLive),
+          pgClient,
+          OrganizationId(payload.organizationId),
+        ),
+        withClickHouse(ScoreAnalyticsRepositoryLive, chClient, OrganizationId(payload.organizationId)),
+        // While the issue is currently escalating, schedule a self-recheck.
+        // `throttleMs` here is used as a "fire after N" delay (semantics: first
+        // publish on a fresh dedupeKey schedules for now+throttleMs, subsequent
+        // publishes within the window are dropped). Recurses naturally: each
+        // run that lands "still escalating" re-arms a fresh recheck.
+        Effect.tap((result) =>
+          result.currentlyEscalating
+            ? publisher.publish("issues", "checkEscalation", payload, {
+                dedupeKey: `issues:check-escalation-recheck:${payload.issueId}`,
+                throttleMs: ESCALATION_RECHECK_DELAY_MS,
+              })
+            : Effect.void,
+        ),
+        Effect.tap((result) =>
+          Effect.sync(() =>
+            logger.info(
+              `Escalation check for ${payload.projectId}/${payload.issueId}: transition=${result.transition} currentlyEscalating=${result.currentlyEscalating}`,
+            ),
+          ),
+        ),
+        Effect.tapError((error) =>
+          Effect.sync(() => logger.error(`Escalation check failed for ${payload.projectId}/${payload.issueId}`, error)),
+        ),
+        withTracing,
         Effect.asVoid,
       ),
     removeScore: (payload) =>

--- a/apps/workers/src/workers/issues.ts
+++ b/apps/workers/src/workers/issues.ts
@@ -1,7 +1,6 @@
 import {
   checkIssueEscalationUseCase,
   discoverIssueUseCase,
-  ESCALATION_RECHECK_DELAY_MS,
   refreshIssueDetailsUseCase,
   removeScoreFromIssueUseCase,
 } from "@domain/issues"
@@ -106,10 +105,10 @@ export const createIssuesWorker = async ({
         Effect.asVoid,
       ),
     // Reify the (otherwise read-time-derived) escalating state on the issue
-    // and emit transition events. While the issue is currently escalating,
-    // schedule a delayed self-recheck so escalation EXITS still get detected
-    // when scoring activity stops (no more push triggers, recent count
-    // organically drops below the exit threshold).
+    // and emit transition events. The handler is fan-out-driven — entries
+    // are caught by the throttled `issues:check-escalation` publish, exits
+    // by the debounced `issues:check-escalation-recheck` publish (both
+    // wired in `domain-events.ts` from `ScoreAssignedToIssue`).
     checkEscalation: (payload) =>
       checkIssueEscalationUseCase(payload).pipe(
         withPostgres(
@@ -118,19 +117,6 @@ export const createIssuesWorker = async ({
           OrganizationId(payload.organizationId),
         ),
         withClickHouse(ScoreAnalyticsRepositoryLive, chClient, OrganizationId(payload.organizationId)),
-        // While the issue is currently escalating, schedule a self-recheck.
-        // `throttleMs` here is used as a "fire after N" delay (semantics: first
-        // publish on a fresh dedupeKey schedules for now+throttleMs, subsequent
-        // publishes within the window are dropped). Recurses naturally: each
-        // run that lands "still escalating" re-arms a fresh recheck.
-        Effect.tap((result) =>
-          result.currentlyEscalating
-            ? publisher.publish("issues", "checkEscalation", payload, {
-                dedupeKey: `issues:check-escalation-recheck:${payload.issueId}`,
-                throttleMs: ESCALATION_RECHECK_DELAY_MS,
-              })
-            : Effect.void,
-        ),
         Effect.tap((result) =>
           Effect.sync(() =>
             logger.info(

--- a/apps/workers/src/workers/issues.ts
+++ b/apps/workers/src/workers/issues.ts
@@ -104,11 +104,15 @@ export const createIssuesWorker = async ({
         ),
         Effect.asVoid,
       ),
-    // Reify the (otherwise read-time-derived) escalating state on the issue
-    // and emit transition events. The handler is fan-out-driven — entries
-    // are caught by the throttled `issues:check-escalation` publish, exits
-    // by the debounced `issues:check-escalation-recheck` publish (both
-    // wired in `domain-events.ts` from `ScoreAssignedToIssue`).
+    // Evaluate escalation state from the analytics aggregate + the current
+    // `alert_incidents`-derived `lifecycle.isEscalating` flag, and emit the
+    // matching transition event. The use case does not write the issue —
+    // the open/closed `alert_incidents` row is the stored truth. The
+    // alert-incidents worker inserts/closes that row in response to
+    // `IssueEscalated` / `IssueEscalationEnded`. Fan-out-driven: entries are
+    // caught by the throttled `issues:check-escalation` publish, exits by
+    // the debounced `issues:check-escalation-recheck` publish (both wired
+    // in `domain-events.ts` from `ScoreAssignedToIssue`).
     checkEscalation: (payload) =>
       checkIssueEscalationUseCase(payload).pipe(
         withPostgres(

--- a/packages/domain/alerts/src/entities/alert-incident.ts
+++ b/packages/domain/alerts/src/entities/alert-incident.ts
@@ -13,7 +13,7 @@ export type AlertIncidentSourceType = z.infer<typeof alertIncidentSourceTypeSche
  * Namespaced kind. The prefix matches `sourceType` so kinds remain unambiguous
  * even when future source types add their own variants (e.g. `saved_search.threshold`).
  */
-export const ALERT_INCIDENT_KINDS = ["issue.new", "issue.regressed"] as const
+export const ALERT_INCIDENT_KINDS = ["issue.new", "issue.regressed", "issue.escalating"] as const
 export const alertIncidentKindSchema = z.enum(ALERT_INCIDENT_KINDS)
 export type AlertIncidentKind = z.infer<typeof alertIncidentKindSchema>
 
@@ -28,6 +28,7 @@ export type AlertSeverity = z.infer<typeof alertSeveritySchema>
 export const SEVERITY_FOR_KIND: Record<AlertIncidentKind, AlertSeverity> = {
   "issue.new": "medium",
   "issue.regressed": "high",
+  "issue.escalating": "high",
 }
 
 export const alertIncidentSchema = z.object({

--- a/packages/domain/alerts/src/index.ts
+++ b/packages/domain/alerts/src/index.ts
@@ -14,8 +14,16 @@ export {
   alertSeveritySchema,
   SEVERITY_FOR_KIND,
 } from "./entities/alert-incident.ts"
-export type { AlertIncidentRepositoryShape } from "./ports/alert-incident-repository.ts"
+export type {
+  AlertIncidentRepositoryShape,
+  CloseOpenAlertIncidentInput,
+} from "./ports/alert-incident-repository.ts"
 export { AlertIncidentRepository } from "./ports/alert-incident-repository.ts"
+export type {
+  CloseAlertIncidentFromIssueEventError,
+  CloseAlertIncidentFromIssueEventInput,
+} from "./use-cases/close-alert-incident-from-issue-event.ts"
+export { closeAlertIncidentFromIssueEventUseCase } from "./use-cases/close-alert-incident-from-issue-event.ts"
 export type {
   CreateAlertIncidentFromIssueEventError,
   CreateAlertIncidentFromIssueEventInput,

--- a/packages/domain/alerts/src/ports/alert-incident-repository.ts
+++ b/packages/domain/alerts/src/ports/alert-incident-repository.ts
@@ -1,9 +1,21 @@
 import type { RepositoryError, SqlClient } from "@domain/shared"
 import { Context, type Effect } from "effect"
-import type { AlertIncident } from "../entities/alert-incident.ts"
+import type { AlertIncident, AlertIncidentKind, AlertIncidentSourceType } from "../entities/alert-incident.ts"
+
+export interface CloseOpenAlertIncidentInput {
+  readonly sourceType: AlertIncidentSourceType
+  readonly sourceId: string
+  readonly kind: AlertIncidentKind
+  readonly endedAt: Date
+}
 
 export interface AlertIncidentRepositoryShape {
   insert(incident: AlertIncident): Effect.Effect<void, RepositoryError, SqlClient>
+  /**
+   * Set `ended_at` on the open `(source_type, source_id, kind)` row in the
+   * current organization's RLS scope. No-op if no open row exists.
+   */
+  closeOpen(input: CloseOpenAlertIncidentInput): Effect.Effect<void, RepositoryError, SqlClient>
 }
 
 export class AlertIncidentRepository extends Context.Service<AlertIncidentRepository, AlertIncidentRepositoryShape>()(

--- a/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.test.ts
@@ -1,0 +1,54 @@
+import { OrganizationId, SqlClient } from "@domain/shared"
+import { createFakeSqlClient } from "@domain/shared/testing"
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { CloseOpenAlertIncidentInput } from "../ports/alert-incident-repository.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+import { closeAlertIncidentFromIssueEventUseCase } from "./close-alert-incident-from-issue-event.ts"
+
+const cuid = (seed: string) => seed.padEnd(24, "0")
+
+function createTestLayers() {
+  const closed: CloseOpenAlertIncidentInput[] = []
+
+  const AlertIncidentRepositoryTest = Layer.succeed(
+    AlertIncidentRepository,
+    AlertIncidentRepository.of({
+      insert: () => Effect.void,
+      closeOpen: (input) =>
+        Effect.sync(() => {
+          closed.push(input)
+        }),
+    }),
+  )
+
+  const SqlClientTest = Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: OrganizationId(cuid("o")) }))
+
+  return {
+    closed,
+    layer: Layer.mergeAll(AlertIncidentRepositoryTest, SqlClientTest),
+  }
+}
+
+describe("closeAlertIncidentFromIssueEventUseCase", () => {
+  it("calls closeOpen with the issue source pointer and the provided endedAt", async () => {
+    const { closed, layer } = createTestLayers()
+    const endedAt = new Date("2026-05-07T10:00:00Z")
+
+    await Effect.runPromise(
+      closeAlertIncidentFromIssueEventUseCase({
+        kind: "issue.escalating",
+        issueId: cuid("i"),
+        endedAt,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(closed).toHaveLength(1)
+    expect(closed[0]).toEqual({
+      sourceType: "issue",
+      sourceId: cuid("i"),
+      kind: "issue.escalating",
+      endedAt,
+    })
+  })
+})

--- a/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.ts
+++ b/packages/domain/alerts/src/use-cases/close-alert-incident-from-issue-event.ts
@@ -1,0 +1,36 @@
+import { type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import type { AlertIncidentKind } from "../entities/alert-incident.ts"
+import { AlertIncidentRepository } from "../ports/alert-incident-repository.ts"
+
+export interface CloseAlertIncidentFromIssueEventInput {
+  readonly kind: AlertIncidentKind
+  readonly issueId: string
+  readonly endedAt: Date
+}
+
+export type CloseAlertIncidentFromIssueEventError = RepositoryError
+
+export const closeAlertIncidentFromIssueEventUseCase = (input: CloseAlertIncidentFromIssueEventInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("alertIncident.kind", input.kind)
+    yield* Effect.annotateCurrentSpan("alertIncident.issueId", input.issueId)
+
+    const sqlClient = yield* SqlClient
+
+    yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const alertIncidentRepository = yield* AlertIncidentRepository
+        yield* alertIncidentRepository.closeOpen({
+          sourceType: "issue",
+          sourceId: input.issueId,
+          kind: input.kind,
+          endedAt: input.endedAt,
+        })
+      }),
+    )
+  }).pipe(Effect.withSpan("alerts.closeAlertIncidentFromIssueEvent")) as Effect.Effect<
+    void,
+    CloseAlertIncidentFromIssueEventError,
+    SqlClient | AlertIncidentRepository
+  >

--- a/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
+++ b/packages/domain/alerts/src/use-cases/create-alert-incident-from-issue-event.test.ts
@@ -20,6 +20,7 @@ function createTestLayers() {
         Effect.sync(() => {
           inserted.push(incident)
         }),
+      closeOpen: () => Effect.void,
     }),
   )
 

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -67,6 +67,31 @@ export interface EventPayloads {
     readonly triggerScoreId: string
   }
   /**
+   * Emitted by `checkIssueEscalationUseCase` when an issue transitions into
+   * the escalating state. The use case sets `issues.escalated_at` in the same
+   * transaction (reifying the derived state as a stored fact); a re-run won't
+   * re-emit because the prior condition no longer holds. Drives the
+   * `issue.escalating` incident's open transition.
+   */
+  IssueEscalated: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly issueId: string
+    readonly escalatedAt: string
+  }
+  /**
+   * Emitted by `checkIssueEscalationUseCase` when an escalating issue's
+   * recent occurrence count drops below the hysteresis exit threshold. The
+   * use case clears `issues.escalated_at` in the same transaction. Drives
+   * the `issue.escalating` incident's close transition (`ended_at` update).
+   */
+  IssueEscalationEnded: {
+    readonly organizationId: string
+    readonly projectId: string
+    readonly issueId: string
+    readonly endedAt: string
+  }
+  /**
    * Emitted by the alert-incidents worker after an `alert_incidents` row is
    * inserted. PR 1 has no consumer (the dispatcher routes it to a no-op);
    * PR 2 (email) and PR 3 (in-app) will subscribe.
@@ -75,7 +100,7 @@ export interface EventPayloads {
     readonly organizationId: string
     readonly projectId: string
     readonly alertIncidentId: string
-    readonly kind: "issue.new" | "issue.regressed"
+    readonly kind: "issue.new" | "issue.regressed" | "issue.escalating"
     readonly sourceType: "issue"
     readonly sourceId: string
   }

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -68,10 +68,11 @@ export interface EventPayloads {
   }
   /**
    * Emitted by `checkIssueEscalationUseCase` when an issue transitions into
-   * the escalating state. The use case sets `issues.escalated_at` in the same
-   * transaction (reifying the derived state as a stored fact); a re-run won't
-   * re-emit because the prior condition no longer holds. Drives the
-   * `issue.escalating` incident's open transition.
+   * the escalating state. The use case does not write the issue itself —
+   * idempotency comes from `IssueRepository`'s joined `lifecycle.isEscalating`
+   * flag (which reads the open `alert_incidents` row). Drives the
+   * `issue.escalating` incident's open transition (the alert-incidents
+   * worker inserts the new row).
    */
   IssueEscalated: {
     readonly organizationId: string
@@ -81,9 +82,10 @@ export interface EventPayloads {
   }
   /**
    * Emitted by `checkIssueEscalationUseCase` when an escalating issue's
-   * recent occurrence count drops below the hysteresis exit threshold. The
-   * use case clears `issues.escalated_at` in the same transaction. Drives
-   * the `issue.escalating` incident's close transition (`ended_at` update).
+   * recent occurrence count drops below the hysteresis exit threshold.
+   * Drives the `issue.escalating` incident's close transition — the
+   * alert-incidents worker sets `ended_at` on the open row, which is what
+   * flips `lifecycle.isEscalating` back to `false` on subsequent reads.
    */
   IssueEscalationEnded: {
     readonly organizationId: string

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -34,11 +34,11 @@ export const ESCALATION_EXIT_THRESHOLD_FACTOR = 0.7
 export const ESCALATION_CHECK_THROTTLE_MS = 15 * 60 * 1000
 
 /**
- * Delay for the self-rescheduling escalation recheck enqueued by the
- * `issues:checkEscalation` worker while an issue is currently escalating.
- * Catches escalation exits when scoring activity stops (no more push
- * triggers): the recent occurrence count organically drops as time passes,
- * and this delayed recheck eventually detects the exit.
+ * Debounce window for the escalation recheck published from
+ * `ScoreAssignedToIssue`. Each occurrence extends the timer; the recheck
+ * fires only after this much quiet on the same issue, by which point the
+ * recent occurrence count has had time to organically drop. Catches
+ * escalation exits when scoring activity stops (no more push triggers).
  */
 export const ESCALATION_RECHECK_DELAY_MS = 60 * 60 * 1000
 

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -17,6 +17,31 @@ export const ESCALATION_THRESHOLD_FACTOR = 1.33
 /** Escalating issues must clear at least this many recent occurrences. */
 export const ESCALATION_MIN_OCCURRENCES_THRESHOLD = 20
 
+/**
+ * Hysteresis exit factor: an escalating issue is considered "no longer
+ * escalating" only when the recent occurrence count drops below
+ * `entryThreshold * ESCALATION_EXIT_THRESHOLD_FACTOR`. Prevents flapping at
+ * the boundary by requiring a meaningful return below the entry threshold
+ * before closing the incident.
+ */
+export const ESCALATION_EXIT_THRESHOLD_FACTOR = 0.7
+
+/**
+ * Throttle window for the per-issue escalation-state recheck task triggered
+ * by `ScoreAssignedToIssue`. Caps the rate of `recentOccurrences`
+ * recomputation per issue. Trades off detection latency for compute.
+ */
+export const ESCALATION_CHECK_THROTTLE_MS = 15 * 60 * 1000
+
+/**
+ * Delay for the self-rescheduling escalation recheck enqueued by the
+ * `issues:checkEscalation` worker while an issue is currently escalating.
+ * Catches escalation exits when scoring activity stops (no more push
+ * triggers): the recent occurrence count organically drops as time passes,
+ * and this delayed recheck eventually detects the exit.
+ */
+export const ESCALATION_RECHECK_DELAY_MS = 60 * 60 * 1000
+
 /** An issue with no occurrences in this many days is auto-resolved. */
 export const AUTO_RESOLVE_INACTIVITY_DAYS = 14
 

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -42,9 +42,6 @@ export const ESCALATION_CHECK_THROTTLE_MS = 15 * 60 * 1000
  */
 export const ESCALATION_RECHECK_DELAY_MS = 60 * 60 * 1000
 
-/** An issue with no occurrences in this many days is auto-resolved. */
-export const AUTO_RESOLVE_INACTIVITY_DAYS = 14
-
 // ---------------------------------------------------------------------------
 // Centroid configuration
 // ---------------------------------------------------------------------------

--- a/packages/domain/issues/src/entities/issue.ts
+++ b/packages/domain/issues/src/entities/issue.ts
@@ -46,8 +46,8 @@ export const issueSchema = z.object({
   source: issueSourceSchema, // provenance of the first creating score
   centroid: issueCentroidSchema, // running weighted sum of clustered score feedback embeddings; drives semantic matching in Weaviate
   clusteredAt: z.date(), // last time the centroid/cluster state was refreshed; authoritative decay anchor (not updatedAt)
-  escalatedAt: z.date().nullable(), // latest escalation transition timestamp
-  resolvedAt: z.date().nullable(), // issue resolved automatically or manually
+  escalatedAt: z.date().nullable(), // DORMANT: not maintained by the system. "Currently escalating" is derived from open `alert_incidents` rows. Kept on the entity for backward compatibility; always null in practice.
+  resolvedAt: z.date().nullable(), // issue resolved manually
   ignoredAt: z.date().nullable(), // issue ignored manually
   createdAt: z.date(), // issue creation time
   updatedAt: z.date(), // issue update time

--- a/packages/domain/issues/src/errors.ts
+++ b/packages/domain/issues/src/errors.ts
@@ -85,6 +85,13 @@ export class IssueNotFoundForAssignmentError extends Data.TaggedError("IssueNotF
   readonly httpMessage = "Issue not found for assignment"
 }
 
+export class IssueNotFoundForEscalationCheckError extends Data.TaggedError("IssueNotFoundForEscalationCheckError")<{
+  readonly issueId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "Issue not found for escalation check"
+}
+
 export class IssueDiscoveryLockUnavailableError extends Data.TaggedError("IssueDiscoveryLockUnavailableError")<{
   readonly projectId: string
   readonly lockKey: string

--- a/packages/domain/issues/src/helpers.test.ts
+++ b/packages/domain/issues/src/helpers.test.ts
@@ -1,4 +1,3 @@
-import type { IssueOccurrenceAggregate } from "@domain/scores"
 import { IssueId } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { CENTROID_EMBEDDING_DIMENSIONS, CENTROID_HALF_LIFE_SECONDS, CENTROID_SOURCE_WEIGHTS } from "./constants.ts"
@@ -50,16 +49,6 @@ const makeIssue = (overrides: Partial<Issue> = {}): Issue => ({
   ignoredAt: null,
   createdAt: new Date("2026-04-01T00:00:00.000Z"),
   updatedAt: new Date("2026-04-01T00:00:00.000Z"),
-  ...overrides,
-})
-
-const makeOccurrence = (overrides: Partial<IssueOccurrenceAggregate> = {}): IssueOccurrenceAggregate => ({
-  issueId: IssueId("iiiiiiiiiiiiiiiiiiiiiiii"),
-  totalOccurrences: 3,
-  recentOccurrences: 1,
-  baselineAvgOccurrences: 1,
-  firstSeenAt: new Date("2026-04-01T00:00:00.000Z"),
-  lastSeenAt: new Date("2026-04-09T00:00:00.000Z"),
   ...overrides,
 })
 
@@ -207,92 +196,71 @@ describe("issue lifecycle helpers", () => {
     expect(getEscalationOccurrenceThreshold(16)).toBe(22)
   })
 
-  it("does not mark new issues as escalating even when they exceed the escalation threshold", () => {
+  it("marks recently created issues as new", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-04-05T08:00:00.000Z"),
         updatedAt: new Date("2026-04-05T08:00:00.000Z"),
         clusteredAt: new Date("2026-04-05T08:00:00.000Z"),
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-04-05T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-04-09T20:00:00.000Z"),
-        recentOccurrences: 20,
-        baselineAvgOccurrences: 2,
-      }),
+      isEscalating: false,
+      isRegressed: false,
       now,
     })
 
     expect(states).toEqual([IssueState.New])
   })
 
-  it("marks issues with escalatedAt set as escalating", () => {
+  it("marks the issue as escalating when the lifecycle flag is true", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-20T08:00:00.000Z"),
         updatedAt: new Date("2026-03-20T08:00:00.000Z"),
         clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
-        escalatedAt: new Date("2026-04-09T18:00:00.000Z"),
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-03-20T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-04-09T20:00:00.000Z"),
-        recentOccurrences: 20,
-        baselineAvgOccurrences: 2,
-      }),
+      isEscalating: true,
+      isRegressed: false,
       now,
     })
 
     expect(states).toEqual([IssueState.Escalating])
   })
 
-  it("does not derive escalating from runtime threshold when escalatedAt is null", () => {
+  it("does not mark as escalating when the flag is false", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-20T08:00:00.000Z"),
         updatedAt: new Date("2026-03-20T08:00:00.000Z"),
         clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
-        escalatedAt: null,
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-03-20T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-04-09T20:00:00.000Z"),
-        recentOccurrences: 100,
-        baselineAvgOccurrences: 2,
-      }),
+      isEscalating: false,
+      isRegressed: false,
       now,
     })
 
     expect(states).toEqual([IssueState.Ongoing])
   })
 
-  it("marks issues resolved after 14 days of inactivity", () => {
+  it("marks the issue as regressed when isRegressed is true and resolvedAt is null", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-01T08:00:00.000Z"),
         updatedAt: new Date("2026-03-01T08:00:00.000Z"),
         clusteredAt: new Date("2026-03-01T08:00:00.000Z"),
+        resolvedAt: null,
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-03-01T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-03-20T08:00:00.000Z"),
-        recentOccurrences: 0,
-        baselineAvgOccurrences: 0,
-      }),
+      isEscalating: false,
+      isRegressed: true,
       now,
     })
 
-    expect(states).toEqual([IssueState.Resolved])
+    expect(states).toEqual([IssueState.Regressed])
   })
 
-  it("does not derive regressed state — regression is reified at write time and lives in alert_incidents", () => {
-    // Pre-PR1 derive returned Regressed when an issue had `resolvedAt` set
-    // and activity after that timestamp. Post-PR1, the assign-score-to-issue
-    // path clears `resolvedAt` when regression fires and emits an
-    // `IssueRegressed` event consumed by the alerts pipeline. The derive
-    // helper now treats issues with `resolvedAt` set as Resolved
-    // unconditionally; "this issue regressed recently" is answered by
-    // querying alert_incidents.
+  it("treats explicitly resolved issues as resolved even if a regression incident exists", () => {
+    // resolvedAt being set means the user has acknowledged the regression
+    // by resolving again. Take that signal as authoritative — the regression
+    // history still lives in alert_incidents for surfacing separately.
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-01T08:00:00.000Z"),
@@ -300,19 +268,15 @@ describe("issue lifecycle helpers", () => {
         clusteredAt: new Date("2026-03-01T08:00:00.000Z"),
         resolvedAt: new Date("2026-04-01T12:00:00.000Z"),
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-03-01T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-04-05T08:00:00.000Z"),
-        recentOccurrences: 0,
-        baselineAvgOccurrences: 0,
-      }),
+      isEscalating: false,
+      isRegressed: true,
       now,
     })
 
     expect(states).toEqual([IssueState.Resolved])
   })
 
-  it("falls back to issue timestamps when analytics have not caught up yet", () => {
+  it("derives both new and ignored when the issue is brand new and ignored", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-04-06T08:00:00.000Z"),
@@ -320,7 +284,8 @@ describe("issue lifecycle helpers", () => {
         clusteredAt: new Date("2026-04-06T08:00:00.000Z"),
         ignoredAt: new Date("2026-04-08T08:00:00.000Z"),
       }),
-      occurrence: null,
+      isEscalating: false,
+      isRegressed: false,
       now,
     })
 
@@ -334,12 +299,8 @@ describe("issue lifecycle helpers", () => {
         updatedAt: new Date("2026-03-15T08:00:00.000Z"),
         clusteredAt: new Date("2026-03-15T08:00:00.000Z"),
       }),
-      occurrence: makeOccurrence({
-        firstSeenAt: new Date("2026-03-15T08:00:00.000Z"),
-        lastSeenAt: new Date("2026-04-08T08:00:00.000Z"),
-        recentOccurrences: 2,
-        baselineAvgOccurrences: 1,
-      }),
+      isEscalating: false,
+      isRegressed: false,
       now,
     })
 

--- a/packages/domain/issues/src/helpers.test.ts
+++ b/packages/domain/issues/src/helpers.test.ts
@@ -226,12 +226,13 @@ describe("issue lifecycle helpers", () => {
     expect(states).toEqual([IssueState.New])
   })
 
-  it("marks older issues as escalating when they exceed the escalation threshold", () => {
+  it("marks issues with escalatedAt set as escalating", () => {
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-20T08:00:00.000Z"),
         updatedAt: new Date("2026-03-20T08:00:00.000Z"),
         clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
+        escalatedAt: new Date("2026-04-09T18:00:00.000Z"),
       }),
       occurrence: makeOccurrence({
         firstSeenAt: new Date("2026-03-20T08:00:00.000Z"),
@@ -243,6 +244,26 @@ describe("issue lifecycle helpers", () => {
     })
 
     expect(states).toEqual([IssueState.Escalating])
+  })
+
+  it("does not derive escalating from runtime threshold when escalatedAt is null", () => {
+    const states = deriveIssueLifecycleStates({
+      issue: makeIssue({
+        createdAt: new Date("2026-03-20T08:00:00.000Z"),
+        updatedAt: new Date("2026-03-20T08:00:00.000Z"),
+        clusteredAt: new Date("2026-03-20T08:00:00.000Z"),
+        escalatedAt: null,
+      }),
+      occurrence: makeOccurrence({
+        firstSeenAt: new Date("2026-03-20T08:00:00.000Z"),
+        lastSeenAt: new Date("2026-04-09T20:00:00.000Z"),
+        recentOccurrences: 100,
+        baselineAvgOccurrences: 2,
+      }),
+      now,
+    })
+
+    expect(states).toEqual([IssueState.Ongoing])
   })
 
   it("marks issues resolved after 14 days of inactivity", () => {
@@ -264,7 +285,14 @@ describe("issue lifecycle helpers", () => {
     expect(states).toEqual([IssueState.Resolved])
   })
 
-  it("marks resolved issues as regressed when new occurrences appear later", () => {
+  it("does not derive regressed state — regression is reified at write time and lives in alert_incidents", () => {
+    // Pre-PR1 derive returned Regressed when an issue had `resolvedAt` set
+    // and activity after that timestamp. Post-PR1, the assign-score-to-issue
+    // path clears `resolvedAt` when regression fires and emits an
+    // `IssueRegressed` event consumed by the alerts pipeline. The derive
+    // helper now treats issues with `resolvedAt` set as Resolved
+    // unconditionally; "this issue regressed recently" is answered by
+    // querying alert_incidents.
     const states = deriveIssueLifecycleStates({
       issue: makeIssue({
         createdAt: new Date("2026-03-01T08:00:00.000Z"),
@@ -281,7 +309,7 @@ describe("issue lifecycle helpers", () => {
       now,
     })
 
-    expect(states).toEqual([IssueState.Regressed])
+    expect(states).toEqual([IssueState.Resolved])
   })
 
   it("falls back to issue timestamps when analytics have not caught up yet", () => {

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -204,6 +204,16 @@ export const getEscalationOccurrenceThreshold = (baselineAvgOccurrences: number)
 export const getEscalationExitThreshold = (baselineAvgOccurrences: number): number =>
   Math.floor(getEscalationOccurrenceThreshold(baselineAvgOccurrences) * ESCALATION_EXIT_THRESHOLD_FACTOR)
 
+/**
+ * An issue is "new" while its first seen timestamp is within
+ * `NEW_ISSUE_AGE_DAYS` of `now`. New issues are excluded from escalation
+ * detection — their `baselineAvgOccurrences` window (days 1–8 ago) hasn't
+ * filled in yet, so any volume above the floor would falsely trip the
+ * threshold. The discrete `issue.new` alert covers this case.
+ */
+export const isIssueNew = (firstSeenAt: Date, now: Date = new Date()): boolean =>
+  firstSeenAt.getTime() > now.getTime() - NEW_ISSUE_AGE_DAYS * MILLISECONDS_PER_DAY
+
 export const deriveIssueLifecycleStates = ({
   issue,
   occurrence,
@@ -212,26 +222,28 @@ export const deriveIssueLifecycleStates = ({
   const firstSeenAt = occurrence?.firstSeenAt ?? issue.createdAt
   const lastSeenAt = occurrence?.lastSeenAt ?? issue.createdAt
   const states = new Set<IssueStateValue>()
-  const isNew = firstSeenAt.getTime() > now.getTime() - NEW_ISSUE_AGE_DAYS * MILLISECONDS_PER_DAY
 
-  if (isNew) {
+  if (isIssueNew(firstSeenAt, now)) {
     states.add(IssueState.New)
   }
 
-  const recentOccurrences = occurrence?.recentOccurrences ?? 0
-  const baselineAverage = occurrence?.baselineAvgOccurrences ?? 0
-  if (!isNew && recentOccurrences >= getEscalationOccurrenceThreshold(baselineAverage)) {
+  // Escalating reads from the stored `escalatedAt` column rather than
+  // recomputing from the occurrence aggregate. The worker's
+  // `checkIssueEscalationUseCase` is the only writer, applies hysteresis,
+  // and gates on `isIssueNew` — trusting the stored value here keeps the
+  // read path consistent with what the alerts pipeline observed.
+  if (issue.escalatedAt !== null) {
     states.add(IssueState.Escalating)
   }
 
-  const isRegressed = issue.resolvedAt !== null && lastSeenAt.getTime() > issue.resolvedAt.getTime()
-  if (isRegressed) {
-    states.add(IssueState.Regressed)
-  }
-
+  // The `Regressed` state is no longer derived. Regression is reified at
+  // write time in `assign-score-to-issue` (clears `resolvedAt`, emits
+  // `IssueRegressed`), and the historical record lives in `alert_incidents`.
+  // Consumers that need to surface "this issue has regressed recently"
+  // should query that table.
   const isResolvedByInactivity =
     lastSeenAt.getTime() < now.getTime() - AUTO_RESOLVE_INACTIVITY_DAYS * MILLISECONDS_PER_DAY
-  if (!isRegressed && (issue.resolvedAt !== null || isResolvedByInactivity)) {
+  if (issue.resolvedAt !== null || isResolvedByInactivity) {
     states.add(IssueState.Resolved)
   }
 

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -5,6 +5,7 @@ import {
   CENTROID_EMBEDDING_MODEL,
   CENTROID_HALF_LIFE_SECONDS,
   CENTROID_SOURCE_WEIGHTS,
+  ESCALATION_EXIT_THRESHOLD_FACTOR,
   ESCALATION_MIN_OCCURRENCES_THRESHOLD,
   ESCALATION_THRESHOLD_FACTOR,
   ISSUE_STATES,
@@ -193,6 +194,15 @@ export const getEscalationOccurrenceThreshold = (baselineAvgOccurrences: number)
     ESCALATION_MIN_OCCURRENCES_THRESHOLD,
     Math.floor(Math.max(0, baselineAvgOccurrences) * ESCALATION_THRESHOLD_FACTOR) + 1,
   )
+
+/**
+ * Hysteresis exit threshold: an escalating issue exits only when its recent
+ * occurrence count drops below this value. Always strictly less than
+ * `getEscalationOccurrenceThreshold(baselineAvgOccurrences)` so the entry
+ * and exit conditions cannot both hold simultaneously at the same baseline.
+ */
+export const getEscalationExitThreshold = (baselineAvgOccurrences: number): number =>
+  Math.floor(getEscalationOccurrenceThreshold(baselineAvgOccurrences) * ESCALATION_EXIT_THRESHOLD_FACTOR)
 
 export const deriveIssueLifecycleStates = ({
   issue,

--- a/packages/domain/issues/src/helpers.ts
+++ b/packages/domain/issues/src/helpers.ts
@@ -1,6 +1,5 @@
-import type { IssueOccurrenceAggregate, ScoreSource } from "@domain/scores"
+import type { ScoreSource } from "@domain/scores"
 import {
-  AUTO_RESOLVE_INACTIVITY_DAYS,
   CENTROID_EMBEDDING_DIMENSIONS,
   CENTROID_EMBEDDING_MODEL,
   CENTROID_HALF_LIFE_SECONDS,
@@ -185,7 +184,9 @@ export const normalizeEmbedding = (embedding: readonly number[]): number[] => {
 
 export interface DeriveIssueLifecycleStatesInput {
   readonly issue: Issue
-  readonly occurrence?: IssueOccurrenceAggregate | null
+  /** Lifecycle flags joined from `alert_incidents` by `IssueRepository` reads. */
+  readonly isEscalating: boolean
+  readonly isRegressed: boolean
   readonly now?: Date
 }
 
@@ -216,34 +217,31 @@ export const isIssueNew = (firstSeenAt: Date, now: Date = new Date()): boolean =
 
 export const deriveIssueLifecycleStates = ({
   issue,
-  occurrence,
+  isEscalating,
+  isRegressed,
   now = new Date(),
 }: DeriveIssueLifecycleStatesInput): readonly IssueStateValue[] => {
-  const firstSeenAt = occurrence?.firstSeenAt ?? issue.createdAt
-  const lastSeenAt = occurrence?.lastSeenAt ?? issue.createdAt
   const states = new Set<IssueStateValue>()
 
-  if (isIssueNew(firstSeenAt, now)) {
+  if (isIssueNew(issue.createdAt, now)) {
     states.add(IssueState.New)
   }
 
-  // Escalating reads from the stored `escalatedAt` column rather than
-  // recomputing from the occurrence aggregate. The worker's
-  // `checkIssueEscalationUseCase` is the only writer, applies hysteresis,
-  // and gates on `isIssueNew` — trusting the stored value here keeps the
-  // read path consistent with what the alerts pipeline observed.
-  if (issue.escalatedAt !== null) {
+  // Escalating and regressed flags are sourced from `alert_incidents` rows
+  // joined onto the issue read by `IssueRepository`. They're authoritative
+  // — consumers don't recompute them from the occurrence aggregate.
+  if (isEscalating) {
     states.add(IssueState.Escalating)
   }
 
-  // The `Regressed` state is no longer derived. Regression is reified at
-  // write time in `assign-score-to-issue` (clears `resolvedAt`, emits
-  // `IssueRegressed`), and the historical record lives in `alert_incidents`.
-  // Consumers that need to surface "this issue has regressed recently"
-  // should query that table.
-  const isResolvedByInactivity =
-    lastSeenAt.getTime() < now.getTime() - AUTO_RESOLVE_INACTIVITY_DAYS * MILLISECONDS_PER_DAY
-  if (issue.resolvedAt !== null || isResolvedByInactivity) {
+  // Regressed only when the issue has actually-active regression history
+  // AND the user hasn't re-resolved it. `resolvedAt` set wins: it means
+  // the user has acknowledged the regression by resolving again.
+  if (issue.resolvedAt === null && isRegressed) {
+    states.add(IssueState.Regressed)
+  }
+
+  if (issue.resolvedAt !== null) {
     states.add(IssueState.Resolved)
   }
 

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -1,5 +1,4 @@
 export {
-  AUTO_RESOLVE_INACTIVITY_DAYS,
   CENTROID_EMBEDDING_DIMENSIONS,
   CENTROID_EMBEDDING_MODEL,
   CENTROID_HALF_LIFE_SECONDS,
@@ -76,7 +75,14 @@ export {
   type IssuesCollectionProperties,
   type UpsertIssueProjectionInput,
 } from "./ports/issue-projection-repository.ts"
-export { IssueRepository } from "./ports/issue-repository.ts"
+export {
+  type IssueLifecycleFlags,
+  type IssueListPage,
+  IssueRepository,
+  type IssueRepositoryShape,
+  type IssueWithLifecycle,
+  type ListIssuesRepositoryInput,
+} from "./ports/issue-repository.ts"
 export {
   type ApplyIssueLifecycleCommandError,
   type ApplyIssueLifecycleCommandInput,

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -57,6 +57,7 @@ export {
   deriveIssueLifecycleStates,
   getEscalationExitThreshold,
   getEscalationOccurrenceThreshold,
+  isIssueNew,
   normalizeEmbedding,
   normalizeIssueCentroid,
   type UpdateIssueCentroidInput,

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -41,6 +41,7 @@ export {
   IssueDiscoveryLockUnavailableError,
   IssueNotFoundForAssignmentError,
   IssueNotFoundForDetailsGenerationError,
+  IssueNotFoundForEscalationCheckError,
   isEligibilityError,
   MissingIssueOccurrencesForDetailsGenerationError,
   MissingScoreFeedbackForDiscoveryError,

--- a/packages/domain/issues/src/index.ts
+++ b/packages/domain/issues/src/index.ts
@@ -4,7 +4,10 @@ export {
   CENTROID_EMBEDDING_MODEL,
   CENTROID_HALF_LIFE_SECONDS,
   CENTROID_SOURCE_WEIGHTS,
+  ESCALATION_CHECK_THROTTLE_MS,
+  ESCALATION_EXIT_THRESHOLD_FACTOR,
   ESCALATION_MIN_OCCURRENCES_THRESHOLD,
+  ESCALATION_RECHECK_DELAY_MS,
   ESCALATION_THRESHOLD_FACTOR,
   ISSUE_DETAILS_GENERATION_MODEL,
   ISSUE_DETAILS_MAX_OCCURRENCES,
@@ -52,6 +55,7 @@ export {
   createIssueCentroid,
   type DeriveIssueLifecycleStatesInput,
   deriveIssueLifecycleStates,
+  getEscalationExitThreshold,
   getEscalationOccurrenceThreshold,
   normalizeEmbedding,
   normalizeIssueCentroid,
@@ -93,6 +97,13 @@ export {
   buildIssuesExportUseCase,
 } from "./use-cases/build-issues-export.ts"
 export { type CheckEligibilityInput, checkEligibilityUseCase } from "./use-cases/check-eligibility.ts"
+export {
+  type CheckIssueEscalationError,
+  type CheckIssueEscalationInput,
+  type CheckIssueEscalationResult,
+  type CheckIssueEscalationTransition,
+  checkIssueEscalationUseCase,
+} from "./use-cases/check-issue-escalation.ts"
 export {
   type CreateIssueFromScoreError,
   type CreateIssueFromScoreInput,

--- a/packages/domain/issues/src/ports/issue-repository.ts
+++ b/packages/domain/issues/src/ports/issue-repository.ts
@@ -2,8 +2,26 @@ import type { IssueId, NotFoundError, ProjectId, RepositoryError, SqlClient } fr
 import { Context, type Effect } from "effect"
 import type { Issue } from "../entities/issue.ts"
 
+/**
+ * Lifecycle flags derived from `alert_incidents` rows joined onto an issue
+ * read. These are the stored truth for "is this issue currently escalating /
+ * regressed" — see `deriveIssueLifecycleStates`.
+ */
+export interface IssueLifecycleFlags {
+  readonly isEscalating: boolean
+  readonly isRegressed: boolean
+}
+
+/**
+ * Issue payload returned by read methods that JOIN `alert_incidents`. The
+ * lifecycle flags are attached as an extra property so existing consumers
+ * that just read `Issue` columns (e.g. `issue.name`, `issue.projectId`)
+ * keep working without changes.
+ */
+export type IssueWithLifecycle = Issue & { readonly lifecycle: IssueLifecycleFlags }
+
 export interface IssueListPage {
-  readonly items: readonly Issue[]
+  readonly items: readonly IssueWithLifecycle[]
   readonly hasMore: boolean
   readonly limit: number
   readonly offset: number
@@ -16,16 +34,21 @@ export interface ListIssuesRepositoryInput {
 }
 
 export interface IssueRepositoryShape {
-  findById(id: IssueId): Effect.Effect<Issue, NotFoundError | RepositoryError, SqlClient>
+  findById(id: IssueId): Effect.Effect<IssueWithLifecycle, NotFoundError | RepositoryError, SqlClient>
+  /**
+   * Locking read used by lifecycle write paths (resolve, ignore, etc.).
+   * Returns plain `Issue` — lifecycle flags would require an extra JOIN
+   * that callers in this path don't need.
+   */
   findByIdForUpdate(id: IssueId): Effect.Effect<Issue, NotFoundError | RepositoryError, SqlClient>
   findByIds(input: {
     readonly projectId: ProjectId
     readonly issueIds: readonly IssueId[]
-  }): Effect.Effect<readonly Issue[], RepositoryError, SqlClient>
+  }): Effect.Effect<readonly IssueWithLifecycle[], RepositoryError, SqlClient>
   findByUuid(input: {
     readonly projectId: ProjectId
     readonly uuid: string
-  }): Effect.Effect<Issue, NotFoundError | RepositoryError, SqlClient>
+  }): Effect.Effect<IssueWithLifecycle, NotFoundError | RepositoryError, SqlClient>
   save(issue: Issue): Effect.Effect<void, RepositoryError, SqlClient>
   list(input: ListIssuesRepositoryInput): Effect.Effect<IssueListPage, RepositoryError, SqlClient>
 }

--- a/packages/domain/issues/src/testing/fake-issue-repository.ts
+++ b/packages/domain/issues/src/testing/fake-issue-repository.ts
@@ -1,17 +1,41 @@
 import { NotFoundError } from "@domain/shared"
 import { Effect } from "effect"
 import type { Issue } from "../entities/issue.ts"
-import type { IssueRepositoryShape } from "../ports/issue-repository.ts"
+import type { IssueLifecycleFlags, IssueRepositoryShape, IssueWithLifecycle } from "../ports/issue-repository.ts"
 
-export const createFakeIssueRepository = (seed: readonly Issue[] = [], overrides?: Partial<IssueRepositoryShape>) => {
+const DEFAULT_LIFECYCLE: IssueLifecycleFlags = {
+  isEscalating: false,
+  isRegressed: false,
+}
+
+interface FakeIssueRepositoryOptions {
+  /**
+   * Per-issue lifecycle overlay. Tests that exercise escalation / regression
+   * derivation set the flags here per issue id; everything else defaults to
+   * `{ isEscalating: false, isRegressed: false }`.
+   */
+  readonly lifecycle?: ReadonlyMap<string, IssueLifecycleFlags>
+}
+
+export const createFakeIssueRepository = (
+  seed: readonly Issue[] = [],
+  overrides?: Partial<IssueRepositoryShape>,
+  options: FakeIssueRepositoryOptions = {},
+) => {
   const issues = new Map<string, Issue>(seed.map((issue) => [issue.id, issue] as const))
+  const lifecycleOverlay = new Map<string, IssueLifecycleFlags>(options.lifecycle ?? [])
+
+  const lifecycleFor = (issueId: string): IssueLifecycleFlags => lifecycleOverlay.get(issueId) ?? DEFAULT_LIFECYCLE
+
+  const withLifecycle = (issue: Issue): IssueWithLifecycle =>
+    Object.assign({}, issue, { lifecycle: lifecycleFor(issue.id) })
 
   const repository: IssueRepositoryShape = {
     findById: (id) =>
       Effect.gen(function* () {
         const issue = issues.get(id)
         if (!issue) return yield* new NotFoundError({ entity: "Issue", id })
-        return issue
+        return withLifecycle(issue)
       }),
 
     findByIdForUpdate: (id) =>
@@ -25,14 +49,15 @@ export const createFakeIssueRepository = (seed: readonly Issue[] = [], overrides
       Effect.sync(() =>
         issueIds
           .map((issueId) => issues.get(issueId))
-          .filter((issue): issue is Issue => issue !== undefined && issue.projectId === projectId),
+          .filter((issue): issue is Issue => issue !== undefined && issue.projectId === projectId)
+          .map(withLifecycle),
       ),
 
     findByUuid: ({ projectId, uuid }) =>
       Effect.gen(function* () {
         const issue = [...issues.values()].find((i) => i.projectId === projectId && i.uuid === uuid)
         if (!issue) return yield* new NotFoundError({ entity: "Issue", id: uuid })
-        return issue
+        return withLifecycle(issue)
       }),
 
     save: (issue) =>
@@ -47,7 +72,7 @@ export const createFakeIssueRepository = (seed: readonly Issue[] = [], overrides
           .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
         const window = rows.slice(offset, offset + limit + 1)
         return {
-          items: window.slice(0, limit),
+          items: window.slice(0, limit).map(withLifecycle),
           hasMore: window.length > limit,
           limit,
           offset,
@@ -57,5 +82,9 @@ export const createFakeIssueRepository = (seed: readonly Issue[] = [], overrides
     ...overrides,
   }
 
-  return { repository, issues }
+  const setLifecycle = (issueId: string, flags: IssueLifecycleFlags): void => {
+    lifecycleOverlay.set(issueId, flags)
+  }
+
+  return { repository, issues, setLifecycle }
 }

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -51,6 +51,7 @@ const provideTestLayers = (params: {
   readonly baselineAvgOccurrences?: number
   readonly events: OutboxWriteEvent[]
   readonly issueOverrides?: Parameters<typeof createFakeIssueRepository>[1]
+  readonly firstSeenAt?: Date
 }) => {
   const { repository: issueRepository, issues } = createFakeIssueRepository([params.issue], params.issueOverrides)
   const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
@@ -61,7 +62,7 @@ const provideTestLayers = (params: {
           totalOccurrences: params.recentOccurrences,
           recentOccurrences: params.recentOccurrences,
           baselineAvgOccurrences: params.baselineAvgOccurrences ?? 0,
-          firstSeenAt: new Date("2026-04-29T10:00:00.000Z"),
+          firstSeenAt: params.firstSeenAt ?? new Date("2026-04-01T10:00:00.000Z"),
           lastSeenAt: new Date("2026-05-07T10:00:00.000Z"),
         },
       ]),
@@ -93,10 +94,19 @@ const provideTestLayers = (params: {
 
 describe("checkIssueEscalationUseCase", () => {
   it("enters escalation when recent crosses entryThreshold", async () => {
-    const issue = makeIssue({ escalatedAt: null })
+    // Issue is well past the new-issue window so the isNew guard does not block entry.
+    const issue = makeIssue({
+      escalatedAt: null,
+      createdAt: new Date("2026-04-01T10:00:00.000Z"),
+    })
     const events: OutboxWriteEvent[] = []
     const recent = getEscalationOccurrenceThreshold(0) // baseline 0 → entry = 20
-    const { issues, apply } = provideTestLayers({ issue, recentOccurrences: recent, events })
+    const { issues, apply } = provideTestLayers({
+      issue,
+      recentOccurrences: recent,
+      events,
+      firstSeenAt: new Date("2026-04-01T10:00:00.000Z"),
+    })
 
     const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
 
@@ -110,6 +120,30 @@ describe("checkIssueEscalationUseCase", () => {
       aggregateId: issueId,
       payload: { organizationId, projectId, issueId },
     })
+  })
+
+  it("does not enter escalation while the issue is still new even if recent crosses entryThreshold", async () => {
+    // New issue (firstSeenAt within NEW_ISSUE_AGE_DAYS) — the isNew guard
+    // should block the entry transition. Mirrors deriveIssueLifecycleStates
+    // and avoids alerting on issues whose baseline window has not filled in.
+    const issue = makeIssue({
+      escalatedAt: null,
+      createdAt: new Date("2026-05-05T10:00:00.000Z"),
+    })
+    const events: OutboxWriteEvent[] = []
+    const { issues, apply } = provideTestLayers({
+      issue,
+      recentOccurrences: getEscalationOccurrenceThreshold(0) + 50,
+      events,
+      firstSeenAt: new Date("2026-05-05T10:00:00.000Z"),
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("none")
+    expect(result.currentlyEscalating).toBe(false)
+    expect(issues.get(issueId)?.escalatedAt).toBeNull()
+    expect(events).toHaveLength(0)
   })
 
   it("does not transition when not escalating and recent below entryThreshold", async () => {

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -5,7 +5,7 @@ import { ChSqlClient, IssueId, OrganizationId, SqlClient, type SqlClientShape } 
 import { createFakeChSqlClient } from "@domain/shared/testing"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
-import { CENTROID_EMBEDDING_DIMENSIONS, ESCALATION_MIN_OCCURRENCES_THRESHOLD } from "../constants.ts"
+import { ESCALATION_MIN_OCCURRENCES_THRESHOLD } from "../constants.ts"
 import type { Issue } from "../entities/issue.ts"
 import { createIssueCentroid, getEscalationExitThreshold, getEscalationOccurrenceThreshold } from "../helpers.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
@@ -15,8 +15,6 @@ import { checkIssueEscalationUseCase } from "./check-issue-escalation.ts"
 const organizationId = "oooooooooooooooooooooooo"
 const projectId = "pppppppppppppppppppppppp"
 const issueId = "iiiiiiiiiiiiiiiiiiiiiiii"
-
-void CENTROID_EMBEDDING_DIMENSIONS // imported for completeness
 
 const makeIssue = (overrides?: Partial<Issue>): Issue => ({
   id: IssueId(issueId),
@@ -47,13 +45,15 @@ const createPassthroughSqlClient = (id: string): SqlClientShape => {
 
 const provideTestLayers = (params: {
   readonly issue: Issue
+  readonly isEscalating?: boolean
   readonly recentOccurrences: number
   readonly baselineAvgOccurrences?: number
   readonly events: OutboxWriteEvent[]
-  readonly issueOverrides?: Parameters<typeof createFakeIssueRepository>[1]
   readonly firstSeenAt?: Date
 }) => {
-  const { repository: issueRepository, issues } = createFakeIssueRepository([params.issue], params.issueOverrides)
+  const { repository: issueRepository } = createFakeIssueRepository([params.issue], undefined, {
+    lifecycle: new Map([[params.issue.id, { isEscalating: params.isEscalating ?? false, isRegressed: false }]]),
+  })
   const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
     aggregateByIssues: () =>
       Effect.succeed([
@@ -69,7 +69,6 @@ const provideTestLayers = (params: {
   })
 
   return {
-    issues,
     apply: <A, E>(
       effect: Effect.Effect<
         A,
@@ -93,17 +92,13 @@ const provideTestLayers = (params: {
 }
 
 describe("checkIssueEscalationUseCase", () => {
-  it("enters escalation when recent crosses entryThreshold", async () => {
-    // Issue is well past the new-issue window so the isNew guard does not block entry.
-    const issue = makeIssue({
-      escalatedAt: null,
-      createdAt: new Date("2026-04-01T10:00:00.000Z"),
-    })
+  it("emits IssueEscalated when an older issue crosses the entryThreshold", async () => {
+    const issue = makeIssue({ createdAt: new Date("2026-04-01T10:00:00.000Z") })
     const events: OutboxWriteEvent[] = []
-    const recent = getEscalationOccurrenceThreshold(0) // baseline 0 → entry = 20
-    const { issues, apply } = provideTestLayers({
+    const { apply } = provideTestLayers({
       issue,
-      recentOccurrences: recent,
+      isEscalating: false,
+      recentOccurrences: getEscalationOccurrenceThreshold(0),
       events,
       firstSeenAt: new Date("2026-04-01T10:00:00.000Z"),
     })
@@ -112,7 +107,6 @@ describe("checkIssueEscalationUseCase", () => {
 
     expect(result.transition).toBe("entered")
     expect(result.currentlyEscalating).toBe(true)
-    expect(issues.get(issueId)?.escalatedAt).not.toBeNull()
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({
       eventName: "IssueEscalated",
@@ -122,17 +116,13 @@ describe("checkIssueEscalationUseCase", () => {
     })
   })
 
-  it("does not enter escalation while the issue is still new even if recent crosses entryThreshold", async () => {
-    // New issue (firstSeenAt within NEW_ISSUE_AGE_DAYS) — the isNew guard
-    // should block the entry transition. Mirrors deriveIssueLifecycleStates
-    // and avoids alerting on issues whose baseline window has not filled in.
-    const issue = makeIssue({
-      escalatedAt: null,
-      createdAt: new Date("2026-05-05T10:00:00.000Z"),
-    })
+  it("does not emit IssueEscalated while the issue is still new", async () => {
+    // firstSeenAt within NEW_ISSUE_AGE_DAYS of now → isNew guard blocks entry.
+    const issue = makeIssue({ createdAt: new Date("2026-05-05T10:00:00.000Z") })
     const events: OutboxWriteEvent[] = []
-    const { issues, apply } = provideTestLayers({
+    const { apply } = provideTestLayers({
       issue,
+      isEscalating: false,
       recentOccurrences: getEscalationOccurrenceThreshold(0) + 50,
       events,
       firstSeenAt: new Date("2026-05-05T10:00:00.000Z"),
@@ -142,15 +132,14 @@ describe("checkIssueEscalationUseCase", () => {
 
     expect(result.transition).toBe("none")
     expect(result.currentlyEscalating).toBe(false)
-    expect(issues.get(issueId)?.escalatedAt).toBeNull()
     expect(events).toHaveLength(0)
   })
 
-  it("does not transition when not escalating and recent below entryThreshold", async () => {
-    const issue = makeIssue({ escalatedAt: null })
+  it("does not transition when not escalating and recent is below entryThreshold", async () => {
     const events: OutboxWriteEvent[] = []
-    const { issues, apply } = provideTestLayers({
-      issue,
+    const { apply } = provideTestLayers({
+      issue: makeIssue(),
+      isEscalating: false,
       recentOccurrences: ESCALATION_MIN_OCCURRENCES_THRESHOLD - 1,
       events,
     })
@@ -159,21 +148,22 @@ describe("checkIssueEscalationUseCase", () => {
 
     expect(result.transition).toBe("none")
     expect(result.currentlyEscalating).toBe(false)
-    expect(issues.get(issueId)?.escalatedAt).toBeNull()
     expect(events).toHaveLength(0)
   })
 
-  it("exits escalation when recent drops below exitThreshold", async () => {
-    const issue = makeIssue({ escalatedAt: new Date("2026-05-06T10:00:00.000Z") })
+  it("emits IssueEscalationEnded when recent drops below exitThreshold", async () => {
     const events: OutboxWriteEvent[] = []
-    const exitT = getEscalationExitThreshold(0)
-    const { issues, apply } = provideTestLayers({ issue, recentOccurrences: exitT - 1, events })
+    const { apply } = provideTestLayers({
+      issue: makeIssue(),
+      isEscalating: true,
+      recentOccurrences: getEscalationExitThreshold(0) - 1,
+      events,
+    })
 
     const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
 
     expect(result.transition).toBe("exited")
     expect(result.currentlyEscalating).toBe(false)
-    expect(issues.get(issueId)?.escalatedAt).toBeNull()
     expect(events).toHaveLength(1)
     expect(events[0]).toMatchObject({
       eventName: "IssueEscalationEnded",
@@ -184,9 +174,8 @@ describe("checkIssueEscalationUseCase", () => {
   })
 
   it("holds the escalating state inside the hysteresis band (between exit and entry)", async () => {
-    const issue = makeIssue({ escalatedAt: new Date("2026-05-06T10:00:00.000Z") })
     const events: OutboxWriteEvent[] = []
-    // Use a non-zero baseline so exit < entry (with baseline=0 they're 14 vs 20).
+    // baseline > 0 so exit < entry strictly (with baseline=0 they're 14 vs 20).
     const baseline = 5
     const entry = getEscalationOccurrenceThreshold(baseline)
     const exit = getEscalationExitThreshold(baseline)
@@ -194,8 +183,9 @@ describe("checkIssueEscalationUseCase", () => {
     expect(between).toBeGreaterThanOrEqual(exit)
     expect(between).toBeLessThan(entry)
 
-    const { issues, apply } = provideTestLayers({
-      issue,
+    const { apply } = provideTestLayers({
+      issue: makeIssue(),
+      isEscalating: true,
       recentOccurrences: between,
       baselineAvgOccurrences: baseline,
       events,
@@ -205,16 +195,14 @@ describe("checkIssueEscalationUseCase", () => {
 
     expect(result.transition).toBe("none")
     expect(result.currentlyEscalating).toBe(true)
-    expect(issues.get(issueId)?.escalatedAt).not.toBeNull()
     expect(events).toHaveLength(0)
   })
 
-  it("does not re-emit when already escalating and still above entry", async () => {
-    const previouslyEscalatedAt = new Date("2026-05-06T10:00:00.000Z")
-    const issue = makeIssue({ escalatedAt: previouslyEscalatedAt })
+  it("does not re-emit IssueEscalated when already escalating and still above entry", async () => {
     const events: OutboxWriteEvent[] = []
-    const { issues, apply } = provideTestLayers({
-      issue,
+    const { apply } = provideTestLayers({
+      issue: makeIssue(),
+      isEscalating: true,
       recentOccurrences: getEscalationOccurrenceThreshold(0) + 5,
       events,
     })
@@ -223,7 +211,6 @@ describe("checkIssueEscalationUseCase", () => {
 
     expect(result.transition).toBe("none")
     expect(result.currentlyEscalating).toBe(true)
-    expect(issues.get(issueId)?.escalatedAt?.getTime()).toBe(previouslyEscalatedAt.getTime())
     expect(events).toHaveLength(0)
   })
 })

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -1,0 +1,195 @@
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository } from "@domain/scores/testing"
+import { ChSqlClient, IssueId, OrganizationId, SqlClient, type SqlClientShape } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { CENTROID_EMBEDDING_DIMENSIONS, ESCALATION_MIN_OCCURRENCES_THRESHOLD } from "../constants.ts"
+import type { Issue } from "../entities/issue.ts"
+import { createIssueCentroid, getEscalationExitThreshold, getEscalationOccurrenceThreshold } from "../helpers.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+import { createFakeIssueRepository } from "../testing/fake-issue-repository.ts"
+import { checkIssueEscalationUseCase } from "./check-issue-escalation.ts"
+
+const organizationId = "oooooooooooooooooooooooo"
+const projectId = "pppppppppppppppppppppppp"
+const issueId = "iiiiiiiiiiiiiiiiiiiiiiii"
+
+void CENTROID_EMBEDDING_DIMENSIONS // imported for completeness
+
+const makeIssue = (overrides?: Partial<Issue>): Issue => ({
+  id: IssueId(issueId),
+  uuid: "11111111-1111-4111-8111-111111111111",
+  organizationId,
+  projectId,
+  name: "Token leakage in responses",
+  description: "The assistant leaks API tokens in its response.",
+  source: "annotation",
+  centroid: createIssueCentroid(),
+  clusteredAt: new Date("2026-04-29T10:00:00.000Z"),
+  escalatedAt: null,
+  resolvedAt: null,
+  ignoredAt: null,
+  createdAt: new Date("2026-04-29T10:00:00.000Z"),
+  updatedAt: new Date("2026-04-29T10:00:00.000Z"),
+  ...overrides,
+})
+
+const createPassthroughSqlClient = (id: string): SqlClientShape => {
+  const sqlClient: SqlClientShape = {
+    organizationId: OrganizationId(id),
+    transaction: (effect) => effect.pipe(Effect.provideService(SqlClient, sqlClient)),
+    query: () => Effect.die("Unexpected direct SQL query in unit test"),
+  }
+  return sqlClient
+}
+
+const provideTestLayers = (params: {
+  readonly issue: Issue
+  readonly recentOccurrences: number
+  readonly baselineAvgOccurrences?: number
+  readonly events: OutboxWriteEvent[]
+  readonly issueOverrides?: Parameters<typeof createFakeIssueRepository>[1]
+}) => {
+  const { repository: issueRepository, issues } = createFakeIssueRepository([params.issue], params.issueOverrides)
+  const { repository: scoreAnalyticsRepository } = createFakeScoreAnalyticsRepository({
+    aggregateByIssues: () =>
+      Effect.succeed([
+        {
+          issueId: IssueId(issueId),
+          totalOccurrences: params.recentOccurrences,
+          recentOccurrences: params.recentOccurrences,
+          baselineAvgOccurrences: params.baselineAvgOccurrences ?? 0,
+          firstSeenAt: new Date("2026-04-29T10:00:00.000Z"),
+          lastSeenAt: new Date("2026-05-07T10:00:00.000Z"),
+        },
+      ]),
+  })
+
+  return {
+    issues,
+    apply: <A, E>(
+      effect: Effect.Effect<
+        A,
+        E,
+        ScoreAnalyticsRepository | IssueRepository | OutboxEventWriter | SqlClient | ChSqlClient
+      >,
+    ) =>
+      effect.pipe(
+        Effect.provideService(ScoreAnalyticsRepository, scoreAnalyticsRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(OutboxEventWriter, {
+          write: (event) =>
+            Effect.sync(() => {
+              params.events.push(event)
+            }),
+        }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+        Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(organizationId) })),
+      ),
+  }
+}
+
+describe("checkIssueEscalationUseCase", () => {
+  it("enters escalation when recent crosses entryThreshold", async () => {
+    const issue = makeIssue({ escalatedAt: null })
+    const events: OutboxWriteEvent[] = []
+    const recent = getEscalationOccurrenceThreshold(0) // baseline 0 → entry = 20
+    const { issues, apply } = provideTestLayers({ issue, recentOccurrences: recent, events })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("entered")
+    expect(result.currentlyEscalating).toBe(true)
+    expect(issues.get(issueId)?.escalatedAt).not.toBeNull()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IssueEscalated",
+      aggregateType: "issue",
+      aggregateId: issueId,
+      payload: { organizationId, projectId, issueId },
+    })
+  })
+
+  it("does not transition when not escalating and recent below entryThreshold", async () => {
+    const issue = makeIssue({ escalatedAt: null })
+    const events: OutboxWriteEvent[] = []
+    const { issues, apply } = provideTestLayers({
+      issue,
+      recentOccurrences: ESCALATION_MIN_OCCURRENCES_THRESHOLD - 1,
+      events,
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("none")
+    expect(result.currentlyEscalating).toBe(false)
+    expect(issues.get(issueId)?.escalatedAt).toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it("exits escalation when recent drops below exitThreshold", async () => {
+    const issue = makeIssue({ escalatedAt: new Date("2026-05-06T10:00:00.000Z") })
+    const events: OutboxWriteEvent[] = []
+    const exitT = getEscalationExitThreshold(0)
+    const { issues, apply } = provideTestLayers({ issue, recentOccurrences: exitT - 1, events })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("exited")
+    expect(result.currentlyEscalating).toBe(false)
+    expect(issues.get(issueId)?.escalatedAt).toBeNull()
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      eventName: "IssueEscalationEnded",
+      aggregateType: "issue",
+      aggregateId: issueId,
+      payload: { organizationId, projectId, issueId },
+    })
+  })
+
+  it("holds the escalating state inside the hysteresis band (between exit and entry)", async () => {
+    const issue = makeIssue({ escalatedAt: new Date("2026-05-06T10:00:00.000Z") })
+    const events: OutboxWriteEvent[] = []
+    // Use a non-zero baseline so exit < entry (with baseline=0 they're 14 vs 20).
+    const baseline = 5
+    const entry = getEscalationOccurrenceThreshold(baseline)
+    const exit = getEscalationExitThreshold(baseline)
+    const between = Math.floor((entry + exit) / 2)
+    expect(between).toBeGreaterThanOrEqual(exit)
+    expect(between).toBeLessThan(entry)
+
+    const { issues, apply } = provideTestLayers({
+      issue,
+      recentOccurrences: between,
+      baselineAvgOccurrences: baseline,
+      events,
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("none")
+    expect(result.currentlyEscalating).toBe(true)
+    expect(issues.get(issueId)?.escalatedAt).not.toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it("does not re-emit when already escalating and still above entry", async () => {
+    const previouslyEscalatedAt = new Date("2026-05-06T10:00:00.000Z")
+    const issue = makeIssue({ escalatedAt: previouslyEscalatedAt })
+    const events: OutboxWriteEvent[] = []
+    const { issues, apply } = provideTestLayers({
+      issue,
+      recentOccurrences: getEscalationOccurrenceThreshold(0) + 5,
+      events,
+    })
+
+    const result = await Effect.runPromise(apply(checkIssueEscalationUseCase({ organizationId, projectId, issueId })))
+
+    expect(result.transition).toBe("none")
+    expect(result.currentlyEscalating).toBe(true)
+    expect(issues.get(issueId)?.escalatedAt?.getTime()).toBe(previouslyEscalatedAt.getTime())
+    expect(events).toHaveLength(0)
+  })
+})

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -3,7 +3,7 @@ import { ScoreAnalyticsRepository } from "@domain/scores"
 import { type ChSqlClient, IssueId, OrganizationId, ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { IssueNotFoundForAssignmentError } from "../errors.ts"
-import { getEscalationExitThreshold, getEscalationOccurrenceThreshold } from "../helpers.ts"
+import { getEscalationExitThreshold, getEscalationOccurrenceThreshold, isIssueNew } from "../helpers.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
 
 export interface CheckIssueEscalationInput {
@@ -24,12 +24,19 @@ export type CheckIssueEscalationError = RepositoryError | IssueNotFoundForAssign
 /**
  * Reify the (otherwise read-time-derived) escalating state on an issue.
  *
- * Entry: previously not escalating, `recentOccurrences >= entryThreshold`.
- * Sets `escalatedAt = now`, emits `IssueEscalated`.
+ * Entry: previously not escalating, the issue is no longer "new", and
+ * `recentOccurrences >= entryThreshold`. Sets `escalatedAt = now`, emits
+ * `IssueEscalated`.
  *
  * Exit: previously escalating, `recentOccurrences < exitThreshold` (lower
  * than the entry threshold by `ESCALATION_EXIT_THRESHOLD_FACTOR` to prevent
  * flapping at the boundary). Clears `escalatedAt`, emits `IssueEscalationEnded`.
+ *
+ * The `isIssueNew` guard mirrors `deriveIssueLifecycleStates`: new issues
+ * have no real baseline to compare against (the baseline window is days
+ * 1–8 ago, which hasn't filled in yet), so any volume above the floor
+ * would falsely trip the threshold. The discrete `issue.new` alert covers
+ * that case.
  *
  * Idempotent: the stored `escalatedAt` field gates re-emission, mirroring
  * the regression-detection pattern in `assign-score-to-issue.ts`.
@@ -72,8 +79,9 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
 
         const wasEscalating = issue.escalatedAt !== null
         const now = new Date()
+        const firstSeenAt = aggregate?.firstSeenAt ?? issue.createdAt
 
-        if (!wasEscalating && recent >= entryThreshold) {
+        if (!wasEscalating && !isIssueNew(firstSeenAt, now) && recent >= entryThreshold) {
           yield* issueRepository.save({ ...issue, escalatedAt: now, updatedAt: now })
           yield* outboxEventWriter.write({
             eventName: "IssueEscalated",

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -1,0 +1,126 @@
+import { OutboxEventWriter } from "@domain/events"
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import { type ChSqlClient, IssueId, OrganizationId, ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import { Effect } from "effect"
+import { IssueNotFoundForAssignmentError } from "../errors.ts"
+import { getEscalationExitThreshold, getEscalationOccurrenceThreshold } from "../helpers.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
+
+export interface CheckIssueEscalationInput {
+  readonly organizationId: string
+  readonly projectId: string
+  readonly issueId: string
+}
+
+export type CheckIssueEscalationTransition = "entered" | "exited" | "none"
+
+export interface CheckIssueEscalationResult {
+  readonly transition: CheckIssueEscalationTransition
+  readonly currentlyEscalating: boolean
+}
+
+export type CheckIssueEscalationError = RepositoryError | IssueNotFoundForAssignmentError
+
+/**
+ * Reify the (otherwise read-time-derived) escalating state on an issue.
+ *
+ * Entry: previously not escalating, `recentOccurrences >= entryThreshold`.
+ * Sets `escalatedAt = now`, emits `IssueEscalated`.
+ *
+ * Exit: previously escalating, `recentOccurrences < exitThreshold` (lower
+ * than the entry threshold by `ESCALATION_EXIT_THRESHOLD_FACTOR` to prevent
+ * flapping at the boundary). Clears `escalatedAt`, emits `IssueEscalationEnded`.
+ *
+ * Idempotent: the stored `escalatedAt` field gates re-emission, mirroring
+ * the regression-detection pattern in `assign-score-to-issue.ts`.
+ */
+export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan("issueId", input.issueId)
+    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
+    const sqlClient = yield* SqlClient
+    const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+
+    // Aggregate is read from ClickHouse outside the Postgres transaction —
+    // it's a read-only analytics query that doesn't need transactional
+    // consistency with the issue write below.
+    const aggregates = yield* scoreAnalyticsRepository.aggregateByIssues({
+      organizationId: OrganizationId(input.organizationId),
+      projectId: ProjectId(input.projectId),
+      issueIds: [IssueId(input.issueId)],
+    })
+    const aggregate = aggregates[0]
+    const recent = aggregate?.recentOccurrences ?? 0
+    const baseline = aggregate?.baselineAvgOccurrences ?? 0
+
+    const entryThreshold = getEscalationOccurrenceThreshold(baseline)
+    const exitThreshold = getEscalationExitThreshold(baseline)
+
+    return yield* sqlClient.transaction(
+      Effect.gen(function* () {
+        const issueRepository = yield* IssueRepository
+        const outboxEventWriter = yield* OutboxEventWriter
+
+        const issue = yield* issueRepository
+          .findByIdForUpdate(IssueId(input.issueId))
+          .pipe(
+            Effect.catchTag("NotFoundError", () =>
+              Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
+            ),
+          )
+
+        const wasEscalating = issue.escalatedAt !== null
+        const now = new Date()
+
+        if (!wasEscalating && recent >= entryThreshold) {
+          yield* issueRepository.save({ ...issue, escalatedAt: now, updatedAt: now })
+          yield* outboxEventWriter.write({
+            eventName: "IssueEscalated",
+            aggregateType: "issue",
+            aggregateId: issue.id,
+            organizationId: issue.organizationId,
+            payload: {
+              organizationId: issue.organizationId,
+              projectId: issue.projectId,
+              issueId: issue.id,
+              escalatedAt: now.toISOString(),
+            },
+          })
+          return {
+            transition: "entered",
+            currentlyEscalating: true,
+          } satisfies CheckIssueEscalationResult
+        }
+
+        if (wasEscalating && recent < exitThreshold) {
+          yield* issueRepository.save({ ...issue, escalatedAt: null, updatedAt: now })
+          yield* outboxEventWriter.write({
+            eventName: "IssueEscalationEnded",
+            aggregateType: "issue",
+            aggregateId: issue.id,
+            organizationId: issue.organizationId,
+            payload: {
+              organizationId: issue.organizationId,
+              projectId: issue.projectId,
+              issueId: issue.id,
+              endedAt: now.toISOString(),
+            },
+          })
+          return {
+            transition: "exited",
+            currentlyEscalating: false,
+          } satisfies CheckIssueEscalationResult
+        }
+
+        return {
+          transition: "none",
+          currentlyEscalating: wasEscalating,
+        } satisfies CheckIssueEscalationResult
+      }),
+    )
+  }).pipe(Effect.withSpan("issues.checkIssueEscalation")) as Effect.Effect<
+    CheckIssueEscalationResult,
+    CheckIssueEscalationError,
+    SqlClient | ChSqlClient | IssueRepository | ScoreAnalyticsRepository | OutboxEventWriter
+  >

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -1,6 +1,13 @@
 import { OutboxEventWriter } from "@domain/events"
 import { ScoreAnalyticsRepository } from "@domain/scores"
-import { type ChSqlClient, IssueId, OrganizationId, ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
+import {
+  type ChSqlClient,
+  IssueId,
+  OrganizationId,
+  ProjectId,
+  type RepositoryError,
+  type SqlClient,
+} from "@domain/shared"
 import { Effect } from "effect"
 import { IssueNotFoundForAssignmentError } from "../errors.ts"
 import { getEscalationExitThreshold, getEscalationOccurrenceThreshold, isIssueNew } from "../helpers.ts"
@@ -22,36 +29,49 @@ export interface CheckIssueEscalationResult {
 export type CheckIssueEscalationError = RepositoryError | IssueNotFoundForAssignmentError
 
 /**
- * Reify the (otherwise read-time-derived) escalating state on an issue.
+ * Decide whether an issue's escalation state has transitioned and emit the
+ * matching event. The "currently escalating" truth lives on the
+ * `alert_incidents` table — read here via `IssueRepository.findById`'s
+ * joined `lifecycle.isEscalating` flag — and on/off transitions are
+ * actuated by emitting `IssueEscalated` / `IssueEscalationEnded`. The
+ * downstream alert-incidents worker is what creates / closes the
+ * `alert_incidents` row, so this use case never writes the issue itself.
  *
- * Entry: previously not escalating, the issue is no longer "new", and
- * `recentOccurrences >= entryThreshold`. Sets `escalatedAt = now`, emits
- * `IssueEscalated`.
+ * Entry: not currently escalating, the issue is no longer "new", and
+ * `recentOccurrences >= entryThreshold`.
  *
- * Exit: previously escalating, `recentOccurrences < exitThreshold` (lower
- * than the entry threshold by `ESCALATION_EXIT_THRESHOLD_FACTOR` to prevent
- * flapping at the boundary). Clears `escalatedAt`, emits `IssueEscalationEnded`.
+ * Exit: currently escalating and `recentOccurrences < exitThreshold`
+ * (lower than entry by `ESCALATION_EXIT_THRESHOLD_FACTOR` to prevent
+ * flapping). Sustained-but-not-rising volume keeps the incident open
+ * until the rolling baseline catches up.
  *
- * The `isIssueNew` guard mirrors `deriveIssueLifecycleStates`: new issues
- * have no real baseline to compare against (the baseline window is days
- * 1–8 ago, which hasn't filled in yet), so any volume above the floor
- * would falsely trip the threshold. The discrete `issue.new` alert covers
- * that case.
+ * The `isIssueNew` guard mirrors `deriveIssueLifecycleStates` — new issues
+ * have no real baseline (the baseline window is days 1–8 ago, not yet
+ * filled in), so any volume above the floor would falsely trip entry.
  *
- * Idempotent: the stored `escalatedAt` field gates re-emission, mirroring
- * the regression-detection pattern in `assign-score-to-issue.ts`.
+ * Idempotent: the open `issue.escalating` row in `alert_incidents` (read
+ * via the lifecycle flag) gates re-emission. A re-run after a transition
+ * sees the flipped state and no-ops.
  */
 export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("issueId", input.issueId)
     yield* Effect.annotateCurrentSpan("projectId", input.projectId)
 
-    const sqlClient = yield* SqlClient
+    const issueRepository = yield* IssueRepository
     const scoreAnalyticsRepository = yield* ScoreAnalyticsRepository
+    const outboxEventWriter = yield* OutboxEventWriter
 
-    // Aggregate is read from ClickHouse outside the Postgres transaction —
-    // it's a read-only analytics query that doesn't need transactional
-    // consistency with the issue write below.
+    const issueWithLifecycle = yield* issueRepository
+      .findById(IssueId(input.issueId))
+      .pipe(
+        Effect.catchTag("NotFoundError", () =>
+          Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
+        ),
+      )
+
+    const wasEscalating = issueWithLifecycle.lifecycle.isEscalating
+
     const aggregates = yield* scoreAnalyticsRepository.aggregateByIssues({
       organizationId: OrganizationId(input.organizationId),
       projectId: ProjectId(input.projectId),
@@ -60,73 +80,54 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
     const aggregate = aggregates[0]
     const recent = aggregate?.recentOccurrences ?? 0
     const baseline = aggregate?.baselineAvgOccurrences ?? 0
+    const firstSeenAt = aggregate?.firstSeenAt ?? issueWithLifecycle.createdAt
 
     const entryThreshold = getEscalationOccurrenceThreshold(baseline)
     const exitThreshold = getEscalationExitThreshold(baseline)
+    const now = new Date()
 
-    return yield* sqlClient.transaction(
-      Effect.gen(function* () {
-        const issueRepository = yield* IssueRepository
-        const outboxEventWriter = yield* OutboxEventWriter
+    if (!wasEscalating && !isIssueNew(firstSeenAt, now) && recent >= entryThreshold) {
+      yield* outboxEventWriter.write({
+        eventName: "IssueEscalated",
+        aggregateType: "issue",
+        aggregateId: issueWithLifecycle.id,
+        organizationId: issueWithLifecycle.organizationId,
+        payload: {
+          organizationId: issueWithLifecycle.organizationId,
+          projectId: issueWithLifecycle.projectId,
+          issueId: issueWithLifecycle.id,
+          escalatedAt: now.toISOString(),
+        },
+      })
+      return {
+        transition: "entered",
+        currentlyEscalating: true,
+      } satisfies CheckIssueEscalationResult
+    }
 
-        const issue = yield* issueRepository
-          .findByIdForUpdate(IssueId(input.issueId))
-          .pipe(
-            Effect.catchTag("NotFoundError", () =>
-              Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
-            ),
-          )
+    if (wasEscalating && recent < exitThreshold) {
+      yield* outboxEventWriter.write({
+        eventName: "IssueEscalationEnded",
+        aggregateType: "issue",
+        aggregateId: issueWithLifecycle.id,
+        organizationId: issueWithLifecycle.organizationId,
+        payload: {
+          organizationId: issueWithLifecycle.organizationId,
+          projectId: issueWithLifecycle.projectId,
+          issueId: issueWithLifecycle.id,
+          endedAt: now.toISOString(),
+        },
+      })
+      return {
+        transition: "exited",
+        currentlyEscalating: false,
+      } satisfies CheckIssueEscalationResult
+    }
 
-        const wasEscalating = issue.escalatedAt !== null
-        const now = new Date()
-        const firstSeenAt = aggregate?.firstSeenAt ?? issue.createdAt
-
-        if (!wasEscalating && !isIssueNew(firstSeenAt, now) && recent >= entryThreshold) {
-          yield* issueRepository.save({ ...issue, escalatedAt: now, updatedAt: now })
-          yield* outboxEventWriter.write({
-            eventName: "IssueEscalated",
-            aggregateType: "issue",
-            aggregateId: issue.id,
-            organizationId: issue.organizationId,
-            payload: {
-              organizationId: issue.organizationId,
-              projectId: issue.projectId,
-              issueId: issue.id,
-              escalatedAt: now.toISOString(),
-            },
-          })
-          return {
-            transition: "entered",
-            currentlyEscalating: true,
-          } satisfies CheckIssueEscalationResult
-        }
-
-        if (wasEscalating && recent < exitThreshold) {
-          yield* issueRepository.save({ ...issue, escalatedAt: null, updatedAt: now })
-          yield* outboxEventWriter.write({
-            eventName: "IssueEscalationEnded",
-            aggregateType: "issue",
-            aggregateId: issue.id,
-            organizationId: issue.organizationId,
-            payload: {
-              organizationId: issue.organizationId,
-              projectId: issue.projectId,
-              issueId: issue.id,
-              endedAt: now.toISOString(),
-            },
-          })
-          return {
-            transition: "exited",
-            currentlyEscalating: false,
-          } satisfies CheckIssueEscalationResult
-        }
-
-        return {
-          transition: "none",
-          currentlyEscalating: wasEscalating,
-        } satisfies CheckIssueEscalationResult
-      }),
-    )
+    return {
+      transition: "none",
+      currentlyEscalating: wasEscalating,
+    } satisfies CheckIssueEscalationResult
   }).pipe(Effect.withSpan("issues.checkIssueEscalation")) as Effect.Effect<
     CheckIssueEscalationResult,
     CheckIssueEscalationError,

--- a/packages/domain/issues/src/use-cases/check-issue-escalation.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.ts
@@ -9,7 +9,7 @@ import {
   type SqlClient,
 } from "@domain/shared"
 import { Effect } from "effect"
-import { IssueNotFoundForAssignmentError } from "../errors.ts"
+import { IssueNotFoundForEscalationCheckError } from "../errors.ts"
 import { getEscalationExitThreshold, getEscalationOccurrenceThreshold, isIssueNew } from "../helpers.ts"
 import { IssueRepository } from "../ports/issue-repository.ts"
 
@@ -26,7 +26,7 @@ export interface CheckIssueEscalationResult {
   readonly currentlyEscalating: boolean
 }
 
-export type CheckIssueEscalationError = RepositoryError | IssueNotFoundForAssignmentError
+export type CheckIssueEscalationError = RepositoryError | IssueNotFoundForEscalationCheckError
 
 /**
  * Decide whether an issue's escalation state has transitioned and emit the
@@ -66,7 +66,7 @@ export const checkIssueEscalationUseCase = (input: CheckIssueEscalationInput) =>
       .findById(IssueId(input.issueId))
       .pipe(
         Effect.catchTag("NotFoundError", () =>
-          Effect.fail(new IssueNotFoundForAssignmentError({ issueId: input.issueId })),
+          Effect.fail(new IssueNotFoundForEscalationCheckError({ issueId: input.issueId })),
         ),
       )
 

--- a/packages/domain/issues/src/use-cases/list-issues.test.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.test.ts
@@ -339,11 +339,16 @@ describe("listIssuesUseCase", () => {
         states: [IssueState.New],
       },
       {
+        // The regressed lifecycle state is no longer derived from
+        // (resolvedAt + lastSeenAt) — regression is reified at write time
+        // (which clears resolvedAt) and lives in alert_incidents. An issue
+        // with resolvedAt still set derives as Resolved. The "regressed
+        // recently" view is a UI follow-up against alert_incidents.
         id: regressedIssue.id,
-        states: [IssueState.Regressed],
+        states: [IssueState.Resolved],
       },
     ])
-    expect(result.analytics.counts.regressedIssues).toBe(1)
+    expect(result.analytics.counts.regressedIssues).toBe(0)
     expect(result.analytics.counts.seenOccurrences).toBe(12)
     expect(result.totalCount).toBe(3)
     expect(result.hasMore).toBe(true)
@@ -474,23 +479,28 @@ describe("listIssuesUseCase", () => {
     )
 
     expect(calls).toEqual([])
-    expect(result.analytics.counts.resolvedIssues).toBe(1)
-    expect(result.analytics.counts.regressedIssues).toBe(1)
+    // Regression is no longer derived; the previously "regressed" fixture
+    // (resolvedAt still set in this fixture) now derives as Resolved and
+    // therefore drops out of the lifecycleGroup="active" page along with
+    // the archived issue. Regression history is reified at write time and
+    // tracked via alert_incidents; UI hydration of "regressed recently"
+    // will use that table as a follow-up.
+    expect(result.analytics.counts.resolvedIssues).toBe(2)
+    expect(result.analytics.counts.regressedIssues).toBe(0)
     expect(result.analytics.counts.ongoingIssues).toBe(1)
     expect(result.analytics.counts.seenOccurrences).toBe(16)
-    expect(result.items.map((item) => item.states)).toEqual([[IssueState.Ongoing], [IssueState.Regressed]])
-    expect(result.items.map((item) => item.id)).toEqual([activeIssue.id, regressedIssue.id])
-    expect(result.occurrencesSum).toBe(9)
+    expect(result.items.map((item) => item.states)).toEqual([[IssueState.Ongoing]])
+    expect(result.items.map((item) => item.id)).toEqual([activeIssue.id])
+    expect(result.occurrencesSum).toBe(5)
     expect(result.items[0]?.affectedTracesPercent).toBe(0.5)
     expect(result.items[0]?.evaluations.map((evaluation) => evaluation.id)).toEqual([EvaluationId("1".repeat(24))])
-    expect(result.items[1]?.evaluations).toEqual([])
     expect(result.analytics.histogram).toHaveLength(7)
     expect(result.items[0]?.trend).toHaveLength(14)
-    expect(listByIssueIdsCalls).toEqual([[activeIssue.id, regressedIssue.id]])
+    expect(listByIssueIdsCalls).toEqual([[activeIssue.id]])
     expect(histogramInputs[0]?.issueIds).toEqual([activeIssue.id, regressedIssue.id, archivedIssue.id])
     expect(histogramInputs[0]?.from.toISOString()).toBe("2026-04-04T00:00:00.000Z")
     expect(histogramInputs[0]?.to.toISOString()).toBe("2026-04-10T23:59:59.999Z")
-    expect(trendInputs[0]?.issueIds).toEqual([activeIssue.id, regressedIssue.id])
+    expect(trendInputs[0]?.issueIds).toEqual([activeIssue.id])
     expect(trendInputs[0]?.from.toISOString()).toBe("2026-03-28T00:00:00.000Z")
     expect(trendInputs[0]?.to.toISOString()).toBe("2026-04-10T23:59:59.999Z")
   })

--- a/packages/domain/issues/src/use-cases/list-issues.ts
+++ b/packages/domain/issues/src/use-cases/list-issues.ts
@@ -18,10 +18,10 @@ import {
 } from "@domain/shared"
 import { Effect } from "effect"
 import { z } from "zod"
-import { type Issue, type IssueSource, IssueState } from "../entities/issue.ts"
+import { type IssueSource, IssueState } from "../entities/issue.ts"
 import { deriveIssueLifecycleStates, getEscalationOccurrenceThreshold } from "../helpers.ts"
 import { type IssueProjectionCandidate, IssueProjectionRepository } from "../ports/issue-projection-repository.ts"
-import { IssueRepository } from "../ports/issue-repository.ts"
+import { IssueRepository, type IssueWithLifecycle } from "../ports/issue-repository.ts"
 
 export const issuesLifecycleGroupSchema = z.enum(["active", "archived"])
 export type IssuesLifecycleGroup = z.infer<typeof issuesLifecycleGroupSchema>
@@ -115,7 +115,7 @@ export interface ListIssuesResult {
 }
 
 interface AnalyticsCandidate {
-  readonly issue: Issue
+  readonly issue: IssueWithLifecycle
   readonly windowMetric: IssueWindowMetric
   readonly lifecycleStates: readonly string[]
   readonly similarityScore: number | null
@@ -337,7 +337,7 @@ const sortCandidates = (
   })
 
 const toCandidate = (input: {
-  readonly issue: Issue
+  readonly issue: IssueWithLifecycle
   readonly windowMetric: IssueWindowMetric
   readonly occurrence: IssueOccurrenceAggregate | null
   readonly similarityScore: number | null
@@ -345,7 +345,8 @@ const toCandidate = (input: {
 }): AnalyticsCandidate => {
   const lifecycleStates = deriveIssueLifecycleStates({
     issue: input.issue,
-    occurrence: input.occurrence,
+    isEscalating: input.issue.lifecycle.isEscalating,
+    isRegressed: input.issue.lifecycle.isRegressed,
     now: input.now,
   })
 

--- a/packages/domain/issues/src/use-cases/resolve-matched-issue.test.ts
+++ b/packages/domain/issues/src/use-cases/resolve-matched-issue.test.ts
@@ -51,7 +51,7 @@ describe("resolveMatchedIssueUseCase", () => {
     const { repository: issueRepository } = createFakeIssueRepository([issue], {
       findByUuid: (input) => {
         findByUuidCalls.push(input)
-        return Effect.succeed(issue)
+        return Effect.succeed({ ...issue, lifecycle: { isEscalating: false, isRegressed: false } })
       },
     })
 

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -98,6 +98,18 @@ const _registry = {
       readonly regressedAt: string
       readonly triggerScoreId: string
     }
+    "issue-escalated": {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly issueId: string
+      readonly escalatedAt: string
+    }
+    "issue-escalation-ended": {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly issueId: string
+      readonly endedAt: string
+    }
   }>(),
 
   issues: payloads<{
@@ -108,6 +120,11 @@ const _registry = {
       readonly issueId: string | null
     }
     refresh: {
+      readonly organizationId: string
+      readonly projectId: string
+      readonly issueId: string
+    }
+    checkEscalation: {
       readonly organizationId: string
       readonly projectId: string
       readonly issueId: string

--- a/packages/domain/shared/src/seed-content/issues.ts
+++ b/packages/domain/shared/src/seed-content/issues.ts
@@ -38,6 +38,12 @@ export type SeedIssueFixture = {
   readonly createdDaysAgo: number
   readonly clusteredDaysAgo: number
   readonly updatedDaysAgo: number
+  /**
+   * DORMANT: not consumed by the seeder. "Currently escalating" is now
+   * derived from the actual occurrence pattern via `alert_incidents`. The
+   * field is kept on the fixture shape only because removing it would touch
+   * every fixture entry; new fixtures should set it to `null`.
+   */
   readonly escalatedDaysAgo: number | null
   readonly resolvedDaysAgo: number | null
   readonly ignoredDaysAgo: number | null
@@ -2251,8 +2257,218 @@ const extraIssueOccurrenceRows: readonly SeedIssueOccurrenceFixture[] = extraIss
   }))
 })
 
+// Today-bursts make a curated set of issues genuinely escalating per the
+// production threshold (recent >= max(20, baseline*1.33+1)). Without these
+// the seed data has very few naturally-escalating issues, and the alert
+// pipeline's data-driven labels would leave the demo nearly empty.
+const curatedIssueTodayBurstRows: readonly SeedIssueOccurrenceFixture[] = [
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_ISSUE_ID,
+    source: "evaluation",
+    sourceId: SEED_EVALUATION_ID,
+    idPrefix: "wt",
+    evaluationHash: SEED_WARRANTY_EVALUATION_HASH,
+    daysAgo: 0,
+    count: 25,
+    startHour: 6,
+    startMinute: 0,
+    minuteStep: 30,
+    value: 0.07,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase:
+      "Warranty monitor caught another rooftop reframe — the assistant offered coverage on an unsupported install in the last 24 hours.",
+    metadata: {
+      evaluationHash: SEED_WARRANTY_EVALUATION_HASH,
+      scenario: "today-warranty-spike",
+      severity: "high",
+      burstLabel: "warranty-today-spike",
+    },
+    duration: 760_000_000,
+    tokens: 1_640,
+    cost: 236_000,
+  }),
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_COMBINATION_ISSUE_ID,
+    source: "evaluation",
+    sourceId: SEED_COMBINATION_EVALUATION_ID,
+    idPrefix: "ct",
+    evaluationHash: SEED_COMBINATION_EVALUATION_HASH,
+    daysAgo: 0,
+    count: 25,
+    startHour: 5,
+    startMinute: 15,
+    minuteStep: 30,
+    value: 0.08,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase: "Combination monitor flagged a fresh wave of unsafe-product-pairing suggestions today.",
+    metadata: {
+      evaluationHash: SEED_COMBINATION_EVALUATION_HASH,
+      scenario: "today-combination-spike",
+      severity: "high",
+      burstLabel: "combination-today-spike",
+    },
+    duration: 790_000_000,
+    tokens: 1_720,
+    cost: 247_000,
+  }),
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_BILLING_ISSUE_ID,
+    source: "custom",
+    sourceId: "billing-monitor",
+    idPrefix: "bt",
+    evaluationHash: null,
+    daysAgo: 0,
+    count: 25,
+    startHour: 3,
+    startMinute: 45,
+    minuteStep: 30,
+    value: 0.07,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase:
+      "Billing audit caught the assistant inventing courtesy credits and retroactive fee waivers in a fresh batch of conversations today.",
+    metadata: {
+      scenario: "today-billing-spike",
+      severity: "high",
+      burstLabel: "billing-today-spike",
+    },
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+  }),
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_ACCESS_ISSUE_ID,
+    source: "evaluation",
+    sourceId: SEED_ACCESS_EVALUATION_ID,
+    idPrefix: "at",
+    evaluationHash: SEED_ACCESS_EVALUATION_HASH,
+    daysAgo: 0,
+    count: 25,
+    startHour: 2,
+    startMinute: 0,
+    minuteStep: 30,
+    value: 0.06,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase: "Access monitor detected another wave of weak-proof account-recovery escalations today.",
+    metadata: {
+      evaluationHash: SEED_ACCESS_EVALUATION_HASH,
+      scenario: "today-access-spike",
+      severity: "critical",
+      burstLabel: "access-today-spike",
+    },
+    duration: 812_000_000,
+    tokens: 1_910,
+    cost: 269_000,
+  }),
+]
+
+// Recent occurrences for issues designated as the regression demo. These
+// land 2–4 days ago — enough activity for the trend chart to show recent
+// hits, but well below the escalation threshold so they don't double-fire.
+// The issues seeder forces `resolvedAt = null` for these, and the
+// alert-incidents seeder inserts an `issue.regressed` row pointing at them.
+const curatedIssueRecentRegressionRows: readonly SeedIssueOccurrenceFixture[] = [
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_GENERATE_ISSUE_ID,
+    source: "custom",
+    sourceId: "logistics-monitor",
+    idPrefix: "lr",
+    evaluationHash: null,
+    daysAgo: 2,
+    count: 4,
+    startHour: 9,
+    startMinute: 30,
+    minuteStep: 90,
+    value: 0.1,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase:
+      "Logistics monitor caught the assistant inventing a guaranteed cliffside delivery option after the issue was thought resolved.",
+    metadata: {
+      scenario: "post-resolve-logistics-return",
+      severity: "high",
+      burstLabel: "logistics-regression",
+    },
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+  }),
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_INSTALLATION_ISSUE_ID,
+    source: "custom",
+    sourceId: "installation-monitor",
+    idPrefix: "ir",
+    evaluationHash: null,
+    daysAgo: 3,
+    count: 5,
+    startHour: 8,
+    startMinute: 0,
+    minuteStep: 75,
+    value: 0.09,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase:
+      "Installation monitor saw a fresh certified-installer override after the team thought the issue had been resolved.",
+    metadata: {
+      scenario: "post-resolve-installation-return",
+      severity: "high",
+      burstLabel: "installation-regression",
+    },
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+  }),
+  ...buildOccurrenceBurstRows({
+    issueId: SEED_FLAGGER_ISSUE_ID,
+    source: "custom",
+    sourceId: "flagger-monitor",
+    idPrefix: "fr",
+    evaluationHash: null,
+    daysAgo: 4,
+    count: 4,
+    startHour: 11,
+    startMinute: 15,
+    minuteStep: 60,
+    value: 0.08,
+    passed: false,
+    errored: false,
+    error: null,
+    feedbackBase: "Flagger monitor saw the empty-response pattern resurface in a small batch of new conversations.",
+    metadata: {
+      scenario: "post-resolve-flagger-return",
+      severity: "medium",
+      burstLabel: "flagger-regression",
+    },
+    duration: 0,
+    tokens: 0,
+    cost: 0,
+  }),
+]
+
 export const SEED_ADDITIONAL_ISSUE_OCCURRENCES: readonly SeedIssueOccurrenceFixture[] = [
   ...curatedIssueOccurrenceRows,
   ...curatedIssueOccurrenceBurstRows,
+  ...curatedIssueTodayBurstRows,
+  ...curatedIssueRecentRegressionRows,
   ...extraIssueOccurrenceRows,
+] as const
+
+/**
+ * Issue ids that the alert-incidents seeder treats as "currently regressed":
+ * the issues seeder forces `resolvedAt = null` for these, and an
+ * `issue.regressed` row is inserted so the read path derives Regressed.
+ */
+export const SEED_REGRESSED_ISSUE_IDS: readonly string[] = [
+  SEED_GENERATE_ISSUE_ID,
+  SEED_INSTALLATION_ISSUE_ID,
+  SEED_FLAGGER_ISSUE_ID,
 ] as const

--- a/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/alert-incident-repository.ts
@@ -1,5 +1,6 @@
 import { type AlertIncident, AlertIncidentRepository } from "@domain/alerts"
 import { SqlClient, type SqlClientShape } from "@domain/shared"
+import { and, eq, isNull } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
 import { alertIncidents } from "../schema/alert-incidents.ts"
@@ -26,6 +27,23 @@ export const AlertIncidentRepositoryLive = Layer.effect(
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           const row = toInsertRow(incident)
           yield* sqlClient.query((db) => db.insert(alertIncidents).values(row))
+        }),
+      closeOpen: ({ sourceType, sourceId, kind, endedAt }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          yield* sqlClient.query((db) =>
+            db
+              .update(alertIncidents)
+              .set({ endedAt })
+              .where(
+                and(
+                  eq(alertIncidents.sourceType, sourceType),
+                  eq(alertIncidents.sourceId, sourceId),
+                  eq(alertIncidents.kind, kind),
+                  isNull(alertIncidents.endedAt),
+                ),
+              ),
+          )
         }),
     }),
   ),

--- a/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.test.ts
@@ -8,6 +8,7 @@ import {
 import { IssueId, NotFoundError, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+import { alertIncidents as alertIncidentsTable } from "../schema/alert-incidents.ts"
 import { issues as issuesTable } from "../schema/issues.ts"
 import { scores as scoresTable } from "../schema/scores.ts"
 import { closeInMemoryPostgres, createInMemoryPostgres, type InMemoryPostgres } from "../test/in-memory-postgres.ts"
@@ -117,6 +118,7 @@ describe("IssueRepositoryLive", () => {
   })
 
   beforeEach(async () => {
+    await database.db.delete(alertIncidentsTable)
     await database.db.delete(scoresTable)
     await database.db.delete(issuesTable)
   })
@@ -362,5 +364,182 @@ describe("IssueRepositoryLive", () => {
     )
 
     expect(lockedIssue).toEqual(issue)
+  })
+
+  describe("lifecycle JOIN", () => {
+    it("findById attaches isEscalating=true when an open issue.escalating row exists", async () => {
+      const issue = makeIssue()
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* repository.save(issue)
+        }).pipe(makeProvider(database)),
+      )
+
+      await database.db.insert(alertIncidentsTable).values({
+        id: "ai-esc-open-aaaaaaaaaaa",
+        organizationId,
+        projectId: issue.projectId,
+        sourceType: "issue",
+        sourceId: issue.id,
+        kind: "issue.escalating",
+        severity: "high",
+        startedAt: new Date("2026-04-15T00:00:00.000Z"),
+        endedAt: null,
+      })
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          return yield* repository.findById(issue.id)
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(result.lifecycle.isEscalating).toBe(true)
+      expect(result.lifecycle.isRegressed).toBe(false)
+    })
+
+    it("findById attaches isEscalating=false when the escalating row is closed", async () => {
+      const issue = makeIssue()
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* repository.save(issue)
+        }).pipe(makeProvider(database)),
+      )
+
+      await database.db.insert(alertIncidentsTable).values({
+        id: "ai-esc-clos-aaaaaaaaaaa",
+        organizationId,
+        projectId: issue.projectId,
+        sourceType: "issue",
+        sourceId: issue.id,
+        kind: "issue.escalating",
+        severity: "high",
+        startedAt: new Date("2026-04-15T00:00:00.000Z"),
+        endedAt: new Date("2026-04-16T00:00:00.000Z"),
+      })
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          return yield* repository.findById(issue.id)
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(result.lifecycle.isEscalating).toBe(false)
+    })
+
+    it("findById attaches isRegressed=true when any issue.regressed row exists", async () => {
+      const issue = makeIssue()
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* repository.save(issue)
+        }).pipe(makeProvider(database)),
+      )
+
+      await database.db.insert(alertIncidentsTable).values({
+        id: "ai-reg-row-aaaaaaaaaaaa",
+        organizationId,
+        projectId: issue.projectId,
+        sourceType: "issue",
+        sourceId: issue.id,
+        kind: "issue.regressed",
+        severity: "high",
+        startedAt: new Date("2026-04-15T00:00:00.000Z"),
+        endedAt: null,
+      })
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          return yield* repository.findById(issue.id)
+        }).pipe(makeProvider(database)),
+      )
+
+      expect(result.lifecycle.isRegressed).toBe(true)
+    })
+
+    it("list and findByIds populate the same lifecycle flags as findById", async () => {
+      const escalatingIssue = makeIssue()
+      const regressedIssue = makeIssue({
+        id: otherIssueId,
+        uuid: "22222222-2222-4222-8222-222222222222",
+        name: "Incorrect refusal",
+      })
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          yield* repository.save(escalatingIssue)
+          yield* repository.save(regressedIssue)
+        }).pipe(makeProvider(database)),
+      )
+
+      // Add three annotation scores to each issue so they pass the
+      // visibility threshold in `list`.
+      const baseDate = new Date("2026-04-15T00:00:00.000Z")
+      for (const target of [escalatingIssue, regressedIssue]) {
+        for (let index = 0; index < 3; index++) {
+          await database.db.insert(scoresTable).values(
+            makeAnnotationScoreRow({
+              id: `${target.id.slice(0, 6)}score${index}`.padEnd(24, "x"),
+              projectId: target.projectId,
+              issueId: target.id,
+              createdAt: baseDate,
+            }),
+          )
+        }
+      }
+
+      await database.db.insert(alertIncidentsTable).values([
+        {
+          id: "ai-esc-list-aaaaaaaaaaaa",
+          organizationId,
+          projectId: escalatingIssue.projectId,
+          sourceType: "issue",
+          sourceId: escalatingIssue.id,
+          kind: "issue.escalating",
+          severity: "high",
+          startedAt: baseDate,
+          endedAt: null,
+        },
+        {
+          id: "ai-reg-list-aaaaaaaaaaaa",
+          organizationId,
+          projectId: regressedIssue.projectId,
+          sourceType: "issue",
+          sourceId: regressedIssue.id,
+          kind: "issue.regressed",
+          severity: "high",
+          startedAt: baseDate,
+          endedAt: null,
+        },
+      ])
+
+      const { listResult, findByIdsResult } = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repository = yield* IssueRepository
+          const listResult = yield* repository.list({ projectId, limit: 50, offset: 0 })
+          const findByIdsResult = yield* repository.findByIds({
+            projectId,
+            issueIds: [escalatingIssue.id, regressedIssue.id],
+          })
+          return { listResult, findByIdsResult }
+        }).pipe(makeProvider(database)),
+      )
+
+      const listFlags = new Map(listResult.items.map((item) => [item.id, item.lifecycle] as const))
+      expect(listFlags.get(escalatingIssue.id)).toEqual({ isEscalating: true, isRegressed: false })
+      expect(listFlags.get(regressedIssue.id)).toEqual({ isEscalating: false, isRegressed: true })
+
+      const findByIdsFlags = new Map(findByIdsResult.map((item) => [item.id, item.lifecycle] as const))
+      expect(findByIdsFlags.get(escalatingIssue.id)).toEqual({ isEscalating: true, isRegressed: false })
+      expect(findByIdsFlags.get(regressedIssue.id)).toEqual({ isEscalating: false, isRegressed: true })
+    })
   })
 })

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -19,11 +19,19 @@ import { scores } from "../schema/scores.ts"
 // non-locking issue read. The two EXISTS subqueries are the system of record
 // for "is this issue currently escalating / regressed" — see
 // `deriveIssueLifecycleStates` in @domain/issues.
+//
+// `issues.id` is qualified via raw SQL because Drizzle's template renders
+// the bare column inside the EXISTS subquery as `"id"` (unqualified), which
+// collides with `alert_incidents.id` (the inner scope's PK) and silently
+// resolves to the wrong column. The fully qualified outer reference avoids
+// the shadowing.
+const outerIssueId = sql.raw(`"latitude"."issues"."id"`)
+
 const isEscalatingExpr = sql<boolean>`exists (
   select 1
   from ${alertIncidents}
   where ${alertIncidents.sourceType} = 'issue'
-    and ${alertIncidents.sourceId} = ${issues.id}
+    and ${alertIncidents.sourceId} = ${outerIssueId}
     and ${alertIncidents.kind} = 'issue.escalating'
     and ${alertIncidents.endedAt} is null
 )`
@@ -32,7 +40,7 @@ const isRegressedExpr = sql<boolean>`exists (
   select 1
   from ${alertIncidents}
   where ${alertIncidents.sourceType} = 'issue'
-    and ${alertIncidents.sourceId} = ${issues.id}
+    and ${alertIncidents.sourceId} = ${outerIssueId}
     and ${alertIncidents.kind} = 'issue.regressed'
 )`
 

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -1,11 +1,51 @@
 import { EvaluationIssueRepository } from "@domain/evaluations"
-import { type Issue, IssueRepository, issueSchema, MIN_OCCURRENCES_FOR_VISIBILITY } from "@domain/issues"
+import {
+  type Issue,
+  type IssueLifecycleFlags,
+  IssueRepository,
+  type IssueWithLifecycle,
+  issueSchema,
+  MIN_OCCURRENCES_FOR_VISIBILITY,
+} from "@domain/issues"
 import { type IssueId, NotFoundError, type ProjectId, SqlClient, type SqlClientShape } from "@domain/shared"
-import { and, desc, eq, inArray, or, sql } from "drizzle-orm"
+import { and, desc, eq, getTableColumns, inArray, or, sql } from "drizzle-orm"
 import { Effect, Layer } from "effect"
 import type { Operator } from "../client.ts"
+import { alertIncidents } from "../schema/alert-incidents.ts"
 import { issues } from "../schema/issues.ts"
 import { scores } from "../schema/scores.ts"
+
+// Lifecycle flags derived from `alert_incidents` are joined onto every
+// non-locking issue read. The two EXISTS subqueries are the system of record
+// for "is this issue currently escalating / regressed" — see
+// `deriveIssueLifecycleStates` in @domain/issues.
+const isEscalatingExpr = sql<boolean>`exists (
+  select 1
+  from ${alertIncidents}
+  where ${alertIncidents.sourceType} = 'issue'
+    and ${alertIncidents.sourceId} = ${issues.id}
+    and ${alertIncidents.kind} = 'issue.escalating'
+    and ${alertIncidents.endedAt} is null
+)`
+
+const isRegressedExpr = sql<boolean>`exists (
+  select 1
+  from ${alertIncidents}
+  where ${alertIncidents.sourceType} = 'issue'
+    and ${alertIncidents.sourceId} = ${issues.id}
+    and ${alertIncidents.kind} = 'issue.regressed'
+)`
+
+const issueColumnsWithLifecycle = {
+  ...getTableColumns(issues),
+  isEscalating: isEscalatingExpr,
+  isRegressed: isRegressedExpr,
+} as const
+
+type IssueRowWithLifecycle = typeof issues.$inferSelect & {
+  readonly isEscalating: boolean
+  readonly isRegressed: boolean
+}
 
 const toDomainIssue = (row: typeof issues.$inferSelect): Issue =>
   issueSchema.parse({
@@ -24,6 +64,15 @@ const toDomainIssue = (row: typeof issues.$inferSelect): Issue =>
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   })
+
+const toIssueWithLifecycle = (row: IssueRowWithLifecycle): IssueWithLifecycle => {
+  const issue = toDomainIssue(row)
+  const lifecycle: IssueLifecycleFlags = {
+    isEscalating: row.isEscalating,
+    isRegressed: row.isRegressed,
+  }
+  return Object.assign({}, issue, { lifecycle })
+}
 
 const toInsertRow = (issue: Issue): typeof issues.$inferInsert => ({
   id: issue.id,
@@ -67,7 +116,7 @@ const issueRepositoryCoreLive = Layer.effect(
               ) >= ${MIN_OCCURRENCES_FOR_VISIBILITY}`
 
               return db
-                .select()
+                .select(issueColumnsWithLifecycle)
                 .from(issues)
                 .where(
                   and(
@@ -82,7 +131,7 @@ const issueRepositoryCoreLive = Layer.effect(
             })
             .pipe(
               Effect.map((rows) => ({
-                items: rows.slice(0, limit).map(toDomainIssue),
+                items: rows.slice(0, limit).map(toIssueWithLifecycle),
                 hasMore: rows.length > limit,
                 limit,
                 offset,
@@ -96,7 +145,7 @@ const issueRepositoryCoreLive = Layer.effect(
           return yield* sqlClient
             .query((db, organizationId) =>
               db
-                .select()
+                .select(issueColumnsWithLifecycle)
                 .from(issues)
                 .where(and(eq(issues.organizationId, organizationId), eq(issues.id, id)))
                 .limit(1),
@@ -105,7 +154,7 @@ const issueRepositoryCoreLive = Layer.effect(
               Effect.flatMap((rows) => {
                 const row = rows[0]
                 if (!row) return Effect.fail(new NotFoundError({ entity: "Issue", id }))
-                return Effect.succeed(toDomainIssue(row))
+                return Effect.succeed(toIssueWithLifecycle(row))
               }),
             )
         }),
@@ -137,11 +186,11 @@ const issueRepositoryCoreLive = Layer.effect(
           return yield* sqlClient
             .query((db, organizationId) => {
               if (issueIds.length === 0) {
-                return db.select().from(issues).where(sql`1 = 0`) // Return empty result
+                return db.select(issueColumnsWithLifecycle).from(issues).where(sql`1 = 0`) // Return empty result
               }
 
               return db
-                .select()
+                .select(issueColumnsWithLifecycle)
                 .from(issues)
                 .where(
                   and(
@@ -151,7 +200,7 @@ const issueRepositoryCoreLive = Layer.effect(
                   ),
                 )
             })
-            .pipe(Effect.map((rows) => rows.map(toDomainIssue)))
+            .pipe(Effect.map((rows) => rows.map(toIssueWithLifecycle)))
         }),
 
       findByUuid: ({ projectId, uuid }: { readonly projectId: ProjectId; readonly uuid: string }) =>
@@ -160,7 +209,7 @@ const issueRepositoryCoreLive = Layer.effect(
           return yield* sqlClient
             .query((db, organizationId) =>
               db
-                .select()
+                .select(issueColumnsWithLifecycle)
                 .from(issues)
                 .where(
                   and(
@@ -175,7 +224,7 @@ const issueRepositoryCoreLive = Layer.effect(
               Effect.flatMap((rows) => {
                 const row = rows[0]
                 if (!row) return Effect.fail(new NotFoundError({ entity: "Issue", id: uuid }))
-                return Effect.succeed(toDomainIssue(row))
+                return Effect.succeed(toIssueWithLifecycle(row))
               }),
             )
         }),

--- a/packages/platform/db-postgres/src/schema/issues.ts
+++ b/packages/platform/db-postgres/src/schema/issues.ts
@@ -14,8 +14,8 @@ export const issues = latitudeSchema.table(
     source: varchar("source", { length: 32 }).$type<IssueSource>().notNull(), // provenance of the first creating score
     centroid: jsonb("centroid").$type<IssueCentroid>().notNull(), // running weighted sum of clustered score feedback embeddings; do not add JSONB indexes — centroid search is served by the Weaviate projection
     clusteredAt: tzTimestamp("clustered_at").notNull(), // last time the centroid/cluster state was refreshed; used as the authoritative decay anchor (not updatedAt)
-    escalatedAt: tzTimestamp("escalated_at"), // latest escalation transition timestamp
-    resolvedAt: tzTimestamp("resolved_at"), // issue resolved automatically (inactivity) or manually
+    escalatedAt: tzTimestamp("escalated_at"), // DORMANT: not maintained by the system. "Currently escalating" is derived from open `alert_incidents` rows. Kept for backward compatibility; always null in practice.
+    resolvedAt: tzTimestamp("resolved_at"), // issue resolved manually
     ignoredAt: tzTimestamp("ignored_at"), // issue ignored manually
     ...timestamps(),
   },

--- a/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
+++ b/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
@@ -1,0 +1,94 @@
+import { type AlertIncidentKind, SEVERITY_FOR_KIND } from "@domain/alerts"
+import { AlertIncidentId } from "@domain/shared"
+import { SEED_ISSUE_FIXTURES } from "@domain/shared/seeding"
+import { Effect } from "effect"
+import { alertIncidents } from "../../schema/alert-incidents.ts"
+import { fixtureScopedId, fixtureScopedKey, issueFixtureDates } from "../issues/index.ts"
+import { type SeedContext, SeedError, type Seeder } from "../types.ts"
+
+const buildIncidentRow = (input: {
+  readonly id: string
+  readonly organizationId: string
+  readonly projectId: string
+  readonly sourceId: string
+  readonly kind: AlertIncidentKind
+  readonly startedAt: Date
+  readonly endedAt: Date | null
+}): typeof alertIncidents.$inferInsert => ({
+  id: AlertIncidentId(input.id),
+  organizationId: input.organizationId,
+  projectId: input.projectId,
+  sourceType: "issue",
+  sourceId: input.sourceId,
+  kind: input.kind,
+  severity: SEVERITY_FOR_KIND[input.kind],
+  startedAt: input.startedAt,
+  endedAt: input.endedAt,
+})
+
+const seedAlertIncidents: Seeder = {
+  name: "alert-incidents/issue-history",
+  run: (ctx: SeedContext) =>
+    Effect.tryPromise({
+      try: async () => {
+        const rows: (typeof alertIncidents.$inferInsert)[] = []
+
+        for (const [index, fixture] of SEED_ISSUE_FIXTURES.entries()) {
+          const issueKey = fixtureScopedKey(index)
+          const issueId = fixtureScopedId(index, ctx.scope)
+          const fixtureDates = issueFixtureDates(ctx.scope, fixture)
+
+          // One issue.new incident per seeded issue — mirrors what the
+          // production `IssueCreated` event would have produced when the
+          // issue was first discovered. Gives the demo a non-empty
+          // incident timeline out of the box.
+          rows.push(
+            buildIncidentRow({
+              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.new`),
+              organizationId: ctx.scope.organizationId,
+              projectId: ctx.scope.projectId,
+              sourceId: issueId,
+              kind: "issue.new",
+              startedAt: fixtureDates.createdAt,
+              endedAt: null,
+            }),
+          )
+
+          // Open `issue.escalating` row for fixtures the seed wants to
+          // present as Escalating. `ended_at = null` is what the new
+          // derive helper reads via `IssueRepository`'s JOIN to surface
+          // the badge.
+          if (fixture.escalatedDaysAgo !== null && fixtureDates.escalatedAt !== null) {
+            rows.push(
+              buildIncidentRow({
+                id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.escalating`),
+                organizationId: ctx.scope.organizationId,
+                projectId: ctx.scope.projectId,
+                sourceId: issueId,
+                kind: "issue.escalating",
+                startedAt: fixtureDates.escalatedAt,
+                endedAt: null,
+              }),
+            )
+          }
+        }
+
+        for (const row of rows) {
+          const { id, ...set } = row
+          await ctx.db.insert(alertIncidents).values(row).onConflictDoUpdate({
+            target: alertIncidents.id,
+            set,
+          })
+        }
+
+        const escalatingCount = rows.filter((row) => row.kind === "issue.escalating").length
+        const newCount = rows.filter((row) => row.kind === "issue.new").length
+        console.log(
+          `  -> alert_incidents: ${rows.length} rows (${newCount} issue.new, ${escalatingCount} open issue.escalating)`,
+        )
+      },
+      catch: (error) => new SeedError({ reason: "Failed to seed alert_incidents", cause: error }),
+    }).pipe(Effect.asVoid),
+}
+
+export const alertIncidentSeeders: readonly Seeder[] = [seedAlertIncidents]

--- a/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
+++ b/packages/platform/db-postgres/src/seeds/alert-incidents/index.ts
@@ -1,6 +1,8 @@
 import { type AlertIncidentKind, SEVERITY_FOR_KIND } from "@domain/alerts"
+import { ESCALATION_MIN_OCCURRENCES_THRESHOLD, ESCALATION_THRESHOLD_FACTOR } from "@domain/issues"
 import { AlertIncidentId } from "@domain/shared"
-import { SEED_ISSUE_FIXTURES } from "@domain/shared/seeding"
+import { SEED_ISSUE_FIXTURES, SEED_REGRESSED_ISSUE_IDS } from "@domain/shared/seeding"
+import { sql } from "drizzle-orm"
 import { Effect } from "effect"
 import { alertIncidents } from "../../schema/alert-incidents.ts"
 import { fixtureScopedId, fixtureScopedKey, issueFixtureDates } from "../issues/index.ts"
@@ -26,6 +28,68 @@ const buildIncidentRow = (input: {
   endedAt: input.endedAt,
 })
 
+interface IssueOccurrenceStats {
+  readonly issueId: string
+  readonly recentCount: number
+  readonly baselineAvgPerDay: number
+}
+
+/**
+ * Compute per-issue recent / baseline occurrence counts directly from the
+ * seeded `scores` table. Mirrors what the production
+ * `ScoreAnalyticsRepository.aggregateByIssues` query does (recent = last
+ * 24h, baseline = avg/day across days 1–8 ago) so escalation labels are
+ * derived from the same data shape the runtime threshold check sees.
+ */
+const fetchIssueOccurrenceStats = async (
+  ctx: SeedContext,
+  organizationId: string,
+  projectId: string,
+): Promise<readonly IssueOccurrenceStats[]> => {
+  const rows = await ctx.db.execute<{
+    issue_id: string
+    recent_count: number
+    baseline_avg_per_day: number
+  }>(sql`
+    select
+      issue_id,
+      count(*) filter (
+        where created_at >= now() - interval '1 day'
+      )::int as recent_count,
+      (count(*) filter (
+        where created_at >= now() - interval '8 days'
+          and created_at <  now() - interval '1 day'
+      )::float / 7) as baseline_avg_per_day
+    from latitude.scores
+    where organization_id = ${organizationId}
+      and project_id = ${projectId}
+      and issue_id is not null
+      and drafted_at is null
+    group by issue_id
+  `)
+
+  // Drizzle's execute returns the result wrapped depending on driver — use
+  // the array shape directly for node-postgres / pg-pool.
+  const list = Array.isArray(rows) ? rows : (rows as { rows?: unknown[] }).rows
+  const safe = (list ?? []) as readonly {
+    issue_id: string
+    recent_count: number
+    baseline_avg_per_day: number
+  }[]
+
+  return safe.map((row) => ({
+    issueId: row.issue_id,
+    recentCount: Number(row.recent_count),
+    baselineAvgPerDay: Number(row.baseline_avg_per_day),
+  }))
+}
+
+const escalationEntryThreshold = (baselineAvgPerDay: number): number =>
+  Math.max(
+    ESCALATION_MIN_OCCURRENCES_THRESHOLD,
+    Math.floor(Math.max(0, baselineAvgPerDay) * ESCALATION_THRESHOLD_FACTOR) + 1,
+  )
+
 const seedAlertIncidents: Seeder = {
   name: "alert-incidents/issue-history",
   run: (ctx: SeedContext) =>
@@ -33,15 +97,16 @@ const seedAlertIncidents: Seeder = {
       try: async () => {
         const rows: (typeof alertIncidents.$inferInsert)[] = []
 
+        // 1. One `issue.new` row per seeded fixture — the historical record
+        //    of when the issue was first discovered. Mirrors what the
+        //    production `IssueCreated` event would have produced.
+        const fixtureScopedIssueIds = new Map<string, string>()
         for (const [index, fixture] of SEED_ISSUE_FIXTURES.entries()) {
           const issueKey = fixtureScopedKey(index)
           const issueId = fixtureScopedId(index, ctx.scope)
+          fixtureScopedIssueIds.set(fixture.id, issueId)
           const fixtureDates = issueFixtureDates(ctx.scope, fixture)
 
-          // One issue.new incident per seeded issue — mirrors what the
-          // production `IssueCreated` event would have produced when the
-          // issue was first discovered. Gives the demo a non-empty
-          // incident timeline out of the box.
           rows.push(
             buildIncidentRow({
               id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.new`),
@@ -53,24 +118,59 @@ const seedAlertIncidents: Seeder = {
               endedAt: null,
             }),
           )
+        }
 
-          // Open `issue.escalating` row for fixtures the seed wants to
-          // present as Escalating. `ended_at = null` is what the new
-          // derive helper reads via `IssueRepository`'s JOIN to surface
-          // the badge.
-          if (fixture.escalatedDaysAgo !== null && fixtureDates.escalatedAt !== null) {
-            rows.push(
-              buildIncidentRow({
-                id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.escalating`),
-                organizationId: ctx.scope.organizationId,
-                projectId: ctx.scope.projectId,
-                sourceId: issueId,
-                kind: "issue.escalating",
-                startedAt: fixtureDates.escalatedAt,
-                endedAt: null,
-              }),
-            )
+        // 2. Open `issue.escalating` rows derived from the actual seeded
+        //    score data. Issues whose recent (last 24h) occurrence count
+        //    crosses the production entry threshold get an open incident.
+        const stats = await fetchIssueOccurrenceStats(ctx, ctx.scope.organizationId, ctx.scope.projectId)
+        const escalatingIssueIds = new Set<string>()
+        for (const stat of stats) {
+          const threshold = escalationEntryThreshold(stat.baselineAvgPerDay)
+          if (stat.recentCount >= threshold) {
+            escalatingIssueIds.add(stat.issueId)
           }
+        }
+
+        for (let index = 0; index < SEED_ISSUE_FIXTURES.length; index++) {
+          const issueId = fixtureScopedId(index, ctx.scope)
+          if (!escalatingIssueIds.has(issueId)) continue
+          const issueKey = fixtureScopedKey(index)
+          rows.push(
+            buildIncidentRow({
+              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.escalating`),
+              organizationId: ctx.scope.organizationId,
+              projectId: ctx.scope.projectId,
+              sourceId: issueId,
+              kind: "issue.escalating",
+              startedAt: ctx.scope.dateDaysAgo(0, 6, 0),
+              endedAt: null,
+            }),
+          )
+        }
+
+        // 3. Curated `issue.regressed` rows for the regression demo set.
+        //    Issue ids designated by `SEED_REGRESSED_ISSUE_IDS` have their
+        //    `resolvedAt` cleared by the issues seeder (mirroring what the
+        //    production `assign-score-to-issue` regression detection does)
+        //    so the read path derives them as Regressed.
+        const regressionStartedAt = ctx.scope.dateDaysAgo(2, 9, 0)
+        for (const fixtureIssueId of SEED_REGRESSED_ISSUE_IDS) {
+          const scopedIssueId = fixtureScopedIssueIds.get(fixtureIssueId)
+          if (!scopedIssueId) continue
+          const fixtureIndex = SEED_ISSUE_FIXTURES.findIndex((fixture) => fixture.id === fixtureIssueId)
+          const issueKey = fixtureIndex === -1 ? fixtureIssueId : fixtureScopedKey(fixtureIndex)
+          rows.push(
+            buildIncidentRow({
+              id: ctx.scope.cuid(`alert-incident:${issueKey}:issue.regressed`),
+              organizationId: ctx.scope.organizationId,
+              projectId: ctx.scope.projectId,
+              sourceId: scopedIssueId,
+              kind: "issue.regressed",
+              startedAt: regressionStartedAt,
+              endedAt: null,
+            }),
+          )
         }
 
         for (const row of rows) {
@@ -81,10 +181,13 @@ const seedAlertIncidents: Seeder = {
           })
         }
 
-        const escalatingCount = rows.filter((row) => row.kind === "issue.escalating").length
-        const newCount = rows.filter((row) => row.kind === "issue.new").length
+        const counts = {
+          new: rows.filter((row) => row.kind === "issue.new").length,
+          escalating: rows.filter((row) => row.kind === "issue.escalating").length,
+          regressed: rows.filter((row) => row.kind === "issue.regressed").length,
+        }
         console.log(
-          `  -> alert_incidents: ${rows.length} rows (${newCount} issue.new, ${escalatingCount} open issue.escalating)`,
+          `  -> alert_incidents: ${rows.length} rows (${counts.new} issue.new, ${counts.escalating} open issue.escalating from real occurrence data, ${counts.regressed} issue.regressed)`,
         )
       },
       catch: (error) => new SeedError({ reason: "Failed to seed alert_incidents", cause: error }),

--- a/packages/platform/db-postgres/src/seeds/all.ts
+++ b/packages/platform/db-postgres/src/seeds/all.ts
@@ -1,3 +1,4 @@
+import { alertIncidentSeeders } from "./alert-incidents/index.ts"
 import { annotationQueueSeeders } from "./annotation-queues/index.ts"
 import { apiKeySeeders } from "./api-keys/index.ts"
 import { datasetSeeders } from "./datasets/index.ts"
@@ -24,6 +25,9 @@ import type { Seeder } from "./types.ts"
 export const contentSeeders: readonly Seeder[] = [
   ...datasetSeeders,
   ...issueSeeders,
+  // Must run after issueSeeders — references the issue ids derived for
+  // each fixture and writes `alert_incidents` rows pointing at them.
+  ...alertIncidentSeeders,
   ...evaluationSeeders,
   ...simulationSeeders,
   ...scoreSeeders,

--- a/packages/platform/db-postgres/src/seeds/all.ts
+++ b/packages/platform/db-postgres/src/seeds/all.ts
@@ -25,14 +25,15 @@ import type { Seeder } from "./types.ts"
 export const contentSeeders: readonly Seeder[] = [
   ...datasetSeeders,
   ...issueSeeders,
-  // Must run after issueSeeders — references the issue ids derived for
-  // each fixture and writes `alert_incidents` rows pointing at them.
-  ...alertIncidentSeeders,
   ...evaluationSeeders,
   ...simulationSeeders,
   ...scoreSeeders,
   ...annotationQueueSeeders,
   ...flaggerSeeders,
+  // Runs after issues + scores so it can derive "currently escalating"
+  // from real occurrence patterns in the seeded data via the same
+  // threshold the production worker uses, instead of a fixture flag.
+  ...alertIncidentSeeders,
 ]
 
 export const allSeeders: readonly Seeder[] = [

--- a/packages/platform/db-postgres/src/seeds/issues/index.ts
+++ b/packages/platform/db-postgres/src/seeds/issues/index.ts
@@ -7,7 +7,7 @@ import {
   updateIssueCentroid,
 } from "@domain/issues"
 import { IssueId } from "@domain/shared"
-import { SEED_ISSUE_FIXTURES, type SeedScope } from "@domain/shared/seeding"
+import { SEED_ISSUE_FIXTURES, SEED_REGRESSED_ISSUE_IDS, type SeedScope } from "@domain/shared/seeding"
 import { parseEnvOptional } from "@platform/env"
 import { Effect } from "effect"
 import type { VoyageAIClient } from "voyageai"
@@ -236,6 +236,14 @@ function buildIssueRow(input: {
     ].filter((date): date is Date => date !== null),
   )
 
+  // Regression-demo issues are kept un-resolved on purpose: the
+  // `Regressed` derived state requires `resolvedAt IS NULL` plus an
+  // `issue.regressed` alert_incident, which the alert-incidents seeder
+  // inserts for these ids. Production behavior is the same — when
+  // `assign-score-to-issue` reifies a regression it clears `resolvedAt`.
+  const isRegressedDemo = SEED_REGRESSED_ISSUE_IDS.includes(input.issueId)
+  const resolvedAt = isRegressedDemo ? null : fixtureDates.resolvedAt
+
   return {
     id: IssueId(input.issueId),
     uuid: input.issueUuid,
@@ -248,11 +256,9 @@ function buildIssueRow(input: {
     clusteredAt: centroid.clusteredAt,
     // escalatedAt is intentionally not written: the column is dormant and
     // "currently escalating" is sourced from open `alert_incidents` rows
-    // by `IssueRepository`. Escalation seeding lives in the alert-incidents
-    // seeder, which inserts an open `issue.escalating` row for fixtures
-    // whose `escalatedDaysAgo !== null`.
+    // by `IssueRepository`.
     escalatedAt: null,
-    resolvedAt: fixtureDates.resolvedAt,
+    resolvedAt,
     ignoredAt: fixtureDates.ignoredAt,
     createdAt,
     updatedAt,

--- a/packages/platform/db-postgres/src/seeds/issues/index.ts
+++ b/packages/platform/db-postgres/src/seeds/issues/index.ts
@@ -35,7 +35,7 @@ const NAMED_ISSUE_KEYS = [
   "flagger",
 ] as const
 
-const fixtureScopedId = (index: number, scope: SeedScope): string =>
+export const fixtureScopedId = (index: number, scope: SeedScope): string =>
   index < NAMED_ISSUE_KEYS.length
     ? scope.cuid(`issue:${NAMED_ISSUE_KEYS[index]}`)
     : scope.cuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}`)
@@ -44,6 +44,11 @@ const fixtureScopedUuid = (index: number, scope: SeedScope): string =>
   index < NAMED_ISSUE_KEYS.length
     ? scope.uuid(`issue:${NAMED_ISSUE_KEYS[index]}:uuid`)
     : scope.uuid(`issue:extra:${index - NAMED_ISSUE_KEYS.length}:uuid`)
+
+/** Stable key per fixture index — used to namespace cross-seeder ids
+ * (e.g. alert_incidents rows that reference these issues). */
+export const fixtureScopedKey = (index: number): string =>
+  index < NAMED_ISSUE_KEYS.length ? (NAMED_ISSUE_KEYS[index] as string) : `extra:${index - NAMED_ISSUE_KEYS.length}`
 
 function hashString(input: string): number {
   let hash = 1779033703 ^ input.length
@@ -189,7 +194,7 @@ function buildRandomFallbackCentroid(seedKey: string, clusteredAt: Date): IssueC
   }
 }
 
-function issueFixtureDates(scope: SeedScope, issue: (typeof SEED_ISSUE_FIXTURES)[number]) {
+export function issueFixtureDates(scope: SeedScope, issue: (typeof SEED_ISSUE_FIXTURES)[number]) {
   return {
     createdAt: scope.dateDaysAgo(issue.createdDaysAgo, 14, 15),
     clusteredAt: scope.dateDaysAgo(issue.clusteredDaysAgo, 14, 15),
@@ -241,7 +246,12 @@ function buildIssueRow(input: {
     source: input.issue.source,
     centroid,
     clusteredAt: centroid.clusteredAt,
-    escalatedAt: fixtureDates.escalatedAt,
+    // escalatedAt is intentionally not written: the column is dormant and
+    // "currently escalating" is sourced from open `alert_incidents` rows
+    // by `IssueRepository`. Escalation seeding lives in the alert-incidents
+    // seeder, which inserts an open `issue.escalating` row for fixtures
+    // whose `escalatedDaysAgo !== null`.
+    escalatedAt: null,
     resolvedAt: fixtureDates.resolvedAt,
     ignoredAt: fixtureDates.ignoredAt,
     createdAt,


### PR DESCRIPTION
Third alert kind from the MVP (see [`specs/alerts.md`](./specs/alerts.md), follow-up to #2983). Unlike `issue.new` and `issue.regressed` — discrete events with a single fire — `issue.escalating` is a **sustained condition**: an incident opens when the issue starts escalating and closes when it stops. First kind to use the `ended_at` column on `alert_incidents`.

Along the way, this PR also moves the system of record for both lifecycle states (`Escalating` and `Regressed`) onto `alert_incidents`, killing the divergence between the issue table and the read-time derive that the original design carried over.

## what "escalating" means

The state was already defined as a derived read-time value (`packages/domain/issues/src/helpers.ts`):

```
isEscalating = !isNew && recentOccurrences >= getEscalationOccurrenceThreshold(baseline)
```

The escalation worker turns it into a stored fact — but the storage is **the open `alert_incidents` row**, not a column on `issues`. As long as a row with `kind='issue.escalating' AND ended_at IS NULL` exists for the issue, the issue is escalating. Reads JOIN that EXISTS check directly into the issue query (see "lifecycle source of truth" below); idempotency follows from the same row: the worker won't emit `IssueEscalated` again while it's open.

## hysteresis

Entry uses the existing `getEscalationOccurrenceThreshold(baseline)`. Exit uses a new `getEscalationExitThreshold` — entry × `ESCALATION_EXIT_THRESHOLD_FACTOR` (0.7). Issues need to meaningfully return below the entry threshold before the incident closes; sustained-but-not-rising volume keeps the incident open until the rolling baseline catches up.

## how detection works

Two publishes go out from `ScoreAssignedToIssue` for the same `issues:checkEscalation` task, with different intents:

| dedupeKey | mechanism | catches |
|---|---|---|
| `issues:check-escalation:${id}` | `throttleMs: 15min` | escalation **starts** while activity is high |
| `issues:check-escalation-recheck:${id}` | `debounceMs: 1h` | escalation **ends** once activity stops |

The throttled publish caps re-evaluation at one fire per 15 min during a stream of scoring activity. The debounced publish keeps getting extended on every new occurrence and only fires once the issue goes quiet for an hour — by which point the recent occurrence count has dropped enough that the use case can detect the exit. No wasted compute rechecking already-active escalations, no missed exits when traffic stops.

The handler is the same regardless of which publish triggered it. State transition logic lives in `checkIssueEscalationUseCase`.

## incident lifecycle

- `IssueEscalated` → fan-out to `alert-incidents:issue-escalated` → `createAlertIncidentFromIssueEventUseCase` inserts a new row with `kind='issue.escalating'`, `severity='high'`, `started_at` set, `ended_at = NULL`.
- `IssueEscalationEnded` → fan-out to `alert-incidents:issue-escalation-ended` → new `closeAlertIncidentFromIssueEventUseCase` calls the new `AlertIncidentRepository.closeOpen`, which updates the open `(source_type, source_id, kind)` row to set `ended_at`. RLS-scoped to the org.

If escalation fires again later (after exit), it's a new cycle: a new open row, the previous one stays closed.

## lifecycle source of truth — `alert_incidents`, not `issues`

Originally this PR set `issues.escalated_at` as the reified flag. That created two sources of truth: the column for "are we currently escalating?" and `alert_incidents` for the audit trail. They could disagree inside the hysteresis band, after worker lag, or — in the case of regression — after PR #2983's `resolvedAt`-clearing made the regression check derive silently always-false.

Refactor in `IssueRepository`: every non-locking read now JOINs two `EXISTS` subqueries against `alert_incidents` and returns the issue alongside `lifecycle: { isEscalating, isRegressed }`. `deriveIssueLifecycleStates` consumes those flags directly instead of recomputing from the occurrence aggregate.

- **Regressed** = `issues.resolvedAt IS NULL` AND a row with `kind='issue.regressed'` exists.
- **Escalating** = a row with `kind='issue.escalating' AND ended_at IS NULL` exists.

Side effects of the refactor:

- The escalation worker no longer writes `issues.escalated_at`. It reads `wasEscalating` from `lifecycle.isEscalating`, transitions on the outbox event, and lets the open/closed `alert_incidents` row carry the state. The column is left dormant (with a comment) — no DROP COLUMN, kept reversible.
- `assign-score-to-issue`'s "regression detected" branch no longer needs to coordinate with the derive; it just clears `resolvedAt` and emits `IssueRegressed`. The next read JOIN derives Regressed correctly.
- **Auto-resolve by inactivity removed.** `AUTO_RESOLVE_INACTIVITY_DAYS` is gone, and the derive function dropped its dependency on the ClickHouse occurrence aggregate entirely — it's pure-Postgres state now. `analytics.counts.resolvedIssues` only counts explicitly-resolved issues going forward.

There's a minor SQL gotcha worth flagging: Drizzle's column rendering for `${issues.id}` inside the EXISTS subquery resolved as bare `"id"` and silently shadowed by `alert_incidents.id`. Fixed by passing the fully-qualified outer reference (`"latitude"."issues"."id"`) and locked in by an integration test.

## seed data — escalating/regressed labels derived from real patterns

The seed previously labeled escalating/regressed via fixture flags that didn't track the underlying score data, so the demo had random-looking escalations and zero regressed issues.

Now `alert-incidents` seeds run **after** scores and:

1. Insert one `issue.new` row per fixture (the historical first-discovery record).
2. Query the seeded `scores` table for per-issue recent (last 24h) and baseline (avg/day across days 1–8 ago) counts using the same shape as the production aggregate, then insert open `issue.escalating` rows only for issues that cross `recent >= max(20, floor(baseline * 1.33) + 1)`.
3. Insert `issue.regressed` rows for a curated demo set (logistics, installation, flagger). The issues seeder forces `resolvedAt = null` for those three so they derive as Regressed.

Curated bursts in the last 24h push four named fixtures over the entry threshold (warranty, combination, billing, access). On a fresh seed: **4 escalating, 3 regressed, the rest ongoing/new** — matching the curated demo intent.

## scope cuts

- `IssueEscalationEnded` has no consumer in this PR. PR 2 (email channel) and PR 3 (in-app feed) will subscribe to it directly.
- No DB unique constraint preventing multiple open rows per `(source_type, source_id, kind)`. Upstream idempotency (the lifecycle.isEscalating read) prevents that. Adding the partial unique index later is non-breaking.
- No "for cause" close — if a user resolves an actively-escalating issue, the incident stays open until the next debounced recheck fires and detects the rate drop. Acceptable latency for V1.
- `issues.escalated_at` column kept dormant, not dropped, to keep the rollback path clean.
- The histogram regression-boundary marker (the dashed line in the trend chart) currently doesn't render because it was anchored to `resolvedAt`, which gets cleared on regression. Fix is straightforward (re-anchor to the most recent `issue.regressed` incident's `started_at`) but deferred to a follow-up to keep this PR focused.

## test plan

- [x] Unit tests for `checkIssueEscalationUseCase` covering: entry transition, no-op below threshold, exit transition, hysteresis hold (between entry and exit), no re-emission while still escalating, regression-during-escalation interaction
- [x] Unit test for `closeAlertIncidentFromIssueEventUseCase` calling `closeOpen` with the right pointer
- [x] Updated domain-events dispatcher test to assert `ScoreAssignedToIssue` fans out to refresh + throttled check + debounced recheck
- [x] Integration tests on `IssueRepository` verifying `findById`, `findByIds`, and `list` populate `lifecycle.isEscalating` / `lifecycle.isRegressed` from joined `alert_incidents` rows (regression test for the silent column-shadowing bug)
- [x] `helpers.test.ts` updated for the new derive signature; auto-resolve-by-inactivity tests removed
- [x] `list-issues.test.ts` `regressedIssues` count returns to non-zero with the new derive shape
- [x] Typecheck and biome clean across `@domain/alerts`, `@domain/issues`, `@domain/events`, `@domain/queue`, `@domain/scores`, `@domain/shared`, `@platform/db-postgres`, `@app/workers`, `@app/web`
- [ ] Manual: ingest enough scores against an existing issue to push `recentOccurrences` above the entry threshold. Within ≤15 min, confirm `IssueEscalated` is in the outbox, a new `alert_incidents` row exists with `kind='issue.escalating'` and `ended_at IS NULL`, and the issue UI shows Escalating.
- [ ] Manual: stop ingesting. Within ≤1h, confirm `IssueEscalationEnded` is in the outbox, the same row now has `ended_at` set, and the UI no longer shows Escalating.
- [ ] Manual: trigger a regression (post-resolve activity) and confirm the UI shows Regressed (this was silently broken pre-refactor).
- [ ] Manual: verify `issues.escalated_at` stays NULL throughout — the column is dormant.