### PR TITLE
Fix empty response detection to ignore tool calls without text

### DIFF
--- a/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
@@ -2,6 +2,7 @@ import { ExternalUserId, OrganizationId, ProjectId, SessionId, SimulationId, Spa
 import type { TraceDetail } from "@domain/spans"
 import { describe, expect, it } from "vitest"
 
+import { emptyResponseStrategy } from "./empty-response.ts"
 import { frustrationStrategy } from "./frustration.ts"
 import { lazinessStrategy } from "./laziness.ts"
 import { refusalStrategy } from "./refusal.ts"
@@ -62,6 +63,14 @@ let toolCallCounter = 0
 const assistantToolCall = (name: string, args: unknown): TraceMessage => ({
   role: "assistant",
   parts: [{ type: "tool_call", id: `tc_${++toolCallCounter}`, name, arguments: args }],
+})
+
+const assistantToolCallWithText = (name: string, args: unknown, text: string): TraceMessage => ({
+  role: "assistant",
+  parts: [
+    { type: "tool_call", id: `tc_${++toolCallCounter}`, name, arguments: args },
+    { type: "text", content: text },
+  ],
 })
 
 // ---------------------------------------------------------------------------
@@ -512,6 +521,82 @@ describe("frustrationStrategy.detectDeterministically", () => {
         user("I already told you three times — use TypeScript."),
       ])
       expect(frustrationStrategy.detectDeterministically?.(trace)).toEqual({ kind: "ambiguous" })
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty Response
+// ---------------------------------------------------------------------------
+
+describe("emptyResponseStrategy.detectDeterministically", () => {
+  describe("matched on empty assistant response", () => {
+    it("matches empty text content", () => {
+      const trace = makeTrace([user("hi"), assistant("")])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toMatchObject({
+        kind: "matched",
+        feedback: "Assistant response was empty or whitespace only",
+      })
+    })
+
+    it("matches whitespace-only content", () => {
+      const trace = makeTrace([user("hi"), assistant("   ")])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toMatchObject({
+        kind: "matched",
+        feedback: "Assistant response was empty or whitespace only",
+      })
+    })
+
+    it("matches degenerate repeated character", () => {
+      const trace = makeTrace([user("hi"), assistant("aaa")])
+      const result = emptyResponseStrategy.detectDeterministically?.(trace)
+      expect(result?.kind).toBe("matched")
+      if (result?.kind === "matched") {
+        expect(result.feedback).toContain("degenerate")
+        expect(result.feedback).toContain('"a"')
+      }
+    })
+  })
+
+  describe("no-match on valid responses", () => {
+    it("no-match on normal text response", () => {
+      const trace = makeTrace([user("hi"), assistant("Hello! How can I help?")])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match when assistant only emits a tool call (no text part)", () => {
+      const trace = makeTrace([user("check the weather"), assistantToolCall("get_weather", { city: "NYC" })])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match when assistant has tool call WITH empty text part", () => {
+      // This is the key regression test: previously this would incorrectly match as "empty response"
+      const trace = makeTrace([user("check the weather"), assistantToolCallWithText("get_weather", { city: "NYC" }, "")])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match when assistant has tool call with whitespace-only text part", () => {
+      const trace = makeTrace([
+        user("check the weather"),
+        assistantToolCallWithText("get_weather", { city: "NYC" }, "   "),
+      ])
+      expect(emptyResponseStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
+    })
+
+    it("no-match on empty conversation", () => {
+      expect(emptyResponseStrategy.detectDeterministically?.(makeTrace([]))).toEqual({ kind: "no-match" })
+    })
+  })
+
+  describe("hasRequiredContext", () => {
+    it("is true when there are output messages", () => {
+      const trace = makeTrace([user("hi"), assistant("hello")])
+      expect(emptyResponseStrategy.hasRequiredContext(trace)).toBe(true)
+    })
+
+    it("is false when there are no output messages", () => {
+      const trace = makeTrace([])
+      expect(emptyResponseStrategy.hasRequiredContext(trace)).toBe(false)
     })
   })
 })

--- a/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
+++ b/packages/domain/flaggers/src/flagger-strategies/strategies.test.ts
@@ -571,7 +571,10 @@ describe("emptyResponseStrategy.detectDeterministically", () => {
 
     it("no-match when assistant has tool call WITH empty text part", () => {
       // This is the key regression test: previously this would incorrectly match as "empty response"
-      const trace = makeTrace([user("check the weather"), assistantToolCallWithText("get_weather", { city: "NYC" }, "")])
+      const trace = makeTrace([
+        user("check the weather"),
+        assistantToolCallWithText("get_weather", { city: "NYC" }, ""),
+      ])
       expect(emptyResponseStrategy.detectDeterministically?.(trace)).toEqual({ kind: "no-match" })
     })
 

--- a/packages/domain/flaggers/src/helpers.ts
+++ b/packages/domain/flaggers/src/helpers.ts
@@ -219,7 +219,6 @@ export function detectEmptyResponseFlagger(trace: TraceDetail): DeterministicFla
     if (message.role !== "assistant") continue
 
     let hasToolCall = false
-    let hasText = false
     const textParts: string[] = []
 
     for (const part of message.parts) {
@@ -228,13 +227,12 @@ export function detectEmptyResponseFlagger(trace: TraceDetail): DeterministicFla
         continue
       }
       if (part.type === "text") {
-        hasText = true
         const content = (part as { content?: unknown }).content
         if (typeof content === "string") textParts.push(content)
       }
     }
 
-    if (hasToolCall && !hasText) continue
+    if (hasToolCall) continue
     const accumulatedText = textParts.join("").trim()
     if (accumulatedText === "") return match("Assistant response was empty or whitespace only", msgIdx)
     if (accumulatedText.length >= 3 && new Set(accumulatedText).size === 1) {


### PR DESCRIPTION
## Summary
Fixed a bug in the empty response flagger where assistant messages containing tool calls with empty or whitespace-only text parts were incorrectly being flagged as empty responses. Tool calls without accompanying text should not be considered empty responses.

## Key Changes
- **Updated detection logic** in `helpers.ts`: Changed the condition from `if (hasToolCall && !hasText)` to `if (hasToolCall)` to skip any message that contains a tool call, regardless of whether it has text content. This prevents false positives when an assistant makes a tool call without providing text.

- **Added comprehensive test coverage** in `strategies.test.ts`:
  - Added `assistantToolCallWithText` helper to create messages with both tool calls and text parts
  - Added regression test case: "no-match when assistant has tool call WITH empty text part" to prevent this bug from reoccurring
  - Added test for tool calls with whitespace-only text parts
  - Added tests for `hasRequiredContext` method
  - Verified that normal text responses and tool-call-only responses continue to work correctly

## Implementation Details
The fix recognizes that when an assistant makes a tool call, it's actively working on the user's request even if there's no accompanying text. The empty response detection should only flag cases where the assistant provides no meaningful output at all (no tool calls and no substantive text).

https://claude.ai/code/session_01LAa2EUPKdz31KTAEnE4Wth