### PR TITLE
Wrap markdown tables so wide content scrolls inside the message

### DIFF
--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.test.tsx
@@ -57,6 +57,16 @@ describe("MarkdownContent", () => {
     }
   })
 
+  it("wraps tables in a horizontally scrollable container so they never overflow the drawer", () => {
+    const table = "| a | b |\n| - | - |\n| 1 | 2 |"
+    const markup = renderToStaticMarkup(<MarkdownContent content={table} />)
+
+    // The <table> must be nested inside an overflow-x-auto wrapper so wide
+    // tables scroll horizontally within the message instead of pushing the
+    // surrounding layout past the drawer width.
+    expect(markup).toMatch(/<div[^>]*\boverflow-x-auto\b[^>]*>\s*<table\b/)
+  })
+
   it("falls back to a guarded plain-text view for oversized content", () => {
     const oversizedContent = `${"a".repeat(LARGE_MARKDOWN_CONTENT_THRESHOLD + 1)}END_MARKER`
 

--- a/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
+++ b/packages/ui/src/components/genai-conversation/parts/markdown-content.tsx
@@ -59,6 +59,13 @@ const markdownComponents: Components = {
       </CodeBlockShell>
     )
   },
+  // Wide tables would otherwise push their parent past the drawer width;
+  // wrap them so overflow scrolls horizontally inside the message.
+  table: ({ children }) => (
+    <div className="max-w-full overflow-x-auto">
+      <table>{children}</table>
+    </div>
+  ),
 }
 export const LARGE_MARKDOWN_PREVIEW_LENGTH = 12_000
 


### PR DESCRIPTION
Wide markdown tables in the trace detail drawer's conversation tab were pushing past the drawer width. Wrap the table in an overflow-x-auto container so the message itself stays within bounds and wide tables get their own horizontal scroll instead.