### PR TITLE
ci(deploy): suppress pager and warn on main↔dev drift

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -30,10 +30,10 @@ echo "Development is ${release_commits} commit(s) ahead of main:"
 git --no-pager log --oneline origin/main..origin/development
 echo ""
 
-unapplied_on_main=$(git cherry -v origin/development origin/main | awk '$1=="+"')
-if [ -n "$unapplied_on_main" ]; then
+main_commits_not_on_development=$(git cherry -v origin/development origin/main | awk '$1=="+"')
+if [ -n "$main_commits_not_on_development" ]; then
   echo "Warning: main has commits whose changes are not on development:"
-  echo "$unapplied_on_main" | sed 's/^+ /  /'
+  printf '%s\n' "$main_commits_not_on_development" | sed 's/^+ /  /'
   echo ""
   echo "These will likely cause merge conflicts when promoting development → main."
   echo "Back-merge main into development first, or proceed and resolve conflicts in the PR."

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -27,8 +27,26 @@ if [ "$release_commits" -eq 0 ]; then
 fi
 
 echo "Development is ${release_commits} commit(s) ahead of main:"
-git log --oneline origin/main..origin/development
+git --no-pager log --oneline origin/main..origin/development
 echo ""
+
+unapplied_on_main=$(git cherry -v origin/development origin/main | awk '$1=="+"')
+if [ -n "$unapplied_on_main" ]; then
+  echo "Warning: main has commits whose changes are not on development:"
+  echo "$unapplied_on_main" | sed 's/^+ /  /'
+  echo ""
+  echo "These will likely cause merge conflicts when promoting development → main."
+  echo "Back-merge main into development first, or proceed and resolve conflicts in the PR."
+  echo ""
+  read -r -p "Continue anyway? [y/N] " continue_anyway
+  case "$continue_anyway" in
+    y | Y | yes | YES) ;;
+    *)
+      echo "Aborted."
+      exit 0
+      ;;
+  esac
+fi
 
 existing_pr=$(gh pr list \
   --base main \


### PR DESCRIPTION
## Summary

- Add `--no-pager` to the diff preview in `scripts/deploy-production.sh` so it no longer trips git's TTY pager (or `fzf-git`-style integrations) when run interactively.
- Add a `git cherry`-based check that warns only when `origin/main` has commits whose **patches** aren't already applied on `origin/development`. This avoids false positives when changes reached development via a different SHA (e.g. cherry-picks, squashed merges) — the previous "main has N commits dev doesn't" framing flagged those incorrectly.

## Test plan

- [x] Run `./scripts/deploy-production.sh` from a TTY and confirm the commit list prints inline (no pager).
- [x] Run `git cherry -v origin/development origin/main` manually and confirm the script's warning only fires for `+`-prefixed commits.
- [x] Confirm the script still aborts cleanly when `origin/main..origin/development` is empty and when an existing deploy PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)