### PR TITLE
feat(api,domain): pagination helper, rate-limit tiers, plural TracesRef

### DIFF
--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -3,14 +3,17 @@ import { Effect } from "effect"
 import type { Context, Next } from "hono"
 
 /**
- * Redis-backed rate limiter for authentication endpoints.
+ * Redis-backed rate limiter.
  *
  * Uses Redis INCR and EXPIRE for atomic counter operations.
  * Supports distributed deployments across multiple API instances.
  *
- * Default limits:
- * - 5 attempts per 15 minutes per IP address for sign-in
- * - 3 attempts per hour per IP address for sign-up
+ * Two consumers today:
+ * 1. {@link createAuthRateLimiter} — IP-keyed brute-force guard applied
+ *    globally before the auth middleware runs.
+ * 2. {@link createTierRateLimiter} — organization-keyed quota tier applied
+ *    per route group (low / medium / high / critical), used to give cheap
+ *    endpoints more headroom and expensive ones tighter limits.
  */
 
 interface RateLimitConfig {
@@ -115,5 +118,46 @@ export const createAuthRateLimiter = () => {
       return ip.split(",")[0].trim()
     },
     errorMessage: "Too many authentication attempts. Please try again later.",
+  })
+}
+
+type RateLimitTier = "low" | "medium" | "high" | "critical"
+
+const TIER_LIMITS: Record<RateLimitTier, { readonly maxRequests: number; readonly windowSeconds: number }> = {
+  low: { maxRequests: 100, windowSeconds: 60 },
+  medium: { maxRequests: 60, windowSeconds: 60 },
+  high: { maxRequests: 15, windowSeconds: 60 },
+  critical: { maxRequests: 3, windowSeconds: 60 },
+}
+
+/**
+ * Per-route rate-limit tiers, keyed by the authenticated organization id.
+ *
+ * Tiers are sized so that one greedy tenant can't starve another's quota:
+ * - `low` ............ 100 req / min — list/get reads, the cheap stuff
+ * - `medium` (default) 60 req / min — most mutations and single-row writes
+ * - `high` ............ 15 req / min — bulk reads with filter/search/semantic load
+ * - `critical` ......... 3 req / min — bulk imports, exports, monitor-issue (workflow-kicking)
+ *
+ * Apply at the routing site, before the matching subrouter is mounted, e.g.
+ * `routes.use("/projects/:projectSlug/traces", createTierRateLimiter("high"))`.
+ *
+ * The auth middleware must have already populated `c.var.organization` before
+ * this runs, otherwise the limiter falls back to a single shared `unknown`
+ * bucket — fine for unauthenticated requests because the auth middleware will
+ * reject them anyway.
+ *
+ * @public Public API surface for the API expansion plan; consumed by route
+ * mounts in subsequent PRs. Marked `@public` so knip doesn't flag it as
+ * unused while it's waiting for its first consumer.
+ */
+export const createTierRateLimiter = (tier: RateLimitTier) => {
+  const { maxRequests, windowSeconds } = TIER_LIMITS[tier]
+  return createRedisRateLimiter({
+    maxRequests,
+    windowSeconds,
+    keyPrefix: `ratelimit:tier:${tier}:org`,
+    keyGenerator: (c: Context) => c.get("organization")?.id ?? "unknown",
+    errorMessage: `Rate limit exceeded for ${tier}-tier endpoints. Please slow down.`,
   })
 }

--- a/apps/api/src/openapi/pagination.ts
+++ b/apps/api/src/openapi/pagination.ts
@@ -1,0 +1,53 @@
+import { z } from "@hono/zod-openapi"
+
+/**
+ * Pagination shape used by every paginated list endpoint in the API. We pass a
+ * unique `name` because Fern needs each instantiation to be a named OpenAPI
+ * component (otherwise the generator inlines anonymous types and the SDK fails
+ * to typecheck on case-sensitive filesystems).
+ *
+ * ```ts
+ * const PaginatedTraces = Paginated(TraceSchema, "PaginatedTraces")
+ * ```
+ *
+ * The cursor is opaque from the caller's perspective — repositories serialize
+ * their own `(sortValue, id)` tuples behind the scenes.
+ *
+ * @public Public API surface for the API expansion plan; consumed by list
+ * route definitions in subsequent PRs. Marked `@public` so knip doesn't flag
+ * it as unused while it's waiting for its first consumer.
+ */
+export const Paginated = <T extends z.ZodType>(item: T, name: string) =>
+  z
+    .object({
+      items: z.array(item).openapi({ description: "Page of items, in the requested sort order." }),
+      nextCursor: z.string().nullable().openapi({
+        description:
+          "Opaque cursor for fetching the next page. `null` when there are no more pages. Pass it back in `cursor` to continue.",
+      }),
+      hasMore: z.boolean().openapi({
+        description: "`true` when there is at least one more page after this one.",
+      }),
+    })
+    .openapi(name)
+
+/**
+ * Standard query-string params for paginated endpoints. Endpoints with
+ * additional filter/search params should compose with this via `.merge`.
+ *
+ * @public Public API surface for the API expansion plan; consumed by list
+ * route definitions in subsequent PRs. Marked `@public` so knip doesn't flag
+ * it as unused while it's waiting for its first consumer.
+ */
+export const PaginatedQueryParamsSchema = z.object({
+  cursor: z.string().optional().openapi({
+    description: "Opaque cursor returned in a previous response's `nextCursor`. Omit on the first page.",
+  }),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .default(50)
+    .openapi({ description: "Page size. Defaults to 50; max 200." }),
+})

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -37,6 +37,23 @@ export const TraceRefSchema = z
   ])
   .openapi("TraceRef")
 
+/**
+ * Plural sibling of {@link TraceRefSchema} for bulk endpoints (export traces,
+ * import-from-traces into a dataset, etc). Mirrors `tracesRefSchema` from
+ * `@domain/spans` but rebuilt with `.openapi(...)` names — same Fern-generator
+ * workaround as `TraceRefSchema` above.
+ *
+ * @public Public API surface for the API expansion plan; consumed by bulk
+ * route definitions in subsequent PRs. Marked `@public` so knip doesn't flag
+ * it as unused while it's waiting for its first consumer.
+ */
+export const TracesRefSchema = z
+  .discriminatedUnion("by", [
+    z.object({ by: z.literal("ids"), ids: z.array(traceIdSchema).min(1) }),
+    z.object({ by: z.literal("filters"), filters: FilterSetSchema }),
+  ])
+  .openapi("TracesRef")
+
 // All protected endpoints are already org-scoped via the Bearer API key
 // (resolved by `createAuthMiddleware` + `createOrganizationContextMiddleware`),
 // so the path schemas carry only resource identifiers — not the organization.

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,7 @@
   "workspaces": {
     ".": {},
     "apps/api": {
+      "entry": ["src/openapi/pagination.ts"],
       "project": ["src/**/*.ts"]
     },
     "apps/ingest": {

--- a/packages/domain/spans/src/helpers/trace-ref.ts
+++ b/packages/domain/spans/src/helpers/trace-ref.ts
@@ -11,7 +11,7 @@ import {
 } from "@domain/shared"
 import { Effect } from "effect"
 import { z } from "zod"
-import { TraceRepository } from "../ports/trace-repository.ts"
+import { type TraceListCursor, TraceRepository } from "../ports/trace-repository.ts"
 
 /**
  * Discriminated union identifying a target trace for public-API write paths.
@@ -82,4 +82,74 @@ export const resolveTraceIdFromRef = (
     }
 
     return match.traceId
+  })
+
+/**
+ * Plural sibling of {@link traceRefSchema} for bulk endpoints (export traces,
+ * import-from-traces into a dataset, etc).
+ *
+ * - `{ by: "ids", ids }` — explicit list of trace ids. Each id is verified
+ *   against the project before being trusted; ids that don't belong to the
+ *   project are silently dropped (the caller learns about it via the returned
+ *   count, not via an error).
+ * - `{ by: "filters", filters }` — resolves to **every** trace in the project
+ *   matching the filter set. Pagination happens internally; no upper bound is
+ *   enforced at this layer (callers/UIs may impose their own).
+ */
+export const tracesRefSchema = z.discriminatedUnion("by", [
+  z.object({ by: z.literal("ids"), ids: z.array(traceIdSchema).min(1) }),
+  z.object({ by: z.literal("filters"), filters: filterSetSchema }),
+])
+
+export type TracesRef = z.infer<typeof tracesRefSchema>
+
+const RESOLVE_PAGE_SIZE = 1000
+
+/**
+ * Resolve a {@link TracesRef} to the concrete list of `TraceId`s in this
+ * organization + project.
+ *
+ * For the `ids` variant we round-trip through `listByTraceIds` which already
+ * filters by `(organizationId, projectId)` server-side, so any id the caller
+ * doesn't own is dropped from the result.
+ *
+ * For the `filters` variant we walk every page until the cursor is exhausted.
+ * No hard cap is applied here — bulk endpoints that consume the result are
+ * expected to either accept large fan-outs (export → email) or impose their
+ * own limit before invoking this function.
+ */
+export const resolveTraceIdsFromRef = (
+  ref: TracesRef,
+  ctx: { readonly organizationId: string; readonly projectId: ProjectId },
+): Effect.Effect<readonly TraceId[], RepositoryError, TraceRepository | ChSqlClient> =>
+  Effect.gen(function* () {
+    const traceRepository = yield* TraceRepository
+    const organizationId = OrganizationId(ctx.organizationId)
+
+    if (ref.by === "ids") {
+      const found = yield* traceRepository.listByTraceIds({
+        organizationId,
+        projectId: ctx.projectId,
+        traceIds: ref.ids,
+      })
+      return found.map((trace) => trace.traceId)
+    }
+
+    const ids: TraceId[] = []
+    let cursor: TraceListCursor | undefined
+    while (true) {
+      const page = yield* traceRepository.listByProjectId({
+        organizationId,
+        projectId: ctx.projectId,
+        options: {
+          filters: ref.filters,
+          limit: RESOLVE_PAGE_SIZE,
+          ...(cursor ? { cursor } : {}),
+        },
+      })
+      for (const trace of page.items) ids.push(trace.traceId)
+      if (!page.hasMore || !page.nextCursor) break
+      cursor = page.nextCursor
+    }
+    return ids
   })

--- a/packages/domain/spans/src/index.ts
+++ b/packages/domain/spans/src/index.ts
@@ -36,7 +36,14 @@ export {
   resolveLastLlmCompletionSpanId,
 } from "./helpers/resolve-last-llm-completion-span.ts"
 export { resolveScoreTraceContext } from "./helpers/resolve-score-trace-context.ts"
-export { resolveTraceIdFromRef, type TraceRef, traceRefSchema } from "./helpers/trace-ref.ts"
+export {
+  resolveTraceIdFromRef,
+  resolveTraceIdsFromRef,
+  type TraceRef,
+  type TracesRef,
+  traceRefSchema,
+  tracesRefSchema,
+} from "./helpers/trace-ref.ts"
 export {
   alignUnixSecondsToHistogramBucket,
   denseTraceTimeHistogramBuckets,


### PR DESCRIPTION
Foundational helpers for the API expansion plan, decoupled from OAuth (which gets its own follow-up PR).

* `apps/api/src/openapi/pagination.ts` (new) -- `Paginated(item, name)` wrapper + `PaginatedQueryParamsSchema` (cursor + limit). Same shape as the trace/issue list endpoints already use; new endpoints will converge on this single Fern-friendly named component.
* `apps/api/src/openapi/schemas.ts` -- adds `TracesRefSchema`, the plural sibling of `TraceRefSchema` for bulk endpoints. Rebuilt locally with `.openapi(...)` names for the same Fern generator workaround the single-trace `TraceRefSchema` already uses.
* `packages/domain/spans/src/helpers/trace-ref.ts` -- adds `tracesRefSchema` and `resolveTraceIdsFromRef(ref, ctx)`. The `by: "ids"` variant round-trips through `TraceRepository.listByTraceIds` (which already filters by org+project, so caller-supplied stranger ids are silently dropped). The `by: "filters"` variant paginates through `listByProjectId` until the cursor is exhausted -- no upper bound at this layer; consuming endpoints (export -> email, dataset import) own any cap.
* `apps/api/src/middleware/rate-limiter.ts` -- adds `createTierRateLimiter("low" | "medium" | "high" | "critical")` at 100/60/15/3 req/min, keyed by `c.var.organization.id`. Org-keyed (not IP) so one greedy tenant can't starve another's quota. Not wired to any route yet -- per-prefix mounting lands with the new endpoints in later PRs.

Knip housekeeping: the new exports carry `@public` JSDoc tags so knip doesn't flag them as unused while waiting for their first consumer in subsequent PRs. `apps/api/src/openapi/pagination.ts` is added to the `apps/api` entry list in `knip.json` for the same reason -- the file is intentional public API surface, not dead code.

No behavior change to existing endpoints; everything is additive.