### PR TITLE
Add Redis hash tags to billing spend reservation keys

### DIFF
--- a/packages/platform/cache-redis/src/billing-spend-reservation.ts
+++ b/packages/platform/cache-redis/src/billing-spend-reservation.ts
@@ -65,11 +65,14 @@ const buildKeys = (input: Pick<BillingSpendReservationInput, "organizationId" | 
   }
 }
 
+// The `{${organizationId}}` hash tag colocates the counter and idempotency-set keys on the same
+// Redis Cluster slot. EVAL requires every KEYS[*] argument to map to one slot — without the hash
+// tag, the two keys hash independently and cluster-mode Redis returns CROSSSLOT.
 const buildCounterKey = (organizationId: OrganizationId, periodSegment: string): string =>
-  `org:${organizationId}:billing:spend-reservation:${periodSegment}:reserved`
+  `org:{${organizationId}}:billing:spend-reservation:${periodSegment}:reserved`
 
 const buildIdempotencySetKey = (organizationId: OrganizationId, periodSegment: string): string =>
-  `org:${organizationId}:billing:spend-reservation:${periodSegment}:keys`
+  `org:{${organizationId}}:billing:spend-reservation:${periodSegment}:keys`
 
 export const RedisBillingSpendReservationLive = (redis: RedisClient) =>
   Layer.succeed(BillingSpendReservation, {


### PR DESCRIPTION
## Summary
Updated Redis key generation for billing spend reservations to use hash tags, ensuring proper key colocation in Redis Cluster mode.

## Changes
- Added `{${organizationId}}` hash tags to both counter and idempotency-set keys in `buildCounterKey()` and `buildIdempotencySetKey()`
- Added explanatory comment documenting why hash tags are necessary for EVAL script execution in cluster mode

## Implementation Details
Redis Cluster requires all keys accessed within a single EVAL script to hash to the same slot. Without hash tags, the counter and idempotency-set keys were hashing independently, causing cluster-mode Redis to return a CROSSSLOT error. The hash tag syntax `{${organizationId}}` ensures both keys map to the same slot based on the organization ID, allowing the EVAL script to execute successfully.

https://claude.ai/code/session_01FfPyvmVLmxG59SAZsjoaBB