### PR TITLE
Improve OTEL Exporter documentation

### DIFF
--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -3,10 +3,6 @@ title: LangChain
 description: Connect your LangChain-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LangChain**.

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -3,10 +3,6 @@ title: LlamaIndex
 description: Connect your LlamaIndex-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **LlamaIndex**.

--- a/docs/telemetry/frameworks/mastra.mdx
+++ b/docs/telemetry/frameworks/mastra.mdx
@@ -3,10 +3,6 @@ title: Mastra
 description: Connect your Mastra-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Mastra**.

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -3,10 +3,6 @@ title: OpenAI Agents SDK
 description: Connect your OpenAI Agents SDK application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI Agents SDK** (`@openai/agents` for TypeScript, `openai-agents` for Python).

--- a/docs/telemetry/frameworks/vercel-ai-sdk.mdx
+++ b/docs/telemetry/frameworks/vercel-ai-sdk.mdx
@@ -3,10 +3,6 @@ title: Vercel AI SDK
 description: Connect your Vercel AI SDK-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Vercel AI SDK**.

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -186,11 +186,11 @@ span.SetAttributes(
 
 Latitude follows the **[OpenTelemetry Semantic Conventions for Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)** (v1.37+). When your spans include `gen_ai.*` attributes, the Latitude UI displays full LLM call details: the provider, model, input/output messages, token usage, cost, and latency.
 
-Refer to the [GenAI span semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) for the full attribute list. The message content attributes use a Latitude-specific format documented below.
+Refer to the [GenAI span semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) for the full attribute list. The message content attributes use the standard OpenTelemetry GenAI **parts-based** message format, shown below.
 
 ### Message Format
 
-Latitude expects the **parts-based** GenAI message format. Each message has a `role` and an array of `parts`:
+Latitude expects the standard **parts-based** GenAI message format. Each message has a `role` and an array of `parts`:
 
 **`gen_ai.input.messages`** (JSON string):
 

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -300,11 +300,11 @@ The `X-Latitude-Project` header is required on every request. Ensure it is prese
 
 This is the most common issue when integrating via the generic OTLP exporter. Your exporter is configured correctly (you get `202` and traces appear), but the Latitude UI shows empty LLM metadata.
 
-**Cause:** Your spans are missing the `gen_ai.*` semantic convention attributes. Configuring the exporter only ensures spans reach Latitude — it does not add LLM metadata. You must explicitly set attributes like `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.input.messages`, etc. on your spans.
+**Cause:** Your spans are missing the `gen_ai.*` semantic convention attributes. Configuring the exporter only ensures spans reach Latitude — it does not add LLM metadata. You must explicitly set attributes like `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.input.messages`, etc. on your spans.
 
 **Fix:** See [GenAI Span Attributes (LLM Metadata)](#genai-span-attributes-llm-metadata) above for the full list of attributes and message format. At a minimum, set:
 
-1. `gen_ai.system` — provider name
+1. `gen_ai.provider.name` — provider name (e.g. `"openai"`, `"anthropic"`). Latitude also accepts the deprecated `gen_ai.system` as a fallback for older emitters.
 2. `gen_ai.request.model` — model name
 3. `gen_ai.operation.name` — set to `"chat"`
 4. `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` — token counts

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -176,6 +176,50 @@ span.SetAttributes(
 )
 ```
 
+## GenAI Span Attributes (LLM Metadata)
+
+<Warning>
+  Configuring the OTLP exporter (endpoint + headers) only ensures your spans **reach** Latitude. For Latitude to display LLM call details — model name, token counts, input/output messages — your spans must carry the [OpenTelemetry GenAI semantic convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) attributes described below.
+
+  Without these attributes, traces will appear in the dashboard but show no model, token usage, or message content.
+</Warning>
+
+Latitude follows the **[OpenTelemetry Semantic Conventions for Generative AI](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)** (v1.37+). When your spans include `gen_ai.*` attributes, the Latitude UI displays full LLM call details: the provider, model, input/output messages, token usage, cost, and latency.
+
+Refer to the [GenAI span semconv spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) for the full attribute list. The message content attributes use a Latitude-specific format documented below.
+
+### Message Format
+
+Latitude expects the **parts-based** GenAI message format. Each message has a `role` and an array of `parts`:
+
+**`gen_ai.input.messages`** (JSON string):
+
+```json
+[
+  {
+    "role": "user",
+    "parts": [{"type": "text", "content": "What is the capital of France?"}]
+  }
+]
+```
+
+**`gen_ai.output.messages`** (JSON string):
+
+```json
+[
+  {
+    "role": "assistant",
+    "parts": [{"type": "text", "content": "The capital of France is Paris."}]
+  }
+]
+```
+
+**`gen_ai.system_instructions`** (JSON string):
+
+```json
+[{"type": "text", "content": "You are a helpful geography assistant."}]
+```
+
 ## Existing Observability Stack
 
 Latitude works alongside your existing observability tools. Add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
@@ -251,6 +295,24 @@ The `X-Latitude-Project` header is required on every request. Ensure it is prese
 - **Empty body:** An empty request body is accepted with `202` but produces no traces. Ensure your exporter is actually attaching span data.
 - **Smart filter (SDK only):** If you are using a Latitude SDK's `LatitudeSpanProcessor`, only LLM-relevant spans are exported by default. This does not apply when sending OTLP directly — all spans are ingested.
 - **Flush before exit:** Make sure your tracer provider flushes pending spans before the process exits.
+
+### Traces appear but show no model, tokens, or messages
+
+This is the most common issue when integrating via the generic OTLP exporter. Your exporter is configured correctly (you get `202` and traces appear), but the Latitude UI shows empty LLM metadata.
+
+**Cause:** Your spans are missing the `gen_ai.*` semantic convention attributes. Configuring the exporter only ensures spans reach Latitude — it does not add LLM metadata. You must explicitly set attributes like `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.input.messages`, etc. on your spans.
+
+**Fix:** See [GenAI Span Attributes (LLM Metadata)](#genai-span-attributes-llm-metadata) above for the full list of attributes and message format. At a minimum, set:
+
+1. `gen_ai.system` — provider name
+2. `gen_ai.request.model` — model name
+3. `gen_ai.operation.name` — set to `"chat"`
+4. `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` — token counts
+5. `gen_ai.input.messages` and `gen_ai.output.messages` — the actual conversation content
+
+<Note>
+  If you use a Latitude SDK or an OpenTelemetry auto-instrumentation library (e.g. `opentelemetry-instrumentation-openai`), these attributes are set automatically. This section only applies when you manually create spans for LLM calls without auto-instrumentation.
+</Note>
 
 ### Encoding
 

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -3,10 +3,6 @@ title: Amazon Bedrock
 description: Connect your Amazon Bedrock-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Amazon Bedrock**.

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -3,10 +3,6 @@ title: Anthropic
 description: Connect your Anthropic-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Anthropic** SDK.

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -3,10 +3,6 @@ title: Azure OpenAI
 description: Connect your Azure OpenAI-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Azure OpenAI**. Azure OpenAI uses the same `openai` SDK under the hood, so the `"openai"` instrumentation handles it automatically.

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -3,10 +3,6 @@ title: Cohere
 description: Connect your Cohere-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Cohere** SDK.

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -3,10 +3,6 @@ title: Google AI Platform
 description: Connect your Google AI Platform-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud AI Platform**.

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -3,10 +3,6 @@ title: OpenAI
 description: Connect your OpenAI-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **OpenAI** SDK.

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -3,10 +3,6 @@ title: Together AI
 description: Connect your Together AI-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses the **Together AI** SDK.

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -3,10 +3,6 @@ title: Vertex AI
 description: Connect your Vertex AI-powered application to Latitude for observability.
 ---
 
-<Warning>
-  **Work in progress:** Telemetry documentation is still being updated. Integration steps and APIs may be incomplete or out of date. Verify against your SDK versions and check back for revisions.
-</Warning>
-
 ## Overview
 
 This guide shows you how to integrate **Latitude Telemetry** into an application that uses **Google Cloud Vertex AI**.


### PR DESCRIPTION
A user had an issue implementing the OTEL exporter method as they didn't use native GenAI convention, so we didn't parse well the info of the spans. This fix adds this info for the coding agents to be aware of when implementing this