### PR TITLE
feat(platform): add @platform/oauth-token-auth for MCP/OAuth token va…

### DIFF
--- a/packages/platform/oauth-token-auth/package.json
+++ b/packages/platform/oauth-token-auth/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@platform/oauth-token-auth",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "check": "biome check src",
+    "format": "biome format --write src && biome check --fix src",
+    "typecheck": "tsgo -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests --dir src"
+  },
+  "dependencies": {
+    "@platform/cache-redis": "workspace:*",
+    "@platform/db-postgres": "workspace:*",
+    "@repo/utils": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@domain/shared": "workspace:*",
+    "@platform/testkit": "workspace:*",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/platform/oauth-token-auth/src/index.ts
+++ b/packages/platform/oauth-token-auth/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  MIN_VALIDATION_TIME_MS,
+  type OAuthTokenAuthResult,
+  type ValidateOAuthAccessTokenDeps,
+  validateOAuthAccessToken,
+} from "./validate-oauth-token.ts"

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
@@ -1,0 +1,239 @@
+import { generateId } from "@domain/shared"
+import type { RedisClient } from "@platform/cache-redis"
+import type { PostgresDb } from "@platform/db-postgres"
+import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import {
+  closeInMemoryPostgres,
+  createInMemoryPostgres,
+  createOrganizationFixture,
+  createUserFixture,
+  type InMemoryPostgres,
+} from "@platform/testkit"
+import { Effect } from "effect"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { validateOAuthAccessToken } from "./validate-oauth-token.ts"
+
+/**
+ * `@repo/utils` crypto helpers require Node 25+ `Uint8Array` hex APIs (mirrors
+ * the same skip in `@platform/api-key-auth`'s tests). When the host Node is
+ * older the integration block is skipped; the `exports the validator` smoke
+ * test still runs everywhere.
+ */
+const nodeSupportsUint8Hex = typeof Uint8Array.fromHex === "function"
+
+const createFakeRedis = (): RedisClient => {
+  const store = new Map<string, string>()
+  return {
+    get: async (key: string) => store.get(key) ?? null,
+    setex: async (key: string, _ttl: number, value: string) => {
+      store.set(key, value)
+      return "OK"
+    },
+    del: async (key: string) => {
+      store.delete(key)
+      return 1
+    },
+  } as unknown as RedisClient
+}
+
+interface OAuthSetup {
+  readonly accessToken: string
+  readonly tokenRowId: string
+  readonly clientId: string
+  readonly userId: string
+  readonly organizationId: string
+}
+
+interface InsertOAuthSetupOptions {
+  readonly organizationId: string | null
+  readonly disabled?: boolean
+  /** Default: 5 minutes from now. */
+  readonly accessTokenExpiresAt?: Date
+  readonly scopes?: string
+}
+
+/**
+ * Insert one `oauth_applications` + one `oauth_access_tokens` row pointing at
+ * a fresh user. Lets each test set the disabled flag, expiry, and bound org
+ * independently so we can hit each rejection branch.
+ */
+const insertOAuthSetup = async (db: PostgresDb, options: InsertOAuthSetupOptions): Promise<OAuthSetup> => {
+  const userFixture = await Effect.runPromise(createUserFixture(db))
+  const userId = userFixture.id
+  const clientId = `client-${generateId()}`
+  const accessToken = `loa_${generateId()}_${generateId()}`
+  const refreshToken = `lor_${generateId()}_${generateId()}`
+  const tokenRowId = generateId()
+
+  await db.insert(oauthApplications).values({
+    id: generateId(),
+    name: "Test MCP Client",
+    icon: null,
+    metadata: null,
+    clientId,
+    clientSecret: "secret",
+    redirectUrls: "http://localhost/cb",
+    type: "public",
+    disabled: options.disabled ?? false,
+    userId,
+    organizationId: options.organizationId,
+  })
+
+  const expiresAt = options.accessTokenExpiresAt ?? new Date(Date.now() + 5 * 60_000)
+  await db.insert(oauthAccessTokens).values({
+    id: tokenRowId,
+    accessToken,
+    refreshToken,
+    accessTokenExpiresAt: expiresAt,
+    refreshTokenExpiresAt: new Date(expiresAt.getTime() + 60 * 60_000),
+    clientId,
+    userId,
+    scopes: options.scopes ?? "openid profile",
+  })
+
+  return {
+    accessToken,
+    tokenRowId,
+    clientId,
+    userId,
+    organizationId: options.organizationId ?? "",
+  }
+}
+
+describe("validateOAuthAccessToken", () => {
+  it("exports the validator", () => {
+    expect(typeof validateOAuthAccessToken).toBe("function")
+  })
+})
+
+describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, Node 25+)", () => {
+  let database: InMemoryPostgres
+
+  beforeAll(async () => {
+    database = await createInMemoryPostgres()
+  })
+
+  afterAll(async () => {
+    await closeInMemoryPostgres(database)
+  })
+
+  it("returns the resolved auth result for a valid token bound to an org", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+    })
+
+    const redis = createFakeRedis()
+    const touched: string[] = []
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+        onTokenValidated: (id) => touched.push(id),
+      }),
+    )
+
+    expect(result).not.toBeNull()
+    expect(result?.userId).toBe(setup.userId)
+    expect(result?.organizationId).toBe(organization.id)
+    expect(result?.oauthClientId).toBe(setup.clientId)
+    expect(result?.scopes).toEqual(["openid", "profile"])
+    expect(touched).toEqual([setup.tokenRowId])
+  })
+
+  it("returns null for an unknown token", async () => {
+    const redis = createFakeRedis()
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken("loa_unknown_token", {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null for an expired token", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+      accessTokenExpiresAt: new Date(Date.now() - 60_000),
+    })
+
+    const redis = createFakeRedis()
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when the application is disabled", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+      disabled: true,
+    })
+
+    const redis = createFakeRedis()
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it("returns null when the application is not bound to any org (NULL organization_id)", async () => {
+    // The exact failure mode for an MCP client that registered but never
+    // completed the consent flow — `oauth_applications.organization_id` stays
+    // NULL and the validator must reject any tokens issued against it.
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: null,
+    })
+
+    const redis = createFakeRedis()
+
+    const result = await Effect.runPromise(
+      validateOAuthAccessToken(setup.accessToken, {
+        redis,
+        adminClient: database.adminPostgresClient,
+      }),
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it("serves a cached result without calling onTokenValidated again", async () => {
+    const organization = await Effect.runPromise(createOrganizationFixture(database.postgresDb))
+    const setup = await insertOAuthSetup(database.postgresDb, {
+      organizationId: organization.id,
+    })
+
+    const redis = createFakeRedis()
+    const touched: string[] = []
+    const deps = {
+      redis,
+      adminClient: database.adminPostgresClient,
+      onTokenValidated: (id: string) => touched.push(id),
+    }
+
+    // First call — DB hit, touch fires.
+    await Effect.runPromise(validateOAuthAccessToken(setup.accessToken, deps))
+    expect(touched).toEqual([setup.tokenRowId])
+
+    // Second call — cache hit, no second touch.
+    const cached = await Effect.runPromise(validateOAuthAccessToken(setup.accessToken, deps))
+    expect(cached?.userId).toBe(setup.userId)
+    expect(touched).toEqual([setup.tokenRowId])
+  })
+})

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.ts
@@ -1,0 +1,276 @@
+import type { RedisClient } from "@platform/cache-redis"
+// `eq` is re-exported by `@platform/db-postgres` to keep all consumers on one
+// drizzle-orm version (peer-dep collisions cause private-property typecheck
+// errors otherwise).
+import { eq, type PostgresClient } from "@platform/db-postgres"
+import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { hash } from "@repo/utils"
+import { Effect } from "effect"
+
+/**
+ * Minimum time spent inside the validator before returning, in milliseconds.
+ * Mirrors {@link `@platform/api-key-auth`.MIN_VALIDATION_TIME_MS}: matched on
+ * purpose so the two auth paths look indistinguishable from a wall-clock
+ * timing-attack perspective.
+ */
+export const MIN_VALIDATION_TIME_MS = 50
+
+const VALID_TOKEN_TTL_SECONDS = 300
+const INVALID_TOKEN_TTL_SECONDS = 5
+const REDIS_OPERATION_TIMEOUT_MS = 50
+
+const withTimeout = <T>(operation: Promise<T>, fallback: T): Promise<T> =>
+  Promise.race([
+    operation,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), REDIS_OPERATION_TIMEOUT_MS)),
+  ])
+
+const getCacheKey = (tokenHash: string): string => `oauth:${tokenHash}`
+
+/**
+ * Result returned to the API auth middleware on a successful validation. The
+ * middleware wraps this in its own `AuthContext` shape (with `method: "oauth"`)
+ * before stashing it on the Hono context. Keeping the platform-level result
+ * narrow lets future resource servers (ingest, etc.) use the same validator
+ * without a circular dep on the API's auth-context type.
+ */
+export interface OAuthTokenAuthResult {
+  readonly userId: string
+  readonly organizationId: string
+  readonly oauthClientId: string
+  readonly scopes: ReadonlyArray<string>
+  /** Token's `accessTokenExpiresAt`. Cached entries re-check this on hit. */
+  readonly expiresAt: Date
+}
+
+/**
+ * Wire shape used in Redis. {@link OAuthTokenAuthResult.expiresAt} is a `Date`
+ * in memory but JSON-serialized as ISO 8601, so the cached form has to round-
+ * trip through string before being rehydrated.
+ */
+interface CachedOAuthTokenAuthResult {
+  readonly userId: string
+  readonly organizationId: string
+  readonly oauthClientId: string
+  readonly scopes: ReadonlyArray<string>
+  readonly expiresAt: string
+}
+
+const isCachedOAuthResult = (value: unknown): value is CachedOAuthTokenAuthResult | null => {
+  if (value === null) return true
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.userId === "string" &&
+    typeof v.organizationId === "string" &&
+    typeof v.oauthClientId === "string" &&
+    Array.isArray(v.scopes) &&
+    v.scopes.every((s) => typeof s === "string") &&
+    typeof v.expiresAt === "string"
+  )
+}
+
+const getCached = (
+  redis: RedisClient,
+  tokenHash: string,
+): Effect.Effect<OAuthTokenAuthResult | null | undefined, never> =>
+  Effect.tryPromise({
+    try: async () => {
+      const raw = await withTimeout(redis.get(getCacheKey(tokenHash)), null)
+      if (!raw) return undefined
+      const parsed = JSON.parse(raw)
+      if (!isCachedOAuthResult(parsed)) return undefined
+      if (parsed === null) return null
+      return {
+        userId: parsed.userId,
+        organizationId: parsed.organizationId,
+        oauthClientId: parsed.oauthClientId,
+        scopes: parsed.scopes,
+        expiresAt: new Date(parsed.expiresAt),
+      } satisfies OAuthTokenAuthResult
+    },
+    catch: () => undefined,
+  }).pipe(Effect.orDie)
+
+const cache = (
+  redis: RedisClient,
+  tokenHash: string,
+  result: OAuthTokenAuthResult | null,
+  ttl: number,
+): Effect.Effect<void, never> => {
+  const payload =
+    result === null
+      ? null
+      : ({
+          userId: result.userId,
+          organizationId: result.organizationId,
+          oauthClientId: result.oauthClientId,
+          scopes: result.scopes,
+          expiresAt: result.expiresAt.toISOString(),
+        } satisfies CachedOAuthTokenAuthResult)
+  return Effect.tryPromise({
+    try: () => withTimeout(redis.setex(getCacheKey(tokenHash), ttl, JSON.stringify(payload)), undefined),
+    catch: () => undefined,
+  }).pipe(Effect.orDie)
+}
+
+const invalidateCache = (redis: RedisClient, tokenHash: string): Effect.Effect<void, never> =>
+  Effect.tryPromise({
+    try: () => withTimeout(redis.del(getCacheKey(tokenHash)) as Promise<unknown>, undefined),
+    catch: () => undefined,
+  }).pipe(Effect.orDie)
+
+const enforceMinimumTime = (startTime: number, minMs: number): Effect.Effect<void, never> => {
+  const elapsed = Date.now() - startTime
+  if (elapsed < minMs) {
+    return Effect.tryPromise({
+      try: () => new Promise<void>((resolve) => setTimeout(resolve, minMs - elapsed)),
+      catch: () => undefined,
+    }).pipe(Effect.orDie)
+  }
+  return Effect.void
+}
+
+interface DbRow {
+  readonly tokenRowId: string
+  readonly userId: string | null
+  readonly clientId: string | null
+  readonly scopes: string | null
+  readonly accessTokenExpiresAt: Date | null
+  readonly applicationDisabled: boolean | null
+  readonly organizationId: string | null
+}
+
+const lookupByToken = (client: PostgresClient, token: string): Promise<DbRow | undefined> =>
+  client.db
+    .select({
+      tokenRowId: oauthAccessTokens.id,
+      userId: oauthAccessTokens.userId,
+      clientId: oauthAccessTokens.clientId,
+      scopes: oauthAccessTokens.scopes,
+      accessTokenExpiresAt: oauthAccessTokens.accessTokenExpiresAt,
+      applicationDisabled: oauthApplications.disabled,
+      organizationId: oauthApplications.organizationId,
+    })
+    .from(oauthAccessTokens)
+    .innerJoin(oauthApplications, eq(oauthApplications.clientId, oauthAccessTokens.clientId))
+    .where(eq(oauthAccessTokens.accessToken, token))
+    .limit(1)
+    .then((rows) => rows[0])
+
+/**
+ * Parse a BA-stored `scopes` text field (space-separated per RFC 6749 §3.3)
+ * into a stable string array. NULL/empty produces an empty array.
+ */
+const parseScopes = (raw: string | null): ReadonlyArray<string> => {
+  if (!raw) return []
+  return raw.split(/\s+/).filter((s) => s.length > 0)
+}
+
+const isExpired = (expiresAt: Date, now: Date = new Date()): boolean => expiresAt.getTime() <= now.getTime()
+
+const ttlFromExpiry = (expiresAt: Date, now: Date = new Date()): number => {
+  const remainingSeconds = Math.floor((expiresAt.getTime() - now.getTime()) / 1000)
+  return Math.max(1, Math.min(VALID_TOKEN_TTL_SECONDS, remainingSeconds))
+}
+
+export interface ValidateOAuthAccessTokenDeps {
+  readonly redis: RedisClient
+  readonly adminClient: PostgresClient
+  /** Called when a token is validated via DB (not cache-only path). */
+  readonly onTokenValidated?: (tokenRowId: string) => void
+}
+
+/**
+ * Validate a Better-Auth-issued OAuth access token without going through BA's
+ * own session API. Mirrors {@link `@platform/api-key-auth`.validateApiKey}'s
+ * shape so the two auth paths look identical from the consumer's perspective:
+ * Redis cache first (5 min TTL valid / 5 sec TTL invalid), admin Postgres
+ * fallback on miss, minimum-timing pad to defend against timing attacks.
+ *
+ * Why we don't go through `auth.api.getMcpSession({ headers })`:
+ *
+ * 1. BA's `getMcpSession` does NOT check `accessTokenExpiresAt` (verified
+ *    against `better-auth@1.6.9/dist/plugins/mcp/index.mjs`). An expired
+ *    token would be accepted there but rejected here — going through BA
+ *    would force us to re-implement the expiry check anyway.
+ * 2. BA can't return our app-extension columns (`oauth_applications.disabled`,
+ *    `oauth_applications.organization_id`). We need the org binding to
+ *    populate the request's organization context, so the join is mandatory.
+ *
+ * Validation rules (any one rejects the token):
+ *   - row not found
+ *   - `accessTokenExpiresAt < now()`
+ *   - `oauth_applications.disabled = true`
+ *   - `oauth_applications.organization_id IS NULL` (registered but never
+ *     consent-bound to an org — the `/auth/consent` step never happened or
+ *     was abandoned)
+ *
+ * The DB query uses the admin Postgres connection (RLS-bypass) because
+ * `oauth_applications` has RLS scoped by `organization_id` and the org id
+ * is exactly what we're trying to discover from the token.
+ *
+ * Returns `null` for all rejection cases (matches `validateApiKey` shape);
+ * the API auth middleware turns null into a 401 with a `WWW-Authenticate`
+ * header pointing at the protected-resource discovery endpoint.
+ */
+export const validateOAuthAccessToken = (
+  token: string,
+  deps: ValidateOAuthAccessTokenDeps,
+): Effect.Effect<OAuthTokenAuthResult | null, never> => {
+  const { redis, adminClient, onTokenValidated } = deps
+
+  return Effect.gen(function* () {
+    const startTime = Date.now()
+    // Hash for the Redis key only — the DB stores the raw access_token (BA's
+    // schema). We don't put raw bearer tokens in Redis as defense in depth.
+    const tokenHash = yield* hash(token)
+
+    const cached = yield* getCached(redis, tokenHash)
+
+    if (cached !== undefined) {
+      // Belt-and-suspenders: even though the cache TTL is bounded by token
+      // expiry, double-check on hit so a token expiring in the cache window
+      // doesn't keep working.
+      if (cached !== null && isExpired(cached.expiresAt)) {
+        yield* invalidateCache(redis, tokenHash)
+        // Fall through to the DB path so we don't return stale-expired.
+      } else {
+        yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+        return cached
+      }
+    }
+
+    const row = yield* Effect.tryPromise({
+      try: () => lookupByToken(adminClient, token),
+      catch: () => undefined,
+    }).pipe(Effect.orDie)
+
+    if (
+      !row ||
+      row.userId === null ||
+      row.clientId === null ||
+      row.accessTokenExpiresAt === null ||
+      isExpired(row.accessTokenExpiresAt) ||
+      row.applicationDisabled === true ||
+      row.organizationId === null
+    ) {
+      yield* cache(redis, tokenHash, null, INVALID_TOKEN_TTL_SECONDS)
+      yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+      return null
+    }
+
+    const result: OAuthTokenAuthResult = {
+      userId: row.userId,
+      organizationId: row.organizationId,
+      oauthClientId: row.clientId,
+      scopes: parseScopes(row.scopes),
+      expiresAt: row.accessTokenExpiresAt,
+    }
+
+    yield* cache(redis, tokenHash, result, ttlFromExpiry(row.accessTokenExpiresAt))
+    onTokenValidated?.(row.tokenRowId)
+    yield* enforceMinimumTime(startTime, MIN_VALIDATION_TIME_MS)
+    return result
+  }).pipe(Effect.orDie)
+}

--- a/packages/platform/oauth-token-auth/tsconfig.json
+++ b/packages/platform/oauth-token-auth/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1861,6 +1861,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/platform/oauth-token-auth:
+    dependencies:
+      '@platform/cache-redis':
+        specifier: workspace:*
+        version: link:../cache-redis
+      '@platform/db-postgres':
+        specifier: workspace:*
+        version: link:../db-postgres
+      '@repo/utils':
+        specifier: workspace:*
+        version: link:../../utils
+      effect:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.57
+    devDependencies:
+      '@domain/shared':
+        specifier: workspace:*
+        version: link:../../domain/shared
+      '@platform/testkit':
+        specifier: workspace:*
+        version: link:../testkit
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/platform/op-gepa:
     dependencies:
       '@domain/optimizations':


### PR DESCRIPTION
…lidation

New package mirroring `@platform/api-key-auth`'s shape, but for the Better-Auth-issued OAuth access tokens that MCP clients exchange for after the consent flow. Pure Drizzle SQL on the admin Postgres connection
+ Redis cache; deliberately does not import or call Better Auth.

Why not go through `auth.api.getMcpSession({ headers })`:

* Verified against `better-auth@1.6.9/dist/plugins/mcp/index.mjs`: BA's `getMcpSession` does NOT check `accessTokenExpiresAt`. An expired token would be accepted there but rejected here -- routing through BA would force us to re-implement the expiry check anyway.
* BA can't return our app-extension columns (`oauth_applications.disabled`, `oauth_applications.organization_id`). The org binding must come from the join, so the pure-SQL path is the simpler one.

Validation rejects on any of:
* token row not found
* `accessTokenExpiresAt < now()`
* `oauth_applications.disabled = true`
* `oauth_applications.organization_id IS NULL` (registered but never consent-bound -- the `/auth/consent` step never happened or was abandoned)

Cache shape mirrors `validateApiKey`: `oauth:<sha256(token)>` Redis key, 5 min TTL on valid hits clamped to `secondsUntilExpiry`, 5 sec TTL on negative cache, 50 ms minimum-validation-time pad to defend against timing attacks. Cached entries re-check `expiresAt > now()` on hit so a token that lapses inside the cache window is still rejected.

Returns a narrow `OAuthTokenAuthResult` (userId, organizationId, oauthClientId, scopes, expiresAt). The API auth middleware will wrap this in its own `AuthContext` shape (with `method: "oauth"`); keeping the platform-level result narrow lets future resource servers (ingest etc.) reuse the validator without circular deps on the API's auth-context type.

Tests cover the happy path, unknown token, expired token, disabled app, NULL org binding, and cache reuse (no `onTokenValidated` re-fire on cache hit).

This unblocks M2's `apps/api/src/middleware/auth.ts` rewrite, which will dispatch to either `validateApiKey` or `validateOAuthAccessToken` based on the bearer-token prefix.