### PR TITLE
fix(web): show advanced headers config for OAuth-required MCP servers

### DIFF
--- a/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/External.tsx
+++ b/apps/web/src/app/(private)/settings/_components/Integrations/New/_components/Configuration/External.tsx
@@ -242,7 +242,7 @@ export const ExternalIntegrationConfiguration = forwardRef<
           )}
         </>
       )}
-      {authDetection.checked && !authDetection.requiresOAuth && (
+      {authDetection.checked && (
         <CollapsibleBox
           title='Advanced configuration'
           icon='settings'


### PR DESCRIPTION
The "Advanced configuration" panel was hidden whenever the probed MCP server reported it requires authentication, so users could no longer add custom headers (e.g. x-api-key) once OAuth/Bearer was offered. Show it for every probed server instead.