### PR TITLE
fix(web): show bulk actions for select-all in saved searches (LAT-557)

### DIFF
--- a/apps/web/src/domains/datasets/datasets.functions.ts
+++ b/apps/web/src/domains/datasets/datasets.functions.ts
@@ -22,6 +22,7 @@ import {
   DatasetId,
   DatasetRowId,
   DatasetVersionId,
+  filterSetSchema,
   IssueId,
   isValidId,
   OrganizationId,
@@ -612,6 +613,8 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
       datasetId: z.string(),
       issueId: z.string().optional(),
       selection: rowSelectionSchema,
+      searchQuery: z.string().max(500).optional(),
+      filters: filterSetSchema.optional(),
     }),
   )
   .handler(async ({ data }): Promise<{ versionId: string; version: number; rowCount: number }> => {
@@ -625,6 +628,8 @@ export const addTracesToDatasetFunction = createServerFn({ method: "POST" })
         datasetId: DatasetId(data.datasetId),
         source: toTraceSource(data.issueId),
         selection: toTraceSelection(data.selection),
+        ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
+        ...(data.filters ? { filters: data.filters } : {}),
       }).pipe(
         withPostgres(DatasetRepositoryLive, getPostgresClient(), orgId),
         withClickHouse(DatasetRowRepositoryLive, chClient, orgId),
@@ -657,6 +662,8 @@ export const createDatasetFromTracesFunction = createServerFn({
       issueId: z.string().optional(),
       name: z.string().min(1),
       selection: rowSelectionSchema,
+      searchQuery: z.string().max(500).optional(),
+      filters: filterSetSchema.optional(),
     }),
   )
   .handler(
@@ -680,6 +687,8 @@ export const createDatasetFromTracesFunction = createServerFn({
           name: data.name,
           source: toTraceSource(data.issueId),
           selection: toTraceSelection(data.selection),
+          ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
+          ...(data.filters ? { filters: data.filters } : {}),
         }).pipe(
           withPostgres(Layer.mergeAll(DatasetRepositoryLive, OutboxEventWriterLive), pgClient, orgId),
           withClickHouse(DatasetRowRepositoryLive, chClient, orgId),

--- a/apps/web/src/domains/traces/traces.functions.ts
+++ b/apps/web/src/domains/traces/traces.functions.ts
@@ -392,6 +392,7 @@ export const enqueueTracesExport = createServerFn({ method: "POST" })
       projectId: z.string(),
       filters: filterSetSchema.optional(),
       selection: exportSelectionSchema.optional(),
+      searchQuery: z.string().max(500).optional(),
     }),
   )
   .handler(async ({ data }): Promise<EnqueuedExportResult> => {
@@ -420,6 +421,7 @@ export const enqueueTracesExport = createServerFn({ method: "POST" })
         recipientEmail: email,
         ...(data.filters ? { filters: data.filters } : {}),
         ...(data.selection ? { selection: data.selection } : {}),
+        ...(data.searchQuery ? { searchQuery: data.searchQuery } : {}),
       }),
     )
 

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/add-to-dataset-modal.tsx
@@ -1,4 +1,5 @@
 import { MAX_TRACES_PER_DATASET_IMPORT } from "@domain/datasets/constants"
+import type { FilterSet } from "@domain/shared"
 import { Alert, Button, CloseTrigger, Input, Modal, Select, type SelectOption, Text, useToast } from "@repo/ui"
 import { useNavigate } from "@tanstack/react-router"
 import { Plus } from "lucide-react"
@@ -22,6 +23,17 @@ interface AddToDatasetModalProps {
    * to this issue (via score analytics). Omit on the project-wide traces page.
    */
   issueId?: string
+  /**
+   * Saved-search query that scopes "all" / "allExcept" selections. Ignored when
+   * `issueId` is set. Omit outside the search page.
+   */
+  searchQuery?: string
+  /**
+   * Active table filters that scope "all" / "allExcept" selections to the
+   * same set the user sees. Ignored when `issueId` is set. Omit when no
+   * filters are active.
+   */
+  filters?: FilterSet
   selection: BulkSelection<string>
   selectedCount: number
   onSuccess: () => void
@@ -32,6 +44,8 @@ export function AddToDatasetModal({
   onOpenChange,
   projectId,
   issueId,
+  searchQuery,
+  filters,
   selection,
   selectedCount,
   onSuccess,
@@ -71,6 +85,8 @@ export function AddToDatasetModal({
             name: newDatasetName.trim(),
             selection,
             ...(issueId ? { issueId } : {}),
+            ...(searchQuery ? { searchQuery } : {}),
+            ...(filters ? { filters } : {}),
           },
         })
         toast({
@@ -92,6 +108,8 @@ export function AddToDatasetModal({
             datasetId: selectedDatasetId,
             selection,
             ...(issueId ? { issueId } : {}),
+            ...(searchQuery ? { searchQuery } : {}),
+            ...(filters ? { filters } : {}),
           },
         })
         toast({
@@ -119,6 +137,8 @@ export function AddToDatasetModal({
     newDatasetName,
     projectId,
     issueId,
+    searchQuery,
+    filters,
     selection,
     selectedCount,
     toast,

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/index.tsx
@@ -388,6 +388,7 @@ function ProjectPage() {
             selection={bulkSelection}
             selectedCount={selectedCount}
             onSuccess={clearSelections}
+            {...(hasActiveFilters ? { filters } : {})}
           />
         </>
       )}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/search/index.tsx
@@ -113,11 +113,7 @@ function SearchPage() {
 
   const selectedCount = getSelectedCount(selectionState, totalTraceCount)
   const bulkSelection = getBulkSelection(selectionState)
-  // Bulk actions only render for explicitly-picked rows. `mode: "all"` and
-  // `mode: "allExcept"` would resolve server-side against the unfiltered
-  // project, ignoring `searchQuery`, which would silently process more
-  // traces than the user sees in the UI.
-  const showBulkActions = bulkSelection?.mode === "selected"
+  const showBulkActions = selectedCount > 0
 
   const onSortingChange = (next: { column: string; direction: SortDirection }) => {
     setSortBy(next.column)
@@ -159,6 +155,7 @@ function SearchPage() {
           projectId,
           selection: bulkSelection,
           ...(hasActiveFilters ? { filters } : {}),
+          ...(hasSearchQuery ? { searchQuery: q } : {}),
         },
       })
       toast({
@@ -386,6 +383,8 @@ function SearchPage() {
           selection={bulkSelection}
           selectedCount={selectedCount}
           onSuccess={clearSelections}
+          {...(hasSearchQuery ? { searchQuery: q } : {})}
+          {...(hasActiveFilters ? { filters } : {})}
         />
       ) : null}
 

--- a/apps/workers/src/workers/exports.ts
+++ b/apps/workers/src/workers/exports.ts
@@ -128,13 +128,18 @@ function generateTracesExport(
   projectId: ProjectIdType,
   filters?: FilterSet,
   selection?: Extract<ExportPayload, { kind: "traces" }>["selection"],
+  searchQuery?: string,
 ) {
   return buildTracesExportUseCase({
     organizationId,
     projectId,
     ...(filters ? { filters } : {}),
     ...(selection ? { selection } : {}),
-  }).pipe(withClickHouse(TraceRepositoryLive, getClickhouseClient(), organizationId))
+    ...(searchQuery ? { searchQuery } : {}),
+  }).pipe(
+    withClickHouse(TraceRepositoryLive, getClickhouseClient(), organizationId),
+    withAi(AIEmbedLive, getRedisClient()),
+  )
 }
 
 function generateIssuesExport(
@@ -206,7 +211,7 @@ function dispatchExport(payload: ExportPayload) {
     case "dataset":
       return generateDatasetExport(organizationId, DatasetId(payload.datasetId), payload.selection)
     case "traces":
-      return generateTracesExport(organizationId, projectId, payload.filters, payload.selection)
+      return generateTracesExport(organizationId, projectId, payload.filters, payload.selection, payload.searchQuery)
     case "issues":
       return generateIssuesExport(organizationId, projectId, {
         ...(payload.selection ? { selection: payload.selection } : {}),

--- a/packages/domain/datasets/src/use-cases/add-traces-to-dataset.test.ts
+++ b/packages/domain/datasets/src/use-cases/add-traces-to-dataset.test.ts
@@ -1,0 +1,208 @@
+import { OutboxEventWriter } from "@domain/events"
+import { ScoreAnalyticsRepository } from "@domain/scores"
+import { createFakeScoreAnalyticsRepository } from "@domain/scores/testing"
+import { ChSqlClient, type FilterSet, IssueId, OrganizationId, SqlClient, type TraceId } from "@domain/shared"
+import { createFakeChSqlClient } from "@domain/shared/testing"
+import { TraceRepository } from "@domain/spans"
+import { createFakeTraceRepository } from "@domain/spans/testing"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import { DatasetRepository } from "../ports/dataset-repository.ts"
+import { DatasetRowRepository, type DatasetRowRepositoryShape } from "../ports/dataset-row-repository.ts"
+import { createFakeDatasetRepository } from "../testing/fake-dataset-repository.ts"
+import { addTracesToDataset, createDatasetFromTraces } from "./add-traces-to-dataset.ts"
+
+const organizationId = OrganizationId("o".repeat(24))
+const projectId = "p".repeat(24) as Parameters<typeof addTracesToDataset>[0]["projectId"]
+const datasetId = "d".repeat(24) as Parameters<typeof addTracesToDataset>[0]["datasetId"]
+
+// All methods die because the "mode: all" + empty page path returns EMPTY_RESULT
+// before touching the row repository. If a future change starts calling these
+// on the empty-page path, the test will surface that by dying loudly.
+const stubRowRepo: DatasetRowRepositoryShape = {
+  findExistingTraceIds: () => Effect.succeed(new Set<TraceId>()),
+  insertBatch: () => Effect.die("DatasetRowRepository.insertBatch should not be called"),
+  list: () => Effect.die("DatasetRowRepository.list should not be called"),
+  count: () => Effect.die("DatasetRowRepository.count should not be called"),
+  listPage: () => Effect.die("DatasetRowRepository.listPage should not be called"),
+  findById: () => Effect.die("DatasetRowRepository.findById should not be called"),
+  updateRow: () => Effect.die("DatasetRowRepository.updateRow should not be called"),
+  deleteBatch: () => Effect.die("DatasetRowRepository.deleteBatch should not be called"),
+  deleteAll: () => Effect.die("DatasetRowRepository.deleteAll should not be called"),
+}
+
+const baseFilters: FilterSet = { tags: [{ op: "contains", value: "important" }] }
+
+const inertSqlClient = {
+  organizationId,
+  transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+  query: () => Effect.die("SqlClient.query should not be called"),
+}
+
+const provideAllServices = (overrides: {
+  readonly traceRepo: (typeof TraceRepository)["Service"]
+  readonly scoreAnalyticsRepo?: (typeof ScoreAnalyticsRepository)["Service"]
+}) => {
+  const { repository: defaultDatasetRepo } = createFakeDatasetRepository(undefined, undefined, { organizationId })
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.provideService(TraceRepository, overrides.traceRepo),
+      Effect.provideService(DatasetRowRepository, stubRowRepo),
+      Effect.provideService(
+        ScoreAnalyticsRepository,
+        overrides.scoreAnalyticsRepo ?? createFakeScoreAnalyticsRepository().repository,
+      ),
+      Effect.provideService(DatasetRepository, defaultDatasetRepo),
+      Effect.provideService(OutboxEventWriter, { write: () => Effect.void }),
+      Effect.provideService(SqlClient, inertSqlClient),
+      Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId })),
+    )
+}
+
+describe("addTracesToDataset", () => {
+  it("forwards both filters and searchQuery to listByProjectId for mode=all so the resolved set matches the table's filtered+searched view", async () => {
+    const calls: Array<{ filters?: FilterSet; searchQuery?: string }> = []
+    const { repository: traceRepo } = createFakeTraceRepository({
+      listByProjectId: ({ options }) => {
+        calls.push({
+          ...(options.filters ? { filters: options.filters } : {}),
+          ...(options.searchQuery ? { searchQuery: options.searchQuery } : {}),
+        })
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+
+    await Effect.runPromise(
+      provideAllServices({ traceRepo })(
+        addTracesToDataset({
+          projectId,
+          datasetId,
+          source: { kind: "project" },
+          selection: { mode: "all" },
+          searchQuery: "checkout flow",
+          filters: baseFilters,
+        }),
+      ),
+    )
+
+    expect(calls).toEqual([{ filters: baseFilters, searchQuery: "checkout flow" }])
+  })
+
+  it("forwards filters and searchQuery to listByProjectId for mode=allExcept", async () => {
+    const calls: Array<{ filters?: FilterSet; searchQuery?: string }> = []
+    const { repository: traceRepo } = createFakeTraceRepository({
+      listByProjectId: ({ options }) => {
+        calls.push({
+          ...(options.filters ? { filters: options.filters } : {}),
+          ...(options.searchQuery ? { searchQuery: options.searchQuery } : {}),
+        })
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+
+    await Effect.runPromise(
+      provideAllServices({ traceRepo })(
+        addTracesToDataset({
+          projectId,
+          datasetId,
+          source: { kind: "project" },
+          selection: { mode: "allExcept", traceIds: ["t".repeat(32) as TraceId] },
+          searchQuery: "payment errors",
+          filters: baseFilters,
+        }),
+      ),
+    )
+
+    expect(calls).toEqual([{ filters: baseFilters, searchQuery: "payment errors" }])
+  })
+
+  it("omits filters and searchQuery from listByProjectId when neither is supplied", async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const { repository: traceRepo } = createFakeTraceRepository({
+      listByProjectId: ({ options }) => {
+        calls.push({ ...options })
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+
+    await Effect.runPromise(
+      provideAllServices({ traceRepo })(
+        addTracesToDataset({
+          projectId,
+          datasetId,
+          source: { kind: "project" },
+          selection: { mode: "all" },
+        }),
+      ),
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).not.toHaveProperty("filters")
+    expect(calls[0]).not.toHaveProperty("searchQuery")
+  })
+
+  it("does not forward filters or searchQuery when source is an issue (issue-source ignores both)", async () => {
+    const listByProjectIdCalls: number[] = []
+    const issueRepoCalls: Array<Record<string, unknown>> = []
+    const { repository: traceRepo } = createFakeTraceRepository({
+      listByProjectId: () => {
+        listByProjectIdCalls.push(1)
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+    const { repository: scoreAnalyticsRepo } = createFakeScoreAnalyticsRepository({
+      listTracesByIssue: (args) => {
+        issueRepoCalls.push({ ...args })
+        return Effect.succeed({ items: [], hasMore: false, limit: 1_000, offset: 0 })
+      },
+    })
+
+    await Effect.runPromise(
+      provideAllServices({ traceRepo, scoreAnalyticsRepo })(
+        addTracesToDataset({
+          projectId,
+          datasetId,
+          source: { kind: "issue", issueId: IssueId("i".repeat(24)) },
+          selection: { mode: "all" },
+          searchQuery: "ignored on issue source",
+          filters: baseFilters,
+        }),
+      ),
+    )
+
+    expect(listByProjectIdCalls).toEqual([])
+    expect(issueRepoCalls).toHaveLength(1)
+    expect(issueRepoCalls[0]).not.toHaveProperty("filters")
+    expect(issueRepoCalls[0]).not.toHaveProperty("searchQuery")
+  })
+})
+
+describe("createDatasetFromTraces", () => {
+  it("forwards both filters and searchQuery to listByProjectId for mode=all", async () => {
+    const calls: Array<{ filters?: FilterSet; searchQuery?: string }> = []
+    const { repository: traceRepo } = createFakeTraceRepository({
+      listByProjectId: ({ options }) => {
+        calls.push({
+          ...(options.filters ? { filters: options.filters } : {}),
+          ...(options.searchQuery ? { searchQuery: options.searchQuery } : {}),
+        })
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+
+    await Effect.runPromise(
+      provideAllServices({ traceRepo })(
+        createDatasetFromTraces({
+          projectId,
+          name: "search-derived",
+          source: { kind: "project" },
+          selection: { mode: "all" },
+          searchQuery: "vector",
+          filters: baseFilters,
+        }),
+      ),
+    )
+
+    expect(calls).toEqual([{ filters: baseFilters, searchQuery: "vector" }])
+  })
+})

--- a/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
+++ b/packages/domain/datasets/src/use-cases/add-traces-to-dataset.ts
@@ -1,5 +1,5 @@
 import { ScoreAnalyticsRepository } from "@domain/scores"
-import type { DatasetId, IssueId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
+import type { DatasetId, FilterSet, IssueId, OrganizationId, ProjectId, TraceId } from "@domain/shared"
 import { ChSqlClient } from "@domain/shared"
 import type { TraceDetail, TraceListCursor } from "@domain/spans"
 import { TraceRepository } from "@domain/spans"
@@ -45,7 +45,12 @@ function mapTraceToRow(t: TraceDetail) {
 const PAGE_SIZE = 1_000
 const ISSUE_TRACE_PAGE_SIZE = 1_000
 
-function collectAllProjectTraceIds(args: { readonly organizationId: OrganizationId; readonly projectId: ProjectId }) {
+function collectAllProjectTraceIds(args: {
+  readonly organizationId: OrganizationId
+  readonly projectId: ProjectId
+  readonly searchQuery?: string
+  readonly filters?: FilterSet
+}) {
   return Effect.gen(function* () {
     const repo = yield* TraceRepository
     const ids: TraceId[] = []
@@ -56,7 +61,12 @@ function collectAllProjectTraceIds(args: { readonly organizationId: Organization
       const page = yield* repo.listByProjectId({
         organizationId: args.organizationId,
         projectId: args.projectId,
-        options: { limit: PAGE_SIZE, ...(cursor ? { cursor } : {}) },
+        options: {
+          limit: PAGE_SIZE,
+          ...(cursor ? { cursor } : {}),
+          ...(args.searchQuery ? { searchQuery: args.searchQuery } : {}),
+          ...(args.filters ? { filters: args.filters } : {}),
+        },
       })
       for (const trace of page.items) {
         ids.push(trace.traceId)
@@ -103,6 +113,8 @@ function collectAllTraceIds(args: {
   readonly organizationId: OrganizationId
   readonly projectId: ProjectId
   readonly source: TraceSource
+  readonly searchQuery?: string
+  readonly filters?: FilterSet
 }) {
   if (args.source.kind === "issue") {
     return collectAllIssueTraceIds({
@@ -111,7 +123,12 @@ function collectAllTraceIds(args: {
       issueId: args.source.issueId,
     })
   }
-  return collectAllProjectTraceIds({ organizationId: args.organizationId, projectId: args.projectId })
+  return collectAllProjectTraceIds({
+    organizationId: args.organizationId,
+    projectId: args.projectId,
+    ...(args.searchQuery ? { searchQuery: args.searchQuery } : {}),
+    ...(args.filters ? { filters: args.filters } : {}),
+  })
 }
 
 function resolveTraceIds(args: {
@@ -119,6 +136,8 @@ function resolveTraceIds(args: {
   readonly projectId: ProjectId
   readonly source: TraceSource
   readonly selection: TraceSelection
+  readonly searchQuery?: string
+  readonly filters?: FilterSet
 }) {
   return Effect.gen(function* () {
     if (args.selection.mode === "selected") return args.selection.traceIds
@@ -127,6 +146,8 @@ function resolveTraceIds(args: {
       organizationId: args.organizationId,
       projectId: args.projectId,
       source: args.source,
+      ...(args.searchQuery ? { searchQuery: args.searchQuery } : {}),
+      ...(args.filters ? { filters: args.filters } : {}),
     })
 
     if (args.selection.mode === "all") return allIds
@@ -154,6 +175,8 @@ export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(funct
   readonly datasetId: DatasetId
   readonly source: TraceSource
   readonly selection: TraceSelection
+  readonly searchQuery?: string
+  readonly filters?: FilterSet
 }) {
   yield* Effect.annotateCurrentSpan("datasetId", args.datasetId)
   yield* Effect.annotateCurrentSpan("projectId", args.projectId)
@@ -166,6 +189,8 @@ export const addTracesToDataset = Effect.fn("datasets.addTracesToDataset")(funct
     projectId: args.projectId,
     source: args.source,
     selection: args.selection,
+    ...(args.searchQuery ? { searchQuery: args.searchQuery } : {}),
+    ...(args.filters ? { filters: args.filters } : {}),
   })
   if (traceIds.length === 0) return EMPTY_RESULT
   if (traceIds.length > MAX_TRACES_PER_DATASET_IMPORT) {
@@ -200,6 +225,8 @@ export const createDatasetFromTraces = Effect.fn("datasets.createDatasetFromTrac
   readonly name: string
   readonly source: TraceSource
   readonly selection: TraceSelection
+  readonly searchQuery?: string
+  readonly filters?: FilterSet
 }) {
   yield* Effect.annotateCurrentSpan("projectId", args.projectId)
 
@@ -217,6 +244,8 @@ export const createDatasetFromTraces = Effect.fn("datasets.createDatasetFromTrac
       projectId: args.projectId,
       source: args.source,
       selection: args.selection,
+      ...(args.searchQuery ? { searchQuery: args.searchQuery } : {}),
+      ...(args.filters ? { filters: args.filters } : {}),
     })
     if (traceIds.length === 0) {
       return { datasetId: dataset.id, ...EMPTY_RESULT }

--- a/packages/domain/exports/src/entities.ts
+++ b/packages/domain/exports/src/entities.ts
@@ -45,6 +45,7 @@ export interface TracesExportPayload extends BaseExportPayload {
   readonly kind: "traces"
   readonly filters?: FilterSet | undefined
   readonly selection?: ExportSelection | undefined
+  readonly searchQuery?: string | undefined
 }
 
 /**

--- a/packages/domain/spans/src/use-cases/build-traces-export.test.ts
+++ b/packages/domain/spans/src/use-cases/build-traces-export.test.ts
@@ -44,6 +44,34 @@ const makeTrace = (traceId: string, overrides: Partial<Trace> = {}): Trace =>
   }) satisfies Trace
 
 describe("buildTracesExportUseCase", () => {
+  it('forwards searchQuery to listByProjectId for `mode: "all"` selections so saved-search results aren\'t widened', async () => {
+    const trace = makeTrace("a".repeat(32))
+    const calls: Array<{ searchQuery?: string }> = []
+    const { repository } = createFakeTraceRepository({
+      listByProjectId: ({ options }) => {
+        calls.push({ ...(options.searchQuery ? { searchQuery: options.searchQuery } : {}) })
+        if (calls.length === 1) {
+          return Effect.succeed({ items: [trace], hasMore: false })
+        }
+        return Effect.succeed({ items: [], hasMore: false })
+      },
+    })
+
+    await Effect.runPromise(
+      buildTracesExportUseCase({
+        organizationId,
+        projectId,
+        selection: { mode: "all" },
+        searchQuery: "checkout flow",
+      }).pipe(
+        Effect.provideService(TraceRepository, repository),
+        Effect.provideService(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(organizationId) })),
+      ),
+    )
+
+    expect(calls).toEqual([{ searchQuery: "checkout flow" }])
+  })
+
   it("exports only the selected traces that still match the active filters", async () => {
     const firstTrace = makeTrace("a".repeat(32), { rootSpanName: "alpha" })
     const secondTrace = makeTrace("b".repeat(32), { rootSpanName: "beta" })

--- a/packages/domain/spans/src/use-cases/build-traces-export.ts
+++ b/packages/domain/spans/src/use-cases/build-traces-export.ts
@@ -12,6 +12,7 @@ export interface BuildTracesExportInput {
   readonly projectId: ProjectId
   readonly filters?: FilterSet
   readonly selection?: ExportSelection
+  readonly searchQuery?: string
 }
 
 export interface BuildTracesExportResult {
@@ -137,6 +138,7 @@ export const buildTracesExportUseCase = Effect.fn("spans.buildTracesExport")(fun
           limit: BATCH_SIZE,
           ...(cursor ? { cursor } : {}),
           ...(input.filters ? { filters: input.filters } : {}),
+          ...(input.searchQuery ? { searchQuery: input.searchQuery } : {}),
           sortBy: "startTime",
           sortDirection: "desc",
         },


### PR DESCRIPTION
## Summary
- The traces search page hid bulk actions unless the selection was a specific list of row ids. `mode: "all"` / `mode: "allExcept"` were silently rejected because the export and add-to-dataset paths resolved the selection against the unfiltered project, ignoring `searchQuery`.
- Plumb `searchQuery` end-to-end (enqueue → use-case → worker → repo `listByProjectId.options.searchQuery`) for both the traces export and the add-to-dataset flows, then drop the gate so all selection modes are exposed.
- Closes [LAT-557](https://linear.app/latitude/issue/LAT-557/bulk-actions-not-showing-up-when-selecting-all-traces-in-a-saved).

## Notes
- Worker `generateTracesExport` now also provides the `withAi(AIEmbedLive, …)` layer, since the search-aware list path needs query embeddings (matches the other read paths in `traces.functions.ts`).
- Add-to-dataset's issue source path keeps using `listTracesByIssue` and ignores `searchQuery` (it would be unused there); only the project-source path forwards it.
- Added a unit test that asserts `buildTracesExportUseCase` forwards `searchQuery` to `listByProjectId` for `mode: "all"`.

## Test plan
- [x] On a saved search with a non-empty query, click the header checkbox to "Select all" and confirm both **Export Traces** and **Add to Dataset** appear in the toolbar.
- [ ] Trigger an export from "Select all" and verify the resulting CSV contains only traces matching the saved-search query (not the entire project).
- [ ] Repeat with `allExcept` (deselect a couple of rows after Select-all) and confirm the excluded rows are missing from the export and the dataset import.
- [ ] Confirm the project (non-search) traces page bulk actions still behave as before.