### PR TITLE
feat(api): OAuth bearer dispatch + token prefixes + well-known endpoint

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -41,6 +41,24 @@
           "status"
         ]
       },
+      "OAuthProtectedResourceMetadata": {
+        "type": "object",
+        "properties": {
+          "resource": {
+            "type": "string"
+          },
+          "authorization_servers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "resource",
+          "authorization_servers"
+        ]
+      },
       "Project": {
         "type": "object",
         "properties": {
@@ -1127,6 +1145,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/.well-known/oauth-protected-resource": {
+      "get": {
+        "operationId": "wellKnown.oauthProtectedResource",
+        "tags": [
+          "Well-known"
+        ],
+        "summary": "OAuth protected resource metadata",
+        "description": "RFC 9728 metadata document advertising the authorization server(s) trusted to issue access tokens for this API.",
+        "responses": {
+          "200": {
+            "description": "Protected resource metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthProtectedResourceMetadata"
                 }
               }
             }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "@platform/ai": "workspace:*",
     "@platform/ai-voyage": "workspace:*",
     "@platform/api-key-auth": "workspace:*",
+    "@platform/oauth-token-auth": "workspace:*",
     "@platform/cache-redis": "workspace:*",
     "@platform/db-clickhouse": "workspace:*",
     "@platform/db-postgres": "workspace:*",

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,185 @@
+import { API_KEY_TOKEN_PREFIX, generateApiKeyToken } from "@domain/api-keys"
+import { generateId } from "@domain/shared"
+import { apiKeys } from "@platform/db-postgres/schema/api-keys"
+import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import type { InMemoryPostgres } from "@platform/testkit"
+import { encrypt, hash } from "@repo/utils"
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+import {
+  type ApiTestContext,
+  createTenantSetup,
+  setupTestApi,
+  TEST_ENCRYPTION_KEY,
+} from "../test-utils/create-test-app.ts"
+
+const insertApiKey = async (database: InMemoryPostgres, organizationId: string, token: string) => {
+  const tokenHash = await Effect.runPromise(hash(token))
+  const encryptedToken = await Effect.runPromise(encrypt(token, TEST_ENCRYPTION_KEY))
+  const id = generateId()
+  await database.db.insert(apiKeys).values({
+    id,
+    organizationId,
+    token: encryptedToken,
+    tokenHash,
+    name: "test-key",
+  })
+  return { id }
+}
+
+const insertOAuthApplicationAndToken = async (
+  database: InMemoryPostgres,
+  organizationId: string,
+  userId: string,
+  accessToken: string,
+) => {
+  const clientId = `mcp-client-${generateId()}`
+  await database.db.insert(oauthApplications).values({
+    id: generateId(),
+    clientId,
+    name: "Test MCP Client",
+    organizationId,
+    userId,
+    disabled: false,
+  })
+  await database.db.insert(oauthAccessTokens).values({
+    id: generateId(),
+    accessToken,
+    clientId,
+    userId,
+    accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    scopes: "openid",
+  })
+  return { clientId }
+}
+
+describe("auth middleware dispatch", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("authenticates a `lak_`-prefixed token via the API-key validator", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const lakToken = generateApiKeyToken()
+    expect(lakToken.startsWith(API_KEY_TOKEN_PREFIX)).toBe(true)
+    await insertApiKey(database, tenant.organizationId, lakToken)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${lakToken}` },
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it<ApiTestContext>("authenticates a legacy un-prefixed UUID token via the fallback path", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    // `tenant.apiKeyToken` is a plain UUID — pre-prefix-rollout shape.
+    expect(tenant.apiKeyToken.startsWith(API_KEY_TOKEN_PREFIX)).toBe(false)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${tenant.apiKeyToken}` },
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it<ApiTestContext>("authenticates a `loa_`-prefixed token via the OAuth validator", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const loaToken = `loa_${crypto.randomUUID()}`
+    await insertOAuthApplicationAndToken(database, tenant.organizationId, tenant.userId, loaToken)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${loaToken}` },
+      }),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it<ApiTestContext>("rejects an unknown `lak_` token without falling through to OAuth", async ({ app, database }) => {
+    await createTenantSetup(database)
+    const bogus = `${API_KEY_TOKEN_PREFIX}${crypto.randomUUID()}`
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${bogus}` },
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("rejects an unknown `loa_` token without falling through to API key", async ({
+    app,
+    database,
+  }) => {
+    await createTenantSetup(database)
+    const bogus = `loa_${crypto.randomUUID()}`
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${bogus}` },
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("rejects an unknown un-prefixed token after both validators reject it", async ({
+    app,
+    database,
+  }) => {
+    await createTenantSetup(database)
+    const bogus = crypto.randomUUID()
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${bogus}` },
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("rejects requests with no Authorization header", async ({ app }) => {
+    const res = await app.fetch(new Request("http://localhost/v1/api-keys"))
+    expect(res.status).toBe(401)
+  })
+
+  it<ApiTestContext>("rejects an OAuth token whose application has no organization binding", async ({
+    app,
+    database,
+  }) => {
+    // The MCP register flow creates an oauth_applications row with a NULL
+    // organization_id — the bind happens later at consent. A token issued
+    // before consent would have NULL on the joined row; the validator must
+    // refuse it (the auth middleware can't pick a tenant context out of NULL).
+    const tenant = await createTenantSetup(database)
+    const loaToken = `loa_${crypto.randomUUID()}`
+
+    const clientId = `mcp-client-${generateId()}`
+    await database.db.insert(oauthApplications).values({
+      id: generateId(),
+      clientId,
+      name: "Unbound MCP Client",
+      organizationId: null,
+      userId: tenant.userId,
+      disabled: false,
+    })
+    await database.db.insert(oauthAccessTokens).values({
+      id: generateId(),
+      accessToken: loaToken,
+      clientId,
+      userId: tenant.userId,
+      accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      scopes: "openid",
+    })
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/api-keys", {
+        headers: { Authorization: `Bearer ${loaToken}` },
+      }),
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,12 +1,22 @@
+import { API_KEY_TOKEN_PREFIX } from "@domain/api-keys"
 import { OrganizationId, UnauthorizedError, UserId } from "@domain/shared"
 import { validateApiKey } from "@platform/api-key-auth"
 import type { PostgresClient } from "@platform/db-postgres"
+import { type OAuthTokenAuthResult, validateOAuthAccessToken } from "@platform/oauth-token-auth"
 import { withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import type { Context, MiddlewareHandler, Next } from "hono"
 import { getAdminPostgresClient } from "../clients.ts"
 import type { AuthContext } from "../types.ts"
 import { createTouchBuffer } from "./touch-buffer.ts"
+
+/**
+ * Token prefix for OAuth access tokens. Set by the Better Auth `mcp` plugin's
+ * `databaseHooks.oauthAccessToken.create.before` hook on the web app. Mirrors
+ * the `lak_` prefix on API keys: cheap routing, no double lookups, accurate
+ * error messages.
+ */
+const OAUTH_TOKEN_PREFIX = "loa_"
 
 const extractBearerToken = (c: Context): string | undefined => {
   const authHeader = c.req.header("Authorization")
@@ -16,6 +26,26 @@ const extractBearerToken = (c: Context): string | undefined => {
 
   return authHeader.slice(7)
 }
+
+interface AuthMiddlewareOptions {
+  adminClient: PostgresClient | undefined
+  logTouchBuffer: boolean
+}
+
+const apiKeyContext = (result: { keyId: string; organizationId: string }): AuthContext => ({
+  method: "api-key",
+  userId: UserId(`api-key:${result.keyId}`),
+  organizationId: OrganizationId(result.organizationId),
+})
+
+const oauthContext = (result: OAuthTokenAuthResult): AuthContext => ({
+  method: "oauth",
+  userId: UserId(result.userId),
+  organizationId: OrganizationId(result.organizationId),
+  oauthClientId: result.oauthClientId,
+  scopes: result.scopes,
+  expiresAt: result.expiresAt,
+})
 
 const authenticateWithApiKey = (
   redis: Context["var"]["redis"],
@@ -33,51 +63,76 @@ const authenticateWithApiKey = (
       adminClient,
       onKeyValidated: (keyId) => touchBuffer.touch(keyId),
     })
-
-    if (result) {
-      const authContext: AuthContext = {
-        userId: UserId(`api-key:${result.keyId}`),
-        organizationId: OrganizationId(result.organizationId),
-        method: "api-key",
-      }
-
-      return authContext
-    }
-
-    return null
+    return result ? apiKeyContext(result) : null
   }).pipe(Effect.orDie)
 }
 
-const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect<AuthContext, UnauthorizedError> => {
-  return Effect.gen(function* () {
-    const bearerToken = extractBearerToken(c)
+const authenticateWithOAuth = (
+  redis: Context["var"]["redis"],
+  token: string,
+  options: AuthMiddlewareOptions,
+): Effect.Effect<AuthContext | null, never> => {
+  const adminClient = options.adminClient ?? getAdminPostgresClient()
 
+  return Effect.gen(function* () {
+    const result = yield* validateOAuthAccessToken(token, { redis, adminClient })
+    return result ? oauthContext(result) : null
+  }).pipe(Effect.orDie)
+}
+
+/**
+ * Routes a bearer token to its validator using the prefix:
+ *
+ * - `lak_…` → API-key path only.
+ * - `loa_…` → OAuth path only.
+ * - anything else → legacy fallback (try API-key first, then OAuth). Existing
+ *   un-prefixed UUID API keys land here. We try API-key first because that's
+ *   what the legacy population is; the OAuth attempt is a defensive second
+ *   pass so a future stray un-prefixed OAuth-style token doesn't silently 401.
+ *
+ * Each branch performs at most one Redis + DB round-trip. The legacy branch
+ * does at most two (one per validator); both validators have a negative-cache
+ * TTL so a non-existent token only hits the DB once across both attempts.
+ */
+const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect<AuthContext, UnauthorizedError> =>
+  Effect.gen(function* () {
+    const bearerToken = extractBearerToken(c)
     if (!bearerToken) {
-      return yield* new UnauthorizedError({
-        message: "Authentication required",
-      })
+      return yield* new UnauthorizedError({ message: "Authentication required" })
     }
 
-    const authContext = yield* authenticateWithApiKey(c.get("redis"), bearerToken, options)
-    if (authContext) return authContext
+    const redis = c.get("redis")
 
-    return yield* new UnauthorizedError({
-      message: "Invalid API key",
-    })
+    if (bearerToken.startsWith(API_KEY_TOKEN_PREFIX)) {
+      const ctx = yield* authenticateWithApiKey(redis, bearerToken, options)
+      if (ctx) return ctx
+      return yield* new UnauthorizedError({ message: "Invalid API key" })
+    }
+
+    if (bearerToken.startsWith(OAUTH_TOKEN_PREFIX)) {
+      const ctx = yield* authenticateWithOAuth(redis, bearerToken, options)
+      if (ctx) return ctx
+      return yield* new UnauthorizedError({ message: "Invalid OAuth access token" })
+    }
+
+    // Legacy un-prefixed token (pre-prefix-rollout API keys). Try API-key first
+    // since that's what the legacy population is.
+    const apiKeyCtx = yield* authenticateWithApiKey(redis, bearerToken, options)
+    if (apiKeyCtx) return apiKeyCtx
+
+    const oauthCtx = yield* authenticateWithOAuth(redis, bearerToken, options)
+    if (oauthCtx) return oauthCtx
+
+    return yield* new UnauthorizedError({ message: "Invalid credentials" })
   })
-}
 
 /**
  * Create authentication middleware.
  *
- * Validates API keys sent via the Authorization: Bearer header.
- * Public routes should be excluded from this middleware.
+ * Validates `Authorization: Bearer …` tokens. Routes by token prefix to the
+ * API-key validator (`lak_…`), the OAuth validator (`loa_…`), or both
+ * (legacy un-prefixed). Public routes should be excluded from this middleware.
  */
-interface AuthMiddlewareOptions {
-  adminClient: PostgresClient | undefined
-  logTouchBuffer: boolean
-}
-
 export const createAuthMiddleware = (options: AuthMiddlewareOptions): MiddlewareHandler => {
   return async (c: Context, next: Next) => {
     const authContext = await Effect.runPromise(authenticate(c, options).pipe(withTracing))

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -10,6 +10,7 @@ import { apiKeysEndpoints } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
 import { createProjectsRoutes } from "./projects.ts"
 import { createScoresRoutes } from "./scores.ts"
+import { registerWellKnownRoutes } from "./well-known.ts"
 
 /**
  * Register all API routes with versioning.
@@ -19,6 +20,8 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   const routes = new OpenAPIHono<ProtectedEnv>()
 
   registerHealthRoute({ app })
+  // Public discovery routes (no auth) — see `well-known.ts`.
+  registerWellKnownRoutes({ app })
 
   v1.use("*", async (c, next) => {
     c.set("db", options.database.db)

--- a/apps/api/src/routes/well-known.test.ts
+++ b/apps/api/src/routes/well-known.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { type ApiTestContext, setupTestApi } from "../test-utils/create-test-app.ts"
+
+describe("GET /.well-known/oauth-protected-resource", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("returns 200 with no auth header (public route)", async ({ app }) => {
+    const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource"))
+    expect(res.status).toBe(200)
+  })
+
+  it<ApiTestContext>("returns the API origin as `resource` and the web AS as `authorization_servers`", async ({
+    app,
+  }) => {
+    const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource"))
+    const body = (await res.json()) as { resource: string; authorization_servers: string[] }
+
+    // Test env sets LAT_API_URL=http://localhost:3001, LAT_WEB_URL=http://localhost:3000.
+    expect(body.resource).toBe(process.env.LAT_API_URL)
+    expect(body.authorization_servers).toEqual([`${process.env.LAT_WEB_URL}/api/auth`])
+  })
+
+  it<ApiTestContext>("returns JSON content type", async ({ app }) => {
+    const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource"))
+    expect(res.headers.get("content-type")).toContain("application/json")
+  })
+})

--- a/apps/api/src/routes/well-known.ts
+++ b/apps/api/src/routes/well-known.ts
@@ -1,0 +1,65 @@
+/**
+ * Public OAuth/MCP discovery surface for this resource server.
+ *
+ * RFC 9728 (OAuth Protected Resource Metadata) lets a protected resource
+ * advertise the authorization server(s) trusted to issue tokens for it. Our
+ * authorization server is the web app's Better Auth `mcp` plugin, which lives
+ * on a different origin (typical: `app.latitude.so` vs `api.latitude.so`).
+ * RFC 9728 explicitly allows the AS to live on a different origin than the
+ * protected resource — the AS just has to be listed here so MCP clients know
+ * where to start the OAuth dance.
+ *
+ * Public route (no auth, RING 1). The handler reads URLs at request time —
+ * not at module load — so test envs that change `LAT_WEB_URL` / `LAT_API_URL`
+ * between runs see the current values.
+ */
+import { createRoute, type OpenAPIHono, z } from "@hono/zod-openapi"
+import { parseEnv } from "@platform/env"
+import { Effect } from "effect"
+import type { AppEnv } from "../types.ts"
+
+const ProtectedResourceMetadataSchema = z
+  .object({
+    /** This resource server's identifier — the API origin. */
+    resource: z.string(),
+    /** Authorization server issuer URLs that may issue tokens for `resource`. */
+    authorization_servers: z.array(z.string()),
+  })
+  .openapi("OAuthProtectedResourceMetadata")
+
+const oauthProtectedResourceRoute = createRoute({
+  method: "get",
+  path: "/.well-known/oauth-protected-resource",
+  operationId: "wellKnown.oauthProtectedResource",
+  tags: ["Well-known"],
+  summary: "OAuth protected resource metadata",
+  description:
+    "RFC 9728 metadata document advertising the authorization server(s) trusted to issue access tokens for this API.",
+  responses: {
+    200: {
+      content: { "application/json": { schema: ProtectedResourceMetadataSchema } },
+      description: "Protected resource metadata",
+    },
+  },
+})
+
+const buildMetadata = () =>
+  Effect.gen(function* () {
+    const apiUrl = yield* parseEnv("LAT_API_URL", "string")
+    const webUrl = yield* parseEnv("LAT_WEB_URL", "string")
+    return {
+      resource: apiUrl,
+      // BA serves the AS metadata at `<webUrl>/api/auth/.well-known/oauth-authorization-server`;
+      // RFC 8414 lets clients derive the metadata path from the issuer, so the
+      // value here is the issuer (`<webUrl>/api/auth`) without the
+      // `.well-known/...` suffix.
+      authorization_servers: [`${webUrl}/api/auth`],
+    }
+  })
+
+export const registerWellKnownRoutes = ({ app }: { app: OpenAPIHono<AppEnv> }) => {
+  app.openapi(oauthProtectedResourceRoute, async (c) => {
+    const metadata = await Effect.runPromise(buildMetadata())
+    return c.json(metadata, 200)
+  })
+}

--- a/apps/api/src/test-utils/create-test-app.ts
+++ b/apps/api/src/test-utils/create-test-app.ts
@@ -116,6 +116,7 @@ export const setupTestApi = () => {
 }
 
 interface TenantSetup {
+  readonly userId: string
   readonly organizationId: string
   readonly apiKeyToken: string
   readonly authApiKeyId: string
@@ -160,5 +161,5 @@ export const createTenantSetup = async (database: InMemoryPostgres): Promise<Ten
     name: "auth-key",
   })
 
-  return { organizationId, apiKeyToken, authApiKeyId }
+  return { userId, organizationId, apiKeyToken, authApiKeyId }
 }

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -8,18 +8,35 @@ import type { PostgresClient, PostgresDb } from "@platform/db-postgres"
 /**
  * Authentication context set by the auth middleware.
  *
- * This context is available on all protected routes after successful
- * authentication. It provides the authenticated user's ID, the
- * organization context for the request, and the authentication method used.
+ * Discriminated on `method`:
+ *
+ * - `api-key` — request authenticated via an organization-scoped API key
+ *   (Bearer `lak_…` or a legacy unprefixed UUID). `userId` is a synthetic
+ *   `api-key:<keyId>` value because API keys aren't tied to a real user.
+ * - `oauth` — request authenticated via an OAuth access token (`Bearer loa_…`)
+ *   issued through the Better Auth `mcp` plugin on the web app. Carries the
+ *   real `userId` of the granting user, the `oauthClientId` of the MCP client,
+ *   the granted `scopes`, and the `expiresAt` of the access token.
  */
-export interface AuthContext {
-  /** The authenticated user's ID */
-  readonly userId: UserId
-  /** The organization ID for this request (from URL param or API key) */
-  readonly organizationId: OrganizationId
-  /** The authentication method that was used */
-  readonly method: "api-key"
-}
+export type AuthContext =
+  | {
+      readonly method: "api-key"
+      /** Synthetic `api-key:<keyId>` — API keys aren't tied to a real user. */
+      readonly userId: UserId
+      readonly organizationId: OrganizationId
+    }
+  | {
+      readonly method: "oauth"
+      /** Real user id of the user who granted consent to the OAuth client. */
+      readonly userId: UserId
+      /** Org the OAuth client was bound to at consent time. */
+      readonly organizationId: OrganizationId
+      /** `oauth_applications.client_id` of the requesting MCP client. */
+      readonly oauthClientId: string
+      readonly scopes: ReadonlyArray<string>
+      /** Underlying access token's `accessTokenExpiresAt`. */
+      readonly expiresAt: Date
+    }
 
 /**
  * Root-level Hono env. Every request has access to these variables

--- a/packages/domain/api-keys/src/entities/api-key.ts
+++ b/packages/domain/api-keys/src/entities/api-key.ts
@@ -5,8 +5,10 @@ import { z } from "zod"
  * API Key entity - authenticates organization-bound requests.
  *
  * API keys are scoped to an organization and provide token-based
- * authentication for API access. Tokens are UUIDs generated
- * using crypto.randomUUID().
+ * authentication for API access. New tokens are prefixed with `lak_` to let
+ * the API auth middleware route to the API-key validator without a double
+ * lookup. Tokens issued before the prefix rollout (plain UUIDs) are still
+ * accepted via the legacy fallback path; no forced rotation.
  *
  * The token is encrypted at the application level (AES-256-GCM)
  * and a SHA-256 hex hash of the UTF-8 token bytes (tokenHash) is stored for indexed
@@ -55,10 +57,23 @@ export const createApiKey = (params: {
 }
 
 /**
- * Generate a new API key token (UUID v4).
+ * Token prefix for newly issued API keys. The API auth middleware uses it to
+ * dispatch directly to the API-key validator (vs. OAuth or legacy fallback)
+ * without paying for a Redis miss + DB lookup against the wrong validator.
+ *
+ * `lak` (Latitude API Key) is intentionally three letters and avoids `lat_`,
+ * which reads ambiguously as "Latitude" rather than the credential type.
+ */
+export const API_KEY_TOKEN_PREFIX = "lak_"
+
+/**
+ * Generate a new API key token. Format: `lak_<UUID v4>`.
+ *
+ * Legacy un-prefixed UUID tokens issued before this rollout still authenticate
+ * — see `apps/api/src/middleware/auth.ts` for the legacy fallback dispatch.
  */
 export const generateApiKeyToken = (): string => {
-  return crypto.randomUUID()
+  return `${API_KEY_TOKEN_PREFIX}${crypto.randomUUID()}`
 }
 
 /**

--- a/packages/domain/api-keys/src/index.ts
+++ b/packages/domain/api-keys/src/index.ts
@@ -1,7 +1,7 @@
 export { DEFAULT_API_KEY_NAME } from "./constants.ts"
 export {
-  type ApiKey,
   API_KEY_TOKEN_PREFIX,
+  type ApiKey,
   apiKeySchema,
   createApiKey,
   generateApiKeyToken,

--- a/packages/domain/api-keys/src/index.ts
+++ b/packages/domain/api-keys/src/index.ts
@@ -1,6 +1,7 @@
 export { DEFAULT_API_KEY_NAME } from "./constants.ts"
 export {
   type ApiKey,
+  API_KEY_TOKEN_PREFIX,
   apiKeySchema,
   createApiKey,
   generateApiKeyToken,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@platform/env':
         specifier: workspace:*
         version: link:../../packages/platform/env
+      '@platform/oauth-token-auth':
+        specifier: workspace:*
+        version: link:../../packages/platform/oauth-token-auth
       '@platform/queue-bullmq':
         specifier: workspace:*
         version: link:../../packages/platform/queue-bullmq


### PR DESCRIPTION
## Summary

Sets up the API as an OAuth resource server, parallel to the existing API-key path. No web-side BA changes yet — those land in a follow-up PR. Existing un-prefixed UUID API keys keep working through the legacy fallback; no forced rotation.

- **Token-prefix dispatch** — `lak_…` routes only to the API-key validator, `loa_…` routes only to the OAuth validator (`@platform/oauth-token-auth`), un-prefixed tokens fall back to API-key-then-OAuth. Each branch is at most one Redis + DB round-trip.
- **`AuthContext` widened** to a discriminated union: existing api-key variant + new oauth variant carrying `userId` (real user, not a synthetic), `oauthClientId`, `scopes`, `expiresAt`.
- **`generateApiKeyToken()`** now emits `lak_<UUID v4>`. `API_KEY_TOKEN_PREFIX` is exported from `@domain/api-keys` so the middleware uses one source of truth.
- **`GET /.well-known/oauth-protected-resource`** (RFC 9728) — public route, no auth. Advertises `<LAT_API_URL>` as `resource` and `<LAT_WEB_URL>/api/auth` as the authorization server (where the BA `mcp` plugin will live). Reads URLs at request time so tests can vary them.
- **`createTenantSetup`** now exposes `userId` so OAuth fixtures can satisfy the `oauth_applications.user_id` FK.

Plan reference: `plans/mcp-oauth-api-expansion.md` — M2 API-side (sections D4, D19) + token prefixing.

## Test plan

- [x] `pnpm --filter @app/api typecheck`
- [x] `pnpm typecheck` (whole workspace)
- [x] `pnpm --filter @app/api test` — 62 passing (51 prior + 11 new)
- [x] `pnpm --filter @app/api check` (biome)
- [x] `pnpm knip`
- [x] `pnpm openapi:emit` — well-known route + schema added
- [x] `pnpm mcp:emit` — unchanged (well-known is HTTP-only, not an MCP tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)