### PR TITLE
fix(marketing): resolve Loops contact update 400 and 409 swallowing

### DIFF
--- a/packages/domain/marketing/src/use-cases/mark-contact-telemetry-enabled.test.ts
+++ b/packages/domain/marketing/src/use-cases/mark-contact-telemetry-enabled.test.ts
@@ -76,6 +76,9 @@ describe("markContactTelemetryEnabled", () => {
 
     expect(sender.updates).toHaveLength(3)
     expect(new Set(sender.updates.map((u) => u.userId))).toEqual(new Set([USER_OLDEST, USER_OWNER, USER_NEWEST]))
+    expect(new Set(sender.updates.map((u) => u.email))).toEqual(
+      new Set(["oldest@example.com", "owner@example.com", "newest@example.com"]),
+    )
     for (const update of sender.updates) {
       expect(update.telemetryEnabled).toBe(true)
     }

--- a/packages/domain/marketing/src/use-cases/mark-contact-telemetry-enabled.ts
+++ b/packages/domain/marketing/src/use-cases/mark-contact-telemetry-enabled.ts
@@ -9,9 +9,9 @@ export interface MarkContactTelemetryEnabledInput {
 
 /**
  * Marks every member of the org as `telemetryEnabled: true` in the marketing
- * tool once the org has received its first trace. Every current member is
- * already a Loops contact (they either signed up or were registered after
- * accepting an invite), so we update each by `userId`.
+ * tool once the org has received its first trace. We pass both `userId` and
+ * `email` so Loops can resolve the contact by email when an older record
+ * (e.g. a v1-era contact) isn't yet linked to the v2 `userId`.
  */
 export const markContactTelemetryEnabled = ({
   marketingContacts,
@@ -30,6 +30,7 @@ export const markContactTelemetryEnabled = ({
       (member) =>
         marketingContacts.updateContact({
           userId: member.userId,
+          email: member.email,
           telemetryEnabled: true,
         }),
       { concurrency: "unbounded", discard: true },

--- a/packages/domain/marketing/src/use-cases/update-contact-onboarding.test.ts
+++ b/packages/domain/marketing/src/use-cases/update-contact-onboarding.test.ts
@@ -68,6 +68,7 @@ describe("updateContactOnboarding", () => {
     expect(sender.updates).toEqual([
       {
         userId: USER_ID,
+        email: "ada@example.com",
         firstName: "Ada Lovelace",
         jobTitle: "Founder",
         userGroup: MARKETING_USER_GROUP_CODE_AGENTS,

--- a/packages/domain/marketing/src/use-cases/update-contact-onboarding.ts
+++ b/packages/domain/marketing/src/use-cases/update-contact-onboarding.ts
@@ -33,6 +33,7 @@ export const updateContactOnboarding = ({ marketingContacts }: { readonly market
 
     yield* marketingContacts.updateContact({
       userId: input.userId,
+      email: user.email,
       firstName: user.name,
       jobTitle: user.jobTitle,
       userGroup: stackChoiceToUserGroup(input.stackChoice),

--- a/packages/platform/loops/src/client.test.ts
+++ b/packages/platform/loops/src/client.test.ts
@@ -86,6 +86,15 @@ describe("createLoopsContactsSender", () => {
     await Effect.runPromise(sender.createContact({ email: "a@b.co", userId: "user_123" }))
   })
 
+  it("swallows 409 conflict on create regardless of message wording", async () => {
+    const sender = createLoopsContactsSender({ apiKey: "test-key" })
+    createContactMock.mockRejectedValueOnce(
+      new APIError(409, { success: false, message: "An audience member with this email already exists." }),
+    )
+
+    await Effect.runPromise(sender.createContact({ email: "a@b.co", userId: "user_123" }))
+  })
+
   it("surfaces non-duplicate create failures as MarketingContactsError", async () => {
     const sender = createLoopsContactsSender({ apiKey: "test-key" })
     createContactMock.mockRejectedValueOnce(new APIError(429, { success: false, message: "rate limited" }))

--- a/packages/platform/loops/src/client.ts
+++ b/packages/platform/loops/src/client.ts
@@ -26,8 +26,7 @@ const omitUndefined = (input: Record<string, string | number | boolean | null | 
   return out
 }
 
-const isAlreadyOnListError = (error: unknown): boolean =>
-  error instanceof APIError && error.statusCode === 409
+const isAlreadyOnListError = (error: unknown): boolean => error instanceof APIError && error.statusCode === 409
 
 const NOOP_SENDER: MarketingContactsPort = {
   createContact: () => Effect.void,

--- a/packages/platform/loops/src/client.ts
+++ b/packages/platform/loops/src/client.ts
@@ -26,12 +26,8 @@ const omitUndefined = (input: Record<string, string | number | boolean | null | 
   return out
 }
 
-const isAlreadyOnListError = (error: unknown): boolean => {
-  if (!(error instanceof APIError)) return false
-  const message = error.json && "message" in error.json ? error.json.message : undefined
-  if (typeof message !== "string") return false
-  return /already on (the )?list/i.test(message)
-}
+const isAlreadyOnListError = (error: unknown): boolean =>
+  error instanceof APIError && error.statusCode === 409
 
 const NOOP_SENDER: MarketingContactsPort = {
   createContact: () => Effect.void,


### PR DESCRIPTION
## Summary

- Pass `email` alongside `userId` on Loops `updateContact` from `updateContactOnboarding` and `markContactTelemetryEnabled` so contacts whose Loops record isn't yet linked to the v2 `userId` (e.g. v1-era records) can be resolved by email instead of failing with HTTP 400.
- Detect duplicate-on-create by `APIError.statusCode === 409` rather than regexing the response message — Loops reworded the 409 body and `registerContact` started failing for users already on the list.

## Why

Datadog Error Tracking issue [`f7687552-…`](https://app.datadoghq.eu/error-tracking?query=service%3A%2A&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22f7687552-4ac2-11f1-ae72-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D) was firing `MarketingContactsError: updateContact failed for …`. Spans showed `PUT https://app.loops.so/api/v1/contacts/update → 400` (Loops can't find the contact when only `userId` is provided and that id was never linked) plus several `POST /contacts/create → 409` errors that should have been swallowed but weren't because the message regex no longer matched.

## Test plan

- [x] `pnpm --filter @domain/marketing --filter @platform/loops test --run`
- [x] `pnpm --filter @domain/marketing --filter @platform/loops typecheck`
- [ ] After deploy, monitor the error-tracking issue and Loops `register-user` / `update-onboarding` queue tasks for recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)