### PR TITLE
feat(web): install BA mcp plugin + prefix OAuth tokens with loa_/lor_

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -2,21 +2,17 @@ import { API_KEY_TOKEN_PREFIX } from "@domain/api-keys"
 import { OrganizationId, UnauthorizedError, UserId } from "@domain/shared"
 import { validateApiKey } from "@platform/api-key-auth"
 import type { PostgresClient } from "@platform/db-postgres"
-import { type OAuthTokenAuthResult, validateOAuthAccessToken } from "@platform/oauth-token-auth"
+import {
+  OAUTH_ACCESS_TOKEN_PREFIX,
+  type OAuthTokenAuthResult,
+  validateOAuthAccessToken,
+} from "@platform/oauth-token-auth"
 import { withTracing } from "@repo/observability"
 import { Effect } from "effect"
 import type { Context, MiddlewareHandler, Next } from "hono"
 import { getAdminPostgresClient } from "../clients.ts"
 import type { AuthContext } from "../types.ts"
 import { createTouchBuffer } from "./touch-buffer.ts"
-
-/**
- * Token prefix for OAuth access tokens. Set by the Better Auth `mcp` plugin's
- * `databaseHooks.oauthAccessToken.create.before` hook on the web app. Mirrors
- * the `lak_` prefix on API keys: cheap routing, no double lookups, accurate
- * error messages.
- */
-const OAUTH_TOKEN_PREFIX = "loa_"
 
 const extractBearerToken = (c: Context): string | undefined => {
   const authHeader = c.req.header("Authorization")
@@ -109,7 +105,7 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
       return yield* new UnauthorizedError({ message: "Invalid API key" })
     }
 
-    if (bearerToken.startsWith(OAUTH_TOKEN_PREFIX)) {
+    if (bearerToken.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
       const ctx = yield* authenticateWithOAuth(redis, bearerToken, options)
       if (ctx) return ctx
       return yield* new UnauthorizedError({ message: "Invalid OAuth access token" })

--- a/apps/web/src/routes/api/auth/$.ts
+++ b/apps/web/src/routes/api/auth/$.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { getBetterAuth } from "../../../server/clients.ts"
+import { rewriteOAuthTokenResponse } from "../../../server/oauth-token-prefix-rewriter.ts"
 
 export const Route = createFileRoute("/api/auth/$")({
   server: {
@@ -8,7 +9,11 @@ export const Route = createFileRoute("/api/auth/$")({
         return getBetterAuth().handler(request)
       },
       POST: async ({ request }: { request: Request }) => {
-        return getBetterAuth().handler(request)
+        // The rewriter is a no-op for everything except the MCP/OIDC token
+        // endpoint — see `oauth-token-prefix-rewriter.ts` for why every other
+        // request passes through untouched.
+        const response = await getBetterAuth().handler(request)
+        return rewriteOAuthTokenResponse(request, response)
       },
     },
   },

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -23,6 +23,7 @@ import {
   loadTemporalConfig,
 } from "@platform/workflows-temporal"
 import { withTracing } from "@repo/observability"
+import { mcp } from "better-auth/plugins"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
 import { Effect } from "effect"
 
@@ -202,7 +203,27 @@ export const getBetterAuth = () => {
       ...(stripeSecretKey ? { stripeSecretKey } : {}),
       ...(stripeWebhookSecret ? { stripeWebhookSecret } : {}),
       ...(selfServePlans.length > 0 ? { subscriptionPlans: selfServePlans } : {}),
-      extraPlugins: [tanstackStartCookies()],
+      extraPlugins: [
+        tanstackStartCookies(),
+        // OAuth2/OIDC authorization server for MCP clients (Claude Code,
+        // Cursor, …). Issues `loa_…` access + `lor_…` refresh tokens that
+        // the API resource server validates via `@platform/oauth-token-auth`.
+        // The consent page binds the issued token to a specific organization;
+        // until that route ships, the default BA consent UI renders and tokens
+        // get issued with `oauth_applications.organization_id IS NULL`, which
+        // the API auth middleware rejects (so no usable tokens leak out).
+        mcp({
+          loginPage: `${webUrl}/login`,
+          oidcConfig: {
+            // BA's `OIDCOptions` type requires `loginPage` here too even though
+            // the `mcp` plugin already takes one at the top level. Pass the
+            // same value so consent redirects use the same login URL.
+            loginPage: `${webUrl}/login`,
+            consentPage: `${webUrl}/auth/consent`,
+            requirePKCE: true,
+          },
+        }),
+      ],
       onUserCreated: async (user) => {
         await Effect.runPromise(
           outboxWriter

--- a/apps/web/src/server/oauth-token-prefix-rewriter.test.ts
+++ b/apps/web/src/server/oauth-token-prefix-rewriter.test.ts
@@ -1,0 +1,135 @@
+import { OAUTH_ACCESS_TOKEN_PREFIX, OAUTH_REFRESH_TOKEN_PREFIX } from "@platform/db-postgres"
+import { describe, expect, it } from "vitest"
+import { rewriteOAuthTokenResponse } from "./oauth-token-prefix-rewriter.ts"
+
+const tokenEndpoint = "https://app.example.com/api/auth/mcp/token"
+
+const jsonResponse = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+
+describe("rewriteOAuthTokenResponse", () => {
+  it("prefixes `access_token` and `refresh_token` in a 200 response from /api/auth/mcp/token", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = jsonResponse(200, {
+      access_token: "raw-access",
+      refresh_token: "raw-refresh",
+      token_type: "Bearer",
+      expires_in: 3600,
+    })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    const body = (await rewritten.json()) as Record<string, unknown>
+
+    expect(body.access_token).toBe(`${OAUTH_ACCESS_TOKEN_PREFIX}raw-access`)
+    expect(body.refresh_token).toBe(`${OAUTH_REFRESH_TOKEN_PREFIX}raw-refresh`)
+    expect(body.token_type).toBe("Bearer")
+    expect(body.expires_in).toBe(3600)
+  })
+
+  it("recomputes Content-Length to match the prefixed body", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = jsonResponse(200, { access_token: "raw" })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    const body = await rewritten.text()
+
+    expect(rewritten.headers.get("Content-Length")).toBe(String(new TextEncoder().encode(body).byteLength))
+  })
+
+  it("does not double-prefix tokens that are already prefixed", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const already = `${OAUTH_ACCESS_TOKEN_PREFIX}existing`
+    const response = jsonResponse(200, { access_token: already })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    const body = (await rewritten.json()) as Record<string, unknown>
+    expect(body.access_token).toBe(already)
+  })
+
+  it("returns the original response untouched when the URL is not the token endpoint", async () => {
+    const request = new Request("https://app.example.com/api/auth/get-session", { method: "POST" })
+    const response = jsonResponse(200, { access_token: "raw-access" })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+  })
+
+  it("returns the original response untouched on GET requests (token endpoint is POST-only)", async () => {
+    const request = new Request(tokenEndpoint, { method: "GET" })
+    const response = jsonResponse(200, { access_token: "raw-access" })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+  })
+
+  it("returns the original response untouched on error responses", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const errorBody = { error: "invalid_grant", error_description: "code expired" }
+    const response = jsonResponse(401, errorBody)
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+    expect(await rewritten.json()).toEqual(errorBody)
+  })
+
+  it("returns the original response untouched when content-type isn't JSON", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = new Response("ok", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+  })
+
+  it("returns the original response untouched when the body isn't valid JSON", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = new Response("not json", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+  })
+
+  it("returns the original response untouched when neither token field is present", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = jsonResponse(200, { token_type: "Bearer", expires_in: 3600 })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten).toBe(response)
+  })
+
+  it("preserves status, statusText, and other headers", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = new Response(JSON.stringify({ access_token: "raw" }), {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      },
+    })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    expect(rewritten.status).toBe(200)
+    expect(rewritten.statusText).toBe("OK")
+    expect(rewritten.headers.get("Cache-Control")).toBe("no-store")
+    expect(rewritten.headers.get("Content-Type")).toBe("application/json")
+  })
+
+  it("only prefixes access_token when refresh_token isn't returned (auth-code response)", async () => {
+    const request = new Request(tokenEndpoint, { method: "POST" })
+    const response = jsonResponse(200, { access_token: "raw" })
+
+    const rewritten = await rewriteOAuthTokenResponse(request, response)
+    const body = (await rewritten.json()) as Record<string, unknown>
+    expect(body.access_token).toBe(`${OAUTH_ACCESS_TOKEN_PREFIX}raw`)
+    expect(body).not.toHaveProperty("refresh_token")
+  })
+})

--- a/apps/web/src/server/oauth-token-prefix-rewriter.ts
+++ b/apps/web/src/server/oauth-token-prefix-rewriter.ts
@@ -1,0 +1,81 @@
+import { OAUTH_ACCESS_TOKEN_PREFIX, OAUTH_REFRESH_TOKEN_PREFIX } from "@platform/db-postgres"
+
+/**
+ * The Better Auth `mcp` plugin's token endpoint. The plugin's `path` value is
+ * `/mcp/token` relative to the `basePath` (`/api/auth` in our setup).
+ */
+const MCP_TOKEN_PATH = "/api/auth/mcp/token"
+
+/**
+ * RFC 6749 token endpoint response shape that we mutate. Other fields BA may
+ * include (`token_type`, `expires_in`, `scope`, `id_token`) pass through as
+ * unknown values.
+ */
+interface OAuthTokenResponseBody {
+  access_token?: unknown
+  refresh_token?: unknown
+}
+
+/**
+ * Wraps a Better Auth response so MCP clients receive `loa_…`-prefixed access
+ * tokens and `lor_…`-prefixed refresh tokens on the wire.
+ *
+ * Why a rewriter, not a hook: the OIDC Provider plugin's token endpoint
+ * generates the random token string in-memory (`generateRandomString(32, …)`),
+ * persists it via `adapter.create({ model: "oauthAccessToken", … })`, then
+ * returns the same in-memory variable in the JSON response. Our adapter wrap
+ * (in `@platform/db-postgres/oauth-token-prefix.ts`) prefixes the persisted
+ * value, but the in-memory variable is already gone by the time it reaches
+ * the JSON encoder — so the wire response would carry the un-prefixed string
+ * and the round-trip would fail. The rewriter closes that gap.
+ *
+ * Pure function: given a Request and a Response, returns a new Response if
+ * mutation is needed, otherwise the original. Safe to invoke for every
+ * response — non-token URLs, error bodies, and non-JSON responses pass
+ * through untouched.
+ */
+export const rewriteOAuthTokenResponse = async (request: Request, response: Response): Promise<Response> => {
+  if (!shouldRewrite(request, response)) return response
+
+  // `response.json()` consumes the body, so we have to clone first to keep
+  // the original intact in case the rewrite is a no-op.
+  const clone = response.clone()
+
+  let parsed: OAuthTokenResponseBody
+  try {
+    parsed = (await clone.json()) as OAuthTokenResponseBody
+  } catch {
+    return response
+  }
+
+  const next: OAuthTokenResponseBody = { ...parsed }
+  let mutated = false
+  if (typeof parsed.access_token === "string" && !parsed.access_token.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    next.access_token = `${OAUTH_ACCESS_TOKEN_PREFIX}${parsed.access_token}`
+    mutated = true
+  }
+  if (typeof parsed.refresh_token === "string" && !parsed.refresh_token.startsWith(OAUTH_REFRESH_TOKEN_PREFIX)) {
+    next.refresh_token = `${OAUTH_REFRESH_TOKEN_PREFIX}${parsed.refresh_token}`
+    mutated = true
+  }
+  if (!mutated) return response
+
+  const body = JSON.stringify(next)
+  // Reuse the original headers but recompute Content-Length to match the
+  // (potentially longer) prefixed body. Other headers — `Cache-Control`,
+  // `Content-Type`, etc. — are preserved verbatim.
+  const headers = new Headers(response.headers)
+  headers.set("Content-Length", String(new TextEncoder().encode(body).byteLength))
+  return new Response(body, { status: response.status, statusText: response.statusText, headers })
+}
+
+const shouldRewrite = (request: Request, response: Response): boolean => {
+  if (request.method !== "POST") return false
+  // 4xx / 5xx error bodies don't carry a token, and BA may use a different
+  // shape (e.g. RFC 6749 `{ error, error_description }`) — pass them through.
+  if (!response.ok) return false
+  const url = new URL(request.url)
+  if (url.pathname !== MCP_TOKEN_PATH) return false
+  const contentType = response.headers.get("content-type") ?? ""
+  return contentType.toLowerCase().includes("application/json")
+}

--- a/packages/platform/db-postgres/src/create-better-auth.ts
+++ b/packages/platform/db-postgres/src/create-better-auth.ts
@@ -8,6 +8,7 @@ import { admin as adminPlugin, captcha, magicLink, organization as organizationP
 import { Effect } from "effect"
 import Stripe from "stripe"
 import type { PostgresClient } from "./client.ts"
+import { wrapAdapterForOAuthTokenPrefix } from "./oauth-token-prefix.ts"
 
 import {
   accounts,
@@ -108,7 +109,7 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
         })
       : null
 
-  const database = drizzleAdapter(config.client.db, {
+  const innerDatabase = drizzleAdapter(config.client.db, {
     provider: "pg",
     usePlural: true,
     schema: {
@@ -130,6 +131,12 @@ export const createBetterAuth = (config: BetterAuthConfig) => {
       oauthConsents,
     },
   }) as unknown as DBAdapter
+
+  // The OIDC plugin writes `oauth_access_tokens` rows via the raw adapter
+  // (bypassing `databaseHooks`), so token-prefixing has to happen at the
+  // adapter layer. Wrap is a no-op for every other model. See
+  // `oauth-token-prefix.ts` for the full reasoning.
+  const database = wrapAdapterForOAuthTokenPrefix(innerDatabase)
 
   return betterAuth({
     database,

--- a/packages/platform/db-postgres/src/index.ts
+++ b/packages/platform/db-postgres/src/index.ts
@@ -15,6 +15,11 @@ export {
   type User,
 } from "./create-better-auth.ts"
 export { healthcheckPostgres } from "./health.ts"
+export {
+  OAUTH_ACCESS_TOKEN_PREFIX,
+  OAUTH_REFRESH_TOKEN_PREFIX,
+  wrapAdapterForOAuthTokenPrefix,
+} from "./oauth-token-prefix.ts"
 // Outbox consumer for reliable event publishing
 export {
   createPollingOutboxConsumer,

--- a/packages/platform/db-postgres/src/oauth-token-prefix.test.ts
+++ b/packages/platform/db-postgres/src/oauth-token-prefix.test.ts
@@ -1,0 +1,154 @@
+import type { DBAdapter } from "@better-auth/core/db/adapter"
+import { describe, expect, it, vi } from "vitest"
+import {
+  OAUTH_ACCESS_TOKEN_PREFIX,
+  OAUTH_REFRESH_TOKEN_PREFIX,
+  wrapAdapterForOAuthTokenPrefix,
+} from "./oauth-token-prefix.ts"
+
+// Builds a stub adapter where `create` is a spy that records the params it
+// receives and echoes the data back so callers can read the post-wrap shape.
+const makeStubAdapter = () => {
+  const create = vi.fn(async (params: { model: string; data: Record<string, unknown> }) => params.data)
+  // Other methods are stubs — the wrap doesn't call them, so they only have to
+  // satisfy the type.
+  return {
+    adapter: {
+      id: "stub",
+      create,
+      findOne: vi.fn(),
+      findMany: vi.fn(),
+      count: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+      transaction: vi.fn(),
+      createSchema: vi.fn(),
+      options: {},
+    } as unknown as DBAdapter,
+    create,
+  }
+}
+
+describe("wrapAdapterForOAuthTokenPrefix", () => {
+  it("prepends `loa_` to `accessToken` when creating an oauthAccessToken", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    await wrapped.create({
+      model: "oauthAccessToken",
+      data: { accessToken: "xyz123", refreshToken: "abc456" },
+    })
+
+    expect(create).toHaveBeenCalledTimes(1)
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data.accessToken).toBe(`${OAUTH_ACCESS_TOKEN_PREFIX}xyz123`)
+  })
+
+  it("prepends `lor_` to `refreshToken` when creating an oauthAccessToken", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    await wrapped.create({
+      model: "oauthAccessToken",
+      data: { accessToken: "xyz123", refreshToken: "abc456" },
+    })
+
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data.refreshToken).toBe(`${OAUTH_REFRESH_TOKEN_PREFIX}abc456`)
+  })
+
+  it("does not double-prefix tokens that are already prefixed", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    await wrapped.create({
+      model: "oauthAccessToken",
+      data: {
+        accessToken: `${OAUTH_ACCESS_TOKEN_PREFIX}already-prefixed`,
+        refreshToken: `${OAUTH_REFRESH_TOKEN_PREFIX}already-prefixed`,
+      },
+    })
+
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data.accessToken).toBe(`${OAUTH_ACCESS_TOKEN_PREFIX}already-prefixed`)
+    expect(passed?.data.refreshToken).toBe(`${OAUTH_REFRESH_TOKEN_PREFIX}already-prefixed`)
+  })
+
+  it("leaves other models untouched", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    await wrapped.create({
+      model: "users",
+      data: { email: "test@example.com" },
+    })
+
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data).toEqual({ email: "test@example.com" })
+  })
+
+  it("forwards non-token fields on the oauthAccessToken model unchanged", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    const expiresAt = new Date()
+    await wrapped.create({
+      model: "oauthAccessToken",
+      data: {
+        accessToken: "x",
+        refreshToken: "y",
+        clientId: "client-1",
+        userId: "user-1",
+        scopes: "openid",
+        accessTokenExpiresAt: expiresAt,
+      },
+    })
+
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data).toEqual({
+      accessToken: `${OAUTH_ACCESS_TOKEN_PREFIX}x`,
+      refreshToken: `${OAUTH_REFRESH_TOKEN_PREFIX}y`,
+      clientId: "client-1",
+      userId: "user-1",
+      scopes: "openid",
+      accessTokenExpiresAt: expiresAt,
+    })
+  })
+
+  it("handles a missing refreshToken gracefully (auth-code grant only writes one)", async () => {
+    const { adapter, create } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    await wrapped.create({
+      model: "oauthAccessToken",
+      data: { accessToken: "x" },
+    })
+
+    const passed = create.mock.calls[0]?.[0]
+    expect(passed?.data.accessToken).toBe(`${OAUTH_ACCESS_TOKEN_PREFIX}x`)
+    expect(passed?.data.refreshToken).toBeUndefined()
+  })
+
+  it("does not mutate the caller's data object", async () => {
+    const { adapter } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    const data = { accessToken: "x", refreshToken: "y" }
+    await wrapped.create({ model: "oauthAccessToken", data })
+
+    expect(data.accessToken).toBe("x")
+    expect(data.refreshToken).toBe("y")
+  })
+
+  it("preserves non-create methods on the inner adapter", async () => {
+    const { adapter } = makeStubAdapter()
+    const wrapped = wrapAdapterForOAuthTokenPrefix(adapter)
+
+    expect(wrapped.findOne).toBe(adapter.findOne)
+    expect(wrapped.findMany).toBe(adapter.findMany)
+    expect(wrapped.update).toBe(adapter.update)
+    expect(wrapped.delete).toBe(adapter.delete)
+  })
+})

--- a/packages/platform/db-postgres/src/oauth-token-prefix.ts
+++ b/packages/platform/db-postgres/src/oauth-token-prefix.ts
@@ -1,0 +1,64 @@
+import type { DBAdapter } from "@better-auth/core/db/adapter"
+
+/**
+ * Prefix on every OAuth access token issued by the Better Auth `mcp` plugin.
+ * Stored verbatim in `oauth_access_tokens.access_token` and re-sent by the MCP
+ * client as `Authorization: Bearer loa_...`. The API auth middleware uses the
+ * prefix to dispatch directly to the OAuth validator.
+ *
+ * Symmetric with `lak_` on API keys (see `@domain/api-keys.API_KEY_TOKEN_PREFIX`).
+ */
+export const OAUTH_ACCESS_TOKEN_PREFIX = "loa_"
+
+/**
+ * Prefix on every OAuth refresh token issued by the Better Auth `mcp` plugin.
+ * Stored in `oauth_access_tokens.refresh_token` and only ever presented back to
+ * the web's `/api/auth/mcp/token` endpoint (the API never sees refresh tokens).
+ *
+ * Distinct from {@link OAUTH_ACCESS_TOKEN_PREFIX} so a refresh token sent by
+ * mistake on an API call is recognisable and rejected with a clean 401 instead
+ * of being silently routed through the access-token validator.
+ */
+export const OAUTH_REFRESH_TOKEN_PREFIX = "lor_"
+
+/**
+ * The OIDC Provider plugin (which the `mcp` plugin builds on) writes its rows
+ * via `ctx.context.adapter.create(...)` directly, **bypassing the
+ * `databaseHooks` mechanism** documented in Better Auth. The hooks layer is
+ * only invoked through `getWithHooks` in `db/with-hooks.ts`, which the OIDC
+ * plugin doesn't call — confirmed by reading
+ * `better-auth@1.6.9/dist/plugins/oidc-provider/index.mjs`.
+ *
+ * To get prefixes onto stored tokens we therefore wrap the adapter at this
+ * layer instead. The wrap intercepts `create({ model: "oauthAccessToken" })`
+ * calls and prepends the prefixes to `accessToken` / `refreshToken` before
+ * forwarding to the inner adapter; every other model is passed through
+ * untouched.
+ *
+ * The on-the-wire response from `/api/auth/mcp/token` is rewritten separately
+ * (in `apps/web`) — the OIDC plugin returns the in-memory token variable that
+ * was set *before* this hook, so the wire response would otherwise carry the
+ * un-prefixed value. The two pieces have to land together.
+ */
+export const wrapAdapterForOAuthTokenPrefix = (inner: DBAdapter): DBAdapter => ({
+  ...inner,
+  create: async <T extends Record<string, unknown>, R = T>(params: {
+    model: string
+    data: Omit<T, "id">
+    select?: string[] | undefined
+    forceAllowId?: boolean | undefined
+  }): Promise<R> => {
+    if (params.model !== "oauthAccessToken") {
+      return inner.create<T, R>(params)
+    }
+    const data = params.data as Record<string, unknown>
+    const next: Record<string, unknown> = { ...data }
+    if (typeof next.accessToken === "string" && !next.accessToken.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+      next.accessToken = `${OAUTH_ACCESS_TOKEN_PREFIX}${next.accessToken}`
+    }
+    if (typeof next.refreshToken === "string" && !next.refreshToken.startsWith(OAUTH_REFRESH_TOKEN_PREFIX)) {
+      next.refreshToken = `${OAUTH_REFRESH_TOKEN_PREFIX}${next.refreshToken}`
+    }
+    return inner.create<T, R>({ ...params, data: next as Omit<T, "id"> })
+  },
+})

--- a/packages/platform/oauth-token-auth/src/index.ts
+++ b/packages/platform/oauth-token-auth/src/index.ts
@@ -1,3 +1,9 @@
+// Re-export the prefix constants so consumers of this package get OAuth-token
+// helpers from a single import path. The values themselves live in
+// `@platform/db-postgres` next to the schema and adapter wrap (the prefix
+// shape is tied to what's on disk, and `db-postgres` is the lower-level
+// dependency — putting the constants here would create an import cycle).
+export { OAUTH_ACCESS_TOKEN_PREFIX, OAUTH_REFRESH_TOKEN_PREFIX } from "@platform/db-postgres"
 export {
   MIN_VALIDATION_TIME_MS,
   type OAuthTokenAuthResult,


### PR DESCRIPTION
## Summary

Wires the OAuth/MCP **issuer** end on the web app. After this PR, MCP clients can register at `/api/auth/mcp/register`, hit `/api/auth/mcp/authorize`, exchange the auth code at `/api/auth/mcp/token`, and walk away with a `loa_…` access token + `lor_…` refresh token. The tokens still won't authenticate against the API yet — that requires the consent page to bind them to an org (next PR).

- **`mcp()` plugin** in web's `getBetterAuth()`. `consentPage` points at the still-to-be-built `/auth/consent` route; the default BA consent UI renders in the meantime, but tokens issued without org binding (`oauth_applications.organization_id IS NULL`) are rejected by the API auth middleware — no usable tokens leak out.
- **Token prefixing requires two pieces**, because the OIDC plugin generates the random token in-memory, persists via `adapter.create(...)`, and returns the in-memory variable in the JSON response. `databaseHooks.oauthAccessToken.create.before` does NOT fire here — verified by reading `better-auth@1.6.9/dist/plugins/oidc-provider/index.mjs:431-453`:
  - **Adapter wrap** (`@platform/db-postgres/oauth-token-prefix.ts`) intercepts `create({ model: "oauthAccessToken" })` and prepends `loa_` / `lor_` before the row hits the DB. No-op for every other model.
  - **Response rewriter** (`apps/web/src/server/oauth-token-prefix-rewriter.ts`) wraps responses from `POST /api/auth/mcp/token` and prefixes `access_token` / `refresh_token` in the JSON body. Errors, non-token URLs, GET requests, non-JSON bodies, and already-prefixed tokens pass through untouched.
- **Single source of truth** — `OAUTH_ACCESS_TOKEN_PREFIX` / `OAUTH_REFRESH_TOKEN_PREFIX` live in `@platform/db-postgres` (lower-level package, no import cycle), re-exported by `@platform/oauth-token-auth`. The API middleware now imports the constant instead of hardcoding `"loa_"`.

Plan reference: `plans/mcp-oauth-api-expansion.md` — M2 web-side issuer (decision D14, "Token-prefix mechanism caveat" section).

## Test plan

- [x] `pnpm typecheck` (whole workspace)
- [x] `pnpm --filter @platform/db-postgres test` — 8 new tests (adapter wrap)
- [x] `pnpm --filter @app/web test` — 12 new tests (rewriter)
- [x] `pnpm --filter @app/api test` — 62 prior tests still pass (constant import)
- [x] `pnpm --filter @platform/db-postgres check` (biome)
- [x] `pnpm --filter @app/web check` (biome)
- [x] `pnpm knip`

## Out of scope (next PR)

- `/auth/consent` TanStack route + server fn that binds `oauth_applications.organization_id` and calls `betterAuth.api.oauth2Consent({ accept: true, consent_code })`.
- Root-level `/.well-known/oauth-authorization-server` redirect for MCP clients that try the AS root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)