### PR TITLE
feat(auth): install BA mcp() plugin on web; fall through to OAuth on API

### DIFF
--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,4 +1,4 @@
-import { API_KEY_TOKEN_PREFIX, generateApiKeyToken } from "@domain/api-keys"
+import { generateApiKeyToken } from "@domain/api-keys"
 import { generateId } from "@domain/shared"
 import { apiKeys } from "@platform/db-postgres/schema/api-keys"
 import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
@@ -56,86 +56,38 @@ const insertOAuthApplicationAndToken = async (
 describe("auth middleware dispatch", () => {
   setupTestApi()
 
-  it<ApiTestContext>("authenticates a `lak_`-prefixed token via the API-key validator", async ({ app, database }) => {
+  it<ApiTestContext>("authenticates a valid API-key bearer", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    const lakToken = generateApiKeyToken()
-    expect(lakToken.startsWith(API_KEY_TOKEN_PREFIX)).toBe(true)
-    await insertApiKey(database, tenant.organizationId, lakToken)
+    const token = generateApiKeyToken()
+    await insertApiKey(database, tenant.organizationId, token)
 
     const res = await app.fetch(
       new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${lakToken}` },
+        headers: { Authorization: `Bearer ${token}` },
       }),
     )
     expect(res.status).toBe(200)
   })
 
-  it<ApiTestContext>("authenticates a legacy un-prefixed UUID token via the fallback path", async ({
-    app,
-    database,
-  }) => {
+  it<ApiTestContext>("authenticates a valid OAuth access-token bearer", async ({ app, database }) => {
     const tenant = await createTenantSetup(database)
-    // `tenant.apiKeyToken` is a plain UUID — pre-prefix-rollout shape.
-    expect(tenant.apiKeyToken.startsWith(API_KEY_TOKEN_PREFIX)).toBe(false)
+    const token = crypto.randomUUID()
+    await insertOAuthApplicationAndToken(database, tenant.organizationId, tenant.userId, token)
 
     const res = await app.fetch(
       new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${tenant.apiKeyToken}` },
+        headers: { Authorization: `Bearer ${token}` },
       }),
     )
     expect(res.status).toBe(200)
   })
 
-  it<ApiTestContext>("authenticates a `loa_`-prefixed token via the OAuth validator", async ({ app, database }) => {
-    const tenant = await createTenantSetup(database)
-    const loaToken = `loa_${crypto.randomUUID()}`
-    await insertOAuthApplicationAndToken(database, tenant.organizationId, tenant.userId, loaToken)
-
-    const res = await app.fetch(
-      new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${loaToken}` },
-      }),
-    )
-    expect(res.status).toBe(200)
-  })
-
-  it<ApiTestContext>("rejects an unknown `lak_` token without falling through to OAuth", async ({ app, database }) => {
+  it<ApiTestContext>("rejects an unknown bearer (no API-key match, no OAuth match)", async ({ app, database }) => {
     await createTenantSetup(database)
-    const bogus = `${API_KEY_TOKEN_PREFIX}${crypto.randomUUID()}`
 
     const res = await app.fetch(
       new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${bogus}` },
-      }),
-    )
-    expect(res.status).toBe(401)
-  })
-
-  it<ApiTestContext>("rejects an unknown `loa_` token without falling through to API key", async ({
-    app,
-    database,
-  }) => {
-    await createTenantSetup(database)
-    const bogus = `loa_${crypto.randomUUID()}`
-
-    const res = await app.fetch(
-      new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${bogus}` },
-      }),
-    )
-    expect(res.status).toBe(401)
-  })
-
-  it<ApiTestContext>("rejects an unknown un-prefixed token after both validators reject it", async ({
-    app,
-    database,
-  }) => {
-    await createTenantSetup(database)
-    const bogus = crypto.randomUUID()
-
-    const res = await app.fetch(
-      new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${bogus}` },
+        headers: { Authorization: `Bearer ${crypto.randomUUID()}` },
       }),
     )
     expect(res.status).toBe(401)
@@ -155,7 +107,7 @@ describe("auth middleware dispatch", () => {
     // before consent would have NULL on the joined row; the validator must
     // refuse it (the auth middleware can't pick a tenant context out of NULL).
     const tenant = await createTenantSetup(database)
-    const loaToken = `loa_${crypto.randomUUID()}`
+    const token = crypto.randomUUID()
 
     const clientId = `mcp-client-${generateId()}`
     await database.db.insert(oauthApplications).values({
@@ -168,7 +120,7 @@ describe("auth middleware dispatch", () => {
     })
     await database.db.insert(oauthAccessTokens).values({
       id: generateId(),
-      accessToken: loaToken,
+      accessToken: token,
       clientId,
       userId: tenant.userId,
       accessTokenExpiresAt: new Date(Date.now() + 60 * 60 * 1000),
@@ -177,7 +129,7 @@ describe("auth middleware dispatch", () => {
 
     const res = await app.fetch(
       new Request("http://localhost/v1/api-keys", {
-        headers: { Authorization: `Bearer ${loaToken}` },
+        headers: { Authorization: `Bearer ${token}` },
       }),
     )
     expect(res.status).toBe(401)

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,4 +1,3 @@
-import { API_KEY_TOKEN_PREFIX } from "@domain/api-keys"
 import { OrganizationId, UnauthorizedError, UserId } from "@domain/shared"
 import { validateApiKey } from "@platform/api-key-auth"
 import type { PostgresClient } from "@platform/db-postgres"
@@ -9,14 +8,6 @@ import type { Context, MiddlewareHandler, Next } from "hono"
 import { getAdminPostgresClient } from "../clients.ts"
 import type { AuthContext } from "../types.ts"
 import { createTouchBuffer } from "./touch-buffer.ts"
-
-/**
- * Token prefix for OAuth access tokens. Set by the Better Auth `mcp` plugin's
- * `databaseHooks.oauthAccessToken.create.before` hook on the web app. Mirrors
- * the `lak_` prefix on API keys: cheap routing, no double lookups, accurate
- * error messages.
- */
-const OAUTH_TOKEN_PREFIX = "loa_"
 
 const extractBearerToken = (c: Context): string | undefined => {
   const authHeader = c.req.header("Authorization")
@@ -81,18 +72,14 @@ const authenticateWithOAuth = (
 }
 
 /**
- * Routes a bearer token to its validator using the prefix:
+ * Authenticates a bearer token by trying both validators in sequence: API key
+ * first, then OAuth, then 401. Both validators have a short negative-cache TTL,
+ * so an unknown bearer hits each underlying DB at most once per cache window.
  *
- * - `lak_…` → API-key path only.
- * - `loa_…` → OAuth path only.
- * - anything else → legacy fallback (try API-key first, then OAuth). Existing
- *   un-prefixed UUID API keys land here. We try API-key first because that's
- *   what the legacy population is; the OAuth attempt is a defensive second
- *   pass so a future stray un-prefixed OAuth-style token doesn't silently 401.
- *
- * Each branch performs at most one Redis + DB round-trip. The legacy branch
- * does at most two (one per validator); both validators have a negative-cache
- * TTL so a non-existent token only hits the DB once across both attempts.
+ * No prefix-based dispatch — bearer tokens are opaque random strings, and
+ * matching against the wrong validator just returns null cheaply. The trade-off
+ * is one extra Redis + DB round-trip on the OAuth happy path; the user knows
+ * their throughput envelope and the simplicity wins.
  */
 const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect<AuthContext, UnauthorizedError> =>
   Effect.gen(function* () {
@@ -103,20 +90,6 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
 
     const redis = c.get("redis")
 
-    if (bearerToken.startsWith(API_KEY_TOKEN_PREFIX)) {
-      const ctx = yield* authenticateWithApiKey(redis, bearerToken, options)
-      if (ctx) return ctx
-      return yield* new UnauthorizedError({ message: "Invalid API key" })
-    }
-
-    if (bearerToken.startsWith(OAUTH_TOKEN_PREFIX)) {
-      const ctx = yield* authenticateWithOAuth(redis, bearerToken, options)
-      if (ctx) return ctx
-      return yield* new UnauthorizedError({ message: "Invalid OAuth access token" })
-    }
-
-    // Legacy un-prefixed token (pre-prefix-rollout API keys). Try API-key first
-    // since that's what the legacy population is.
     const apiKeyCtx = yield* authenticateWithApiKey(redis, bearerToken, options)
     if (apiKeyCtx) return apiKeyCtx
 
@@ -129,9 +102,9 @@ const authenticate = (c: Context, options: AuthMiddlewareOptions): Effect.Effect
 /**
  * Create authentication middleware.
  *
- * Validates `Authorization: Bearer …` tokens. Routes by token prefix to the
- * API-key validator (`lak_…`), the OAuth validator (`loa_…`), or both
- * (legacy un-prefixed). Public routes should be excluded from this middleware.
+ * Validates `Authorization: Bearer …` tokens against both the API-key store
+ * and the OAuth access-token store, in that order. Public routes should be
+ * excluded from this middleware.
  */
 export const createAuthMiddleware = (options: AuthMiddlewareOptions): MiddlewareHandler => {
   return async (c: Context, next: Next) => {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -10,13 +10,13 @@ import type { PostgresClient, PostgresDb } from "@platform/db-postgres"
  *
  * Discriminated on `method`:
  *
- * - `api-key` — request authenticated via an organization-scoped API key
- *   (Bearer `lak_…` or a legacy unprefixed UUID). `userId` is a synthetic
- *   `api-key:<keyId>` value because API keys aren't tied to a real user.
- * - `oauth` — request authenticated via an OAuth access token (`Bearer loa_…`)
- *   issued through the Better Auth `mcp` plugin on the web app. Carries the
- *   real `userId` of the granting user, the `oauthClientId` of the MCP client,
- *   the granted `scopes`, and the `expiresAt` of the access token.
+ * - `api-key` — request authenticated via an organization-scoped API key.
+ *   `userId` is a synthetic `api-key:<keyId>` value because API keys aren't
+ *   tied to a real user.
+ * - `oauth` — request authenticated via an OAuth access token issued through
+ *   the Better Auth `mcp` plugin on the web app. Carries the real `userId` of
+ *   the granting user, the `oauthClientId` of the MCP client, the granted
+ *   `scopes`, and the `expiresAt` of the access token.
  */
 export type AuthContext =
   | {

--- a/apps/web/src/server/clients.ts
+++ b/apps/web/src/server/clients.ts
@@ -23,6 +23,7 @@ import {
   loadTemporalConfig,
 } from "@platform/workflows-temporal"
 import { withTracing } from "@repo/observability"
+import { mcp } from "better-auth/plugins"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
 import { Effect } from "effect"
 
@@ -202,7 +203,40 @@ export const getBetterAuth = () => {
       ...(stripeSecretKey ? { stripeSecretKey } : {}),
       ...(stripeWebhookSecret ? { stripeWebhookSecret } : {}),
       ...(selfServePlans.length > 0 ? { subscriptionPlans: selfServePlans } : {}),
-      extraPlugins: [tanstackStartCookies()],
+      extraPlugins: [
+        tanstackStartCookies(),
+        // OAuth2/OIDC authorization server for MCP clients (Claude Code,
+        // Cursor, …). Issues opaque random access + refresh tokens that the
+        // API resource server validates via `@platform/oauth-token-auth`.
+        // The consent page binds the issued token to a specific organization;
+        // until that route ships, the default BA consent UI renders and
+        // tokens get issued with `oauth_applications.organization_id IS NULL`,
+        // which the API auth middleware rejects (so no usable tokens leak out).
+        mcp({
+          loginPage: `${webUrl}/login`,
+          oidcConfig: {
+            // BA's `OIDCOptions` type requires `loginPage` here too even though
+            // the `mcp` plugin already takes one at the top level. Pass the
+            // same value so consent redirects use the same login URL.
+            loginPage: `${webUrl}/login`,
+            consentPage: `${webUrl}/auth/consent`,
+            requirePKCE: true,
+            // RFC 7591 dynamic client registration. MCP clients (Claude Code,
+            // Cursor, ...) hit `POST /api/auth/mcp/register` before any user
+            // has signed in — they're bootstrapping themselves. Without this
+            // flag the BA endpoint requires a session (see
+            // `better-auth@1.6.9/dist/plugins/oidc-provider/index.mjs:830`)
+            // and every MCP client registration would 401. Enabling it is
+            // safe: registered clients only become useful once a user
+            // completes the consent flow at `/auth/consent`, which is what
+            // binds the application to an organization. Until that binding
+            // happens `oauth_applications.organization_id IS NULL` and the
+            // API auth middleware rejects any tokens issued against the
+            // unbound row.
+            allowDynamicClientRegistration: true,
+          },
+        }),
+      ],
       onUserCreated: async (user) => {
         await Effect.runPromise(
           outboxWriter

--- a/packages/domain/api-keys/src/entities/api-key.ts
+++ b/packages/domain/api-keys/src/entities/api-key.ts
@@ -5,10 +5,8 @@ import { z } from "zod"
  * API Key entity - authenticates organization-bound requests.
  *
  * API keys are scoped to an organization and provide token-based
- * authentication for API access. New tokens are prefixed with `lak_` to let
- * the API auth middleware route to the API-key validator without a double
- * lookup. Tokens issued before the prefix rollout (plain UUIDs) are still
- * accepted via the legacy fallback path; no forced rotation.
+ * authentication for API access. Tokens are UUIDs generated
+ * using crypto.randomUUID().
  *
  * The token is encrypted at the application level (AES-256-GCM)
  * and a SHA-256 hex hash of the UTF-8 token bytes (tokenHash) is stored for indexed
@@ -57,23 +55,10 @@ export const createApiKey = (params: {
 }
 
 /**
- * Token prefix for newly issued API keys. The API auth middleware uses it to
- * dispatch directly to the API-key validator (vs. OAuth or legacy fallback)
- * without paying for a Redis miss + DB lookup against the wrong validator.
- *
- * `lak` (Latitude API Key) is intentionally three letters and avoids `lat_`,
- * which reads ambiguously as "Latitude" rather than the credential type.
- */
-export const API_KEY_TOKEN_PREFIX = "lak_"
-
-/**
- * Generate a new API key token. Format: `lak_<UUID v4>`.
- *
- * Legacy un-prefixed UUID tokens issued before this rollout still authenticate
- * — see `apps/api/src/middleware/auth.ts` for the legacy fallback dispatch.
+ * Generate a new API key token (UUID v4).
  */
 export const generateApiKeyToken = (): string => {
-  return `${API_KEY_TOKEN_PREFIX}${crypto.randomUUID()}`
+  return crypto.randomUUID()
 }
 
 /**

--- a/packages/domain/api-keys/src/index.ts
+++ b/packages/domain/api-keys/src/index.ts
@@ -1,6 +1,5 @@
 export { DEFAULT_API_KEY_NAME } from "./constants.ts"
 export {
-  API_KEY_TOKEN_PREFIX,
   type ApiKey,
   apiKeySchema,
   createApiKey,

--- a/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
+++ b/packages/platform/oauth-token-auth/src/validate-oauth-token.test.ts
@@ -61,8 +61,8 @@ const insertOAuthSetup = async (db: PostgresDb, options: InsertOAuthSetupOptions
   const userFixture = await Effect.runPromise(createUserFixture(db))
   const userId = userFixture.id
   const clientId = `client-${generateId()}`
-  const accessToken = `loa_${generateId()}_${generateId()}`
-  const refreshToken = `lor_${generateId()}_${generateId()}`
+  const accessToken = `${generateId()}_${generateId()}`
+  const refreshToken = `${generateId()}_${generateId()}`
   const tokenRowId = generateId()
 
   await db.insert(oauthApplications).values({
@@ -146,7 +146,7 @@ describe.skipIf(!nodeSupportsUint8Hex)("validateOAuthAccessToken (integration, N
     const redis = createFakeRedis()
 
     const result = await Effect.runPromise(
-      validateOAuthAccessToken("loa_unknown_token", {
+      validateOAuthAccessToken("unknown_token", {
         redis,
         adminClient: database.adminPostgresClient,
       }),

--- a/plans/mcp-oauth-api-expansion.md
+++ b/plans/mcp-oauth-api-expansion.md
@@ -18,8 +18,8 @@ Stack confirmed: `better-auth@1.6.9` (catalog), `@better-auth/core@1.6.9`, `@bet
 | - | - | - |
 | D1 | **Keep our custom API-key system; add OAuth2 alongside.** Add a code-level `TODO` referencing migration to better-auth's `apiKey` plugin once we're ready. | BA's `apiKey` plugin (per docs) supports **organization-owned API keys** via `references` config. Our keys today are already org-scoped; migrating would unify under one auth backend. Out of scope for this plan. |
 | D2 | **MCP at `/v1/mcp` inside `apps/api`.** Not a separate process. | Reuses existing middleware chain (validation, rate-limit, auth, org-context), Effect layers, and Zod schemas. |
-| D3 | **Better Auth lives only on the web app.** The API does **not** mount BA. The web's existing BA instance gains the `mcp()` plugin (so `/api/auth/mcp/authorize`, `/api/auth/mcp/token`, `/api/auth/mcp/register`, `/api/auth/oauth2/consent`, and `/api/auth/.well-known/*` are all served by the web). The API only serves `/v1/mcp` plus a tiny static `/.well-known/oauth-protected-resource` advertising the web origin as the AS. Token validation on the API reads `oauth_access_token` directly from shared Postgres via Drizzle — no BA call. | RFC 9728 explicitly allows the AS to live on a different origin than the protected resource. Keeping OAuth on the web origin means the user's browser never crosses origins during sign-in/consent — the existing session cookie on the web is reused as-is. The MCP client only crosses origins for the final `Authorization: Bearer loa_…` API call, which is a header (not a cookie). **No reverse proxy needed in dev or prod.** |
-| D4 | **Token prefixes**: new API keys → `lak_<random>`; OAuth access tokens → `loa_<random>` (avoiding `lat_` which can read as "Latitude"). Existing un-prefixed API keys keep working via the legacy fallback path (try API-key validator first, then OAuth, then 401). No forced rotation. | Cheap routing, no double lookups, accurate error messages. |
+| D3 | **Better Auth lives only on the web app.** The API does **not** mount BA. The web's existing BA instance gains the `mcp()` plugin (so `/api/auth/mcp/authorize`, `/api/auth/mcp/token`, `/api/auth/mcp/register`, `/api/auth/oauth2/consent`, and `/api/auth/.well-known/*` are all served by the web). The API only serves `/v1/mcp` plus a tiny static `/.well-known/oauth-protected-resource` advertising the web origin as the AS. Token validation on the API reads `oauth_access_token` directly from shared Postgres via Drizzle — no BA call. | RFC 9728 explicitly allows the AS to live on a different origin than the protected resource. Keeping OAuth on the web origin means the user's browser never crosses origins during sign-in/consent — the existing session cookie on the web is reused as-is. The MCP client only crosses origins for the final `Authorization: Bearer …` API call, which is a header (not a cookie). **No reverse proxy needed in dev or prod.** |
+| D4 | **No token prefixes — fall-through dispatch instead.** API keys and OAuth access tokens are both opaque random strings stored verbatim in their respective tables. The auth middleware tries the API-key validator first, falls through to the OAuth validator, and 401s if neither matches. No `lak_` / `loa_` / `lor_` prefixes anywhere — no request rewriters, no response rewriters, no repository-level apply/strip helpers, no validator-level strip. | Simpler everything: one extra Redis + DB round-trip on the OAuth happy path is the entire trade-off, and both validators have a short negative-cache TTL so a known-bad bearer only hits the DB once per cache window. Avoids the in-DB-vs-on-wire mismatch (BA stores raw, BA refresh-grant looks up raw — anything else needs adapter wraps or wire rewriters that we'd have to keep symmetric). |
 | D5 | **OAuth org binding via a typed `organization_id` column on `oauth_applications`** — not a new join table, and not the BA `metadata` JSON. At consent time, the web's `/auth/consent` page writes the picked org id directly into the `organization_id` column. The API's auth middleware joins `oauth_access_tokens → oauth_applications` and reads `a.organization_id` from shared Postgres. | Mirrors the existing `api_keys.organization_id + RLS` pattern (single column + FK + soft-delete-aware RLS policy). RLS is enabled scoped by `organization_id`: the settings/keys page on web reads through the regular tenant-scoped connection and only sees MCP clients bound to the active org; abandoned `/api/auth/mcp/register` rows (NULL `organization_id`) are invisible to all tenant queries by design. Token validation on the API uses the admin Postgres connection (same as `api_keys.findByTokenHash`) so it can resolve the bound org without any `set_organization_id` precondition. The two related tables (`oauth_access_tokens`, `oauth_consents`) stay RLS-free because they're only read either via the admin-bypass path (token validation) or via JOIN through the RLS-protected application — defense in depth without RLS-via-EXISTS overhead on the hot path. |
 | D6 | **Custom consent page at `${webUrl}/auth/consent`** (NOT `/oauth/consent`). The MCP plugin's `oidcConfig.consentPage` redirects there. The page is a TanStack Start route that reads `?consent_code=…&client_id=…&scope=…`, lists the user's orgs, lets them pick one, then runs a server fn that (a) validates user is a member of the chosen org, (b) updates `oauth_applications.organization_id` for the matching `client_id` (via Drizzle on the web's admin Postgres connection — admin needed to bypass RLS while writing the very binding RLS will check against), and (c) calls `betterAuth.api.oauth2Consent({ accept: true, consent_code })` in-process. | All on web — no cross-process call, no API involvement. `/auth/*` is the existing non-reserved namespace on the web app (`/auth/invite` lives there); `/api/auth/*` is reserved for the BA HTTP handler. |
 | D7 | **Slugs regenerate on rename.** Saved-searches already does this (`update-saved-search.ts:62-71` regenerates the slug when the name changes). Apply the same to **projects, organizations, issues, datasets** — anywhere a slug is derived from a name. | URL stability is sacrificed in exchange for slug-tracks-name semantics. Matches the existing pattern; consistency wins. |
@@ -83,8 +83,8 @@ The MCP discovery flow (RFC 9728 + RFC 8414):
 5. BA mints a `consent_code` and redirects to `https://app.latitude.so/auth/consent?consent_code=…&client_id=…&scope=…`. Same origin still.
 6. User picks an org, clicks Approve. The web server fn (a) validates membership, (b) sets `oauth_applications.organization_id` for the matching `client_id` via the admin Drizzle connection, (c) calls `betterAuth.api.oauth2Consent({ accept: true, consent_code })` in-process.
 7. BA returns the auth code to the MCP client's redirect URI.
-8. MCP client → `POST https://app.latitude.so/api/auth/mcp/token` (server-to-server, no cookies) → returns `loa_…` access token.
-9. MCP client → `https://api.latitude.so/v1/mcp` with `Authorization: Bearer loa_…`. The API's auth middleware queries shared Postgres (admin connection, RLS-bypass) for the token, joins to `oauth_applications.organization_id`, sets `c.var.auth` and `c.var.organization`. Tool dispatch proceeds.
+8. MCP client → `POST https://app.latitude.so/api/auth/mcp/token` (server-to-server, no cookies) → returns an opaque access token.
+9. MCP client → `https://api.latitude.so/v1/mcp` with `Authorization: Bearer …`. The API's auth middleware tries the API-key validator first, falls through to the OAuth validator, queries shared Postgres (admin connection, RLS-bypass) for the token, joins to `oauth_applications.organization_id`, sets `c.var.auth` and `c.var.organization`. Tool dispatch proceeds.
 
 The browser only ever talks to `app.latitude.so` (the web origin). The MCP client (CLI agent) talks to both origins via plain HTTPS — no CORS or cookies in play. Local dev: `localhost:3000` web ↔ `localhost:3001` API works as-is, no proxy needed.
 
@@ -121,7 +121,7 @@ mcp({
 })
 ```
 
-Plus the `databaseHooks.oauthAccessToken.create.before` hook that prepends `loa_` to access tokens (and `lor_` to refresh tokens).
+No request / response rewriting on `/api/auth/mcp/token` — BA's plugin issues opaque tokens, stores them raw, and looks them up raw on refresh. Token prefixes (D4) are out.
 
 Optional convenience: a root-level redirect `app.latitude.so/.well-known/oauth-authorization-server` → `app.latitude.so/api/auth/.well-known/oauth-authorization-server` for MCP clients that try the AS root. RFC 8414 supports the path-prefixed form (`<host>/<path>` issuer), so this is belt-and-suspenders.
 
@@ -130,14 +130,12 @@ Optional convenience: a root-level redirect `app.latitude.so/.well-known/oauth-a
 ```
 authenticate(c) -> AuthContext | 401
   bearer = extractBearerToken(c) ?? throw 401
-  switch classifyTokenByPrefix(bearer):
-    case "api-key" (lak_…):  return authenticateWithApiKey(bearer) ?? 401
-    case "oauth"   (loa_…):  return authenticateWithOAuth(bearer)  ?? 401
-    default:                 # legacy unprefixed
-      return authenticateWithApiKey(bearer)
-          ?? authenticateWithOAuth(bearer)
-          ?? 401
+  return authenticateWithApiKey(bearer)
+      ?? authenticateWithOAuth(bearer)
+      ?? 401
 ```
+
+Bearer tokens are opaque — there's no prefix to dispatch on, so we just try both validators in sequence. Both have a short negative-cache TTL (~5s), so an unknown bearer or an OAuth-shaped bearer hits each underlying DB at most once per cache window.
 
 #### Why we don't call Better Auth for verification
 
@@ -226,10 +224,6 @@ export type AuthContext =
 ```
 
 `expiresAt` is on the OAuth variant only (API keys don't expire). The middleware writes the chosen variant onto `c.var.auth`.
-
-### Token-prefix mechanism caveat
-
-The OIDC Provider plugin doesn't expose a documented `generateAccessToken` hook (confirmed in docs). The `databaseHooks.oauthAccessToken.create.before` storage hook works, but the response body BA returns from `/api/auth/mcp/token` may use the in-memory token variable that was set before our hook. **Fallback**: a tiny response-rewriter middleware on the web's `/api/auth/mcp/token` route that reads the response JSON, finds `access_token` / `refresh_token`, prepends prefixes, recomputes content-length, returns. Lives on the **web** now (not the API). Resolve in M2.
 
 ### Local-dev story — no proxy needed
 
@@ -427,25 +421,28 @@ Ship the OAuth layer end-to-end with one migrated route as a smoke test. **All B
   ```ts
   mcp({
     loginPage: `${webUrl}/login`,
-    oidcConfig: { consentPage: `${webUrl}/auth/consent`, requirePKCE: true },
+    oidcConfig: {
+      consentPage: `${webUrl}/auth/consent`,
+      requirePKCE: true,
+      // Without this, `/api/auth/mcp/register` requires a session (BA source
+      // `oidc-provider/index.mjs:830`). MCP clients register before any user
+      // signs in — they're machines bootstrapping themselves.
+      allowDynamicClientRegistration: true,
+    },
   })
   ```
-  Plus `databaseHooks.oauthAccessToken.create.before` to prepend `loa_` to access tokens, `lor_` to refresh tokens.
 - `apps/web/src/routes/auth.consent.tsx` — new TanStack route. Reads `consent_code` + `client_id` from query, fetches user's orgs, renders org-picker. Approve runs a server fn that:
   1. Validates user is a member of the chosen org.
   2. Updates `oauth_applications.organization_id` for the matching `client_id` via Drizzle on the admin connection (admin needed because the RLS policy this row will satisfy is scoped to the very org id we're about to write).
   3. Calls `getBetterAuth().api.oauth2Consent({ accept: true, consent_code })` in-process.
-- Optional: a response-rewriter Hono middleware fronting `/api/auth/mcp/token` if the BA before-create hook approach doesn't prefix the on-the-wire token. Prototype both in M2; pick the simpler one.
 - Root-level redirect `/.well-known/oauth-authorization-server` → `/api/auth/.well-known/oauth-authorization-server` for MCP clients that try the AS root.
 
 **API changes** (resource server only):
 - `apps/api/src/routes/well-known.ts` — new file. Serves `GET /.well-known/oauth-protected-resource` returning a static `{ resource: <apiUrl>, authorization_servers: [<webUrl> + "/api/auth"] }`. Public route (RING 1).
-- `apps/api/src/middleware/auth.ts` — rewrite `authenticate()` per D4. Validates `loa_…` tokens via `validateOAuthAccessToken` (the M1 platform package) — pure Drizzle, no BA. Extend `AuthContext` type per D14.
+- `apps/api/src/middleware/auth.ts` — extend `authenticate()` to fall through to OAuth (D4): try the API-key validator first, then `validateOAuthAccessToken` (the M1 platform package — pure Drizzle, no BA), then 401. Extend `AuthContext` type per D14.
 - `apps/api/src/routes/index.ts` — three-ring restructure; mount `/.well-known/oauth-protected-resource` in RING 1.
 
-**Token prefixing** (split between web and API):
-- `packages/domain/api-keys/src/entities/api-key.ts` (API/shared) — `generateApiKeyToken()` returns `lak_${random}`.
-- The web BA hook handles `loa_` / `lor_` prefixes for OAuth tokens (above).
+**No token prefixing** (D4). Bearer tokens are opaque random strings throughout — `crypto.randomUUID()` for API keys, `generateRandomString(32, …)` for OAuth tokens. Storage, transport, and lookup all use the raw value. The auth middleware's two-validator fall-through (API-key → OAuth → 401) replaces the prefix-based dispatch.
 
 **Migrate one route to `defineApiEndpoint`** (proof of concept):
 - `apps/api/src/routes/api-keys.ts` — wrap existing routes (list/create/revoke) in `defineApiEndpoint`. Add `name` and `description` fields to each `createRoute` call (replace `operationId`). Verify `pnpm openapi:emit` produces a clean diff (just `operationId` field renames). Verify `pnpm mcp:emit` lists 3 tools.
@@ -561,7 +558,7 @@ These can ship in a single PR after M2 is merged (so the BA OAuth tables exist).
 - `packages/domain/issues/src/{ports/issue-repository,use-cases/create-issue-from-score,use-cases/discover-issue}.ts`
 - `packages/domain/datasets/src/{ports/dataset-repository,use-cases/{create,rename,update-details}-dataset}.ts`
 - `packages/domain/projects/src/use-cases/update-project.ts` — slug-on-rename
-- `packages/domain/api-keys/src/entities/api-key.ts` — `lak_` prefix
+- `packages/domain/api-keys/src/entities/api-key.ts` — `generateApiKeyToken()` returns plain UUID; no prefix helpers
 - `apps/web/src/server/clients.ts` — install `mcp()` plugin in `getBetterAuth()` extraPlugins
 - `apps/web/src/domains/evaluations/evaluation-alignment.functions.ts` — delegate to new use-cases
 - `apps/web/src/routes/_authenticated/settings/account.tsx` — Sessions section
@@ -569,7 +566,6 @@ These can ship in a single PR after M2 is merged (so the BA OAuth tables exist).
 ## Risks / unknowns
 
 - **BA `mcp` plugin is documented as deprecated in favor of an OAuth Provider plugin** (per the BA mcp.md docs page). Both share the OIDC schema, so migration cost is low later. Confirm in M2 which to use; if a non-deprecated equivalent exists in 1.6.9 prefer that.
-- **Custom access-token prefix (`loa_`)**: OIDC Provider plugin doesn't expose a documented `generateAccessToken` hook. The `databaseHooks.oauthAccessToken.create.before` storage hook works, but the response body BA returns from `/api/auth/mcp/token` may carry the unprefixed token unless we either (a) mutate `data.accessToken` in the hook (verify BA reads from the same object after the hook returns), or (b) add a small response-rewriter middleware on the **web's** `/api/auth/mcp/token` route. Resolve in M2 prototyping.
 - **MCP-client AS discovery quirks**: some MCP clients strictly fetch `<as>/.well-known/oauth-authorization-server` at the AS root rather than honoring the path-prefixed issuer (`<webUrl>/api/auth`). Add the root-level redirect on the web app (covered in M2). If a particular client still fails, document the workaround.
 - **`WebStandardStreamableHttpServerTransport` API shape** — newer than the README example (`StreamableHTTPServerTransport`). Verify constructor + method names against the installed `@modelcontextprotocol/sdk@1.29.0` source.
 - **Zod-v4 `.openapi()` metadata propagating into MCP tool inputSchema** via `zod-to-json-schema` — different package than `@asteasolutions/zod-to-openapi`. Need a unit test confirming descriptions survive; if not, add a small reflection helper that copies metadata into `.describe(...)` before MCP registration.
@@ -594,8 +590,8 @@ pnpm generate:sdk                        # confirm Fern produces a clean SDK del
 End-to-end (M2 onward), no proxy needed — vanilla web on `localhost:3000` and API on `localhost:3001`:
 
 1. `GET http://localhost:3001/.well-known/oauth-protected-resource` → returns `{ resource: "http://localhost:3001", authorization_servers: ["http://localhost:3000/api/auth"] }`.
-2. `GET http://localhost:3001/v1/account` with a `lak_` API key → 200, returns `{ organization, role: null, user: null }`.
-3. Run `npx @modelcontextprotocol/inspector http://localhost:3001/v1/mcp` → discovery hops to the web AS → user signs in on `localhost:3000` (existing magic-link flow) → org picker on `localhost:3000/auth/consent` → consent → MCP client receives `loa_…` token → tool list returns ≥3 tools after M2.
+2. `GET http://localhost:3001/v1/account` with an organization API key → 200, returns `{ organization, role: null, user: null }`.
+3. Run `npx @modelcontextprotocol/inspector http://localhost:3001/v1/mcp` → discovery hops to the web AS → user signs in on `localhost:3000` (existing magic-link flow) → org picker on `localhost:3000/auth/consent` → consent → MCP client receives an opaque access token → tool list returns ≥3 tools after M2.
 4. Issue `tools/call listApiKeys` from the inspector → 200 returns the org's keys (masked).
 5. Issue `tools/call getApiKey { id }` → 200 returns full unmasked token.
 6. After M3: `account_get`, `members_*`, `projects_*` tool calls succeed with org-bound OAuth token.


### PR DESCRIPTION
## Summary

Wires the OAuth/MCP **issuer** end on the web app and teaches the API auth middleware to validate OAuth bearer tokens alongside API keys. After this PR, MCP clients (Claude Code, Cursor, …) can complete the full RFC 7591 + OIDC dance against `app.latitude.so/api/auth/mcp/*`, walk away with an opaque access token, and present it to `api.latitude.so/v1/*` as `Authorization: Bearer …`.

This is the M2 **issuer + resource-server-auth** slice from `plans/mcp-oauth-api-expansion.md`. The consent page that binds tokens to an organization, and the root-level AS-metadata redirect for clients that don't honor path-prefixed issuers, ship in follow-ups.

## Design

**Tokens stay opaque end-to-end.** No `lak_` / `loa_` / `lor_` prefixes — bearer tokens are just the random strings `crypto.randomUUID()` and BA's `generateRandomString(32, …)` produce. The middleware tries the API-key validator first, falls through to the OAuth validator, and 401s if neither matches:

\`\`\`ts
authenticate(c) -> AuthContext | 401
  bearer = extractBearerToken(c) ?? throw 401
  return authenticateWithApiKey(bearer)
      ?? authenticateWithOAuth(bearer)
      ?? 401
\`\`\`

Cost: one extra Redis + DB round-trip on the OAuth happy path, amortized by the existing 5-second negative-cache TTL on both validators (an unknown bearer or OAuth-shaped bearer hits the API-key DB once per cache window). Trade-off discussed and accepted in the plan's D4 entry.

## Web (issuer)

`apps/web/src/server/clients.ts > getBetterAuth()` installs the `mcp()` plugin in `extraPlugins`:

\`\`\`ts
mcp({
  loginPage: \`\${webUrl}/login\`,
  oidcConfig: {
    loginPage: \`\${webUrl}/login\`,
    consentPage: \`\${webUrl}/auth/consent\`,
    requirePKCE: true,
    allowDynamicClientRegistration: true,
  },
})
\`\`\`

**Why `allowDynamicClientRegistration: true`** — MCP clients hit `POST /api/auth/mcp/register` (RFC 7591) **before** any user has signed in; they're machines bootstrapping themselves. Without this flag the BA endpoint demands a session (\`oidc-provider/index.mjs:830\`) and every registration 401s.

**Safety while the consent page is still pending** — the consent page (next PR) is what writes the picked org id into \`oauth_applications.organization_id\`. Until it lands, the default BA consent UI renders and tokens issue with \`organization_id IS NULL\`. The API auth middleware's existing \`organizationId === null\` rejection branch (already in \`@platform/oauth-token-auth\`) makes those tokens unusable, so no usable tokens leak out before the org-binding step ships.

## API (resource server)

\`apps/api/src/middleware/auth.ts\` — extended \`authenticate()\` per the snippet above. Imports \`validateOAuthAccessToken\` from \`@platform/oauth-token-auth\` (the M1 platform package — pure Drizzle, no BA dep on the API). \`AuthContext\` already discriminates on \`method: \"api-key\" | \"oauth\"\` (from the earlier dispatch PR); the OAuth variant carries the real \`userId\`, \`oauthClientId\`, granted \`scopes\`, and \`expiresAt\`. No type-shape change here.

## Plan doc updates

\`plans/mcp-oauth-api-expansion.md\`:
- D4 rewritten as **\"No token prefixes — fall-through dispatch instead\"**.
- The earlier \"Token-prefix mechanism\" section deleted (no rewriters to document).
- M2 web-changes describe the new \`mcp()\` config (with \`allowDynamicClientRegistration\`).
- M2 API-changes describe the fall-through extension to \`authenticate()\`.
- Risks list dropped the resolved access-token-prefix concern.

## What's deliberately out of scope

- \`apps/web/src/routes/auth.consent.tsx\` — TanStack route + server fn that writes \`oauth_applications.organization_id\` and calls \`betterAuth.api.oauth2Consent({ accept: true, consent_code })\`. Next PR.
- Root-level \`.well-known/oauth-authorization-server\` redirect for MCP clients that try the AS root rather than honoring the path-prefixed issuer. Next PR.
- \`/v1/mcp\` mount handler (\`apps/api/src/mcp/server.ts\`). Was already gated on the auth-middleware refactor; lands once this is in.

## Test plan

- [x] \`pnpm typecheck\` (whole workspace)
- [x] \`pnpm --filter @app/api test\` — 59 passing (rewrote 8 prefix-dispatch tests as 5 fall-through tests covering: valid API-key bearer, valid OAuth bearer, unknown bearer, no Authorization header, OAuth token with NULL \`organization_id\`)
- [x] \`pnpm --filter @platform/oauth-token-auth test\` — 7 passing
- [x] \`pnpm --filter @platform/api-key-auth test\` — 4 passing
- [x] \`pnpm --filter @platform/db-postgres test\` — 168 passing
- [x] \`pnpm --filter @app/web test\` — 260 passing
- [x] \`pnpm --filter @app/web typecheck\`
- [x] biome check on every touched package
- [x] \`pnpm knip\`

Net diff: +96 / -157 lines across 8 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)