### PR TITLE
fix(telemetry-python): repair instrument_test exporter patch and re-enable in CI

### DIFF
--- a/.github/workflows/python-telemetry-ci.yml
+++ b/.github/workflows/python-telemetry-ci.yml
@@ -53,5 +53,4 @@ jobs:
       - name: Run tests
         run: |
           cd packages/telemetry/python
-          # Skip instrument_test.py due to test infrastructure issue with exporter patching
-          uv run pytest tests/ -x --ignore=tests/telemetry/instrument_test.py
+          uv run pytest tests/ -x

--- a/packages/telemetry/python/tests/telemetry/instrument_test.py
+++ b/packages/telemetry/python/tests/telemetry/instrument_test.py
@@ -57,7 +57,7 @@ class TestInstrument(TestCase):
 
         span = spans[0]
         self.assert_span_name(span, "openai.chat")
-        self.assert_span_has_attribute(span, "gen_ai.system", "OpenAI")
+        self.assert_span_has_attribute(span, "gen_ai.system", "openai")
         self.assert_span_has_attribute(span, "gen_ai.request.model", "gpt-4o-mini")
         self.assert_span_has_attribute(span, "gen_ai.response.model", "gpt-4o-mini")
         self.assert_span_has_attribute(span, "gen_ai.usage.input_tokens", 10)

--- a/packages/telemetry/python/tests/utils/utils.py
+++ b/packages/telemetry/python/tests/utils/utils.py
@@ -62,15 +62,11 @@ class TestCase(unittest.TestCase):
             if hasattr(processor, "span_exporter"):
                 processor.span_exporter = self.test_exporter
                 return True
-            inner = getattr(processor, "_inner", None)
-            if inner is not None and patch_span_exporter(inner):
-                return True
-            export_processor = getattr(processor, "_export_processor", None)
-            if export_processor is not None and patch_span_exporter(export_processor):
-                return True
+            for attr in ("_tail", "_inner", "_export_processor"):
+                child = getattr(processor, attr, None)
+                if child is not None and patch_span_exporter(child):
+                    return True
             return False
-
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 
         for processor in self.provider._active_span_processor._span_processors:
             patch_span_exporter(processor)


### PR DESCRIPTION
## Summary

- `tests/utils/utils.py` `patch_span_exporter` now also descends `LatitudeSpanProcessor._tail`, so the in-memory `TestExporter` actually replaces the real OTLP exporter in tests.
- Update `gen_ai.system` assertion in `instrument_test.py` from `"OpenAI"` to `"openai"` to match what `opentelemetry-instrumentation-openai==0.50.1` emits (GenAI semconv).
- Drop the `--ignore=tests/telemetry/instrument_test.py` workaround from `.github/workflows/python-telemetry-ci.yml` now that the test passes.

## Why this surfaced now

The failure was actually introduced **five weeks ago** in commit cf9c4067a ("v3.0.0-alpha.1 — complete OpenTelemetry-first SDK re-architecture", Apr 2). That commit:

1. Renamed the internal processor chain attribute on `LatitudeSpanProcessor` to `_tail`, but the new test helper `patch_span_exporter` only walked `_inner` / `_export_processor`. So in tests the `TestExporter` was never wired in and spans went to the real OTLP endpoint, which returned 401 for `fake-api-key`.
2. Added the wrong `gen_ai.system` assertion (`"OpenAI"` vs the lowercase value the library actually emits).
3. Hid both problems by adding `--ignore=tests/telemetry/instrument_test.py` to `python-telemetry-ci.yml` with a comment: *"test infrastructure issue with exporter patching"*.

CI then stayed green on PRs. The `publish-python-telemetry.yml` workflow has **always** run `uv run pytest tests/telemetry/ -x` **without** `--ignore` — but its trigger used to be `push` to `main` with a path filter on `packages/telemetry/python/**`, so it only ran when the Python package itself changed.

That changed in #3009 (commit f09da7bb3, May 8): the publish trigger was switched from `push` + path filter to `workflow_call` invoked from `deploy.yml` on every successful production deploy. From that point on, the publish workflow runs on every prod rollout regardless of which package changed — and it has been hitting the broken test ever since. That's how the issue surfaced.

This PR fixes the root cause in test infrastructure and removes the `--ignore` so CI catches future regressions in the same place where publish would fail anyway.

## Test plan

- [x] `uv run pytest tests/telemetry/` passes locally (48/48)
- [x] Python Telemetry CI is green on this PR
- [ ] Next production deploy's `publish-python-telemetry` job succeeds (or no-ops on version match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)