### PR TITLE
fix(docker): pin pnpm to 9.8.0 via corepack in app Dockerfiles

### DIFF
--- a/apps/gateway/docker/Dockerfile
+++ b/apps/gateway/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update --no-cache \
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --update --no-cache \
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"

--- a/apps/websockets/docker/Dockerfile
+++ b/apps/websockets/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache libc6-compat curl
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"

--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache libc6-compat curl python3 make g++ gcc
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable
+RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"


### PR DESCRIPTION
## Summary
- Docker builds started failing because corepack's default `pnpm` drifted to `11.0.8`, which moved the global bin directory to `$PNPM_HOME/bin`. Our Dockerfiles only add `$PNPM_HOME` (`/pnpm`) to `PATH`, so `pnpm i -g turbo` fails with: `The configured global bin directory "/pnpm/bin" is not in PATH`.
- `pnpm i -g turbo` runs before `COPY . .`, so corepack can't read the repo's `packageManager` field and falls back to its latest default.
- Pin `pnpm@9.8.0` via `corepack prepare --activate` in all four app Dockerfiles (gateway, web, websockets, workers) to match the version pinned in `package.json`.

## Test plan
- [ ] Workers Docker image builds successfully in CI
- [ ] Web, gateway, websockets Docker images build successfully in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)