### PR TITLE
fix(docker): let corepack read packageManager from package.json

### DIFF
--- a/apps/gateway/docker/Dockerfile
+++ b/apps/gateway/docker/Dockerfile
@@ -23,11 +23,16 @@ RUN apk add --update --no-cache \
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
+RUN npm install -g corepack@0.31.0 && corepack enable
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 9 uses $PNPM_HOME as the global bin dir; pnpm 10+ moved it to $PNPM_HOME/bin. Include both so future bumps don't break the build.
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+# Copy package.json so corepack reads `packageManager` and pins pnpm to the project's version.
+WORKDIR /app
+COPY package.json ./
 
 RUN pnpm i -g turbo
 

--- a/apps/web/docker/Dockerfile
+++ b/apps/web/docker/Dockerfile
@@ -44,11 +44,16 @@ RUN apk add --update --no-cache \
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
+RUN npm install -g corepack@0.31.0 && corepack enable
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 9 uses $PNPM_HOME as the global bin dir; pnpm 10+ moved it to $PNPM_HOME/bin. Include both so future bumps don't break the build.
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+# Copy package.json so corepack reads `packageManager` and pins pnpm to the project's version.
+WORKDIR /app
+COPY package.json ./
 
 # Install turbo globally
 RUN pnpm install -g turbo

--- a/apps/websockets/docker/Dockerfile
+++ b/apps/websockets/docker/Dockerfile
@@ -9,11 +9,16 @@ RUN apk add --no-cache libc6-compat curl
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
+RUN npm install -g corepack@0.31.0 && corepack enable
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 9 uses $PNPM_HOME as the global bin dir; pnpm 10+ moved it to $PNPM_HOME/bin. Include both so future bumps don't break the build.
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+# Copy package.json so corepack reads `packageManager` and pins pnpm to the project's version.
+WORKDIR /app
+COPY package.json ./
 
 RUN pnpm i -g turbo
 

--- a/apps/workers/docker/Dockerfile
+++ b/apps/workers/docker/Dockerfile
@@ -11,11 +11,16 @@ RUN apk add --no-cache libc6-compat curl python3 make g++ gcc
 FROM alpine AS base
 
 # Will be used to cache pnpm store
-RUN npm install -g corepack@0.31.0 && corepack enable && corepack prepare pnpm@9.8.0 --activate
+RUN npm install -g corepack@0.31.0 && corepack enable
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 9 uses $PNPM_HOME as the global bin dir; pnpm 10+ moved it to $PNPM_HOME/bin. Include both so future bumps don't break the build.
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+# Copy package.json so corepack reads `packageManager` and pins pnpm to the project's version.
+WORKDIR /app
+COPY package.json ./
 
 RUN pnpm i -g turbo
 


### PR DESCRIPTION
## Summary

Take 2 on fixing the Docker build failure that started when corepack's default pnpm drifted to `11.0.8`, which moved the global bin directory from `\$PNPM_HOME` to `\$PNPM_HOME/bin`, breaking `pnpm i -g turbo` since only `\$PNPM_HOME` was on PATH.

**Why a second PR?** In #3047 we tried pinning pnpm via `corepack prepare pnpm@9.8.0 --activate` in the same RUN that enables corepack. That didn't stick — corepack 0.31.0 still resolved to the latest pnpm (11.0.8) on the next RUN, and the build kept failing with the same error:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.0.8.tgz
[ERROR] The configured global bin directory "/pnpm/bin" is not in PATH
```

This PR fixes the root cause: corepack picks pnpm version by walking up from CWD looking for a `package.json` with a `packageManager` field. In the `base` stage, no `package.json` exists yet (the `COPY . .` happens later in `pruner`), so corepack falls back to "latest". We now pre-copy the root `package.json` into `/app` before running pnpm, so corepack reads `"packageManager": "pnpm@9.8.0+sha512..."` and pins correctly.

Also extended `PATH` to include both `\$PNPM_HOME` and `\$PNPM_HOME/bin` as defense-in-depth, so a future pnpm 10+ bump won't reintroduce the same PATH bug.

Verified locally:

\`\`\`
#12 [base 4/4] RUN pnpm i -g turbo
#12 0.227 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-9.8.0.tgz
...
#12 5.308 + turbo 2.9.12
#12 DONE 5.7s
\`\`\`

Applied to all four app Dockerfiles: workers, web, gateway, websockets.

## Test plan

- [x] Local build of workers Dockerfile downloads pnpm 9.8.0 (not 11.x) and completes
- [ ] CI builds all four images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)