### PR TITLE
fix(docker): apply pnpm/corepack fix to migrations Dockerfile

### DIFF
--- a/packages/core/docker/Dockerfile
+++ b/packages/core/docker/Dockerfile
@@ -12,7 +12,12 @@ RUN npm install -g corepack@0.31.0 && corepack enable
 
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+# pnpm 9 uses $PNPM_HOME as the global bin dir; pnpm 10+ moved it to $PNPM_HOME/bin. Include both so future bumps don't break the build.
+ENV PATH="$PNPM_HOME:$PNPM_HOME/bin:$PATH"
+
+# Copy package.json so corepack reads `packageManager` and pins pnpm to the project's version.
+WORKDIR /app
+COPY package.json ./
 
 RUN pnpm i -g turbo
 


### PR DESCRIPTION
## Summary

Follow-up to #3048. The CI run after #3048 merged showed `build-and-push-public (migrations)` failing with the same corepack/pnpm error — turns out `packages/core/docker/Dockerfile` (the migrations image) has the same `RUN pnpm i -g turbo` pattern and was missed in the previous sweep, which only covered `apps/*/docker/`.

Applies the same fix:
- Pre-copy root `package.json` so corepack reads `packageManager` and pins pnpm to `9.8.0`.
- Extend `PATH` with `\$PNPM_HOME/bin` for future-proofing against pnpm 10+.

## Test plan

- [ ] CI builds the migrations image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)