### PR TITLE
fix(api,ingest): suppress 4xx HttpError telemetry at the OTel boundary

### DIFF
--- a/apps/api/src/middleware/suppress-http-error-telemetry.test.ts
+++ b/apps/api/src/middleware/suppress-http-error-telemetry.test.ts
@@ -1,0 +1,46 @@
+import { NotFoundError, RepositoryError } from "@domain/shared"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { suppressHttpErrorTelemetry } from "./suppress-http-error-telemetry.ts"
+
+const buildApp = (thrown: unknown) => {
+  let observedError: Error | undefined
+  const app = new Hono()
+  app.use(async (c, next) => {
+    await next()
+    observedError = c.error
+  })
+  app.use(suppressHttpErrorTelemetry)
+  app.get("/throws", () => {
+    throw thrown as Error
+  })
+  app.onError((err, c) => c.json({ error: err.message }, 500))
+  return { app, getObservedError: () => observedError }
+}
+
+describe("suppressHttpErrorTelemetry", () => {
+  it("clears c.error for 4xx HttpErrors so @hono/otel skips recordException", async () => {
+    const { app, getObservedError } = buildApp(new NotFoundError({ entity: "Project", id: "missing" }))
+
+    await app.request("/throws")
+
+    expect(getObservedError()).toBeUndefined()
+  })
+
+  it("leaves c.error in place for 5xx HttpErrors", async () => {
+    const { app, getObservedError } = buildApp(new RepositoryError({ operation: "findById", cause: "boom" }))
+
+    await app.request("/throws")
+
+    expect(getObservedError()).toBeInstanceOf(RepositoryError)
+  })
+
+  it("leaves c.error in place for non-HttpErrors", async () => {
+    const plain = new Error("kaboom")
+    const { app, getObservedError } = buildApp(plain)
+
+    await app.request("/throws")
+
+    expect(getObservedError()).toBe(plain)
+  })
+})

--- a/apps/api/src/middleware/suppress-http-error-telemetry.ts
+++ b/apps/api/src/middleware/suppress-http-error-telemetry.ts
@@ -1,0 +1,11 @@
+import { isHttpError } from "@repo/utils"
+import { createMiddleware } from "hono/factory"
+
+// Must be registered after `app.use(otel())` — clears `c.error` before
+// `@hono/otel` reads it to call `recordException`.
+export const suppressHttpErrorTelemetry = createMiddleware(async (c, next) => {
+  await next()
+  if (c.error && isHttpError(c.error) && c.error.httpStatus < 500) {
+    c.error = undefined
+  }
+})

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,7 @@ import { logger as honoLogger } from "hono/logger"
 import { getClickhouseClient, getPostgresClient, getQueuePublisher, getRedisClient } from "./clients.ts"
 import { registerCorsMiddleware } from "./middleware/cors.ts"
 import { honoErrorHandler } from "./middleware/error-handler.ts"
+import { suppressHttpErrorTelemetry } from "./middleware/suppress-http-error-telemetry.ts"
 import { destroyTouchBuffer } from "./middleware/touch-buffer.ts"
 import { registerRoutes } from "./routes/index.ts"
 import type { AppEnv } from "./types.ts"
@@ -33,6 +34,7 @@ const startServer = async () => {
 
   // Add Hono OpenTelemetry middleware
   app.use(otel())
+  app.use(suppressHttpErrorTelemetry)
 
   app.onError(honoErrorHandler)
 

--- a/apps/ingest/src/middleware/suppress-http-error-telemetry.ts
+++ b/apps/ingest/src/middleware/suppress-http-error-telemetry.ts
@@ -1,0 +1,11 @@
+import { isHttpError } from "@repo/utils"
+import { createMiddleware } from "hono/factory"
+
+// Must be registered after `app.use(otel())` — clears `c.error` before
+// `@hono/otel` reads it to call `recordException`.
+export const suppressHttpErrorTelemetry = createMiddleware(async (c, next) => {
+  await next()
+  if (c.error && isHttpError(c.error) && c.error.httpStatus < 500) {
+    c.error = undefined
+  }
+})

--- a/apps/ingest/src/server.ts
+++ b/apps/ingest/src/server.ts
@@ -8,6 +8,7 @@ import { loadDevelopmentEnvironments } from "@repo/utils/env"
 import { Effect } from "effect"
 import { Hono } from "hono"
 import { getQueuePublisher, getRedisClient } from "./clients.ts"
+import { suppressHttpErrorTelemetry } from "./middleware/suppress-http-error-telemetry.ts"
 import { destroyTouchBuffer } from "./middleware/touch-buffer.ts"
 import { registerRoutes } from "./routes/index.ts"
 import type { IngestEnv } from "./types.ts"
@@ -25,6 +26,7 @@ const start = async () => {
 
   // Add Hono OpenTelemetry middleware
   app.use(otel())
+  app.use(suppressHttpErrorTelemetry)
 
   app.onError((err, c) => {
     if (err instanceof LatitudeObservabilityTestError) {


### PR DESCRIPTION
## Summary

Fixes a Datadog Error Tracking issue (`fcf74994-…`) where expected client 4xx errors (a typo'd project slug → `NotFoundError`, an unauthenticated probe → `UnauthorizedError`, etc.) were being recorded as application exceptions on the HTTP server span and grouped into Error Tracking issues.

Diagnosis: `@hono/otel` reads `c.error` after `await next()` and unconditionally calls `span.recordException(c.error)` + `span.setStatus({ code: ERROR })`. Hono's `compose` sets `c.error` whenever a handler throws — even when the central `onError` already mapped it to a clean 4xx response. So *any* thrown domain error reaches telemetry as a span exception, regardless of the final HTTP status.

## Approach

Keep the codebase's convention of "throw domain errors, handle them centrally" — don't push nullable lookup plumbing into every route handler, and don't ship an entity-specific fix that misses the same bug for other entities (`OrganizationNotFoundError`, `UnauthorizedError`, `ValidationError`, …).

Instead, add a tiny Hono middleware that runs *inside* `@hono/otel` (registered immediately after `app.use(otel())`) and clears `c.error` once the global `onError` has produced a 4xx response. OTel then reads `c.error === undefined`, skips `recordException`, and leaves the span clean.

- 4xx `HttpError` (`httpStatus < 500`): suppressed from telemetry.
- 5xx `HttpError` (`RepositoryError`, `CacheError`, `StorageError`, etc.): pass through untouched — those are real infra issues worth seeing in Error Tracking.
- Non-`HttpError` throws: pass through untouched — those are bugs.

Applied to both `apps/api` and `apps/ingest` (both use `@hono/otel` and the same `isHttpError`-based error handler).

## Files

- `apps/api/src/middleware/suppress-http-error-telemetry.ts` — new middleware (+ unit test)
- `apps/ingest/src/middleware/suppress-http-error-telemetry.ts` — same middleware
- `apps/api/src/server.ts`, `apps/ingest/src/server.ts` — register after `otel()`

## Test plan

- [x] `pnpm typecheck` (full workspace)
- [x] `pnpm vitest run apps/api/src/middleware/suppress-http-error-telemetry.test.ts` — 3 cases (4xx HttpError cleared, 5xx HttpError preserved, plain `Error` preserved)
- [x] `pnpm --filter @app/api vitest run src/routes/projects.test.ts src/routes/annotations.test.ts src/routes/scores.test.ts` — all 16 tests still pass (no route changes)
- [ ] After merge: confirm in Datadog that no new `NotFoundError`/`UnauthorizedError` issues open for `service:api` or `service:ingest`, while 5xx issues continue to surface normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)