### PR TITLE
fix(workflows): declare voyageai dep so demo-project seed can require it (LAT-554)

### DIFF
--- a/apps/workflows/package.json
+++ b/apps/workflows/package.json
@@ -40,7 +40,8 @@
     "@temporalio/workflow": "catalog:",
     "@temporalio/worker": "catalog:",
     "effect": "catalog:",
-    "tsx": "catalog:"
+    "tsx": "catalog:",
+    "voyageai": "catalog:"
   },
   "devDependencies": {
     "@repo/vitest-config": "workspace:*",

--- a/knip.json
+++ b/knip.json
@@ -16,14 +16,13 @@
     "apps/workflows": {
       "project": ["src/**/*.ts"],
       "ignore": ["src/workflows/**/*.ts"],
-      "ignoreDependencies": ["@temporalio/worker"]
+      "ignoreDependencies": ["@temporalio/worker", "voyageai"]
     },
     "apps/web": {
       "entry": ["src/router.tsx", "src/start.ts", "src/routes/**/*.tsx"],
       "project": ["src/**/*.ts", "src/**/*.tsx"],
       "ignore": [
-        "src/domains/feature-flags/feature-flags.collection.ts",
-        "src/domains/feature-flags/feature-flags.functions.ts"
+        "src/domains/feature-flags/feature-flags.collection.ts"
       ],
       "ignoreDependencies": ["@temporalio/client"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,6 +780,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.21.0
+      voyageai:
+        specifier: 'catalog:'
+        version: 0.2.1
     devDependencies:
       '@repo/vitest-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- The issues seeder in `@platform/db-postgres` does `require("voyageai")`. After tsdown bundles `@platform/db-postgres` into `apps/workflows/dist/server.cjs` (`alwaysBundle`), that runtime require resolves against the workflows app's own `node_modules`, where `voyageai` (`neverBundle`) wasn't declared as a direct dep. Staging `seedDemoProjectPostgresActivity` died at step 2/9 (`issues`) with `MODULE_NOT_FOUND: Cannot find module 'voyageai'`, leaving demo projects with only the `datasets` row and no issues / scores / spans / Weaviate projections.
- Adds `voyageai` to `apps/workflows/package.json` direct deps so the runtime require resolves.
- Adds the matching `ignoreDependencies` entry to `knip.json` — knip can't see the cross-package dynamic `require`, so without it knip flags the dep as unused and the pre-commit hook fails.

Diagnostic trail in CloudWatch (`/ecs/latitude-staging/workflows`):

```
SeedError reason: 'Failed to seed issues'
[cause]: Error: Cannot find module 'voyageai'
Require stack: - /app/apps/workflows/dist/server.cjs
```

## Test plan

- [x] `pnpm --filter @platform/db-postgres typecheck` — clean
- [x] `pnpm --filter @app/workflows typecheck` — clean
- [x] `pnpm --filter @platform/db-postgres test` — 175/175 pass
- [x] Local repro of the demo-project Postgres seed completes all 9 seeders end-to-end (datasets → notifications), both with and without `LAT_VOYAGE_API_KEY` set
- [ ] After deploy to staging: trigger Create Demo Project from backoffice, verify all 9 PG seeders run, ClickHouse spans appear, dataset rows in CH are populated, Weaviate issue projections written

🤖 Generated with [Claude Code](https://claude.com/claude-code)