### PR TITLE
feat(analytics): track FlaggerToggled and SavedSearchCreated in PostHog

### DIFF
--- a/apps/web/src/domains/flaggers/flaggers.functions.ts
+++ b/apps/web/src/domains/flaggers/flaggers.functions.ts
@@ -8,10 +8,10 @@ import {
 } from "@domain/flaggers"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
-import { FlaggerRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { FlaggerRepositoryLive, OutboxEventWriterLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getPostgresClient, getRedisClient } from "../../server/clients.ts"
@@ -80,14 +80,20 @@ export const updateFlagger = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }): Promise<FlaggerRecord | null> => {
-    const { organizationId } = await requireSession()
+    const { organizationId, userId } = await requireSession()
     const orgId = OrganizationId(organizationId)
     const projectId = ProjectId(data.projectId)
     const client = getPostgresClient()
 
     const flagger = await Effect.runPromise(
-      updateFlaggerUseCase({ organizationId, projectId, slug: data.slug, enabled: data.enabled }).pipe(
-        withPostgres(FlaggerRepositoryLive, client, orgId),
+      updateFlaggerUseCase({
+        organizationId,
+        projectId,
+        slug: data.slug,
+        enabled: data.enabled,
+        actorUserId: userId,
+      }).pipe(
+        withPostgres(Layer.mergeAll(FlaggerRepositoryLive, OutboxEventWriterLive), client, orgId),
         Effect.provide(RedisCacheStoreLive(getRedisClient())),
         withTracing,
       ),

--- a/apps/web/src/domains/saved-searches/saved-searches.functions.ts
+++ b/apps/web/src/domains/saved-searches/saved-searches.functions.ts
@@ -9,10 +9,10 @@ import {
   updateSavedSearch,
 } from "@domain/saved-searches"
 import { filterSetSchema, OrganizationId, ProjectId, SavedSearchId, UserId } from "@domain/shared"
-import { SavedSearchRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { OutboxEventWriterLive, SavedSearchRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { z } from "zod"
 import { requireSession } from "../../server/auth.ts"
 import { getPostgresClient } from "../../server/clients.ts"
@@ -100,7 +100,10 @@ export const createSavedSearchFn = createServerFn({ method: "POST" })
         query: data.query,
         filterSet: data.filterSet,
         createdByUserId: UserId(userId),
-      }).pipe(withPostgres(SavedSearchRepositoryLive, getPostgresClient(), orgId), withTracing),
+      }).pipe(
+        withPostgres(Layer.mergeAll(SavedSearchRepositoryLive, OutboxEventWriterLive), getPostgresClient(), orgId),
+        withTracing,
+      ),
     )
     return toRecord(created)
   })

--- a/apps/workers/src/workers/domain-events.ts
+++ b/apps/workers/src/workers/domain-events.ts
@@ -307,6 +307,8 @@ export const createDomainEventsWorker = ({
     EvaluationConfigured: () => Effect.void,
     AnnotationQueueItemCompleted: () => Effect.void,
     ProjectDeleted: () => Effect.void,
+    FlaggerToggled: () => Effect.void,
+    SavedSearchCreated: () => Effect.void,
     // Impersonation events are audit-only — their value is being
     // persisted in the outbox for support / compliance queries.
     // No downstream worker consumes them, so these handlers are no-ops.

--- a/packages/domain/events/src/event-payloads.ts
+++ b/packages/domain/events/src/event-payloads.ts
@@ -197,6 +197,20 @@ export interface EventPayloads {
     readonly datasetId: string
     readonly name: string
   }
+  FlaggerToggled: {
+    readonly organizationId: string
+    readonly actorUserId: string
+    readonly projectId: string
+    readonly flaggerSlug: string
+    readonly enabled: boolean
+  }
+  SavedSearchCreated: {
+    readonly organizationId: string
+    readonly actorUserId: string
+    readonly projectId: string
+    readonly searchId: string
+    readonly name: string
+  }
   EvaluationConfigured: {
     readonly organizationId: string
     readonly actorUserId: string

--- a/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
@@ -1,5 +1,5 @@
-import { OutboxEventWriter } from "@domain/events"
-import { CacheStore, FlaggerId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
+import { CacheStore, FlaggerId, OrganizationId, ProjectId, SqlClient, UserId } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
 import { describe, expect, it } from "vitest"
@@ -36,6 +36,17 @@ const createCacheLayer = () => {
     },
   })
   return { layer, deletedKeys }
+}
+
+const createOutboxLayer = () => {
+  const written: OutboxWriteEvent[] = []
+  const layer = Layer.succeed(OutboxEventWriter, {
+    write: (event) => {
+      written.push(event)
+      return Effect.void
+    },
+  })
+  return { layer, written }
 }
 
 describe("updateFlaggerUseCase", () => {
@@ -115,6 +126,69 @@ describe("updateFlaggerUseCase", () => {
 
     expect(updated).toBeNull()
     expect(deletedKeys).toEqual([`org:${ORG_ID}:flaggers:${PROJECT_ID}`])
+  })
+
+  it("emits a FlaggerToggled outbox event with the actor and new state when the row was updated", async () => {
+    const ACTOR_USER_ID = UserId("u".repeat(24))
+    const seed = makeFlagger("jailbreaking", true)
+    const { repository } = createFakeFlaggerRepository([seed])
+    const { layer: cacheLayer } = createCacheLayer()
+    const { layer: outboxLayer, written } = createOutboxLayer()
+
+    const layer = Layer.mergeAll(
+      Layer.succeed(FlaggerRepository, repository),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      outboxLayer,
+      cacheLayer,
+    )
+
+    await Effect.runPromise(
+      updateFlaggerUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        slug: "jailbreaking",
+        enabled: false,
+        actorUserId: ACTOR_USER_ID,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(written).toHaveLength(1)
+    const [event] = written
+    expect(event?.eventName).toBe("FlaggerToggled")
+    expect(event?.aggregateType).toBe("flagger")
+    expect(event?.aggregateId).toBe(seed.id)
+    expect(event?.organizationId).toBe(ORG_ID)
+    expect(event?.payload).toEqual({
+      organizationId: ORG_ID,
+      actorUserId: ACTOR_USER_ID,
+      projectId: PROJECT_ID,
+      flaggerSlug: "jailbreaking",
+      enabled: false,
+    })
+  })
+
+  it("does NOT emit FlaggerToggled when no matching row exists", async () => {
+    const { repository } = createFakeFlaggerRepository([])
+    const { layer: cacheLayer } = createCacheLayer()
+    const { layer: outboxLayer, written } = createOutboxLayer()
+
+    const layer = Layer.mergeAll(
+      Layer.succeed(FlaggerRepository, repository),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      outboxLayer,
+      cacheLayer,
+    )
+
+    await Effect.runPromise(
+      updateFlaggerUseCase({
+        organizationId: ORG_ID,
+        projectId: PROJECT_ID,
+        slug: "jailbreaking",
+        enabled: false,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(written).toEqual([])
   })
 
   it("succeeds even when no CacheStore is in the layer (eviction is best-effort)", async () => {

--- a/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.test.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import { CacheStore, FlaggerId, OrganizationId, ProjectId, SqlClient } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -46,6 +47,7 @@ describe("updateFlaggerUseCase", () => {
     const layer = Layer.mergeAll(
       Layer.succeed(FlaggerRepository, repository),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
       cacheLayer,
     )
 
@@ -73,6 +75,7 @@ describe("updateFlaggerUseCase", () => {
     const layer = Layer.mergeAll(
       Layer.succeed(FlaggerRepository, repository),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
       cacheLayer,
     )
 
@@ -97,6 +100,7 @@ describe("updateFlaggerUseCase", () => {
     const layer = Layer.mergeAll(
       Layer.succeed(FlaggerRepository, repository),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
       cacheLayer,
     )
 
@@ -120,6 +124,7 @@ describe("updateFlaggerUseCase", () => {
     const layer = Layer.mergeAll(
       Layer.succeed(FlaggerRepository, repository),
       Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORG_ID })),
+      Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
     )
 
     const updated = await Effect.runPromise(

--- a/packages/domain/flaggers/src/use-cases/update-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.ts
@@ -1,5 +1,5 @@
 import { OutboxEventWriter } from "@domain/events"
-import type { ProjectId, RepositoryError } from "@domain/shared"
+import { type ProjectId, type RepositoryError, SqlClient } from "@domain/shared"
 import { Effect } from "effect"
 import type { Flagger } from "../entities/flagger.ts"
 import type { FlaggerSlug } from "../flagger-strategies/types.ts"
@@ -28,34 +28,43 @@ export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function
   yield* Effect.annotateCurrentSpan("flagger.projectId", input.projectId)
   yield* Effect.annotateCurrentSpan("flagger.slug", input.slug)
 
-  const repository = yield* FlaggerRepository
-  const updated = yield* repository.update({
-    projectId: input.projectId,
-    slug: input.slug,
-    enabled: input.enabled,
-  })
+  const sqlClient = yield* SqlClient
+  const updated = yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repository = yield* FlaggerRepository
+      const row = yield* repository.update({
+        projectId: input.projectId,
+        slug: input.slug,
+        enabled: input.enabled,
+      })
 
+      if (row) {
+        const outboxEventWriter = yield* OutboxEventWriter
+        yield* outboxEventWriter.write({
+          eventName: "FlaggerToggled",
+          aggregateType: "flagger",
+          aggregateId: row.id,
+          organizationId: input.organizationId,
+          payload: {
+            organizationId: input.organizationId,
+            actorUserId: input.actorUserId ?? "",
+            projectId: input.projectId,
+            flaggerSlug: input.slug,
+            enabled: input.enabled,
+          },
+        })
+      }
+
+      return row
+    }),
+  )
+
+  // Evict AFTER the transaction commits so a concurrent reader can't
+  // repopulate the cache with the stale value between eviction and commit.
   yield* evictProjectFlaggersUseCase({
     organizationId: input.organizationId,
     projectId: input.projectId,
   })
-
-  if (updated) {
-    const outboxEventWriter = yield* OutboxEventWriter
-    yield* outboxEventWriter.write({
-      eventName: "FlaggerToggled",
-      aggregateType: "flagger",
-      aggregateId: updated.id,
-      organizationId: input.organizationId,
-      payload: {
-        organizationId: input.organizationId,
-        actorUserId: input.actorUserId ?? "",
-        projectId: input.projectId,
-        flaggerSlug: input.slug,
-        enabled: input.enabled,
-      },
-    })
-  }
 
   return updated satisfies Flagger | null
 })

--- a/packages/domain/flaggers/src/use-cases/update-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/update-flagger.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import type { ProjectId, RepositoryError } from "@domain/shared"
 import { Effect } from "effect"
 import type { Flagger } from "../entities/flagger.ts"
@@ -10,6 +11,7 @@ export interface UpdateFlaggerInput {
   readonly projectId: ProjectId
   readonly slug: FlaggerSlug
   readonly enabled: boolean
+  readonly actorUserId?: string
 }
 
 export type UpdateFlaggerError = RepositoryError
@@ -37,6 +39,23 @@ export const updateFlaggerUseCase = Effect.fn("flaggers.updateFlagger")(function
     organizationId: input.organizationId,
     projectId: input.projectId,
   })
+
+  if (updated) {
+    const outboxEventWriter = yield* OutboxEventWriter
+    yield* outboxEventWriter.write({
+      eventName: "FlaggerToggled",
+      aggregateType: "flagger",
+      aggregateId: updated.id,
+      organizationId: input.organizationId,
+      payload: {
+        organizationId: input.organizationId,
+        actorUserId: input.actorUserId ?? "",
+        projectId: input.projectId,
+        flaggerSlug: input.slug,
+        enabled: input.enabled,
+      },
+    })
+  }
 
   return updated satisfies Flagger | null
 })

--- a/packages/domain/saved-searches/package.json
+++ b/packages/domain/saved-searches/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run --passWithNoTests --dir src"
   },
   "dependencies": {
+    "@domain/events": "workspace:*",
     "@domain/shared": "workspace:*",
     "effect": "catalog:",
     "zod": "catalog:"

--- a/packages/domain/saved-searches/src/use-cases/create-saved-search.test.ts
+++ b/packages/domain/saved-searches/src/use-cases/create-saved-search.test.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import { ProjectId, SqlClient, UserId } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -15,6 +16,7 @@ function makeLayer() {
   return Layer.mergeAll(
     Layer.succeed(SavedSearchRepository, repository),
     Layer.succeed(SqlClient, createFakeSqlClient()),
+    Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
   )
 }
 

--- a/packages/domain/saved-searches/src/use-cases/create-saved-search.test.ts
+++ b/packages/domain/saved-searches/src/use-cases/create-saved-search.test.ts
@@ -1,4 +1,4 @@
-import { OutboxEventWriter } from "@domain/events"
+import { OutboxEventWriter, type OutboxWriteEvent } from "@domain/events"
 import { ProjectId, SqlClient, UserId } from "@domain/shared"
 import { createFakeSqlClient } from "@domain/shared/testing"
 import { Effect, Layer } from "effect"
@@ -13,16 +13,23 @@ const CREATED_BY = UserId("u".repeat(24))
 
 function makeLayer() {
   const { repository } = createFakeSavedSearchRepository()
-  return Layer.mergeAll(
+  const written: OutboxWriteEvent[] = []
+  const layer = Layer.mergeAll(
     Layer.succeed(SavedSearchRepository, repository),
     Layer.succeed(SqlClient, createFakeSqlClient()),
-    Layer.succeed(OutboxEventWriter, { write: () => Effect.void }),
+    Layer.succeed(OutboxEventWriter, {
+      write: (event) => {
+        written.push(event)
+        return Effect.void
+      },
+    }),
   )
+  return { layer, written }
 }
 
 describe("createSavedSearch", () => {
   it("creates a saved search with a slugified name", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     const result = await Effect.runPromise(
       createSavedSearch({
         projectId: PROJECT_ID,
@@ -39,7 +46,7 @@ describe("createSavedSearch", () => {
   })
 
   it("appends a random suffix on slug collision", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* createSavedSearch({
@@ -65,7 +72,7 @@ describe("createSavedSearch", () => {
   })
 
   it("rejects an empty search (no query and no filters)", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     await expect(
       Effect.runPromise(
         createSavedSearch({
@@ -80,7 +87,7 @@ describe("createSavedSearch", () => {
   })
 
   it("rejects an empty name", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     await expect(
       Effect.runPromise(
         createSavedSearch({
@@ -95,7 +102,7 @@ describe("createSavedSearch", () => {
   })
 
   it("rejects a too-long name", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     await expect(
       Effect.runPromise(
         createSavedSearch({
@@ -110,7 +117,7 @@ describe("createSavedSearch", () => {
   })
 
   it("treats a whitespace-only query as null and accepts when filters are present", async () => {
-    const layer = makeLayer()
+    const { layer } = makeLayer()
     const result = await Effect.runPromise(
       createSavedSearch({
         projectId: PROJECT_ID,
@@ -121,5 +128,49 @@ describe("createSavedSearch", () => {
       }).pipe(Effect.provide(layer)),
     )
     expect(result.query).toBeNull()
+  })
+
+  it("emits a SavedSearchCreated outbox event with the creator and identifiers", async () => {
+    const { layer, written } = makeLayer()
+    const result = await Effect.runPromise(
+      createSavedSearch({
+        projectId: PROJECT_ID,
+        name: "Failed Payments",
+        query: "failed payments",
+        filterSet: { status: [{ op: "eq", value: "error" }] },
+        createdByUserId: CREATED_BY,
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(written).toHaveLength(1)
+    const [event] = written
+    expect(event?.eventName).toBe("SavedSearchCreated")
+    expect(event?.aggregateType).toBe("saved-search")
+    expect(event?.aggregateId).toBe(result.id)
+    expect(event?.organizationId).toBe(result.organizationId)
+    expect(event?.payload).toEqual({
+      organizationId: result.organizationId,
+      actorUserId: CREATED_BY,
+      projectId: PROJECT_ID,
+      searchId: result.id,
+      name: "Failed Payments",
+    })
+  })
+
+  it("does NOT emit SavedSearchCreated when validation rejects the input", async () => {
+    const { layer, written } = makeLayer()
+    await expect(
+      Effect.runPromise(
+        createSavedSearch({
+          projectId: PROJECT_ID,
+          name: "Empty",
+          query: null,
+          filterSet: {},
+          createdByUserId: CREATED_BY,
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toBeInstanceOf(EmptySavedSearchError)
+
+    expect(written).toEqual([])
   })
 })

--- a/packages/domain/saved-searches/src/use-cases/create-saved-search.ts
+++ b/packages/domain/saved-searches/src/use-cases/create-saved-search.ts
@@ -1,5 +1,12 @@
 import { OutboxEventWriter } from "@domain/events"
-import { type FilterSet, generateSlug, type ProjectId, type SavedSearchId, type UserId } from "@domain/shared"
+import {
+  type FilterSet,
+  generateSlug,
+  type ProjectId,
+  type SavedSearchId,
+  SqlClient,
+  type UserId,
+} from "@domain/shared"
 import { Effect } from "effect"
 import { SAVED_SEARCH_NAME_MAX_LENGTH } from "../constants.ts"
 import { isEmptySearch } from "../entities/saved-search.ts"
@@ -38,37 +45,42 @@ export const createSavedSearch = Effect.fn("savedSearches.createSavedSearch")(fu
     return yield* new EmptySavedSearchError({})
   }
 
-  const repo = yield* SavedSearchRepository
-  const slug = yield* generateSlug({
-    name: trimmedName,
-    count: (slug) => repo.countBySlug({ projectId: input.projectId, slug }),
-  })
+  const sqlClient = yield* SqlClient
+  return yield* sqlClient.transaction(
+    Effect.gen(function* () {
+      const repo = yield* SavedSearchRepository
+      const slug = yield* generateSlug({
+        name: trimmedName,
+        count: (slug) => repo.countBySlug({ projectId: input.projectId, slug }),
+      })
 
-  const created = yield* repo.create({
-    ...(input.id ? { id: input.id } : {}),
-    projectId: input.projectId,
-    slug,
-    name: trimmedName,
-    query: normalizedQuery,
-    filterSet: input.filterSet,
-    assignedUserId: input.assignedUserId ?? null,
-    createdByUserId: input.createdByUserId,
-  })
+      const created = yield* repo.create({
+        ...(input.id ? { id: input.id } : {}),
+        projectId: input.projectId,
+        slug,
+        name: trimmedName,
+        query: normalizedQuery,
+        filterSet: input.filterSet,
+        assignedUserId: input.assignedUserId ?? null,
+        createdByUserId: input.createdByUserId,
+      })
 
-  const outboxEventWriter = yield* OutboxEventWriter
-  yield* outboxEventWriter.write({
-    eventName: "SavedSearchCreated",
-    aggregateType: "saved-search",
-    aggregateId: created.id,
-    organizationId: created.organizationId,
-    payload: {
-      organizationId: created.organizationId,
-      actorUserId: created.createdByUserId,
-      projectId: created.projectId,
-      searchId: created.id,
-      name: created.name,
-    },
-  })
+      const outboxEventWriter = yield* OutboxEventWriter
+      yield* outboxEventWriter.write({
+        eventName: "SavedSearchCreated",
+        aggregateType: "saved-search",
+        aggregateId: created.id,
+        organizationId: created.organizationId,
+        payload: {
+          organizationId: created.organizationId,
+          actorUserId: created.createdByUserId,
+          projectId: created.projectId,
+          searchId: created.id,
+          name: created.name,
+        },
+      })
 
-  return created
+      return created
+    }),
+  )
 })

--- a/packages/domain/saved-searches/src/use-cases/create-saved-search.ts
+++ b/packages/domain/saved-searches/src/use-cases/create-saved-search.ts
@@ -1,3 +1,4 @@
+import { OutboxEventWriter } from "@domain/events"
 import { type FilterSet, generateSlug, type ProjectId, type SavedSearchId, type UserId } from "@domain/shared"
 import { Effect } from "effect"
 import { SAVED_SEARCH_NAME_MAX_LENGTH } from "../constants.ts"
@@ -43,7 +44,7 @@ export const createSavedSearch = Effect.fn("savedSearches.createSavedSearch")(fu
     count: (slug) => repo.countBySlug({ projectId: input.projectId, slug }),
   })
 
-  return yield* repo.create({
+  const created = yield* repo.create({
     ...(input.id ? { id: input.id } : {}),
     projectId: input.projectId,
     slug,
@@ -53,4 +54,21 @@ export const createSavedSearch = Effect.fn("savedSearches.createSavedSearch")(fu
     assignedUserId: input.assignedUserId ?? null,
     createdByUserId: input.createdByUserId,
   })
+
+  const outboxEventWriter = yield* OutboxEventWriter
+  yield* outboxEventWriter.write({
+    eventName: "SavedSearchCreated",
+    aggregateType: "saved-search",
+    aggregateId: created.id,
+    organizationId: created.organizationId,
+    payload: {
+      organizationId: created.organizationId,
+      actorUserId: created.createdByUserId,
+      projectId: created.projectId,
+      searchId: created.id,
+      name: created.name,
+    },
+  })
+
+  return created
 })

--- a/packages/platform/analytics-posthog/src/whitelist.ts
+++ b/packages/platform/analytics-posthog/src/whitelist.ts
@@ -19,6 +19,8 @@ export const POSTHOG_TRACKED_EVENTS = new Set<TrackedEventName>([
   "AnnotationQueueItemCompleted",
   "ProjectDeleted",
   "FirstTraceReceived",
+  "FlaggerToggled",
+  "SavedSearchCreated",
 ])
 
 export const isPostHogTracked = (name: string): name is TrackedEventName =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1331,6 +1331,9 @@ importers:
 
   packages/domain/saved-searches:
     dependencies:
+      '@domain/events':
+        specifier: workspace:*
+        version: link:../events
       '@domain/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary

Adds two new domain events to the PostHog product-analytics fan-out, wired end-to-end through the existing outbox → `domain-events` worker → `posthog-analytics` worker path.

- **`FlaggerToggled`** — emitted from `updateFlaggerUseCase` after a successful toggle. `actorUserId` is now an optional field on `UpdateFlaggerInput` and is plumbed through from the web session.
- **`SavedSearchCreated`** — emitted from `createSavedSearch` using the existing `createdByUserId` as actor.

Both events follow the established pattern (payload on `EventPayloads`, whitelist entry in `@platform/analytics-posthog`, no-op handler in the `domain-events` worker for completeness). PostHog fan-out is automatic via the whitelist filter.

## Out of scope

- **Backend events stopped firing on April 16 (in prod).** Investigated and the code path is intact — `LAT_POSTHOG_API_KEY` and `VITE_LAT_POSTHOG_KEY` are two independent env vars and the silent failure mode (missing key → no-op client → events vanish) lines up with the symptom. Fix is operational (verify the workers deploy has the key), not a code change.
- **`ScoreCreated`** is intentionally NOT re-added — it was removed in `8e1b304e` due to per-trace cardinality. Left as-is.
- **`IssueStatusChanged`** skipped — the issue lifecycle uses commands (`resolve` / `unresolve` / `ignore` / `unignore`) rather than the `new` / `ongoing` / `resolved` model the original spec described; needs a design pass before emission.

## Test plan

- [x] `pnpm --filter @domain/flaggers test` — 163 passing (includes 4 updated tests provisioning `OutboxEventWriter` in the layer)
- [x] `pnpm --filter @domain/saved-searches test` — 22 passing
- [x] `pnpm --filter @platform/analytics-posthog test` — 13 passing
- [x] `pnpm --filter @app/workers exec vitest run src/workers/domain-events.test.ts` — 14 passing
- [x] Typecheck clean for `@domain/events`, `@domain/flaggers`, `@domain/saved-searches`, `@platform/analytics-posthog`, `@app/web`
- [ ] After merge + deploy: toggle a flagger in project settings, confirm `FlaggerToggled` lands in PostHog with `flaggerSlug` + `enabled` properties and the correct `actorUserId` as distinctId
- [ ] After merge + deploy: save a search, confirm `SavedSearchCreated` lands in PostHog with `searchId` + `name` and the correct creator as distinctId
- [ ] After merge + deploy: confirm `groups: { organization: <orgId> }` is attached on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes request authentication (adds OAuth bearer token validation alongside API keys) and enforces billing at trace ingestion, which can affect access control and production traffic acceptance. It also modifies release automation to publish multiple public packages after deploys.
> 
> **Overview**
> Adds an MCP tool registry to `apps/api` (new `defineApiEndpoint` + `mountWithMcp`) and a checked-in `mcp.json` manifest emitted via `pnpm mcp:emit`, wiring `/api-keys` endpoints through this path and aligning OpenAPI `operationId`s with deterministic route `name`s.
> 
> Extends API auth to accept **either** API-key or OAuth access-token `Bearer` credentials, adds a public `/.well-known/oauth-protected-resource` discovery endpoint, introduces org-tier rate limiting helpers, and standardizes/names OpenAPI schemas for `TraceRef`/filter sets (including updating score/annotation request shapes to use `trace` refs and dropping the draft-annotation request path).
> 
> Updates ingestion to run `ingestSpansWithBillingUseCase` and return a structured error when credits are exhausted, and adds substantial web server-function surface for **admin feature flags** and **billing** (org billing retrieval + overrides, user billing overview/spend-limit, Stripe checkout/portal helpers), plus dataset trace-selection support for optional `issueId` sources.
> 
> CI/CD now includes a reusable `.github/actions/publish-npm-package` composite action, converts multiple package publish workflows to `workflow_call`, and triggers those publishes automatically after a successful production deploy; `.env.example` and agent docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c04594e4e178a87e422667db1399df5cf73f93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->