### PR TITLE
feat(evaluations): scope which traces an evaluation runs on (LAT-570)

### DIFF
--- a/apps/web/src/domains/evaluations/evaluation-alignment.functions.ts
+++ b/apps/web/src/domains/evaluations/evaluation-alignment.functions.ts
@@ -6,10 +6,19 @@ import {
   isActiveEvaluation,
   softDeleteEvaluation,
   updateEvaluationSampling,
+  updateEvaluationTriggerFilter,
 } from "@domain/evaluations"
 import { IssueRepository } from "@domain/issues"
 import type { WorkflowAlreadyStartedError } from "@domain/queue"
-import { BadRequestError, EvaluationId, generateId, IssueId, OrganizationId, ProjectId } from "@domain/shared"
+import {
+  BadRequestError,
+  EvaluationId,
+  filterSetSchema,
+  generateId,
+  IssueId,
+  OrganizationId,
+  ProjectId,
+} from "@domain/shared"
 import { EvaluationRepositoryLive, IssueRepositoryLive, SqlClientLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { createServerFn } from "@tanstack/react-start"
@@ -40,6 +49,13 @@ const updateEvaluationSamplingInputSchema = z.object({
   issueId: z.string(),
   evaluationId: z.string(),
   sampling: z.number().int().min(0).max(100),
+})
+
+const updateEvaluationTriggerFilterInputSchema = z.object({
+  projectId: z.string(),
+  issueId: z.string(),
+  evaluationId: z.string(),
+  filter: filterSetSchema,
 })
 
 const issueAlignmentStateInputSchema = z.object({
@@ -340,6 +356,33 @@ export const updateIssueEvaluationSampling = createServerFn({ method: "POST" })
         }
 
         const updatedEvaluation = updateEvaluationSampling({ evaluation, sampling: data.sampling })
+        yield* repository.save(updatedEvaluation)
+
+        return toEvaluationSummaryRecord(updatedEvaluation)
+      }).pipe(withPostgres(EvaluationRepositoryLive, client, OrganizationId(organizationId)), withTracing),
+    )
+  })
+
+export const updateIssueEvaluationTriggerFilter = createServerFn({ method: "POST" })
+  .inputValidator(updateEvaluationTriggerFilterInputSchema)
+  .handler(async ({ data }): Promise<EvaluationSummaryRecord> => {
+    const { organizationId } = await requireSession()
+    const client = getPostgresClient()
+    const projectId = ProjectId(data.projectId)
+    const issueId = IssueId(data.issueId)
+
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const repository = yield* EvaluationRepository
+        const evaluation = yield* repository.findById(EvaluationId(data.evaluationId))
+
+        if (evaluation.projectId !== projectId || evaluation.issueId !== issueId) {
+          return yield* new BadRequestError({
+            message: `Evaluation ${evaluation.id} does not match the requested issue or project`,
+          })
+        }
+
+        const updatedEvaluation = updateEvaluationTriggerFilter({ evaluation, filter: data.filter })
         yield* repository.save(updatedEvaluation)
 
         return toEvaluationSummaryRecord(updatedEvaluation)

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/evaluation-filter-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/evaluation-filter-modal.tsx
@@ -1,0 +1,170 @@
+import type { FilterCondition, FilterSet } from "@domain/shared"
+import { Button, CloseTrigger, Modal, Text, useToast } from "@repo/ui"
+import { useCallback, useMemo, useState } from "react"
+import { MetadataFilter } from "../../../../../../components/filters-builder/metadata-filter/metadata-filter.tsx"
+import { MultiSelectFilter } from "../../../../../../components/filters-builder/multi-select-filter.tsx"
+import type { DistinctColumn } from "../../../../../../components/filters-builder/types.ts"
+import {
+  type EvaluationSummaryRecord,
+  updateIssueEvaluationTriggerFilter,
+} from "../../../../../../domains/evaluations/evaluation-alignment.functions.ts"
+import { invalidateIssueQueries } from "../../../../../../domains/issues/issues.collection.ts"
+import { toUserMessage } from "../../../../../../lib/errors.ts"
+
+// Dimensions surfaced to users for evaluation scoping. Numeric/percentile
+// dimensions (cost, duration, etc.) are intentionally excluded — they describe
+// trace shape, not which agent/feature a trace belongs to, which is what users
+// are scoping by.
+const EVAL_FILTER_DIMENSIONS: ReadonlyArray<{ readonly field: DistinctColumn; readonly label: string }> = [
+  { field: "tags", label: "Tags" },
+  { field: "serviceNames", label: "Services" },
+  { field: "models", label: "Models" },
+  { field: "providers", label: "Providers" },
+]
+
+function getInValues(filter: FilterSet, field: string): readonly string[] {
+  const cond = filter[field]?.find((c) => c.op === "in")
+  return Array.isArray(cond?.value) ? cond.value.map(String) : []
+}
+
+function setMultiSelect(filter: FilterSet, field: string, values: readonly string[]): FilterSet {
+  if (values.length === 0) {
+    const { [field]: _, ...rest } = filter
+    return rest
+  }
+  return { ...filter, [field]: [{ op: "in", value: [...values] }] }
+}
+
+function extractMetadataEntries(filter: FilterSet): { readonly key: string; readonly value: string }[] {
+  const entries: { key: string; value: string }[] = []
+  for (const [field, conditions] of Object.entries(filter)) {
+    if (!field.startsWith("metadata.")) continue
+    const key = field.slice("metadata.".length)
+    for (const cond of conditions) {
+      if (cond.op === "eq" && typeof cond.value === "string") {
+        entries.push({ key, value: cond.value })
+      }
+    }
+  }
+  return entries
+}
+
+function applyMetadataEntries(filter: FilterSet, entries: readonly { key: string; value: string }[]): FilterSet {
+  const next: Record<string, readonly FilterCondition[]> = {}
+  for (const [key, value] of Object.entries(filter)) {
+    if (!key.startsWith("metadata.")) next[key] = value
+  }
+  for (const entry of entries) {
+    next[`metadata.${entry.key}`] = [{ op: "eq", value: entry.value }]
+  }
+  return next
+}
+
+export function EvaluationFilterModal({
+  evaluation,
+  projectId,
+  issueId,
+  onClose,
+}: {
+  readonly evaluation: EvaluationSummaryRecord | null
+  readonly projectId: string
+  readonly issueId: string
+  readonly onClose: () => void
+}) {
+  if (evaluation === null) return null
+  return <EvaluationFilterModalForm evaluation={evaluation} projectId={projectId} issueId={issueId} onClose={onClose} />
+}
+
+function EvaluationFilterModalForm({
+  evaluation,
+  projectId,
+  issueId,
+  onClose,
+}: {
+  readonly evaluation: EvaluationSummaryRecord
+  readonly projectId: string
+  readonly issueId: string
+  readonly onClose: () => void
+}) {
+  const { toast } = useToast()
+  const [draft, setDraft] = useState<FilterSet>(evaluation.trigger.filter)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const metadataEntries = useMemo(() => extractMetadataEntries(draft), [draft])
+
+  const handleMultiSelectChange = useCallback((field: DistinctColumn, values: string[]) => {
+    setDraft((current) => setMultiSelect(current, field, values))
+  }, [])
+
+  const handleMetadataChange = useCallback((entries: { key: string; value: string }[]) => {
+    setDraft((current) => applyMetadataEntries(current, entries))
+  }, [])
+
+  const handleClear = useCallback(() => {
+    setDraft({})
+  }, [])
+
+  const handleSave = async () => {
+    setIsSaving(true)
+    try {
+      await updateIssueEvaluationTriggerFilter({
+        data: {
+          projectId,
+          issueId,
+          evaluationId: evaluation.id,
+          filter: draft,
+        },
+      })
+      onClose()
+      await invalidateIssueQueries(projectId, issueId)
+      toast({ description: "Scope updated." })
+    } catch (error) {
+      toast({ variant: "destructive", description: toUserMessage(error) })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Modal
+      open
+      dismissible
+      scrollable={false}
+      onOpenChange={(open) => (!open ? onClose() : undefined)}
+      title="Scope evaluation"
+      description="Run this evaluation only on traces matching the filters below. Leave empty to evaluate all traces."
+      footer={
+        <>
+          <Button variant="ghost" onClick={handleClear} disabled={isSaving}>
+            Clear all
+          </Button>
+          <CloseTrigger />
+          <Button onClick={() => void handleSave()} isLoading={isSaving}>
+            Save
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-5 pb-2">
+        {EVAL_FILTER_DIMENSIONS.map(({ field, label }) => {
+          const selected = getInValues(draft, field)
+          return (
+            <div key={field} className="flex flex-col gap-1.5">
+              <Text.H6 color="foregroundMuted">{label}</Text.H6>
+              <MultiSelectFilter
+                projectId={projectId}
+                column={field}
+                selected={selected}
+                onChange={(values) => handleMultiSelectChange(field, values)}
+              />
+            </div>
+          )
+        })}
+        <div className="flex flex-col gap-1.5">
+          <Text.H6 color="foregroundMuted">Metadata</Text.H6>
+          <MetadataFilter entries={metadataEntries} onChange={handleMetadataChange} />
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/evaluation-filter-modal.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/evaluation-filter-modal.tsx
@@ -54,7 +54,11 @@ function applyMetadataEntries(filter: FilterSet, entries: readonly { key: string
   for (const [key, value] of Object.entries(filter)) {
     if (!key.startsWith("metadata.")) next[key] = value
   }
+  // `MetadataFilter` emits onChange on every keystroke, so partial rows with an
+  // empty key/value reach us mid-typing. Persisting `metadata.` would be
+  // rejected by `filterSetSchema` on save; drop incomplete rows instead.
   for (const entry of entries) {
+    if (entry.key === "" || entry.value === "") continue
     next[`metadata.${entry.key}`] = [{ op: "eq", value: entry.value }]
   }
   return next
@@ -115,12 +119,13 @@ function EvaluationFilterModalForm({
           filter: draft,
         },
       })
-      onClose()
       await invalidateIssueQueries(projectId, issueId)
       toast({ description: "Scope updated." })
+      // `onClose` unmounts the modal — no need (and no point) resetting
+      // `isSaving` afterwards, so the reset lives in the failure path only.
+      onClose()
     } catch (error) {
       toast({ variant: "destructive", description: toUserMessage(error) })
-    } finally {
       setIsSaving(false)
     }
   }

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/issues/-components/issue-drawer-evaluations.tsx
@@ -1,3 +1,4 @@
+import type { FilterSet } from "@domain/shared"
 import {
   Button,
   CloseTrigger,
@@ -12,7 +13,7 @@ import {
   useToast,
 } from "@repo/ui"
 import { useForm } from "@tanstack/react-form"
-import { BellPlusIcon, PencilIcon, RotateCwIcon, ShieldCheckIcon, XIcon } from "lucide-react"
+import { BellPlusIcon, FilterIcon, PencilIcon, RotateCwIcon, ShieldCheckIcon, XIcon } from "lucide-react"
 import { type ReactNode, useEffect, useRef, useState } from "react"
 import {
   type EvaluationSummaryRecord,
@@ -26,6 +27,7 @@ import {
 import { invalidateIssueQueries } from "../../../../../../domains/issues/issues.collection.ts"
 import { toUserMessage } from "../../../../../../lib/errors.ts"
 import { AlignmentStatsModal } from "./alignment-stats-modal.tsx"
+import { EvaluationFilterModal } from "./evaluation-filter-modal.tsx"
 import { formatPercent, getAlignmentVariant } from "./issue-formatters.ts"
 
 const POLL_INTERVAL_MS = 5000
@@ -99,6 +101,21 @@ function AlignmentTooltipContent({
 }
 
 function SamplingModal({
+  evaluation,
+  projectId,
+  issueId,
+  onClose,
+}: {
+  readonly evaluation: EvaluationSummaryRecord | null
+  readonly projectId: string
+  readonly issueId: string
+  readonly onClose: () => void
+}) {
+  if (evaluation === null) return null
+  return <SamplingModalForm evaluation={evaluation} projectId={projectId} issueId={issueId} onClose={onClose} />
+}
+
+function SamplingModalForm({
   evaluation,
   projectId,
   issueId,
@@ -183,6 +200,14 @@ function SamplingModal({
   )
 }
 
+function countFilterConditions(filter: FilterSet): number {
+  let total = 0
+  for (const conditions of Object.values(filter)) {
+    if (conditions.length > 0) total += 1
+  }
+  return total
+}
+
 const toTracked = (state: IssueAlignmentStateRecord): TrackedWorkflow | null => {
   if (state.kind === "generating") {
     return { kind: "initial" }
@@ -215,8 +240,9 @@ export function IssueDrawerEvaluations({
   const [monitorModalOpen, setMonitorModalOpen] = useState(false)
   const [realignEvaluationId, setRealignEvaluationId] = useState<string | null>(null)
   const [deleteEvaluationId, setDeleteEvaluationId] = useState<string | null>(null)
-  const [statsEvaluationId, setStatsEvaluationId] = useState<string | null>(null)
-  const [samplingEvaluationId, setSamplingEvaluationId] = useState<string | null>(null)
+  const [statsEvaluation, setStatsEvaluation] = useState<EvaluationSummaryRecord | null>(null)
+  const [samplingEvaluation, setSamplingEvaluation] = useState<EvaluationSummaryRecord | null>(null)
+  const [filterEvaluation, setFilterEvaluation] = useState<EvaluationSummaryRecord | null>(null)
   const [isStartingGenerate, setIsStartingGenerate] = useState(false)
   const [isStartingRealign, setIsStartingRealign] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -414,21 +440,22 @@ export function IssueDrawerEvaluations({
             monitorButton
           )}
         </div>
-        <Modal.Root open={monitorModalOpen} onOpenChange={setMonitorModalOpen}>
-          <Modal.Content dismissible>
-            <Modal.Header
-              title="Monitor issue"
-              description="We will use the latest traces and related human annotations to generate an evaluation aligned to monitor this issue. This may take some time"
-            />
-            <Modal.Footer>
+        <Modal
+          open={monitorModalOpen}
+          onOpenChange={setMonitorModalOpen}
+          dismissible
+          title="Monitor issue"
+          description="We will use the latest traces and related human annotations to generate an evaluation aligned to monitor this issue. This may take some time"
+          footer={
+            <>
               <CloseTrigger />
               <Button onClick={() => void handleGenerate()} disabled={isActionPending} isLoading={isStartingGenerate}>
                 <Icon icon={BellPlusIcon} size="sm" />
                 {isStartingGenerate ? "Generating" : "Monitor"}
               </Button>
-            </Modal.Footer>
-          </Modal.Content>
-        </Modal.Root>
+            </>
+          }
+        />
       </>
     )
   }
@@ -454,7 +481,7 @@ export function IssueDrawerEvaluations({
                 >
                   <AlignmentTooltipContent
                     evaluation={primaryEvaluation}
-                    onOpenStats={() => setStatsEvaluationId(primaryEvaluation.id)}
+                    onOpenStats={() => setStatsEvaluation(primaryEvaluation)}
                   />
                 </Tooltip>
               }
@@ -467,7 +494,7 @@ export function IssueDrawerEvaluations({
                   trigger={
                     <button
                       type="button"
-                      onClick={() => setSamplingEvaluationId(primaryEvaluation.id)}
+                      onClick={() => setSamplingEvaluation(primaryEvaluation)}
                       disabled={isActionPending}
                       className="inline-flex h-5 cursor-pointer items-center gap-1 bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50"
                     >
@@ -483,16 +510,55 @@ export function IssueDrawerEvaluations({
                 </Tooltip>
               }
             />
+            <SummaryField
+              label="Scope"
+              value={(() => {
+                const conditionCount = countFilterConditions(primaryEvaluation.trigger.filter)
+                const summary =
+                  conditionCount === 0 ? "All traces" : `${conditionCount} filter${conditionCount === 1 ? "" : "s"}`
+                return (
+                  <Tooltip
+                    asChild
+                    trigger={
+                      <button
+                        type="button"
+                        onClick={() => setFilterEvaluation(primaryEvaluation)}
+                        disabled={isActionPending}
+                        className="inline-flex h-5 cursor-pointer items-center gap-1 bg-transparent p-0 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Icon icon={FilterIcon} size="xs" color="foregroundMuted" />
+                        <Text.H5 color="foreground">{summary}</Text.H5>
+                        <Icon icon={PencilIcon} size="xs" color="foregroundMuted" />
+                      </button>
+                    }
+                  >
+                    <Text.H6 color="foregroundMuted">
+                      {conditionCount === 0
+                        ? "Click to limit which traces this evaluation runs on."
+                        : "Click to change which traces this evaluation runs on."}
+                    </Text.H6>
+                  </Tooltip>
+                )
+              })()}
+            />
             <div className="flex min-w-0 flex-1 items-end justify-end gap-x-1">
-              <Button
-                variant="ghost"
-                className="text-foreground group-hover:text-secondary-foreground/80"
-                onClick={() => setDeleteEvaluationId(primaryEvaluation.id)}
-                disabled={isActionPending}
+              <Tooltip
+                asChild
+                trigger={
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-foreground group-hover:text-secondary-foreground/80"
+                    onClick={() => setDeleteEvaluationId(primaryEvaluation.id)}
+                    disabled={isActionPending}
+                    aria-label="Unmonitor"
+                  >
+                    <Icon icon={XIcon} size="sm" />
+                  </Button>
+                }
               >
-                <Icon icon={XIcon} size="sm" />
-                Unmonitor
-              </Button>
+                <Text.H6 color="foregroundMuted">Unmonitor</Text.H6>
+              </Tooltip>
               <Button
                 variant="outline"
                 onClick={() => setRealignEvaluationId(primaryEvaluation.id)}
@@ -513,16 +579,14 @@ export function IssueDrawerEvaluations({
         ) : null}
       </div>
 
-      <Modal.Root
+      <Modal
         open={realignEvaluationId !== null}
         onOpenChange={(open) => (!open ? setRealignEvaluationId(null) : undefined)}
-      >
-        <Modal.Content dismissible>
-          <Modal.Header
-            title="Realign evaluation"
-            description="We realign evaluations to the latest traces periodically to ensure they are up to date. You can realign this evaluation on demand. This may take some time"
-          />
-          <Modal.Footer>
+        dismissible
+        title="Realign evaluation"
+        description="We realign evaluations to the latest traces periodically to ensure they are up to date. You can realign this evaluation on demand. This may take some time"
+        footer={
+          <>
             <CloseTrigger />
             <Button
               onClick={() => (realignEvaluationId ? void handleRealign(realignEvaluationId) : undefined)}
@@ -532,52 +596,42 @@ export function IssueDrawerEvaluations({
               <Icon icon={RotateCwIcon} size="sm" />
               {isStartingRealign ? "Realigning" : "Realign"}
             </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal.Root>
+          </>
+        }
+      />
 
-      <Modal.Root
+      <Modal
         open={deleteEvaluationId !== null}
         onOpenChange={(open) => (!open ? setDeleteEvaluationId(null) : undefined)}
-      >
-        <Modal.Content dismissible>
-          <Modal.Header
-            title="Unmonitor issue"
-            description="Are you sure you want to remove the evaluation monitoring this issue? You can generate a new evaluation at any time"
-          />
-          <Modal.Footer>
+        dismissible
+        title="Unmonitor issue"
+        description="Are you sure you want to remove the evaluation monitoring this issue? You can generate a new evaluation at any time"
+        footer={
+          <>
             <CloseTrigger />
             <Button variant="destructive" onClick={() => void handleDelete()} disabled={isDeleting}>
               <Icon icon={XIcon} size="sm" />
               Unmonitor
             </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal.Root>
-
-      <AlignmentStatsModal
-        evaluation={
-          statsEvaluationId === null
-            ? null
-            : (visibleEvaluations.find((evaluation) => evaluation.id === statsEvaluationId) ?? null)
+          </>
         }
-        onClose={() => setStatsEvaluationId(null)}
       />
 
-      {samplingEvaluationId !== null
-        ? (() => {
-            const target = visibleEvaluations.find((evaluation) => evaluation.id === samplingEvaluationId)
-            if (!target) return null
-            return (
-              <SamplingModal
-                evaluation={target}
-                projectId={projectId}
-                issueId={issueId}
-                onClose={() => setSamplingEvaluationId(null)}
-              />
-            )
-          })()
-        : null}
+      <AlignmentStatsModal evaluation={statsEvaluation} onClose={() => setStatsEvaluation(null)} />
+
+      <SamplingModal
+        evaluation={samplingEvaluation}
+        projectId={projectId}
+        issueId={issueId}
+        onClose={() => setSamplingEvaluation(null)}
+      />
+
+      <EvaluationFilterModal
+        evaluation={filterEvaluation}
+        projectId={projectId}
+        issueId={issueId}
+        onClose={() => setFilterEvaluation(null)}
+      />
     </>
   )
 }

--- a/apps/web/src/routes/backoffice/-components/organization-actions/create-demo-project.tsx
+++ b/apps/web/src/routes/backoffice/-components/organization-actions/create-demo-project.tsx
@@ -122,7 +122,11 @@ export function CreateDemoProjectButton({ organizationId }: CreateDemoProjectBut
               </FormWrapper>
             </Modal.Body>
             <Modal.Footer>
-              <CloseTrigger />
+              <CloseTrigger>
+                <Button variant="outline" size="sm">
+                  Close
+                </Button>
+              </CloseTrigger>
               <Button type="submit" size="sm" disabled={form.state.isSubmitting}>
                 {form.state.isSubmitting ? "Creating…" : "Create demo project"}
               </Button>

--- a/packages/domain/evaluations/src/browser.ts
+++ b/packages/domain/evaluations/src/browser.ts
@@ -28,7 +28,12 @@ export {
   isPausedEvaluation,
 } from "./entities/evaluation.ts"
 export { EvaluationNotFoundError } from "./errors.ts"
-export { deriveEvaluationAlignmentMetrics, softDeleteEvaluation, updateEvaluationSampling } from "./helpers.ts"
+export {
+  deriveEvaluationAlignmentMetrics,
+  softDeleteEvaluation,
+  updateEvaluationSampling,
+  updateEvaluationTriggerFilter,
+} from "./helpers.ts"
 export {
   DEFAULT_ALIGNMENT_EXAMPLE_LIMIT,
   type EvaluationAlignmentExample,

--- a/packages/domain/evaluations/src/helpers.test.ts
+++ b/packages/domain/evaluations/src/helpers.test.ts
@@ -34,6 +34,7 @@ import {
   totalConfusionMatrixObservations,
   unarchiveEvaluation,
   updateEvaluationSampling,
+  updateEvaluationTriggerFilter,
 } from "./helpers.ts"
 import { wrapPromptAsEvaluationScript } from "./runtime/evaluation-execution.ts"
 
@@ -179,6 +180,87 @@ describe("evaluation lifecycle helpers", () => {
 
     const full = updateEvaluationSampling({ evaluation: makeEvaluation(), sampling: 100 })
     expect(full.trigger.sampling).toBe(100)
+  })
+
+  it("updates the trigger filter and bumps updatedAt", () => {
+    const updatedAt = new Date("2026-05-12T00:00:00.000Z")
+    const updated = updateEvaluationTriggerFilter({
+      evaluation: makeEvaluation(),
+      filter: { tags: [{ op: "in", value: ["agent-a"] }] },
+      updatedAt,
+    })
+
+    expect(updated.trigger.filter).toEqual({ tags: [{ op: "in", value: ["agent-a"] }] })
+    expect(updated.updatedAt).toEqual(updatedAt)
+  })
+
+  it("preserves other trigger fields when updating the filter", () => {
+    const evaluation = makeEvaluation({
+      trigger: { filter: {}, turn: "every", debounce: 0, sampling: 42 },
+    })
+
+    const updated = updateEvaluationTriggerFilter({
+      evaluation,
+      filter: { serviceNames: [{ op: "in", value: ["checkout"] }] },
+    })
+
+    expect(updated.trigger.sampling).toBe(42)
+    expect(updated.trigger.turn).toBe("every")
+    expect(updated.trigger.debounce).toBe(0)
+  })
+
+  it("returns the same evaluation when the filter is structurally equal", () => {
+    const evaluation = makeEvaluation({
+      trigger: {
+        filter: { tags: [{ op: "in", value: ["a"] }] },
+        turn: "every",
+        debounce: 0,
+        sampling: 10,
+      },
+    })
+
+    // Same shape but with an empty array on an absent key — should be treated as a no-op.
+    const same = updateEvaluationTriggerFilter({
+      evaluation,
+      filter: { tags: [{ op: "in", value: ["a"] }], serviceNames: [] },
+    })
+
+    expect(same).toBe(evaluation)
+  })
+
+  it("rejects filter updates on deleted evaluations", () => {
+    const deleted = makeEvaluation({
+      deletedAt: new Date("2026-04-04T00:00:00.000Z"),
+    })
+
+    expect(() => updateEvaluationTriggerFilter({ evaluation: deleted, filter: {} })).toThrowError(
+      EvaluationDeletedError,
+    )
+  })
+
+  it("rejects structurally invalid filters", () => {
+    expect(() =>
+      updateEvaluationTriggerFilter({
+        evaluation: makeEvaluation(),
+        // gtePercentile requires a number in [0, 100].
+        filter: { duration: [{ op: "gtePercentile", value: 200 }] },
+      }),
+    ).toThrow()
+  })
+
+  it("clears the filter when given an empty filter set", () => {
+    const evaluation = makeEvaluation({
+      trigger: {
+        filter: { tags: [{ op: "in", value: ["a"] }] },
+        turn: "every",
+        debounce: 0,
+        sampling: 10,
+      },
+    })
+
+    const cleared = updateEvaluationTriggerFilter({ evaluation, filter: {} })
+
+    expect(cleared.trigger.filter).toEqual({})
   })
 })
 

--- a/packages/domain/evaluations/src/helpers.ts
+++ b/packages/domain/evaluations/src/helpers.ts
@@ -1,4 +1,4 @@
-import { deterministicSampling, type ResolvedSettings } from "@domain/shared"
+import { deterministicSampling, type FilterSet, filterSetSchema, type ResolvedSettings } from "@domain/shared"
 import { ALIGNMENT_METRIC_TOLERANCE } from "./constants.ts"
 import type { ConfusionMatrix, Evaluation } from "./entities/evaluation.ts"
 import { isPausedEvaluation } from "./entities/evaluation.ts"
@@ -145,6 +145,45 @@ export const updateEvaluationSampling = (input: {
   return {
     ...input.evaluation,
     trigger: { ...input.evaluation.trigger, sampling: input.sampling },
+    updatedAt,
+  }
+}
+
+// Empty arrays carry no constraint; treat them as absent so the no-op check
+// doesn't bump updatedAt when the UI sends `{ tags: [] }` for a cleared field.
+const canonicalizeFilterSet = (filter: FilterSet): Record<string, readonly unknown[]> => {
+  const out: Record<string, readonly unknown[]> = {}
+  for (const key of Object.keys(filter).sort()) {
+    const conditions = filter[key]
+    if (conditions && conditions.length > 0) {
+      out[key] = conditions
+    }
+  }
+  return out
+}
+
+const areFilterSetsEqual = (left: FilterSet, right: FilterSet): boolean =>
+  JSON.stringify(canonicalizeFilterSet(left)) === JSON.stringify(canonicalizeFilterSet(right))
+
+export const updateEvaluationTriggerFilter = (input: {
+  readonly evaluation: Evaluation
+  readonly filter: FilterSet
+  readonly updatedAt?: Date
+}): Evaluation => {
+  assertEvaluationNotDeleted(input.evaluation)
+
+  // Defence-in-depth: the server function validates filter shape at the request
+  // boundary, but the helper is also reachable from internal call sites.
+  const filter = filterSetSchema.parse(input.filter)
+
+  if (areFilterSetsEqual(input.evaluation.trigger.filter, filter)) {
+    return input.evaluation
+  }
+
+  const updatedAt = input.updatedAt ?? new Date()
+  return {
+    ...input.evaluation,
+    trigger: { ...input.evaluation.trigger, filter },
     updatedAt,
   }
 }

--- a/packages/domain/evaluations/src/index.ts
+++ b/packages/domain/evaluations/src/index.ts
@@ -81,6 +81,7 @@ export {
   totalConfusionMatrixObservations,
   unarchiveEvaluation,
   updateEvaluationSampling,
+  updateEvaluationTriggerFilter,
 } from "./helpers.ts"
 export {
   DEFAULT_ALIGNMENT_EXAMPLE_LIMIT,


### PR DESCRIPTION
## Summary

- Users with multiple agents in one project were getting eval false positives because every evaluation ran on every trace ([LAT-570](https://linear.app/latitude/issue/LAT-570/evals-are-executing-for-all-traces-when-user-doesnt-want)).
- Surface `evaluation.trigger.filter` (already in the schema, already enforced by `selectTraceEndItemsUseCase`) in the issue drawer so users can restrict an eval to tags / services / models / providers / metadata. Empty filter = all traces (current behavior).
- New pure helper `updateEvaluationTriggerFilter` mirroring `updateEvaluationSampling`, new server fn `updateIssueEvaluationTriggerFilter`, and a new `EvaluationFilterModal` reusing the existing `MultiSelectFilter` + `MetadataFilter` primitives from the traces sidebar.

Out of scope (per Slack thread): per-flagger filters, separation of flagger-sourced issues from the rest.

## Test plan

- [x] `pnpm --filter @domain/evaluations test` — 70/70 pass, includes 6 new helper tests (happy path, preserves other trigger fields, structural no-op equality, deleted-rejection, filterSetSchema rejection, clear-to-empty).
- [x] `pnpm --filter @domain/evaluations typecheck`
- [x] `pnpm --filter @app/web typecheck`
- [x] `pnpm exec biome check` on touched files
- [x] Manual: open an issue → click the "Scope" affordance on its evaluation → pick a tag → save → confirm the next trace-end run skips traces that don't match (`filter-miss` decision in `trace-end` logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)