### PR TITLE
feat: add Latitude telemetry bootstrap class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,25 +22,30 @@ At a glance: **`apps/*`** own HTTP boundaries (validation, authz, routing to use
 
 Detailed policies, command examples, and code samples live under **`.agents/skills/<skill-name>/SKILL.md`**. Load narrow skills instead of memorizing the entire monorepo at once.
 
-**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **17** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
+**Index coverage:** The glossary lists **every** skill in `.agents/skills/` (one row per `*/SKILL.md`, **22** total), ordered **alphabetically by folder name**. When you add or remove a skill folder, update this table in the same change.
 
 ## Skill glossary
 
 | Skill | Path | Use when |
 | --- | --- | --- |
 | **Agentation watch mode** | [.agents/skills/agentation-watch-mode/SKILL.md](.agents/skills/agentation-watch-mode/SKILL.md) | Agentation annotation watch loops, continuous feedback handling, or when the user says **`watch mode`** and wants annotations acknowledged, fixed, and resolved as they arrive |
+| **Analyze problem** | [.agents/skills/analyze-problem/SKILL.md](.agents/skills/analyze-problem/SKILL.md) | Investigating a bug, task, or reported issue to explain behavior, root cause, proposed fix, and verification steps before implementation |
 | **API endpoints (HTTP, MCP, SDK)** | [.agents/skills/api-endpoints/SKILL.md](.agents/skills/api-endpoints/SKILL.md) | Adding or changing routes in **`apps/api`**, **`defineApiEndpoint`**, **`openapi.json` / `mcp.json` regen**, **`createXxxRoutes`** factories, writing **field descriptions** that propagate to both the **TS SDK** and **MCP tool** consumers |
 | **Architecture and boundaries** | [.agents/skills/architecture-boundaries/SKILL.md](.agents/skills/architecture-boundaries/SKILL.md) | Layering, web vs public API, **app layout** (clients, routes, logging), ports/adapters, **web-standard APIs in domain/shared/utils**, multi-tenancy, DDD layout, anti-patterns, **machine-facing MCP/API product surfaces** |
 | **Background jobs and events** | [.agents/skills/async-jobs-and-events/SKILL.md](.agents/skills/async-jobs-and-events/SKILL.md) | **Queues/workers**, **domain events**, side effects **outside** HTTP handlers, task payload design, debounce/dedupe, delayed job semantics, **domain event naming**, **publisher–consumer decoupling** |
 | **Authentication** | [.agents/skills/authentication/SKILL.md](.agents/skills/authentication/SKILL.md) | **Better Auth**, sessions, web session helpers, org context on session, **`@domain/auth`** flows |
 | **Backoffice** | [.agents/skills/backoffice/SKILL.md](.agents/skills/backoffice/SKILL.md) | Staff-only `/backoffice` features, **`createAdminServerFn`** factory, admin guards + RLS-bypass path, `@domain/admin` feature-folder layout |
 | **Better Auth best practices** | [.agents/skills/better-auth-best-practices/SKILL.md](.agents/skills/better-auth-best-practices/SKILL.md) | **Better Auth** server/client setup, DB adapters, sessions, plugins, env (`auth.ts`); email/password, OAuth; **better-auth.com** API reference |
+| **CI watchdog** | [.agents/skills/ci-watchdog/SKILL.md](.agents/skills/ci-watchdog/SKILL.md) | Watching GitHub PR checks, monitoring CI status, diagnosing failures from logs, and looping on fixes until checks pass |
 | **Code style and TypeScript** | [.agents/skills/code-style/SKILL.md](.agents/skills/code-style/SKILL.md) | Biome, imports, strict TS, naming, **Zod-first shared contracts**, literal-union enums, named constants, generated files |
+| **Create PR** | [.agents/skills/create-pr/SKILL.md](.agents/skills/create-pr/SKILL.md) | Creating PRs, writing PR descriptions, summarizing changes, and preparing a reviewable pull request |
 | **ClickHouse and Weaviate** | [.agents/skills/database-clickhouse-weaviate/SKILL.md](.agents/skills/database-clickhouse-weaviate/SKILL.md) | Parameterized CH queries, Goose migrations, append-only migration rules, Weaviate collections/migrations |
 | **Postgres and SqlClient** | [.agents/skills/database-postgres/SKILL.md](.agents/skills/database-postgres/SKILL.md) | Drizzle schema, RLS, SqlClient, migrations (Drizzle Kit), no-FK rules, repository mappers |
 | **Documentation and specs** | [.agents/skills/docs/SKILL.md](.agents/skills/docs/SKILL.md) | **`dev-docs/*.md`** (domain), **`docs/`** (ADRs, Mintlify), **`specs/*.md`**, durable documentation sync, spec structure, promoting stable knowledge into `dev-docs/` |
 | **Effect and errors** | [.agents/skills/effect-and-errors/SKILL.md](.agents/skills/effect-and-errors/SKILL.md) | `Effect` composition, `Data.TaggedError`, `HttpError`, boundary error handling |
 | **Environment configuration** | [.agents/skills/env-configuration/SKILL.md](.agents/skills/env-configuration/SKILL.md) | **`LAT_*` / `VITE_LAT_*`**, `.env.example`, **`parseEnv` / `parseEnvOptional`** |
+| **GitHub issues** | [.agents/skills/gh-issue/SKILL.md](.agents/skills/gh-issue/SKILL.md) | Creating clear, actionable GitHub issues for bugs, features, and improvements, optimized for LLM/actionability |
+| **Review PR comments** | [.agents/skills/review-pr-comments/SKILL.md](.agents/skills/review-pr-comments/SKILL.md) | Loading issue-level and inline PR feedback with GitHub CLI/API, deduping comments, replying in the right thread, and resolving addressed review threads |
 | **Temporal workflows** | [.agents/skills/temporal-developer/SKILL.md](.agents/skills/temporal-developer/SKILL.md) | Editing workflows or activities in **`apps/workflows`**, **reordering/inserting activities** in a running workflow, **`patched()` / `deprecatePatch()` / Worker Versioning**, debugging **non-determinism errors**, terminating stuck workflows, replay/history semantics |
 | **Testing** | [.agents/skills/testing/SKILL.md](.agents/skills/testing/SKILL.md) | Vitest layers, PGlite/chdb testkit, **`/testing` package exports**, avoiding `vi.mock` for repositories |
 | **Toolchain and commands** | [.agents/skills/toolchain-commands/SKILL.md](.agents/skills/toolchain-commands/SKILL.md) | Node/pnpm/Turbo/Vitest/Biome, scripts, filters, CI, `.env.*` setup, **Docker Compose, dev servers, Mailpit** |

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ npm install @latitude-data/telemetry
 ### Instrument
 
 ```ts
-import { initLatitude } from "@latitude-data/telemetry"
+import { Latitude } from "@latitude-data/telemetry"
 
-initLatitude({
+new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
@@ -271,10 +271,10 @@ export function getOnboardingSnippet(
 }
 
 function snippetTsOpenai() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import OpenAI from "openai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
@@ -323,10 +323,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsAnthropic() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import Anthropic from "@anthropic-ai/sdk"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["anthropic"],
@@ -377,13 +377,13 @@ latitude["shutdown"]()
 }
 
 function snippetTsBedrock() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from "@aws-sdk/client-bedrock-runtime"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["bedrock"],
@@ -444,10 +444,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsCohere() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { CohereClient } from "cohere-ai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["cohere"],
@@ -496,10 +496,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsTogether() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import Together from "together-ai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["togetherai"],
@@ -548,10 +548,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsVertex() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { VertexAI } from "@google-cloud/vertexai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["vertexai"],
@@ -600,10 +600,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsAiplatform() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { PredictionServiceClient } from "@google-cloud/aiplatform"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["aiplatform"],
@@ -651,10 +651,10 @@ latitude["shutdown"]()
 }
 
 function snippetTsAzureOpenai() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { AzureOpenAI } from "openai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
@@ -711,11 +711,11 @@ latitude["shutdown"]()
 }
 
 function snippetTsVercelAiSdk() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { generateText } from "ai"
 import { openai } from "@ai-sdk/openai"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
 })
@@ -738,11 +738,11 @@ await latitude.shutdown()
 }
 
 function snippetTsLangchain() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { ChatOpenAI } from "@langchain/openai"
 import { HumanMessage } from "@langchain/core/messages"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["langchain"],
@@ -786,12 +786,12 @@ latitude["shutdown"]()
 }
 
 function snippetTsLlamaindex() {
-  return `import { initLatitude, capture } from "@latitude-data/telemetry"
+  return `import { Latitude, capture } from "@latitude-data/telemetry"
 import { Settings } from "llamaindex"
 import { openai } from "@llamaindex/openai"
 import { agent } from "@llamaindex/workflow"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["llamaindex"],

--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-integration-snippets.ts
@@ -298,10 +298,10 @@ await latitude.shutdown()
 
 function snippetPyOpenai() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from openai import OpenAI
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -318,7 +318,7 @@ def generate_support_reply():
 
 capture("generate-support-reply", generate_support_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -351,10 +351,10 @@ await latitude.shutdown()
 
 function snippetPyAnthropic() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from anthropic import Anthropic
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["anthropic"],
@@ -372,7 +372,7 @@ def generate_reply():
 
 capture("generate-reply", generate_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -414,10 +414,10 @@ await latitude.shutdown()
 function snippetPyBedrock() {
   return `import json
 import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 import boto3
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["bedrock"],
@@ -439,7 +439,7 @@ def generate_reply():
 
 capture("generate-reply", generate_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -471,10 +471,10 @@ await latitude.shutdown()
 
 function snippetPyCohere() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 import cohere
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["cohere"],
@@ -491,7 +491,7 @@ def generate_reply():
 
 capture("generate-reply", generate_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -523,10 +523,10 @@ await latitude.shutdown()
 
 function snippetPyTogether() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from together import Together
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["togetherai"],
@@ -543,7 +543,7 @@ def generate_reply():
 
 capture("generate-reply", generate_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -576,11 +576,11 @@ await latitude.shutdown()
 
 function snippetPyVertex() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 import vertexai
 from vertexai.generative_models import GenerativeModel
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["vertexai"],
@@ -595,7 +595,7 @@ def generate_reply():
 
 capture("generate-reply", generate_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -628,10 +628,10 @@ await latitude.shutdown()
 
 function snippetPyAiplatform() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from google.cloud import aiplatform
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["aiplatform"],
@@ -646,7 +646,7 @@ def generate_prediction():
 
 capture("generate-prediction", generate_prediction)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -682,10 +682,10 @@ await latitude.shutdown()
 
 function snippetPyAzureOpenai() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from openai import AzureOpenAI
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -706,7 +706,7 @@ def generate_support_reply():
 
 capture("generate-support-reply", generate_support_reply)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -763,11 +763,11 @@ await latitude.shutdown()
 
 function snippetPyLangchain() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["langchain"],
@@ -781,7 +781,7 @@ def langchain_query():
 
 capture("langchain-query", langchain_query)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
@@ -813,10 +813,10 @@ await latitude.shutdown()
 
 function snippetPyLlamaindex() {
   return `import os
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["llamaindex"],
@@ -832,17 +832,17 @@ def llamaindex_query():
 
 capture("llamaindex-query", llamaindex_query)
 
-latitude["shutdown"]()
+latitude.shutdown()
 `
 }
 
 function snippetPyGemini() {
   return `import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry before importing google.genai so instrumentation can patch it.
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["google_generativeai"],
@@ -863,16 +863,16 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
 function snippetPyGroq() {
   return `import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["groq"],
@@ -894,16 +894,16 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
 function snippetPyMistral() {
   return `import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["mistralai"],
@@ -926,7 +926,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -934,9 +934,9 @@ function snippetPyOllama() {
   return `import os
 
 import ollama
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["ollama"],
@@ -954,7 +954,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -962,9 +962,9 @@ function snippetPyLitellm() {
   return `import os
 
 import litellm
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["litellm"],
@@ -983,7 +983,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -991,9 +991,9 @@ function snippetPyReplicate() {
   return `import os
 
 import replicate
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["replicate"],
@@ -1011,7 +1011,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -1020,9 +1020,9 @@ function snippetPySagemaker() {
 import os
 
 import boto3
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["sagemaker"],
@@ -1052,7 +1052,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -1061,9 +1061,9 @@ function snippetPyWatsonx() {
 
 from ibm_watsonx_ai.foundation_models import Model
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["watsonx"],
@@ -1088,7 +1088,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
@@ -1096,9 +1096,9 @@ function snippetPyAlephAlpha() {
   return `import os
 
 from aleph_alpha_client import Client, CompletionRequest, Prompt
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["aleph_alpha"],
@@ -1118,17 +1118,17 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 
 function snippetPyTransformers() {
   return `import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 from transformers import pipeline
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["transformers"],
@@ -1148,7 +1148,7 @@ def main():
 
 if __name__ == "__main__":
     main()
-    latitude["shutdown"]()
+    latitude.shutdown()
 `
 }
 

--- a/dev-docs/telemetry-sdk.md
+++ b/dev-docs/telemetry-sdk.md
@@ -1,0 +1,28 @@
+# Telemetry SDKs
+
+Latitude's TypeScript and Python telemetry SDKs expose a class-based bootstrap API for application instrumentation.
+
+## Bootstrap API
+
+- TypeScript uses `new Latitude({ ... })` from `@latitude-data/telemetry`.
+- Python uses `Latitude(...)` from `latitude_telemetry`.
+- The bootstrap object exposes the OpenTelemetry tracer provider as `provider` and lifecycle methods for flushing and shutdown.
+- TypeScript also exposes `ready: Promise<void>` because instrumentation registration is asynchronous; Python registration is synchronous and does not expose `ready`.
+
+The bootstrap class is responsible for:
+
+- validating `apiKey` / `api_key` and `projectSlug` / `project_slug`
+- configuring the Latitude span processor and exporter
+- registering requested LLM instrumentations
+- installing W3C trace-context and baggage propagation when the SDK owns the provider
+- registering graceful shutdown handling
+
+## Existing OpenTelemetry providers
+
+The class-based bootstrap should be constructed after any existing OpenTelemetry-compatible observability SDK, such as Sentry, Datadog, New Relic, Honeycomb, or a custom OTel SDK. When a provider is already registered, Latitude attaches its `LatitudeSpanProcessor` to that provider instead of replacing the app's context manager, propagator, sampler, or other processors.
+
+For manual setups, applications can still add `LatitudeSpanProcessor` directly to their own provider and call the instrumentation registration helper.
+
+## Python compatibility
+
+`init_latitude()` remains available in the Python package as a backwards-compatible wrapper. New docs and examples should prefer `Latitude(...)`; legacy code using `init_latitude()` receives the previous dict shape containing `provider`, `flush`, and `shutdown`.

--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -69,11 +69,11 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { ChatOpenAI } from "@langchain/openai"
         import { HumanMessage } from "@langchain/core/messages"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["langchain"],

--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -93,11 +93,11 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from langchain_openai import ChatOpenAI
         from langchain_core.messages import HumanMessage
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["langchain"],

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -69,12 +69,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { Settings } from "llamaindex"
         import { openai } from "@llamaindex/openai"
         import { agent } from "@llamaindex/workflow"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["llamaindex"],

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -95,10 +95,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["llamaindex"],

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -106,10 +106,10 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from agents import Agent, Runner
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["openai-agents"],

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -71,11 +71,11 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { Agent, run, tool } from "@openai/agents"
         import { z } from "zod"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["openai-agents"],

--- a/docs/telemetry/frameworks/vercel-ai-sdk.mdx
+++ b/docs/telemetry/frameworks/vercel-ai-sdk.mdx
@@ -56,11 +56,11 @@ The Vercel AI SDK has built-in OpenTelemetry support via its `experimental_telem
     Initialize Latitude **without** an `instrumentations` array. The Vercel AI SDK emits its own OpenTelemetry spans. Set `experimental_telemetry.isEnabled` to `true` on your AI SDK calls.
 
     ```ts
-    import { initLatitude, capture } from "@latitude-data/telemetry"
+    import { Latitude, capture } from "@latitude-data/telemetry"
     import { generateText } from "ai"
     import { openai } from "@ai-sdk/openai"
 
-    const latitude = initLatitude({
+    const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
       projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
     })

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -222,7 +222,7 @@ Latitude expects the standard **parts-based** GenAI message format. Each message
 
 ## Existing Observability Stack
 
-Latitude works alongside your existing observability tools. Add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
+Latitude works alongside your existing observability tools. In TypeScript, `new Latitude()` detects common OpenTelemetry-compatible providers (Sentry, Datadog, New Relic, Honeycomb, and custom OTel SDKs) and attaches Latitude when possible; custom setups can also add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
 
 ### With Datadog (TypeScript)
 
@@ -247,38 +247,44 @@ provider.register()
 ### With Sentry (TypeScript)
 
 ```ts
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
 import * as Sentry from "@sentry/node"
-import {
-  LatitudeSpanProcessor,
-  registerLatitudeInstrumentations,
-} from "@latitude-data/telemetry"
+import { Latitude } from "@latitude-data/telemetry"
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })
 
-const provider = new NodeTracerProvider({
-  spanProcessors: [
-    new LatitudeSpanProcessor(
-      process.env.LATITUDE_API_KEY!,
-      process.env.LATITUDE_PROJECT_SLUG!,
-    ),
-  ],
-})
-
-await registerLatitudeInstrumentations({
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
-  tracerProvider: provider,
 })
 
-provider.register()
+await latitude.ready
+```
+
+### With New Relic or Honeycomb (TypeScript)
+
+Initialize the vendor SDK first, then construct `new Latitude()`. New Relic's OpenTelemetry bridge and Honeycomb's `HoneycombSDK` both register OpenTelemetry providers that Latitude can reuse.
+
+```ts
+import { Latitude } from "@latitude-data/telemetry"
+
+// Initialize New Relic or Honeycomb first.
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+})
+
+await latitude.ready
 ```
 
 ### Other Platforms
 
-For any observability platform that supports OpenTelemetry (Jaeger, Grafana Tempo, Honeycomb, etc.), the pattern is the same: configure an additional OTLP exporter pointed at `https://ingest.latitude.so/v1/traces` with the required `Authorization` and `X-Latitude-Project` headers alongside your existing exporter.
+For any observability platform that supports OpenTelemetry (Jaeger, Grafana Tempo, etc.), the pattern is the same: initialize the existing SDK first and then construct `new Latitude()`, or configure an additional OTLP exporter pointed at `https://ingest.latitude.so/v1/traces` with the required `Authorization` and `X-Latitude-Project` headers alongside your existing exporter.
 
 ## Troubleshooting
 

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -222,7 +222,7 @@ Latitude expects the standard **parts-based** GenAI message format. Each message
 
 ## Existing Observability Stack
 
-Latitude works alongside your existing observability tools. In TypeScript, `new Latitude()` detects common OpenTelemetry-compatible providers (Sentry, Datadog, New Relic, Honeycomb, and custom OTel SDKs) and attaches Latitude when possible; custom setups can also add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
+Latitude works alongside your existing observability tools. In TypeScript, `new Latitude()` detects common OpenTelemetry-compatible providers (Sentry, Datadog, New Relic, Honeycomb, and custom OTel SDKs) and attaches Latitude when possible. In Python, `Latitude(...)` attaches to the registered OpenTelemetry provider when one already exists or creates one when none exists. Custom setups in either SDK can also add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
 
 ### With Datadog (TypeScript)
 
@@ -281,7 +281,7 @@ await latitude.ready
 
 ### Other Platforms
 
-For any observability platform that supports OpenTelemetry (Jaeger, Grafana Tempo, etc.), the pattern is the same: initialize the existing SDK first and then construct `new Latitude()`, or configure an additional OTLP exporter pointed at `https://ingest.latitude.so/v1/traces` with the required `Authorization` and `X-Latitude-Project` headers alongside your existing exporter.
+For any observability platform that supports OpenTelemetry (Jaeger, Grafana Tempo, etc.), the pattern is the same: initialize the existing SDK first and then construct `Latitude`, or configure an additional OTLP exporter pointed at `https://ingest.latitude.so/v1/traces` with the required `Authorization` and `X-Latitude-Project` headers alongside your existing exporter.
 
 ## Troubleshooting
 

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -228,20 +228,17 @@ Latitude works alongside your existing observability tools. In TypeScript, `new 
 
 ```ts
 import tracer from "dd-trace"
-import { LatitudeSpanProcessor } from "@latitude-data/telemetry"
+import { Latitude } from "@latitude-data/telemetry"
 
 tracer.init({ service: "my-app", env: "production" })
 
-const provider = new tracer.TracerProvider()
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+})
 
-provider.addSpanProcessor(
-  new LatitudeSpanProcessor(
-    process.env.LATITUDE_API_KEY!,
-    process.env.LATITUDE_PROJECT_SLUG!,
-  ),
-)
-
-provider.register()
+await latitude.ready
 ```
 
 ### With Sentry (TypeScript)

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -224,6 +224,8 @@ Latitude expects the standard **parts-based** GenAI message format. Each message
 
 Latitude works alongside your existing observability tools. In TypeScript, `new Latitude()` detects common OpenTelemetry-compatible providers (Sentry, Datadog, New Relic, Honeycomb, and custom OTel SDKs) and attaches Latitude when possible. In Python, `Latitude(...)` attaches to the registered OpenTelemetry provider when one already exists or creates one when none exists. Custom setups in either SDK can also add `LatitudeSpanProcessor` as an additional span processor so traces go to both Latitude and your current backend.
 
+`await latitude.ready` is optional in these examples. Use it during startup only when you need to guarantee Latitude's instrumentations are registered before the first LLM call.
+
 ### With Datadog (TypeScript)
 
 ```ts
@@ -237,8 +239,6 @@ const latitude = new Latitude({
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
 })
-
-await latitude.ready
 ```
 
 ### With Sentry (TypeScript)
@@ -257,26 +257,39 @@ const latitude = new Latitude({
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
 })
-
-await latitude.ready
 ```
 
-### With New Relic or Honeycomb (TypeScript)
+### With New Relic (TypeScript)
 
-Initialize the vendor SDK first, then construct `new Latitude()`. New Relic's OpenTelemetry bridge and Honeycomb's `HoneycombSDK` both register OpenTelemetry providers that Latitude can reuse.
+Enable New Relic's OpenTelemetry bridge first, then construct `new Latitude()`. New Relic registers an OpenTelemetry provider that Latitude can reuse.
 
 ```ts
+import "newrelic"
 import { Latitude } from "@latitude-data/telemetry"
-
-// Initialize New Relic or Honeycomb first.
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
 })
+```
 
-await latitude.ready
+### With Honeycomb (TypeScript)
+
+Start Honeycomb's `HoneycombSDK` first, then construct `new Latitude()`. Honeycomb registers an OpenTelemetry provider that Latitude can reuse.
+
+```ts
+import { HoneycombSDK } from "@honeycombio/opentelemetry-node"
+import { Latitude } from "@latitude-data/telemetry"
+
+const honeycomb = new HoneycombSDK({ serviceName: "my-app" })
+honeycomb.start()
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+})
 ```
 
 ### Other Platforms

--- a/docs/telemetry/overview.mdx
+++ b/docs/telemetry/overview.mdx
@@ -35,7 +35,7 @@ The skill covers TypeScript and Python, the providers and frameworks listed in [
 
 ## Manual installation
 
-One function sets up everything: auto-instrumentation, the Latitude exporter, and async context propagation:
+One TypeScript class sets up everything: auto-instrumentation, the Latitude exporter, and async context propagation:
 
 <Tabs>
   <Tab title="TypeScript">
@@ -44,10 +44,10 @@ One function sets up everything: auto-instrumentation, the Latitude exporter, an
     ```
 
     ```ts
-    import { initLatitude } from "@latitude-data/telemetry"
+    import { Latitude } from "@latitude-data/telemetry"
     import OpenAI from "openai"
 
-    const latitude = initLatitude({
+    const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
       projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
       instrumentations: ["openai"],
@@ -99,9 +99,9 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
 <Tabs>
   <Tab title="TypeScript">
     ```ts
-    import { initLatitude, capture } from "@latitude-data/telemetry"
+    import { Latitude, capture } from "@latitude-data/telemetry"
 
-    const latitude = initLatitude({
+    const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
       projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
       instrumentations: ["openai"],
@@ -209,7 +209,7 @@ Latitude Telemetry is built on OpenTelemetry standards:
 2. **`LatitudeSpanProcessor`** filters for LLM-relevant spans (`gen_ai.*`, `ai.*`, `openinference.*` attributes) and exports them to Latitude via OTLP.
 3. **`capture()`** uses OpenTelemetry's native `context.with()` to attach Latitude-specific attributes (user, session, tags) to spans within its scope.
 
-If you already run OpenTelemetry for other backends, you can add `LatitudeSpanProcessor` alongside your existing processors. See the [TypeScript SDK](typescript) or [Python SDK](python) reference for advanced setup.
+If you already run Sentry or another OpenTelemetry-compatible SDK, initialize it first and construct TypeScript `new Latitude()` second so Latitude can attach to the existing provider when possible. You can also add `LatitudeSpanProcessor` explicitly alongside existing processors. See the [TypeScript SDK](typescript) or [Python SDK](python) reference for advanced setup.
 
 ## Supported Integrations
 

--- a/docs/telemetry/overview.mdx
+++ b/docs/telemetry/overview.mdx
@@ -35,7 +35,7 @@ The skill covers TypeScript and Python, the providers and frameworks listed in [
 
 ## Manual installation
 
-One TypeScript class sets up everything: auto-instrumentation, the Latitude exporter, and async context propagation:
+One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude exporter, and async context propagation:
 
 <Tabs>
   <Tab title="TypeScript">
@@ -70,10 +70,10 @@ One TypeScript class sets up everything: auto-instrumentation, the Latitude expo
     ```
 
     ```python
-    from latitude_telemetry import init_latitude
+    from latitude_telemetry import Latitude
     from openai import OpenAI
 
-    latitude = init_latitude(
+    latitude = Latitude(
         api_key="your-api-key",
         project_slug="your-project-slug",
         instrumentations=["openai"],
@@ -85,7 +85,7 @@ One TypeScript class sets up everything: auto-instrumentation, the Latitude expo
         messages=[{"role": "user", "content": "Hello"}],
     )
 
-    latitude["shutdown"]()
+    latitude.shutdown()
     ```
   </Tab>
 </Tabs>
@@ -131,9 +131,9 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
   </Tab>
   <Tab title="Python">
     ```python
-    from latitude_telemetry import init_latitude, capture
+    from latitude_telemetry import Latitude, capture
 
-    latitude = init_latitude(
+    latitude = Latitude(
         api_key="your-api-key",
         project_slug="your-project-slug",
         instrumentations=["openai"],
@@ -153,7 +153,7 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
         },
     )
 
-    latitude["shutdown"]()
+    latitude.shutdown()
     ```
   </Tab>
 </Tabs>
@@ -209,7 +209,7 @@ Latitude Telemetry is built on OpenTelemetry standards:
 2. **`LatitudeSpanProcessor`** filters for LLM-relevant spans (`gen_ai.*`, `ai.*`, `openinference.*` attributes) and exports them to Latitude via OTLP.
 3. **`capture()`** uses OpenTelemetry's native `context.with()` to attach Latitude-specific attributes (user, session, tags) to spans within its scope.
 
-If you already run Sentry or another OpenTelemetry-compatible SDK, initialize it first and construct TypeScript `new Latitude()` second so Latitude can attach to the existing provider when possible. You can also add `LatitudeSpanProcessor` explicitly alongside existing processors. See the [TypeScript SDK](typescript) or [Python SDK](python) reference for advanced setup.
+If you already run Sentry or another OpenTelemetry-compatible SDK, initialize it first and construct `Latitude` second so Latitude can attach to the existing provider when possible. You can also add `LatitudeSpanProcessor` explicitly alongside existing processors. See the [TypeScript SDK](typescript) or [Python SDK](python) reference for advanced setup.
 
 ## Supported Integrations
 

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -105,10 +105,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="Python">
         ```python
         import json
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         import boto3
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["bedrock"],

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -69,13 +69,13 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import {
           BedrockRuntimeClient,
           InvokeModelCommand,
         } from "@aws-sdk/client-bedrock-runtime"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["bedrock"],

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -96,10 +96,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from anthropic import Anthropic
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["anthropic"],

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -69,10 +69,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import Anthropic from "@anthropic-ai/sdk"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["anthropic"],

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -71,10 +71,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { AzureOpenAI } from "openai"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["openai"],

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -101,10 +101,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from openai import AzureOpenAI
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["openai"],

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -69,10 +69,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { CohereClient } from "cohere-ai"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["cohere"],

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -95,10 +95,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         import cohere
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["cohere"],

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -96,10 +96,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from google.cloud import aiplatform
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["aiplatform"],

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -69,10 +69,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { PredictionServiceClient } from "@google-cloud/aiplatform"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["aiplatform"],

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -99,10 +99,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from openai import OpenAI
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["openai"],

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -73,10 +73,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import OpenAI from "openai"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["openai"],

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -69,10 +69,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import Together from "together-ai"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["togetherai"],

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -95,10 +95,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         from together import Together
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["togetherai"],

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -69,10 +69,10 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
     <Tabs>
       <Tab title="TypeScript">
         ```ts
-        import { initLatitude, capture } from "@latitude-data/telemetry"
+        import { Latitude, capture } from "@latitude-data/telemetry"
         import { VertexAI } from "@google-cloud/vertexai"
 
-        const latitude = initLatitude({
+        const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: ["vertexai"],

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -96,11 +96,11 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import init_latitude, capture
+        from latitude_telemetry import Latitude, capture
         import vertexai
         from vertexai.generative_models import GenerativeModel
 
-        latitude = init_latitude(
+        latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
             instrumentations=["vertexai"],

--- a/docs/telemetry/python.md
+++ b/docs/telemetry/python.md
@@ -17,13 +17,13 @@ Requires Python 3.11+.
 
 ## Bootstrap (Recommended)
 
-The fastest way to start. One function sets up a complete OpenTelemetry pipeline with LLM auto-instrumentation and the Latitude exporter:
+The fastest way to start. One class sets up a complete OpenTelemetry pipeline with LLM auto-instrumentation and the Latitude exporter:
 
 ```python
-from latitude_telemetry import init_latitude
+from latitude_telemetry import Latitude
 from openai import OpenAI
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
     instrumentations=["openai"],
@@ -48,9 +48,9 @@ Auto-instrumentation traces LLM calls without `capture()`. Use `capture()` when 
 - **Filter and analyze**: Use tags and metadata to filter traces in Latitude
 
 ```python
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
     instrumentations=["openai"],
@@ -89,13 +89,14 @@ latitude.shutdown()
 If your app already uses OpenTelemetry, add Latitude alongside your existing processors:
 
 ```python
+from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
 
 provider = TracerProvider()
 provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
 
-provider.register()
+trace.set_tracer_provider(provider)
 
 register_latitude_instrumentations(
     instrumentations=["openai"],
@@ -111,37 +112,44 @@ For examples of integrating with **Datadog**, **Sentry**, or other observability
 
 ```python
 from latitude_telemetry import (
-    init_latitude,
+    Latitude,
+    LatitudeOptions,
     LatitudeSpanProcessor,
     capture,
     register_latitude_instrumentations,
 )
 ```
 
-### `init_latitude(api_key, project_slug, **options)`
+### `Latitude(**options)`
 
-Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export.
+Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export. If an OpenTelemetry provider is already registered, Latitude attaches its span processor to that provider instead of replacing it.
 
 ```python
-def init_latitude(
-    api_key: str,
-    project_slug: str,
-    instrumentations: list[str] | None = None,
-    disable_redact: bool = False,
-    disable_batch: bool = False,
-    disable_smart_filter: bool = False,
-    should_export_span: Callable[[ReadableSpan], bool] | None = None,
-    blocked_instrumentation_scopes: list[str] | None = None,
-) -> dict:
-    ...
+class Latitude:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        project_slug: str,
+        instrumentations: list[str] | None = None,
+        service_name: str | None = None,
+        disable_batch: bool = False,
+        disable_smart_filter: bool = False,
+        should_export_span: Callable[[ReadableSpan], bool] | None = None,
+        blocked_instrumentation_scopes: list[str] | None = None,
+        disable_redact: bool = False,
+        redact: RedactSpanProcessorOptions | None = None,
+        exporter: SpanExporter | None = None,
+        tracer_provider: TracerProvider | None = None,
+    ):
+        ...
 
-# Returns:
-# {
-#     "provider": TracerProvider,
-#     "flush": Callable[[], None],
-#     "shutdown": Callable[[], None],
-# }
+    provider: TracerProvider
+    def flush(self) -> None: ...
+    def shutdown(self) -> None: ...
 ```
+
+`init_latitude()` remains available as a backwards-compatible wrapper that returns `{"provider", "flush", "shutdown"}`.
 
 ### `capture(name, fn, options=None)`
 
@@ -195,6 +203,8 @@ class LatitudeSpanProcessorOptions:
     disable_smart_filter: bool = False
     should_export_span: Callable[[ReadableSpan], bool] | None = None
     blocked_instrumentation_scopes: tuple[str, ...] = ()
+    exporter: SpanExporter | None = None
+    service_name: str | None = None
 ```
 
 ### `register_latitude_instrumentations(instrumentations, tracer_provider)`
@@ -288,7 +298,7 @@ processor = LatitudeSpanProcessor(
 ### Spans not appearing in Latitude
 
 1. **Check API key and project slug**: Must be non-empty strings.
-2. **Verify instrumentations are registered**: Use `register_latitude_instrumentations()`.
+2. **Verify instrumentations are registered**: Create `Latitude(...)` before importing or constructing clients when possible, or use `register_latitude_instrumentations()` for manual setups.
 3. **Flush before exit**: Call `latitude.flush()` or `provider.force_flush()`.
 4. **Check smart filter**: Only LLM spans are exported by default. Use `disable_smart_filter=True` to export all spans.
 5. **Ensure `capture()` wraps the code that creates spans**: `capture()` itself doesn't create spans; it only attaches context.
@@ -315,4 +325,4 @@ set_global_textmap(
 )
 ```
 
-`init_latitude()` does this automatically. For shared-provider setups, your existing OTel setup should already have this.
+`Latitude(...)` does this automatically when it owns the provider. For shared-provider setups, your existing OTel setup should already have this.

--- a/docs/telemetry/typescript.md
+++ b/docs/telemetry/typescript.md
@@ -15,12 +15,12 @@ npm install @latitude-data/telemetry
 
 ## Bootstrap (Recommended)
 
-The fastest way to start. One function sets up a complete OpenTelemetry pipeline with LLM auto-instrumentation and the Latitude exporter:
+The fastest way to start. One class detects an existing OpenTelemetry pipeline (Sentry, Datadog, New Relic, Honeycomb, etc.) or creates one when none exists, then adds LLM auto-instrumentation and the Latitude exporter:
 
 ```ts
-import { initLatitude } from "@latitude-data/telemetry"
+import { Latitude } from "@latitude-data/telemetry"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
@@ -36,10 +36,11 @@ const response = await openai.chat.completions.create({
 await latitude.shutdown()
 ```
 
-`initLatitude` returns **immediately**. Instrumentation registration happens in the background. This avoids top-level await issues in CommonJS environments while still supporting ESM.
+`new Latitude()` returns **immediately**. Instrumentation registration happens in the background. This avoids top-level await issues in CommonJS environments while still supporting ESM.
 
 - **Fire-and-forget**: Start using your LLM clients right away. Early spans are captured once instrumentations finish registering.
 - **Optional `await latitude.ready`**: If you need instrumentations fully registered before making LLM calls, await the `ready` promise.
+- **Existing tracing SDKs**: Initialize Sentry or another tracing SDK first, then construct `new Latitude()`. Latitude attaches its span processor to the existing provider when possible. `latitude.shutdown()` only shuts down Latitude-owned processing and does not shut down the other SDK.
 
 ## Using `capture()` for Context
 
@@ -51,9 +52,9 @@ Auto-instrumentation traces LLM calls without `capture()`. Use `capture()` when 
 - **Filter and analyze**: Use tags and metadata to filter traces in Latitude
 
 ```ts
-import { initLatitude, capture } from "@latitude-data/telemetry"
+import { Latitude, capture } from "@latitude-data/telemetry"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
@@ -89,9 +90,33 @@ await latitude.shutdown()
 | `metadata` | Shallow merge |
 | `tags` | Append and dedupe, preserving order |
 
-## Existing OpenTelemetry Setup (Advanced)
+## Existing Sentry or OpenTelemetry Setup
 
-If your app already uses OpenTelemetry, add Latitude alongside your existing processors:
+For Sentry, Datadog, New Relic, Honeycomb, and other OpenTelemetry-compatible SDKs, initialize the existing SDK first and construct `new Latitude()` second. Latitude detects the installed provider and attaches its processor when possible without replacing the existing SDK's context manager, propagator, sampler, or processors:
+
+```ts
+import * as Sentry from "@sentry/node"
+import { Latitude } from "@latitude-data/telemetry"
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN!,
+  tracesSampleRate: 1.0,
+})
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+})
+
+await latitude.ready
+
+// LLM spans are exported to both Sentry and Latitude.
+await latitude.flush()
+await latitude.shutdown()
+```
+
+If you want full control over provider construction, add Latitude alongside your existing processors explicitly:
 
 ```ts
 import { NodeSDK } from "@opentelemetry/sdk-node"
@@ -118,25 +143,25 @@ await registerLatitudeInstrumentations({
 })
 ```
 
-For examples of integrating with **Datadog**, **Sentry**, or other observability platforms, see the [OpenTelemetry Exporter](otel-exporter) guide. That guide also covers connecting from **any language** beyond TypeScript and Python.
+For examples of integrating with **Datadog**, **Sentry**, **New Relic**, **Honeycomb**, or other observability platforms, see the [OpenTelemetry Exporter](otel-exporter) guide. That guide also covers connecting from **any language** beyond TypeScript and Python.
 
 ## Public API Reference
 
 ```ts
 import {
-  initLatitude,
+  Latitude,
   LatitudeSpanProcessor,
   capture,
   registerLatitudeInstrumentations,
 } from "@latitude-data/telemetry"
 ```
 
-### `initLatitude(options)`
+### `new Latitude(options)`
 
 Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export.
 
 ```ts
-type InitLatitudeOptions = {
+type LatitudeOptions = {
   apiKey: string
   projectSlug: string
   instrumentations?: InstrumentationType[]
@@ -148,10 +173,12 @@ type InitLatitudeOptions = {
   disableRedact?: boolean
   redact?: RedactSpanProcessorOptions
   exporter?: SpanExporter
+  tracerProvider?: TracerProvider
 }
 
-function initLatitude(options: InitLatitudeOptions): {
-  provider: NodeTracerProvider
+class Latitude {
+  constructor(options: LatitudeOptions)
+  provider: TracerProvider
   ready: Promise<void>
   flush(): Promise<void>
   shutdown(): Promise<void>
@@ -327,4 +354,4 @@ import { context } from "@opentelemetry/api"
 context.setGlobalContextManager(new AsyncLocalStorageContextManager())
 ```
 
-`initLatitude()` does this automatically. For shared-provider setups, your existing OTel setup should already have this.
+`new Latitude()` does this automatically. For shared-provider setups, your existing OTel setup should already have this.

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0a5] - 2026-05-13
+
 ### Added
 
 - **Class-based bootstrap API** — `Latitude(...)` is now the primary entry point, matching the TypeScript SDK. It exposes `.provider`, `.flush()`, and `.shutdown()`, attaches to an existing OpenTelemetry provider when one is registered, and keeps `init_latitude()` as a backwards-compatible wrapper.
+
+### Changed
+
+- **Existing OpenTelemetry provider coexistence** — `Latitude(...)` attaches the Latitude span processor to a registered or explicitly passed provider when possible instead of replacing the application's provider or propagator setup.
+- **`service_name` ownership is provider-aware** — when Latitude creates its own provider, `service_name` is applied to the provider resource as `service.name`; when Latitude attaches to an existing provider, the host SDK remains the source of truth for `service.name`.
+
+### Fixed
+
+- **Provider detection no longer depends on private OpenTelemetry globals** — the SDK now uses the public tracer provider API and treats proxy/no-op providers as unregistered providers.
 
 ## [3.0.0a4] - 2026-05-08
 

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Class-based bootstrap API** — `Latitude(...)` is now the primary entry point, matching the TypeScript SDK. It exposes `.provider`, `.flush()`, and `.shutdown()`, attaches to an existing OpenTelemetry provider when one is registered, and keeps `init_latitude()` as a backwards-compatible wrapper.
+
 ## [3.0.0a4] - 2026-05-08
 
 ### Changed
@@ -17,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **OpenAI Agents SDK auto-instrumentation** — new `"openai-agents"` instrumentation type wires `openinference-instrumentation-openai-agents` (Arize OpenInference) into the SDK. Spans cover agent runs, generations, responses, function calls, handoffs, and guardrails. Pass `instrumentations=["openai-agents"]` to `init_latitude()` and install the `openai-agents` package in your project.
+- **OpenAI Agents SDK auto-instrumentation** — new `"openai-agents"` instrumentation type wires `openinference-instrumentation-openai-agents` (Arize OpenInference) into the SDK. Spans cover agent runs, generations, responses, function calls, handoffs, and guardrails. Pass `instrumentations=["openai-agents"]` to `Latitude(...)` and install the `openai-agents` package in your project.
 
 
 

--- a/packages/telemetry/python/README.md
+++ b/packages/telemetry/python/README.md
@@ -14,12 +14,12 @@ Requires Python 3.11+.
 
 ### Bootstrap (Recommended)
 
-The fastest way to start tracing your LLM calls. One function sets up everything:
+The fastest way to start tracing your LLM calls. One class sets up everything:
 
 ```python
-from latitude_telemetry import init_latitude
+from latitude_telemetry import Latitude
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
     instrumentations=["openai"],  # Auto-instrument OpenAI, Anthropic, etc.
@@ -54,6 +54,7 @@ latitude.shutdown()
 If your app already uses OpenTelemetry, add Latitude alongside your existing setup:
 
 ```python
+from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
 
@@ -62,7 +63,7 @@ provider = TracerProvider()
 provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
 # Add your other processors (Datadog, console exporter, etc.)
 
-provider.register()
+trace.set_tracer_provider(provider)
 
 # Enable LLM auto-instrumentation
 register_latitude_instrumentations(
@@ -103,9 +104,9 @@ You don't need `capture()` to get started—auto-instrumentation handles LLM cal
 ### Example
 
 ```python
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
     instrumentations=["openai"],
@@ -130,7 +131,7 @@ latitude.shutdown()
 
 ## Key Concepts
 
-- **`init_latitude()`** — The primary way to use Latitude. Bootstraps a complete OpenTelemetry setup with LLM auto-instrumentation and the Latitude exporter. Best for most applications.
+- **`Latitude`** — The primary way to use Latitude. Bootstraps a complete OpenTelemetry setup with LLM auto-instrumentation and the Latitude exporter, attaching to an existing provider when one is already registered.
 - **`LatitudeSpanProcessor`** — For advanced use cases where you already have an OpenTelemetry setup. Exports spans to Latitude alongside your existing observability stack.
 - **`register_latitude_instrumentations()`** — Registers LLM auto-instrumentations (OpenAI, Anthropic, etc.) when using the advanced setup with your own provider.
 - **`capture()`** — Optional. Wraps your code to attach Latitude context (tags, user_id, session_id, metadata) to all spans created inside the callback. Use this when you want to group traces by user, session, or add business context.
@@ -150,37 +151,44 @@ Latitude Telemetry is built entirely on OpenTelemetry standards. When you're rea
 
 ```python
 from latitude_telemetry import (
-    init_latitude,
+    Latitude,
+    LatitudeOptions,
     LatitudeSpanProcessor,
     capture,
     register_latitude_instrumentations,
 )
 ```
 
-### `init_latitude(api_key, project_slug, **options)`
+### `Latitude(**options)`
 
-The primary entry point. Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export.
+The primary entry point. Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export. If an OpenTelemetry provider is already registered, Latitude attaches its span processor to that provider instead of replacing it.
 
 ```python
-def init_latitude(
-    api_key: str,
-    project_slug: str,
-    instrumentations: list[str] | None = None,
-    disable_redact: bool = False,
-    disable_batch: bool = False,
-    disable_smart_filter: bool = False,
-    should_export_span: Callable[[ReadableSpan], bool] | None = None,
-    blocked_instrumentation_scopes: list[str] | None = None,
-) -> dict:
-    ...
+class Latitude:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        project_slug: str,
+        instrumentations: list[str] | None = None,
+        service_name: str | None = None,
+        disable_batch: bool = False,
+        disable_smart_filter: bool = False,
+        should_export_span: Callable[[ReadableSpan], bool] | None = None,
+        blocked_instrumentation_scopes: list[str] | None = None,
+        disable_redact: bool = False,
+        redact: RedactSpanProcessorOptions | None = None,
+        exporter: SpanExporter | None = None,
+        tracer_provider: TracerProvider | None = None,
+    ):
+        ...
 
-# Returns:
-# {
-#     "provider": TracerProvider,  # Access to underlying provider for advanced use
-#     "flush": Callable[[], None],   # Flush spans to Latitude
-#     "shutdown": Callable[[], None],  # Graceful shutdown
-# }
+    provider: TracerProvider
+    def flush(self) -> None: ...
+    def shutdown(self) -> None: ...
 ```
+
+`init_latitude()` remains available as a backwards-compatible wrapper that returns `{"provider", "flush", "shutdown"}`.
 
 ### `LatitudeSpanProcessor`
 
@@ -203,6 +211,8 @@ class LatitudeSpanProcessorOptions:
     disable_smart_filter: bool = False
     should_export_span: Callable[[ReadableSpan], bool] | None = None
     blocked_instrumentation_scopes: tuple[str, ...] = ()
+    exporter: SpanExporter | None = None
+    service_name: str | None = None
 ```
 
 ### `capture(name, fn, options=None)`
@@ -343,7 +353,7 @@ processor = LatitudeSpanProcessor(
 ### Spans not appearing in Latitude
 
 1. **Check API key and project slug** — Must be non-empty strings
-2. **Verify instrumentations are registered** — Use `register_latitude_instrumentations()`
+2. **Verify instrumentations are registered** — Create `Latitude(...)` before importing or constructing clients when possible, or use `register_latitude_instrumentations()` for manual setups
 3. **Flush before exit** — Call `latitude.flush()` or `provider.force_flush()`
 4. **Check smart filter** — Only LLM spans are exported by default. Use `disable_smart_filter=True` to export all spans
 5. **Ensure `capture()` wraps the code that creates spans** — `capture()` itself doesn't create spans; it only attaches context to spans created by instrumentations
@@ -370,7 +380,7 @@ set_global_textmap(
 )
 ```
 
-`init_latitude()` does this automatically. For shared-provider setups, your app's existing OTel setup should already have this.
+`Latitude(...)` does this automatically when it owns the provider. For shared-provider setups, your app's existing OTel setup should already have this.
 
 ## License
 

--- a/packages/telemetry/python/examples/README.md
+++ b/packages/telemetry/python/examples/README.md
@@ -125,7 +125,7 @@ uv run python examples/test_openai.py
 
 Each example should:
 
-1. Initialize telemetry with `init_latitude()`
+1. Initialize telemetry with `Latitude()`
 2. Wrap the LLM call with `@capture` decorator
 3. Print the response
 4. Send a trace to your local Latitude instance
@@ -133,9 +133,9 @@ Each example should:
 Example pattern:
 
 ```python
-from latitude_telemetry import init_latitude, capture
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -149,7 +149,7 @@ def test_function():
 
 if __name__ == "__main__":
     test_function()
-    latitude["flush"]()
+    latitude.flush()
 ```
 
 Check the Latitude dashboard to verify:

--- a/packages/telemetry/python/examples/test_aleph_alpha.py
+++ b/packages/telemetry/python/examples/test_aleph_alpha.py
@@ -13,10 +13,10 @@ import os
 
 from aleph_alpha_client import Client, CompletionRequest, Prompt
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["aleph_alpha"],
@@ -40,4 +40,4 @@ def test_aleph_alpha_completion():
 
 if __name__ == "__main__":
     test_aleph_alpha_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_anthropic.py
+++ b/packages/telemetry/python/examples/test_anthropic.py
@@ -13,10 +13,10 @@ import os
 
 from anthropic import Anthropic
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["anthropic"],
@@ -39,4 +39,4 @@ def test_anthropic_completion():
 
 if __name__ == "__main__":
     test_anthropic_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_azure.py
+++ b/packages/telemetry/python/examples/test_azure.py
@@ -12,10 +12,10 @@ Install: uv add openai
 
 import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing openai so instrumentation can patch it
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -48,4 +48,4 @@ def test_azure_completion():
 
 if __name__ == "__main__":
     test_azure_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_bedrock.py
+++ b/packages/telemetry/python/examples/test_bedrock.py
@@ -16,10 +16,10 @@ import os
 
 import boto3
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["bedrock"],
@@ -49,4 +49,4 @@ def test_bedrock_completion():
 
 if __name__ == "__main__":
     test_bedrock_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_capture_nesting.py
+++ b/packages/telemetry/python/examples/test_capture_nesting.py
@@ -18,10 +18,10 @@ import os
 
 from openai import OpenAI
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -147,5 +147,5 @@ if __name__ == "__main__":
     result2 = test_nested_capture_with_callback()
     print(f"Callback result: {result2}")
 
-    latitude["flush"]()
+    latitude.flush()
     print("\nDone! Check Latitude dashboard for context merging verification.")

--- a/packages/telemetry/python/examples/test_cohere.py
+++ b/packages/telemetry/python/examples/test_cohere.py
@@ -13,10 +13,10 @@ import os
 
 import cohere
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["cohere"],
@@ -39,4 +39,4 @@ def test_cohere_completion():
 
 if __name__ == "__main__":
     test_cohere_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_crewai.py
+++ b/packages/telemetry/python/examples/test_crewai.py
@@ -13,11 +13,11 @@ import os
 
 from crewai import Agent, Crew, Task
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
 # Note: CrewAI uses OpenAI by default, so we instrument both
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["crewai", "openai"],
@@ -52,4 +52,4 @@ def test_crewai_crew():
 
 if __name__ == "__main__":
     test_crewai_crew()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_dspy.py
+++ b/packages/telemetry/python/examples/test_dspy.py
@@ -10,10 +10,10 @@ Install: uv add dspy
 
 import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing dspy so instrumentation can patch it
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["dspy"],
@@ -48,4 +48,4 @@ def test_dspy_completion():
 
 if __name__ == "__main__":
     test_dspy_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_gemini.py
+++ b/packages/telemetry/python/examples/test_gemini.py
@@ -10,10 +10,10 @@ Install: uv add google-genai
 
 import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing google.genai so instrumentation can patch it
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["google_generativeai"],
@@ -38,4 +38,4 @@ def test_gemini_completion():
 
 if __name__ == "__main__":
     test_gemini_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_groq.py
+++ b/packages/telemetry/python/examples/test_groq.py
@@ -12,10 +12,10 @@ import os
 
 from groq import Groq
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["groq"],
@@ -38,4 +38,4 @@ def test_groq_completion():
 
 if __name__ == "__main__":
     test_groq_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_haystack.py
+++ b/packages/telemetry/python/examples/test_haystack.py
@@ -14,10 +14,10 @@ from haystack import Pipeline
 from haystack.components.builders import PromptBuilder
 from haystack.components.generators import OpenAIGenerator
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["haystack"],
@@ -42,4 +42,4 @@ def test_haystack_completion():
 
 if __name__ == "__main__":
     test_haystack_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_langchain.py
+++ b/packages/telemetry/python/examples/test_langchain.py
@@ -10,10 +10,10 @@ Install: uv add langchain-core langchain-openai
 
 import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing langchain so instrumentation can patch it
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["langchain"],
@@ -38,4 +38,4 @@ def test_langchain_completion():
 
 if __name__ == "__main__":
     test_langchain_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_litellm.py
+++ b/packages/telemetry/python/examples/test_litellm.py
@@ -12,10 +12,10 @@ import os
 
 import litellm
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["litellm"],
@@ -37,4 +37,4 @@ def test_litellm_completion():
 
 if __name__ == "__main__":
     test_litellm_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_llamaindex.py
+++ b/packages/telemetry/python/examples/test_llamaindex.py
@@ -12,10 +12,10 @@ import os
 
 from llama_index.llms.openai import OpenAI
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["llamaindex"],
@@ -34,4 +34,4 @@ def test_llamaindex_completion():
 
 if __name__ == "__main__":
     test_llamaindex_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_manual_instrumentation.py
+++ b/packages/telemetry/python/examples/test_manual_instrumentation.py
@@ -19,10 +19,10 @@ import os
 
 from openai import OpenAI
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -54,7 +54,7 @@ def agent_with_manual_spans():
     print(f"DEBUG agent_with_manual_spans: current_span={current_span}, is_recording={is_recording}")
 
     # Get tracer from the provider - this is a standard OTel tracer
-    tracer = latitude["provider"].get_tracer("custom.manual.instrumentation")
+    tracer = latitude.provider.get_tracer("custom.manual.instrumentation")
 
     # Create a custom span for a non-LLM operation
     # This span will receive latitude.tags, latitude.metadata, etc.
@@ -108,7 +108,7 @@ def outer_with_manual_spans():
     is_recording = current_span.is_recording() if current_span else False
     print(f"DEBUG outer_with_manual_spans: current_span={current_span}, is_recording={is_recording}")
 
-    tracer = latitude["provider"].get_tracer("custom.manual.instrumentation")
+    tracer = latitude.provider.get_tracer("custom.manual.instrumentation")
 
     # Manual span in outer context
     with tracer.start_as_current_span("outer.preprocess") as span:
@@ -140,7 +140,7 @@ def inner_with_manual_spans():
     is_recording = current_span.is_recording() if current_span else False
     print(f"DEBUG inner_with_manual_spans: current_span={current_span}, is_recording={is_recording}")
 
-    tracer = latitude["provider"].get_tracer("custom.manual.instrumentation")
+    tracer = latitude.provider.get_tracer("custom.manual.instrumentation")
 
     # Manual span in inner context
     with tracer.start_as_current_span("inner.llm_prep") as span:
@@ -167,7 +167,7 @@ def test_manual_spans_with_callback():
         is_recording = current_span.is_recording() if current_span else False
         print(f"DEBUG callback agent_logic: current_span={current_span}, is_recording={is_recording}")
 
-        tracer = latitude["provider"].get_tracer("custom.manual.instrumentation")
+        tracer = latitude.provider.get_tracer("custom.manual.instrumentation")
 
         # Manual span in callback
         with tracer.start_as_current_span("callback.data_fetch") as span:
@@ -215,7 +215,7 @@ if __name__ == "__main__":
     print("Expected spans: callback.data_fetch (with latitude.* attributes)")
 
     print("\nFlushing telemetry...")
-    latitude["flush"]()
+    latitude.flush()
 
     print("\n" + "=" * 60)
     print("Done! Check Latitude dashboard for verification:")

--- a/packages/telemetry/python/examples/test_mistral.py
+++ b/packages/telemetry/python/examples/test_mistral.py
@@ -10,10 +10,10 @@ Install: uv add mistralai
 
 import os
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing mistralai so instrumentation can patch it
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["mistralai"],
@@ -41,4 +41,4 @@ def test_mistral_completion():
 
 if __name__ == "__main__":
     test_mistral_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_ollama.py
+++ b/packages/telemetry/python/examples/test_ollama.py
@@ -14,10 +14,10 @@ import os
 
 import ollama
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["ollama"],
@@ -37,4 +37,4 @@ def test_ollama_completion():
 
 if __name__ == "__main__":
     test_ollama_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_openai.py
+++ b/packages/telemetry/python/examples/test_openai.py
@@ -13,10 +13,10 @@ import os
 
 from openai import OpenAI
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -112,4 +112,4 @@ if __name__ == "__main__":
     test_openai_completion()
     test_openai_streaming_completion()
     test_openai_completion_callback()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_openai_agents.py
+++ b/packages/telemetry/python/examples/test_openai_agents.py
@@ -14,10 +14,10 @@ import os
 
 from agents import Agent, Runner, function_tool
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai-agents"],
@@ -59,4 +59,4 @@ def test_openai_agents_run():
 if __name__ == "__main__":
     output = test_openai_agents_run()
     print(f"Final output: {output}")
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_openai_responses.py
+++ b/packages/telemetry/python/examples/test_openai_responses.py
@@ -13,9 +13,9 @@ import os
 
 from openai import OpenAI
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["openai"],
@@ -77,4 +77,4 @@ def test_openai_responses_streaming():
 if __name__ == "__main__":
     test_openai_responses()
     test_openai_responses_streaming()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_replicate.py
+++ b/packages/telemetry/python/examples/test_replicate.py
@@ -12,10 +12,10 @@ import os
 
 import replicate
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["replicate"],
@@ -39,4 +39,4 @@ def test_replicate_completion():
 
 if __name__ == "__main__":
     test_replicate_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_sagemaker.py
+++ b/packages/telemetry/python/examples/test_sagemaker.py
@@ -16,10 +16,10 @@ import os
 
 import boto3
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["sagemaker"],
@@ -58,4 +58,4 @@ def test_sagemaker_completion():
 
 if __name__ == "__main__":
     test_sagemaker_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_together.py
+++ b/packages/telemetry/python/examples/test_together.py
@@ -12,10 +12,10 @@ import os
 
 from together import Together
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["together"],
@@ -38,4 +38,4 @@ def test_together_completion():
 
 if __name__ == "__main__":
     test_together_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_transformers.py
+++ b/packages/telemetry/python/examples/test_transformers.py
@@ -11,10 +11,10 @@ import os
 
 from transformers import pipeline
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["transformers"],
@@ -38,4 +38,4 @@ def test_transformers_completion():
 
 if __name__ == "__main__":
     test_transformers_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_vertex.py
+++ b/packages/telemetry/python/examples/test_vertex.py
@@ -14,10 +14,10 @@ import os
 import vertexai
 from vertexai.generative_models import GenerativeModel
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["vertexai"],
@@ -41,4 +41,4 @@ def test_vertex_completion():
 
 if __name__ == "__main__":
     test_vertex_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/examples/test_watsonx.py
+++ b/packages/telemetry/python/examples/test_watsonx.py
@@ -15,10 +15,10 @@ import os
 from ibm_watsonx_ai.foundation_models import Model
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 
-from latitude_telemetry import capture, init_latitude
+from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry pointing to local instance
-latitude = init_latitude(
+latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations=["watsonx"],
@@ -51,4 +51,4 @@ def test_watsonx_completion():
 
 if __name__ == "__main__":
     test_watsonx_completion()
-    latitude["flush"]()
+    latitude.flush()

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a4"
+version = "3.0.0a5"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/__init__.py
+++ b/packages/telemetry/python/src/latitude_telemetry/__init__.py
@@ -5,9 +5,9 @@ Instruments AI provider calls and forwards traces to Latitude.
 Built on OpenTelemetry.
 
 Example (Bootstrap - Recommended):
-    from latitude_telemetry import init_latitude, capture
+    from latitude_telemetry import Latitude, capture
 
-    latitude = init_latitude(
+    latitude = Latitude(
         api_key="your-api-key",
         project_slug="my-project",
         instrumentations=["openai", "anthropic"],
@@ -22,15 +22,16 @@ Example (Bootstrap - Recommended):
     # Or with the functional pattern:
     result = capture("agent-run", lambda: agent.process(input), {"tags": ["prod"]})
 
-    await latitude.shutdown()
+    latitude.shutdown()
 
 Example (Advanced - Existing OTel Setup):
+    from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
     from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
 
     provider = TracerProvider()
     provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
-    provider.register()
+    trace.set_tracer_provider(provider)
 
     register_latitude_instrumentations(["openai"], provider)
 """
@@ -40,6 +41,8 @@ from latitude_telemetry.sdk import (
     ContextOptions,
     InitLatitudeOptions,
     InstrumentationType,
+    Latitude,
+    LatitudeOptions,
     LatitudeSpanProcessorOptions,
     SmartFilterOptions,
     capture,
@@ -66,6 +69,7 @@ from latitude_telemetry.telemetry.span_filter import (
 
 __all__ = [
     # New SDK API (OpenTelemetry-first)
+    "Latitude",
     "init_latitude",
     "capture",
     "register_latitude_instrumentations",
@@ -74,6 +78,7 @@ __all__ = [
     "ContextOptions",
     "InitLatitudeOptions",
     "InstrumentationType",
+    "LatitudeOptions",
     "LatitudeSpanProcessorOptions",
     "SmartFilterOptions",
     # Span Processor (composable mode)

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/__init__.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/__init__.py
@@ -3,12 +3,13 @@ SDK module public exports.
 """
 
 from latitude_telemetry.sdk.context import capture, get_latitude_context
-from latitude_telemetry.sdk.init import init_latitude
+from latitude_telemetry.sdk.init import Latitude, init_latitude
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
 from latitude_telemetry.sdk.types import (
     ContextOptions,
     InitLatitudeOptions,
     InstrumentationType,
+    LatitudeOptions,
     LatitudeSpanProcessorOptions,
     SmartFilterOptions,
 )
@@ -16,11 +17,13 @@ from latitude_telemetry.sdk.types import (
 __all__ = [
     "capture",
     "get_latitude_context",
+    "Latitude",
     "init_latitude",
     "register_latitude_instrumentations",
     "ContextOptions",
     "InitLatitudeOptions",
     "InstrumentationType",
+    "LatitudeOptions",
     "LatitudeSpanProcessorOptions",
     "SmartFilterOptions",
 ]

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -1,25 +1,33 @@
 """
-Bootstrap function for Latitude Telemetry SDK.
+Bootstrap class and compatibility function for Latitude Telemetry SDK.
 """
 
 import atexit
+import logging
 import signal
 import sys
-from typing import Callable, TypedDict
+from typing import Callable, TypedDict, cast
 
 from opentelemetry import trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
+from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
 from latitude_telemetry.sdk.types import InstrumentationType, SmartFilterOptions
 from latitude_telemetry.telemetry.latitude_span_processor import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
+from latitude_telemetry.telemetry.redact_span_processor import RedactSpanProcessorOptions
+
+logger = logging.getLogger(__name__)
 
 SERVICE_NAME_DEFAULT = "latitude-telemetry-python"
+
+_shutdown_handlers_registered = False
 
 
 class _InitLatitudeResult(TypedDict):
@@ -28,103 +36,162 @@ class _InitLatitudeResult(TypedDict):
     shutdown: Callable[[], None]
 
 
+def _get_registered_tracer_provider() -> TracerProvider | None:
+    registered_provider = cast(TracerProvider | None, getattr(trace, "_TRACER_PROVIDER", None))
+    if registered_provider is None or isinstance(registered_provider, NoOpTracerProvider):
+        return None
+
+    return registered_provider
+
+
+class Latitude:
+    """
+    Bootstrap Latitude telemetry with an OpenTelemetry-first API.
+
+    The class mirrors the TypeScript SDK: it detects an existing OpenTelemetry
+    tracer provider or creates one when none exists, attaches the Latitude span
+    processor, registers requested LLM instrumentations, and exposes `provider`,
+    `flush()`, and `shutdown()`.
+    """
+
+    provider: TracerProvider
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        project_slug: str,
+        instrumentations: list[InstrumentationType] | None = None,
+        disable_redact: bool = False,
+        redact: RedactSpanProcessorOptions | None = None,
+        disable_batch: bool = False,
+        disable_smart_filter: bool = False,
+        should_export_span: Callable[[ReadableSpan], bool] | None = None,
+        blocked_instrumentation_scopes: list[str] | None = None,
+        exporter: SpanExporter | None = None,
+        tracer_provider: TracerProvider | None = None,
+        service_name: str | None = None,
+    ):
+        if not api_key or not api_key.strip():
+            raise ValueError("[Latitude] api_key is required and cannot be empty")
+        if not project_slug or not project_slug.strip():
+            raise ValueError("[Latitude] project_slug is required and cannot be empty")
+
+        self._latitude_processor = LatitudeSpanProcessor(
+            api_key=api_key,
+            project_slug=project_slug,
+            options=LatitudeSpanProcessorOptions(
+                disable_batch=disable_batch,
+                disable_redact=disable_redact,
+                redact=redact,
+                disable_smart_filter=disable_smart_filter,
+                should_export_span=should_export_span,
+                blocked_instrumentation_scopes=tuple(blocked_instrumentation_scopes or []),
+                exporter=exporter,
+                service_name=service_name,
+            ),
+        )
+
+        existing_provider = tracer_provider or _get_registered_tracer_provider()
+        if existing_provider is not None:
+            existing_provider.add_span_processor(self._latitude_processor)
+            self.provider = existing_provider
+            self._owns_provider = False
+        else:
+            raw_service_name = service_name.strip() if service_name else ""
+            resource_service_name = raw_service_name or SERVICE_NAME_DEFAULT
+
+            set_global_textmap(CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()]))
+
+            provider = TracerProvider(
+                resource=Resource.create({SERVICE_NAME: resource_service_name}),
+            )
+            provider.add_span_processor(self._latitude_processor)
+            trace.set_tracer_provider(provider)
+
+            self.provider = provider
+            self._owns_provider = True
+
+        if instrumentations:
+            register_latitude_instrumentations(
+                instrumentations=instrumentations,
+                tracer_provider=self.provider,
+            )
+
+        self._register_shutdown_handlers()
+
+    def flush(self) -> None:
+        if self._owns_provider:
+            self.provider.force_flush()
+            return
+
+        self._latitude_processor.force_flush()
+
+    def shutdown(self) -> None:
+        if self._owns_provider:
+            self.provider.shutdown()
+            return
+
+        self._latitude_processor.shutdown()
+
+    def _register_shutdown_handlers(self) -> None:
+        global _shutdown_handlers_registered
+
+        if _shutdown_handlers_registered:
+            return
+
+        atexit.register(self.shutdown)
+
+        def _handle_signal(_signum: int, _frame: object) -> None:
+            try:
+                self.shutdown()
+            except Exception:
+                logger.exception("Error during Latitude Telemetry shutdown")
+            sys.exit(0)
+
+        signal.signal(signal.SIGTERM, _handle_signal)
+        signal.signal(signal.SIGINT, _handle_signal)
+        _shutdown_handlers_registered = True
+
+
 def init_latitude(
     api_key: str,
     project_slug: str,
     instrumentations: list[InstrumentationType] | None = None,
     disable_redact: bool = False,
+    redact: RedactSpanProcessorOptions | None = None,
     disable_batch: bool = False,
+    exporter: SpanExporter | None = None,
+    tracer_provider: TracerProvider | None = None,
+    service_name: str | None = None,
     **kwargs: SmartFilterOptions,
 ) -> _InitLatitudeResult:
     """
-    Bootstrap a complete OpenTelemetry setup with Latitude.
+    Compatibility wrapper around `Latitude`.
 
-    This is the recommended way to use Latitude Telemetry. It sets up:
-    - OpenTelemetry context manager for async propagation
-    - W3C trace context and baggage propagators
-    - TracerProvider with LatitudeSpanProcessor
-    - LLM auto-instrumentation for specified providers
-    - Graceful shutdown handlers
-
-    Args:
-        api_key: Your Latitude API key
-        project_slug: Your Latitude project slug
-        instrumentations: List of instrumentation types to enable (e.g., ["openai", "anthropic"])
-        disable_redact: Disable PII redaction (default: False)
-        disable_batch: Disable batching, send spans immediately (default: False)
-        **kwargs: Additional smart filter options (disable_smart_filter, should_export_span,
-            blocked_instrumentation_scopes)
-
-    Returns:
-        Object with provider, flush(), and shutdown() methods
-
-    Example:
-        latitude = init_latitude(
-            api_key="your-api-key",
-            project_slug="your-project",
-            instrumentations=["openai", "anthropic"],
-        )
-
-        # Your LLM calls are now traced
-        response = await openai.chat.completions.create(...)
-
-        await latitude.shutdown()
+    Prefer `Latitude(...)` for new code. This function keeps the existing dict
+    return shape for applications already using `init_latitude()`.
     """
-    if not api_key or not api_key.strip():
-        raise ValueError("[Latitude] api_key is required and cannot be empty")
-    if not project_slug or not project_slug.strip():
-        raise ValueError("[Latitude] project_slug is required and cannot be empty")
+    should_export_span = cast(Callable[[ReadableSpan], bool] | None, kwargs.get("should_export_span"))
+    blocked_instrumentation_scopes = cast(list[str] | None, kwargs.get("blocked_instrumentation_scopes"))
 
-    # Set up global propagator
-    set_global_textmap(CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()]))
-
-    provider = TracerProvider(
-        resource=Resource.create({SERVICE_NAME: SERVICE_NAME_DEFAULT}),
-    )
-
-    processor = LatitudeSpanProcessor(
+    latitude = Latitude(
         api_key=api_key,
         project_slug=project_slug,
-        options=LatitudeSpanProcessorOptions(
-            disable_batch=disable_batch,
-            disable_redact=disable_redact,
-            disable_smart_filter=kwargs.get("disable_smart_filter", False),  # type: ignore[arg-type]
-            should_export_span=kwargs.get("should_export_span"),  # type: ignore[arg-type]
-            blocked_instrumentation_scopes=tuple(kwargs.get("blocked_instrumentation_scopes", [])),  # type: ignore[arg-type]
-        ),
+        instrumentations=instrumentations,
+        disable_batch=disable_batch,
+        disable_redact=disable_redact,
+        redact=redact,
+        exporter=exporter,
+        tracer_provider=tracer_provider,
+        service_name=service_name,
+        disable_smart_filter=kwargs.get("disable_smart_filter", False),  # type: ignore[arg-type]
+        should_export_span=should_export_span,
+        blocked_instrumentation_scopes=blocked_instrumentation_scopes,
     )
 
-    provider.add_span_processor(processor)
-
-    # Set as global tracer provider so capture() can use it
-    trace.set_tracer_provider(provider)
-
-    if instrumentations:
-        register_latitude_instrumentations(
-            instrumentations=instrumentations,
-            tracer_provider=provider,
-        )
-
-    def flush() -> None:
-        provider.force_flush()
-
-    def shutdown() -> None:
-        provider.shutdown()
-
-    atexit.register(shutdown)
-
-    # Register SIGTERM handler for graceful shutdown in containers/Kubernetes
-    # atexit handlers don't fire on SIGTERM, so we need explicit signal handling
-    # Handler must call sys.exit(0) because Python signal handlers replace the
-    # default termination behavior - without exit, the process would continue running
-    def _handle_sigterm(_signum: int, _frame: object) -> None:
-        shutdown()
-        sys.exit(0)
-
-    signal.signal(signal.SIGTERM, _handle_sigterm)
-
     return {
-        "provider": provider,
-        "flush": flush,
-        "shutdown": shutdown,
+        "provider": latitude.provider,
+        "flush": latitude.flush,
+        "shutdown": latitude.shutdown,
     }

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -15,7 +15,7 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter
-from opentelemetry.trace import NoOpTracerProvider
+from opentelemetry.trace import NoOpTracerProvider, ProxyTracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
@@ -37,11 +37,24 @@ class _InitLatitudeResult(TypedDict):
 
 
 def _get_registered_tracer_provider() -> TracerProvider | None:
-    registered_provider = cast(TracerProvider | None, getattr(trace, "_TRACER_PROVIDER", None))
-    if registered_provider is None or isinstance(registered_provider, NoOpTracerProvider):
+    # `trace.get_tracer_provider()` returns the singleton ProxyTracerProvider when nothing has been
+    # explicitly registered, and the real provider once `trace.set_tracer_provider()` has been called.
+    # Using the public API instead of the module-private `_TRACER_PROVIDER` makes this resilient to
+    # OTel internal refactors.
+    provider = trace.get_tracer_provider()
+    if isinstance(provider, (ProxyTracerProvider, NoOpTracerProvider)):
         return None
 
-    return registered_provider
+    return cast(TracerProvider, provider)
+
+
+def _attach_span_processor(provider: object, processor: LatitudeSpanProcessor) -> bool:
+    add = getattr(provider, "add_span_processor", None)
+    if callable(add):
+        add(processor)
+        return True
+
+    return False
 
 
 class Latitude:
@@ -77,6 +90,14 @@ class Latitude:
         if not project_slug or not project_slug.strip():
             raise ValueError("[Latitude] project_slug is required and cannot be empty")
 
+        target_provider = tracer_provider or _get_registered_tracer_provider()
+
+        # `service_name` is a Latitude-owned-provider concern. When piggy-backing on an existing
+        # provider, the host's resource is the source of truth for `service.name` — overriding it
+        # would silently relabel spans the host SDK also processes. So we only pass `service_name`
+        # to the processor when Latitude will create + own its own provider.
+        processor_service_name = service_name if target_provider is None else None
+
         self._latitude_processor = LatitudeSpanProcessor(
             api_key=api_key,
             project_slug=project_slug,
@@ -88,26 +109,43 @@ class Latitude:
                 should_export_span=should_export_span,
                 blocked_instrumentation_scopes=tuple(blocked_instrumentation_scopes or []),
                 exporter=exporter,
-                service_name=service_name,
+                service_name=processor_service_name,
             ),
         )
 
-        existing_provider = tracer_provider or _get_registered_tracer_provider()
-        if existing_provider is not None:
-            existing_provider.add_span_processor(self._latitude_processor)
-            self.provider = existing_provider
+        attached = _attach_span_processor(target_provider, self._latitude_processor) if target_provider else False
+
+        if target_provider is not None and not attached:
+            source = (
+                "the provider passed via `tracer_provider`"
+                if tracer_provider is not None
+                else "the global OpenTelemetry provider"
+            )
+            logger.warning(
+                "[Latitude] Could not attach LatitudeSpanProcessor to %s: it does not expose "
+                "`add_span_processor`. Falling back to a Latitude-owned provider that is NOT "
+                "registered globally — instrumentations will still send spans to Latitude, but "
+                "the host SDK's spans will not. To fix, pass a provider exposing "
+                "`add_span_processor` (e.g. `opentelemetry.sdk.trace.TracerProvider`).",
+                source,
+            )
+
+        if target_provider is not None and attached:
+            self.provider = target_provider
             self._owns_provider = False
         else:
             raw_service_name = service_name.strip() if service_name else ""
             resource_service_name = raw_service_name or SERVICE_NAME_DEFAULT
 
-            set_global_textmap(CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()]))
+            if target_provider is None:
+                set_global_textmap(CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()]))
 
             provider = TracerProvider(
                 resource=Resource.create({SERVICE_NAME: resource_service_name}),
             )
             provider.add_span_processor(self._latitude_processor)
-            trace.set_tracer_provider(provider)
+            if target_provider is None:
+                trace.set_tracer_provider(provider)
 
             self.provider = provider
             self._owns_provider = True

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
@@ -4,7 +4,8 @@ Type definitions for the Latitude Telemetry SDK.
 
 from typing import Callable, Literal, Required, TypedDict
 
-from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
 
 from latitude_telemetry.telemetry.redact_span_processor import RedactSpanProcessorOptions
 
@@ -36,16 +37,25 @@ class ContextOptions(TypedDict, total=False):
     user_id: str
 
 
-class InitLatitudeOptions(SmartFilterOptions, total=False):
+class LatitudeOptions(SmartFilterOptions, total=False):
     api_key: Required[str]
     project_slug: Required[str]
     instrumentations: list[InstrumentationType]
     disable_redact: bool
     redact: RedactSpanProcessorOptions
     disable_batch: bool
+    exporter: SpanExporter
+    tracer_provider: TracerProvider
+    service_name: str
+
+
+class InitLatitudeOptions(LatitudeOptions, total=False):
+    pass
 
 
 class LatitudeSpanProcessorOptions(SmartFilterOptions, total=False):
     disable_redact: bool
     redact: RedactSpanProcessorOptions
     disable_batch: bool
+    exporter: SpanExporter
+    service_name: str

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
@@ -6,12 +6,14 @@ without replacing your current telemetry setup.
 """
 
 import json
+import typing
 from collections.abc import Callable
 from dataclasses import dataclass
 
 from opentelemetry.context import Context
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter, SpanExportResult
 
 from latitude_telemetry.constants import ATTRIBUTES
 from latitude_telemetry.env import env
@@ -27,6 +29,52 @@ from latitude_telemetry.telemetry.span_filter import (
     RedactThenExportSpanProcessor,
     build_should_export_span,
 )
+
+
+class _ResourceOverrideSpan:
+    """
+    Lightweight ReadableSpan-shaped wrapper that delegates everything to the underlying span
+    except `resource`, which is replaced with a merged copy carrying the Latitude override.
+
+    Used by `_ServiceNameResourceExporter` so we don't mutate the original span (which is shared
+    with other span processors on the host TracerProvider).
+    """
+
+    def __init__(self, span: ReadableSpan, resource: Resource) -> None:
+        self._span = span
+        self._resource = resource
+
+    @property
+    def resource(self) -> Resource:
+        return self._resource
+
+    def __getattr__(self, name: str) -> typing.Any:
+        return getattr(self._span, name)
+
+
+class _ServiceNameResourceExporter(SpanExporter):
+    """
+    Wraps a SpanExporter and rewrites each exported span's resource to carry the configured
+    `service.name`. `service.name` is a resource attribute per OTel semantic conventions, not a
+    span attribute — exporting through this wrapper keeps Latitude spec-compliant even when
+    piggy-backing on a host SDK's TracerProvider (whose resource we can't change).
+    """
+
+    def __init__(self, inner: SpanExporter, service_name: str) -> None:
+        self._inner = inner
+        self._overlay = Resource.create({SERVICE_NAME: service_name})
+
+    def export(self, spans: typing.Sequence[ReadableSpan]) -> SpanExportResult:
+        overridden = [
+            typing.cast(ReadableSpan, _ResourceOverrideSpan(span, span.resource.merge(self._overlay))) for span in spans
+        ]
+        return self._inner.export(overridden)
+
+    def shutdown(self) -> None:
+        self._inner.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._inner.force_flush(timeout_millis)
 
 
 @dataclass
@@ -57,7 +105,7 @@ class LatitudeSpanProcessor(SpanProcessor):
     ):
         options = options or LatitudeSpanProcessorOptions()
 
-        exporter = options.exporter or create_exporter(
+        base_exporter = options.exporter or create_exporter(
             ExporterOptions(
                 api_key=api_key,
                 project_slug=project_slug,
@@ -65,6 +113,9 @@ class LatitudeSpanProcessor(SpanProcessor):
                 timeout=30,
             )
         )
+
+        raw_service_name = options.service_name.strip() if options.service_name else ""
+        exporter = _ServiceNameResourceExporter(base_exporter, raw_service_name) if raw_service_name else base_exporter
 
         if options.disable_redact:
             redact: RedactSpanProcessor | None = None
@@ -88,13 +139,7 @@ class LatitudeSpanProcessor(SpanProcessor):
         redact_then_export = RedactThenExportSpanProcessor(redact, batch_or_simple)
         self._tail: SpanProcessor = ExportFilterSpanProcessor(should_export, redact_then_export)
 
-        raw_service_name = options.service_name.strip() if options.service_name else ""
-        self._service_name = raw_service_name or None
-
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
-        if self._service_name is not None:
-            span.set_attribute("service.name", self._service_name)
-
         # Read Latitude context from OTel context and stamp onto span
         # Try parent_context first, then fall back to current context
         latitude_data = None

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter
 
 from latitude_telemetry.constants import ATTRIBUTES
 from latitude_telemetry.env import env
@@ -37,6 +37,8 @@ class LatitudeSpanProcessorOptions:
     disable_smart_filter: bool = False
     should_export_span: Callable[[ReadableSpan], bool] | None = None
     blocked_instrumentation_scopes: tuple[str, ...] = ()
+    exporter: SpanExporter | None = None
+    service_name: str | None = None
 
 
 class LatitudeSpanProcessor(SpanProcessor):
@@ -55,7 +57,7 @@ class LatitudeSpanProcessor(SpanProcessor):
     ):
         options = options or LatitudeSpanProcessorOptions()
 
-        exporter = create_exporter(
+        exporter = options.exporter or create_exporter(
             ExporterOptions(
                 api_key=api_key,
                 project_slug=project_slug,
@@ -86,7 +88,13 @@ class LatitudeSpanProcessor(SpanProcessor):
         redact_then_export = RedactThenExportSpanProcessor(redact, batch_or_simple)
         self._tail: SpanProcessor = ExportFilterSpanProcessor(should_export, redact_then_export)
 
+        raw_service_name = options.service_name.strip() if options.service_name else ""
+        self._service_name = raw_service_name or None
+
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        if self._service_name is not None:
+            span.set_attribute("service.name", self._service_name)
+
         # Read Latitude context from OTel context and stamp onto span
         # Try parent_context first, then fall back to current context
         latitude_data = None

--- a/packages/telemetry/python/tests/telemetry/instrument_test.py
+++ b/packages/telemetry/python/tests/telemetry/instrument_test.py
@@ -1,4 +1,4 @@
-"""Tests for LLM instrumentation with init_latitude()."""
+"""Tests for LLM instrumentation registration."""
 
 from datetime import datetime
 from unittest import mock
@@ -9,7 +9,7 @@ from openai.types.chat import ChatCompletionMessage as OpenAIChatCompletionMessa
 from openai.types.chat.chat_completion import Choice as OpenAIChoice
 from openai.types.completion_usage import CompletionUsage as OpenAICompletionUsage
 
-from latitude_telemetry import init_latitude, register_latitude_instrumentations
+from latitude_telemetry import register_latitude_instrumentations
 from tests.utils import TestCase
 
 

--- a/packages/telemetry/python/tests/telemetry/span_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_test.py
@@ -1,9 +1,13 @@
 """Tests for tracer access via Latitude bootstrap."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from latitude_telemetry import Latitude, init_latitude
 
@@ -59,3 +63,93 @@ class TestTracerAccess:
             assert lat["provider"] is not None
             lat["flush"]()
             lat["shutdown"]()
+
+
+class TestServiceNameOverride:
+    """`service.name` must be applied as a resource attribute, not as a span attribute."""
+
+    def test_service_name_is_a_resource_attribute_when_latitude_owns_the_provider(self):
+        """When Latitude creates its own provider, `service_name` lands on the resource (not as a span attribute)."""
+        latitude_exporter = InMemorySpanExporter()
+
+        lat = Latitude(
+            api_key="test-api-key",
+            project_slug="test-project",
+            disable_batch=True,
+            # No tracer_provider: Latitude owns the provider.
+            service_name="latitude-service",
+            exporter=latitude_exporter,
+        )
+
+        tracer = lat.provider.get_tracer("svc-name-test")
+        with tracer.start_as_current_span("llm-call") as span:
+            span.set_attribute("gen_ai.system", "openai")
+
+        lat.flush()
+
+        finished = latitude_exporter.get_finished_spans()
+        assert len(finished) == 1
+        # Resource attribute carries the value (semantic-conventions-correct).
+        assert finished[0].resource.attributes.get(SERVICE_NAME) == "latitude-service"
+        # Span attribute does NOT carry service.name (which would be off-spec).
+        assert "service.name" not in (finished[0].attributes or {})
+
+        lat.shutdown()
+
+    def test_service_name_is_ignored_when_piggy_backing(self):
+        """When piggy-backing on a host provider, `service_name` is ignored — host resource wins."""
+        host_exporter = InMemorySpanExporter()
+        latitude_exporter = InMemorySpanExporter()
+        host_provider = TracerProvider(resource=Resource.create({SERVICE_NAME: "host-service"}))
+        host_provider.add_span_processor(SimpleSpanProcessor(host_exporter))
+
+        lat = Latitude(
+            api_key="test-api-key",
+            project_slug="test-project",
+            disable_batch=True,
+            tracer_provider=host_provider,
+            service_name="latitude-service",  # explicitly passed — should be ignored
+            exporter=latitude_exporter,
+        )
+
+        tracer = lat.provider.get_tracer("svc-name-piggy")
+        with tracer.start_as_current_span("llm-call") as span:
+            span.set_attribute("gen_ai.system", "openai")
+
+        lat.flush()
+
+        # Both exporters see the host's service.name — Latitude defers to the host.
+        assert host_exporter.get_finished_spans()[0].resource.attributes.get(SERVICE_NAME) == "host-service"
+        assert latitude_exporter.get_finished_spans()[0].resource.attributes.get(SERVICE_NAME) == "host-service"
+
+        lat.shutdown()
+
+
+class TestUnattachableProvider:
+    """When the target provider has no `add_span_processor`, fall back with a warning."""
+
+    def test_warns_and_falls_back_when_provider_cannot_be_attached(self, caplog):
+        class OpaqueProvider:
+            def get_tracer(self, *args, **kwargs):  # noqa: D401, ANN002, ANN003
+                from opentelemetry.trace import NoOpTracer
+
+                return NoOpTracer()
+
+        opaque = OpaqueProvider()
+
+        with (
+            patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"),
+            caplog.at_level(logging.WARNING, logger="latitude_telemetry.sdk.init"),
+        ):
+            lat = Latitude(
+                api_key="test-api-key",
+                project_slug="test-project",
+                disable_batch=True,
+                tracer_provider=opaque,  # type: ignore[arg-type]
+            )
+
+        assert any("Could not attach LatitudeSpanProcessor" in r.message for r in caplog.records)
+        # Fallback creates a Latitude-owned provider that is NOT the passed-in opaque one.
+        assert lat.provider is not opaque
+
+        lat.shutdown()

--- a/packages/telemetry/python/tests/telemetry/span_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_test.py
@@ -1,46 +1,61 @@
-"""Tests for tracer access via init_latitude()."""
+"""Tests for tracer access via Latitude bootstrap."""
 
 from unittest.mock import patch
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
 
-from latitude_telemetry import init_latitude
+from latitude_telemetry import Latitude, init_latitude
 
 
 class TestTracerAccess:
-    """Tests that the tracer is properly exposed via init_latitude()."""
+    """Tests that the tracer is properly exposed via Latitude()."""
 
     @pytest.fixture
     def latitude(self):
         """Create a latitude instance with mocked exporter."""
-        with patch("latitude_telemetry.exporter.create_exporter"):
-            lat = init_latitude(
+        with patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"):
+            lat = Latitude(
                 api_key="test-api-key",
                 project_slug="test-project",
                 disable_batch=True,
+                tracer_provider=TracerProvider(),
             )
             yield lat
-            lat["shutdown"]()
+            lat.shutdown()
 
     def test_provider_is_exposed(self, latitude):
         """Test that latitude.provider is available."""
-        assert latitude["provider"] is not None
+        assert latitude.provider is not None
 
     def test_tracer_can_be_obtained_from_provider(self, latitude):
         """Test that we can get a tracer from the provider."""
-        tracer = latitude["provider"].get_tracer("test")
+        tracer = latitude.provider.get_tracer("test")
         assert tracer is not None
 
     def test_tracer_can_start_span(self, latitude):
         """Test that we can create spans via the tracer."""
-        tracer = latitude["provider"].get_tracer("test")
+        tracer = latitude.provider.get_tracer("test")
         span = tracer.start_span("test-span")
         assert span is not None
         span.end()
 
     def test_tracer_start_as_current_span(self, latitude):
         """Test using start_as_current_span context manager."""
-        tracer = latitude["provider"].get_tracer("test")
+        tracer = latitude.provider.get_tracer("test")
         with tracer.start_as_current_span("test-span") as span:
             assert span is not None
             span.set_attribute("test.key", "test-value")
+
+    def test_init_latitude_keeps_dict_compatibility(self):
+        """Test that init_latitude keeps the previous dict return shape."""
+        with patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"):
+            lat = init_latitude(
+                api_key="test-api-key",
+                project_slug="test-project",
+                disable_batch=True,
+            )
+
+            assert lat["provider"] is not None
+            lat["flush"]()
+            lat["shutdown"]()

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.0.0a4"
+version = "3.0.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.9] - 2026-05-13
+
 ### Breaking Changes
 
 - **Bootstrap API is now class-based** — `new Latitude(options)` replaces `initLatitude(options)` as the public TypeScript SDK entry point. `LatitudeOptions` replaces `InitLatitudeOptions`.
@@ -14,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Automatic existing OTel provider coexistence** — `new Latitude()` detects common existing tracing providers (Sentry, Datadog, New Relic, Honeycomb, and custom OpenTelemetry SDKs) and attaches the Latitude span processor when possible instead of replacing their tracer provider, context manager, propagator, sampler, or processors.
+- **`serviceName` ownership is provider-aware** — when Latitude creates its own provider, `serviceName` is applied to the provider resource as `service.name`; when Latitude attaches to an existing provider, the host SDK remains the source of truth for `service.name`.
+
+### Fixed
+
+- **Provider detection no longer relies on private constructor names** — the SDK now uses OpenTelemetry's proxy provider delegate API and known span-processor containers to detect and attach to existing providers more reliably, including OTel JS v2 and Datadog bridge setups.
 
 ## [3.0.0-alpha.8] - 2026-05-08
 

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Bootstrap API is now class-based** — `new Latitude(options)` replaces `initLatitude(options)` as the public TypeScript SDK entry point. `LatitudeOptions` replaces `InitLatitudeOptions`.
+
+### Changed
+
+- **Automatic existing OTel provider coexistence** — `new Latitude()` detects common existing tracing providers (Sentry, Datadog, New Relic, Honeycomb, and custom OpenTelemetry SDKs) and attaches the Latitude span processor when possible instead of replacing their tracer provider, context manager, propagator, sampler, or processors.
+
 ## [3.0.0-alpha.8] - 2026-05-08
 
 ### Changed

--- a/packages/telemetry/typescript/README.md
+++ b/packages/telemetry/typescript/README.md
@@ -12,12 +12,12 @@ npm install @latitude-data/telemetry
 
 ### Bootstrap (Recommended)
 
-The fastest way to start tracing your LLM calls. One function sets up everything:
+The fastest way to start tracing your LLM calls. One class sets up everything:
 
 ```typescript
-import { initLatitude } from "@latitude-data/telemetry";
+import { Latitude } from "@latitude-data/telemetry";
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"], // Auto-instrument OpenAI, Anthropic, etc.
@@ -37,29 +37,53 @@ await latitude.shutdown();
 
 **What this does:**
 
-- Creates a complete OpenTelemetry setup
+- Detects an existing OpenTelemetry provider (Sentry, Datadog, New Relic, Honeycomb, etc.) and adds Latitude to it when possible
+- Creates a complete OpenTelemetry setup when your app does not already have one
 - Registers LLM auto-instrumentation (OpenAI, Anthropic, etc.) **asynchronously in the background**
 - Configures the Latitude span processor and exporter
-- Sets up async context propagation (for passing context through async operations)
+- Sets up async context propagation (for passing context through async operations) when Latitude owns the OTel setup
 
 **Key point about async instrumentations:**
 
-`initLatitude` returns **immediately** — no top-level await needed. Instrumentation registration happens in the background. This avoids top-level await issues in CommonJS environments while still supporting ESM.
+`new Latitude()` returns **immediately** — no top-level await needed. Instrumentation registration happens in the background. This avoids top-level await issues in CommonJS environments while still supporting ESM.
 
 - **Fire-and-forget**: Start using your LLM clients right away. Early spans will be captured once instrumentations finish registering.
 - **Optional `await latitude.ready`**: If you want to ensure instrumentations are fully registered before making LLM calls, await the `ready` promise.
 
-**When to use this:** Most applications should start here. It's the simplest path to get LLM observability into Latitude.
+**When to use this:** Most applications should start here. If you already initialize Sentry or another tracing SDK, initialize it first and construct `new Latitude()` second. Latitude will reuse the existing tracing pipeline when possible, and `latitude.shutdown()` only shuts down Latitude-owned processing.
 
 **When you might need the advanced setup:**
 
-- You already have OpenTelemetry configured for other backends (Datadog, Sentry, Jaeger)
 - You need custom span processing, sampling, or filtering
-- You want multiple observability backends receiving the same spans
+- You want to wire span processors explicitly instead of letting `new Latitude()` detect your provider
 
-### Existing OpenTelemetry Setup (Advanced)
+### Existing Sentry or OpenTelemetry Setup
 
-If your app already uses OpenTelemetry, add Latitude alongside your existing setup:
+If your app already uses Sentry or another OpenTelemetry-compatible SDK, initialize that SDK first and then construct `new Latitude()`:
+
+```typescript
+import * as Sentry from "@sentry/node";
+import { Latitude } from "@latitude-data/telemetry";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN!,
+  tracesSampleRate: 1.0,
+});
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+});
+
+await latitude.ready;
+
+// LLM spans are exported to both Sentry (via its provider) and Latitude.
+await latitude.flush();
+await latitude.shutdown(); // Does not shut down Sentry.
+```
+
+For fully custom OTel setups, you can also wire the Latitude processor explicitly:
 
 ```typescript
 import { NodeSDK } from "@opentelemetry/sdk-node";
@@ -126,9 +150,9 @@ You don't need `capture()` to get started—auto-instrumentation handles LLM cal
 ### Example
 
 ```typescript
-import { initLatitude, capture } from "@latitude-data/telemetry";
+import { Latitude, capture } from "@latitude-data/telemetry";
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
@@ -159,7 +183,7 @@ await latitude.shutdown();
 
 ## Key Concepts
 
-- **`initLatitude()`** — The primary way to use Latitude. Bootstraps a complete OpenTelemetry setup with LLM auto-instrumentation and the Latitude exporter. Best for most applications.
+- **`new Latitude()`** — The primary way to use Latitude. Bootstraps a complete OpenTelemetry setup with LLM auto-instrumentation and the Latitude exporter. Best for most applications.
 - **`LatitudeSpanProcessor`** — For advanced use cases where you already have an OpenTelemetry setup. Exports spans to Latitude alongside your existing observability stack.
 - **`registerLatitudeInstrumentations()`** — Registers LLM auto-instrumentations (OpenAI, Anthropic, etc.) when using the advanced setup with your own provider.
 - **`capture()`** — Optional. Wraps your code to attach Latitude context (tags, userId, sessionId, metadata) to all spans created inside the callback. Use this when you want to group traces by user, session, or add business context.
@@ -170,19 +194,19 @@ await latitude.shutdown();
 
 ```typescript
 import {
-  initLatitude,
+  Latitude,
   LatitudeSpanProcessor,
   capture,
   registerLatitudeInstrumentations,
 } from "@latitude-data/telemetry";
 ```
 
-### `initLatitude(options)`
+### `new Latitude(options)`
 
 The primary entry point. Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude export.
 
 ```typescript
-type InitLatitudeOptions = {
+type LatitudeOptions = {
   apiKey: string;
   projectSlug: string;
   instrumentations?: InstrumentationType[]; // ["openai", "anthropic", etc.]
@@ -194,14 +218,16 @@ type InitLatitudeOptions = {
   disableRedact?: boolean;
   redact?: RedactSpanProcessorOptions;
   exporter?: SpanExporter;
+  tracerProvider?: TracerProvider; // Optional explicit provider for Sentry/Datadog/New Relic/Honeycomb/custom OTel
 };
 
-function initLatitude(options: InitLatitudeOptions): {
-  provider: NodeTracerProvider; // Access to underlying provider for advanced use
+class Latitude {
+  constructor(options: LatitudeOptions);
+  provider: TracerProvider; // Existing provider when detected, otherwise Latitude's NodeTracerProvider
   ready: Promise<void>; // Resolves when instrumentations are registered
   flush(): Promise<void>;
   shutdown(): Promise<void>;
-};
+}
 ```
 
 ### `LatitudeSpanProcessor`
@@ -285,7 +311,7 @@ For users with existing observability infrastructure.
 
 ### With Datadog
 
-Use Datadog's OTel `TracerProvider` with `LatitudeSpanProcessor`:
+Initialize Datadog first, then construct `new Latitude()` so Latitude can attach to Datadog's OTel `TracerProvider` when possible. Datadog exposes a public `addSpanProcessor` API, so Latitude can share the Datadog provider without replacing it. If your setup exposes the provider directly, you can also pass it as `tracerProvider` or wire `LatitudeSpanProcessor` explicitly:
 
 ```typescript
 import tracer from "dd-trace";
@@ -310,63 +336,64 @@ provider.register();
 
 ### With Sentry
 
-Use Sentry's custom OpenTelemetry setup with `skipOpenTelemetrySetup: true`:
+Initialize Sentry first, then Latitude. Sentry installs an OpenTelemetry `BasicTracerProvider`; Latitude detects it and adds its processor without replacing Sentry's context manager, propagator, sampler, or span processor:
 
 ```typescript
 import * as Sentry from "@sentry/node";
-import {
-  SentrySpanProcessor,
-  SentrySampler,
-  SentryPropagator,
-} from "@sentry/opentelemetry";
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import {
-  LatitudeSpanProcessor,
-  registerLatitudeInstrumentations,
-} from "@latitude-data/telemetry";
+import { Latitude } from "@latitude-data/telemetry";
 
-// Initialize Sentry with custom OTel setup flag
-const sentryClient = Sentry.init({
+Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  skipOpenTelemetrySetup: true,
   tracesSampleRate: 1.0,
 });
 
-// Create a shared provider with both Sentry and Latitude processors
-const provider = new NodeTracerProvider({
-  sampler: sentryClient ? new SentrySampler(sentryClient) : undefined,
-  spanProcessors: [
-    new SentrySpanProcessor(), // Send spans to Sentry
-    new LatitudeSpanProcessor(
-      process.env.LATITUDE_API_KEY!,
-      process.env.LATITUDE_PROJECT_SLUG!,
-    ), // Send spans to Latitude
-  ],
-});
-
-// Register with Sentry's propagator and context manager
-provider.register({
-  propagator: new SentryPropagator(),
-  contextManager: new Sentry.SentryContextManager(),
-});
-
-// Add LLM instrumentations
-await registerLatitudeInstrumentations({
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
-  tracerProvider: provider,
 });
 
-// Validate the setup
-Sentry.validateOpenTelemetrySetup();
+await latitude.ready;
 
-// LLM calls are now traced and sent to both Sentry and Latitude
+// LLM calls are now traced and sent to both Sentry and Latitude.
+await latitude.flush();
+await latitude.shutdown(); // Does not shut down Sentry.
 ```
 
 **Adding context:** Use `capture()` if you want to add user IDs, session IDs, or tags to your traces (see [Using `capture()` for Context and Boundaries](#using-capture-for-context-and-boundaries)).
 
-**Required Sentry packages:** `@sentry/node`, `@sentry/opentelemetry`
+### With New Relic
 
-**Note:** See [Sentry's custom OTel setup documentation](https://docs.sentry.io/platforms/javascript/guides/node/opentelemetry/custom-setup/) for version-specific details.
+Enable New Relic's OpenTelemetry bridge first, then construct `new Latitude()`. New Relic registers an OpenTelemetry `BasicTracerProvider`; Latitude attaches to that provider when possible and only shuts down Latitude's own processor.
+
+```typescript
+import "newrelic";
+import { Latitude } from "@latitude-data/telemetry";
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+});
+```
+
+### With Honeycomb
+
+Start Honeycomb's `HoneycombSDK` first, then construct `new Latitude()`. Honeycomb extends OpenTelemetry's `NodeSDK`, so Latitude reuses the global provider created by `sdk.start()`.
+
+```typescript
+import { HoneycombSDK } from "@honeycombio/opentelemetry-node";
+import { Latitude } from "@latitude-data/telemetry";
+
+const honeycomb = new HoneycombSDK({ serviceName: "my-app" });
+honeycomb.start();
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+});
+```
 
 ## Supported AI Providers
 
@@ -471,7 +498,7 @@ import { context } from "@opentelemetry/api";
 context.setGlobalContextManager(new AsyncLocalStorageContextManager());
 ```
 
-`initLatitude()` does this automatically. For shared-provider setups, your app's existing OTel setup should already have this.
+`new Latitude()` does this automatically. For shared-provider setups, your app's existing OTel setup should already have this.
 
 ## License
 

--- a/packages/telemetry/typescript/README.md
+++ b/packages/telemetry/typescript/README.md
@@ -311,25 +311,25 @@ For users with existing observability infrastructure.
 
 ### With Datadog
 
-Initialize Datadog first, then construct `new Latitude()` so Latitude can attach to Datadog's OTel `TracerProvider` when possible. Datadog exposes a public `addSpanProcessor` API, so Latitude can share the Datadog provider without replacing it. If your setup exposes the provider directly, you can also pass it as `tracerProvider` or wire `LatitudeSpanProcessor` explicitly:
+Initialize Datadog first, then construct `new Latitude()` so Latitude can attach to Datadog's OTel provider when possible:
 
 ```typescript
 import tracer from "dd-trace";
-import { LatitudeSpanProcessor } from "@latitude-data/telemetry";
+import { Latitude } from "@latitude-data/telemetry";
 
-const ddTracer = tracer.init({ service: "my-app", env: "production" });
-const provider = new ddTracer.TracerProvider();
+tracer.init({ service: "my-app", env: "production" });
 
-provider.addSpanProcessor(
-  new LatitudeSpanProcessor(
-    process.env.LATITUDE_API_KEY!,
-    process.env.LATITUDE_PROJECT_SLUG!,
-  ),
-);
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: ["openai"],
+});
 
-provider.register();
+await latitude.ready;
 
-// LLM calls are now traced and sent to both Datadog and Latitude
+// LLM calls are now traced and sent to both Datadog and Latitude.
+await latitude.flush();
+await latitude.shutdown(); // Does not shut down Datadog.
 ```
 
 **Adding context:** Use `capture()` if you want to add user IDs, session IDs, or tags to your traces (see [Using `capture()` for Context and Boundaries](#using-capture-for-context-and-boundaries)).

--- a/packages/telemetry/typescript/examples/test_anthropic.ts
+++ b/packages/telemetry/typescript/examples/test_anthropic.ts
@@ -10,9 +10,9 @@
  */
 
 import Anthropic from "@anthropic-ai/sdk"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_azure.ts
+++ b/packages/telemetry/typescript/examples/test_azure.ts
@@ -12,10 +12,10 @@
  */
 
 import { AzureOpenAI } from "openai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
 // Note: Azure OpenAI uses the same OpenAI instrumentor
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_bedrock.ts
+++ b/packages/telemetry/typescript/examples/test_bedrock.ts
@@ -12,9 +12,9 @@
  */
 
 import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_capture_nesting.ts
+++ b/packages/telemetry/typescript/examples/test_capture_nesting.ts
@@ -14,11 +14,11 @@
  * Install: npm install openai
  */
 
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 import OpenAI from "openai"
 
 // Initialize telemetry
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],

--- a/packages/telemetry/typescript/examples/test_cohere.ts
+++ b/packages/telemetry/typescript/examples/test_cohere.ts
@@ -10,9 +10,9 @@
  */
 
 import { CohereClient } from "cohere-ai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_langchain.ts
+++ b/packages/telemetry/typescript/examples/test_langchain.ts
@@ -11,9 +11,9 @@
 
 import { HumanMessage } from "@langchain/core/messages"
 import { ChatOpenAI } from "@langchain/openai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_llamaindex.ts
+++ b/packages/telemetry/typescript/examples/test_llamaindex.ts
@@ -10,9 +10,9 @@
  */
 
 import { OpenAI } from "llamaindex"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
+++ b/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
@@ -17,10 +17,10 @@
 
 import { trace } from "@opentelemetry/api"
 import OpenAI from "openai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
 // Initialize telemetry
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],

--- a/packages/telemetry/typescript/examples/test_openai.ts
+++ b/packages/telemetry/typescript/examples/test_openai.ts
@@ -10,9 +10,9 @@
  */
 
 import OpenAI from "openai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_openai_agents.ts
+++ b/packages/telemetry/typescript/examples/test_openai_agents.ts
@@ -11,9 +11,9 @@
 
 import { Agent, run, tool } from "@openai/agents"
 import { z } from "zod"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_openai_responses.ts
+++ b/packages/telemetry/typescript/examples/test_openai_responses.ts
@@ -10,9 +10,9 @@
  */
 
 import OpenAI from "openai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_sentry.ts
+++ b/packages/telemetry/typescript/examples/test_sentry.ts
@@ -14,10 +14,9 @@
  * Install: npm install openai @sentry/node
  */
 
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
 import * as Sentry from "@sentry/node"
 import OpenAI from "openai"
-import { capture, LatitudeSpanProcessor, registerLatitudeInstrumentations } from "../src"
+import { capture, Latitude } from "../src"
 
 // ─── 1. Initialize Sentry (native SDK) ───────────────────
 
@@ -27,20 +26,15 @@ Sentry.init({
   // Sentry auto-instruments HTTP, DB, etc. and sends to Sentry
 })
 
-// ─── 2. Add Latitude to Sentry's OTel provider ─────────────
+// ─── 2. Initialize Latitude second ────────────────────────
 
-// Get Sentry's tracer provider (when using Sentry's OTel integration)
-// Note: This requires Sentry's custom OTel setup. See Sentry docs for details.
-const provider = new NodeTracerProvider({
-  spanProcessors: [new LatitudeSpanProcessor(process.env.LATITUDE_API_KEY!, process.env.LATITUDE_PROJECT_SLUG!)],
-})
-
-await registerLatitudeInstrumentations({
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: ["openai"],
-  tracerProvider: provider,
 })
 
-provider.register()
+await latitude.ready
 
 // ─── 3. Use instrumented clients ──────────────────────────
 
@@ -74,8 +68,8 @@ async function main() {
     console.log("Error captured by Sentry")
   }
 
-  await provider.forceFlush()
-  await provider.shutdown()
+  await latitude.flush()
+  await latitude.shutdown()
 }
 
 main().catch(console.error)

--- a/packages/telemetry/typescript/examples/test_together.ts
+++ b/packages/telemetry/typescript/examples/test_together.ts
@@ -10,9 +10,9 @@
  */
 
 import Together from "together-ai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_vercel_ai.ts
+++ b/packages/telemetry/typescript/examples/test_vercel_ai.ts
@@ -17,7 +17,7 @@
 
 import { openai } from "@ai-sdk/openai"
 import { generateText, streamText } from "ai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
 const apiKey = process.env.LATITUDE_API_KEY
 const projectSlug = process.env.LATITUDE_PROJECT_SLUG
@@ -30,7 +30,7 @@ if (!projectSlug) {
   throw new Error("LATITUDE_PROJECT_SLUG is required")
 }
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey,
   projectSlug,
   disableBatch: true,

--- a/packages/telemetry/typescript/examples/test_vertex.ts
+++ b/packages/telemetry/typescript/examples/test_vertex.ts
@@ -11,9 +11,9 @@
  */
 
 import { VertexAI } from "@google-cloud/vertexai"
-import { capture, initLatitude } from "../src"
+import { capture, Latitude } from "../src"
 
-const latitude = initLatitude({
+const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.8",
+  "version": "3.0.0-alpha.9",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/sdk/index.ts
+++ b/packages/telemetry/typescript/src/sdk/index.ts
@@ -1,5 +1,5 @@
 export { capture } from "./context.ts"
-export { Latitude } from "./init.ts"
+export { initLatitude, Latitude } from "./init.ts"
 export type { InstrumentationType } from "./instrumentations.ts"
 export { registerLatitudeInstrumentations } from "./instrumentations.ts"
 export { LatitudeSpanProcessor } from "./processor.ts"
@@ -18,4 +18,4 @@ export {
   RedactThenExportSpanProcessor,
 } from "./span-filter.ts"
 export { getLatitudeTracer } from "./tracer.ts"
-export type { ContextOptions, LatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"
+export type { ContextOptions, InitLatitudeOptions, LatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"

--- a/packages/telemetry/typescript/src/sdk/index.ts
+++ b/packages/telemetry/typescript/src/sdk/index.ts
@@ -1,5 +1,5 @@
 export { capture } from "./context.ts"
-export { initLatitude } from "./init.ts"
+export { Latitude } from "./init.ts"
 export type { InstrumentationType } from "./instrumentations.ts"
 export { registerLatitudeInstrumentations } from "./instrumentations.ts"
 export { LatitudeSpanProcessor } from "./processor.ts"
@@ -18,4 +18,4 @@ export {
   RedactThenExportSpanProcessor,
 } from "./span-filter.ts"
 export { getLatitudeTracer } from "./tracer.ts"
-export type { ContextOptions, InitLatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"
+export type { ContextOptions, LatitudeOptions, LatitudeSpanProcessorOptions } from "./types.ts"

--- a/packages/telemetry/typescript/src/sdk/init.test.ts
+++ b/packages/telemetry/typescript/src/sdk/init.test.ts
@@ -1,6 +1,8 @@
 import { context, propagation, type Tracer, type TracerProvider, trace } from "@opentelemetry/api"
+import { resourceFromAttributes } from "@opentelemetry/resources"
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
-import { afterEach, describe, expect, it } from "vitest"
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { initLatitude, Latitude } from "./init.ts"
 
 describe("Latitude", () => {
@@ -110,6 +112,104 @@ describe("Latitude", () => {
 
     expect(result.provider).toBe(datadogLikeProvider)
     expect(spanProcessors).toHaveLength(1)
+
+    await result.shutdown()
+  })
+
+  it("supports OTel JS v2 NodeSDK-style providers via the MultiSpanProcessor list", async () => {
+    const spanProcessors: unknown[] = []
+    const nodeSdkLikeProvider = {
+      getTracer: () => ({}) as Tracer,
+      _activeSpanProcessor: {
+        _spanProcessors: spanProcessors,
+      },
+    } satisfies TracerProvider & { _activeSpanProcessor: { _spanProcessors: unknown[] } }
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      tracerProvider: nodeSdkLikeProvider,
+    })
+
+    expect(result.provider).toBe(nodeSdkLikeProvider)
+    expect(spanProcessors).toHaveLength(1)
+
+    await result.shutdown()
+  })
+
+  it("warns and falls back when the provider exposes no known attach hook", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const opaqueProvider = { getTracer: () => ({}) as Tracer } satisfies TracerProvider
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      tracerProvider: opaqueProvider,
+    })
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Could not attach LatitudeSpanProcessor"))
+    // The fallback creates its own provider (not registered globally) so the caller can still
+    // get Latitude spans through explicit instrumentation.
+    expect(result.provider).not.toBe(opaqueProvider)
+    expect(trace.getTracerProvider()).not.toBe(result.provider)
+
+    warnSpy.mockRestore()
+    await result.shutdown()
+  })
+
+  it("applies serviceName to exported spans as a resource attribute, not a span attribute", async () => {
+    const latitudeExporter = new InMemorySpanExporter()
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      serviceName: "custom-service",
+      exporter: latitudeExporter,
+      disableBatch: true,
+    })
+
+    const span = trace.getTracer("svc-name-test").startSpan("llm-call")
+    span.setAttribute("gen_ai.system", "openai")
+    span.end()
+
+    await result.flush()
+
+    const finished = latitudeExporter.getFinishedSpans()
+    expect(finished).toHaveLength(1)
+    // Resource carries the override (correct per OTel semantic conventions).
+    expect(finished[0]?.resource.attributes[ATTR_SERVICE_NAME]).toBe("custom-service")
+    // Span attributes do NOT carry service.name (which would be off-spec).
+    expect(finished[0]?.attributes[ATTR_SERVICE_NAME]).toBeUndefined()
+
+    await result.shutdown()
+  })
+
+  it("ignores serviceName when piggy-backing — host provider's resource is the source of truth", async () => {
+    const hostExporter = new InMemorySpanExporter()
+    const latitudeExporter = new InMemorySpanExporter()
+    const existingProvider = new NodeTracerProvider({
+      resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: "host-service" }),
+      spanProcessors: [new SimpleSpanProcessor(hostExporter)],
+    })
+    trace.setGlobalTracerProvider(existingProvider)
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      serviceName: "latitude-service", // explicitly passed — should be ignored when piggy-backing
+      exporter: latitudeExporter,
+      disableBatch: true,
+    })
+
+    const span = trace.getTracer("svc-name-piggy").startSpan("llm-call")
+    span.setAttribute("gen_ai.system", "openai")
+    span.end()
+
+    await result.flush()
+
+    // Both exporters see the host's service.name — Latitude defers to the host.
+    expect(hostExporter.getFinishedSpans()[0]?.resource.attributes[ATTR_SERVICE_NAME]).toBe("host-service")
+    expect(latitudeExporter.getFinishedSpans()[0]?.resource.attributes[ATTR_SERVICE_NAME]).toBe("host-service")
 
     await result.shutdown()
   })

--- a/packages/telemetry/typescript/src/sdk/init.test.ts
+++ b/packages/telemetry/typescript/src/sdk/init.test.ts
@@ -1,22 +1,102 @@
-import { describe, expect, it } from "vitest"
-import { initLatitude } from "./init.ts"
+import { context, propagation, type Tracer, type TracerProvider, trace } from "@opentelemetry/api"
+import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
+import { afterEach, describe, expect, it } from "vitest"
+import { Latitude } from "./init.ts"
 
-describe("initLatitude", () => {
+describe("Latitude", () => {
+  afterEach(() => {
+    trace.disable()
+    context.disable()
+    propagation.disable()
+  })
+
   it("should throw if apiKey is missing", () => {
-    expect(() => initLatitude({ apiKey: "", projectSlug: "test" })).toThrow("apiKey is required")
+    expect(() => new Latitude({ apiKey: "", projectSlug: "test" })).toThrow("apiKey is required")
   })
 
   it("should throw if projectSlug is missing", () => {
-    expect(() => initLatitude({ apiKey: "test", projectSlug: "" })).toThrow("projectSlug is required")
+    expect(() => new Latitude({ apiKey: "test", projectSlug: "" })).toThrow("projectSlug is required")
   })
 
-  it("should return provider, flush, and shutdown functions", async () => {
-    const result = await initLatitude({
+  it("should return provider, flush, shutdown, and ready functions", async () => {
+    const result = new Latitude({
       apiKey: "test-key",
       projectSlug: "test-project",
     })
     expect(result.provider).toBeDefined()
     expect(result.flush).toBeTypeOf("function")
     expect(result.shutdown).toBeTypeOf("function")
+    await result.shutdown()
+  })
+
+  it("adds Latitude's processor to an existing global provider", async () => {
+    const existingExporter = new InMemorySpanExporter()
+    const latitudeExporter = new InMemorySpanExporter()
+    const existingProvider = new NodeTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(existingExporter)],
+    })
+    trace.setGlobalTracerProvider(existingProvider)
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      exporter: latitudeExporter,
+      disableBatch: true,
+    })
+
+    expect(result.provider).toBe(existingProvider)
+
+    const span = trace.getTracer("init-test").startSpan("llm-call")
+    span.setAttribute("gen_ai.system", "openai")
+    span.end()
+
+    await result.flush()
+
+    expect(existingExporter.getFinishedSpans()).toHaveLength(1)
+    expect(latitudeExporter.getFinishedSpans()).toHaveLength(1)
+
+    await result.shutdown()
+  })
+
+  it("uses an explicitly provided tracer provider", async () => {
+    const spanProcessors: unknown[] = []
+    const explicitProvider: TracerProvider & { addSpanProcessor: (processor: unknown) => void } = {
+      getTracer: () => ({}) as Tracer,
+      addSpanProcessor: (processor) => {
+        spanProcessors.push(processor)
+      },
+    }
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      tracerProvider: explicitProvider,
+    })
+
+    expect(result.provider).toBe(explicitProvider)
+    expect(spanProcessors).toHaveLength(1)
+
+    await result.shutdown()
+  })
+
+  it("supports Datadog-style private processor lists when addSpanProcessor is unavailable", async () => {
+    const spanProcessors: unknown[] = []
+    const datadogLikeProvider = {
+      getTracer: () => ({}) as Tracer,
+      _activeProcessor: {
+        _processors: spanProcessors,
+      },
+    } satisfies TracerProvider & { _activeProcessor: { _processors: unknown[] } }
+
+    const result = new Latitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+      tracerProvider: datadogLikeProvider,
+    })
+
+    expect(result.provider).toBe(datadogLikeProvider)
+    expect(spanProcessors).toHaveLength(1)
+
+    await result.shutdown()
   })
 })

--- a/packages/telemetry/typescript/src/sdk/init.test.ts
+++ b/packages/telemetry/typescript/src/sdk/init.test.ts
@@ -1,7 +1,7 @@
 import { context, propagation, type Tracer, type TracerProvider, trace } from "@opentelemetry/api"
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { afterEach, describe, expect, it } from "vitest"
-import { Latitude } from "./init.ts"
+import { initLatitude, Latitude } from "./init.ts"
 
 describe("Latitude", () => {
   afterEach(() => {
@@ -24,6 +24,20 @@ describe("Latitude", () => {
       projectSlug: "test-project",
     })
     expect(result.provider).toBeDefined()
+    expect(result.flush).toBeTypeOf("function")
+    expect(result.shutdown).toBeTypeOf("function")
+    await result.shutdown()
+  })
+
+  it("keeps initLatitude as a deprecated compatibility wrapper", async () => {
+    const result = initLatitude({
+      apiKey: "test-key",
+      projectSlug: "test-project",
+    })
+
+    expect(result).toBeInstanceOf(Latitude)
+    expect(result.provider).toBeDefined()
+    expect(result.ready).toBeInstanceOf(Promise)
     expect(result.flush).toBeTypeOf("function")
     expect(result.shutdown).toBeTypeOf("function")
     await result.shutdown()

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -6,7 +6,7 @@ import { NodeTracerProvider, type SpanProcessor } from "@opentelemetry/sdk-trace
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
 import { registerLatitudeInstrumentations } from "./instrumentations.ts"
 import { LatitudeSpanProcessor } from "./processor.ts"
-import type { LatitudeOptions } from "./types.ts"
+import type { InitLatitudeOptions, LatitudeOptions } from "./types.ts"
 
 const SERVICE_NAME = process.env.npm_package_name || "unknown"
 
@@ -155,4 +155,11 @@ export class Latitude {
       console.error("Error during Latitude Telemetry shutdown:", err)
     }
   }
+}
+
+/**
+ * @deprecated Use `new Latitude(options)` instead.
+ */
+export function initLatitude(options: InitLatitudeOptions): Latitude {
+  return new Latitude(options)
 }

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -1,90 +1,158 @@
-import { context, propagation } from "@opentelemetry/api"
+import { context, propagation, type TracerProvider, trace } from "@opentelemetry/api"
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
 import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } from "@opentelemetry/core"
 import { resourceFromAttributes } from "@opentelemetry/resources"
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
+import { NodeTracerProvider, type SpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
 import { registerLatitudeInstrumentations } from "./instrumentations.ts"
 import { LatitudeSpanProcessor } from "./processor.ts"
-import type { InitLatitudeOptions } from "./types.ts"
+import type { LatitudeOptions } from "./types.ts"
 
 const SERVICE_NAME = process.env.npm_package_name || "unknown"
 
-/** Module-level flag to prevent duplicate signal handler registration on repeated initLatitude calls */
+/** Module-level flag to prevent duplicate signal handler registration on repeated Latitude construction */
 let shutdownHandlersRegistered = false
 
-export function initLatitude(options: InitLatitudeOptions): {
-  provider: NodeTracerProvider
-  flush: () => Promise<void>
-  shutdown: () => Promise<void>
-  ready: Promise<void>
-} {
-  const { apiKey, projectSlug, instrumentations = [], ...processorOptions } = options
+interface ProxyTracerProviderLike extends TracerProvider {
+  getDelegate?: () => TracerProvider
+}
 
-  if (!apiKey || apiKey.trim() === "") {
-    throw new Error("[Latitude] apiKey is required and cannot be empty")
+interface ProviderWithSpanProcessor extends TracerProvider {
+  addSpanProcessor?: (processor: SpanProcessor) => void
+  _activeSpanProcessor?: {
+    _spanProcessors?: SpanProcessor[]
   }
-  if (!projectSlug || projectSlug.trim() === "") {
-    throw new Error("[Latitude] projectSlug is required and cannot be empty")
+  _activeProcessor?: {
+    _processors?: SpanProcessor[]
   }
+}
 
-  const contextManager = new AsyncLocalStorageContextManager()
-  contextManager.enable()
+function getRegisteredTracerProvider(): TracerProvider | undefined {
+  const provider = trace.getTracerProvider() as ProxyTracerProviderLike
+  const delegate = provider.getDelegate?.() ?? provider
 
-  const propagator = new CompositePropagator({
-    propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
-  })
+  return delegate.constructor.name === "NoopTracerProvider" ? undefined : delegate
+}
 
-  context.setGlobalContextManager(contextManager)
-  propagation.setGlobalPropagator(propagator)
+function addSpanProcessor(provider: TracerProvider, processor: SpanProcessor): boolean {
+  const providerWithProcessor = provider as ProviderWithSpanProcessor
 
-  const resourceServiceName =
-    typeof processorOptions.serviceName === "string" && processorOptions.serviceName.trim() !== ""
-      ? processorOptions.serviceName.trim()
-      : SERVICE_NAME
-
-  const provider = new NodeTracerProvider({
-    resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: resourceServiceName,
-    }),
-    spanProcessors: [new LatitudeSpanProcessor(apiKey, projectSlug, processorOptions)],
-  })
-
-  provider.register()
-
-  const ready = registerLatitudeInstrumentations({
-    instrumentations,
-    tracerProvider: provider,
-  }).catch((err) => {
-    console.warn("[Latitude] Failed to register instrumentations:", err)
-  })
-
-  const shutdown = async (): Promise<void> => {
-    await provider.shutdown()
+  if (typeof providerWithProcessor.addSpanProcessor === "function") {
+    providerWithProcessor.addSpanProcessor(processor)
+    return true
   }
 
-  const flush = async (): Promise<void> => {
-    await provider.forceFlush()
+  // OTel JS v2 removed the public addSpanProcessor API. Sentry, New Relic, Honeycomb,
+  // and NodeSDK-based setups still keep processors in this MultiSpanProcessor array.
+  const otelSpanProcessors = providerWithProcessor._activeSpanProcessor?._spanProcessors
+  if (Array.isArray(otelSpanProcessors)) {
+    otelSpanProcessors.push(processor)
+    return true
   }
 
-  const handleShutdown = async () => {
-    try {
-      await shutdown()
-    } catch (err) {
-      console.error("Error during Latitude Telemetry shutdown:", err)
+  // Datadog's OTel bridge stores processors on `_activeProcessor`.
+  const datadogSpanProcessors = providerWithProcessor._activeProcessor?._processors
+  if (Array.isArray(datadogSpanProcessors)) {
+    datadogSpanProcessors.push(processor)
+    return true
+  }
+
+  return false
+}
+
+export class Latitude {
+  readonly provider: TracerProvider
+  readonly ready: Promise<void>
+
+  private readonly latitudeProcessor: LatitudeSpanProcessor
+  private readonly ownsProvider: boolean
+
+  constructor(options: LatitudeOptions) {
+    const { apiKey, projectSlug, instrumentations = [], tracerProvider, ...processorOptions } = options
+
+    if (!apiKey || apiKey.trim() === "") {
+      throw new Error("[Latitude] apiKey is required and cannot be empty")
+    }
+    if (!projectSlug || projectSlug.trim() === "") {
+      throw new Error("[Latitude] projectSlug is required and cannot be empty")
+    }
+
+    this.latitudeProcessor = new LatitudeSpanProcessor(apiKey, projectSlug, processorOptions)
+    const existingProvider = tracerProvider ?? getRegisteredTracerProvider()
+
+    if (existingProvider && addSpanProcessor(existingProvider, this.latitudeProcessor)) {
+      this.provider = existingProvider
+      this.ownsProvider = false
+    } else {
+      const contextManager = new AsyncLocalStorageContextManager()
+      contextManager.enable()
+
+      const propagator = new CompositePropagator({
+        propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+      })
+
+      if (!existingProvider) {
+        context.setGlobalContextManager(contextManager)
+        propagation.setGlobalPropagator(propagator)
+      }
+
+      const resourceServiceName =
+        typeof processorOptions.serviceName === "string" && processorOptions.serviceName.trim() !== ""
+          ? processorOptions.serviceName.trim()
+          : SERVICE_NAME
+
+      const latitudeProvider = new NodeTracerProvider({
+        resource: resourceFromAttributes({
+          [ATTR_SERVICE_NAME]: resourceServiceName,
+        }),
+        spanProcessors: [this.latitudeProcessor],
+      })
+
+      if (!existingProvider) {
+        latitudeProvider.register()
+      }
+
+      this.ownsProvider = true
+      this.provider = latitudeProvider
+    }
+
+    this.ready = registerLatitudeInstrumentations({
+      instrumentations,
+      tracerProvider: this.provider,
+    }).catch((err) => {
+      console.warn("[Latitude] Failed to register instrumentations:", err)
+    })
+
+    if (!shutdownHandlersRegistered) {
+      process.once("SIGTERM", () => void this.handleShutdown())
+      process.once("SIGINT", () => void this.handleShutdown())
+      shutdownHandlersRegistered = true
     }
   }
 
-  if (!shutdownHandlersRegistered) {
-    process.once("SIGTERM", handleShutdown)
-    process.once("SIGINT", handleShutdown)
-    shutdownHandlersRegistered = true
+  async shutdown(): Promise<void> {
+    if (this.ownsProvider && this.provider instanceof NodeTracerProvider) {
+      await this.provider.shutdown()
+      return
+    }
+
+    await this.latitudeProcessor.shutdown()
   }
 
-  return {
-    provider,
-    flush,
-    shutdown,
-    ready,
+  async flush(): Promise<void> {
+    if (this.ownsProvider && this.provider instanceof NodeTracerProvider) {
+      await this.provider.forceFlush()
+      return
+    }
+
+    await this.latitudeProcessor.forceFlush()
+  }
+
+  private async handleShutdown(): Promise<void> {
+    try {
+      await this.shutdown()
+    } catch (err) {
+      console.error("Error during Latitude Telemetry shutdown:", err)
+    }
   }
 }

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -1,4 +1,4 @@
-import { context, propagation, type TracerProvider, trace } from "@opentelemetry/api"
+import { context, ProxyTracerProvider, propagation, type TracerProvider, trace } from "@opentelemetry/api"
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
 import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } from "@opentelemetry/core"
 import { resourceFromAttributes } from "@opentelemetry/resources"
@@ -9,13 +9,10 @@ import { LatitudeSpanProcessor } from "./processor.ts"
 import type { InitLatitudeOptions, LatitudeOptions } from "./types.ts"
 
 const SERVICE_NAME = process.env.npm_package_name || "unknown"
+const DETECT_PROBE = "@latitude-data/telemetry-detect"
 
 /** Module-level flag to prevent duplicate signal handler registration on repeated Latitude construction */
 let shutdownHandlersRegistered = false
-
-interface ProxyTracerProviderLike extends TracerProvider {
-  getDelegate?: () => TracerProvider
-}
 
 interface ProviderWithSpanProcessor extends TracerProvider {
   addSpanProcessor?: (processor: SpanProcessor) => void
@@ -28,10 +25,16 @@ interface ProviderWithSpanProcessor extends TracerProvider {
 }
 
 function getRegisteredTracerProvider(): TracerProvider | undefined {
-  const provider = trace.getTracerProvider() as ProxyTracerProviderLike
-  const delegate = provider.getDelegate?.() ?? provider
+  const provider = trace.getTracerProvider()
 
-  return delegate.constructor.name === "NoopTracerProvider" ? undefined : delegate
+  // The OTel global is a ProxyTracerProvider that's installed at module load. `getDelegateTracer`
+  // returns `undefined` when nothing has been registered behind the proxy — this is the public way
+  // to detect "no global provider set" without reaching into `constructor.name` or private state.
+  if (provider instanceof ProxyTracerProvider) {
+    return provider.getDelegateTracer(DETECT_PROBE) === undefined ? undefined : provider.getDelegate()
+  }
+
+  return provider
 }
 
 function addSpanProcessor(provider: TracerProvider, processor: SpanProcessor): boolean {
@@ -68,7 +71,7 @@ export class Latitude {
   private readonly ownsProvider: boolean
 
   constructor(options: LatitudeOptions) {
-    const { apiKey, projectSlug, instrumentations = [], tracerProvider, ...processorOptions } = options
+    const { apiKey, projectSlug, instrumentations = [], tracerProvider, ...processorOptionsRaw } = options
 
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")
@@ -77,28 +80,53 @@ export class Latitude {
       throw new Error("[Latitude] projectSlug is required and cannot be empty")
     }
 
-    this.latitudeProcessor = new LatitudeSpanProcessor(apiKey, projectSlug, processorOptions)
-    const existingProvider = tracerProvider ?? getRegisteredTracerProvider()
+    const targetProvider = tracerProvider ?? getRegisteredTracerProvider()
 
-    if (existingProvider && addSpanProcessor(existingProvider, this.latitudeProcessor)) {
-      this.provider = existingProvider
+    // `serviceName` is a Latitude-owned-provider concern. When piggy-backing on an existing
+    // provider, the host's resource is the source of truth for `service.name`; overriding it
+    // would silently relabel spans the host SDK is also processing. Strip it here so the
+    // exporter wrapper inside LatitudeSpanProcessor is not installed in the piggy-back path.
+    let processorOptions = processorOptionsRaw
+    if (targetProvider) {
+      const { serviceName: _ignored, ...rest } = processorOptionsRaw
+      processorOptions = rest
+    }
+
+    this.latitudeProcessor = new LatitudeSpanProcessor(apiKey, projectSlug, processorOptions)
+    const attached = targetProvider ? addSpanProcessor(targetProvider, this.latitudeProcessor) : false
+
+    if (targetProvider && !attached) {
+      const source = tracerProvider ? "the provider passed via `tracerProvider`" : "the global OpenTelemetry provider"
+      console.warn(
+        `[Latitude] Could not attach LatitudeSpanProcessor to ${source}: it exposes neither ` +
+          "`addSpanProcessor` nor a known internal span-processor list (OTel JS v2 / Datadog). " +
+          "Falling back to a Latitude-owned provider that is NOT registered globally — instrumentations " +
+          "will still send spans to Latitude, but the host SDK's spans will not. To fix, pass a provider " +
+          "exposing `addSpanProcessor` or attach `LatitudeSpanProcessor` to your provider manually.",
+      )
+    }
+
+    if (targetProvider && attached) {
+      this.provider = targetProvider
       this.ownsProvider = false
     } else {
-      const contextManager = new AsyncLocalStorageContextManager()
-      contextManager.enable()
-
-      const propagator = new CompositePropagator({
-        propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
-      })
-
-      if (!existingProvider) {
+      // We only install global context manager + propagator when no provider was discovered or
+      // explicitly passed — otherwise the host SDK already owns those, and replacing them would
+      // break their propagation pipeline.
+      if (!targetProvider) {
+        const contextManager = new AsyncLocalStorageContextManager()
+        contextManager.enable()
         context.setGlobalContextManager(contextManager)
-        propagation.setGlobalPropagator(propagator)
+        propagation.setGlobalPropagator(
+          new CompositePropagator({
+            propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+          }),
+        )
       }
 
       const resourceServiceName =
-        typeof processorOptions.serviceName === "string" && processorOptions.serviceName.trim() !== ""
-          ? processorOptions.serviceName.trim()
+        typeof processorOptionsRaw.serviceName === "string" && processorOptionsRaw.serviceName.trim() !== ""
+          ? processorOptionsRaw.serviceName.trim()
           : SERVICE_NAME
 
       const latitudeProvider = new NodeTracerProvider({
@@ -108,7 +136,7 @@ export class Latitude {
         spanProcessors: [this.latitudeProcessor],
       })
 
-      if (!existingProvider) {
+      if (!targetProvider) {
         latitudeProvider.register()
       }
 

--- a/packages/telemetry/typescript/src/sdk/processor.test.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.test.ts
@@ -67,14 +67,16 @@ describe("LatitudeSpanProcessor", () => {
     expect(mockSpan.updateName).not.toHaveBeenCalled()
   })
 
-  it("should stamp service.name when serviceName option is set", () => {
+  it("should NOT stamp service.name as a span attribute when serviceName option is set", () => {
+    // service.name is a resource attribute per OTel semantic conventions, not a span attribute.
+    // It's applied via the exporter wrapper instead — covered by the init.test.ts integration tests.
     const processor = new LatitudeSpanProcessor(apiKey, projectSlug, { serviceName: "billing-api" })
     const mockSpan = createMockSpan()
     const ctx = context.active()
 
     processor.onStart(mockSpan as unknown as Span, ctx)
 
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTR_SERVICE_NAME, "billing-api")
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(ATTR_SERVICE_NAME, "billing-api")
   })
 
   it("should not stamp empty tags", () => {

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -1,10 +1,13 @@
 import type { Context } from "@opentelemetry/api"
+import type { ExportResult } from "@opentelemetry/core"
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { resourceFromAttributes } from "@opentelemetry/resources"
 import {
   BatchSpanProcessor,
   type ReadableSpan,
   SimpleSpanProcessor,
   type Span,
+  type SpanExporter,
   type SpanProcessor,
 } from "@opentelemetry/sdk-trace-node"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
@@ -19,9 +22,45 @@ import {
 } from "./span-filter.ts"
 import type { LatitudeSpanProcessorOptions } from "./types.ts"
 
+// `service.name` is a resource attribute per OTel semantic conventions, not a span attribute.
+// When piggy-backing on another SDK's provider we can't change the host's resource, so we wrap
+// the exporter to rewrite each exported span's resource. The original span is untouched, so other
+// span processors on the host provider keep seeing the host's resource.
+class ServiceNameResourceExporter implements SpanExporter {
+  private readonly overlay: ReturnType<typeof resourceFromAttributes>
+
+  constructor(
+    private readonly inner: SpanExporter,
+    serviceName: string,
+  ) {
+    this.overlay = resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName })
+  }
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    const overlay = this.overlay
+    const overridden = spans.map(
+      (span) =>
+        new Proxy(span, {
+          get(target, prop, receiver) {
+            if (prop === "resource") return target.resource.merge(overlay)
+            return Reflect.get(target, prop, receiver)
+          },
+        }),
+    )
+    this.inner.export(overridden, resultCallback)
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner.shutdown()
+  }
+
+  forceFlush(): Promise<void> {
+    return this.inner.forceFlush?.() ?? Promise.resolve()
+  }
+}
+
 export class LatitudeSpanProcessor implements SpanProcessor {
   private readonly tail: SpanProcessor
-  private readonly serviceName: string | undefined
 
   constructor(apiKey: string, projectSlug: string, options?: LatitudeSpanProcessorOptions) {
     if (!apiKey || apiKey.trim() === "") {
@@ -31,7 +70,7 @@ export class LatitudeSpanProcessor implements SpanProcessor {
       throw new Error("[Latitude] projectSlug is required and cannot be empty")
     }
 
-    const exporter =
+    const baseExporter =
       options?.exporter ??
       new OTLPTraceExporter({
         url: `${env.EXPORTER_URL}/v1/traces`,
@@ -42,6 +81,9 @@ export class LatitudeSpanProcessor implements SpanProcessor {
         },
         timeoutMillis: 30_000,
       })
+
+    const rawServiceName = options?.serviceName?.trim()
+    const exporter = rawServiceName ? new ServiceNameResourceExporter(baseExporter, rawServiceName) : baseExporter
 
     const redact = options?.disableRedact
       ? null
@@ -59,16 +101,9 @@ export class LatitudeSpanProcessor implements SpanProcessor {
 
     const redactThenExport = new RedactThenExportSpanProcessor(redact, batchOrSimple)
     this.tail = new ExportFilterSpanProcessor(shouldExport, redactThenExport)
-
-    const rawServiceName = options?.serviceName?.trim()
-    this.serviceName = rawServiceName === "" ? undefined : rawServiceName
   }
 
   onStart(span: Span, parentContext: Context): void {
-    if (this.serviceName !== undefined) {
-      span.setAttribute(ATTR_SERVICE_NAME, this.serviceName)
-    }
-
     const latitudeData = getLatitudeContext(parentContext)
 
     if (latitudeData) {

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -1,3 +1,4 @@
+import type { TracerProvider } from "@opentelemetry/api"
 import type { SpanExporter } from "@opentelemetry/sdk-trace-node"
 import type { InstrumentationType } from "./instrumentations.ts"
 import type { RedactSpanProcessorOptions } from "./redact.ts"
@@ -11,7 +12,7 @@ export type ContextOptions = {
   userId?: string
 }
 
-export type InitLatitudeOptions = SmartFilterOptions & {
+export type LatitudeOptions = SmartFilterOptions & {
   apiKey: string
   projectSlug: string
   instrumentations?: InstrumentationType[]
@@ -19,7 +20,13 @@ export type InitLatitudeOptions = SmartFilterOptions & {
   redact?: RedactSpanProcessorOptions
   disableBatch?: boolean
   exporter?: SpanExporter
-  /** Sets `service.name` on exported spans (and on the provider resource when using `initLatitude`). */
+  /**
+   * Existing OpenTelemetry tracer provider to attach Latitude to.
+   * Usually omitted because `new Latitude()` detects the global provider installed by Sentry,
+   * Datadog, New Relic, Honeycomb, or a custom OTel SDK setup.
+   */
+  tracerProvider?: TracerProvider
+  /** Sets `service.name` on exported spans (and on the provider resource when using `new Latitude()`). */
   serviceName?: string
 }
 

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -30,6 +30,11 @@ export type LatitudeOptions = SmartFilterOptions & {
   serviceName?: string
 }
 
+/**
+ * @deprecated Use `LatitudeOptions` with `new Latitude(options)` instead.
+ */
+export type InitLatitudeOptions = LatitudeOptions
+
 export type LatitudeSpanProcessorOptions = SmartFilterOptions & {
   disableRedact?: boolean
   redact?: RedactSpanProcessorOptions

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -26,7 +26,13 @@ export type LatitudeOptions = SmartFilterOptions & {
    * Datadog, New Relic, Honeycomb, or a custom OTel SDK setup.
    */
   tracerProvider?: TracerProvider
-  /** Sets `service.name` on exported spans (and on the provider resource when using `new Latitude()`). */
+  /**
+   * Sets the OpenTelemetry `service.name` resource attribute on the Latitude-owned provider.
+   * Honored only when `new Latitude()` creates its own provider. When piggy-backing on an
+   * existing provider (via `tracerProvider` or the detected global), this option is ignored
+   * and the host provider's `service.name` is used — overriding the host's resource would
+   * silently relabel spans the host SDK also processes.
+   */
   serviceName?: string
 }
 
@@ -40,7 +46,11 @@ export type LatitudeSpanProcessorOptions = SmartFilterOptions & {
   redact?: RedactSpanProcessorOptions
   disableBatch?: boolean
   exporter?: SpanExporter
-  /** Sets `service.name` on each span so Latitude ingest can attribute telemetry to your service. */
+  /**
+   * Overrides the `service.name` resource attribute on spans exported through this processor.
+   * Applied via an exporter wrapper, so other span processors on the host provider continue
+   * to see the host's original resource.
+   */
   serviceName?: string
 }
 


### PR DESCRIPTION
## Summary

Adds the class-based TypeScript telemetry bootstrap API:

```ts
const latitude = new Latitude({
  apiKey,
  projectSlug,
  instrumentations: ["openai"],
})
```

`initLatitude()` is kept as a `@deprecated` compatibility wrapper around `new Latitude(...)`, and the public option type is now `LatitudeOptions`.

## Existing tracing SDK integration

`Latitude` now checks for an existing OpenTelemetry provider before creating its own provider. When an existing provider is present, it attaches the Latitude span processor to that provider instead of replacing the application's tracing setup. This keeps the existing provider, context manager, propagator, sampler, and vendor span processors in place.

The integration path covers the common Node tracing SDK shapes used by Sentry, Datadog, New Relic, Honeycomb, and custom OTel SDK setups:

- public `addSpanProcessor()` providers
- OTel JS v2 `MultiSpanProcessor` internals used by `NodeSDK`/`BasicTracerProvider` setups
- Datadog's `_activeProcessor._processors` bridge shape
- explicit `tracerProvider` injection for custom setups

Provider detection uses the public `ProxyTracerProvider.getDelegateTracer()` API (replacing earlier `constructor.name` / private `_TRACER_PROVIDER` reads), so it survives OTel internal refactors and minified bundles. When a provider is discovered but none of the known attach hooks match, Latitude logs a clear warning and falls back to its own non-globally-registered provider so instrumentations still reach Latitude.

`flush()` and `shutdown()` only affect Latitude's processor when Latitude shares a provider owned by another SDK.

## service.name handling

`service.name` is treated as a resource attribute per OTel semantic conventions, not a span attribute:

- When Latitude owns the provider, `serviceName` is set on the provider's `Resource`.
- When piggy-backing on an existing provider, `serviceName` is ignored — the host provider's resource is the source of truth, so Latitude does not silently relabel spans the host SDK also processes.
- Advanced use of `LatitudeSpanProcessor({ serviceName })` directly (without the bootstrap) applies the value via a span-exporter wrapper that overrides only spans flowing through Latitude's exporter, leaving the host provider's other processors untouched.

## Docs and examples

Updates TypeScript telemetry docs, provider/framework guides, package README, examples, root README, and web onboarding snippets to use `new Latitude(...)`.

## Validation

Local:

- `pnpm knip`
- `pnpm --filter @latitude-data/telemetry test`
- `pnpm --filter @latitude-data/telemetry typecheck`
- `pnpm --filter @latitude-data/telemetry check`
- `cd packages/telemetry/python && uv run pytest tests/`
- `cd packages/telemetry/python && uv run pyright src`
- `cd packages/telemetry/python && uv run ruff check src tests`

CI:

- check: pass
- typecheck: pass
- test: pass
- knip: pass
- web-bundle-size: pass
- check-migration-versions: pass
- CodeQL: pass