### PR TITLE
fix(flaggers): silence false-positive Datadog error for tolerated schema mismatch

### DIFF
--- a/packages/domain/ai/src/index.ts
+++ b/packages/domain/ai/src/index.ts
@@ -59,6 +59,14 @@ export interface GenerateInput<T> {
    * Does not affect generation semantics; excluded from AI cache keys (see `withAICache`).
    */
   readonly telemetry?: GenerateTelemetryCapture
+  /**
+   * When `true`, an `AI_NoObjectGeneratedError` from the underlying SDK (model output that does
+   * not parse against the schema) is recovered inside the adapter: the call resolves with
+   * `object: undefined` and zeroed token usage instead of rejecting. Callers that opt in must
+   * handle the `undefined` case. Used by flows where a schema mismatch is a valid "no result"
+   * signal and should not surface as an error on the telemetry span.
+   */
+  readonly tolerateSchemaMismatch?: boolean
 }
 
 export interface GenerateResult<T> {
@@ -124,6 +132,9 @@ export interface RerankResult {
 // ---------------------------------------------------------------------------
 
 export interface AIGenerateShape {
+  generate<T>(
+    input: GenerateInput<T> & { readonly tolerateSchemaMismatch: true },
+  ): Effect.Effect<GenerateResult<T | undefined>, AIError | AICredentialError>
   generate<T>(input: GenerateInput<T>): Effect.Effect<GenerateResult<T>, AIError | AICredentialError>
 }
 

--- a/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.test.ts
@@ -395,7 +395,10 @@ describe("runFlaggerUseCase", () => {
     }
   })
 
-  it("recovers to matched=false when the AI returns output that fails schema validation", async () => {
+  // The Vercel adapter recovers `NoObjectGeneratedError` inside its capture span when
+  // `tolerateSchemaMismatch: true` is set (which the flagger does), surfacing the result
+  // as `object: undefined` instead of failing. The flagger collapses that into matched=false.
+  it("recovers to matched=false when the adapter signals a schema mismatch via object: undefined", async () => {
     const { repository } = createFakeTraceRepository({
       findByTraceId: () =>
         Effect.succeed(
@@ -412,20 +415,14 @@ describe("runFlaggerUseCase", () => {
         ),
     })
 
-    // Simulates Vercel AI SDK's NoObjectGeneratedError, which is surfaced by
-    // @platform/ai-vercel as AIError with the original SDK error on `cause`.
-    const sdkError = new Error("No object generated: response did not match schema.")
-    sdkError.name = "AI_NoObjectGeneratedError"
-
-    const { layer: aiLayer } = createFakeAI({
-      generate: () =>
-        Effect.fail(
-          new AIError({
-            message:
-              "AI generation failed (amazon-bedrock/amazon.nova-2-lite-v1:0): No object generated: response did not match schema.",
-            cause: sdkError,
-          }),
-        ),
+    const { calls, layer: aiLayer } = createFakeAI({
+      generate: <T>() =>
+        Effect.succeed({
+          object: undefined as T,
+          tokens: 0,
+          tokenUsage: { input: 0, output: 0 },
+          duration: 0,
+        }),
     })
 
     const result = await Effect.runPromise(
@@ -441,49 +438,8 @@ describe("runFlaggerUseCase", () => {
     )
 
     expect(result).toEqual({ matched: false })
-  })
-
-  it("recovers to matched=false when the SDK cause has no AI_NoObjectGeneratedError name but the message indicates a schema mismatch", async () => {
-    const { repository } = createFakeTraceRepository({
-      findByTraceId: () =>
-        Effect.succeed(
-          makeTraceDetail([
-            {
-              role: "user",
-              parts: [{ type: "text", content: "Please do the task." }],
-            },
-            {
-              role: "assistant",
-              parts: [{ type: "text", content: "I'll look into that." }],
-            },
-          ]),
-        ),
-    })
-
-    const { layer: aiLayer } = createFakeAI({
-      generate: () =>
-        Effect.fail(
-          new AIError({
-            message:
-              "AI generation failed (amazon-bedrock/amazon.nova-2-lite-v1:0): No object generated: response did not match schema.",
-            cause: new Error("No object generated: response did not match schema."),
-          }),
-        ),
-    })
-
-    const result = await Effect.runPromise(
-      runFlaggerUseCase({ ...INPUT, flaggerSlug: "laziness" }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Layer.succeed(TraceRepository, repository),
-            Layer.succeed(ChSqlClient, createFakeChSqlClient({ organizationId: OrganizationId(INPUT.organizationId) })),
-            aiLayer,
-          ),
-        ),
-      ),
-    )
-
-    expect(result).toEqual({ matched: false })
+    expect(calls.generate).toHaveLength(1)
+    expect(calls.generate[0]?.tolerateSchemaMismatch).toBe(true)
   })
 
   it("uses flagger-specific prompt for laziness with work signals", async () => {

--- a/packages/domain/flaggers/src/use-cases/run-flagger.ts
+++ b/packages/domain/flaggers/src/use-cases/run-flagger.ts
@@ -3,7 +3,7 @@ import {
   AI_GENERATE_TELEMETRY_SPAN_NAMES,
   AI_GENERATE_TELEMETRY_TAGS,
   type AICredentialError,
-  AIError,
+  type AIError,
   buildProjectScopedAiMetadata,
 } from "@domain/ai"
 import { type NotFoundError, OrganizationId, ProjectId, type RepositoryError, TraceId } from "@domain/shared"
@@ -63,17 +63,6 @@ const loadTraceDetail = (input: RunFlaggerInput) =>
     })
   })
 
-// The Vercel AI SDK raises a `NoObjectGeneratedError` (name `AI_NoObjectGeneratedError`)
-// when the model returns output that does not match the requested schema. The flagger
-// treats this as a "no match" signal instead of propagating the failure — the model
-// effectively failed to classify, which for a triage flagger is indistinguishable
-// from matched=false.
-const isSchemaMismatchCause = (cause: unknown): boolean => {
-  if (!(cause instanceof Error)) return false
-  if (cause.name === "AI_NoObjectGeneratedError") return true
-  return typeof cause.message === "string" && cause.message.includes("response did not match schema")
-}
-
 /**
  * LLM classification for an already-loaded trace.
  *
@@ -93,35 +82,33 @@ export const classifyTraceForFlaggerUseCase = Effect.fn("flaggers.classifyTraceF
 
   const ai = yield* AI
 
-  const decisions = yield* ai
-    .generate({
-      ...FLAGGER_MODEL,
-      maxTokens: FLAGGER_MAX_TOKENS,
-      system: strategy.buildSystemPrompt!(input.trace),
-      prompt: strategy.buildPrompt!(input.trace),
-      schema: flaggerOutputSchema,
-      telemetry: {
-        spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
-        tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
-        metadata: buildProjectScopedAiMetadata(
-          { organizationId: input.organizationId, projectId: input.projectId },
-          { traceId: input.traceId, flaggerSlug: input.flaggerSlug },
-        ),
-      },
-    })
-    .pipe(
-      Effect.map((result) => result.object),
-      Effect.catchIf(
-        (error): error is AIError => error instanceof AIError && isSchemaMismatchCause(error.cause),
-        () =>
-          Effect.gen(function* () {
-            yield* Effect.annotateCurrentSpan("flagger.flaggerSchemaMismatch", true)
-            return { matched: false }
-          }),
+  // `tolerateSchemaMismatch` recovers a Vercel AI SDK `NoObjectGeneratedError` (model output
+  // that does not parse against the schema) inside the adapter. The flagger treats that as
+  // "no match", same as a deterministic miss — and recovering before the capture span sees
+  // the error keeps the false-positive out of Datadog error tracking.
+  const result = yield* ai.generate({
+    ...FLAGGER_MODEL,
+    maxTokens: FLAGGER_MAX_TOKENS,
+    system: strategy.buildSystemPrompt!(input.trace),
+    prompt: strategy.buildPrompt!(input.trace),
+    schema: flaggerOutputSchema,
+    tolerateSchemaMismatch: true,
+    telemetry: {
+      spanName: AI_GENERATE_TELEMETRY_SPAN_NAMES.flaggerClassify,
+      tags: [...AI_GENERATE_TELEMETRY_TAGS.flaggerClassify],
+      metadata: buildProjectScopedAiMetadata(
+        { organizationId: input.organizationId, projectId: input.projectId },
+        { traceId: input.traceId, flaggerSlug: input.flaggerSlug },
       ),
-    )
+    },
+  })
 
-  return { matched: decisions.matched } satisfies RunFlaggerResult
+  if (result.object === undefined) {
+    yield* Effect.annotateCurrentSpan("flagger.flaggerSchemaMismatch", true)
+    return { matched: false } satisfies RunFlaggerResult
+  }
+
+  return { matched: result.object.matched } satisfies RunFlaggerResult
 })
 
 /**

--- a/packages/platform/ai-vercel/src/ai.ts
+++ b/packages/platform/ai-vercel/src/ai.ts
@@ -11,7 +11,7 @@ import {
 } from "@domain/ai"
 import { getLatitudeTracer, runWithAiTelemetry } from "@platform/ai-latitude"
 import { parseEnv, parseEnvOptional } from "@platform/env"
-import { generateText, Output } from "ai"
+import { generateText, NoObjectGeneratedError, Output } from "ai"
 import { Effect, Layer } from "effect"
 
 const latitudeTracer = getLatitudeTracer("vercelai")
@@ -277,20 +277,38 @@ export const AIGenerateLive = Layer.effect(
               },
             }
 
-            const result = await generateText(call)
-            const usage = result.usage
+            try {
+              const result = await generateText(call)
+              const usage = result.usage
 
-            return {
-              object: result.output,
-              tokens: usage?.totalTokens ?? 0,
-              tokenUsage: {
-                input: usage?.inputTokens ?? 0,
-                output: usage?.outputTokens ?? 0,
-                ...(usage?.reasoningTokens !== undefined ? { reasoning: usage.reasoningTokens } : {}),
-                ...(usage?.cachedInputTokens !== undefined ? { cacheRead: usage.cachedInputTokens } : {}),
-              },
-              duration: Math.round((performance.now() - startTime) * 1_000_000),
-            } satisfies GenerateResult<T>
+              return {
+                object: result.output,
+                tokens: usage?.totalTokens ?? 0,
+                tokenUsage: {
+                  input: usage?.inputTokens ?? 0,
+                  output: usage?.outputTokens ?? 0,
+                  ...(usage?.reasoningTokens !== undefined ? { reasoning: usage.reasoningTokens } : {}),
+                  ...(usage?.cachedInputTokens !== undefined ? { cacheRead: usage.cachedInputTokens } : {}),
+                },
+                duration: Math.round((performance.now() - startTime) * 1_000_000),
+              } satisfies GenerateResult<T>
+            } catch (error) {
+              // Recover schema mismatch inside execute — before the Latitude `capture` span
+              // observes it — so opt-in callers don't surface an error in Datadog for an
+              // outcome that they intentionally treat as "no object". The `as T` cast is sound
+              // because the recovery only runs when `tolerateSchemaMismatch === true`, and the
+              // public `AIGenerateShape.generate` overload widens the result to `T | undefined`
+              // for those callers.
+              if (input.tolerateSchemaMismatch === true && NoObjectGeneratedError.isInstance(error)) {
+                return {
+                  object: undefined as T,
+                  tokens: 0,
+                  tokenUsage: { input: 0, output: 0 },
+                  duration: Math.round((performance.now() - startTime) * 1_000_000),
+                } satisfies GenerateResult<T>
+              }
+              throw error
+            }
           }
 
           return await runWithAiTelemetry(input.telemetry, execute)


### PR DESCRIPTION
## Summary

- Datadog Error Tracking issue [bd420c54-3f4a-11f1-8634-da7ad0900005](https://app.datadoghq.eu/error-tracking?query=service%3A%2A&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22bd420c54-3f4a-11f1-8634-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D) was firing on `AI_NoObjectGeneratedError` from `flagger.classify`. The flagger already treats this as `matched: false` in business logic, but the Latitude `capture` span recorded the exception *before* `Effect.catchIf` recovered it — so Datadog kept reporting a tolerated outcome as an error.
- Recover the SDK error inside the ai-vercel adapter via an opt-in `tolerateSchemaMismatch` flag on `GenerateInput`. When set, `generateText` rejections that match `NoObjectGeneratedError` are caught inside `execute` (before the capture span sees them) and resolved as `{ object: undefined, tokens: 0, ... }`.
- Flagger opts in and branches on `result.object === undefined`; the cause-introspecting `Effect.catchIf` workaround is gone. Schema-mismatch unknowns from any *other* `ai.generate` call site remain visible as errors.

## Test plan

- [x] `pnpm --filter @platform/ai-vercel --filter @domain/ai --filter @domain/flaggers --filter @platform/ai --filter @domain/annotations --filter @domain/evaluations --filter @domain/issues --filter workflows typecheck`
- [x] `pnpm --filter @domain/flaggers test` — 164/164 passing
- [x] `pnpm --filter @platform/ai --filter @platform/ai-vercel test` — 13/13 passing
- [ ] After deploy: confirm in Datadog that the `flagger.classify` resource no longer surfaces `NoObjectGeneratedError`, while unrelated `ai.generate` callers still report it on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)