### PR TITLE
fix(core): surface live-eval results for traces missing an ingested root

### DIFF
--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.test.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.test.ts
@@ -13,6 +13,7 @@ import {
   UnprocessableEntityError,
 } from '../../../lib/errors'
 import { generateUUIDIdentifier } from '../../../lib/generateUUID'
+import { EvaluationResultsV2Repository } from '../../../repositories'
 import { type Commit } from '../../../schema/models/types/Commit'
 import { type Dataset } from '../../../schema/models/types/Dataset'
 import { type DatasetRow } from '../../../schema/models/types/DatasetRow'
@@ -412,6 +413,67 @@ describe('runEvaluationV2Job', () => {
       })
       expect(evaluationFinishedSpy).not.toHaveBeenCalled()
       expect(evaluationErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('records an error evaluation result when trace assembly fails on the final attempt', async () => {
+      // Live-eval (no experiment) job: when the trace assembly cannot find
+      // the completion span and all retries are exhausted, the failure must
+      // be persisted as an evaluation result row so the UI shows it instead
+      // of "-".
+      runEvaluationV2Spy.mockReset()
+      runEvaluationV2Spy.mockResolvedValueOnce(
+        Result.error(
+          new UnprocessableEntityError('Cannot find completion span'),
+        ),
+      )
+
+      const finalAttemptJob = {
+        ...jobData,
+        attemptsMade: 4,
+        opts: { attempts: 5 },
+      } as Job<RunEvaluationV2JobData>
+
+      await runEvaluationV2Job(finalAttemptJob)
+
+      const resultsRepository = new EvaluationResultsV2Repository(workspace.id)
+      const persisted =
+        await resultsRepository.findByEvaluatedSpanAndEvaluation({
+          evaluatedSpanId: span.id,
+          evaluatedTraceId: span.traceId,
+          evaluationUuid: evaluation.uuid,
+        })
+
+      expect(persisted).toBeDefined()
+      expect(persisted?.error?.message).toBe('Cannot find completion span')
+    })
+
+    it('does not record an error result while retries remain', async () => {
+      runEvaluationV2Spy.mockReset()
+      runEvaluationV2Spy.mockResolvedValueOnce(
+        Result.error(
+          new UnprocessableEntityError('Cannot find completion span'),
+        ),
+      )
+
+      const earlyAttemptJob = {
+        ...jobData,
+        attemptsMade: 0,
+        opts: { attempts: 5 },
+      } as Job<RunEvaluationV2JobData>
+
+      await expect(runEvaluationV2Job(earlyAttemptJob)).rejects.toThrowError(
+        new UnprocessableEntityError('Cannot find completion span'),
+      )
+
+      const resultsRepository = new EvaluationResultsV2Repository(workspace.id)
+      const persisted =
+        await resultsRepository.findByEvaluatedSpanAndEvaluation({
+          evaluatedSpanId: span.id,
+          evaluatedTraceId: span.traceId,
+          evaluationUuid: evaluation.uuid,
+        })
+
+      expect(persisted).toBeUndefined()
     })
   })
 

--- a/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.ts
+++ b/packages/core/src/jobs/job-definitions/evaluations/runEvaluationV2Job.ts
@@ -1,4 +1,9 @@
-import { MainSpanType, SpanWithDetails } from '@latitude-data/constants'
+import {
+  EvaluationResultValue,
+  MainSpanType,
+  Span,
+  SpanWithDetails,
+} from '@latitude-data/constants'
 import { Job } from 'bullmq'
 import { unsafelyFindWorkspace } from '../../../data-access/workspaces'
 import { NotFoundError, UnprocessableEntityError } from '../../../lib/errors'
@@ -7,12 +12,15 @@ import {
   CommitsRepository,
   DatasetRowsRepository,
   DatasetsRepository,
+  EvaluationResultsV2Repository,
   EvaluationsV2Repository,
   ExperimentsRepository,
   SpanMetadatasRepository,
   SpansRepository,
 } from '../../../repositories'
+import { Workspace } from '../../../schema/models/types/Workspace'
 import { runEvaluationV2 } from '../../../services/evaluationsV2/run'
+import { createEvaluationResultV2 } from '../../../services/evaluationsV2/results/create'
 import { updateExperimentStatus } from '../../../services/experiments/updateStatus'
 import { captureException } from '../../../utils/datadogCapture'
 
@@ -158,6 +166,14 @@ export const runEvaluationV2Job = async (job: Job<RunEvaluationV2JobData>) => {
         (progressTracker) =>
           progressTracker.evaluationError(span.documentLogUuid!),
       )
+    } else if (!experiment && !dry && span && isTraceAssemblyError(error)) {
+      await recordLiveEvalAssemblyFailure({
+        workspace,
+        span,
+        commitId,
+        evaluationUuid,
+        error: error as Error,
+      })
     }
     if (dry) throw error
   }
@@ -179,9 +195,82 @@ function shouldRetryTraceAssembly(
   error: Error,
   job: Job<RunEvaluationV2JobData>,
 ): boolean {
-  if (!(error instanceof UnprocessableEntityError)) return false
-  if (!RETRYABLE_TRACE_ASSEMBLY_MESSAGES.has(error.message)) return false
+  if (!isTraceAssemblyError(error)) return false
 
   const maxAttempts = job.opts.attempts ?? 1
   return job.attemptsMade + 1 < maxAttempts
+}
+
+function isTraceAssemblyError(error: unknown): boolean {
+  return (
+    error instanceof UnprocessableEntityError &&
+    RETRYABLE_TRACE_ASSEMBLY_MESSAGES.has(error.message)
+  )
+}
+
+/**
+ * Persists a failed evaluation result for live-eval jobs that exhausted their
+ * retries on a trace-assembly error. Without this the failure disappears (the
+ * catch block returns silently for non-experiment runs) and the UI shows "-",
+ * which is indistinguishable from "not yet evaluated".
+ */
+async function recordLiveEvalAssemblyFailure({
+  workspace,
+  span,
+  commitId,
+  evaluationUuid,
+  error,
+}: {
+  workspace: Workspace
+  span: Span
+  commitId: number
+  evaluationUuid: string
+  error: Error
+}) {
+  try {
+    if (!span.documentUuid) return
+
+    const commitsRepository = new CommitsRepository(workspace.id)
+    const commitResult = await commitsRepository.getCommitById(commitId)
+    if (commitResult.error) {
+      captureException(commitResult.error)
+      return
+    }
+    const commit = commitResult.unwrap()
+
+    const evaluationsRepository = new EvaluationsV2Repository(workspace.id)
+    const evaluationResult = await evaluationsRepository.getAtCommitByDocument({
+      commitUuid: commit.uuid,
+      documentUuid: span.documentUuid,
+      evaluationUuid,
+    })
+    if (evaluationResult.error) {
+      captureException(evaluationResult.error)
+      return
+    }
+    const evaluation = evaluationResult.unwrap()
+
+    const resultsRepository = new EvaluationResultsV2Repository(workspace.id)
+    const existing = await resultsRepository.findByEvaluatedSpanAndEvaluation({
+      evaluatedSpanId: span.id,
+      evaluatedTraceId: span.traceId,
+      evaluationUuid,
+    })
+    if (existing) return
+
+    const writeResult = await createEvaluationResultV2({
+      evaluation,
+      span,
+      commit,
+      workspace,
+      value: {
+        error: { message: error.message },
+      } as EvaluationResultValue,
+    })
+    if (writeResult.error) {
+      captureException(writeResult.error)
+    }
+  } catch (recordingError) {
+    captureException(recordingError as Error)
+  }
 }

--- a/packages/core/src/services/tracing/traces/assemble.test.ts
+++ b/packages/core/src/services/tracing/traces/assemble.test.ts
@@ -175,6 +175,59 @@ describe('assembleTraceStructure', () => {
     expect(spans[1]?.endOffset).toBe(1500)
   })
 
+  it('treats spans whose parent is not in the result set as virtual roots', async () => {
+    // Simulates the live-eval race: a sub-prompt (and its completion) have
+    // been ingested before the agent's root prompt lands. The orphan tool —
+    // which still references a not-yet-ingested parent — must be surfaced as
+    // a root so the sub-prompt remains reachable via findSpanById.
+    const startTime = new Date()
+
+    const orphanTool = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-orphan',
+      parentId: '0123456789abcdef',
+      type: SpanType.Tool,
+      name: 'lat_agent_confidence-scorer',
+      startedAt: startTime,
+      duration: 1000,
+    })
+
+    const subPrompt = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-orphan',
+      parentId: orphanTool.id,
+      type: SpanType.Prompt,
+      name: 'confidence-scorer',
+      startedAt: new Date(startTime.getTime() + 50),
+      duration: 800,
+    })
+
+    const subCompletion = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-orphan',
+      parentId: subPrompt.id,
+      type: SpanType.Completion,
+      name: 'openai / gpt-5',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 700,
+    })
+
+    const result = await assembleTraceStructure({
+      traceId: 'trace-orphan',
+      workspace,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.trace.children).toHaveLength(1)
+
+    const root = result.value?.trace.children[0]
+    expect(root?.id).toBe(orphanTool.id)
+    expect(root?.parentId).toBeUndefined()
+    expect(root?.children).toHaveLength(1)
+    expect(root?.children[0]?.id).toBe(subPrompt.id)
+    expect(root?.children[0]?.children[0]?.id).toBe(subCompletion.id)
+  })
+
   it('does not fetch metadata for any spans', async () => {
     await factories.createSpan({
       workspaceId: workspace.id,
@@ -581,6 +634,66 @@ describe('assembleTraceWithMessages', () => {
       0,
     )
     expect(totalPromptTokens).toBe(1400)
+  })
+
+  it('returns the sub-prompt completion when the agent root span has not been ingested yet', async () => {
+    // Reproduces the live-eval race for workspaces with confidence-scorer
+    // sub-prompts: the eval fires for a sub-prompt before its enclosing agent
+    // root span lands. Without orphan-root handling, trace.children would be
+    // empty and Cannot find completion span would be thrown.
+    const startTime = new Date()
+
+    const orphanTool = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-pre-root',
+      parentId: 'fedcba9876543210',
+      type: SpanType.Tool,
+      name: 'lat_agent_confidence-scorer',
+      startedAt: startTime,
+      duration: 1000,
+    })
+
+    const subPrompt = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-pre-root',
+      parentId: orphanTool.id,
+      type: SpanType.Prompt,
+      name: 'confidence-scorer',
+      startedAt: new Date(startTime.getTime() + 50),
+      duration: 800,
+    })
+
+    const subCompletion = await factories.createSpan({
+      workspaceId: workspace.id,
+      traceId: 'trace-pre-root',
+      parentId: subPrompt.id,
+      type: SpanType.Completion,
+      name: 'openai / gpt-5',
+      startedAt: new Date(startTime.getTime() + 100),
+      duration: 700,
+    })
+
+    const completionMetadata = {
+      input: [{ role: 'user', content: [{ type: 'text', text: 'judge me' }] }],
+      output: [{ role: 'assistant', content: [{ type: 'text', text: '5' }] }],
+      provider: 'openai',
+      model: 'gpt-5',
+      configuration: {},
+    } as unknown as CompletionSpanMetadata
+
+    vi.spyOn(SpanMetadatasRepository.prototype, 'getBatch').mockResolvedValue(
+      new Map([[`trace-pre-root:${subCompletion.id}`, completionMetadata]]),
+    )
+
+    const result = await assembleTraceWithMessages({
+      traceId: 'trace-pre-root',
+      workspace,
+      spanId: subPrompt.id,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.value?.completionSpan?.id).toBe(subCompletion.id)
+    expect(result.value?.completionSpan?.metadata).toBeDefined()
   })
 })
 

--- a/packages/core/src/services/tracing/traces/assemble.ts
+++ b/packages/core/src/services/tracing/traces/assemble.ts
@@ -47,9 +47,21 @@ export async function assembleTraceStructure(
   const endedAt = new Date(Math.max(...spans.map((s) => s.endedAt.getTime()))) // prettier-ignore
   const duration = endedAt.getTime() - startedAt.getTime()
 
+  // Spans whose declared `parentId` is not present in the result set are
+  // treated as virtual roots. This happens when an eval fires for a nested
+  // prompt before its ancestor span has been ingested (e.g. sub-prompt of an
+  // in-flight agent run). Without this, partial traces collapse to no roots
+  // and the assembler cannot locate any completion span.
+  const spanIds = new Set(spans.map((s) => s.id))
+  const orphanIds = new Set<string>()
+
   const childrens = new Map<string, Span[]>()
   for (const span of spans) {
     if (!span.parentId) continue
+    if (!spanIds.has(span.parentId)) {
+      orphanIds.add(span.id)
+      continue
+    }
     const children = childrens.get(span.parentId) || []
     childrens.set(span.parentId, [...children, span])
   }
@@ -59,11 +71,17 @@ export async function assembleTraceStructure(
   }
 
   const roots = spans
-    .filter((span) => !span.parentId)
+    .filter((span) => !span.parentId || orphanIds.has(span.id))
     .sort((a, b) => a.startedAt.getTime() - b.startedAt.getTime())
 
   const assembledSpans = roots.map((span) =>
-    assembleSpanStructure({ span, depth: 0, startedAt, childrens }),
+    assembleSpanStructure({
+      span,
+      depth: 0,
+      startedAt,
+      childrens,
+      isOrphanRoot: orphanIds.has(span.id),
+    }),
   )
 
   const trace: AssembledTrace = {
@@ -156,11 +174,13 @@ function assembleSpanStructure({
   depth,
   startedAt,
   childrens,
+  isOrphanRoot = false,
 }: {
   span: Span
   depth: number
   startedAt: Date
   childrens: Map<string, Span[]>
+  isOrphanRoot?: boolean
 }): AssembledSpan {
   const children = childrens.get(span.id) || []
 
@@ -178,6 +198,7 @@ function assembleSpanStructure({
 
   return {
     ...span,
+    parentId: isOrphanRoot ? undefined : span.parentId,
     children: assembledSpans,
     depth: depth,
     startOffset: startOffset,


### PR DESCRIPTION
## Summary

- `assembleTraceStructure` treats spans whose `parentId` is not present in the trace's result set as virtual roots, so a sub-prompt eval that fires before the agent's root span is ingested can still locate its completion span instead of failing with `Cannot find completion span`.
- `runEvaluationV2Job` records an `evaluation_results_v2` row (with `value.error.message`) when a live-eval (non-experiment) job exhausts the trace-assembly retries — previously these failures hit `captureException` and disappeared, leaving the UI with a silent `-`.

## Why

Investigating the Datadog error-tracking issue `5b0993c8-4d27-11f1-b674-da7ad0900005` (~9.2k errored `runEvaluationV2Job` spans / day, ~78% error rate on `runEvaluationV2Job` since the PR #3038 deploy) we traced workspace 16707's failures to:

1. The customer's evaluation is configured on the `confidence-scorer` document (`bbd1bd44-…`), not the agent doc (`e2b363e3-…`). `evaluateLiveLogJob` runs for every `Prompt` span, so it fires for the 3 confidence-scorer sub-prompts inside each agent run.
2. The sub-prompt's `spanCreated` event fires as soon as its batch is ingested. The agent's root prompt isn't ingested until ~20 s later. In that 20 s window `SpansRepository.list({traceId})` returns a partial result where every span's `parentId` points at something not in the set, so `assembleTraceStructure` produces `roots = []`, both `findSpanById` and `findCompletionSpanFromTrace` return `undefined`, and the job throws `Cannot find completion span`.
3. PR #3038's 15 s retry budget can't bridge the ~20 s gap, so all 5 attempts fail. The catch-block in `runEvaluationV2Job` only records an error row when `experiment` is set, so live-eval failures vanish (`-` in the UI).

The orphan-root handling removes the dependency on the agent's root for sub-prompt evals — the sub-prompt's subtree is reachable on its own and the eval succeeds on the first attempt. The new live-eval error-recording branch ensures any residual permanent failures (e.g. the still-rarer `Cannot assemble trace` or `Completion span metadata is missing`) become visible.

## Test plan

- [x] CI: new `assembleTraceStructure` test asserts an orphan tool becomes a root and its `parentId` is normalized to `undefined`.
- [x] CI: new `assembleTraceWithMessages` test asserts a sub-prompt's completion is found when the agent's root span hasn't been ingested yet.
- [x] CI: new `runEvaluationV2Job` test asserts that on the final attempt of a trace-assembly error for a live-eval (no experiment), an `evaluation_results_v2` row is written with the error message.
- [x] CI: new `runEvaluationV2Job` test asserts no row is written while retries remain.
- [x] `pnpm tc` across the monorepo.
- [ ] Post-deploy: in Datadog APM, query `service:latitude-llm-workers resource_name:runEvaluationV2Job @error.message:"Cannot find completion span"` — expect count to drop sharply (most failures previously came from this race).
- [ ] Post-deploy: in production DB, check workspace 16707's recent `evaluation_results_v2` rows for `63d5d8b7-384f-4e33-b422-ba687028db25` — `-` rows in the UI should turn into real `1/1` / `0/1` results, with residual failures appearing as rows with `error.message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)