### PR TITLE
feat(api): GET /api-keys/:id, PATCH /api-keys/:id, masked token on list

### DIFF
--- a/.agents/skills/api-endpoints/SKILL.md
+++ b/.agents/skills/api-endpoints/SKILL.md
@@ -109,10 +109,11 @@ export const createWidgetsRoutes = () => {
 ```ts
 import { createWidgetsRoutes, widgetsPath } from "./widgets.ts"
 // ...
+routes.use(widgetsPath, createTierRateLimiter("low"))   // pick a tier — see below
 routes.route(widgetsPath, createWidgetsRoutes())
 ```
 
-Plain Hono mount — the MCP registration is a side effect of `mountHttp` inside `createWidgetsRoutes()`.
+The `routes.route(...)` call is plain Hono mount — MCP registration is a side effect of `mountHttp` inside `createWidgetsRoutes()`. The `routes.use(...)` line is the rate-limit tier — **don't skip it** (see "Rate limiting" below).
 
 ### 3. Regenerate manifests
 
@@ -167,6 +168,38 @@ filters: filterSetSchema, // ← what shape? what semantics? agent has to guess.
 
 If you find yourself writing `.openapi({ description })`, replace it with `.describe()` — descriptions hidden in the openapi WeakMap are invisible to MCP clients, which silently degrades agent UX.
 
+## Rate limiting — every new endpoint group needs a tier
+
+`createTierRateLimiter(tier)` is keyed on the authenticated org id (not IP), so one tenant's traffic doesn't eat another's quota. Apply it at the parent router, **before** the matching `routes.route(prefix, …)` call:
+
+```ts
+routes.use(myPath, createTierRateLimiter("low"))
+routes.route(myPath, createMyRoutes())
+```
+
+One tier per sub-app — Hono's `routes.use(prefix, …)` covers everything mounted under that prefix. Method-level granularity is possible (apply the limiter inside the route file per endpoint) but rarely worth the code spread.
+
+### Picking a tier
+
+Default to `low`. Most CRUD endpoints don't need more — `low` is 100 req/min/org, which comfortably covers SDK polling, MCP tool calls, and human-driven dashboards. Step up only when the endpoint genuinely warrants tighter limits.
+
+| Tier | Quota (per org / min) | Pick this when… |
+| --- | --- | --- |
+| `low` | 100 | **The default**: id-keyed CRUD, list of bounded size, simple lookups, account/settings reads. Most endpoints land here. |
+| `medium` | 60 | Mutations with non-trivial side effects (publishing events, writing to multiple tables, cache invalidation that fan-outs). |
+| `high` | 15 | Bulk reads with filter / search / semantic / vector load that scan large data sets per request. |
+| `critical` | 3 | Workflow-kicking ops: imports, exports, monitor-issue, anything that sends email or enqueues a heavy job. |
+
+Don't be harsh. A tighter tier doesn't make the API safer in any meaningful way for cheap endpoints — it just frustrates legitimate callers. When in doubt, pick `low` and bump it later if a specific endpoint shows up in incident traffic.
+
+### What if a sub-app mixes cheap and expensive endpoints?
+
+Size to the heaviest endpoint in the group, OR split the sub-app. A pure-CRUD sub-app with one expensive export endpoint deserves `low` for the CRUD and `critical` for the export — easiest to express by giving the export its own sub-app (`/widgets/export`).
+
+### Always add the line
+
+This is in the recipe (step 2) for a reason: **shipping a route group without a tier means it inherits no per-route limit at all** — only the global IP-keyed brute-force guard. That's an easy oversight in PR review. The `routes.use(myPath, createTierRateLimiter(...))` line is part of "wiring up", not optional.
+
 ## Choosing route names and shapes
 
 - **`name`** is camelCase, verb-first, and reads like an SDK method: `createApiKey`, `listProjects`, `assignSavedSearch`. Avoid resource-prefixed names that read awkwardly as SDK calls (`apiKeysList` → use `listApiKeys`).
@@ -197,6 +230,8 @@ pnpm mcp:emit && git diff --exit-code apps/api/mcp.json           # no drift
 ```
 
 Spot-check both manifests by hand: open `apps/api/mcp.json` and `apps/api/openapi.json`, find your operation, confirm every field has a `description`. If something is missing, it'll silently degrade SDK docs and agent UX — fix it at the Zod schema, not in the JSON output.
+
+And glance at `apps/api/src/routes/index.ts` next to your `routes.route(prefix, …)` line — there should be a `routes.use(prefix, createTierRateLimiter("…"))` on the line above. If it's missing, your endpoints are uncapped per-org.
 
 ## Where the machinery lives
 

--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -13,7 +13,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Human-readable name for the API key"
+            "description": "Human-readable name for the API key. Used to distinguish keys in the UI."
           }
         },
         "required": [
@@ -26,20 +26,20 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable API-key identifier."
           },
           "organizationId": {
-            "type": "string"
+            "type": "string",
+            "description": "Organization that owns this API key."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable name."
           },
           "token": {
             "type": "string",
-            "description": "The API key token. Only included in the creation response — store it securely."
-          },
-          "tokenHash": {
-            "type": "string"
+            "description": "The full API key token. Returned by create / get / update — store it securely; treat it as a password."
           },
           "lastUsedAt": {
             "anyOf": [
@@ -49,7 +49,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
           },
           "deletedAt": {
             "anyOf": [
@@ -59,13 +60,16 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
           },
           "createdAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
           },
           "updatedAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."
           }
         },
         "required": [
@@ -73,7 +77,6 @@
           "organizationId",
           "name",
           "token",
-          "tokenHash",
           "lastUsedAt",
           "deletedAt",
           "createdAt",
@@ -102,13 +105,20 @@
               "type": "object",
               "properties": {
                 "id": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Stable API-key identifier."
                 },
                 "organizationId": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Organization that owns this API key."
                 },
                 "name": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Human-readable name."
+                },
+                "token": {
+                  "type": "string",
+                  "description": "Masked token preview safe to display in lists. Use `GET /api-keys/{id}` to retrieve the full token."
                 },
                 "lastUsedAt": {
                   "anyOf": [
@@ -118,7 +128,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
                 },
                 "deletedAt": {
                   "anyOf": [
@@ -128,19 +139,23 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
                 },
                 "createdAt": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "ISO-8601 timestamp of creation."
                 },
                 "updatedAt": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "ISO-8601 timestamp of the last metadata update."
                 }
               },
               "required": [
                 "id",
                 "organizationId",
                 "name",
+                "token",
                 "lastUsedAt",
                 "deletedAt",
                 "createdAt",
@@ -152,6 +167,176 @@
         },
         "required": [
           "apiKeys"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "getApiKey",
+      "title": "Get API key",
+      "description": "Returns a single API key including the full unmasked `token`. Useful for retrieving a stored token by id without rotating it.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Resource ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable API-key identifier."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this API key."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "token": {
+            "type": "string",
+            "description": "The full API key token. Returned by create / get / update — store it securely; treat it as a password."
+          },
+          "lastUsedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "token",
+          "lastUsedAt",
+          "deletedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "updateApiKey",
+      "title": "Update API key",
+      "description": "Renames an API key. The token itself is immutable — use create + revoke if you need a new value.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Resource ID"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New human-readable name for the API key."
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable API-key identifier."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this API key."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "token": {
+            "type": "string",
+            "description": "The full API key token. Returned by create / get / update — store it securely; treat it as a password."
+          },
+          "lastUsedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "token",
+          "lastUsedAt",
+          "deletedAt",
+          "createdAt",
+          "updatedAt"
         ],
         "additionalProperties": false
       }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1013,38 +1013,42 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable API-key identifier."
           },
           "organizationId": {
-            "type": "string"
+            "type": "string",
+            "description": "Organization that owns this API key."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable name."
           },
           "token": {
             "type": "string",
-            "description": "The API key token. Only included in the creation response — store it securely."
-          },
-          "tokenHash": {
-            "type": "string"
+            "description": "The full API key token. Returned by create / get / update — store it securely; treat it as a password."
           },
           "lastUsedAt": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
           },
           "deletedAt": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
           },
           "createdAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
           },
           "updatedAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."
           }
         },
         "required": [
@@ -1052,7 +1056,6 @@
           "organizationId",
           "name",
           "token",
-          "tokenHash",
           "lastUsedAt",
           "deletedAt",
           "createdAt",
@@ -1065,7 +1068,7 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Human-readable name for the API key"
+            "description": "Human-readable name for the API key. Used to distinguish keys in the UI."
           }
         },
         "required": [
@@ -1090,41 +1093,66 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable API-key identifier."
           },
           "organizationId": {
-            "type": "string"
+            "type": "string",
+            "description": "Organization that owns this API key."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "token": {
+            "type": "string",
+            "description": "Masked token preview safe to display in lists. Use `GET /api-keys/{id}` to retrieve the full token."
           },
           "lastUsedAt": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "ISO-8601 timestamp of the most recent successful authentication. `null` until first use."
           },
           "deletedAt": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "ISO-8601 timestamp at which the key was revoked. `null` while the key is active."
           },
           "createdAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
           },
           "updatedAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata update."
           }
         },
         "required": [
           "id",
           "organizationId",
           "name",
+          "token",
           "lastUsedAt",
           "deletedAt",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "UpdateApiKeyBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "New human-readable name for the API key."
+          }
+        },
+        "required": [
+          "name"
         ]
       },
       "AccountResponse": {
@@ -1816,6 +1844,154 @@
       }
     },
     "/v1/api-keys/{id}": {
+      "get": {
+        "tags": [
+          "API Keys"
+        ],
+        "x-fern-sdk-group-name": "apiKeys",
+        "x-fern-sdk-method-name": "get",
+        "summary": "Get API key",
+        "description": "Returns a single API key including the full unmasked `token`. Useful for retrieving a stored token by id without rotating it.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "getApiKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Resource ID"
+            },
+            "required": true,
+            "description": "Resource ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "API Keys"
+        ],
+        "x-fern-sdk-group-name": "apiKeys",
+        "x-fern-sdk-method-name": "update",
+        "summary": "Update API key",
+        "description": "Renames an API key. The token itself is immutable — use create + revoke if you need a new value.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "updateApiKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Resource ID"
+            },
+            "required": true,
+            "description": "Resource ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateApiKeyBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "API key updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "API Keys"

--- a/apps/api/src/routes/api-keys.test.ts
+++ b/apps/api/src/routes/api-keys.test.ts
@@ -75,6 +75,86 @@ describe("API Keys Routes Integration", () => {
     expect(body.token.length).toBeGreaterThan(0)
   })
 
+  it<ApiTestContext>("GET /v1/api-keys list response includes a masked token preview", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request("http://localhost/v1/api-keys", { headers: createApiKeyAuthHeaders(tenant.apiKeyToken) }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      apiKeys: ReadonlyArray<{ id: string; token: string }>
+    }
+    const authKey = body.apiKeys.find((k) => k.id === tenant.authApiKeyId)
+    expect(authKey).toBeDefined()
+    expect(authKey?.token).toMatch(/^.{4}\*+.{4}$/)
+    // The full token must NOT appear in the list response.
+    expect(authKey?.token).not.toBe(tenant.apiKeyToken)
+  })
+
+  it<ApiTestContext>("GET /v1/api-keys/:id returns the full unmasked token", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/api-keys/${tenant.authApiKeyId}`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { id: string; token: string }
+    expect(body.id).toBe(tenant.authApiKeyId)
+    expect(body.token).toBe(tenant.apiKeyToken)
+  })
+
+  it<ApiTestContext>("GET /v1/api-keys/:id is org-scoped (404 across tenants)", async ({ app, database }) => {
+    const tenantA = await createTenantSetup(database)
+    const tenantB = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/api-keys/${tenantB.authApiKeyId}`, {
+        headers: createApiKeyAuthHeaders(tenantA.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(404)
+  })
+
+  it<ApiTestContext>("PATCH /v1/api-keys/:id renames the key", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/api-keys/${tenant.authApiKeyId}`, {
+        method: "PATCH",
+        headers: { ...createApiKeyAuthHeaders(tenant.apiKeyToken), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "renamed" }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { id: string; name: string; token: string }
+    expect(body.id).toBe(tenant.authApiKeyId)
+    expect(body.name).toBe("renamed")
+    // The token field is included in the update response (full token, like create/get).
+    expect(body.token).toBe(tenant.apiKeyToken)
+  })
+
+  it<ApiTestContext>("PATCH /v1/api-keys/:id is org-scoped (404 across tenants)", async ({ app, database }) => {
+    const tenantA = await createTenantSetup(database)
+    const tenantB = await createTenantSetup(database)
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/api-keys/${tenantB.authApiKeyId}`, {
+        method: "PATCH",
+        headers: { ...createApiKeyAuthHeaders(tenantA.apiKeyToken), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "should-not-apply" }),
+      }),
+    )
+
+    expect(response.status).toBe(404)
+  })
+
   it<ApiTestContext>("DELETE /v1/api-keys/:id cannot revoke cross-tenant keys", async ({ app, database }) => {
     const tenantA = await createTenantSetup(database)
     const tenantB = await createTenantSetup(database)

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -1,9 +1,12 @@
 import {
   type ApiKey,
   ApiKeyCacheInvalidator,
+  ApiKeyNotFoundError,
   ApiKeyRepository,
   generateApiKeyUseCase,
+  maskApiKeyToken,
   revokeApiKeyUseCase,
+  updateApiKeyUseCase,
 } from "@domain/api-keys"
 import { ApiKeyId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -25,44 +28,67 @@ import type { OrganizationScopedEnv } from "../types.ts"
 
 const ResponseSchema = z
   .object({
-    id: z.string(),
-    organizationId: z.string(),
-    name: z.string(),
-    token: z.string().describe("The API key token. Only included in the creation response — store it securely."),
-    tokenHash: z.string(),
-    lastUsedAt: z.string().nullable(),
-    deletedAt: z.string().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
+    id: z.string().describe("Stable API-key identifier."),
+    organizationId: z.string().describe("Organization that owns this API key."),
+    name: z.string().describe("Human-readable name."),
+    token: z
+      .string()
+      .describe(
+        "The full API key token. Returned by create / get / update — store it securely; treat it as a password.",
+      ),
+    lastUsedAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp of the most recent successful authentication. `null` until first use."),
+    deletedAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp at which the key was revoked. `null` while the key is active."),
+    createdAt: z.string().describe("ISO-8601 timestamp of creation."),
+    updatedAt: z.string().describe("ISO-8601 timestamp of the last metadata update (rename, revoke, last-used touch)."),
   })
   .openapi("ApiKey")
 
 const ListItemSchema = z
   .object({
-    id: z.string(),
-    organizationId: z.string(),
-    name: z.string(),
-    lastUsedAt: z.string().nullable(),
-    deletedAt: z.string().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
+    id: z.string().describe("Stable API-key identifier."),
+    organizationId: z.string().describe("Organization that owns this API key."),
+    name: z.string().describe("Human-readable name."),
+    token: z
+      .string()
+      .describe("Masked token preview safe to display in lists. Use `GET /api-keys/{id}` to retrieve the full token."),
+    lastUsedAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp of the most recent successful authentication. `null` until first use."),
+    deletedAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp at which the key was revoked. `null` while the key is active."),
+    createdAt: z.string().describe("ISO-8601 timestamp of creation."),
+    updatedAt: z.string().describe("ISO-8601 timestamp of the last metadata update."),
   })
   .openapi("ApiKeyListItem")
 
 const ListResponseSchema = z.object({ apiKeys: z.array(ListItemSchema) }).openapi("ApiKeyList")
 
-const RequestSchema = z
+const CreateApiKeyBody = z
   .object({
-    name: z.string().min(1).describe("Human-readable name for the API key"),
+    name: z.string().min(1).describe("Human-readable name for the API key. Used to distinguish keys in the UI."),
   })
   .openapi("CreateApiKeyBody")
+
+const UpdateApiKeyBody = z
+  .object({
+    name: z.string().min(1).describe("New human-readable name for the API key."),
+  })
+  .openapi("UpdateApiKeyBody")
 
 const toResponse = (apiKey: ApiKey) => ({
   id: apiKey.id as string,
   organizationId: apiKey.organizationId as string,
   name: apiKey.name,
   token: apiKey.token,
-  tokenHash: apiKey.tokenHash,
   lastUsedAt: apiKey.lastUsedAt ? apiKey.lastUsedAt.toISOString() : null,
   deletedAt: apiKey.deletedAt ? apiKey.deletedAt.toISOString() : null,
   createdAt: apiKey.createdAt.toISOString(),
@@ -73,6 +99,7 @@ const toListItemResponse = (apiKey: ApiKey) => ({
   id: apiKey.id as string,
   organizationId: apiKey.organizationId as string,
   name: apiKey.name,
+  token: maskApiKeyToken(apiKey.token),
   lastUsedAt: apiKey.lastUsedAt ? apiKey.lastUsedAt.toISOString() : null,
   deletedAt: apiKey.deletedAt ? apiKey.deletedAt.toISOString() : null,
   createdAt: apiKey.createdAt.toISOString(),
@@ -122,7 +149,7 @@ const createApiKey = apiKeyEndpoint({
     description: "Generates a new API key for the organization. The token is only returned once — store it securely.",
     security: PROTECTED_SECURITY,
     request: {
-      body: jsonBody(RequestSchema),
+      body: jsonBody(CreateApiKeyBody),
     },
     responses: openApiResponses({ status: 201, schema: ResponseSchema, description: "API key generated" }),
   }),
@@ -169,6 +196,62 @@ const listApiKeys = apiKeyEndpoint({
   },
 })
 
+const getApiKey = apiKeyEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/{id}",
+    name: "getApiKey",
+    tags: ["API Keys"],
+    ...apiKeysFernGroup("get"),
+    summary: "Get API key",
+    description:
+      "Returns a single API key including the full unmasked `token`. Useful for retrieving a stored token by id without rotating it.",
+    security: PROTECTED_SECURITY,
+    request: { params: IdParamsSchema },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "API key" }),
+  }),
+  handler: async (c) => {
+    const { id: idParam } = c.req.valid("param")
+
+    const apiKey = await Effect.runPromise(
+      Effect.gen(function* () {
+        const repo = yield* ApiKeyRepository
+        return yield* repo
+          .findById(ApiKeyId(idParam))
+          .pipe(Effect.catchTag("NotFoundError", () => Effect.fail(new ApiKeyNotFoundError({ id: ApiKeyId(idParam) }))))
+      }).pipe(withPostgres(ApiKeyRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
+    )
+    return c.json(toResponse(apiKey), 200)
+  },
+})
+
+const updateApiKey = apiKeyEndpoint({
+  route: createRoute({
+    method: "patch",
+    path: "/{id}",
+    name: "updateApiKey",
+    tags: ["API Keys"],
+    ...apiKeysFernGroup("update"),
+    summary: "Update API key",
+    description: "Renames an API key. The token itself is immutable — use create + revoke if you need a new value.",
+    security: PROTECTED_SECURITY,
+    request: { params: IdParamsSchema, body: jsonBody(UpdateApiKeyBody) },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "API key updated" }),
+  }),
+  handler: async (c) => {
+    const { id: idParam } = c.req.valid("param")
+    const { name } = c.req.valid("json")
+
+    const apiKey = await Effect.runPromise(
+      updateApiKeyUseCase({ id: ApiKeyId(idParam), name }).pipe(
+        withPostgres(ApiKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.json(toResponse(apiKey), 200)
+  },
+})
+
 const revokeApiKey = apiKeyEndpoint({
   route: createRoute({
     method: "delete",
@@ -198,6 +281,6 @@ const revokeApiKey = apiKeyEndpoint({
 
 export const createApiKeysRoutes = () => {
   const app = new OpenAPIHono<OrganizationScopedEnv>()
-  for (const ep of [createApiKey, listApiKeys, revokeApiKey]) ep.mountHttp(app)
+  for (const ep of [createApiKey, listApiKeys, getApiKey, updateApiKey, revokeApiKey]) ep.mountHttp(app)
   return app
 }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -47,6 +47,8 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   routes.route("/projects", createProjectsRoutes())
   routes.route("/projects/:projectSlug/scores", createScoresRoutes())
   routes.route("/projects/:projectSlug/annotations", createAnnotationsRoutes())
+
+  routes.use(apiKeysPath, createTierRateLimiter("low"))
   routes.route(apiKeysPath, createApiKeysRoutes())
 
   routes.use(accountPath, createTierRateLimiter("low"))

--- a/packages/domain/api-keys/src/helpers/mask-token.test.ts
+++ b/packages/domain/api-keys/src/helpers/mask-token.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { maskApiKeyToken } from "./mask-token.ts"
+
+describe("maskApiKeyToken", () => {
+  it("masks a UUID-shaped token keeping the first 4 and last 4 characters", () => {
+    const masked = maskApiKeyToken("658e8f6a-1234-5678-9abc-def012341ceb")
+    expect(masked).toBe("658e***********1ceb")
+  })
+
+  it("returns a fully-masked placeholder for too-short tokens", () => {
+    expect(maskApiKeyToken("short")).toBe("***********")
+    expect(maskApiKeyToken("12345678")).toBe("***********")
+  })
+
+  it("masks an empty string defensively", () => {
+    expect(maskApiKeyToken("")).toBe("***********")
+  })
+
+  it("works for arbitrary-length tokens", () => {
+    const masked = maskApiKeyToken("ABCD-middle-content-XYZW")
+    expect(masked.startsWith("ABCD")).toBe(true)
+    expect(masked.endsWith("XYZW")).toBe(true)
+    expect(masked).not.toContain("middle")
+  })
+})

--- a/packages/domain/api-keys/src/helpers/mask-token.ts
+++ b/packages/domain/api-keys/src/helpers/mask-token.ts
@@ -1,0 +1,20 @@
+/**
+ * Masks an API key token for display in list responses and UI surfaces.
+ *
+ * Returns the first 4 and last 4 characters of the token separated by a
+ * fixed-width run of `*`. Tokens are 36-character UUIDs in practice, so the
+ * "short token" guard exists only as defense against future format changes
+ * (or test fixtures) — never triggered by real keys.
+ *
+ * Example: `658e8f6a-1234-…-1ceb` → `658e***********1ceb`.
+ */
+const VISIBLE_PREFIX = 4
+const VISIBLE_SUFFIX = 4
+const MASK_RUN = "***********"
+
+export const maskApiKeyToken = (token: string): string => {
+  if (token.length <= VISIBLE_PREFIX + VISIBLE_SUFFIX) {
+    return MASK_RUN
+  }
+  return `${token.slice(0, VISIBLE_PREFIX)}${MASK_RUN}${token.slice(-VISIBLE_SUFFIX)}`
+}

--- a/packages/domain/api-keys/src/index.ts
+++ b/packages/domain/api-keys/src/index.ts
@@ -9,6 +9,7 @@ export {
   touch,
 } from "./entities/api-key.ts"
 export { ApiKeyAlreadyRevokedError, ApiKeyNotFoundError, InvalidApiKeyNameError } from "./errors.ts"
+export { maskApiKeyToken } from "./helpers/mask-token.ts"
 export { ApiKeyRepository } from "./ports/api-key-repository.ts"
 export {
   type GenerateApiKeyError,


### PR DESCRIPTION
Second slice of M3 (Identity ergonomics). Closes out the API-key resource's public surface so SDK and MCP callers can retrieve and rename keys without going through the web UI.

- `GET /api-keys/{id}` returns the full unmasked `token` (decrypted at the repository layer via `LAT_MASTER_ENCRYPTION_KEY`)
- `PATCH /api-keys/{id}` renames via the existing `updateApiKeyUseCase`
- List response's `token` field is now a masked preview; the full token comes only from create / get / update
- `tokenHash` dropped from the public response — internal implementation detail with no consumer value
- New `maskApiKeyToken` helper in `@domain/api-keys`
- Auto-publishes to OpenAPI + MCP (now 6 tools)