### PR TITLE
fix(core): allow updating LLM evaluations whose provider was deleted

### DIFF
--- a/packages/core/src/services/evaluationsV2/llm/customLabeled.ts
+++ b/packages/core/src/services/evaluationsV2/llm/customLabeled.ts
@@ -28,7 +28,16 @@ async function validate(
   >,
   db = database,
 ) {
-  return await LlmEvaluationCustomSpecification.validate({ ...rest }, db)
+  // Safe: the Custom validator only reads `configuration`. The cast is
+  // needed because `evaluation.metric` is the literal `CustomLabeled`, which
+  // isn't assignable to the inner signature's `Custom`.
+  return await LlmEvaluationCustomSpecification.validate(
+    { ...rest } as unknown as EvaluationMetricValidateArgs<
+      EvaluationType.Llm,
+      LlmEvaluationMetric.Custom
+    >,
+    db,
+  )
 }
 
 async function run(

--- a/packages/core/src/services/evaluationsV2/llm/index.ts
+++ b/packages/core/src/services/evaluationsV2/llm/index.ts
@@ -48,6 +48,7 @@ async function validate<M extends LlmEvaluationMetric>(
   {
     mode,
     metric,
+    evaluation,
     configuration,
     workspace,
     ...rest
@@ -66,7 +67,22 @@ async function validate<M extends LlmEvaluationMetric>(
     return Result.error(parsing.error)
   }
 
-  if (!metric.startsWith(LlmEvaluationMetric.Custom) || mode !== 'update') {
+  // Custom prompts embed provider/model in the prompt body, so they skip
+  // provider validation on update entirely. For non-custom metrics, also skip
+  // re-validating the provider on update when it hasn't changed — otherwise
+  // users can't edit (e.g. disable live evals on) an evaluation whose provider
+  // was deleted.
+  const isCustom = metric.startsWith(LlmEvaluationMetric.Custom)
+  const providerUnchangedOnUpdate =
+    mode === 'update' &&
+    !isCustom &&
+    !!evaluation &&
+    configuration.provider?.trim() === evaluation.configuration.provider &&
+    configuration.model?.trim() === evaluation.configuration.model
+  const skipProviderValidation =
+    (isCustom && mode === 'update') || providerUnchangedOnUpdate
+
+  if (!skipProviderValidation) {
     configuration.provider = configuration.provider.trim()
     if (!configuration.provider) {
       return Result.error(new BadRequestError('Provider is required'))
@@ -85,10 +101,13 @@ async function validate<M extends LlmEvaluationMetric>(
     if (!configuration.model) {
       return Result.error(new BadRequestError('Model is required'))
     }
+  } else if (providerUnchangedOnUpdate) {
+    configuration.provider = configuration.provider.trim()
+    configuration.model = configuration.model.trim()
   }
 
   const validation = await metricSpecification.validate(
-    { mode, configuration, workspace, ...rest },
+    { mode, evaluation, configuration, workspace, ...rest },
     db,
   )
   if (validation.error) {

--- a/packages/core/src/services/evaluationsV2/shared.ts
+++ b/packages/core/src/services/evaluationsV2/shared.ts
@@ -33,6 +33,7 @@ export type EvaluationMetricValidateArgs<
 > = {
   mode: 'create' | 'update'
   uuid?: string
+  evaluation?: EvaluationV2<T, M>
   configuration: EvaluationConfiguration<T, M>
   document: DocumentVersion
   evaluations: EvaluationV2[]

--- a/packages/core/src/services/evaluationsV2/update.test.ts
+++ b/packages/core/src/services/evaluationsV2/update.test.ts
@@ -489,4 +489,55 @@ describe('updateEvaluationV2', () => {
       },
     })
   })
+
+  it('allows updating an LLM evaluation whose provider has been deleted', async () => {
+    const { createEvaluationV2: createEval } = await import('./create')
+    const { destroyProviderApiKey } = await import('../providerApiKeys/destroy')
+    const { findFirstProviderApiKey } = await import(
+      '../../queries/providerApiKeys/findFirst'
+    )
+
+    const created = await createEval({
+      document: document,
+      commit: commit,
+      workspace: workspace,
+      settings: {
+        name: 'broken provider eval',
+        description: 'test',
+        type: EvaluationType.Llm,
+        metric: LlmEvaluationMetric.Binary,
+        configuration: {
+          reverseScale: false,
+          actualOutput: {
+            messageSelection: 'last',
+            parsingFormat: 'string',
+          },
+          provider: 'openai',
+          model: 'gpt-4o',
+          criteria: 'criteria',
+          passDescription: 'pass',
+          failDescription: 'fail',
+        },
+      },
+      options: { evaluateLiveLogs: true },
+    }).then((r) => r.unwrap())
+
+    const liveEvaluation = created.evaluation
+
+    const provider = await findFirstProviderApiKey({
+      workspaceId: workspace.id,
+    })
+    await destroyProviderApiKey(provider!).then((r) => r.unwrap())
+
+    mocks.publisher.mockClear()
+
+    const { evaluation: updatedEvaluation } = await updateEvaluationV2({
+      evaluation: liveEvaluation,
+      commit: commit,
+      workspace: workspace,
+      options: { evaluateLiveLogs: false },
+    }).then((r) => r.unwrap())
+
+    expect(updatedEvaluation.evaluateLiveLogs).toBe(false)
+  })
 })

--- a/packages/core/src/services/evaluationsV2/validate.ts
+++ b/packages/core/src/services/evaluationsV2/validate.ts
@@ -115,6 +115,7 @@ export async function validateEvaluationV2<
     {
       mode: mode,
       uuid: evaluation?.uuid,
+      evaluation: evaluation,
       metric: settings.metric,
       configuration: settings.configuration,
       document: document,


### PR DESCRIPTION
## Summary
- LLM evaluation updates always re-validated the configured provider, so a live evaluation became uneditable once its provider was deleted or renamed — even when the user only wanted to disable live evals.
- In update mode, skip the `findProviderApiKeyByName` lookup when both the provider and model are unchanged from the stored evaluation. Provider validation still runs on create and whenever a user actually switches providers.
- Threads the original `evaluation` into `EvaluationMetricValidateArgs` so the LLM type-spec validator can diff against it.

## Test plan
- [x] `pnpm test src/services/evaluationsV2/update.test.ts` — 10/10 pass, including the new regression test that destroys the provider and then disables live logs on the eval
- [x] `pnpm test src/services/evaluationsV2/create.test.ts` — still 5/5 pass (provider validation on create is unchanged)
- [ ] Manual: with a non-prod workspace, soft-delete a provider used by an LLM-as-judge evaluation, then toggle the eval's `Evaluate live logs` off — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)