### PR TITLE
feat(api): projects routes through defineApiEndpoint with paginated list

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -3,6 +3,553 @@
   "version": "1.0.0",
   "tools": [
     {
+      "name": "createProject",
+      "title": "Create project",
+      "description": "Creates a new project within the organization. The name must be unique within the org.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable name for the project. Must be unique within the organization."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable project identifier (CUID2)."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this project."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
+          },
+          "settings": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "keepMonitoring": {
+                    "type": "boolean"
+                  },
+                  "alertNotifications": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string",
+                      "enum": [
+                        "issue.new",
+                        "issue.regressed",
+                        "issue.escalating"
+                      ]
+                    },
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+          },
+          "firstTraceAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+          },
+          "lastEditedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the most recent name/settings edit."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata change."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "slug",
+          "settings",
+          "firstTraceAt",
+          "deletedAt",
+          "lastEditedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "listProjects",
+      "title": "List projects",
+      "description": "Returns every project in the organization. The response uses the standard paginated shape; the project list currently fits in a single page (`nextCursor` is always `null`).",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable project identifier (CUID2)."
+                },
+                "organizationId": {
+                  "type": "string",
+                  "description": "Organization that owns this project."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Human-readable name."
+                },
+                "slug": {
+                  "type": "string",
+                  "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
+                },
+                "settings": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "keepMonitoring": {
+                          "type": "boolean"
+                        },
+                        "alertNotifications": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string",
+                            "enum": [
+                              "issue.new",
+                              "issue.regressed",
+                              "issue.escalating"
+                            ]
+                          },
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+                },
+                "firstTraceAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."
+                },
+                "deletedAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+                },
+                "lastEditedAt": {
+                  "type": "string",
+                  "description": "ISO-8601 timestamp of the most recent name/settings edit."
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "ISO-8601 timestamp of creation."
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "description": "ISO-8601 timestamp of the last metadata change."
+                }
+              },
+              "required": [
+                "id",
+                "organizationId",
+                "name",
+                "slug",
+                "settings",
+                "firstTraceAt",
+                "deletedAt",
+                "lastEditedAt",
+                "createdAt",
+                "updatedAt"
+              ],
+              "additionalProperties": false
+            },
+            "description": "Page of items, in the requested sort order."
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for fetching the next page. `null` when there are no more pages. Pass it back in `cursor` to continue."
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "`true` when there is at least one more page after this one."
+          }
+        },
+        "required": [
+          "items",
+          "nextCursor",
+          "hasMore"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "getProject",
+      "title": "Get project",
+      "description": "Returns a single project by slug.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          }
+        },
+        "required": [
+          "projectSlug"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable project identifier (CUID2)."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this project."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
+          },
+          "settings": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "keepMonitoring": {
+                    "type": "boolean"
+                  },
+                  "alertNotifications": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string",
+                      "enum": [
+                        "issue.new",
+                        "issue.regressed",
+                        "issue.escalating"
+                      ]
+                    },
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+          },
+          "firstTraceAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+          },
+          "lastEditedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the most recent name/settings edit."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata change."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "slug",
+          "settings",
+          "firstTraceAt",
+          "deletedAt",
+          "lastEditedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "updateProject",
+      "title": "Update project",
+      "description": "Updates a project's name and/or settings. Renaming may regenerate the slug — clients should re-read the response or rely on the `id` for stable references.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          },
+          "name": {
+            "description": "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable).",
+            "type": "string",
+            "minLength": 1
+          },
+          "settings": {
+            "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
+            "type": "object",
+            "properties": {
+              "keepMonitoring": {
+                "type": "boolean"
+              },
+              "alertNotifications": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string",
+                  "enum": [
+                    "issue.new",
+                    "issue.regressed",
+                    "issue.escalating"
+                  ]
+                },
+                "additionalProperties": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "projectSlug"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable project identifier (CUID2)."
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "Organization that owns this project."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "slug": {
+            "type": "string",
+            "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
+          },
+          "settings": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "keepMonitoring": {
+                    "type": "boolean"
+                  },
+                  "alertNotifications": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string",
+                      "enum": [
+                        "issue.new",
+                        "issue.regressed",
+                        "issue.escalating"
+                      ]
+                    },
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+          },
+          "firstTraceAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."
+          },
+          "deletedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+          },
+          "lastEditedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the most recent name/settings edit."
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata change."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "name",
+          "slug",
+          "settings",
+          "firstTraceAt",
+          "deletedAt",
+          "lastEditedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "deleteProject",
+      "title": "Delete project",
+      "description": "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          }
+        },
+        "required": [
+          "projectSlug"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "createApiKey",
       "title": "Generate API key",
       "description": "Generates a new API key for the organization. The token is only returned once — store it securely.",
@@ -955,7 +1502,7 @@
     {
       "name": "removeMember",
       "title": "Remove a member",
-      "description": "Removes a member from the caller's organization. Self-removal is rejected — use the org-leave flow on the web. Requires OAuth authentication.",
+      "description": "Removes a member from the caller's organization. Self-removal and removing the organization owner are rejected — transfer ownership first. Requires OAuth authentication.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -63,28 +63,72 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "type": "string",
+            "description": "Stable project identifier (CUID2)."
           },
           "organizationId": {
-            "type": "string"
+            "type": "string",
+            "description": "Organization that owns this project."
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable name."
           },
           "slug": {
-            "type": "string"
+            "type": "string",
+            "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
+          },
+          "settings": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "keepMonitoring": {
+                "type": "boolean"
+              },
+              "alertNotifications": {
+                "type": "object",
+                "properties": {
+                  "issue.new": {
+                    "type": "boolean"
+                  },
+                  "issue.regressed": {
+                    "type": "boolean"
+                  },
+                  "issue.escalating": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+          },
+          "firstTraceAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."
           },
           "deletedAt": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+          },
+          "lastEditedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp of the most recent name/settings edit."
           },
           "createdAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of creation."
           },
           "updatedAt": {
-            "type": "string"
+            "type": "string",
+            "description": "ISO-8601 timestamp of the last metadata change."
           }
         },
         "required": [
@@ -92,7 +136,10 @@
           "organizationId",
           "name",
           "slug",
+          "settings",
+          "firstTraceAt",
           "deletedAt",
+          "lastEditedAt",
           "createdAt",
           "updatedAt"
         ]
@@ -114,25 +161,39 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "Project name"
+            "description": "Human-readable name for the project. Must be unique within the organization."
           }
         },
         "required": [
           "name"
         ]
       },
-      "ProjectList": {
+      "PaginatedProjects": {
         "type": "object",
         "properties": {
-          "projects": {
+          "items": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Project"
-            }
+            },
+            "description": "Page of items, in the requested sort order."
+          },
+          "nextCursor": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Opaque cursor for fetching the next page. `null` when there are no more pages. Pass it back in `cursor` to continue."
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "`true` when there is at least one more page after this one."
           }
         },
         "required": [
-          "projects"
+          "items",
+          "nextCursor",
+          "hasMore"
         ]
       },
       "UpdateProjectBody": {
@@ -141,7 +202,30 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "description": "New project name"
+            "description": "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable)."
+          },
+          "settings": {
+            "type": "object",
+            "properties": {
+              "keepMonitoring": {
+                "type": "boolean"
+              },
+              "alertNotifications": {
+                "type": "object",
+                "properties": {
+                  "issue.new": {
+                    "type": "boolean"
+                  },
+                  "issue.regressed": {
+                    "type": "boolean"
+                  },
+                  "issue.escalating": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
           }
         }
       },
@@ -1502,17 +1586,19 @@
     },
     "/v1/projects": {
       "post": {
-        "operationId": "projects.create",
         "tags": [
           "Projects"
         ],
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "create",
         "summary": "Create project",
-        "description": "Creates a new project within the organization.",
+        "description": "Creates a new project within the organization. The name must be unique within the org.",
         "security": [
           {
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "createProject",
         "requestBody": {
           "required": true,
           "content": {
@@ -1525,7 +1611,7 @@
         },
         "responses": {
           "201": {
-            "description": "Project created successfully",
+            "description": "Project created",
             "content": {
               "application/json": {
                 "schema": {
@@ -1567,73 +1653,36 @@
         }
       },
       "get": {
-        "operationId": "projects.list",
         "tags": [
           "Projects"
         ],
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "list",
         "summary": "List projects",
-        "description": "Returns all projects in the organization.",
+        "description": "Returns every project in the organization. The response uses the standard paginated shape; the project list currently fits in a single page (`nextCursor` is always `null`).",
         "security": [
           {
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "listProjects",
         "responses": {
           "200": {
             "description": "List of projects",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProjectList"
+                  "$ref": "#/components/schemas/PaginatedProjects"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
+          "400": {
+            "description": "Validation error",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/projects/{projectSlug}": {
-      "get": {
-        "operationId": "projects.get",
-        "tags": [
-          "Projects"
-        ],
-        "summary": "Get project",
-        "description": "Returns a single project by slug.",
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Project slug (human-readable identifier)"
-            },
-            "required": true,
-            "description": "Project slug (human-readable identifier)",
-            "name": "projectSlug",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Project details",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Project"
                 }
               }
             }
@@ -1649,7 +1698,78 @@
             }
           },
           "404": {
-            "description": "Project not found",
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/projects/{projectSlug}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "get",
+        "summary": "Get project",
+        "description": "Returns a single project by slug.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "getProject",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Project slug (human-readable identifier)"
+            },
+            "required": true,
+            "description": "Project slug (human-readable identifier)",
+            "name": "projectSlug",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1661,17 +1781,19 @@
         }
       },
       "patch": {
-        "operationId": "projects.update",
         "tags": [
           "Projects"
         ],
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "update",
         "summary": "Update project",
-        "description": "Updates a project's name and/or description.",
+        "description": "Updates a project's name and/or settings. Renaming may regenerate the slug — clients should re-read the response or rely on the `id` for stable references.",
         "security": [
           {
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "updateProject",
         "parameters": [
           {
             "schema": {
@@ -1738,17 +1860,19 @@
         }
       },
       "delete": {
-        "operationId": "projects.delete",
         "tags": [
           "Projects"
         ],
+        "x-fern-sdk-group-name": "projects",
+        "x-fern-sdk-method-name": "delete",
         "summary": "Delete project",
-        "description": "Soft-deletes a project by slug.",
+        "description": "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
         "security": [
           {
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "deleteProject",
         "parameters": [
           {
             "schema": {
@@ -1763,7 +1887,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Project deleted successfully"
+            "description": "Project deleted"
           },
           "401": {
             "description": "Unauthorized",
@@ -2595,7 +2719,7 @@
         "x-fern-sdk-group-name": "members",
         "x-fern-sdk-method-name": "remove",
         "summary": "Remove a member",
-        "description": "Removes a member from the caller's organization. Self-removal is rejected — use the org-leave flow on the web. Requires OAuth authentication.",
+        "description": "Removes a member from the caller's organization. Self-removal and removing the organization owner are rejected — transfer ownership first. Requires OAuth authentication.",
         "security": [
           {
             "ApiKeyAuth": []

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -11,7 +11,7 @@ import { createAnnotationsRoutes } from "./annotations.ts"
 import { apiKeysPath, createApiKeysRoutes } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
 import { createMembersRoutes, membersPath } from "./members.ts"
-import { createProjectsRoutes } from "./projects.ts"
+import { createProjectsRoutes, projectsPath } from "./projects.ts"
 import { createScoresRoutes } from "./scores.ts"
 import { registerWellKnownRoutes } from "./well-known.ts"
 
@@ -45,7 +45,9 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   )
   routes.use("*", createOrganizationContextMiddleware())
 
-  routes.route("/projects", createProjectsRoutes())
+  routes.use(projectsPath, createTierRateLimiter("medium"))
+  routes.route(projectsPath, createProjectsRoutes())
+
   routes.route("/projects/:projectSlug/scores", createScoresRoutes())
   routes.route("/projects/:projectSlug/annotations", createAnnotationsRoutes())
 

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -4,6 +4,25 @@ import { createApiKeyAuthHeaders, type InMemoryPostgres } from "@platform/testki
 import { describe, expect, it } from "vitest"
 import { type ApiTestContext, createTenantSetup, setupTestApi } from "../test-utils/create-test-app.ts"
 
+interface ProjectRow {
+  readonly id: string
+  readonly organizationId: string
+  readonly name: string
+  readonly slug: string
+  readonly settings: { keepMonitoring?: boolean } | null
+  readonly firstTraceAt: string | null
+  readonly deletedAt: string | null
+  readonly lastEditedAt: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+interface PaginatedProjects {
+  readonly items: ReadonlyArray<ProjectRow>
+  readonly nextCursor: string | null
+  readonly hasMore: boolean
+}
+
 const createProjectRecord = async (database: InMemoryPostgres, organizationId: string, name: string) => {
   const id = generateId()
   const slug = `${name.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${id.slice(0, 6)}`
@@ -35,11 +54,79 @@ describe("Projects Routes Integration", () => {
     )
 
     expect(response.status).toBe(200)
-    const body = await response.json()
-    const ids = body.projects.map((project: { id: string }) => project.id)
+    const body = (await response.json()) as PaginatedProjects
+    const ids = body.items.map((project) => project.id)
 
     expect(ids).toContain(tenantAProject.id)
     expect(ids).not.toContain(tenantBProject.id)
+    expect(body.nextCursor).toBeNull()
+    expect(body.hasMore).toBe(false)
+  })
+
+  it<ApiTestContext>("GET /v1/projects returns the full project shape including new fields", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    await createProjectRecord(database, tenant.organizationId, "Shape Project")
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as PaginatedProjects
+    const project = body.items[0]
+    expect(project).toBeDefined()
+    expect(project).toHaveProperty("settings")
+    expect(project).toHaveProperty("firstTraceAt")
+    expect(project).toHaveProperty("lastEditedAt")
+  })
+
+  it<ApiTestContext>("GET /v1/projects excludes soft-deleted projects", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const live = await createProjectRecord(database, tenant.organizationId, "Live")
+
+    const deleteResponse = await app.fetch(
+      new Request(`http://localhost/v1/projects/${live.slug}`, {
+        method: "DELETE",
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+    expect(deleteResponse.status).toBe(204)
+
+    const listResponse = await app.fetch(
+      new Request(`http://localhost/v1/projects`, {
+        headers: createApiKeyAuthHeaders(tenant.apiKeyToken),
+      }),
+    )
+    const body = (await listResponse.json()) as PaginatedProjects
+    expect(body.items.find((p) => p.id === live.id)).toBeUndefined()
+  })
+
+  it<ApiTestContext>("PATCH /v1/projects/:projectSlug updates settings and regenerates slug on rename", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Old Name")
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects/${project.slug}`, {
+        method: "PATCH",
+        headers: { ...createApiKeyAuthHeaders(tenant.apiKeyToken), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Completely Different", settings: { keepMonitoring: true } }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as ProjectRow
+    expect(body.name).toBe("Completely Different")
+    expect(body.slug).not.toBe(project.slug)
+    expect(body.slug).toContain("completely-different")
+    expect(body.settings).toEqual({ keepMonitoring: true })
   })
 
   it<ApiTestContext>("DELETE /v1/projects/:projectSlug does not delete cross-tenant project", async ({

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -5,14 +5,15 @@ import {
   ProjectRepository,
   updateProjectUseCase,
 } from "@domain/projects"
+import { projectSettingsSchema } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { OutboxEventWriterLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
+import { defineApiEndpoint } from "../mcp/index.ts"
+import { Paginated } from "../openapi/pagination.ts"
 import {
-  errorResponse,
   jsonBody,
-  jsonResponse,
   openApiNoContentResponses,
   openApiResponses,
   PROTECTED_SECURITY,
@@ -20,29 +21,68 @@ import {
 } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
 
+// Fern uses `x-fern-sdk-group-name` + `x-fern-sdk-method-name` to derive the
+// SDK resource namespace (`client.projects.*`) and method names independently
+// of the OpenAPI `tag` and `operationId`. Without these explicit overrides Fern
+// falls back to deriving SDK names from the (multi-word) tag, which produces
+// awkward `projectsList`-style methods and case-sensitivity issues on CI.
+const projectsFernGroup = (methodName: string) =>
+  ({
+    "x-fern-sdk-group-name": "projects",
+    "x-fern-sdk-method-name": methodName,
+  }) as const
+
 const ResponseSchema = z
   .object({
-    id: z.string(),
-    organizationId: z.string(),
-    name: z.string(),
-    slug: z.string(),
-    deletedAt: z.string().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
+    id: z.string().describe("Stable project identifier (CUID2)."),
+    organizationId: z.string().describe("Organization that owns this project."),
+    name: z.string().describe("Human-readable name."),
+    slug: z
+      .string()
+      .describe(
+        "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form.",
+      ),
+    settings: projectSettingsSchema
+      .nullable()
+      .describe(
+        "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches.",
+      ),
+    firstTraceAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp of the first ingested trace. `null` until the first trace lands."),
+    deletedAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."),
+    lastEditedAt: z.string().describe("ISO-8601 timestamp of the most recent name/settings edit."),
+    createdAt: z.string().describe("ISO-8601 timestamp of creation."),
+    updatedAt: z.string().describe("ISO-8601 timestamp of the last metadata change."),
   })
   .openapi("Project")
 
-const ListResponseSchema = z.object({ projects: z.array(ResponseSchema) }).openapi("ProjectList")
+const PaginatedProjectsSchema = Paginated(ResponseSchema, "PaginatedProjects")
 
 const CreateRequestSchema = z
   .object({
-    name: z.string().min(1).describe("Project name"),
+    name: z.string().min(1).describe("Human-readable name for the project. Must be unique within the organization."),
   })
   .openapi("CreateProjectBody")
 
 const UpdateRequestSchema = z
   .object({
-    name: z.string().min(1).optional().describe("New project name"),
+    name: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable).",
+      ),
+    settings: projectSettingsSchema
+      .optional()
+      .describe(
+        "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
+      ),
   })
   .openapi("UpdateProjectBody")
 
@@ -51,86 +91,34 @@ const toResponse = (project: Project) => ({
   organizationId: project.organizationId as string,
   name: project.name,
   slug: project.slug,
+  settings: project.settings,
+  firstTraceAt: project.firstTraceAt ? project.firstTraceAt.toISOString() : null,
   deletedAt: project.deletedAt ? project.deletedAt.toISOString() : null,
+  lastEditedAt: project.lastEditedAt.toISOString(),
   createdAt: project.createdAt.toISOString(),
   updatedAt: project.updatedAt.toISOString(),
 })
 
-const createProjectRoute = createRoute({
-  method: "post",
-  path: "/",
-  operationId: "projects.create",
-  tags: ["Projects"],
-  summary: "Create project",
-  description: "Creates a new project within the organization.",
-  security: PROTECTED_SECURITY,
-  request: {
-    body: jsonBody(CreateRequestSchema),
-  },
-  responses: openApiResponses({ status: 201, schema: ResponseSchema, description: "Project created successfully" }),
-})
+export const projectsPath = "/projects"
 
-const listProjectsRoute = createRoute({
-  method: "get",
-  path: "/",
-  operationId: "projects.list",
-  tags: ["Projects"],
-  summary: "List projects",
-  description: "Returns all projects in the organization.",
-  security: PROTECTED_SECURITY,
-  responses: {
-    200: jsonResponse(ListResponseSchema, "List of projects"),
-    401: errorResponse("Unauthorized"),
-  },
-})
+const projectEndpoint = defineApiEndpoint<OrganizationScopedEnv>(projectsPath)
 
-const getProjectRoute = createRoute({
-  method: "get",
-  path: "/{projectSlug}",
-  operationId: "projects.get",
-  tags: ["Projects"],
-  summary: "Get project",
-  description: "Returns a single project by slug.",
-  security: PROTECTED_SECURITY,
-  request: { params: ProjectParamsSchema },
-  responses: {
-    200: jsonResponse(ResponseSchema, "Project details"),
-    401: errorResponse("Unauthorized"),
-    404: errorResponse("Project not found"),
-  },
-})
-
-const updateProjectRoute = createRoute({
-  method: "patch",
-  path: "/{projectSlug}",
-  operationId: "projects.update",
-  tags: ["Projects"],
-  summary: "Update project",
-  description: "Updates a project's name and/or description.",
-  security: PROTECTED_SECURITY,
-  request: {
-    params: ProjectParamsSchema,
-    body: jsonBody(UpdateRequestSchema),
-  },
-  responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "Updated project" }),
-})
-
-const deleteProjectRoute = createRoute({
-  method: "delete",
-  path: "/{projectSlug}",
-  operationId: "projects.delete",
-  tags: ["Projects"],
-  summary: "Delete project",
-  description: "Soft-deletes a project by slug.",
-  security: PROTECTED_SECURITY,
-  request: { params: ProjectParamsSchema },
-  responses: openApiNoContentResponses({ description: "Project deleted successfully" }),
-})
-
-export const createProjectsRoutes = () => {
-  const app = new OpenAPIHono<OrganizationScopedEnv>()
-
-  app.openapi(createProjectRoute, async (c) => {
+const createProject = projectEndpoint({
+  route: createRoute({
+    method: "post",
+    path: "/",
+    name: "createProject",
+    tags: ["Projects"],
+    ...projectsFernGroup("create"),
+    summary: "Create project",
+    description: "Creates a new project within the organization. The name must be unique within the org.",
+    security: PROTECTED_SECURITY,
+    request: {
+      body: jsonBody(CreateRequestSchema),
+    },
+    responses: openApiResponses({ status: 201, schema: ResponseSchema, description: "Project created" }),
+  }),
+  handler: async (c) => {
     const body = c.req.valid("json")
 
     const input: CreateProjectInput = {
@@ -148,9 +136,23 @@ export const createProjectsRoutes = () => {
       ),
     )
     return c.json(toResponse(project), 201)
-  })
+  },
+})
 
-  app.openapi(listProjectsRoute, async (c) => {
+const listProjects = projectEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/",
+    name: "listProjects",
+    tags: ["Projects"],
+    ...projectsFernGroup("list"),
+    summary: "List projects",
+    description:
+      "Returns every project in the organization. The response uses the standard paginated shape; the project list currently fits in a single page (`nextCursor` is always `null`).",
+    security: PROTECTED_SECURITY,
+    responses: openApiResponses({ status: 200, schema: PaginatedProjectsSchema, description: "List of projects" }),
+  }),
+  handler: async (c) => {
     const projects = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
@@ -158,10 +160,24 @@ export const createProjectsRoutes = () => {
       }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
 
-    return c.json({ projects: projects.map(toResponse) }, 200)
-  })
+    return c.json({ items: projects.map(toResponse), nextCursor: null, hasMore: false }, 200)
+  },
+})
 
-  app.openapi(getProjectRoute, async (c) => {
+const getProject = projectEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/{projectSlug}",
+    name: "getProject",
+    tags: ["Projects"],
+    ...projectsFernGroup("get"),
+    summary: "Get project",
+    description: "Returns a single project by slug.",
+    security: PROTECTED_SECURITY,
+    request: { params: ProjectParamsSchema },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "Project" }),
+  }),
+  handler: async (c) => {
     const { projectSlug } = c.req.valid("param")
 
     const project = await Effect.runPromise(
@@ -172,9 +188,27 @@ export const createProjectsRoutes = () => {
     )
 
     return c.json(toResponse(project), 200)
-  })
+  },
+})
 
-  app.openapi(updateProjectRoute, async (c) => {
+const updateProject = projectEndpoint({
+  route: createRoute({
+    method: "patch",
+    path: "/{projectSlug}",
+    name: "updateProject",
+    tags: ["Projects"],
+    ...projectsFernGroup("update"),
+    summary: "Update project",
+    description:
+      "Updates a project's name and/or settings. Renaming may regenerate the slug — clients should re-read the response or rely on the `id` for stable references.",
+    security: PROTECTED_SECURITY,
+    request: {
+      params: ProjectParamsSchema,
+      body: jsonBody(UpdateRequestSchema),
+    },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "Updated project" }),
+  }),
+  handler: async (c) => {
     const { projectSlug } = c.req.valid("param")
     const body = c.req.valid("json")
 
@@ -185,14 +219,29 @@ export const createProjectsRoutes = () => {
         return yield* updateProjectUseCase({
           id: project.id,
           ...(body.name !== undefined ? { name: body.name } : {}),
+          ...(body.settings !== undefined ? { settings: body.settings } : {}),
         })
       }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
 
     return c.json(toResponse(updatedProject), 200)
-  })
+  },
+})
 
-  app.openapi(deleteProjectRoute, async (c) => {
+const deleteProject = projectEndpoint({
+  route: createRoute({
+    method: "delete",
+    path: "/{projectSlug}",
+    name: "deleteProject",
+    tags: ["Projects"],
+    ...projectsFernGroup("delete"),
+    summary: "Delete project",
+    description: "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
+    security: PROTECTED_SECURITY,
+    request: { params: ProjectParamsSchema },
+    responses: openApiNoContentResponses({ description: "Project deleted" }),
+  }),
+  handler: async (c) => {
     const { projectSlug } = c.req.valid("param")
 
     await Effect.runPromise(
@@ -203,7 +252,13 @@ export const createProjectsRoutes = () => {
       }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
     )
     return c.body(null, 204)
-  })
+  },
+})
 
+export const createProjectsRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+  for (const ep of [createProject, listProjects, getProject, updateProject, deleteProject]) {
+    ep.mountHttp(app)
+  }
   return app
 }


### PR DESCRIPTION
Migrates the projects routes to `defineApiEndpoint` so the five operations (create, list, get, update, delete) surface as MCP tools alongside the HTTP endpoints. List response switches to the standard `Paginated(ProjectSchema, "PaginatedProjects")` shape so SDK consumers see a consistent envelope across resources. Adds field descriptions on every schema property, exposes the previously-dropped `settings`, `firstTraceAt`, and `lastEditedAt` fields on reads, and lets PATCH update settings (the use-case already supported it). Applies the `medium` rate-limit tier and wires the Fern SDK group naming so the generated SDK lands at `client.projects.*`.