### PR TITLE
fix(release): detect squash-merged cherry-picks and disable interactive pagers

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# Prevent gh and git from invoking a pager (less) on long output — otherwise
+# `gh pr list` or `gh pr create` can drop the terminal into a `less` screen
+# that traps keys other than `q`, making it confusing to dismiss.
+export GH_PAGER=cat
+export GIT_PAGER=cat
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "GitHub CLI (gh) is required. Install: https://cli.github.com"
   exit 1
@@ -29,17 +35,37 @@ echo "Development differs from main:"
 git diff --shortstat origin/main..origin/development
 echo ""
 
-main_only_commits=$(git log \
-  --format='%h %s' \
+# Candidate main-only commits by SHA reachability. We verify each below by
+# checking whether the files it touched still differ between main and
+# development — this catches cherry-picks that were squash-merged, which
+# `git log --cherry-pick` (patch-id based) cannot detect.
+candidate_shas=$(git log \
+  --format='%H' \
   --right-only \
   --invert-grep \
   --grep='^Deploy production' \
   --grep='^Release -' \
   origin/development...origin/main)
 
+main_only_commits=""
+while IFS= read -r sha; do
+  [ -z "$sha" ] && continue
+  reflected=true
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    if ! git diff --quiet origin/development origin/main -- "$file" 2>/dev/null; then
+      reflected=false
+      break
+    fi
+  done < <(git show --name-only --format='' "$sha")
+  if [ "$reflected" = false ]; then
+    main_only_commits+="$(git log -1 --format='%h %s' "$sha")"$'\n'
+  fi
+done <<<"$candidate_shas"
+
 if [ -n "$main_only_commits" ]; then
   echo "main has non-release commits that development does not contain:"
-  printf '%s\n' "$main_only_commits"
+  printf '%s' "$main_only_commits"
   echo ""
   echo "Promoting development would remove these changes from production."
   echo "Cherry-pick or merge them into development first, then run this script again."
@@ -51,7 +77,8 @@ existing_pr=$(gh pr list \
   --state open \
   --limit 100 \
   --json number,headRefName,url \
-  --jq '[.[] | select(.headRefName | startswith("release/"))]')
+  --jq '[.[] | select(.headRefName | startswith("release/"))]' \
+  </dev/null)
 
 if [ "$(echo "$existing_pr" | jq 'length')" -gt 0 ]; then
   url=$(echo "$existing_pr" | jq -r '.[0].url')
@@ -94,4 +121,5 @@ gh pr create \
   --base main \
   --head "$branch" \
   --title "Release ${timestamp}" \
-  --body "$body"
+  --body "$body" \
+  </dev/null


### PR DESCRIPTION
## Summary

Two fixes to `scripts/release.sh` after #3099 exposed both.

### 1. Cherry-pick detection across squash-merges

The pre-flight safety check finds commits on `main` that are missing from `development` (e.g. a hotfix landed directly on main and was never brought back). It used `git log --right-only origin/development...origin/main` — SHA reachability — to do this. Even `git log --cherry-pick` (patch-id matching) wouldn't have helped, because when a cherry-pick PR is **squash-merged** on `development`, the resulting commit combines multiple diffs into one with a different patch-id than the original.

That's exactly what happened with #3091 → #3099: #3099 was a squash-merge that bundled the cherry-pick of #3091 with two unrelated commits, so the script falsely flagged `d19880ec3` as missing from development and refused to open a release PR.

The fix: after gathering candidate main-only SHAs, verify each by checking whether the files it touched still differ between `origin/main` and `origin/development` at HEAD. If every touched file matches, the commit's changes are present on development (regardless of how they got there — cherry-pick, squash-merge, independent edit) and it's dropped from the "missing" list.

### 2. Disable interactive pagers / pickers

`gh pr list` and `gh pr create` can drop the terminal into a `less` screen or an arrow-key submission picker that doesn't respond to ESC. To prevent that:

- Set `GH_PAGER=cat` and `GIT_PAGER=cat` at the top of the script.
- Redirect stdin from `/dev/null` on both `gh` calls so neither can show an interactive prompt.

## Test plan

- [x] Locally: `./scripts/release.sh` no longer reports `d19880ec3` as missing from `development` (cherry-picked via squash-merge in #3099).
- [x] Script reaches the `Open a release PR now? [y/N]` prompt without launching any pager.
- [ ] On next real release, confirm `gh pr create` submits the PR directly with no "Submit?" picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)