### PR TITLE
feat(api): toggle project flaggers via PATCH /projects/{slug}

### DIFF
--- a/.agents/skills/api-endpoints/SKILL.md
+++ b/.agents/skills/api-endpoints/SKILL.md
@@ -182,6 +182,38 @@ filters: filterSetSchema, // ← what shape? what semantics? agent has to guess.
 
 If you find yourself writing `.openapi({ description })`, replace it with `.describe()` — descriptions hidden in the openapi WeakMap are invisible to MCP clients, which silently degrades agent UX.
 
+### Don't leak internal implementation into descriptions
+
+User-facing descriptions (route `description`, schema `.describe()`, `openApiResponses({ description })`) are read by SDK users and AI agents. They aren't release notes for our backend. Keep them about the *contract*, not how we implement it.
+
+Concretely, avoid:
+
+- **Storage mechanics**: "soft-deletes", "hard-deletes", "marks as deleted", "removes from cache", "writes to outbox", "RLS-scoped", "via the admin connection". Just say "deletes" / "revokes" / "creates".
+- **Side-effect details on related data**: "Traces remain in storage but the project no longer appears in lists.", "The associated rows are kept for auditing." If the caller can't observe it through the API, don't mention it.
+- **Internal table or column names**, queue names, worker names, event-bus topics.
+- **Comments about why the code is structured a certain way** — those belong in code comments, not in `description:`.
+
+Examples:
+
+```ts
+// Bad — leaks soft-delete + retention behavior of an unrelated entity
+description: "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists."
+// Good
+description: "Deletes a project by slug."
+
+// Bad — describes the mechanism
+description: "Revokes an API key by setting deletedAt and busting the Redis cache."
+// Good
+description: "Revokes an API key."
+
+// Bad — leaks that we don't actually delete the row
+deletedAt: z.string().nullable().describe("ISO-8601 timestamp at which the project was soft-deleted...")
+// Good
+deletedAt: z.string().nullable().describe("ISO-8601 timestamp at which the project was deleted...")
+```
+
+Same rule for the verbs used in route/operation `summary`: "Delete project" beats "Soft-delete project".
+
 ## Rate limiting — every new endpoint group needs a tier
 
 `createTierRateLimiter(tier)` is keyed on the authenticated org id (not IP), so one tenant's traffic doesn't eat another's quota. Apply it at the parent router, **before** the matching `routes.route(prefix, …)` call:

--- a/.agents/skills/database-postgres/SKILL.md
+++ b/.agents/skills/database-postgres/SKILL.md
@@ -105,15 +105,21 @@ export const ProjectRepositoryLive = Layer.effect(
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
           return yield* sqlClient
-            .query((db) => db.select().from(projects).where(eq(projects.id, id)))
+            .query((db, organizationId) =>
+              db
+                .select()
+                .from(projects)
+                .where(and(eq(projects.organizationId, organizationId), eq(projects.id, id)))
+                .limit(1),
+            )
             .pipe(Effect.flatMap(...))
         }),
 
       save: (project) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
-          yield* sqlClient.query((db) =>
-            db.insert(projects).values(row).onConflictDoUpdate({...})
+          yield* sqlClient.query((db, organizationId) =>
+            db.insert(projects).values({ ...row, organizationId }).onConflictDoUpdate({...})
           )
         }),
     }
@@ -122,6 +128,54 @@ export const ProjectRepositoryLive = Layer.effect(
 ```
 
 The layer-build effect doesn't `yield* SqlClient` at all — the dependency is declared via each method's `R` channel, and resolved per call. A build-time yield is redundant and (if captured) re-introduces the very bug this pattern avoids.
+
+### Pull `organizationId` from the RLS context, not from method params
+
+The `query((db, organizationId) => …)` callback receives the active organization id from the `SqlClient`'s RLS context. **Use that value** in `WHERE` predicates and `INSERT … VALUES` rows. Don't accept `organizationId` as a parameter on the repository method just to re-thread it into the SQL.
+
+Why:
+
+- **Consistency** — every repo call is scoped the same way regardless of which caller invokes it. Use-cases don't get to pick a different org from the one their request authenticated against.
+- **Defense in depth alongside RLS** — RLS already filters rows by `app.current_organization_id`, but the explicit predicate makes intent obvious in the query plan and catches accidental "I forgot RLS is on" mistakes during code review.
+- **Insert safety** — for `create`/`save` methods, writing the RLS-supplied org id (instead of trusting `entity.organizationId`) prevents a caller from fabricating an entity for a different org and inserting it through the right org's transaction.
+
+```ts
+// Good — orgId comes from RLS, name reflects the actual action.
+findMemberByEmail: (email: string) =>
+  Effect.gen(function* () {
+    const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+    return yield* sqlClient.query((db, organizationId) =>
+      db
+        .select({ id: members.id })
+        .from(members)
+        .where(and(eq(members.organizationId, organizationId), eq(members.email, email.toLowerCase())))
+        .limit(1),
+    )
+  }),
+
+create: (invitation: Invitation) =>
+  Effect.gen(function* () {
+    const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+    yield* sqlClient.query((db, organizationId) =>
+      db.insert(invitations).values({ ...row, organizationId }),
+    )
+  }),
+
+// Bad — orgId is a redundant input the caller could mis-pass.
+findMemberByEmail: ({ email, organizationId }: { email: string; organizationId: OrganizationId }) =>
+  /* … query((db) => …where(eq(members.organizationId, organizationId))) */,
+
+// Bad — trusts the entity for the inserted org id; nothing stops a caller
+// from passing an entity for a different org through this org's transaction.
+create: (invitation: Invitation) =>
+  /* … query((db) => db.insert(invitations).values({ ...invitation })) */,
+```
+
+Naming: if dropping the explicit param makes the method's name redundant (e.g. `listPendingByOrganizationId` → `listPending`), rename it. The repository contract should describe what the method *does*, not which scope it's bound to — the scope is the RLS context by construction.
+
+**Exceptions** — methods that legitimately operate outside the current RLS org are rare and should be obvious from the name and a comment:
+- `findPublicPendingPreviewById(invitationId)` — invite landing pages query before the invitee has authenticated, so there is no RLS context to lean on. Document the cross-org scope explicitly.
+- Admin/maintenance scripts that go through `withAdmin(...)` rather than `withPostgres(...)`.
 
 The repository port's method signatures must list `SqlClient` in their `R` channel:
 

--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -92,7 +92,7 @@
                 "type": "null"
               }
             ],
-            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+            "description": "ISO-8601 timestamp at which the project was deleted. `null` while the project is active."
           },
           "lastEditedAt": {
             "type": "string",
@@ -208,7 +208,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+                  "description": "ISO-8601 timestamp at which the project was deleted. `null` while the project is active."
                 },
                 "lastEditedAt": {
                   "type": "string",
@@ -352,7 +352,7 @@
                 "type": "null"
               }
             ],
-            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+            "description": "ISO-8601 timestamp at which the project was deleted. `null` while the project is active."
           },
           "lastEditedAt": {
             "type": "string",
@@ -422,6 +422,28 @@
               }
             },
             "additionalProperties": false
+          },
+          "flaggers": {
+            "description": "Enable or disable specific flaggers for the project. Keys are flagger slugs; values are the new `enabled` state. Omitted slugs are left untouched.",
+            "type": "object",
+            "propertyNames": {
+              "type": "string",
+              "enum": [
+                "frustration",
+                "nsfw",
+                "refusal",
+                "laziness",
+                "jailbreaking",
+                "forgetting",
+                "trashing",
+                "tool-call-errors",
+                "output-schema-validation",
+                "empty-response"
+              ]
+            },
+            "additionalProperties": {
+              "type": "boolean"
+            }
           }
         },
         "required": [
@@ -500,7 +522,7 @@
                 "type": "null"
               }
             ],
-            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+            "description": "ISO-8601 timestamp at which the project was deleted. `null` while the project is active."
           },
           "lastEditedAt": {
             "type": "string",
@@ -533,7 +555,7 @@
     {
       "name": "deleteProject",
       "title": "Delete project",
-      "description": "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
+      "description": "Deletes a project by slug.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -891,7 +913,7 @@
     {
       "name": "revokeApiKey",
       "title": "Revoke API key",
-      "description": "Soft-deletes an API key, immediately invalidating it.",
+      "description": "Revokes an API key.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -116,7 +116,7 @@
               "string",
               "null"
             ],
-            "description": "ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."
+            "description": "ISO-8601 timestamp at which the project was deleted. `null` while the project is active."
           },
           "lastEditedAt": {
             "type": "string",
@@ -226,6 +226,42 @@
               }
             },
             "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
+          },
+          "flaggers": {
+            "type": "object",
+            "properties": {
+              "frustration": {
+                "type": "boolean"
+              },
+              "nsfw": {
+                "type": "boolean"
+              },
+              "refusal": {
+                "type": "boolean"
+              },
+              "laziness": {
+                "type": "boolean"
+              },
+              "jailbreaking": {
+                "type": "boolean"
+              },
+              "forgetting": {
+                "type": "boolean"
+              },
+              "trashing": {
+                "type": "boolean"
+              },
+              "tool-call-errors": {
+                "type": "boolean"
+              },
+              "output-schema-validation": {
+                "type": "boolean"
+              },
+              "empty-response": {
+                "type": "boolean"
+              }
+            },
+            "description": "Enable or disable specific flaggers for the project. Keys are flagger slugs; values are the new `enabled` state. Omitted slugs are left untouched."
           }
         }
       },
@@ -1866,7 +1902,7 @@
         "x-fern-sdk-group-name": "projects",
         "x-fern-sdk-method-name": "delete",
         "summary": "Delete project",
-        "description": "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
+        "description": "Deletes a project by slug.",
         "security": [
           {
             "ApiKeyAuth": []
@@ -2332,7 +2368,7 @@
         "x-fern-sdk-group-name": "apiKeys",
         "x-fern-sdk-method-name": "revoke",
         "summary": "Revoke API key",
-        "description": "Soft-deletes an API key, immediately invalidating it.",
+        "description": "Revokes an API key.",
         "security": [
           {
             "ApiKeyAuth": []

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@clickhouse/client": "catalog:",
     "@domain/annotations": "workspace:*",
     "@domain/api-keys": "workspace:*",
+    "@domain/flaggers": "workspace:*",
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -260,7 +260,7 @@ const revokeApiKey = apiKeyEndpoint({
     tags: ["API Keys"],
     ...apiKeysFernGroup("revoke"),
     summary: "Revoke API key",
-    description: "Soft-deletes an API key, immediately invalidating it.",
+    description: "Revokes an API key.",
     security: PROTECTED_SECURITY,
     request: { params: IdParamsSchema },
     responses: openApiNoContentResponses({ description: "API key revoked" }),

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -1,4 +1,6 @@
 import { generateId } from "@domain/shared"
+import { and, eq } from "@platform/db-postgres"
+import { flaggers as flaggersTable } from "@platform/db-postgres/schema/flaggers"
 import { projects } from "@platform/db-postgres/schema/projects"
 import { createApiKeyAuthHeaders, type InMemoryPostgres } from "@platform/testkit"
 import { describe, expect, it } from "vitest"
@@ -127,6 +129,72 @@ describe("Projects Routes Integration", () => {
     expect(body.slug).not.toBe(project.slug)
     expect(body.slug).toContain("completely-different")
     expect(body.settings).toEqual({ keepMonitoring: true })
+  })
+
+  it<ApiTestContext>("PATCH /v1/projects/:projectSlug toggles flaggers when the body includes them", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Flagger Host")
+
+    // Seed two flaggers for the project so the toggle has a row to update.
+    await database.db.insert(flaggersTable).values([
+      {
+        id: generateId(),
+        organizationId: tenant.organizationId,
+        projectId: project.id,
+        slug: "frustration",
+        enabled: true,
+        sampling: 10,
+      },
+      {
+        id: generateId(),
+        organizationId: tenant.organizationId,
+        projectId: project.id,
+        slug: "refusal",
+        enabled: true,
+        sampling: 10,
+      },
+    ])
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects/${project.slug}`, {
+        method: "PATCH",
+        headers: { ...createApiKeyAuthHeaders(tenant.apiKeyToken), "Content-Type": "application/json" },
+        body: JSON.stringify({ flaggers: { frustration: false } }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+
+    const frustration = await database.db
+      .select({ enabled: flaggersTable.enabled })
+      .from(flaggersTable)
+      .where(and(eq(flaggersTable.projectId, project.id), eq(flaggersTable.slug, "frustration")))
+    expect(frustration[0]?.enabled).toBe(false)
+
+    // Untouched slug stays enabled.
+    const refusal = await database.db
+      .select({ enabled: flaggersTable.enabled })
+      .from(flaggersTable)
+      .where(and(eq(flaggersTable.projectId, project.id), eq(flaggersTable.slug, "refusal")))
+    expect(refusal[0]?.enabled).toBe(true)
+  })
+
+  it<ApiTestContext>("PATCH /v1/projects/:projectSlug rejects unknown flagger slugs", async ({ app, database }) => {
+    const tenant = await createTenantSetup(database)
+    const project = await createProjectRecord(database, tenant.organizationId, "Slug Guard")
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects/${project.slug}`, {
+        method: "PATCH",
+        headers: { ...createApiKeyAuthHeaders(tenant.apiKeyToken), "Content-Type": "application/json" },
+        body: JSON.stringify({ flaggers: { "not-a-real-flagger": false } }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
   })
 
   it<ApiTestContext>("DELETE /v1/projects/:projectSlug does not delete cross-tenant project", async ({

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -1,3 +1,4 @@
+import { FLAGGER_STRATEGY_SLUGS, type FlaggerSlug, updateFlaggerUseCase } from "@domain/flaggers"
 import {
   type CreateProjectInput,
   createProjectUseCase,
@@ -7,7 +8,13 @@ import {
 } from "@domain/projects"
 import { projectSettingsSchema } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { OutboxEventWriterLive, ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { RedisCacheStoreLive } from "@platform/cache-redis"
+import {
+  FlaggerRepositoryLive,
+  OutboxEventWriterLive,
+  ProjectRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
 import { defineApiEndpoint } from "../mcp/index.ts"
@@ -54,7 +61,7 @@ const ResponseSchema = z
     deletedAt: z
       .string()
       .nullable()
-      .describe("ISO-8601 timestamp at which the project was soft-deleted. `null` while the project is active."),
+      .describe("ISO-8601 timestamp at which the project was deleted. `null` while the project is active."),
     lastEditedAt: z.string().describe("ISO-8601 timestamp of the most recent name/settings edit."),
     createdAt: z.string().describe("ISO-8601 timestamp of creation."),
     updatedAt: z.string().describe("ISO-8601 timestamp of the last metadata change."),
@@ -82,6 +89,12 @@ const UpdateRequestSchema = z
       .optional()
       .describe(
         "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
+      ),
+    flaggers: z
+      .partialRecord(z.enum(FLAGGER_STRATEGY_SLUGS), z.boolean())
+      .optional()
+      .describe(
+        "Enable or disable specific flaggers for the project. Keys are flagger slugs; values are the new `enabled` state. Omitted slugs are left untouched.",
       ),
   })
   .openapi("UpdateProjectBody")
@@ -211,17 +224,42 @@ const updateProject = projectEndpoint({
   handler: async (c) => {
     const { projectSlug } = c.req.valid("param")
     const body = c.req.valid("json")
+    const organizationId = c.var.organization.id
+    const actorUserId = c.var.auth?.method === "oauth" ? (c.var.auth.userId as string) : undefined
 
     const updatedProject = await Effect.runPromise(
       Effect.gen(function* () {
         const repo = yield* ProjectRepository
         const project = yield* repo.findBySlug(projectSlug)
-        return yield* updateProjectUseCase({
+
+        const updated = yield* updateProjectUseCase({
           id: project.id,
           ...(body.name !== undefined ? { name: body.name } : {}),
           ...(body.settings !== undefined ? { settings: body.settings } : {}),
         })
-      }).pipe(withPostgres(ProjectRepositoryLive, c.var.postgresClient, c.var.organization.id), withTracing),
+
+        if (body.flaggers) {
+          for (const [slug, enabled] of Object.entries(body.flaggers)) {
+            yield* updateFlaggerUseCase({
+              organizationId,
+              projectId: updated.id,
+              slug: slug as FlaggerSlug,
+              enabled,
+              ...(actorUserId !== undefined ? { actorUserId } : {}),
+            })
+          }
+        }
+
+        return updated
+      }).pipe(
+        withPostgres(
+          Layer.mergeAll(ProjectRepositoryLive, FlaggerRepositoryLive, OutboxEventWriterLive),
+          c.var.postgresClient,
+          c.var.organization.id,
+        ),
+        Effect.provide(RedisCacheStoreLive(c.var.redis)),
+        withTracing,
+      ),
     )
 
     return c.json(toResponse(updatedProject), 200)
@@ -236,7 +274,7 @@ const deleteProject = projectEndpoint({
     tags: ["Projects"],
     ...projectsFernGroup("delete"),
     summary: "Delete project",
-    description: "Soft-deletes a project by slug. Traces remain in storage but the project no longer appears in lists.",
+    description: "Deletes a project by slug.",
     security: PROTECTED_SECURITY,
     request: { params: ProjectParamsSchema },
     responses: openApiNoContentResponses({ description: "Project deleted" }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@domain/api-keys':
         specifier: workspace:*
         version: link:../../packages/domain/api-keys
+      '@domain/flaggers':
+        specifier: workspace:*
+        version: link:../../packages/domain/flaggers
       '@domain/organizations':
         specifier: workspace:*
         version: link:../../packages/domain/organizations


### PR DESCRIPTION
Lets the projects PATCH endpoint flip individual flaggers on or off through an optional `flaggers: Record<slug, boolean>` field. The route handler fans out to the existing `updateFlaggerUseCase` per entry so we avoid coupling `@domain/projects` to the heavier flaggers graph. Slugs are validated against `FLAGGER_STRATEGY_SLUGS` at the request boundary, and `actorUserId` is only forwarded for OAuth callers.

Also scrubs the user-facing route descriptions of internal storage mechanics ("soft-deletes", retention details on related entities) and captures two conventions in the agent skills:

- api-endpoints SKILL — don't leak implementation details into route or schema descriptions; they reach SDK users and MCP agents.
- database-postgres SKILL — repository methods should pull `organizationId` from the RLS-supplied `query((db, organizationId) => …)` callback instead of taking it as a parameter; matches insert safety and review intent.