### PR TITLE
feat(api): annotations + scores routes through defineApiEndpoint

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -572,6 +572,929 @@
       }
     },
     {
+      "name": "createScore",
+      "title": "Create project score",
+      "description": "Creates a score against a target trace. The trace is resolved by explicit id (`trace.by = \"id\"`) or by a filter set (`trace.by = \"filters\"`, exactly one match required). Annotations use the separate `/annotations` endpoint.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          },
+          "body": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "simulationId": {
+                    "default": null,
+                    "description": "Simulation this score is tied to, if any. `null` (default) when not part of a simulation.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 24,
+                        "maxLength": 24
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": "Normalized score value in [0, 1]. Higher = better."
+                  },
+                  "passed": {
+                    "type": "boolean",
+                    "description": "Whether the scored output passes the evaluator's bar."
+                  },
+                  "feedback": {
+                    "type": "string",
+                    "description": "Free-text feedback explaining the score."
+                  },
+                  "error": {
+                    "default": null,
+                    "description": "Generation error text, when score generation itself failed. `null` (default) for successful scores.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "duration": {
+                    "default": 0,
+                    "description": "Score generation duration in nanoseconds. `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "tokens": {
+                    "default": 0,
+                    "description": "LLM tokens consumed generating the score, if any. `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "cost": {
+                    "default": 0,
+                    "description": "Score cost in microcents (1/1,000,000 of a USD). `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "trace": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "by": {
+                            "type": "string",
+                            "const": "id",
+                            "description": "Match a single trace by its identifier. Pair with `id`."
+                          },
+                          "id": {
+                            "type": "string",
+                            "minLength": 32,
+                            "maxLength": 32,
+                            "description": "32-character trace identifier."
+                          }
+                        },
+                        "required": [
+                          "by",
+                          "id"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "by": {
+                            "type": "string",
+                            "const": "filters",
+                            "description": "Match a single trace by a filter set. Pair with `filters`; exactly one trace must match."
+                          },
+                          "filters": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            },
+                            "additionalProperties": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "op": {
+                                    "type": "string",
+                                    "enum": [
+                                      "eq",
+                                      "neq",
+                                      "gt",
+                                      "gte",
+                                      "lt",
+                                      "lte",
+                                      "in",
+                                      "notIn",
+                                      "contains",
+                                      "notContains",
+                                      "gtePercentile"
+                                    ],
+                                    "description": "Comparison operator applied to the field's value (e.g. `eq`, `neq`, `in`). The full operator list lives in the API reference."
+                                  },
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ],
+                                    "description": "Right-hand value compared against the field. Arrays are required for `in` / `notIn`-style operators."
+                                  }
+                                },
+                                "required": [
+                                  "op",
+                                  "value"
+                                ],
+                                "additionalProperties": false
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "by",
+                          "filters"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Target trace. Either an explicit id or a filter set matching exactly one trace."
+                  },
+                  "sourceId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "description": "User-supplied tag identifying the score's origin (e.g. `\"prod-pipeline\"`, `\"qa-script-v2\"`)."
+                  },
+                  "metadata": {
+                    "default": {},
+                    "description": "Arbitrary user-supplied metadata persisted alongside the score.",
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "_evaluation": {
+                    "default": false,
+                    "description": "Discriminator: omit (or `false`) for custom scores. Required `true` for evaluation scores.",
+                    "type": "boolean",
+                    "const": false
+                  }
+                },
+                "required": [
+                  "simulationId",
+                  "value",
+                  "passed",
+                  "feedback",
+                  "error",
+                  "duration",
+                  "tokens",
+                  "cost",
+                  "trace",
+                  "sourceId",
+                  "metadata",
+                  "_evaluation"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "simulationId": {
+                    "default": null,
+                    "description": "Simulation this score is tied to, if any. `null` (default) when not part of a simulation.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 24,
+                        "maxLength": 24
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": "Normalized score value in [0, 1]. Higher = better."
+                  },
+                  "passed": {
+                    "type": "boolean",
+                    "description": "Whether the scored output passes the evaluator's bar."
+                  },
+                  "feedback": {
+                    "type": "string",
+                    "description": "Free-text feedback explaining the score."
+                  },
+                  "error": {
+                    "default": null,
+                    "description": "Generation error text, when score generation itself failed. `null` (default) for successful scores.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "duration": {
+                    "default": 0,
+                    "description": "Score generation duration in nanoseconds. `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "tokens": {
+                    "default": 0,
+                    "description": "LLM tokens consumed generating the score, if any. `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "cost": {
+                    "default": 0,
+                    "description": "Score cost in microcents (1/1,000,000 of a USD). `0` for externally-computed scores.",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "trace": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "by": {
+                            "type": "string",
+                            "const": "id",
+                            "description": "Match a single trace by its identifier. Pair with `id`."
+                          },
+                          "id": {
+                            "type": "string",
+                            "minLength": 32,
+                            "maxLength": 32,
+                            "description": "32-character trace identifier."
+                          }
+                        },
+                        "required": [
+                          "by",
+                          "id"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "by": {
+                            "type": "string",
+                            "const": "filters",
+                            "description": "Match a single trace by a filter set. Pair with `filters`; exactly one trace must match."
+                          },
+                          "filters": {
+                            "type": "object",
+                            "propertyNames": {
+                              "type": "string"
+                            },
+                            "additionalProperties": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "op": {
+                                    "type": "string",
+                                    "enum": [
+                                      "eq",
+                                      "neq",
+                                      "gt",
+                                      "gte",
+                                      "lt",
+                                      "lte",
+                                      "in",
+                                      "notIn",
+                                      "contains",
+                                      "notContains",
+                                      "gtePercentile"
+                                    ],
+                                    "description": "Comparison operator applied to the field's value (e.g. `eq`, `neq`, `in`). The full operator list lives in the API reference."
+                                  },
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ],
+                                    "description": "Right-hand value compared against the field. Arrays are required for `in` / `notIn`-style operators."
+                                  }
+                                },
+                                "required": [
+                                  "op",
+                                  "value"
+                                ],
+                                "additionalProperties": false
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "by",
+                          "filters"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Target trace. Either an explicit id or a filter set matching exactly one trace."
+                  },
+                  "_evaluation": {
+                    "type": "boolean",
+                    "const": true,
+                    "description": "Discriminator: `true` flags the body as an evaluation score (internal); `false`/omit for custom."
+                  },
+                  "sourceId": {
+                    "type": "string",
+                    "minLength": 24,
+                    "maxLength": 24,
+                    "description": "CUID of the evaluation that produced this score."
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "properties": {
+                      "evaluationHash": {
+                        "type": "string",
+                        "description": "Hash of the evaluation script that produced this score; lets the platform track which version generated it."
+                      }
+                    },
+                    "required": [
+                      "evaluationHash"
+                    ],
+                    "additionalProperties": false,
+                    "description": "Evaluation-specific metadata."
+                  }
+                },
+                "required": [
+                  "simulationId",
+                  "value",
+                  "passed",
+                  "feedback",
+                  "error",
+                  "duration",
+                  "tokens",
+                  "cost",
+                  "trace",
+                  "_evaluation",
+                  "sourceId",
+                  "metadata"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "required": [
+          "projectSlug",
+          "body"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "createAnnotation",
+      "title": "Create project annotation",
+      "description": "Creates a published annotation score against a target trace. The trace is resolved by explicit id (`trace.by = \"id\"`) or by a filter set (`trace.by = \"filters\"`, exactly one match required). When called with an OAuth token, the annotation is attributed to the authenticated user.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "projectSlug": {
+            "type": "string",
+            "description": "Project slug (human-readable identifier)"
+          },
+          "simulationId": {
+            "default": null,
+            "description": "Simulation this annotation is tied to, if any. `null` (default) when not part of a simulation.",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "issueId": {
+            "default": null,
+            "description": "Pre-selected issue this annotation belongs to. Leave `null` (default) to let the automatic issue-discovery pipeline route the annotation.",
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "value": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]. Higher = better."
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the annotated output passes the reviewer's bar."
+          },
+          "feedback": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Free-text feedback explaining the score. Surfaced alongside the trace."
+          },
+          "anchor": {
+            "description": "Optional anchor pinning the annotation to a specific message / part / offset range inside the trace.",
+            "type": "object",
+            "properties": {
+              "messageIndex": {
+                "description": "0-based message index inside the conversation. Omit for conversation-level annotations.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "partIndex": {
+                "description": "0-based index into the target message's `parts[]`. Requires `messageIndex`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "startOffset": {
+                "description": "Inclusive start offset for substring annotations. Must be paired with `endOffset` and `partIndex`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "endOffset": {
+                "description": "Exclusive end offset for substring annotations. Must be paired with `startOffset` and `partIndex`, and `>= startOffset`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "textFormat": {
+                "description": "UI-side text transform applied before the offsets were captured (e.g. `\"pretty-json\"`). Resolvers must apply the same transform before slicing.",
+                "type": "string",
+                "enum": [
+                  "pretty-json"
+                ]
+              }
+            },
+            "additionalProperties": false
+          },
+          "trace": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "by": {
+                    "type": "string",
+                    "const": "id",
+                    "description": "Match a single trace by its identifier. Pair with `id`."
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 32,
+                    "maxLength": 32,
+                    "description": "32-character trace identifier."
+                  }
+                },
+                "required": [
+                  "by",
+                  "id"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "by": {
+                    "type": "string",
+                    "const": "filters",
+                    "description": "Match a single trace by a filter set. Pair with `filters`; exactly one trace must match."
+                  },
+                  "filters": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "op": {
+                            "type": "string",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "gt",
+                              "gte",
+                              "lt",
+                              "lte",
+                              "in",
+                              "notIn",
+                              "contains",
+                              "notContains",
+                              "gtePercentile"
+                            ],
+                            "description": "Comparison operator applied to the field's value (e.g. `eq`, `neq`, `in`). The full operator list lives in the API reference."
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "description": "Right-hand value compared against the field. Arrays are required for `in` / `notIn`-style operators."
+                          }
+                        },
+                        "required": [
+                          "op",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "by",
+                  "filters"
+                ],
+                "additionalProperties": false
+              }
+            ],
+            "description": "Target trace. Either an explicit id or a filter set matching exactly one trace."
+          }
+        },
+        "required": [
+          "projectSlug",
+          "simulationId",
+          "issueId",
+          "value",
+          "passed",
+          "feedback",
+          "trace"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Stable annotation-score identifier."
+          },
+          "organizationId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Organization that owns this annotation."
+          },
+          "projectId": {
+            "type": "string",
+            "minLength": 24,
+            "maxLength": 24,
+            "description": "Project this annotation lives in."
+          },
+          "sessionId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "description": "Session identifier lifted from instrumentation. Up to 128 characters."
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Session id lifted from the trace, when set. `null` when the trace has no session."
+          },
+          "traceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 32,
+                "maxLength": 32,
+                "description": "32-character trace identifier."
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Identifier of the annotated trace."
+          },
+          "spanId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 16,
+                "maxLength": 16,
+                "description": "16-character span identifier."
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Span the annotation pins to. Defaults to the trace's last LLM-completion span."
+          },
+          "simulationId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Simulation reference, if any."
+          },
+          "issueId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Issue this annotation contributes to, if any."
+          },
+          "value": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]."
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether the annotation marks the output as passing."
+          },
+          "feedback": {
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Generation error text, when the annotation itself errored. `null` for successful annotations."
+          },
+          "errored": {
+            "type": "boolean",
+            "description": "`true` when the annotation could not be generated successfully."
+          },
+          "duration": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Generation duration in nanoseconds. `0` for human annotations."
+          },
+          "tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Total LLM tokens consumed generating the score, if any. `0` for human annotations."
+          },
+          "cost": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Total LLM cost in microcents (1/1,000,000 of a USD). `0` for human annotations."
+          },
+          "draftedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Always `null` for public-API annotations — they're written as published."
+          },
+          "annotatorId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User who authored the annotation. `null` for API-key callers (organization-scoped); set to the authenticated user for OAuth callers."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "description": "ISO-8601 timestamp at which the annotation was created."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "description": "ISO-8601 timestamp of the last metadata update."
+          },
+          "source": {
+            "type": "string",
+            "const": "annotation",
+            "description": "Always `\"annotation\"` for this endpoint's responses."
+          },
+          "sourceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "UI",
+                  "API",
+                  "SYSTEM"
+                ]
+              },
+              {
+                "type": "string",
+                "minLength": 24,
+                "maxLength": 24
+              }
+            ],
+            "description": "Origin marker. Sentinel `\"UI\"` / `\"API\"` / `\"SYSTEM\"` for drafts and automation, or an annotation-queue CUID for queue-authored rows. Public-API annotations are always `\"API\"`."
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "rawFeedback": {
+                "type": "string",
+                "description": "Original feedback text before enrichment. Human-authored for human annotations, model-authored for system drafts."
+              },
+              "messageIndex": {
+                "description": "0-based message index inside the conversation. Omit for conversation-level annotations.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "partIndex": {
+                "description": "0-based index into the target message's `parts[]`. Requires `messageIndex`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "startOffset": {
+                "description": "Inclusive start offset for substring annotations. Must be paired with `endOffset` and `partIndex`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "endOffset": {
+                "description": "Exclusive end offset for substring annotations. Must be paired with `startOffset` and `partIndex`, and `>= startOffset`.",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              },
+              "textFormat": {
+                "description": "UI-side text transform applied before the offsets were captured (e.g. `\"pretty-json\"`). Resolvers must apply the same transform before slicing.",
+                "type": "string",
+                "enum": [
+                  "pretty-json"
+                ]
+              }
+            },
+            "required": [
+              "rawFeedback"
+            ],
+            "additionalProperties": false,
+            "description": "Annotation-specific metadata: `rawFeedback` plus a snapshot of the anchor at write time."
+          }
+        },
+        "required": [
+          "id",
+          "organizationId",
+          "projectId",
+          "sessionId",
+          "traceId",
+          "spanId",
+          "simulationId",
+          "issueId",
+          "value",
+          "passed",
+          "feedback",
+          "error",
+          "errored",
+          "duration",
+          "tokens",
+          "cost",
+          "draftedAt",
+          "annotatorId",
+          "createdAt",
+          "updatedAt",
+          "source",
+          "sourceId",
+          "metadata"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "createApiKey",
       "title": "Generate API key",
       "description": "Generates a new API key for the organization. The token is only returned once — store it securely.",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -281,24 +281,28 @@
           "id": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Stable score identifier."
           },
           "organizationId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Organization that owns this score."
           },
           "projectId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Project this score lives in."
           },
           "sessionId": {
             "type": [
               "string",
               "null"
             ],
-            "maxLength": 128
+            "maxLength": 128,
+            "description": "Session id lifted from the trace, when set. `null` when the trace has no session."
           },
           "traceId": {
             "type": [
@@ -306,7 +310,8 @@
               "null"
             ],
             "minLength": 32,
-            "maxLength": 32
+            "maxLength": 32,
+            "description": "Identifier of the scored trace."
           },
           "spanId": {
             "type": [
@@ -314,7 +319,8 @@
               "null"
             ],
             "minLength": 16,
-            "maxLength": 16
+            "maxLength": 16,
+            "description": "Span the score pins to. Defaults to the trace's last LLM-completion span."
           },
           "simulationId": {
             "type": [
@@ -322,7 +328,8 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Simulation reference, if any."
           },
           "issueId": {
             "type": [
@@ -330,47 +337,57 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Issue this score contributes to, if any."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the score marks the output as passing."
           },
           "feedback": {
-            "type": "string"
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
           },
           "error": {
             "type": [
               "string",
               "null"
             ],
-            "minLength": 1
+            "minLength": 1,
+            "description": "Generation error text, when score generation itself errored. `null` for successful scores."
           },
           "errored": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when the score could not be generated successfully."
           },
           "duration": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Score generation duration in nanoseconds."
           },
           "tokens": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "LLM tokens consumed generating the score."
           },
           "cost": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Score cost in microcents (1/1,000,000 of a USD)."
           },
           "draftedAt": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp while the score is awaiting human confirmation. `null` for published / system scores."
           },
           "annotatorId": {
             "type": [
@@ -378,30 +395,36 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "User who authored the score, if any."
           },
           "createdAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp at which the score was created."
           },
           "updatedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp of the last metadata update."
           },
           "source": {
             "type": "string",
             "enum": [
               "custom"
-            ]
+            ],
+            "description": "Discriminator. `\"custom\"` denotes a user-supplied score."
           },
           "sourceId": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128
+            "maxLength": 128,
+            "description": "User-supplied tag identifying the score's origin (echoed from the request)."
           },
           "metadata": {
             "type": "object",
-            "additionalProperties": {}
+            "additionalProperties": {},
+            "description": "Arbitrary user-supplied metadata persisted alongside the score."
           }
         },
         "required": [
@@ -436,24 +459,28 @@
           "id": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Stable score identifier."
           },
           "organizationId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Organization that owns this score."
           },
           "projectId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Project this score lives in."
           },
           "sessionId": {
             "type": [
               "string",
               "null"
             ],
-            "maxLength": 128
+            "maxLength": 128,
+            "description": "Session id lifted from the trace, when set. `null` when the trace has no session."
           },
           "traceId": {
             "type": [
@@ -461,7 +488,8 @@
               "null"
             ],
             "minLength": 32,
-            "maxLength": 32
+            "maxLength": 32,
+            "description": "Identifier of the scored trace."
           },
           "spanId": {
             "type": [
@@ -469,7 +497,8 @@
               "null"
             ],
             "minLength": 16,
-            "maxLength": 16
+            "maxLength": 16,
+            "description": "Span the score pins to. Defaults to the trace's last LLM-completion span."
           },
           "simulationId": {
             "type": [
@@ -477,7 +506,8 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Simulation reference, if any."
           },
           "issueId": {
             "type": [
@@ -485,47 +515,57 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Issue this score contributes to, if any."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the score marks the output as passing."
           },
           "feedback": {
-            "type": "string"
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
           },
           "error": {
             "type": [
               "string",
               "null"
             ],
-            "minLength": 1
+            "minLength": 1,
+            "description": "Generation error text, when score generation itself errored. `null` for successful scores."
           },
           "errored": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when the score could not be generated successfully."
           },
           "duration": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Score generation duration in nanoseconds."
           },
           "tokens": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "LLM tokens consumed generating the score."
           },
           "cost": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Score cost in microcents (1/1,000,000 of a USD)."
           },
           "draftedAt": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp while the score is awaiting human confirmation. `null` for published / system scores."
           },
           "annotatorId": {
             "type": [
@@ -533,37 +573,34 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "User who authored the score, if any."
           },
           "createdAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp at which the score was created."
           },
           "updatedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp of the last metadata update."
           },
           "source": {
             "type": "string",
             "enum": [
               "evaluation"
-            ]
+            ],
+            "description": "Discriminator. `\"evaluation\"` denotes a platform-generated evaluation score."
           },
           "sourceId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "CUID of the evaluation that produced this score."
           },
           "metadata": {
-            "type": "object",
-            "properties": {
-              "evaluationHash": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluationHash"
-            ]
+            "$ref": "#/components/schemas/EvaluationScoreMetadata"
           }
         },
         "required": [
@@ -592,6 +629,19 @@
           "metadata"
         ]
       },
+      "EvaluationScoreMetadata": {
+        "type": "object",
+        "properties": {
+          "evaluationHash": {
+            "type": "string",
+            "description": "Hash of the evaluation script that produced this score; lets the platform track which version generated it."
+          }
+        },
+        "required": [
+          "evaluationHash"
+        ],
+        "description": "Evaluation-specific metadata."
+      },
       "CreateScoreBody": {
         "anyOf": [
           {
@@ -612,18 +662,22 @@
             ],
             "minLength": 24,
             "maxLength": 24,
-            "default": null
+            "default": null,
+            "description": "Simulation this score is tied to, if any. `null` (default) when not part of a simulation."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]. Higher = better."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the scored output passes the evaluator's bar."
           },
           "feedback": {
-            "type": "string"
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
           },
           "error": {
             "type": [
@@ -631,22 +685,26 @@
               "null"
             ],
             "minLength": 1,
-            "default": null
+            "default": null,
+            "description": "Generation error text, when score generation itself failed. `null` (default) for successful scores."
           },
           "duration": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "Score generation duration in nanoseconds. `0` for externally-computed scores."
           },
           "tokens": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "LLM tokens consumed generating the score, if any. `0` for externally-computed scores."
           },
           "cost": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "Score cost in microcents (1/1,000,000 of a USD). `0` for externally-computed scores."
           },
           "trace": {
             "$ref": "#/components/schemas/TraceRef"
@@ -654,19 +712,22 @@
           "sourceId": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 128
+            "maxLength": 128,
+            "description": "User-supplied tag identifying the score's origin (e.g. `\"prod-pipeline\"`, `\"qa-script-v2\"`)."
           },
           "metadata": {
             "type": "object",
             "additionalProperties": {},
-            "default": {}
+            "default": {},
+            "description": "Arbitrary user-supplied metadata persisted alongside the score."
           },
           "_evaluation": {
             "type": "boolean",
             "enum": [
               false
             ],
-            "default": false
+            "default": false,
+            "description": "Discriminator: omit (or `false`) for custom scores. Required `true` for evaluation scores."
           }
         },
         "required": [
@@ -686,12 +747,14 @@
                 "type": "string",
                 "enum": [
                   "id"
-                ]
+                ],
+                "description": "Match a single trace by its identifier. Pair with `id`."
               },
               "id": {
                 "type": "string",
                 "minLength": 32,
-                "maxLength": 32
+                "maxLength": 32,
+                "description": "32-character trace identifier."
               }
             },
             "required": [
@@ -706,7 +769,8 @@
                 "type": "string",
                 "enum": [
                   "filters"
-                ]
+                ],
+                "description": "Match a single trace by a filter set. Pair with `filters`; exactly one trace must match."
               },
               "filters": {
                 "$ref": "#/components/schemas/FilterSet"
@@ -717,7 +781,8 @@
               "filters"
             ]
           }
-        ]
+        ],
+        "description": "Target trace. Either an explicit id or a filter set matching exactly one trace."
       },
       "FilterSet": {
         "type": "object",
@@ -726,7 +791,8 @@
           "items": {
             "$ref": "#/components/schemas/FilterCondition"
           }
-        }
+        },
+        "description": "Filter set keyed by field name. Each entry holds an array of conditions ANDed together for that field; field-level groups are also ANDed across the set."
       },
       "FilterCondition": {
         "type": "object",
@@ -745,7 +811,8 @@
               "contains",
               "notContains",
               "gtePercentile"
-            ]
+            ],
+            "description": "Comparison operator applied to the field's value (e.g. `eq`, `neq`, `in`). The full operator list lives in the API reference."
           },
           "value": {
             "anyOf": [
@@ -771,7 +838,8 @@
                   ]
                 }
               }
-            ]
+            ],
+            "description": "Right-hand value compared against the field. Arrays are required for `in` / `notIn`-style operators."
           }
         },
         "required": [
@@ -789,18 +857,22 @@
             ],
             "minLength": 24,
             "maxLength": 24,
-            "default": null
+            "default": null,
+            "description": "Simulation this score is tied to, if any. `null` (default) when not part of a simulation."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]. Higher = better."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the scored output passes the evaluator's bar."
           },
           "feedback": {
-            "type": "string"
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
           },
           "error": {
             "type": [
@@ -808,22 +880,26 @@
               "null"
             ],
             "minLength": 1,
-            "default": null
+            "default": null,
+            "description": "Generation error text, when score generation itself failed. `null` (default) for successful scores."
           },
           "duration": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "Score generation duration in nanoseconds. `0` for externally-computed scores."
           },
           "tokens": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "LLM tokens consumed generating the score, if any. `0` for externally-computed scores."
           },
           "cost": {
             "type": "integer",
             "minimum": 0,
-            "default": 0
+            "default": 0,
+            "description": "Score cost in microcents (1/1,000,000 of a USD). `0` for externally-computed scores."
           },
           "trace": {
             "$ref": "#/components/schemas/TraceRef"
@@ -832,23 +908,17 @@
             "type": "boolean",
             "enum": [
               true
-            ]
+            ],
+            "description": "Discriminator: `true` flags the body as an evaluation score (internal); `false`/omit for custom."
           },
           "sourceId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "CUID of the evaluation that produced this score."
           },
           "metadata": {
-            "type": "object",
-            "properties": {
-              "evaluationHash": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "evaluationHash"
-            ]
+            "$ref": "#/components/schemas/EvaluationScoreMetadata"
           }
         },
         "required": [
@@ -868,24 +938,28 @@
           "id": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Stable annotation-score identifier."
           },
           "organizationId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Organization that owns this annotation."
           },
           "projectId": {
             "type": "string",
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Project this annotation lives in."
           },
           "sessionId": {
             "type": [
               "string",
               "null"
             ],
-            "maxLength": 128
+            "maxLength": 128,
+            "description": "Session id lifted from the trace, when set. `null` when the trace has no session."
           },
           "traceId": {
             "type": [
@@ -893,7 +967,8 @@
               "null"
             ],
             "minLength": 32,
-            "maxLength": 32
+            "maxLength": 32,
+            "description": "Identifier of the annotated trace."
           },
           "spanId": {
             "type": [
@@ -901,7 +976,8 @@
               "null"
             ],
             "minLength": 16,
-            "maxLength": 16
+            "maxLength": 16,
+            "description": "Span the annotation pins to. Defaults to the trace's last LLM-completion span."
           },
           "simulationId": {
             "type": [
@@ -909,7 +985,8 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Simulation reference, if any."
           },
           "issueId": {
             "type": [
@@ -917,47 +994,57 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "Issue this annotation contributes to, if any."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the annotation marks the output as passing."
           },
           "feedback": {
-            "type": "string"
+            "type": "string",
+            "description": "Free-text feedback explaining the score."
           },
           "error": {
             "type": [
               "string",
               "null"
             ],
-            "minLength": 1
+            "minLength": 1,
+            "description": "Generation error text, when the annotation itself errored. `null` for successful annotations."
           },
           "errored": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "`true` when the annotation could not be generated successfully."
           },
           "duration": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Generation duration in nanoseconds. `0` for human annotations."
           },
           "tokens": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Total LLM tokens consumed generating the score, if any. `0` for human annotations."
           },
           "cost": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Total LLM cost in microcents (1/1,000,000 of a USD). `0` for human annotations."
           },
           "draftedAt": {
             "type": [
               "string",
               "null"
             ],
-            "format": "date-time"
+            "format": "date-time",
+            "description": "Always `null` for public-API annotations — they're written as published."
           },
           "annotatorId": {
             "type": [
@@ -965,21 +1052,25 @@
               "null"
             ],
             "minLength": 24,
-            "maxLength": 24
+            "maxLength": 24,
+            "description": "User who authored the annotation. `null` for API-key callers (organization-scoped); set to the authenticated user for OAuth callers."
           },
           "createdAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp at which the annotation was created."
           },
           "updatedAt": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "description": "ISO-8601 timestamp of the last metadata update."
           },
           "source": {
             "type": "string",
             "enum": [
               "annotation"
-            ]
+            ],
+            "description": "Always `\"annotation\"` for this endpoint's responses."
           },
           "sourceId": {
             "anyOf": [
@@ -996,40 +1087,11 @@
                 "minLength": 24,
                 "maxLength": 24
               }
-            ]
+            ],
+            "description": "Origin marker. Sentinel `\"UI\"` / `\"API\"` / `\"SYSTEM\"` for drafts and automation, or an annotation-queue CUID for queue-authored rows. Public-API annotations are always `\"API\"`."
           },
           "metadata": {
-            "type": "object",
-            "properties": {
-              "rawFeedback": {
-                "type": "string"
-              },
-              "messageIndex": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "partIndex": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "startOffset": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "endOffset": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "textFormat": {
-                "type": "string",
-                "enum": [
-                  "pretty-json"
-                ]
-              }
-            },
-            "required": [
-              "rawFeedback"
-            ]
+            "$ref": "#/components/schemas/AnnotationScoreMetadata"
           }
         },
         "required": [
@@ -1058,6 +1120,46 @@
           "metadata"
         ]
       },
+      "AnnotationScoreMetadata": {
+        "type": "object",
+        "properties": {
+          "rawFeedback": {
+            "type": "string",
+            "description": "Original feedback text before enrichment. Human-authored for human annotations, model-authored for system drafts."
+          },
+          "messageIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based message index inside the conversation. Omit for conversation-level annotations."
+          },
+          "partIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based index into the target message's `parts[]`. Requires `messageIndex`."
+          },
+          "startOffset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Inclusive start offset for substring annotations. Must be paired with `endOffset` and `partIndex`."
+          },
+          "endOffset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Exclusive end offset for substring annotations. Must be paired with `startOffset` and `partIndex`, and `>= startOffset`."
+          },
+          "textFormat": {
+            "type": "string",
+            "enum": [
+              "pretty-json"
+            ],
+            "description": "UI-side text transform applied before the offsets were captured (e.g. `\"pretty-json\"`). Resolvers must apply the same transform before slicing."
+          }
+        },
+        "required": [
+          "rawFeedback"
+        ],
+        "description": "Annotation-specific metadata: `rawFeedback` plus a snapshot of the anchor at write time."
+      },
       "CreateAnnotationBody": {
         "type": "object",
         "properties": {
@@ -1068,7 +1170,8 @@
             ],
             "minLength": 24,
             "maxLength": 24,
-            "default": null
+            "default": null,
+            "description": "Simulation this annotation is tied to, if any. `null` (default) when not part of a simulation."
           },
           "issueId": {
             "type": [
@@ -1077,46 +1180,26 @@
             ],
             "minLength": 24,
             "maxLength": 24,
-            "default": null
+            "default": null,
+            "description": "Pre-selected issue this annotation belongs to. Leave `null` (default) to let the automatic issue-discovery pipeline route the annotation."
           },
           "value": {
             "type": "number",
             "minimum": 0,
-            "maximum": 1
+            "maximum": 1,
+            "description": "Normalized score value in [0, 1]. Higher = better."
           },
           "passed": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the annotated output passes the reviewer's bar."
           },
           "feedback": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "description": "Free-text feedback explaining the score. Surfaced alongside the trace."
           },
           "anchor": {
-            "type": "object",
-            "properties": {
-              "messageIndex": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "partIndex": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "startOffset": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "endOffset": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "textFormat": {
-                "type": "string",
-                "enum": [
-                  "pretty-json"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/AnnotationAnchor"
           },
           "trace": {
             "$ref": "#/components/schemas/TraceRef"
@@ -1128,6 +1211,39 @@
           "feedback",
           "trace"
         ]
+      },
+      "AnnotationAnchor": {
+        "type": "object",
+        "properties": {
+          "messageIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based message index inside the conversation. Omit for conversation-level annotations."
+          },
+          "partIndex": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "0-based index into the target message's `parts[]`. Requires `messageIndex`."
+          },
+          "startOffset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Inclusive start offset for substring annotations. Must be paired with `endOffset` and `partIndex`."
+          },
+          "endOffset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Exclusive end offset for substring annotations. Must be paired with `startOffset` and `partIndex`, and `>= startOffset`."
+          },
+          "textFormat": {
+            "type": "string",
+            "enum": [
+              "pretty-json"
+            ],
+            "description": "UI-side text transform applied before the offsets were captured (e.g. `\"pretty-json\"`). Resolvers must apply the same transform before slicing."
+          }
+        },
+        "description": "Optional anchor pinning the annotation to a specific message / part / offset range inside the trace."
       },
       "ApiKey": {
         "type": "object",
@@ -1950,10 +2066,11 @@
     },
     "/v1/projects/{projectSlug}/scores": {
       "post": {
-        "operationId": "scores.create",
         "tags": [
           "Scores"
         ],
+        "x-fern-sdk-group-name": "scores",
+        "x-fern-sdk-method-name": "create",
         "summary": "Create project score",
         "description": "Creates a score against a target trace. The trace is resolved by explicit id (`trace.by = \"id\"`) or by a filter set (`trace.by = \"filters\"`, exactly one match required). Annotations use the separate `/annotations` endpoint.",
         "security": [
@@ -1961,6 +2078,7 @@
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "createScore",
         "parameters": [
           {
             "schema": {
@@ -1985,7 +2103,7 @@
         },
         "responses": {
           "201": {
-            "description": "Score created successfully",
+            "description": "Score created",
             "content": {
               "application/json": {
                 "schema": {
@@ -2029,17 +2147,19 @@
     },
     "/v1/projects/{projectSlug}/annotations": {
       "post": {
-        "operationId": "annotations.create",
         "tags": [
           "Annotations"
         ],
+        "x-fern-sdk-group-name": "annotations",
+        "x-fern-sdk-method-name": "create",
         "summary": "Create project annotation",
-        "description": "Creates a published annotation score against a target trace. The trace is resolved by explicit id (`trace.by = \"id\"`) or by a filter set (`trace.by = \"filters\"`, exactly one match required).",
+        "description": "Creates a published annotation score against a target trace. The trace is resolved by explicit id (`trace.by = \"id\"`) or by a filter set (`trace.by = \"filters\"`, exactly one match required). When called with an OAuth token, the annotation is attributed to the authenticated user.",
         "security": [
           {
             "ApiKeyAuth": []
           }
         ],
+        "operationId": "createAnnotation",
         "parameters": [
           {
             "schema": {
@@ -2064,7 +2184,7 @@
         },
         "responses": {
           "201": {
-            "description": "Annotation created successfully",
+            "description": "Annotation created",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/src/mcp/define-endpoint.ts
+++ b/apps/api/src/mcp/define-endpoint.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono, RouteConfig, RouteHandler } from "@hono/zod-openapi"
 import type { Env } from "hono"
+import { honoPathToOpenApi } from "./normalize-path.ts"
 import { registerEndpoint } from "./registry.ts"
 
 /**
@@ -64,6 +65,12 @@ export interface AnyApiEndpoint {
  * prefix as a constant (e.g. `export const apiKeysPath = "/api-keys"`) and pass
  * it both here and to the parent — so the value is declared once.
  *
+ * Accepts either Hono-style `:param` syntax or OpenAPI-style `{param}` syntax;
+ * the registry stores the OpenAPI form so the dispatcher only has to substitute
+ * one placeholder shape. This lets route files declare a single Hono-form
+ * constant (`/projects/:projectSlug/annotations`) usable both at the parent
+ * mount and here.
+ *
  * The two-step shape (`defineApiEndpoint<E>(prefix)(args)`) exists because
  * TypeScript can't partially-infer one type argument while accepting another
  * explicitly: we need the caller to specify `Env` (which depends on which
@@ -109,11 +116,15 @@ export const defineApiEndpoint =
     // the OpenAPI spec and the MCP tool registry.
     const { name, ...rest } = route
     const routeForHono = { ...rest, operationId: name } as unknown as R
+    // Canonicalize the mount prefix to OpenAPI form (`{param}`) for the registry —
+    // the dispatcher in server.ts only knows how to substitute that shape. Hono's
+    // `parent.route(prefix, …)` happily accepts either form.
+    const normalizedPrefix = honoPathToOpenApi(prefix)
     const endpoint: ApiEndpoint<R, E> = {
       route,
       handler,
       tool,
-      prefix,
+      prefix: normalizedPrefix,
       mountHttp(app) {
         // Cast through `any` because OpenAPIHono.openapi is parameterised on a
         // concrete RouteConfig, not our AppRouteConfig superset. The runtime call

--- a/apps/api/src/mcp/normalize-path.test.ts
+++ b/apps/api/src/mcp/normalize-path.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { honoPathToOpenApi } from "./normalize-path.ts"
+
+describe("honoPathToOpenApi", () => {
+  it("converts a single :param to {param}", () => {
+    expect(honoPathToOpenApi("/projects/:projectSlug/annotations")).toBe("/projects/{projectSlug}/annotations")
+  })
+
+  it("converts multiple :params on the same path", () => {
+    expect(honoPathToOpenApi("/projects/:projectSlug/datasets/:datasetSlug/rows")).toBe(
+      "/projects/{projectSlug}/datasets/{datasetSlug}/rows",
+    )
+  })
+
+  it("leaves the path untouched when it has no params", () => {
+    expect(honoPathToOpenApi("/api-keys")).toBe("/api-keys")
+    expect(honoPathToOpenApi("/")).toBe("/")
+    expect(honoPathToOpenApi("")).toBe("")
+  })
+
+  it("is idempotent on already-OpenAPI-form paths", () => {
+    const openApi = "/projects/{projectSlug}/annotations"
+    expect(honoPathToOpenApi(openApi)).toBe(openApi)
+    expect(honoPathToOpenApi(honoPathToOpenApi(openApi))).toBe(openApi)
+  })
+
+  it("terminates the param name at the first non-identifier character", () => {
+    // `-`, `.`, `/`, etc. end the param — matching Hono's own parameter grammar.
+    expect(honoPathToOpenApi("/a/:id-suffix")).toBe("/a/{id}-suffix")
+    expect(honoPathToOpenApi("/a/:id.json")).toBe("/a/{id}.json")
+    expect(honoPathToOpenApi("/a/:id/b")).toBe("/a/{id}/b")
+  })
+
+  it("accepts underscore-leading and underscore-containing names", () => {
+    expect(honoPathToOpenApi("/a/:_internal/b")).toBe("/a/{_internal}/b")
+    expect(honoPathToOpenApi("/a/:my_param/b")).toBe("/a/{my_param}/b")
+  })
+
+  it("does not strip a leading colon from a non-identifier (e.g. `:0xyz` is invalid Hono syntax)", () => {
+    expect(honoPathToOpenApi("/a/:0bad")).toBe("/a/:0bad")
+  })
+})

--- a/apps/api/src/mcp/normalize-path.ts
+++ b/apps/api/src/mcp/normalize-path.ts
@@ -1,0 +1,23 @@
+/**
+ * Path-style normalization for MCP-bound prefixes.
+ *
+ * Hono routes use `:param` syntax for path parameters
+ * (`/projects/:projectSlug/annotations`). OpenAPI and MCP both use `{param}`
+ * syntax (`/projects/{projectSlug}/annotations`). Inside the MCP registry we
+ * canonicalize on the OpenAPI form so the URL dispatcher in `server.ts` only
+ * has to substitute one placeholder syntax.
+ *
+ * Route files can therefore declare a single constant in Hono form and reuse
+ * it for both the parent mount (`routes.route(annotationsPath, …)`) and
+ * `defineApiEndpoint(annotationsPath)` — the latter normalizes on the way in.
+ *
+ * The pattern matches Hono's own parameter grammar (alphanumeric + underscore,
+ * starting with a letter or underscore). It deliberately doesn't try to
+ * support regex constraints (`/:id{[0-9]+}`) or wildcards (`*`) — neither has
+ * a sensible MCP-tool input representation. Inputs in the OpenAPI form pass
+ * through unchanged.
+ */
+const PARAM_PATTERN = /:([A-Za-z_][A-Za-z0-9_]*)/g
+
+/** Converts `:param` segments to `{param}`. Idempotent on already-OpenAPI-form paths. */
+export const honoPathToOpenApi = (path: string): string => path.replace(PARAM_PATTERN, "{$1}")

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -139,14 +139,17 @@ const buildInternalRequestUrl = (
   params: Record<string, unknown>,
   query: Record<string, unknown>,
 ): string => {
-  let path = route.pathTemplate
-  for (const [name, value] of Object.entries(params)) {
-    path = path.replaceAll(`{${name}}`, encodeURIComponent(String(value)))
-  }
+  const path = route.pathTemplate
   const prefix = route.routerPrefix.replace(/\/$/, "")
   // `pathTemplate === "/"` collapses to the bare prefix — Hono treats
   // `/api-keys` and `/api-keys/` as distinct routes; ours mount un-trailing.
-  const joined = path === "/" ? prefix : `${prefix}${path.startsWith("/") ? path : `/${path}`}`
+  let joined = path === "/" ? prefix : `${prefix}${path.startsWith("/") ? path : `/${path}`}`
+  // Substitute `{name}` placeholders across the full joined string — params
+  // can appear either in the route's own path (e.g. `/api-keys/{id}`) or in
+  // the mount prefix (e.g. `/projects/{projectSlug}/annotations`).
+  for (const [name, value] of Object.entries(params)) {
+    joined = joined.replaceAll(`{${name}}`, encodeURIComponent(String(value)))
+  }
   const subAppPath = joined === "" ? "/" : joined
   const search = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -1,5 +1,19 @@
-import { FILTER_OPERATORS, traceIdSchema } from "@domain/shared"
+import { FILTER_OPERATORS, SESSION_ID_LENGTH, SPAN_ID_LENGTH, TRACE_ID_LENGTH } from "@domain/shared"
 import { z } from "@hono/zod-openapi"
+
+// Plain (non-transformed) telemetry-id schemas for use in request / response
+// bodies exposed via OpenAPI + MCP. The domain's branded variants
+// (`traceIdSchema = z.string().length(...).transform(TraceId)`, etc.) can't be
+// serialized to JSON Schema — transforms have no JSON-Schema representation,
+// and the MCP SDK fails when registering a tool whose inputSchema contains one.
+// We keep the same length validation as the domain schemas but drop the brand
+// transform; handlers cast to the branded type at the boundary where needed.
+export const traceIdSchema = z.string().length(TRACE_ID_LENGTH).describe("32-character trace identifier.")
+export const spanIdSchema = z.string().length(SPAN_ID_LENGTH).describe("16-character span identifier.")
+export const sessionIdSchema = z
+  .string()
+  .max(SESSION_ID_LENGTH)
+  .describe(`Session identifier lifted from instrumentation. Up to ${SESSION_ID_LENGTH} characters.`)
 
 const ErrorSchema = z
   .object({
@@ -23,17 +37,36 @@ const ErrorSchema = z
 // chain so each level emits as a named OpenAPI component.
 const FilterConditionSchema = z
   .object({
-    op: z.enum(FILTER_OPERATORS),
-    value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
+    op: z
+      .enum(FILTER_OPERATORS)
+      .describe(
+        "Comparison operator applied to the field's value (e.g. `eq`, `neq`, `in`). The full operator list lives in the API reference.",
+      ),
+    value: z
+      .union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))])
+      .describe("Right-hand value compared against the field. Arrays are required for `in` / `notIn`-style operators."),
   })
   .openapi("FilterCondition")
 
-const FilterSetSchema = z.record(z.string(), z.array(FilterConditionSchema)).openapi("FilterSet")
+const FilterSetSchema = z
+  .record(z.string(), z.array(FilterConditionSchema))
+  .describe(
+    "Filter set keyed by field name. Each entry holds an array of conditions ANDed together for that field; field-level groups are also ANDed across the set.",
+  )
+  .openapi("FilterSet")
 
 export const TraceRefSchema = z
   .discriminatedUnion("by", [
-    z.object({ by: z.literal("id"), id: traceIdSchema }),
-    z.object({ by: z.literal("filters"), filters: FilterSetSchema }),
+    z.object({
+      by: z.literal("id").describe("Match a single trace by its identifier. Pair with `id`."),
+      id: traceIdSchema,
+    }),
+    z.object({
+      by: z
+        .literal("filters")
+        .describe("Match a single trace by a filter set. Pair with `filters`; exactly one trace must match."),
+      filters: FilterSetSchema,
+    }),
   ])
   .openapi("TraceRef")
 
@@ -49,8 +82,16 @@ export const TraceRefSchema = z
  */
 export const TracesRefSchema = z
   .discriminatedUnion("by", [
-    z.object({ by: z.literal("ids"), ids: z.array(traceIdSchema).min(1) }),
-    z.object({ by: z.literal("filters"), filters: FilterSetSchema }),
+    z.object({
+      by: z.literal("ids").describe("Match an explicit list of traces by their identifiers. Pair with `ids`."),
+      ids: z.array(traceIdSchema).min(1).describe("Non-empty list of trace identifiers."),
+    }),
+    z.object({
+      by: z
+        .literal("filters")
+        .describe("Match every trace produced by a filter set. Pair with `filters`; result count is not bounded."),
+      filters: FilterSetSchema,
+    }),
   ])
   .openapi("TracesRef")
 

--- a/apps/api/src/routes/annotations.test.ts
+++ b/apps/api/src/routes/annotations.test.ts
@@ -8,7 +8,13 @@ import { scores as scoresTable } from "@platform/db-postgres/schema/scores"
 import { createApiKeyAuthHeaders, type InMemoryPostgres } from "@platform/testkit"
 import { Effect } from "effect"
 import { describe, expect, it } from "vitest"
-import { type ApiTestContext, createTenantSetup, setupTestApi } from "../test-utils/create-test-app.ts"
+import {
+  type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
+  createTenantSetup,
+  setupTestApi,
+} from "../test-utils/create-test-app.ts"
 
 const API_TEST_ANCHOR_TRACE_ID = "22222222222222222222222222222222" as const
 
@@ -153,6 +159,51 @@ describe("Annotations Routes Integration", () => {
     expect(persistedScores[0]?.source).toBe("annotation")
     expect(persistedScores[0]?.sourceId).toBe("API")
     expect(persistedScores[0]?.draftedAt).toBeNull()
+    expect(persistedScores[0]?.annotatorId).toBeNull()
+  })
+
+  it<ApiTestContext>("attributes the annotation to the caller when authenticated via OAuth", async ({
+    app,
+    database,
+    clickhouse,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const projectId = "ffffffffffffffffffffffff"
+    const traceId = "44444444444444444444444444444444"
+    const projectSlug = await createProjectRecord(database, tenant.organizationId, projectId)
+    await seedAnnotationTrace({
+      clickhouse,
+      organizationId: tenant.organizationId,
+      projectId,
+      traceId,
+    })
+
+    const response = await app.fetch(
+      new Request(`http://localhost/v1/projects/${projectSlug}/annotations`, {
+        method: "POST",
+        headers: {
+          ...createOAuthAuthHeaders(tenant.oauthAccessToken),
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          value: 0.9,
+          passed: true,
+          feedback: "Great answer",
+          trace: { by: "id", id: traceId },
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    const body = (await response.json()) as { annotatorId: string | null }
+    expect(body.annotatorId).toBe(tenant.userId)
+
+    const persistedScores = await database.db
+      .select()
+      .from(scoresTable)
+      .where(eq(scoresTable.organizationId, tenant.organizationId))
+    expect(persistedScores).toHaveLength(1)
+    expect(persistedScores[0]?.annotatorId).toBe(tenant.userId)
   })
 
   it<ApiTestContext>("resolves a trace by filters when exactly one trace matches", async ({

--- a/apps/api/src/routes/annotations.ts
+++ b/apps/api/src/routes/annotations.ts
@@ -1,7 +1,11 @@
-import { submitApiAnnotationInputSchema, submitApiAnnotationUseCase } from "@domain/annotations"
+import { submitApiAnnotationUseCase } from "@domain/annotations"
 import { ProjectRepository } from "@domain/projects"
-import { type AnnotationScore, annotationScoreSchema } from "@domain/scores"
-import { cuidSchema } from "@domain/shared"
+import {
+  ANNOTATION_ANCHOR_TEXT_FORMATS,
+  ANNOTATION_SCORE_PARTIAL_SOURCE_IDS,
+  type AnnotationScore,
+} from "@domain/scores"
+import { cuidSchema, UserId } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { withAi } from "@platform/ai"
 import { AIEmbedLive } from "@platform/ai-voyage"
@@ -15,52 +19,170 @@ import { OutboxEventWriterLive, ProjectRepositoryLive, ScoreRepositoryLive, with
 import { QueuePublisherLive } from "@platform/queue-bullmq"
 import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
+import { defineApiEndpoint } from "../mcp/index.ts"
 import {
   jsonBody,
   openApiResponses,
   PROTECTED_SECURITY,
   ProjectParamsSchema,
+  sessionIdSchema,
+  spanIdSchema,
   TraceRefSchema,
+  traceIdSchema,
 } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
 
-// `trace` is overridden so the named `TraceRefSchema` is what the OpenAPI
-// emitter sees — the un-named domain version inlines the discriminated union
-// and trips a Fern name-mangling bug. See `../openapi/schemas.ts` for details.
+// Anchor pins an annotation to a position inside a trace. Shape mirrors
+// `annotationAnchorSchema` from `@domain/scores` field-for-field; redeclared
+// here so every property carries a description for the SDK + MCP surfaces
+// (the domain schema is description-free by design).
+//
+// The fields are exposed as a plain object so `AnnotationMetadataSchema` can
+// spread them alongside `rawFeedback` — server-persisted annotation metadata
+// is the original anchor snapshotted, so the same field shapes apply.
+const annotationAnchorFields = {
+  messageIndex: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("0-based message index inside the conversation. Omit for conversation-level annotations."),
+  partIndex: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("0-based index into the target message's `parts[]`. Requires `messageIndex`."),
+  startOffset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Inclusive start offset for substring annotations. Must be paired with `endOffset` and `partIndex`."),
+  endOffset: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe(
+      "Exclusive end offset for substring annotations. Must be paired with `startOffset` and `partIndex`, and `>= startOffset`.",
+    ),
+  textFormat: z
+    .enum(ANNOTATION_ANCHOR_TEXT_FORMATS)
+    .optional()
+    .describe(
+      'UI-side text transform applied before the offsets were captured (e.g. `"pretty-json"`). Resolvers must apply the same transform before slicing.',
+    ),
+} as const
+
+const AnnotationAnchorSchema = z.object(annotationAnchorFields).openapi("AnnotationAnchor")
+
+// `trace` uses the named `TraceRefSchema` so the OpenAPI emitter sees a single
+// component — the un-named domain version inlines the discriminated union and
+// trips a Fern name-mangling bug. See `../openapi/schemas.ts` for details.
 const RequestSchema = z
   .object({
-    ...submitApiAnnotationInputSchema.shape,
-    trace: TraceRefSchema,
+    simulationId: cuidSchema
+      .nullable()
+      .default(null)
+      .describe("Simulation this annotation is tied to, if any. `null` (default) when not part of a simulation."),
+    issueId: cuidSchema
+      .nullable()
+      .default(null)
+      .describe(
+        "Pre-selected issue this annotation belongs to. Leave `null` (default) to let the automatic issue-discovery pipeline route the annotation.",
+      ),
+    value: z.number().min(0).max(1).describe("Normalized score value in [0, 1]. Higher = better."),
+    passed: z.boolean().describe("Whether the annotated output passes the reviewer's bar."),
+    feedback: z.string().min(1).describe("Free-text feedback explaining the score. Surfaced alongside the trace."),
+    anchor: AnnotationAnchorSchema.optional().describe(
+      "Optional anchor pinning the annotation to a specific message / part / offset range inside the trace.",
+    ),
+    trace: TraceRefSchema.describe("Target trace. Either an explicit id or a filter set matching exactly one trace."),
   })
   .openapi("CreateAnnotationBody")
 
+// Metadata persisted alongside annotation scores. `rawFeedback` plus the
+// anchor fields snapshotted at write time — server-side resolvers re-derive
+// the targeted message / part / offset range from this exact shape.
+const AnnotationMetadataSchema = z
+  .object({
+    rawFeedback: z
+      .string()
+      .describe(
+        "Original feedback text before enrichment. Human-authored for human annotations, model-authored for system drafts.",
+      ),
+    ...annotationAnchorFields,
+  })
+  .openapi("AnnotationScoreMetadata")
+
+// Transformed branded-ID schemas from the domain (`sessionIdSchema`,
+// `traceIdSchema`, `spanIdSchema`, etc.) can't be serialized to JSON Schema —
+// `z.toJSONSchema` throws on `.transform()` nodes. We re-shape the response
+// here field-for-field so every property carries a description and every
+// branded ID is exposed as a plain string.
 const ResponseSchema = z
   .object({
-    ...annotationScoreSchema.shape,
-    id: cuidSchema,
-    organizationId: cuidSchema,
-    projectId: cuidSchema,
-    draftedAt: z.iso.datetime().nullable(),
-    createdAt: z.iso.datetime(),
-    updatedAt: z.iso.datetime(),
+    id: cuidSchema.describe("Stable annotation-score identifier."),
+    organizationId: cuidSchema.describe("Organization that owns this annotation."),
+    projectId: cuidSchema.describe("Project this annotation lives in."),
+    sessionId: sessionIdSchema
+      .nullable()
+      .describe("Session id lifted from the trace, when set. `null` when the trace has no session."),
+    traceId: traceIdSchema.nullable().describe("Identifier of the annotated trace."),
+    spanId: spanIdSchema
+      .nullable()
+      .describe("Span the annotation pins to. Defaults to the trace's last LLM-completion span."),
+    simulationId: cuidSchema.nullable().describe("Simulation reference, if any."),
+    issueId: cuidSchema.nullable().describe("Issue this annotation contributes to, if any."),
+    value: z.number().min(0).max(1).describe("Normalized score value in [0, 1]."),
+    passed: z.boolean().describe("Whether the annotation marks the output as passing."),
+    feedback: z.string().describe("Free-text feedback explaining the score."),
+    error: z
+      .string()
+      .min(1)
+      .nullable()
+      .describe("Generation error text, when the annotation itself errored. `null` for successful annotations."),
+    errored: z.boolean().describe("`true` when the annotation could not be generated successfully."),
+    duration: z.number().int().nonnegative().describe("Generation duration in nanoseconds. `0` for human annotations."),
+    tokens: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe("Total LLM tokens consumed generating the score, if any. `0` for human annotations."),
+    cost: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe("Total LLM cost in microcents (1/1,000,000 of a USD). `0` for human annotations."),
+    draftedAt: z.iso
+      .datetime()
+      .nullable()
+      .describe("Always `null` for public-API annotations — they're written as published."),
+    annotatorId: cuidSchema
+      .nullable()
+      .describe(
+        "User who authored the annotation. `null` for API-key callers (organization-scoped); set to the authenticated user for OAuth callers.",
+      ),
+    createdAt: z.iso.datetime().describe("ISO-8601 timestamp at which the annotation was created."),
+    updatedAt: z.iso.datetime().describe("ISO-8601 timestamp of the last metadata update."),
+    source: z.literal("annotation").describe('Always `"annotation"` for this endpoint\'s responses.'),
+    sourceId: z
+      .union([z.enum(ANNOTATION_SCORE_PARTIAL_SOURCE_IDS), cuidSchema])
+      .describe(
+        'Origin marker. Sentinel `"UI"` / `"API"` / `"SYSTEM"` for drafts and automation, or an annotation-queue CUID for queue-authored rows. Public-API annotations are always `"API"`.',
+      ),
+    metadata: AnnotationMetadataSchema.describe(
+      "Annotation-specific metadata: `rawFeedback` plus a snapshot of the anchor at write time.",
+    ),
   })
   .openapi("AnnotationScoreResponse")
 
-const route = createRoute({
-  method: "post",
-  path: "/",
-  operationId: "annotations.create",
-  tags: ["Annotations"],
-  summary: "Create project annotation",
-  description:
-    'Creates a published annotation score against a target trace. The trace is resolved by explicit id (`trace.by = "id"`) or by a filter set (`trace.by = "filters"`, exactly one match required).',
-  security: PROTECTED_SECURITY,
-  request: {
-    params: ProjectParamsSchema,
-    body: jsonBody(RequestSchema),
-  },
-  responses: openApiResponses({ status: 201, schema: ResponseSchema, description: "Annotation created successfully" }),
-})
+const annotationsFernGroup = (methodName: string) =>
+  ({
+    "x-fern-sdk-group-name": "annotations",
+    "x-fern-sdk-method-name": methodName,
+  }) as const
 
 const toResponse = (score: AnnotationScore) => ({
   id: score.id as string,
@@ -73,6 +195,7 @@ const toResponse = (score: AnnotationScore) => ({
   sourceId: score.sourceId,
   simulationId: score.simulationId,
   issueId: score.issueId,
+  annotatorId: score.annotatorId,
   value: score.value,
   passed: score.passed,
   feedback: score.feedback,
@@ -87,13 +210,32 @@ const toResponse = (score: AnnotationScore) => ({
   updatedAt: score.updatedAt.toISOString(),
 })
 
-export const createAnnotationsRoutes = () => {
-  const app = new OpenAPIHono<OrganizationScopedEnv>()
+export const annotationsPath = "/projects/:projectSlug/annotations"
 
-  app.openapi(route, async (c) => {
+const annotationEndpoint = defineApiEndpoint<OrganizationScopedEnv>(annotationsPath)
+
+const createAnnotation = annotationEndpoint({
+  route: createRoute({
+    method: "post",
+    path: "/",
+    name: "createAnnotation",
+    tags: ["Annotations"],
+    ...annotationsFernGroup("create"),
+    summary: "Create project annotation",
+    description:
+      'Creates a published annotation score against a target trace. The trace is resolved by explicit id (`trace.by = "id"`) or by a filter set (`trace.by = "filters"`, exactly one match required). When called with an OAuth token, the annotation is attributed to the authenticated user.',
+    security: PROTECTED_SECURITY,
+    request: {
+      params: ProjectParamsSchema,
+      body: jsonBody(RequestSchema),
+    },
+    responses: openApiResponses({ status: 201, schema: ResponseSchema, description: "Annotation created" }),
+  }),
+  handler: async (c) => {
     const body = c.req.valid("json")
     const { projectSlug } = c.req.valid("param")
     const organizationId = c.var.organization.id
+    const annotatorId = c.var.auth?.method === "oauth" ? UserId(c.var.auth.userId as string) : null
 
     const score = await Effect.runPromise(
       Effect.gen(function* () {
@@ -104,6 +246,7 @@ export const createAnnotationsRoutes = () => {
           ...body,
           projectId: project.id,
           organizationId,
+          annotatorId,
         })
       }).pipe(
         withPostgres(
@@ -123,7 +266,11 @@ export const createAnnotationsRoutes = () => {
     )
 
     return c.json(toResponse(score), 201)
-  })
+  },
+})
 
+export const createAnnotationsRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+  createAnnotation.mountHttp(app)
   return app
 }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -7,12 +7,12 @@ import { createAuthRateLimiter, createTierRateLimiter } from "../middleware/rate
 import { validationErrorMiddleware } from "../middleware/validation.ts"
 import type { ApiOptions, AppEnv, ProtectedEnv } from "../types.ts"
 import { accountPath, createAccountRoutes } from "./account.ts"
-import { createAnnotationsRoutes } from "./annotations.ts"
+import { annotationsPath, createAnnotationsRoutes } from "./annotations.ts"
 import { apiKeysPath, createApiKeysRoutes } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
 import { createMembersRoutes, membersPath } from "./members.ts"
 import { createProjectsRoutes, projectsPath } from "./projects.ts"
-import { createScoresRoutes } from "./scores.ts"
+import { createScoresRoutes, scoresPath } from "./scores.ts"
 import { registerWellKnownRoutes } from "./well-known.ts"
 
 /**
@@ -45,11 +45,14 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
   )
   routes.use("*", createOrganizationContextMiddleware())
 
-  routes.use(projectsPath, createTierRateLimiter("medium"))
+  routes.use(projectsPath, createTierRateLimiter("low"))
   routes.route(projectsPath, createProjectsRoutes())
 
-  routes.route("/projects/:projectSlug/scores", createScoresRoutes())
-  routes.route("/projects/:projectSlug/annotations", createAnnotationsRoutes())
+  routes.use(scoresPath, createTierRateLimiter("medium"))
+  routes.route(scoresPath, createScoresRoutes())
+
+  routes.use(annotationsPath, createTierRateLimiter("medium"))
+  routes.route(annotationsPath, createAnnotationsRoutes())
 
   routes.use(apiKeysPath, createTierRateLimiter("low"))
   routes.route(apiKeysPath, createApiKeysRoutes())

--- a/apps/api/src/routes/scores.ts
+++ b/apps/api/src/routes/scores.ts
@@ -1,10 +1,8 @@
 import { ProjectRepository } from "@domain/projects"
 import {
-  baseSubmitApiScoreSchema,
   type CustomScore,
-  customScoreSchema,
   type EvaluationScore,
-  evaluationScoreSchema,
+  SCORE_SOURCE_ID_MAX_LENGTH,
   type SubmitApiScoreInput,
   submitApiScoreUseCase,
 } from "@domain/scores"
@@ -19,63 +17,163 @@ import {
 import { OutboxEventWriterLive, ProjectRepositoryLive, ScoreRepositoryLive, withPostgres } from "@platform/db-postgres"
 import { withTracing } from "@repo/observability"
 import { Effect, Layer } from "effect"
+import { defineApiEndpoint } from "../mcp/index.ts"
 import {
   jsonBody,
   openApiResponses,
   PROTECTED_SECURITY,
   ProjectParamsSchema,
+  sessionIdSchema,
+  spanIdSchema,
   TraceRefSchema,
+  traceIdSchema,
 } from "../openapi/schemas.ts"
 import type { OrganizationScopedEnv } from "../types.ts"
 
-// `trace` is overridden so the named `TraceRefSchema` is what the OpenAPI
-// emitter sees — the un-named domain version inlines the discriminated union
-// and trips a Fern name-mangling bug. See `../openapi/schemas.ts` for details.
-const ApiScoreBodyCommonSchema = z.object({
-  ...baseSubmitApiScoreSchema.shape,
-  trace: TraceRefSchema,
-})
+// Lifecycle / measurement fields shared between custom and evaluation score
+// request bodies. Field shapes mirror `baseSubmitApiScoreSchema` from
+// `@domain/scores` (constraints + defaults preserved); redeclared here so each
+// property carries an SDK / MCP description (the domain schema is bare).
+const scoreBodyCommonFields = {
+  simulationId: cuidSchema
+    .nullable()
+    .default(null)
+    .describe("Simulation this score is tied to, if any. `null` (default) when not part of a simulation."),
+  value: z.number().min(0).max(1).describe("Normalized score value in [0, 1]. Higher = better."),
+  passed: z.boolean().describe("Whether the scored output passes the evaluator's bar."),
+  feedback: z.string().describe("Free-text feedback explaining the score."),
+  error: z
+    .string()
+    .min(1)
+    .nullable()
+    .default(null)
+    .describe("Generation error text, when score generation itself failed. `null` (default) for successful scores."),
+  duration: z
+    .number()
+    .int()
+    .nonnegative()
+    .default(0)
+    .describe("Score generation duration in nanoseconds. `0` for externally-computed scores."),
+  tokens: z
+    .number()
+    .int()
+    .nonnegative()
+    .default(0)
+    .describe("LLM tokens consumed generating the score, if any. `0` for externally-computed scores."),
+  cost: z
+    .number()
+    .int()
+    .nonnegative()
+    .default(0)
+    .describe("Score cost in microcents (1/1,000,000 of a USD). `0` for externally-computed scores."),
+  trace: TraceRefSchema.describe("Target trace. Either an explicit id or a filter set matching exactly one trace."),
+} as const
 
 const CreateCustomScoreBodySchema = z
   .object({
-    ...ApiScoreBodyCommonSchema.shape,
-    sourceId: customScoreSchema.shape.sourceId,
-    metadata: customScoreSchema.shape.metadata.default({}),
-    _evaluation: z.literal(false).optional().default(false),
+    ...scoreBodyCommonFields,
+    sourceId: z
+      .string()
+      .min(1)
+      .max(SCORE_SOURCE_ID_MAX_LENGTH)
+      .describe('User-supplied tag identifying the score\'s origin (e.g. `"prod-pipeline"`, `"qa-script-v2"`).'),
+    metadata: z
+      .record(z.string(), z.unknown())
+      .default({})
+      .describe("Arbitrary user-supplied metadata persisted alongside the score."),
+    _evaluation: z
+      .literal(false)
+      .optional()
+      .default(false)
+      .describe("Discriminator: omit (or `false`) for custom scores. Required `true` for evaluation scores."),
   })
   .openapi("CreateCustomScoreBody")
 
+const EvaluationScoreMetadataSchema = z
+  .object({
+    evaluationHash: z
+      .string()
+      .describe(
+        "Hash of the evaluation script that produced this score; lets the platform track which version generated it.",
+      ),
+  })
+  .openapi("EvaluationScoreMetadata")
+
 const CreateEvaluationScoreBodySchema = z
   .object({
-    ...ApiScoreBodyCommonSchema.shape,
-    _evaluation: z.literal(true),
-    sourceId: evaluationScoreSchema.shape.sourceId,
-    metadata: evaluationScoreSchema.shape.metadata,
+    ...scoreBodyCommonFields,
+    _evaluation: z
+      .literal(true)
+      .describe("Discriminator: `true` flags the body as an evaluation score (internal); `false`/omit for custom."),
+    sourceId: cuidSchema.describe("CUID of the evaluation that produced this score."),
+    metadata: EvaluationScoreMetadataSchema.describe("Evaluation-specific metadata."),
   })
   .openapi("CreateEvaluationScoreBody", { description: "Internal, don't use" })
 
 const RequestSchema = z.union([CreateCustomScoreBodySchema, CreateEvaluationScoreBodySchema]).openapi("CreateScoreBody")
 
-const apiScoreResponseOverrides = {
-  id: cuidSchema,
-  organizationId: cuidSchema,
-  projectId: cuidSchema,
-  draftedAt: z.iso.datetime().nullable(),
-  createdAt: z.iso.datetime(),
-  updatedAt: z.iso.datetime(),
+// Lifecycle / measurement fields on the response, shared between custom and
+// evaluation variants. Field shapes mirror `baseScoreSchema` from
+// `@domain/scores` (with branded-ID schemas replaced by plain strings — the
+// domain transforms aren't representable in JSON Schema and would break the
+// MCP tool's `outputSchema`).
+const scoreResponseCommonFields = {
+  id: cuidSchema.describe("Stable score identifier."),
+  organizationId: cuidSchema.describe("Organization that owns this score."),
+  projectId: cuidSchema.describe("Project this score lives in."),
+  sessionId: sessionIdSchema
+    .nullable()
+    .describe("Session id lifted from the trace, when set. `null` when the trace has no session."),
+  traceId: traceIdSchema.nullable().describe("Identifier of the scored trace."),
+  spanId: spanIdSchema.nullable().describe("Span the score pins to. Defaults to the trace's last LLM-completion span."),
+  simulationId: cuidSchema.nullable().describe("Simulation reference, if any."),
+  issueId: cuidSchema.nullable().describe("Issue this score contributes to, if any."),
+  value: z.number().min(0).max(1).describe("Normalized score value in [0, 1]."),
+  passed: z.boolean().describe("Whether the score marks the output as passing."),
+  feedback: z.string().describe("Free-text feedback explaining the score."),
+  error: z
+    .string()
+    .min(1)
+    .nullable()
+    .describe("Generation error text, when score generation itself errored. `null` for successful scores."),
+  errored: z.boolean().describe("`true` when the score could not be generated successfully."),
+  duration: z.number().int().nonnegative().describe("Score generation duration in nanoseconds."),
+  tokens: z.number().int().nonnegative().describe("LLM tokens consumed generating the score."),
+  cost: z.number().int().nonnegative().describe("Score cost in microcents (1/1,000,000 of a USD)."),
+  draftedAt: z.iso
+    .datetime()
+    .nullable()
+    .describe(
+      "ISO-8601 timestamp while the score is awaiting human confirmation. `null` for published / system scores.",
+    ),
+  annotatorId: cuidSchema.nullable().describe("User who authored the score, if any."),
+  createdAt: z.iso.datetime().describe("ISO-8601 timestamp at which the score was created."),
+  updatedAt: z.iso.datetime().describe("ISO-8601 timestamp of the last metadata update."),
 } as const
 
 const CustomScoreResponseSchema = z
   .object({
-    ...customScoreSchema.shape,
-    ...apiScoreResponseOverrides,
+    ...scoreResponseCommonFields,
+    source: z.literal("custom").describe('Discriminator. `"custom"` denotes a user-supplied score.'),
+    sourceId: z
+      .string()
+      .min(1)
+      .max(SCORE_SOURCE_ID_MAX_LENGTH)
+      .describe("User-supplied tag identifying the score's origin (echoed from the request)."),
+    metadata: z
+      .record(z.string(), z.unknown())
+      .describe("Arbitrary user-supplied metadata persisted alongside the score."),
   })
   .openapi("CustomScoreResponse")
 
 const EvaluationScoreResponseSchema = z
   .object({
-    ...evaluationScoreSchema.shape,
-    ...apiScoreResponseOverrides,
+    ...scoreResponseCommonFields,
+    source: z
+      .literal("evaluation")
+      .describe('Discriminator. `"evaluation"` denotes a platform-generated evaluation score.'),
+    sourceId: cuidSchema.describe("CUID of the evaluation that produced this score."),
+    metadata: EvaluationScoreMetadataSchema.describe("Evaluation-specific metadata."),
   })
   .openapi("EvaluationScoreResponse")
 
@@ -83,25 +181,11 @@ const ResponseSchema = z.union([CustomScoreResponseSchema, EvaluationScoreRespon
 
 type ApiScore = CustomScore | EvaluationScore
 
-const route = createRoute({
-  method: "post",
-  path: "/",
-  operationId: "scores.create",
-  tags: ["Scores"],
-  summary: "Create project score",
-  description:
-    'Creates a score against a target trace. The trace is resolved by explicit id (`trace.by = "id"`) or by a filter set (`trace.by = "filters"`, exactly one match required). Annotations use the separate `/annotations` endpoint.',
-  security: PROTECTED_SECURITY,
-  request: {
-    params: ProjectParamsSchema,
-    body: jsonBody(RequestSchema),
-  },
-  responses: openApiResponses({
-    status: 201,
-    schema: ResponseSchema,
-    description: "Score created successfully",
-  }),
-})
+const scoresFernGroup = (methodName: string) =>
+  ({
+    "x-fern-sdk-group-name": "scores",
+    "x-fern-sdk-method-name": methodName,
+  }) as const
 
 const toResponse = (score: ApiScore) => {
   const baseResponse = {
@@ -143,10 +227,32 @@ const toResponse = (score: ApiScore) => {
   }
 }
 
-export const createScoresRoutes = () => {
-  const app = new OpenAPIHono<OrganizationScopedEnv>()
+export const scoresPath = "/projects/:projectSlug/scores"
 
-  app.openapi(route, async (c) => {
+const scoreEndpoint = defineApiEndpoint<OrganizationScopedEnv>(scoresPath)
+
+const createScore = scoreEndpoint({
+  route: createRoute({
+    method: "post",
+    path: "/",
+    name: "createScore",
+    tags: ["Scores"],
+    ...scoresFernGroup("create"),
+    summary: "Create project score",
+    description:
+      'Creates a score against a target trace. The trace is resolved by explicit id (`trace.by = "id"`) or by a filter set (`trace.by = "filters"`, exactly one match required). Annotations use the separate `/annotations` endpoint.',
+    security: PROTECTED_SECURITY,
+    request: {
+      params: ProjectParamsSchema,
+      body: jsonBody(RequestSchema),
+    },
+    responses: openApiResponses({
+      status: 201,
+      schema: ResponseSchema,
+      description: "Score created",
+    }),
+  }),
+  handler: async (c) => {
     const body = c.req.valid("json")
     const { projectSlug } = c.req.valid("param")
     const organizationId = c.var.organization.id
@@ -198,7 +304,11 @@ export const createScoresRoutes = () => {
     )
 
     return c.json(toResponse(score), 201)
-  })
+  },
+})
 
+export const createScoresRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+  createScore.mountHttp(app)
   return app
 }

--- a/packages/domain/annotations/src/use-cases/submit-api-annotation.ts
+++ b/packages/domain/annotations/src/use-cases/submit-api-annotation.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, type ProjectId } from "@domain/shared"
+import { BadRequestError, type ProjectId, type UserId } from "@domain/shared"
 import { resolveTraceIdFromRef, traceRefSchema } from "@domain/spans"
 import { Effect } from "effect"
 import { z } from "zod"
@@ -26,11 +26,13 @@ const PUBLIC_API_SOURCE_ID = "API" as const
  *     span defaulted to the last LLM completion). Internal callers can still
  *     pass concrete values via the lower-level `writeDraftAnnotationUseCase`
  *     / `writePublishedAnnotationUseCase` primitives.
- *   - `annotatorId` — API keys are organization-scoped, not user-scoped, so
- *     there is no real Latitude user behind an API request. The use case
- *     forces `annotatorId = null`; lying about authorship by accepting a
- *     caller-supplied user id would let any token holder attribute work to
- *     any teammate.
+ *   - `annotatorId` — the body never carries it. The route layer attaches
+ *     it from the verified auth context: an OAuth caller's token is bound to
+ *     a specific user, so we set `annotatorId = auth.userId`; an API-key
+ *     caller is organization-scoped (no real user), so it stays `null`.
+ *     Accepting a caller-supplied user id from the body would let any token
+ *     holder attribute work to any teammate, hence it lives in the context
+ *     parameter — not the request schema.
  *
  * The public API does not expose draft state: every API-submitted annotation
  * is written as published. Internal callers that need a draft path go through
@@ -64,6 +66,12 @@ const parseOrBadRequest = <T>(schema: z.ZodType<T>, input: unknown, fallbackMess
 interface SubmitApiAnnotationContext {
   readonly organizationId: string
   readonly projectId: ProjectId
+  /**
+   * Authenticated user id, when known. OAuth callers carry a real user
+   * behind the token; API-key callers don't, so they pass `null` (or omit).
+   * The route layer is the trusted source — never the request body.
+   */
+  readonly annotatorId?: UserId | null
 }
 
 type SubmitApiAnnotationRequest = z.input<typeof submitApiAnnotationInputSchema> & SubmitApiAnnotationContext
@@ -102,8 +110,9 @@ export const submitApiAnnotationUseCase = Effect.fn("annotations.submitApiAnnota
   // the session from the trace and pins the annotation to the trace's last
   // LLM completion span — the public API doesn't accept overrides for these.
   // `id` is omitted entirely so `writeScoreUseCase` mints a fresh one — the
-  // public API is creation-only. `annotatorId` is forced to null — see the
-  // schema doc-block for the rationale.
+  // public API is creation-only. `annotatorId` comes from the context (set by
+  // the route layer from the verified auth), never the body — see the schema
+  // doc-block for the rationale.
   return yield* writePublishedAnnotationUseCase({
     projectId: input.projectId,
     sourceId: PUBLIC_API_SOURCE_ID,
@@ -112,7 +121,7 @@ export const submitApiAnnotationUseCase = Effect.fn("annotations.submitApiAnnota
     spanId: null,
     simulationId: parsed.simulationId,
     issueId: parsed.issueId,
-    annotatorId: null,
+    annotatorId: input.annotatorId ?? null,
     value: parsed.value,
     passed: parsed.passed,
     feedback: parsed.feedback,

--- a/plans/mcp-oauth-api-expansion.md
+++ b/plans/mcp-oauth-api-expansion.md
@@ -554,8 +554,7 @@ Account, Members, finish API Keys, finish Projects (incl. pagination migration +
 **Projects**:
 - `apps/api/src/routes/projects.ts` — switch list response to `Paginated(ProjectSchema, "PaginatedProjects")`. Add slug-on-rename via `generateUniqueSlug` in `updateProjectUseCase`. Move schemas to `apps/api/src/openapi/entities/project.ts`.
 
-**Slug-on-rename for organizations**:
-- `updateOrganizationUseCase` (or wherever org rename lives — verify in `@domain/organizations`) regenerates slug. Consult Better Auth's organization plugin: it owns the `organizations.slug` column, so we either hook into BA's update path or run our own update. Likely we hook BA's `databaseHooks.organization.update.after` to regenerate.
+**Slug-on-rename for organizations**: **dropped from scope.** Org slugs aren't user-facing in our app (no routes key off them) and Better Auth owns the column. Not worth the BA-hook plumbing for a value nobody reads.
 
 ### M4 — Traces + bulk export
 
@@ -684,3 +683,76 @@ CI:
 - Existing typecheck + test jobs gate the PR.
 - New job: `pnpm openapi:emit && git diff --exit-code apps/api/openapi.json` — fails on drift.
 - Same for `pnpm mcp:emit && git diff --exit-code apps/api/mcp.json`.
+
+## Tasklist (status as of 2026-05-13)
+
+Source of truth for what's shipped vs. outstanding. Update inline as PRs land.
+
+### Done
+
+- **M1 — Groundwork**
+  - [x] OAuth schema migrations + Drizzle defs (`oauth_applications`, `oauth_access_tokens`, `oauth_consents`)
+  - [x] `slug` columns on `issues` and `datasets`
+  - [x] `tracesRefSchema` + `resolveTraceIdsFromRef` in `@domain/spans`
+  - [x] `generateUniqueSlug` helper in `@domain/shared`
+  - [x] `apps/api/src/openapi/pagination.ts` (`Paginated`, `PaginatedQueryParamsSchema`)
+  - [x] `TracesRefSchema` in `apps/api/src/openapi/schemas.ts`
+  - [x] Tier rate-limit presets (`low`/`medium`/`high`/`critical`)
+  - [x] MCP scaffolding (`apps/api/src/mcp/*`, `pnpm mcp:emit`)
+  - [x] `@platform/oauth-token-auth` package (pure Drizzle, Redis cache)
+- **M2 — OAuth + MCP wiring (API + web)**
+  - [x] `apps/web/src/server/clients.ts` — `mcp()` plugin installed in `getBetterAuth()`
+  - [x] `apps/web/src/routes/auth/consent.tsx` — org-picker consent page
+  - [x] `apps/web/src/domains/oauth/oauth-consent.functions.ts` — server-fn flow
+  - [x] `apps/web/src/routes/[.well-known]/oauth-authorization-server.ts` — root-level AS discovery
+  - [x] `apps/api/src/routes/well-known.ts` — protected-resource discovery
+  - [x] `apps/api/src/middleware/auth.ts` — unified API-key + OAuth dispatch
+  - [x] Three-ring `apps/api/src/routes/index.ts`
+  - [x] `api-keys.ts` migrated to `defineApiEndpoint` (smoke test)
+- **M3 — Identity ergonomics**
+  - [x] **Account**: `GET /account`
+  - [x] **Members**: list / get / invite / update / remove (all 5 endpoints, OAuth-only for mutations, owner-protection)
+  - [x] **API Keys**: list (masked) / get (unmasked) / create / update / revoke (all 5 endpoints)
+  - [x] **Projects**: list (paginated) / get / create / update (incl. settings + per-flagger toggle) / delete (all 5 endpoints)
+  - [x] Slug-on-rename for projects in `updateProjectUseCase`
+  - [x] **Org slug-on-rename**: dropped from scope (see decision above)
+
+### Outstanding
+
+- **M2 — proof-of-concept loose ends**
+  - [x] Migrate `apps/api/src/routes/annotations.ts` to `defineApiEndpoint`; OAuth callers' annotations carry `annotatorId = auth.userId`
+  - [x] Migrate `apps/api/src/routes/scores.ts` to `defineApiEndpoint`
+  - [x] End-to-end verification with an MCP client against a running web+API stack — confirmed working from Cursor
+- **M4 — Traces + bulk export** (3 endpoints, prefix `/projects/{projectSlug}/traces`)
+  - [ ] `GET /` — list with filters + searchQuery + cursor, `Paginated(TraceSchema, "PaginatedTraces")` (`high` tier)
+  - [ ] `GET /{traceId}` — get (`medium` tier)
+  - [ ] `POST /export` — `tracesRef` + `recipientEmail`, validates recipient is an org member, enqueues worker (`critical` tier)
+  - [ ] `packages/domain/spans/src/use-cases/build-traces-export.ts` — accept `TracesRef`
+- **M5 — Saved Searches** (6 endpoints, prefix `/projects/{projectSlug}/searches`, `medium` tier across)
+  - [ ] `GET /`, `GET /{searchSlug}`, `POST /`, `PATCH /{searchSlug}`, `DELETE /{searchSlug}`
+  - [ ] `POST /{searchSlug}/assign` — new `assignSavedSearchUseCase` in `@domain/saved-searches` (validates assignee membership)
+- **M6 — Issues** (8 endpoints, prefix `/projects/{projectSlug}/issues`)
+  - [ ] `IssueRepository.findBySlug` + `existsBySlug`
+  - [ ] Wire `generateUniqueSlug` into `createIssueFromScoreUseCase` + `discoverIssueUseCase`
+  - [ ] `@domain/evaluations/src/use-cases/monitor-issue.ts` + `unmonitor-issue.ts`; migrate `evaluation-alignment.functions.ts` web fns to delegate
+  - [ ] Inject `getWorkflowStarter()` through `apps/api/src/clients.ts` + `ApiOptions`
+  - [ ] `GET /` (`high`), `GET /{issueSlug}` (`medium`)
+  - [ ] `POST /resolve`, `POST /unresolve`, `POST /ignore`, `POST /unignore` — bulk by id list (`medium`)
+  - [ ] `POST /{issueSlug}/monitor` (`critical`), `POST /{issueSlug}/unmonitor` (`medium`)
+  - [ ] `POST /export` (`critical`) — `recipientEmail` validated; reuses `buildIssuesExportUseCase`
+- **M7 — Datasets** (10 endpoints, prefix `/projects/{projectSlug}/datasets`)
+  - [ ] `DatasetRepository.findBySlug` + `existsBySlug`
+  - [ ] Slug generation in `createDataset`; slug regeneration in `renameDataset` + `updateDatasetDetails`
+  - [ ] Datasets CRUD: `GET /` (`low`), `GET /{datasetSlug}` (`low`), `POST /` (`medium`), `PATCH /{datasetSlug}` (`medium`), `DELETE /{datasetSlug}` (`medium`)
+  - [ ] Rows: `GET /{datasetSlug}/rows` (`high`), `POST /{datasetSlug}/rows` (`medium`), `DELETE /{datasetSlug}/rows` (`medium`)
+  - [ ] `POST /{datasetSlug}/rows/import/traces` (`critical`) — takes `tracesRef`
+  - [ ] `POST /{datasetSlug}/rows/export` (`critical`) — recipient-email validated
+  - [ ] CSV import (`POST /rows/import/files`) — **deferred (D16)**; leave `// TODO(file-imports)` comment
+  - [ ] Refactor `addTracesToDataset` to take `TracesRef` (or thin route-level adapter)
+- **M-Settings (web)** — independent of M4–M7; ships standalone
+  - [ ] Sessions section in `settings/account.tsx` (BA `listSessions` / `revokeSession` / `revokeOtherSessions`)
+  - [ ] Rename `settings/api-keys.tsx` → `settings/keys.tsx` (+ redirect from old URL)
+  - [ ] OAuth Keys table + "Revoke OAuth key" server-fn (deletes `oauth_access_tokens` rows by `(client_id, user_id)`, disables `oauth_applications` row when last token removed)
+- **Wrap-up**
+  - [ ] `pnpm generate:sdk` — batched at the end of the plan, single PR (per the standing memo)
+  - [ ] CI drift jobs for `apps/api/openapi.json` and `apps/api/mcp.json` (verification §)


### PR DESCRIPTION
Migrates the two remaining old-shaped routes to `defineApiEndpoint` so they surface as MCP tools (`createAnnotation`, `createScore`) alongside the HTTP endpoints. The manifest grew from 16 → 18 tools and both routes gain the `medium` rate-limit tier (projects drops to `low`).

Behavior changes:

- Annotations created via OAuth callers now carry `annotatorId = auth.userId`; API-key callers stay unauthored (the use-case takes the value from the trusted route context, never the body).
- Mount-path constants (`annotationsPath`, `scoresPath`) declared once in Hono's `:param` form and reused for both the parent `routes.route(...)` and `defineApiEndpoint`. The factory normalizes to OpenAPI `{param}` form internally so the MCP dispatcher only has to substitute one placeholder shape.
- Plain (non-transformed) `traceIdSchema`, `spanIdSchema`, `sessionIdSchema` exposed from `apps/api/src/openapi/schemas.ts` so request / response bodies keep the domain's length validation without dragging the branded-ID transforms into JSON Schema — the MCP SDK can't represent transforms and was previously throwing.
- Request and response schemas for both routes are now declared explicitly field-by-field with `.describe()` on every property (instead of spreading the un-described domain shapes). Shared anchor field bag lets the metadata schema reuse the same five fields without duplication. Verified field-by-field that no top-level property was added or dropped relative to the previous OpenAPI spec.