### PR TITLE
fix(issues): guard discovery creation with Postgres centroids

### DIFF
--- a/dev-docs/issues.md
+++ b/dev-docs/issues.md
@@ -200,8 +200,9 @@ Inside locked serialization must:
 5. assign the score to the matched issue if the locked re-check now finds one
 6. otherwise acquire the project-scoped Redis lock and repeat the retrieval/rerank/Postgres resolution check
 7. assign to the project-lock match if one is found
-8. otherwise generate issue details, create one new issue, and claim `scores.issue_id`
-9. sync the issue projection before releasing the locks
+8. otherwise compare the incoming normalized embedding against recent project issue centroids from Postgres and assign to the best above-threshold centroid match
+9. otherwise generate issue details, create one new issue, and claim `scores.issue_id`
+10. sync the issue projection before releasing the locks
 
 This intentionally moves the long external retrieval/rerank/generation section outside Postgres transactions. Lock acquisition must use Redis `SET ... NX EX`; if the key is already held, serialization exits immediately and the workflow performs an explicit sleep-and-retry loop instead of occupying a database connection as a lock waiter. Redis lock keys must be organization-prefixed (`org:${organizationId}:...`) and released with token comparison so one worker cannot release another worker's lock after TTL expiry.
 
@@ -211,7 +212,7 @@ The correctness invariant is:
 - contended workers retry instead of waiting on Postgres or holding database transactions
 - project-level brand-new issue creation is serialized by the Redis project lock
 - assignment to an existing issue remains row-safe through the issue row lock and conditional score ownership claim
-- Weaviate projection lag can delay matching quality, but it must not allow duplicate issue creation from concurrent no-match workflows
+- Weaviate projection lag can delay matching quality, but it must not allow duplicate issue creation from concurrent no-match workflows; the project-locked no-match path uses Postgres centroids as the final duplicate guard before creating a new issue
 
 Concrete v1 mechanics worth carrying forward:
 

--- a/packages/domain/issues/src/constants.ts
+++ b/packages/domain/issues/src/constants.ts
@@ -138,6 +138,16 @@ export const ISSUE_REFRESH_THROTTLE_MS = 8 * 60 * 60 * 1000
 export const MIN_OCCURRENCES_FOR_VISIBILITY = 3
 
 // ---------------------------------------------------------------------------
+// Postgres centroid duplicate guard
+// ---------------------------------------------------------------------------
+
+/** Maximum recent project issues compared by the Postgres centroid duplicate guard. */
+export const ISSUE_DISCOVERY_POSTGRES_CENTROID_GUARD_CANDIDATES = 250
+
+/** Minimum cosine similarity for assigning to an existing issue during locked no-match serialization. */
+export const ISSUE_DISCOVERY_POSTGRES_CENTROID_MIN_SIMILARITY = 0.92
+
+// ---------------------------------------------------------------------------
 // Discovery serialization locks
 // ---------------------------------------------------------------------------
 

--- a/packages/domain/issues/src/ports/issue-repository.ts
+++ b/packages/domain/issues/src/ports/issue-repository.ts
@@ -49,6 +49,10 @@ export interface IssueRepositoryShape {
     readonly projectId: ProjectId
     readonly uuid: string
   }): Effect.Effect<IssueWithLifecycle, NotFoundError | RepositoryError, SqlClient>
+  listRecentWithCentroids(input: {
+    readonly projectId: ProjectId
+    readonly limit: number
+  }): Effect.Effect<readonly Issue[], RepositoryError, SqlClient>
   /**
    * Returns the number of non-deleted issues with this slug in the project,
    * scoped to the active organization (issues aren't soft-deleted, so this

--- a/packages/domain/issues/src/testing/fake-issue-repository.ts
+++ b/packages/domain/issues/src/testing/fake-issue-repository.ts
@@ -60,6 +60,14 @@ export const createFakeIssueRepository = (
         return withLifecycle(issue)
       }),
 
+    listRecentWithCentroids: ({ projectId, limit }) =>
+      Effect.sync(() =>
+        [...issues.values()]
+          .filter((issue) => issue.projectId === projectId && issue.centroid.mass > 0)
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, limit),
+      ),
+
     save: (issue) =>
       Effect.sync(() => {
         issues.set(issue.id, issue)

--- a/packages/domain/issues/src/use-cases/serialize-issue-discovery.test.ts
+++ b/packages/domain/issues/src/use-cases/serialize-issue-discovery.test.ts
@@ -157,6 +157,74 @@ describe("serializeIssueDiscoveryUseCase", () => {
     expect(fakeAi.calls.generate).toHaveLength(0)
   })
 
+  it("uses a Postgres centroid guard inside the project lock before creating a duplicate issue", async () => {
+    const existingIssue = makeIssue({
+      centroid: {
+        ...createIssueCentroid(),
+        base: makeEmbedding(),
+        mass: 1,
+      },
+    })
+    const score = makeScore()
+    const { repository: scoreRepository, scores } = createFakeScoreRepository()
+    const { repository: issueRepository, issues } = createFakeIssueRepository([existingIssue])
+    const { service: issueProjectionRepository } = createFakeIssueProjectionRepository({ organizationId })
+    const lockCalls: string[] = []
+    const writtenEvents: unknown[] = []
+    const fakeAi = createFakeAI({
+      generate: (input) =>
+        Effect.succeed({
+          object: input.schema.parse({
+            name: "Token leakage in assistant responses",
+            description: "The assistant exposes secrets or tokens in its replies.",
+          }),
+          tokens: 10,
+          duration: 5,
+        }),
+    })
+
+    scores.set(score.id, score)
+
+    const result = await Effect.runPromise(
+      serializeIssueDiscoveryUseCase({
+        organizationId,
+        projectId,
+        scoreId: score.id,
+        feedback: score.feedback,
+        normalizedEmbedding: makeEmbedding(),
+      }).pipe(
+        Effect.provide(fakeAi.layer),
+        Effect.provideService(ScoreRepository, scoreRepository),
+        Effect.provideService(IssueRepository, issueRepository),
+        Effect.provideService(IssueProjectionRepository, issueProjectionRepository),
+        Effect.provideService(IssueDiscoveryLockRepository, {
+          withLock: (input, effect) =>
+            Effect.gen(function* () {
+              lockCalls.push(`${input.organizationId}:${input.projectId}:${input.lockKey}`)
+              return yield* effect
+            }),
+        }),
+        Effect.provideService(OutboxEventWriter, {
+          write: (event) =>
+            Effect.sync(() => {
+              writtenEvents.push(event)
+            }),
+        }),
+        Effect.provideService(SqlClient, createPassthroughSqlClient(organizationId)),
+      ),
+    )
+
+    expect(result).toEqual({ action: "assigned", issueId: existingIssue.id })
+    expect(scores.get(score.id)?.issueId).toBe(existingIssue.id)
+    expect(issues.size).toBe(1)
+    expect(lockCalls).toHaveLength(3)
+    expect(lockCalls[0]).toMatch(new RegExp(`^${organizationId}:${projectId}:feedback:[a-f0-9]{64}$`))
+    expect(lockCalls[1]).toBe(`${organizationId}:${projectId}:project`)
+    expect(lockCalls[2]).toBe(`${organizationId}:${projectId}:issue:${existingIssue.id}`)
+    expect(writtenEvents).toHaveLength(1)
+    expect(fakeAi.calls.generate).toHaveLength(0)
+  })
+
   it("falls through to the project lock before creating a new issue", async () => {
     const score = makeScore()
     const { repository: scoreRepository, scores } = createFakeScoreRepository()

--- a/packages/domain/issues/src/use-cases/serialize-issue-discovery.ts
+++ b/packages/domain/issues/src/use-cases/serialize-issue-discovery.ts
@@ -4,11 +4,15 @@ import { Effect } from "effect"
 import {
   ISSUE_DISCOVERY_FEEDBACK_LOCK_KEY,
   ISSUE_DISCOVERY_FEEDBACK_LOCK_TTL_SECONDS,
+  ISSUE_DISCOVERY_POSTGRES_CENTROID_GUARD_CANDIDATES,
+  ISSUE_DISCOVERY_POSTGRES_CENTROID_MIN_SIMILARITY,
   ISSUE_DISCOVERY_PROJECT_LOCK_KEY,
   ISSUE_DISCOVERY_PROJECT_LOCK_TTL_SECONDS,
 } from "../constants.ts"
 import { type CheckEligibilityError, type IssueDiscoveryLockUnavailableError, isEligibilityError } from "../errors.ts"
+import { normalizeEmbedding, normalizeIssueCentroid } from "../helpers.ts"
 import { IssueDiscoveryLockRepository } from "../ports/issue-discovery-lock-repository.ts"
+import { IssueRepository } from "../ports/issue-repository.ts"
 import type { AssignScoreToIssueError, AssignScoreToIssueResult } from "./assign-score-to-issue.ts"
 import { assignScoreToIssueUseCase } from "./assign-score-to-issue.ts"
 import { checkEligibilityUseCase } from "./check-eligibility.ts"
@@ -90,6 +94,38 @@ const createIssue = (input: SerializeIssueDiscoveryInput) =>
     normalizedEmbedding: input.normalizedEmbedding,
   })
 
+const cosineSimilarity = (left: readonly number[], right: readonly number[]): number => {
+  if (left.length === 0 || left.length !== right.length) {
+    return 0
+  }
+
+  let sum = 0
+  for (let index = 0; index < left.length; index++) {
+    sum += (left[index] ?? 0) * (right[index] ?? 0)
+  }
+  return sum
+}
+
+const findPostgresCentroidMatchedIssueId = (input: SerializeIssueDiscoveryInput) =>
+  Effect.gen(function* () {
+    const issueRepository = yield* IssueRepository
+    const queryVector = normalizeEmbedding(input.normalizedEmbedding)
+    const candidates = yield* issueRepository.listRecentWithCentroids({
+      projectId: ProjectId(input.projectId),
+      limit: ISSUE_DISCOVERY_POSTGRES_CENTROID_GUARD_CANDIDATES,
+    })
+
+    const best = candidates
+      .map((issue) => ({
+        issueId: issue.id,
+        similarity: cosineSimilarity(queryVector, normalizeIssueCentroid(issue.centroid)),
+      }))
+      .filter((candidate) => candidate.similarity >= ISSUE_DISCOVERY_POSTGRES_CENTROID_MIN_SIMILARITY)
+      .sort((left, right) => right.similarity - left.similarity)[0]
+
+    return best?.issueId ?? null
+  })
+
 export const serializeIssueDiscoveryUseCase = (input: SerializeIssueDiscoveryInput) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("scoreId", input.scoreId)
@@ -127,6 +163,11 @@ export const serializeIssueDiscoveryUseCase = (input: SerializeIssueDiscoveryInp
             const projectMatchedIssueId = yield* findMatchedIssueId(input)
             if (projectMatchedIssueId !== null) {
               return yield* assignToIssue(input, projectMatchedIssueId)
+            }
+
+            const postgresCentroidMatchedIssueId = yield* findPostgresCentroidMatchedIssueId(input)
+            if (postgresCentroidMatchedIssueId !== null) {
+              return yield* assignToIssue(input, postgresCentroidMatchedIssueId)
             }
 
             return yield* createIssue(input)

--- a/packages/domain/notifications/src/use-cases/create-incident-notifications.test.ts
+++ b/packages/domain/notifications/src/use-cases/create-incident-notifications.test.ts
@@ -138,6 +138,7 @@ function setup(opts: SetupOpts = {}) {
     findByIdForUpdate: () => Effect.die("not used"),
     findByIds: () => Effect.die("not used"),
     findByUuid: () => Effect.die("not used"),
+    listRecentWithCentroids: () => Effect.die("not used"),
     save: () => Effect.die("not used"),
     list: () => Effect.die("not used"),
     countBySlug: () => Effect.die("not used"),

--- a/packages/platform/db-postgres/src/repositories/issue-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/issue-repository.ts
@@ -239,6 +239,21 @@ const issueRepositoryCoreLive = Layer.effect(
             )
         }),
 
+      listRecentWithCentroids: ({ projectId, limit }: { readonly projectId: ProjectId; readonly limit: number }) =>
+        Effect.gen(function* () {
+          const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+          return yield* sqlClient
+            .query((db, organizationId) =>
+              db
+                .select()
+                .from(issues)
+                .where(and(eq(issues.organizationId, organizationId), eq(issues.projectId, projectId)))
+                .orderBy(desc(issues.createdAt))
+                .limit(limit),
+            )
+            .pipe(Effect.map((rows) => rows.map(toDomainIssue).filter((issue) => issue.centroid.mass > 0)))
+        }),
+
       save: (issue: Issue) =>
         Effect.gen(function* () {
           const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>


### PR DESCRIPTION
## Summary

Adds a final Postgres centroid duplicate guard in the project-locked issue discovery no-match path. When Weaviate retrieval still returns no candidate, discovery now compares the incoming normalized score embedding against recent project issue centroids from Postgres and assigns to the best above-threshold match before creating a new issue.

## Why

The Redis serialization fix prevents concurrent brand-new issue writes, but it still depended on Weaviate read-after-write visibility. Under high-volume bursts of similar traces, the next serialized workflow can acquire the project lock before the previous issue projection is searchable, see another no-match, and create a duplicate issue. Postgres already has the canonical issue centroid immediately after creation, so this PR uses it as the final source-of-truth duplicate guard.

## Validation

- `pnpm --filter @domain/issues test -- serialize-issue-discovery.test.ts`
- `pnpm --filter @domain/issues typecheck`
- `pnpm --filter @platform/db-postgres typecheck`
- `pnpm --filter @domain/issues check`
- `pnpm --filter @platform/db-postgres check`
- commit hook: `pnpm format`, `pnpm knip`
