### PR TITLE
feat(spans): per-span project scoping via .capture({ projectSlug })

### DIFF
--- a/apps/ingest/package.json
+++ b/apps/ingest/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@domain/api-keys": "workspace:*",
     "@domain/billing": "workspace:*",
-    "@domain/projects": "workspace:^",
     "@domain/queue": "workspace:*",
     "@domain/shared": "workspace:*",
     "@domain/spans": "workspace:*",

--- a/apps/ingest/src/middleware/project.ts
+++ b/apps/ingest/src/middleware/project.ts
@@ -1,39 +1,20 @@
-import { ProjectRepository } from "@domain/projects"
-import { isNotFoundError, OrganizationId } from "@domain/shared"
-import { ProjectRepositoryLive, withPostgres } from "@platform/db-postgres"
-import { withTracing } from "@repo/observability"
-import { Effect } from "effect"
 import type { MiddlewareHandler } from "hono"
-import { getPostgresClient } from "../clients.ts"
 import type { IngestEnv } from "../types.ts"
 
 /**
- * Resolves the project from the X-Latitude-Project header (project slug).
- * Must run after auth middleware (requires organizationId on context).
+ * Reads the optional `X-Latitude-Project` header and exposes it as the per-request default
+ * project slug.
+ *
+ * Best-effort: this middleware does not validate the slug or hit Postgres. Per-span resolution
+ * (and the OTLP `partial_success` accounting that follows from it) happens in the ingest use
+ * case. When the header is missing, spans must carry a `latitude.project` attribute on the span
+ * or its OTEL resource — otherwise they're rejected with `400` or counted as partial_success
+ * rejections, depending on whether any span in the batch resolved.
  */
 export const projectMiddleware: MiddlewareHandler<IngestEnv> = async (c, next) => {
   const projectSlug = c.req.header("X-Latitude-Project")
-  if (!projectSlug) {
-    return c.json({ error: "X-Latitude-Project header is required" }, 400)
+  if (projectSlug) {
+    c.set("defaultProjectSlug", projectSlug)
   }
-
-  const organizationId = c.get("organizationId")
-  const client = getPostgresClient()
-
-  try {
-    const project = await Effect.runPromise(
-      Effect.gen(function* () {
-        const repo = yield* ProjectRepository
-        return yield* repo.findBySlug(projectSlug)
-      }).pipe(withPostgres(ProjectRepositoryLive, client, OrganizationId(organizationId)), withTracing),
-    )
-
-    c.set("projectId", project.id as string)
-    await next()
-  } catch (error) {
-    if (isNotFoundError(error)) {
-      return c.json({ error: "Project not found" }, 404)
-    }
-    throw error
-  }
+  await next()
 }

--- a/apps/ingest/src/rate-limit/trace-ingestion.test.ts
+++ b/apps/ingest/src/rate-limit/trace-ingestion.test.ts
@@ -90,7 +90,6 @@ const testConfig = {
 const createInput = (redis: TraceIngestionRateLimitRedis, payloadBytes: number) => ({
   redis,
   organizationId: "org-1",
-  projectId: "project-1",
   apiKeyId: "key-1",
   payloadBytes,
   config: testConfig,
@@ -136,5 +135,18 @@ describe("checkTraceIngestionRateLimit", () => {
     const result = await checkTraceIngestionRateLimit(createInput(new ThrowingRedis(), 60))
 
     expect(result).toEqual({ allowed: true })
+  })
+
+  it("rate-limits across projects within the same org+apiKey (no `projectId` in the key)", async () => {
+    // Per-span project scoping moved project resolution into the use case. The rate-limit
+    // bucket is now `org + apiKey`, matching billing's scope — two projects in the same org
+    // share the same trace-ingestion allowance.
+    const redis = new FakeRedis()
+
+    await checkTraceIngestionRateLimit(createInput(redis, 10))
+    await checkTraceIngestionRateLimit(createInput(redis, 10))
+    const third = await checkTraceIngestionRateLimit(createInput(redis, 10))
+
+    expect(third).toEqual({ allowed: false, limitedBy: "requests", retryAfterSeconds: 30 })
   })
 })

--- a/apps/ingest/src/rate-limit/trace-ingestion.ts
+++ b/apps/ingest/src/rate-limit/trace-ingestion.ts
@@ -34,7 +34,6 @@ export interface TraceIngestionRateLimitRedis {
 interface CheckTraceIngestionRateLimitInput {
   readonly redis: TraceIngestionRateLimitRedis
   readonly organizationId: string
-  readonly projectId: string
   readonly apiKeyId: string
   readonly payloadBytes: number
   readonly config?: TraceIngestionRateLimitConfig
@@ -83,7 +82,7 @@ const normalizeRetryAfterSeconds = (ttl: number, fallback: number): number => {
 const buildRateLimitKey = (
   input: Omit<CheckTraceIngestionRateLimitInput, "redis" | "payloadBytes" | "config">,
 ): string => {
-  return `ratelimit:ingest:traces:${input.organizationId}:${input.projectId}:${input.apiKeyId}`
+  return `ratelimit:ingest:traces:${input.organizationId}:${input.apiKeyId}`
 }
 
 export const checkTraceIngestionRateLimit = async (

--- a/apps/ingest/src/routes/project-scoping-docs.test.ts
+++ b/apps/ingest/src/routes/project-scoping-docs.test.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+/**
+ * CI guard: the OTLP `partial_success.errorMessage` in `traces.ts` hard-codes
+ * https://docs.latitude.so/telemetry/project-scoping, and customer exporters log that URL on
+ * rejection. If anyone moves the docs page or drops it from the nav, these tests fail loudly
+ * so the author can coordinate a server-side error-message update before the page 404s.
+ */
+
+const repoRoot = resolve(__dirname, "../../../..")
+const docsPath = resolve(repoRoot, "docs/telemetry/project-scoping.md")
+const docsConfigPath = resolve(repoRoot, "docs/docs.json")
+
+describe("project-scoping docs integrity", () => {
+  it("docs/telemetry/project-scoping.md still exists", () => {
+    if (!existsSync(docsPath)) {
+      throw new Error(
+        `Missing ${docsPath}. The ingest service references https://docs.latitude.so/telemetry/project-scoping ` +
+          "in its OTLP error response — please restore the page or coordinate a server-side error-message update.",
+      )
+    }
+  })
+
+  it("`telemetry/project-scoping` is wired into docs.json under the Telemetry group", () => {
+    const config = JSON.parse(readFileSync(docsConfigPath, "utf-8")) as {
+      navigation?: { groups?: Array<{ group: string; pages: unknown[] }> }
+    }
+    const groups = config.navigation?.groups ?? []
+    const telemetryGroup = groups.find((g) => g.group === "Telemetry")
+
+    if (!telemetryGroup) {
+      throw new Error(
+        "Could not find the `Telemetry` group in docs/docs.json. The ingest service expects " +
+          "the `telemetry/project-scoping` page to live there — coordinate a server-side update " +
+          "if the nav was restructured.",
+      )
+    }
+
+    expect(telemetryGroup.pages).toContain("telemetry/project-scoping")
+  })
+})

--- a/apps/ingest/src/routes/traces.ts
+++ b/apps/ingest/src/routes/traces.ts
@@ -1,9 +1,10 @@
 import { NoCreditsRemainingError } from "@domain/billing"
-import { OrganizationId, ProjectId } from "@domain/shared"
+import { OrganizationId } from "@domain/shared"
 import { ingestSpansWithBillingUseCase } from "@domain/spans"
 import {
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
+  ProjectRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
   withPostgres,
@@ -26,9 +27,23 @@ interface TracesRouteContext {
 const traceIngestionBillingLayers = Layer.mergeAll(
   BillingOverrideRepositoryLive,
   BillingUsagePeriodRepositoryLive,
+  ProjectRepositoryLive,
   SettingsReaderLive,
   StripeSubscriptionLookupLive,
 )
+
+/**
+ * Docs URL surfaced in OTLP `partial_success.errorMessage` so a customer's exporter logs point
+ * them at the right page. **Hard-coded by contract** — if the docs path moves, the docs page's
+ * link-integrity test (in `docs/`) will fail, prompting a coordinated update of this string.
+ */
+const PROJECT_SCOPING_DOCS_URL = "https://docs.latitude.so/telemetry/project-scoping"
+
+const buildRejectionMessage = (rejected: number): string =>
+  `${rejected} span(s) rejected: no project could be resolved ` +
+  "(missing `latitude.project` attribute, missing OTEL resource attribute, and no " +
+  "`X-Latitude-Project` header), or the resolved slug doesn't belong to this organization. " +
+  `See ${PROJECT_SCOPING_DOCS_URL} for project-scoping options.`
 
 export const registerTracesRoute = ({ app }: TracesRouteContext) => {
   app.post("/v1/traces", authMiddleware, projectMiddleware, async (c) => {
@@ -39,7 +54,6 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
     const rateLimit = await checkTraceIngestionRateLimit({
       redis: getRedisClient(),
       organizationId: c.get("organizationId"),
-      projectId: c.get("projectId"),
       apiKeyId: c.get("apiKeyId"),
       payloadBytes: body.byteLength,
     })
@@ -61,20 +75,18 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
     }
 
     const organization = OrganizationId(c.get("organizationId"))
-    const project = ProjectId(c.get("projectId"))
     const apiKeyId = c.get("apiKeyId")
+    const defaultProjectSlug = c.get("defaultProjectSlug")
 
     const disk = getStorageDisk()
     const publisher = await getQueuePublisher()
     const postgresClient = getPostgresClient()
-    const ingestionEffect = Effect.gen(function* () {
-      yield* ingestSpansWithBillingUseCase({
-        organizationId: organization,
-        projectId: project,
-        apiKeyId,
-        payload: new Uint8Array(body),
-        contentType,
-      })
+    const ingestionEffect = ingestSpansWithBillingUseCase({
+      organizationId: organization,
+      apiKeyId,
+      payload: new Uint8Array(body),
+      contentType,
+      ...(defaultProjectSlug ? { defaultProjectSlug } : {}),
     }).pipe(
       withPostgres(traceIngestionBillingLayers, postgresClient, organization),
       Effect.provide(Layer.mergeAll(StorageDiskLive(disk), QueuePublisherLive(publisher))),
@@ -89,9 +101,39 @@ export const registerTracesRoute = ({ app }: TracesRouteContext) => {
         const err = failure.value
         return c.json({ error: err.httpMessage, kind: "NoCreditsRemaining" }, err.httpStatus)
       }
+      if (Option.isSome(failure) && (failure.value as { _tag?: string })._tag === "SpanDecodingError") {
+        const err = failure.value as { httpMessage?: string }
+        return c.json({ error: err.httpMessage ?? "Invalid OTLP payload" }, 400)
+      }
       throw new Error(Cause.pretty(exit.cause))
     }
 
-    return c.json({}, 202)
+    const result = exit.value
+
+    // OTLP response contract:
+    //  - All-valid batch                   → 200 OK, empty `ExportTraceServiceResponse`
+    //  - Mixed (some rejected, some kept)  → 200 OK + `partialSuccess { rejectedSpans, errorMessage }`
+    //    (spec §3.2: `partialSuccess` ONLY belongs on 2xx — it conveys "we kept some")
+    //  - Empty batch (no spans to ingest)  → 202 Accepted (legacy no-op, OTLP-permissive)
+    //  - All rejected                      → 400 with a `google.rpc.Status`-shaped body
+    //    ({ code, message }) — NOT `partialSuccess`, since nothing was persisted
+    if (result.totalSpans === 0) {
+      return c.json({}, 202)
+    }
+
+    if (result.acceptedSpans === 0) {
+      return c.json({ code: 400, message: buildRejectionMessage(result.rejectedSpans) }, 400)
+    }
+
+    if (result.rejectedSpans > 0) {
+      return c.json({
+        partialSuccess: {
+          rejectedSpans: result.rejectedSpans,
+          errorMessage: buildRejectionMessage(result.rejectedSpans),
+        },
+      })
+    }
+
+    return c.json({})
   })
 }

--- a/apps/ingest/src/types.ts
+++ b/apps/ingest/src/types.ts
@@ -2,6 +2,11 @@ export interface IngestEnv {
   Variables: {
     organizationId: string
     apiKeyId: string
-    projectId: string
+    /**
+     * Optional default project slug from the `X-Latitude-Project` header. The middleware
+     * is best-effort — it never fails if the header is missing or the slug doesn't resolve.
+     * Per-span resolution happens in the ingest use case.
+     */
+    defaultProjectSlug?: string
   }
 }

--- a/apps/workers/src/workers/span-ingestion.test.ts
+++ b/apps/workers/src/workers/span-ingestion.test.ts
@@ -72,9 +72,10 @@ const dispatchValidIngest = async (
     inlinePayload: null,
     contentType: "application/json",
     organizationId,
-    projectId,
     apiKeyId: `api-key-${organizationId}`,
     ingestedAt: "2026-03-18T10:00:00.000Z",
+    defaultProjectId: projectId,
+    projectIdBySlug: {},
   })
 }
 
@@ -165,9 +166,10 @@ describe("createSpanIngestionWorker", () => {
       inlinePayload: null,
       contentType: "application/json",
       organizationId: "org_span_ingestion_test",
-      projectId: "proj_span_ingestion_test",
       apiKeyId: "api_key_span_ingestion_test",
       ingestedAt: "2026-03-18T10:00:00.000Z",
+      defaultProjectId: "proj_span_ingestion_test",
+      projectIdBySlug: {},
     })
 
     const rows = await Effect.runPromise(
@@ -205,6 +207,54 @@ describe("createSpanIngestionWorker", () => {
     })
   })
 
+  it("falls back to legacy `projectId` field when `defaultProjectId` and `projectIdBySlug` are missing", async () => {
+    // Covers in-flight queue messages enqueued before the per-span scoping refactor:
+    // they carried `projectId` at the batch level and had no `projectIdBySlug`. The
+    // worker treats the legacy `projectId` as the default so the queue drains cleanly
+    // during rollout. See span-ingestion.ts:60-65.
+    const consumer = new TestQueueConsumer()
+    const disk = new FakeStorageDisk()
+    const pub = createFakeEventsPublisher()
+    const fileKey = "span-ingestion/test-legacy-shape.json"
+    disk.putBytes(fileKey, Buffer.from(JSON.stringify(validRequest), "utf-8"))
+
+    createSpanIngestionWorker({
+      consumer,
+      eventsPublisher: pub,
+      clickhouseClient: ch.client,
+      disk,
+      postgresClient: pg.appPostgresClient,
+      redisClient: testRedisClient,
+    })
+
+    await consumer.dispatchTask("span-ingestion", "ingest", {
+      fileKey,
+      inlinePayload: null,
+      contentType: "application/json",
+      organizationId: "org_legacy_shape_test",
+      apiKeyId: "api_key_legacy_shape_test",
+      ingestedAt: "2026-03-18T10:00:00.000Z",
+      projectId: "proj_legacy_shape_test",
+    })
+
+    const rows = await Effect.runPromise(
+      queryClickhouse<{ project_id: string }>(
+        ch.client,
+        "SELECT project_id FROM spans WHERE organization_id = {organizationId:String}",
+        { organizationId: "org_legacy_shape_test" },
+      ),
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.project_id).toBe("proj_legacy_shape_test")
+
+    expect(pub.published).toHaveLength(1)
+    expect(pub.published[0]).toMatchObject({
+      name: "TracesIngested",
+      payload: { projectId: "proj_legacy_shape_test" },
+    })
+  })
+
   it("returns early when neither inlinePayload nor fileKey is provided", async () => {
     const consumer = new TestQueueConsumer()
     const disk = new FakeStorageDisk()
@@ -224,9 +274,10 @@ describe("createSpanIngestionWorker", () => {
       inlinePayload: null,
       contentType: "application/json",
       organizationId: "org_no_payload_test",
-      projectId: "proj_no_payload_test",
       apiKeyId: "api_key_no_payload_test",
       ingestedAt: "2026-03-18T10:00:00.000Z",
+      defaultProjectId: "proj_no_payload_test",
+      projectIdBySlug: {},
     })
 
     const [count] = await Effect.runPromise(
@@ -264,9 +315,10 @@ describe("createSpanIngestionWorker", () => {
         inlinePayload: null,
         contentType: "application/json",
         organizationId: "org_span_ingestion_test",
-        projectId: "proj_span_ingestion_test",
         apiKeyId: "api_key_span_ingestion_test",
         ingestedAt: "2026-03-18T10:00:00.000Z",
+        defaultProjectId: "proj_span_ingestion_test",
+        projectIdBySlug: {},
       })
 
       const [count] = await Effect.runPromise(
@@ -305,9 +357,10 @@ describe("createSpanIngestionWorker", () => {
       inlinePayload: null,
       contentType: "application/json",
       organizationId: "org_vercel_wrapper_test",
-      projectId: "proj_vercel_wrapper_test",
       apiKeyId: "api_key_vercel_wrapper_test",
       ingestedAt: "2026-03-18T10:00:00.000Z",
+      defaultProjectId: "proj_vercel_wrapper_test",
+      projectIdBySlug: {},
     })
 
     const rows = await Effect.runPromise(

--- a/apps/workers/src/workers/span-ingestion.ts
+++ b/apps/workers/src/workers/span-ingestion.ts
@@ -1,6 +1,6 @@
 import type { EventsPublisher } from "@domain/events"
 import type { QueueConsumer, QueuePublishError } from "@domain/queue"
-import { OrganizationId, ProjectId, type StorageDiskPort } from "@domain/shared"
+import { OrganizationId, type StorageDiskPort } from "@domain/shared"
 import { processIngestedSpansUseCase } from "@domain/spans"
 import { RedisCacheStoreLive, type RedisClient } from "@platform/cache-redis"
 import type { ClickHouseClient } from "@platform/db-clickhouse"
@@ -52,11 +52,17 @@ export const createSpanIngestionWorker = ({
     {
       ingest: (wire) => {
         const organizationId = wire.organizationId
-        const projectId = wire.projectId
-        if (!organizationId || !projectId) {
-          logger.error("Span ingestion: missing organizationId or projectId in message")
+        if (!organizationId) {
+          logger.error("Span ingestion: missing organizationId in message")
           return Effect.void
         }
+
+        // In-flight queue messages enqueued before this PR carried `projectId` at the batch
+        // level and no `projectIdBySlug`. Treat them as a single-project ingest using that
+        // legacy `projectId` as the default — keeps the queue draining cleanly during rollout.
+        const legacy = wire as unknown as { projectId?: string }
+        const defaultProjectId = wire.defaultProjectId ?? legacy.projectId ?? null
+        const projectIdBySlug = wire.projectIdBySlug ?? {}
 
         const processEffect = Effect.gen(function* () {
           const orgPlan = yield* resolveEffectivePlanCached(OrganizationId(organizationId)).pipe(
@@ -65,12 +71,13 @@ export const createSpanIngestionWorker = ({
 
           yield* processSpans({
             organizationId: OrganizationId(organizationId),
-            projectId: ProjectId(projectId),
             apiKeyId: wire.apiKeyId,
             contentType: wire.contentType || "application/json",
             ingestedAt: wire.ingestedAt ? new Date(wire.ingestedAt) : new Date(),
             inlinePayload: wire.inlinePayload,
             fileKey: wire.fileKey,
+            defaultProjectId,
+            projectIdBySlug,
             ...(orgPlan ? { retentionDays: orgPlan.plan.retentionDays } : {}),
             ...(orgPlan
               ? {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,6 +66,7 @@
         "group": "Telemetry",
         "pages": [
           "telemetry/overview",
+          "telemetry/project-scoping",
           "telemetry/otel-exporter",
           "telemetry/typescript",
           "telemetry/python",

--- a/docs/telemetry/project-scoping.md
+++ b/docs/telemetry/project-scoping.md
@@ -1,0 +1,184 @@
+---
+title: Project scoping
+description: Route spans to the right Latitude project — one project per process, or many.
+---
+
+Latitude can route spans to different projects based on how each capture is configured. Most
+SDKs already set a project at startup; this page covers the additional knobs available when
+**one process needs to emit to multiple projects** (for example, a service that runs several
+agents that should each show up as a distinct Latitude project).
+
+## The resolution chain
+
+For every span Latitude ingests, the server applies this order (highest priority first):
+
+1. **Span attribute** `latitude.project`
+   Set by `capture({ projectSlug })` in the TypeScript SDK or `capture({"project_slug": ...})`
+   in Python. The slug travels on the span itself, so a single OTLP export can carry spans
+   for multiple projects.
+2. **OTEL resource attribute** `latitude.project`
+   For bare-OpenTelemetry setups: set `latitude.project` once on the SDK's `Resource` and every
+   span inherits it.
+3. **HTTP header** `X-Latitude-Project`
+   The Latitude SDKs send this automatically when a `projectSlug` is passed to the constructor.
+   Acts as the per-batch default.
+
+If none of those resolve to a project that belongs to your organization, the span is rejected.
+
+## Response contract (OTLP `partial_success`)
+
+Latitude follows the [OTLP specification](https://opentelemetry.io/docs/specs/otlp/) for
+partial-success responses. Customers writing their own exporters can rely on these guarantees:
+
+| Batch shape                          | HTTP status | Body                                                            |
+| ------------------------------------ | ----------- | --------------------------------------------------------------- |
+| All spans resolve                    | **200 OK**  | empty `ExportTraceServiceResponse`                              |
+| Some spans rejected (mixed)          | **200 OK**  | `partialSuccess { rejectedSpans: N, errorMessage: "..." }`      |
+| Every span rejected                  | **400**     | `google.rpc.Status` shape: `{ code: 400, message: "..." }`      |
+| Malformed OTLP payload               | **400**     | `{ error: "..." }`                                              |
+
+Note: `partialSuccess` only appears on **2xx** responses — it means "some spans were
+persisted, here is a count of what we dropped". When **nothing** was persisted we return a
+plain `google.rpc.Status`-shaped error body so exporters don't mistakenly treat the rejection
+as a partial save.
+
+The `errorMessage` always points back to this page so an exporter that logs the response
+gives operators a single place to look. **Don't move this page** without coordinating a
+server-side update — the URL is hard-coded in the ingest error response.
+
+## Patterns
+
+Three runnable examples ship with each SDK. Start with the one that matches your shape.
+
+### 1. Single-project default (existing setup)
+
+For services that emit to exactly one Latitude project. The ctor `projectSlug` is sent on
+every export as `X-Latitude-Project`, and every `capture()` inherits it.
+
+**TypeScript** — see [`examples/test_project_scoping_single.ts`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/typescript/examples/test_project_scoping_single.ts):
+
+```ts
+import { capture, Latitude } from "@latitude-data/telemetry"
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+})
+
+await capture("greet", async () => {
+  // routed to LATITUDE_PROJECT_SLUG
+})
+```
+
+**Python** — see [`examples/test_project_scoping_single.py`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/python/examples/test_project_scoping_single.py):
+
+```python
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+)
+
+@capture("greet")
+def greet():
+    ...  # routed to LATITUDE_PROJECT_SLUG
+```
+
+### 2. Multi-project from day 1 (no ctor default)
+
+For services that emit to multiple Latitude projects — e.g. one process that runs several
+agents. Skip the ctor `projectSlug` and set `projectSlug` on every `capture()`.
+
+**TypeScript** — see [`examples/test_project_scoping_multi.ts`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/typescript/examples/test_project_scoping_multi.ts):
+
+```ts
+import { capture, Latitude } from "@latitude-data/telemetry"
+
+const latitude = new Latitude({ apiKey: process.env.LATITUDE_API_KEY! })
+
+await capture(
+  "full-stack-agent-run",
+  async () => { /* ... */ },
+  { projectSlug: "full-stack-agent" },
+)
+
+await capture(
+  "call-summariser-run",
+  async () => { /* ... */ },
+  { projectSlug: "call-summariser" },
+)
+```
+
+**Python** — see [`examples/test_project_scoping_multi.py`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/python/examples/test_project_scoping_multi.py):
+
+```python
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(api_key=os.environ["LATITUDE_API_KEY"])
+
+@capture("full-stack-agent-run", {"project_slug": "full-stack-agent"})
+def run_full_stack_agent():
+    ...
+
+@capture("call-summariser-run", {"project_slug": "call-summariser"})
+def run_call_summariser():
+    ...
+```
+
+A `capture()` that doesn't set `projectSlug` AND a SDK that doesn't have a ctor default →
+the spans are rejected with `partialSuccess`. Pick one of the two so every span has a route.
+
+### 3. Per-span override on top of a default
+
+Most common when the default project comes from an env var but specific runs need to route
+elsewhere (e.g. shipping evaluation runs to a separate project).
+
+**TypeScript** — see [`examples/test_project_scoping_env.ts`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/typescript/examples/test_project_scoping_env.ts):
+
+```ts
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,  // env-driven default
+})
+
+// inherits the default
+await capture("default-route", async () => { /* ... */ })
+
+// per-capture override — wins over the ctor default
+await capture(
+  "evaluation-batch",
+  async () => { /* ... */ },
+  { projectSlug: "evaluation-runs" },
+)
+```
+
+**Python** — see [`examples/test_project_scoping_env.py`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/python/examples/test_project_scoping_env.py):
+
+```python
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+)
+
+@capture("default-route")
+def default_route():
+    ...
+
+@capture("evaluation-batch", {"project_slug": "evaluation-runs"})
+def evaluation_batch():
+    ...
+```
+
+## Handling `partial_success` in custom exporters
+
+If you're integrating from bare OpenTelemetry (no Latitude SDK) and want to surface
+rejections, watch for `partialSuccess.rejectedSpans > 0` in the OTLP response body. The
+common causes:
+
+- Missing `latitude.project` on the span AND no `X-Latitude-Project` header on the export.
+- The resolved slug doesn't exist in your organization (typo, or a stale slug after the
+  project was renamed).
+
+The fix is always to make sure each span has a way to resolve a project — either the span
+attribute, a resource attribute, or the header default.

--- a/packages/domain/queue/src/topic-registry.ts
+++ b/packages/domain/queue/src/topic-registry.ts
@@ -49,9 +49,21 @@ const _registry = {
       readonly inlinePayload: string | null
       readonly contentType: string
       readonly organizationId: string
-      readonly projectId: string
       readonly apiKeyId: string
       readonly ingestedAt: string
+      /**
+       * `projectId` to apply to spans that carry no `latitude.project` attribute on the span or
+       * its OTEL resource. Resolved from the `X-Latitude-Project` header by the ingest route;
+       * `null` when no header was sent (in which case those spans are dropped here).
+       */
+      readonly defaultProjectId: string | null
+      /**
+       * Pre-resolved slug → `projectId` map for every distinct `latitude.project` attribute
+       * value seen in the batch (and the header default, if set). The request handler does the
+       * DB lookups once per batch and counts rejected spans for the OTLP `partial_success`
+       * response; the worker uses this map and avoids re-querying Postgres.
+       */
+      readonly projectIdBySlug: Readonly<Record<string, string>>
     }
   }>(),
 

--- a/packages/domain/spans/src/otlp/tests/claude-code.test.ts
+++ b/packages/domain/spans/src/otlp/tests/claude-code.test.ts
@@ -17,9 +17,10 @@ const USER_ID = "4ea2a748152ed22e21039407af95bbe77b563ab0ada3836ed3fd3879e835930
 
 const context: TransformContext = {
   organizationId: "org-1",
-  projectId: "proj-1",
   apiKeyId: "key-1",
   ingestedAt: new Date("2026-04-10T12:00:00.000Z"),
+  defaultProjectId: "proj-1",
+  projectIdBySlug: new Map(),
 }
 
 function runTransform(span: OtlpSpan): SpanDetail {
@@ -31,7 +32,8 @@ function runTransform(span: OtlpSpan): SpanDetail {
       },
     ],
   }
-  const [out] = transformOtlpToSpans(req, context)
+  const [out] = transformOtlpToSpans(req, context).spans
+  if (!out) throw new Error("expected at least one span from transform")
   return out
 }
 

--- a/packages/domain/spans/src/otlp/tests/genai.test.ts
+++ b/packages/domain/spans/src/otlp/tests/genai.test.ts
@@ -96,9 +96,10 @@ const TOOL_DEFS = [
 
 const CONTEXT: TransformContext = {
   organizationId: "org_test",
-  projectId: "proj_test",
   apiKeyId: "key_test",
   ingestedAt: new Date("2026-03-16T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
 }
 
 // ─── Span builders (GenAI v1.37+ convention) ──────────────
@@ -382,7 +383,7 @@ describe("TravelPlanner trace — GenAI v1.37+ (current)", () => {
   }
 
   beforeAll(() => {
-    spans = transformOtlpToSpans(buildTrace(), CONTEXT)
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as typeof spans
   })
 
   // ── Trace structure ───────────────────────────────────

--- a/packages/domain/spans/src/otlp/tests/genai_deprecated.test.ts
+++ b/packages/domain/spans/src/otlp/tests/genai_deprecated.test.ts
@@ -67,9 +67,10 @@ const TOOL_DEFS = [
 
 const CONTEXT: TransformContext = {
   organizationId: "org_test",
-  projectId: "proj_test",
   apiKeyId: "key_test",
   ingestedAt: new Date("2026-03-16T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
 }
 
 // ─── Span builders (GenAI deprecated / OpenLLMetry convention) ──
@@ -311,7 +312,7 @@ describe("TravelPlanner trace — GenAI deprecated / OpenLLMetry", () => {
   }
 
   beforeAll(() => {
-    spans = transformOtlpToSpans(buildTrace(), CONTEXT)
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as typeof spans
   })
 
   // ── Trace structure ───────────────────────────────────

--- a/packages/domain/spans/src/otlp/tests/genai_indexed.test.ts
+++ b/packages/domain/spans/src/otlp/tests/genai_indexed.test.ts
@@ -28,9 +28,10 @@ const SPAN_IDS = {
 
 const CONTEXT: TransformContext = {
   organizationId: "org_test",
-  projectId: "proj_test",
   apiKeyId: "key_test",
   ingestedAt: new Date("2026-03-16T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
 }
 
 // ─── Span builders (Traceloop/OpenLLMetry flattened indexed format) ──
@@ -120,7 +121,7 @@ describe("Traceloop/OpenLLMetry — flattened indexed gen_ai.prompt/completion",
   }
 
   beforeAll(() => {
-    spans = transformOtlpToSpans(buildTrace(), CONTEXT)
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as typeof spans
   })
 
   describe("trace structure", () => {

--- a/packages/domain/spans/src/otlp/tests/openinference.test.ts
+++ b/packages/domain/spans/src/otlp/tests/openinference.test.ts
@@ -75,9 +75,10 @@ const TOOL_DEFS = [
 
 const CONTEXT: TransformContext = {
   organizationId: "org_test",
-  projectId: "proj_test",
   apiKeyId: "key_test",
   ingestedAt: new Date("2026-03-16T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
 }
 
 // ─── Explicit cost values for LLM call 1 ─────────────────
@@ -288,7 +289,7 @@ describe("TravelPlanner trace — OpenInference (Arize Phoenix)", () => {
   }
 
   beforeAll(() => {
-    spans = transformOtlpToSpans(buildTrace(), CONTEXT)
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as typeof spans
   })
 
   // ── Trace structure ───────────────────────────────────

--- a/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
+++ b/packages/domain/spans/src/otlp/tests/project-scoping.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest"
+import { resolveSpanProjectSlug, transformOtlpToSpans } from "../transform.ts"
+import type { OtlpExportTraceServiceRequest, OtlpKeyValue } from "../types.ts"
+
+const TRACE = "0af7651916cd43dd8448eb211c80319c"
+
+const str = (key: string, value: string): OtlpKeyValue => ({ key, value: { stringValue: value } })
+
+const buildSpan = (spanId: string, slug?: string): NonNullable<OtlpExportTraceServiceRequest["resourceSpans"]> => [
+  {
+    resource: { attributes: [str("service.name", "test")] },
+    scopeSpans: [
+      {
+        scope: { name: "scope", version: "1" },
+        spans: [
+          {
+            traceId: TRACE,
+            spanId,
+            name: spanId,
+            startTimeUnixNano: "1710590400000000000",
+            endTimeUnixNano: "1710590401000000000",
+            attributes: slug ? [str("latitude.project", slug)] : [],
+            status: { code: 1 },
+          },
+        ],
+      },
+    ],
+  },
+]
+
+const baseContext = {
+  organizationId: "org-1",
+  apiKeyId: "key-1",
+  ingestedAt: new Date("2026-04-10T12:00:00.000Z"),
+}
+
+describe("resolveSpanProjectSlug", () => {
+  it("prefers a span attribute over a resource attribute", () => {
+    const span = [str("latitude.project", "span-slug"), str("other.attr", "x")]
+    const resource = [str("latitude.project", "resource-slug")]
+    expect(resolveSpanProjectSlug(span, resource)).toBe("span-slug")
+  })
+
+  it("falls back to the resource attribute when the span attribute is missing", () => {
+    const span = [str("other.attr", "x")]
+    const resource = [str("latitude.project", "resource-slug")]
+    expect(resolveSpanProjectSlug(span, resource)).toBe("resource-slug")
+  })
+
+  it("returns undefined when neither is set", () => {
+    expect(resolveSpanProjectSlug([], [])).toBeUndefined()
+  })
+})
+
+describe("transformOtlpToSpans per-span project resolution", () => {
+  it("uses the span attribute slug → projectId map", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpan("s1", "primary") },
+      {
+        ...baseContext,
+        defaultProjectId: null,
+        projectIdBySlug: new Map([["primary", "proj-primary"]]),
+      },
+    )
+    expect(rejectedSpans).toBe(0)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-primary")
+  })
+
+  it("uses the resource attribute when the span has none", () => {
+    const { spans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("latitude.project", "secondary")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: TRACE,
+                    spanId: "r1",
+                    name: "r1",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...baseContext,
+        defaultProjectId: null,
+        projectIdBySlug: new Map([["secondary", "proj-secondary"]]),
+      },
+    )
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-secondary")
+  })
+
+  it("falls back to defaultProjectId when neither attribute is set", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpan("d1") },
+      {
+        ...baseContext,
+        defaultProjectId: "proj-default",
+        projectIdBySlug: new Map(),
+      },
+    )
+    expect(rejectedSpans).toBe(0)
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-default")
+  })
+
+  it("rejects spans whose slug is not in the map and has no default", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpan("x1", "unknown-slug") },
+      {
+        ...baseContext,
+        defaultProjectId: null,
+        projectIdBySlug: new Map(),
+      },
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(0)
+  })
+
+  it("rejects spans with no slug and no default", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      { resourceSpans: buildSpan("u1") },
+      {
+        ...baseContext,
+        defaultProjectId: null,
+        projectIdBySlug: new Map(),
+      },
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(0)
+  })
+
+  it("span attribute wins over resource attribute and over the header default", () => {
+    const { spans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("latitude.project", "resource-slug")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: TRACE,
+                    spanId: "pre",
+                    name: "pre",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [str("latitude.project", "span-slug")],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...baseContext,
+        defaultProjectId: "proj-default",
+        projectIdBySlug: new Map([
+          ["resource-slug", "proj-resource"],
+          ["span-slug", "proj-span"],
+        ]),
+      },
+    )
+    expect(spans).toHaveLength(1)
+    expect(spans[0]?.projectId).toBe("proj-span")
+  })
+
+  it("handles a mixed batch: some valid spans, some rejected", () => {
+    const { spans, rejectedSpans } = transformOtlpToSpans(
+      {
+        resourceSpans: [
+          {
+            resource: { attributes: [str("service.name", "test")] },
+            scopeSpans: [
+              {
+                scope: { name: "scope", version: "1" },
+                spans: [
+                  {
+                    traceId: TRACE,
+                    spanId: "ok1",
+                    name: "ok1",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [str("latitude.project", "primary")],
+                    status: { code: 1 },
+                  },
+                  {
+                    traceId: TRACE,
+                    spanId: "rej1",
+                    name: "rej1",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [str("latitude.project", "unknown")],
+                    status: { code: 1 },
+                  },
+                  {
+                    traceId: TRACE,
+                    spanId: "ok2",
+                    name: "ok2",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        ...baseContext,
+        defaultProjectId: "proj-default",
+        projectIdBySlug: new Map([["primary", "proj-primary"]]),
+      },
+    )
+    expect(rejectedSpans).toBe(1)
+    expect(spans).toHaveLength(2)
+    expect(spans[0]?.projectId).toBe("proj-primary")
+    expect(spans[1]?.projectId).toBe("proj-default")
+  })
+})

--- a/packages/domain/spans/src/otlp/tests/vercel.test.ts
+++ b/packages/domain/spans/src/otlp/tests/vercel.test.ts
@@ -73,9 +73,10 @@ const TOOL_DEFS = [
 
 const CONTEXT: TransformContext = {
   organizationId: "org_test",
-  projectId: "proj_test",
   apiKeyId: "key_test",
   ingestedAt: new Date("2026-03-16T12:00:00Z"),
+  defaultProjectId: "proj_test",
+  projectIdBySlug: new Map(),
 }
 
 // ─── Span builders (Vercel AI SDK convention) ─────────────
@@ -467,7 +468,7 @@ describe("TravelPlanner trace — Vercel AI SDK", () => {
   }
 
   beforeAll(() => {
-    spans = transformOtlpToSpans(buildTrace(), CONTEXT)
+    spans = transformOtlpToSpans(buildTrace(), CONTEXT).spans as typeof spans
   })
 
   // ── Trace structure (Vercel dual-span pattern) ────────
@@ -927,7 +928,7 @@ function buildDuplicatedOuterUsageTrace(): OtlpExportTraceServiceRequest {
 
 describe("Vercel AI SDK duplicate usage normalization", () => {
   it("preserves raw outer wrapper usage before ingestion-time sanitization", () => {
-    const spans = transformOtlpToSpans(buildDuplicatedOuterUsageTrace(), CONTEXT)
+    const { spans } = transformOtlpToSpans(buildDuplicatedOuterUsageTrace(), CONTEXT)
     const outer = spans.find((span) => span.spanId === "cccccccccccccccc")
     const inner = spans.find((span) => span.spanId === "dddddddddddddddd")
 
@@ -991,7 +992,7 @@ describe("Vercel AI SDK streamObject / generateObject output", () => {
     ["ai.generateObject"],
   ])("%s surfaces ai.response.object as assistant output", (operationId) => {
     const obj = { city: "Barcelona", temperature: 22 }
-    const spans = transformOtlpToSpans(buildObjectSpan(operationId, obj), CONTEXT)
+    const { spans } = transformOtlpToSpans(buildObjectSpan(operationId, obj), CONTEXT)
     const span = spans[0]
     expect(span).toBeDefined()
 
@@ -1008,7 +1009,7 @@ describe("Vercel AI SDK streamObject / generateObject output", () => {
 
 describe("Vercel AI SDK top-level prompt fallback", () => {
   it("treats ai.prompt.prompt as a user input message when ai.prompt.messages is absent", () => {
-    const spans = transformOtlpToSpans(
+    const { spans } = transformOtlpToSpans(
       {
         resourceSpans: [
           {

--- a/packages/domain/spans/src/otlp/transform.ts
+++ b/packages/domain/spans/src/otlp/transform.ts
@@ -5,7 +5,7 @@ import { parseContent } from "./content/index.ts"
 import { resolveAttributes } from "./resolvers/index.ts"
 import { resolvePerformance } from "./resolvers/performance.ts"
 import { resolveToolExecution } from "./resolvers/tool-execution.ts"
-import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpResource, OtlpSpan } from "./types.ts"
+import type { OtlpAnyValue, OtlpExportTraceServiceRequest, OtlpKeyValue, OtlpResource, OtlpSpan } from "./types.ts"
 
 const INT_TO_SPAN_KIND: Record<number, SpanKind> = {
   0: "unspecified",
@@ -50,11 +50,57 @@ function extractResourceString(resource: OtlpResource | undefined): Record<strin
   return result
 }
 
+/**
+ * Per-span project scoping. Each span resolves a `projectId` independently:
+ *
+ *   1. span attribute `latitude.project`            (set by `.capture({ projectSlug })`)
+ *   2. OTEL resource attribute `latitude.project`   (bare-OTEL pattern)
+ *   3. `defaultProjectId` from `X-Latitude-Project` header                       *
+ *
+ * Slugs resolve to project IDs via `projectIdBySlug`. A span is rejected if its slug
+ * doesn't resolve and `defaultProjectId` is also absent (or if the slug isn't in the map).
+ */
 export interface TransformContext {
   readonly organizationId: string
-  readonly projectId: string
   readonly apiKeyId: string
   readonly ingestedAt: Date
+  /**
+   * `projectId` to use when neither a span nor resource `latitude.project` attribute is present.
+   * Resolved from the `X-Latitude-Project` header by the ingest middleware; `null` when no
+   * header was sent (in which case unscoped spans are rejected).
+   */
+  readonly defaultProjectId: string | null
+  /**
+   * Slug → projectId map pre-resolved by the request handler (one DB lookup per unique slug).
+   * Unknown / wrong-org slugs are absent from this map.
+   */
+  readonly projectIdBySlug: ReadonlyMap<string, string>
+}
+
+interface TransformResult {
+  readonly spans: readonly SpanDetail[]
+  /** Spans skipped because no `projectId` could be resolved for them. */
+  readonly rejectedSpans: number
+}
+
+/** Reads `latitude.project` from span attrs first, falling back to resource attrs. */
+export function resolveSpanProjectSlug(
+  spanAttrs: readonly OtlpKeyValue[],
+  resourceAttrs: readonly OtlpKeyValue[],
+): string | undefined {
+  return stringAttr(spanAttrs, "latitude.project") ?? stringAttr(resourceAttrs, "latitude.project")
+}
+
+function resolveSpanProjectId(
+  spanAttrs: readonly OtlpKeyValue[],
+  resourceAttrs: readonly OtlpKeyValue[],
+  context: TransformContext,
+): string | null {
+  const slug = resolveSpanProjectSlug(spanAttrs, resourceAttrs)
+  if (slug) {
+    return context.projectIdBySlug.get(slug) ?? null
+  }
+  return context.defaultProjectId
 }
 
 function transformSpan({
@@ -63,6 +109,7 @@ function transformSpan({
   scopeName,
   scopeVersion,
   context,
+  projectId,
   ingestedAt,
 }: {
   span: OtlpSpan
@@ -70,6 +117,7 @@ function transformSpan({
   scopeName: string
   scopeVersion: string
   context: TransformContext
+  projectId: string
   ingestedAt: Date
 }): SpanDetail {
   const spanAttrs = span.attributes ?? []
@@ -113,7 +161,7 @@ function transformSpan({
 
   return {
     organizationId: OrganizationId(context.organizationId),
-    projectId: ProjectId(context.projectId),
+    projectId: ProjectId(projectId),
     sessionId: SessionId(resolved.sessionId),
     userId: ExternalUserId(resolved.userId),
     traceId: TraceId(span.traceId),
@@ -171,20 +219,30 @@ function transformSpan({
   }
 }
 
-export function transformOtlpToSpans(request: OtlpExportTraceServiceRequest, context: TransformContext): SpanDetail[] {
+export function transformOtlpToSpans(
+  request: OtlpExportTraceServiceRequest,
+  context: TransformContext,
+): TransformResult {
   const spans: SpanDetail[] = []
+  let rejectedSpans = 0
   const { ingestedAt } = context
 
   for (const resourceSpans of request.resourceSpans ?? []) {
     const resource = resourceSpans.resource
+    const resourceAttrs = resource?.attributes ?? []
     for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
       const scopeName = scopeSpans.scope?.name ?? ""
       const scopeVersion = scopeSpans.scope?.version ?? ""
       for (const span of scopeSpans.spans ?? []) {
-        spans.push(transformSpan({ span, resource, scopeName, scopeVersion, context, ingestedAt }))
+        const projectId = resolveSpanProjectId(span.attributes ?? [], resourceAttrs, context)
+        if (!projectId) {
+          rejectedSpans++
+          continue
+        }
+        spans.push(transformSpan({ span, resource, scopeName, scopeVersion, context, projectId, ingestedAt }))
       }
     }
   }
 
-  return spans
+  return { spans, rejectedSpans }
 }

--- a/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans-with-billing.ts
@@ -3,20 +3,27 @@ import {
   type NoCreditsRemainingError,
   type UnknownStripePlanError,
 } from "@domain/billing"
+import type { ProjectRepository } from "@domain/projects"
 import type { QueuePublishError, QueuePublisher } from "@domain/queue"
 import type { RepositoryError, SettingsReader, SqlClient, StorageDisk, StorageError } from "@domain/shared"
 import { Effect } from "effect"
-import { type IngestSpansInput, ingestSpansUseCase } from "./ingest-spans.ts"
+import type { SpanDecodingError } from "../errors.ts"
+import { type IngestSpansInput, type IngestSpansResult, ingestSpansUseCase } from "./ingest-spans.ts"
 
 export const ingestSpansWithBillingUseCase = Effect.fn("spans.ingestSpansWithBilling")(function* (
   input: IngestSpansInput,
 ) {
   yield* checkTraceIngestionBillingUseCase(input.organizationId)
-  yield* ingestSpansUseCase(input)
+  return yield* ingestSpansUseCase(input)
 }) as (
   input: IngestSpansInput,
 ) => Effect.Effect<
-  void,
-  NoCreditsRemainingError | QueuePublishError | RepositoryError | StorageError | UnknownStripePlanError,
-  QueuePublisher | StorageDisk | SettingsReader | SqlClient
+  IngestSpansResult,
+  | NoCreditsRemainingError
+  | QueuePublishError
+  | RepositoryError
+  | SpanDecodingError
+  | StorageError
+  | UnknownStripePlanError,
+  ProjectRepository | QueuePublisher | StorageDisk | SettingsReader | SqlClient
 >

--- a/packages/domain/spans/src/use-cases/ingest-spans.test.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.test.ts
@@ -10,10 +10,20 @@ import {
   createFakeStripeSubscriptionLookup,
   seedBillingUsagePeriod,
 } from "@domain/billing/testing"
+import { createProject, ProjectRepository } from "@domain/projects"
 import type { QueuePublisherShape } from "@domain/queue"
 import { QueuePublishError, QueuePublisher } from "@domain/queue"
 import { createFakeQueuePublisher } from "@domain/queue/testing"
-import { OrganizationId, ProjectId, SettingsReader, SqlClient, StorageDisk, type StorageDiskPort } from "@domain/shared"
+import {
+  generateId,
+  NotFoundError,
+  OrganizationId,
+  ProjectId,
+  SettingsReader,
+  SqlClient,
+  StorageDisk,
+  type StorageDiskPort,
+} from "@domain/shared"
 import { createFakeSqlClient, createFakeStorageDisk } from "@domain/shared/testing"
 import { base64Decode } from "@repo/utils"
 import { Effect, Layer, Result } from "effect"
@@ -21,21 +31,115 @@ import { describe, expect, it } from "vitest"
 import { ingestSpansUseCase } from "./ingest-spans.ts"
 import { ingestSpansWithBillingUseCase } from "./ingest-spans-with-billing.ts"
 
-const smallPayload = new TextEncoder().encode('{"spans":[]}')
+// Branded IDs are CUID2s — 24 characters exactly.
+const ORGANIZATION_ID = OrganizationId(generateId())
+const PRIMARY_PROJECT_ID = generateId()
+const SECONDARY_PROJECT_ID = generateId()
 
-const largePayload = new Uint8Array(60_000).fill(65) // 60 KB, above 50 KB threshold
+const emptyBatch = new TextEncoder().encode(JSON.stringify({ resourceSpans: [] }))
 
-const makeInput = (payload: Uint8Array) => ({
-  organizationId: OrganizationId("org-1"),
-  projectId: ProjectId("proj-1"),
+const buildOtlpJson = (slug?: string): Uint8Array =>
+  new TextEncoder().encode(
+    JSON.stringify({
+      resourceSpans: [
+        {
+          resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+          scopeSpans: [
+            {
+              scope: { name: "test", version: "1.0.0" },
+              spans: [
+                {
+                  traceId: "0af7651916cd43dd8448eb211c80319c",
+                  spanId: "b7ad6b7169203331",
+                  name: "test-span",
+                  startTimeUnixNano: "1710590400000000000",
+                  endTimeUnixNano: "1710590401000000000",
+                  attributes: slug ? [{ key: "latitude.project", value: { stringValue: slug } }] : [],
+                  status: { code: 1 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+const largeSinglePayload = (() => {
+  // Pad an OTLP batch past 50 KB by adding many spans.
+  const spans = Array.from({ length: 200 }, (_, i) => ({
+    traceId: "0af7651916cd43dd8448eb211c80319c",
+    spanId: `b7ad6b716920${String(i).padStart(4, "0")}`,
+    name: "test-span",
+    startTimeUnixNano: "1710590400000000000",
+    endTimeUnixNano: "1710590401000000000",
+    attributes: [{ key: "fill", value: { stringValue: "x".repeat(300) } }],
+    status: { code: 1 },
+  }))
+  return new TextEncoder().encode(
+    JSON.stringify({
+      resourceSpans: [
+        {
+          resource: { attributes: [{ key: "service.name", value: { stringValue: "test" } }] },
+          scopeSpans: [{ scope: { name: "test", version: "1.0.0" }, spans }],
+        },
+      ],
+    }),
+  )
+})()
+
+const makeProject = (slug: string, id: string) =>
+  createProject({
+    id: ProjectId(id),
+    organizationId: ORGANIZATION_ID,
+    name: `Project ${slug}`,
+    slug,
+    settings: {},
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    lastEditedAt: new Date("2026-01-01T00:00:00Z"),
+  })
+
+const makeProjectRepository = (resolutions: Record<string, string | null>) =>
+  ProjectRepository.of({
+    findById: () => Effect.die("not used"),
+    findBySlug: (slug: string) => {
+      const id = resolutions[slug]
+      if (!id) return Effect.fail(new NotFoundError({ entity: "Project", id: slug }))
+      return Effect.succeed(makeProject(slug, id))
+    },
+    list: () => Effect.die("not used"),
+    listIncludingDeleted: () => Effect.die("not used"),
+    save: () => Effect.die("not used"),
+    softDelete: () => Effect.die("not used"),
+    hardDelete: () => Effect.die("not used"),
+    existsByName: () => Effect.die("not used"),
+    countBySlug: () => Effect.die("not used"),
+  })
+
+const makeInput = (payload: Uint8Array, opts: { defaultProjectSlug?: string } = {}) => ({
+  organizationId: ORGANIZATION_ID,
   apiKeyId: "key-1",
   payload,
   contentType: "application/json",
+  ...(opts.defaultProjectSlug ? { defaultProjectSlug: opts.defaultProjectSlug } : {}),
 })
 
-const runUseCase = (input: ReturnType<typeof makeInput>, diskPort: StorageDiskPort, publisher: QueuePublisherShape) =>
+const runUseCase = (
+  input: ReturnType<typeof makeInput>,
+  diskPort: StorageDiskPort,
+  publisher: QueuePublisherShape,
+  resolutions: Record<string, string | null> = { primary: PRIMARY_PROJECT_ID },
+) =>
   ingestSpansUseCase(input).pipe(
-    Effect.provide(Layer.merge(Layer.succeed(StorageDisk, diskPort), Layer.succeed(QueuePublisher, publisher))),
+    Effect.provide(
+      Layer.mergeAll(
+        Layer.succeed(StorageDisk, diskPort),
+        Layer.succeed(QueuePublisher, publisher),
+        Layer.succeed(ProjectRepository, makeProjectRepository(resolutions)),
+        Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+      ),
+    ),
   )
 
 const createBillingLayer = () => {
@@ -49,7 +153,8 @@ const createBillingLayer = () => {
       Layer.succeed(BillingOverrideRepository, billingOverrides),
       Layer.succeed(BillingUsagePeriodRepository, billingPeriods),
       Layer.succeed(StripeSubscriptionLookup, stripeSubscriptions),
-      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: makeInput(smallPayload).organizationId })),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+      Layer.succeed(ProjectRepository, makeProjectRepository({ primary: PRIMARY_PROJECT_ID })),
       Layer.succeed(SettingsReader, {
         getOrganizationSettings: () => Effect.succeed(null),
         getProjectSettings: () => Effect.die("ingestSpansWithBillingUseCase tests do not read project settings"),
@@ -59,66 +164,57 @@ const createBillingLayer = () => {
 }
 
 describe("ingestSpansUseCase", () => {
+  it("returns zeros for an empty batch and does not publish", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    const result = await Effect.runPromise(
+      runUseCase(makeInput(emptyBatch, { defaultProjectSlug: "primary" }), disk, publisher),
+    )
+
+    expect(result).toEqual({ totalSpans: 0, acceptedSpans: 0, rejectedSpans: 0 })
+    expect(published).toHaveLength(0)
+  })
+
   it("inlines small payloads without writing to disk", async () => {
     const { disk, written } = createFakeStorageDisk()
     const { publisher, published } = createFakeQueuePublisher()
 
-    await Effect.runPromise(runUseCase(makeInput(smallPayload), disk, publisher))
+    const result = await Effect.runPromise(
+      runUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" }), disk, publisher),
+    )
 
+    expect(result).toEqual({ totalSpans: 1, acceptedSpans: 1, rejectedSpans: 0 })
     expect(written).toHaveLength(0)
     expect(published).toHaveLength(1)
     expect(published[0]?.queue).toBe("span-ingestion")
     expect(published[0]?.task).toBe("ingest")
 
-    const payload = published[0]?.payload as { fileKey: string | null; inlinePayload: string | null }
+    const payload = published[0]?.payload as {
+      fileKey: string | null
+      inlinePayload: string | null
+      defaultProjectId: string | null
+    }
     expect(payload.fileKey).toBeNull()
     expect(payload.inlinePayload).toBeDefined()
-    expect(new TextDecoder().decode(base64Decode(payload.inlinePayload ?? ""))).toBe('{"spans":[]}')
+    expect(payload.defaultProjectId).toBe(PRIMARY_PROJECT_ID)
   })
 
   it("writes large payloads to disk and sends fileKey", async () => {
     const { disk, written } = createFakeStorageDisk()
     const { publisher, published } = createFakeQueuePublisher()
 
-    await Effect.runPromise(runUseCase(makeInput(largePayload), disk, publisher))
+    await Effect.runPromise(
+      runUseCase(makeInput(largeSinglePayload, { defaultProjectSlug: "primary" }), disk, publisher),
+    )
 
     expect(written).toHaveLength(1)
-    expect(written[0]?.key).toContain("tmp-ingest/org-1/proj-1/")
+    expect(written[0]?.key).toContain(`tmp-ingest/${ORGANIZATION_ID}/${PRIMARY_PROJECT_ID}/`)
 
     expect(published).toHaveLength(1)
     const payload = published[0]?.payload as { fileKey: string | null; inlinePayload: string | null }
     expect(payload.fileKey).toBe(written[0]?.key)
     expect(payload.inlinePayload).toBeNull()
-  })
-
-  it("uses protobuf extension for protobuf content type", async () => {
-    const { disk, written } = createFakeStorageDisk()
-    const { publisher } = createFakeQueuePublisher()
-
-    await Effect.runPromise(
-      ingestSpansUseCase({ ...makeInput(largePayload), contentType: "application/x-protobuf" }).pipe(
-        Effect.provide(Layer.merge(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher))),
-      ),
-    )
-
-    expect(written[0]?.key).toMatch(/\.protobuf$/)
-  })
-
-  it("fails with StorageError when disk write fails for large payloads", async () => {
-    const { disk } = createFakeStorageDisk({
-      put: async () => {
-        throw new Error("disk unavailable")
-      },
-    })
-    const { publisher, published } = createFakeQueuePublisher()
-
-    const res = await Effect.runPromise(Effect.result(runUseCase(makeInput(largePayload), disk, publisher)))
-
-    expect(Result.isFailure(res)).toBe(true)
-    if (Result.isFailure(res)) {
-      expect(res.failure._tag).toBe("StorageError")
-    }
-    expect(published).toHaveLength(0)
   })
 
   it("fails with QueuePublishError when publish fails (inline path)", async () => {
@@ -127,7 +223,9 @@ describe("ingestSpansUseCase", () => {
       publish: (queue) => Effect.fail(new QueuePublishError({ cause: new Error("queue down"), queue })),
     })
 
-    const res = await Effect.runPromise(Effect.result(runUseCase(makeInput(smallPayload), disk, publisher)))
+    const res = await Effect.runPromise(
+      Effect.result(runUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" }), disk, publisher)),
+    )
 
     expect(Result.isFailure(res)).toBe(true)
     if (Result.isFailure(res)) {
@@ -135,25 +233,160 @@ describe("ingestSpansUseCase", () => {
     }
   })
 
-  it("passes ingest fields in queue payload", async () => {
+  it("passes per-span resolution map and apiKey/org in queue payload", async () => {
     const { disk } = createFakeStorageDisk()
     const { publisher, published } = createFakeQueuePublisher()
 
-    await Effect.runPromise(runUseCase(makeInput(smallPayload), disk, publisher))
+    await Effect.runPromise(
+      runUseCase(makeInput(buildOtlpJson("primary"), { defaultProjectSlug: "primary" }), disk, publisher),
+    )
 
     expect(published).toHaveLength(1)
     const payload = published[0]?.payload as {
       contentType: string
       organizationId: string
-      projectId: string
       apiKeyId: string
       ingestedAt: string
+      defaultProjectId: string | null
+      projectIdBySlug: Record<string, string>
     }
     expect(payload.contentType).toBe("application/json")
-    expect(payload.organizationId).toBe("org-1")
-    expect(payload.projectId).toBe("proj-1")
+    expect(payload.organizationId).toBe(ORGANIZATION_ID)
     expect(payload.apiKeyId).toBe("key-1")
     expect(payload.ingestedAt).toBeDefined()
+    expect(payload.defaultProjectId).toBe(PRIMARY_PROJECT_ID)
+    expect(payload.projectIdBySlug).toEqual({ primary: PRIMARY_PROJECT_ID })
+  })
+
+  it("decodes inline payload back to original JSON", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    await Effect.runPromise(runUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" }), disk, publisher))
+
+    const payload = published[0]?.payload as { inlinePayload: string | null }
+    expect(payload.inlinePayload).toBeDefined()
+    expect(JSON.parse(new TextDecoder().decode(base64Decode(payload.inlinePayload ?? "")))).toHaveProperty(
+      "resourceSpans",
+    )
+  })
+})
+
+describe("ingestSpansUseCase project scoping", () => {
+  it("rejects every span when neither header nor per-span attribute resolves", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    const result = await Effect.runPromise(runUseCase(makeInput(buildOtlpJson()), disk, publisher, {}))
+
+    expect(result).toEqual({ totalSpans: 1, acceptedSpans: 0, rejectedSpans: 1 })
+    expect(published).toHaveLength(0)
+  })
+
+  it("rejects spans whose latitude.project slug isn't in the org and keeps the rest", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher, published } = createFakeQueuePublisher()
+
+    const twoSpans = new TextEncoder().encode(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                scope: { name: "test", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "0000000000000001",
+                    name: "ok",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [{ key: "latitude.project", value: { stringValue: "primary" } }],
+                    status: { code: 1 },
+                  },
+                  {
+                    traceId: "0af7651916cd43dd8448eb211c80319c",
+                    spanId: "0000000000000002",
+                    name: "reject",
+                    startTimeUnixNano: "1710590400000000000",
+                    endTimeUnixNano: "1710590401000000000",
+                    attributes: [{ key: "latitude.project", value: { stringValue: "other-org-project" } }],
+                    status: { code: 1 },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      runUseCase(makeInput(twoSpans), disk, publisher, { primary: PRIMARY_PROJECT_ID }),
+    )
+
+    expect(result).toEqual({ totalSpans: 2, acceptedSpans: 1, rejectedSpans: 1 })
+    expect(published).toHaveLength(1)
+    const payload = published[0]?.payload as { projectIdBySlug: Record<string, string> }
+    expect(payload.projectIdBySlug).toEqual({ primary: PRIMARY_PROJECT_ID })
+  })
+
+  it("resolves each unique slug exactly once even across many spans", async () => {
+    const { disk } = createFakeStorageDisk()
+    const { publisher } = createFakeQueuePublisher()
+
+    let findBySlugCalls = 0
+    const layer = Layer.mergeAll(
+      Layer.succeed(StorageDisk, disk),
+      Layer.succeed(QueuePublisher, publisher),
+      Layer.succeed(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID })),
+      Layer.succeed(
+        ProjectRepository,
+        ProjectRepository.of({
+          findById: () => Effect.die("not used"),
+          findBySlug: (slug: string) => {
+            findBySlugCalls++
+            return Effect.succeed(makeProject(slug, slug === "primary" ? PRIMARY_PROJECT_ID : SECONDARY_PROJECT_ID))
+          },
+          list: () => Effect.die("not used"),
+          listIncludingDeleted: () => Effect.die("not used"),
+          save: () => Effect.die("not used"),
+          softDelete: () => Effect.die("not used"),
+          hardDelete: () => Effect.die("not used"),
+          existsByName: () => Effect.die("not used"),
+          countBySlug: () => Effect.die("not used"),
+        }),
+      ),
+    )
+
+    const manySpans = new TextEncoder().encode(
+      JSON.stringify({
+        resourceSpans: [
+          {
+            scopeSpans: [
+              {
+                scope: { name: "test", version: "1.0.0" },
+                spans: Array.from({ length: 50 }, (_, i) => ({
+                  traceId: "0af7651916cd43dd8448eb211c80319c",
+                  spanId: `aa${String(i).padStart(14, "0")}`,
+                  name: "s",
+                  startTimeUnixNano: "1710590400000000000",
+                  endTimeUnixNano: "1710590401000000000",
+                  attributes: [
+                    { key: "latitude.project", value: { stringValue: i % 2 === 0 ? "primary" : "secondary" } },
+                  ],
+                  status: { code: 1 },
+                })),
+              },
+            ],
+          },
+        ],
+      }),
+    )
+
+    await Effect.runPromise(ingestSpansUseCase(makeInput(manySpans)).pipe(Effect.provide(layer)))
+
+    expect(findBySlugCalls).toBe(2)
   })
 })
 
@@ -164,7 +397,7 @@ describe("ingestSpansWithBillingUseCase", () => {
     const { layer } = createBillingLayer()
 
     await Effect.runPromise(
-      ingestSpansWithBillingUseCase(makeInput(smallPayload)).pipe(
+      ingestSpansWithBillingUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" })).pipe(
         Effect.provide(
           Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
         ),
@@ -183,7 +416,7 @@ describe("ingestSpansWithBillingUseCase", () => {
       billingPeriods
         .upsert(
           seedBillingUsagePeriod({
-            organizationId: makeInput(smallPayload).organizationId,
+            organizationId: ORGANIZATION_ID,
             planSlug: "free",
             periodStart: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)),
             periodEnd: new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth() + 1, 1)),
@@ -191,17 +424,12 @@ describe("ingestSpansWithBillingUseCase", () => {
             consumedCredits: 20_000,
           }),
         )
-        .pipe(
-          Effect.provideService(
-            SqlClient,
-            createFakeSqlClient({ organizationId: makeInput(smallPayload).organizationId }),
-          ),
-        ),
+        .pipe(Effect.provideService(SqlClient, createFakeSqlClient({ organizationId: ORGANIZATION_ID }))),
     )
 
     const result = await Effect.runPromise(
       Effect.result(
-        ingestSpansWithBillingUseCase(makeInput(smallPayload)).pipe(
+        ingestSpansWithBillingUseCase(makeInput(buildOtlpJson(), { defaultProjectSlug: "primary" })).pipe(
           Effect.provide(
             Layer.mergeAll(Layer.succeed(StorageDisk, disk), Layer.succeed(QueuePublisher, publisher), layer),
           ),

--- a/packages/domain/spans/src/use-cases/ingest-spans.ts
+++ b/packages/domain/spans/src/use-cases/ingest-spans.ts
@@ -1,39 +1,170 @@
+import { ProjectRepository } from "@domain/projects"
 import type { QueuePublishError } from "@domain/queue"
 import { QueuePublisher } from "@domain/queue"
-import { type OrganizationId, type ProjectId, putInDisk, StorageDisk, type StorageError } from "@domain/shared"
+import {
+  type OrganizationId,
+  ProjectId,
+  putInDisk,
+  type RepositoryError,
+  type SqlClient,
+  StorageDisk,
+  type StorageError,
+} from "@domain/shared"
 import { base64Encode } from "@repo/utils"
 import { Effect } from "effect"
+import { SpanDecodingError } from "../errors.ts"
+import { decodeOtlpProtobuf } from "../otlp/proto.ts"
+import { resolveSpanProjectSlug } from "../otlp/transform.ts"
+import type { OtlpExportTraceServiceRequest } from "../otlp/types.ts"
 
 const INLINE_PAYLOAD_MAX_BYTES = 50_000 // 50 KB
 
 export interface IngestSpansInput {
   readonly organizationId: OrganizationId
-  readonly projectId: ProjectId
   readonly apiKeyId: string
   readonly payload: Uint8Array
   readonly contentType: string
+  /**
+   * Project slug from the `X-Latitude-Project` header. Used as the fallback for spans that
+   * carry no `latitude.project` attribute on the span or its OTEL resource. Optional — when
+   * absent, spans without a per-span / resource attribute are rejected.
+   */
+  readonly defaultProjectSlug?: string
 }
+
+/**
+ * Per-batch outcome of project resolution. Drives the OTLP `partial_success` response shape
+ * at the HTTP boundary.
+ */
+export interface IngestSpansResult {
+  readonly totalSpans: number
+  readonly acceptedSpans: number
+  readonly rejectedSpans: number
+}
+
+function decodeRequest(value: Uint8Array, contentType: string): OtlpExportTraceServiceRequest | null {
+  try {
+    if (contentType.includes("application/x-protobuf")) {
+      return decodeOtlpProtobuf(value)
+    }
+    return JSON.parse(new TextDecoder().decode(value)) as OtlpExportTraceServiceRequest
+  } catch {
+    return null
+  }
+}
+
+interface PayloadInspection {
+  readonly totalSpans: number
+  readonly spanSlugs: readonly (string | undefined)[]
+  readonly uniqueSlugs: ReadonlySet<string>
+}
+
+function inspectPayload(request: OtlpExportTraceServiceRequest): PayloadInspection {
+  const uniqueSlugs = new Set<string>()
+  const spanSlugs: (string | undefined)[] = []
+  let totalSpans = 0
+
+  for (const resourceSpans of request.resourceSpans ?? []) {
+    const resourceAttrs = resourceSpans.resource?.attributes ?? []
+    for (const scopeSpans of resourceSpans.scopeSpans ?? []) {
+      for (const span of scopeSpans.spans ?? []) {
+        totalSpans++
+        const slug = resolveSpanProjectSlug(span.attributes ?? [], resourceAttrs)
+        spanSlugs.push(slug)
+        if (slug) uniqueSlugs.add(slug)
+      }
+    }
+  }
+
+  return { totalSpans, spanSlugs, uniqueSlugs }
+}
+
+const resolveSlug = (slug: string): Effect.Effect<string | null, RepositoryError, ProjectRepository | SqlClient> =>
+  Effect.gen(function* () {
+    const repo = yield* ProjectRepository
+    return yield* repo.findBySlug(slug).pipe(
+      Effect.map((project) => project.id as string),
+      Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+    )
+  })
 
 export const ingestSpansUseCase = (
   input: IngestSpansInput,
-): Effect.Effect<void, StorageError | QueuePublishError, StorageDisk | QueuePublisher> =>
+): Effect.Effect<
+  IngestSpansResult,
+  StorageError | QueuePublishError | RepositoryError | SpanDecodingError,
+  StorageDisk | QueuePublisher | ProjectRepository | SqlClient
+> =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
-    yield* Effect.annotateCurrentSpan("projectId", input.projectId)
+
+    const decoded = decodeRequest(input.payload, input.contentType)
+    if (!decoded) {
+      return yield* new SpanDecodingError({ reason: "failed to decode OTLP message" })
+    }
+
+    const { totalSpans, spanSlugs, uniqueSlugs } = inspectPayload(decoded)
+    if (totalSpans === 0) {
+      return { totalSpans: 0, acceptedSpans: 0, rejectedSpans: 0 }
+    }
+
+    // Resolve every unique slug (including the header default) against the org. One DB call per
+    // unique slug; the request handler treats this map as the source of truth.
+    const slugsToResolve = new Set<string>(uniqueSlugs)
+    if (input.defaultProjectSlug) slugsToResolve.add(input.defaultProjectSlug)
+
+    const projectIdBySlug = new Map<string, string>()
+    for (const slug of slugsToResolve) {
+      const projectId = yield* resolveSlug(slug)
+      if (projectId) projectIdBySlug.set(slug, projectId)
+    }
+
+    const defaultProjectId = input.defaultProjectSlug ? (projectIdBySlug.get(input.defaultProjectSlug) ?? null) : null
+
+    let acceptedSpans = 0
+    let rejectedSpans = 0
+    for (const slug of spanSlugs) {
+      if (slug) {
+        if (projectIdBySlug.has(slug)) acceptedSpans++
+        else rejectedSpans++
+      } else if (defaultProjectId) {
+        acceptedSpans++
+      } else {
+        rejectedSpans++
+      }
+    }
+
+    yield* Effect.annotateCurrentSpan("totalSpans", totalSpans)
+    yield* Effect.annotateCurrentSpan("acceptedSpans", acceptedSpans)
+    yield* Effect.annotateCurrentSpan("rejectedSpans", rejectedSpans)
+
+    if (acceptedSpans === 0) {
+      return { totalSpans, acceptedSpans: 0, rejectedSpans }
+    }
 
     const publisher = yield* QueuePublisher
 
+    // Storage path needs *a* projectId for the existing `tmp-ingest/{org}/{project}/{id}` layout
+    // — the actual per-span routing is done downstream from `projectIdBySlug` + `defaultProjectId`,
+    // not from this key. Pick anything resolvable so the path stays predictable.
+    const storageProjectId =
+      defaultProjectId ?? (projectIdBySlug.size > 0 ? (projectIdBySlug.values().next().value as string) : null)
+
     let fileKey: string | null = null
     let inlinePayload: string | null = null
-
     if (input.payload.byteLength <= INLINE_PAYLOAD_MAX_BYTES) {
       inlinePayload = base64Encode(input.payload)
     } else {
+      if (!storageProjectId) {
+        // Unreachable given `acceptedSpans > 0` guarantees at least one resolved projectId,
+        // but keeps the type-narrowing honest.
+        return { totalSpans, acceptedSpans: 0, rejectedSpans: totalSpans }
+      }
       const disk = yield* StorageDisk
       fileKey = yield* putInDisk(disk, {
         namespace: "ingest",
         organizationId: input.organizationId,
-        projectId: input.projectId,
+        projectId: ProjectId(storageProjectId),
         content: input.payload,
         extension: input.contentType.includes("protobuf") ? "protobuf" : "json",
       })
@@ -44,8 +175,11 @@ export const ingestSpansUseCase = (
       inlinePayload,
       contentType: input.contentType,
       organizationId: input.organizationId,
-      projectId: input.projectId,
       apiKeyId: input.apiKeyId,
       ingestedAt: new Date().toISOString(),
+      defaultProjectId,
+      projectIdBySlug: Object.fromEntries(projectIdBySlug),
     })
+
+    return { totalSpans, acceptedSpans, rejectedSpans }
   }).pipe(Effect.withSpan("spans.ingestSpans"))

--- a/packages/domain/spans/src/use-cases/process-ingested-spans.ts
+++ b/packages/domain/spans/src/use-cases/process-ingested-spans.ts
@@ -3,7 +3,7 @@ import {
   type ChSqlClient,
   getFromDisk,
   type OrganizationId,
-  type ProjectId,
+  ProjectId,
   type RepositoryError,
   StorageDisk,
   type StorageError,
@@ -63,7 +63,6 @@ function sanitizePersistedSpans(spans: readonly SpanDetail[]): readonly SpanDeta
 
 export interface ProcessIngestedSpansInput {
   readonly organizationId: OrganizationId
-  readonly projectId: ProjectId
   readonly apiKeyId: string
   readonly contentType: string
   readonly ingestedAt: Date
@@ -80,6 +79,17 @@ export interface ProcessIngestedSpansInput {
   }
   readonly inlinePayload: string | null
   readonly fileKey: string | null
+  /**
+   * Resolved by the request handler from the `X-Latitude-Project` header. Used for spans that
+   * carry no `latitude.project` attribute on the span or its OTEL resource.
+   */
+  readonly defaultProjectId: string | null
+  /**
+   * Slug → projectId map pre-resolved by the request handler. Spans whose slug isn't in this
+   * map (and have no default) are dropped here; the request handler has already accounted
+   * for them in the OTLP `partial_success` response.
+   */
+  readonly projectIdBySlug: Readonly<Record<string, string>>
 }
 
 function decodeRequest(value: Uint8Array, contentType: string): OtlpExportTraceServiceRequest | null {
@@ -125,14 +135,15 @@ function decodeAndTransform(
       return []
     }
 
-    return sanitizePersistedSpans(
-      transformOtlpToSpans(request, {
-        organizationId: input.organizationId,
-        projectId: input.projectId,
-        apiKeyId: input.apiKeyId,
-        ingestedAt: input.ingestedAt,
-      }),
-    )
+    const { spans } = transformOtlpToSpans(request, {
+      organizationId: input.organizationId,
+      apiKeyId: input.apiKeyId,
+      ingestedAt: input.ingestedAt,
+      defaultProjectId: input.defaultProjectId,
+      projectIdBySlug: new Map(Object.entries(input.projectIdBySlug)),
+    })
+
+    return sanitizePersistedSpans(spans)
   })
 }
 
@@ -151,7 +162,6 @@ export const processIngestedSpansUseCase =
   > =>
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan("organizationId", input.organizationId)
-      yield* Effect.annotateCurrentSpan("projectId", input.projectId)
 
       const payload = yield* resolvePayload(input)
       const spans = yield* decodeAndTransform(payload, input)
@@ -170,27 +180,41 @@ export const processIngestedSpansUseCase =
       const repo = yield* SpanRepository
       yield* repo.insert(persistedSpans)
 
-      const traceIds = [...new Set(persistedSpans.map((span) => span.traceId))]
+      // Spans in a single OTLP batch may now belong to different projects (per-span scoping).
+      // Group by projectId so each TracesIngested event addresses one project at a time —
+      // downstream consumers (issues discovery, billing, flaggers, etc.) are project-scoped.
+      const traceIdsByProject = new Map<string, Set<string>>()
+      for (const span of persistedSpans) {
+        const projectKey = span.projectId as string
+        let set = traceIdsByProject.get(projectKey)
+        if (!set) {
+          set = new Set<string>()
+          traceIdsByProject.set(projectKey, set)
+        }
+        set.add(span.traceId as string)
+      }
 
-      yield* eventsPublisher.publish({
-        name: "TracesIngested",
-        organizationId: input.organizationId,
-        payload: {
+      for (const [projectIdRaw, traceIdSet] of traceIdsByProject) {
+        yield* eventsPublisher.publish({
+          name: "TracesIngested",
           organizationId: input.organizationId,
-          projectId: input.projectId,
-          traceIds,
-          ...(input.traceUsage?.context
-            ? {
-                billing: {
-                  planSlug: input.traceUsage.context.planSlug,
-                  planSource: input.traceUsage.context.planSource,
-                  periodStart: input.traceUsage.context.periodStart.toISOString(),
-                  periodEnd: input.traceUsage.context.periodEnd.toISOString(),
-                  includedCredits: input.traceUsage.context.includedCredits,
-                  overageAllowed: input.traceUsage.context.overageAllowed,
-                },
-              }
-            : {}),
-        },
-      } satisfies DomainEvent)
+          payload: {
+            organizationId: input.organizationId,
+            projectId: ProjectId(projectIdRaw),
+            traceIds: [...traceIdSet],
+            ...(input.traceUsage?.context
+              ? {
+                  billing: {
+                    planSlug: input.traceUsage.context.planSlug,
+                    planSource: input.traceUsage.context.planSource,
+                    periodStart: input.traceUsage.context.periodStart.toISOString(),
+                    periodEnd: input.traceUsage.context.periodEnd.toISOString(),
+                    includedCredits: input.traceUsage.context.includedCredits,
+                    overageAllowed: input.traceUsage.context.overageAllowed,
+                  },
+                }
+              : {}),
+          },
+        } satisfies DomainEvent)
+      }
     }).pipe(Effect.withSpan("spans.processIngestedSpans"))

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0a6] - 2026-05-14
+
+### Added
+
+- **Per-span project scoping** — `capture({"project_slug": ...})` routes the wrapping function (and its OTel children) to a specific Latitude project by stamping `latitude.project` on the span. Useful when one process emits to multiple projects (e.g. multiple agents sharing a runtime). Server-side precedence: span attribute `latitude.project` → OTEL resource attribute `latitude.project` → `X-Latitude-Project` header.
+- **Optional ctor `project_slug`** — `Latitude(api_key=...)` is now valid without a default project. When omitted the SDK sends no `X-Latitude-Project` header, and each `capture()` must set its own `project_slug` (or rely on a resource/span attribute). Existing callers passing `project_slug` in the ctor see no behavior change.
+
 ## [3.0.0a5] - 2026-05-13
 
 ### Added

--- a/packages/telemetry/python/examples/test_project_scoping_env.py
+++ b/packages/telemetry/python/examples/test_project_scoping_env.py
@@ -1,0 +1,71 @@
+"""
+Project scoping — env-driven default + per-capture override.
+
+Reads the default project slug from `LATITUDE_PROJECT_SLUG` and lets specific captures
+override it via `capture({"project_slug": ...})`. A common shape for services that run in
+many environments (staging/prod each have their own project slug) but still need to route
+a subset of spans elsewhere.
+
+Resolution precedence (highest → lowest):
+  1. capture({"project_slug": ...})         — emits `latitude.project` on the span
+  2. OTEL resource attribute `latitude.project`  — bare-OTEL setups
+  3. ctor `project_slug`                    — sent as `X-Latitude-Project` header
+
+The override slug (`evaluation-runs` below) must exist in the same org as `LATITUDE_API_KEY`.
+
+Required env vars:
+- LATITUDE_API_KEY
+- LATITUDE_PROJECT_SLUG  (env-driven default for the ctor)
+- OPENAI_API_KEY
+
+Install: uv add openai
+Run from `packages/telemetry/python/`:
+    uv run --env-file examples/.env python examples/test_project_scoping_env.py
+"""
+
+import os
+
+from openai import OpenAI
+
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations=["openai"],
+    disable_batch=True,
+)
+
+OVERRIDE_SLUG = "evaluation-runs"
+
+
+@capture("default-route")
+def default_route() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Reply with 'default' in one word."}],
+        max_tokens=10,
+    )
+    print("default-route →", r.choices[0].message.content)
+
+
+@capture("evaluation-batch", {"project_slug": OVERRIDE_SLUG})
+def evaluation_batch() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Reply with 'override' in one word."}],
+        max_tokens=10,
+    )
+    print(f"{OVERRIDE_SLUG} →", r.choices[0].message.content)
+
+
+def main() -> None:
+    default_route()
+    evaluation_batch()
+    latitude.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/telemetry/python/examples/test_project_scoping_multi.py
+++ b/packages/telemetry/python/examples/test_project_scoping_multi.py
@@ -1,0 +1,83 @@
+"""
+Project scoping — multi-project per-capture override.
+
+`Latitude(api_key=...)` is initialized *without* a default `project_slug`. Every `capture()`
+must declare its own `project_slug` and spans are routed per-capture via the
+`latitude.project` span attribute. Use this when a single process emits to several Latitude
+projects (e.g. multiple agents sharing one runtime).
+
+Both projects must exist in the org behind `LATITUDE_API_KEY`. The slugs below default to
+`primary` / `secondary` to match what `pnpm --filter @tools/live-seeds seed:multi-project-demo`
+provisions — run that once first and this example works without any UI clicks. Or override
+via `LATITUDE_PRIMARY_PROJECT_SLUG` / `LATITUDE_SECONDARY_PROJECT_SLUG` to target your own.
+
+Required env vars:
+- LATITUDE_API_KEY
+- OPENAI_API_KEY
+
+Optional env vars:
+- LATITUDE_PRIMARY_PROJECT_SLUG    (defaults to "primary")
+- LATITUDE_SECONDARY_PROJECT_SLUG  (defaults to "secondary")
+
+Install: uv add openai
+Run from `packages/telemetry/python/`:
+    uv run --env-file examples/.env python examples/test_project_scoping_multi.py
+"""
+
+import os
+
+from openai import OpenAI
+
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    instrumentations=["openai"],
+    disable_batch=True,
+)
+
+FULL_STACK_AGENT_SLUG = os.environ.get("LATITUDE_PRIMARY_PROJECT_SLUG", "primary")
+CALL_SUMMARISER_SLUG = os.environ.get("LATITUDE_SECONDARY_PROJECT_SLUG", "secondary")
+
+
+@capture(
+    "full-stack-agent-run",
+    {"project_slug": FULL_STACK_AGENT_SLUG, "tags": ["agent:full-stack"]},
+)
+def run_full_stack_agent() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Ship feature X — what's step 1? Reply in 5 words."}],
+        max_tokens=30,
+    )
+    print("full-stack-agent →", r.choices[0].message.content)
+
+
+@capture(
+    "call-summariser-run",
+    {"project_slug": CALL_SUMMARISER_SLUG, "tags": ["agent:summariser"]},
+)
+def run_call_summariser() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Summarize: 'Customer asked for refund.' in 4 words."}],
+        max_tokens=30,
+    )
+    print("call-summariser →", r.choices[0].message.content)
+
+
+def main() -> None:
+    run_full_stack_agent()
+    run_call_summariser()
+
+    # Spans with no `project_slug` AND no ctor default are rejected by the ingest service
+    # with a `partial_success` body — exporters log the rejection but don't retry. Always
+    # set a slug either on the ctor or on each `capture()` when running this pattern.
+
+    latitude.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/telemetry/python/examples/test_project_scoping_single.py
+++ b/packages/telemetry/python/examples/test_project_scoping_single.py
@@ -1,0 +1,61 @@
+"""
+Project scoping — single-project default (existing pattern).
+
+`Latitude(api_key=..., project_slug=...)` sets a default project for every span. `capture()`
+inherits it, so all spans land in the same Latitude project. This is the recommended setup
+for processes that emit to one project.
+
+Required env vars:
+- LATITUDE_API_KEY
+- LATITUDE_PROJECT_SLUG
+- OPENAI_API_KEY
+
+Install: uv add openai
+Run from `packages/telemetry/python/`:
+    uv run --env-file examples/.env python examples/test_project_scoping_single.py
+"""
+
+import os
+
+from openai import OpenAI
+
+from latitude_telemetry import Latitude, capture
+
+latitude = Latitude(
+    api_key=os.environ["LATITUDE_API_KEY"],
+    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    instrumentations=["openai"],
+    disable_batch=True,
+)
+
+
+@capture("greet")
+def greet() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Say 'Hello!' in exactly 2 words."}],
+        max_tokens=20,
+    )
+    print("greet →", r.choices[0].message.content)
+
+
+@capture("summarize", {"tags": ["demo"]})
+def summarize() -> None:
+    client = OpenAI()
+    r = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Summarize 'OpenAI is fun' in 3 words."}],
+        max_tokens=20,
+    )
+    print("summarize →", r.choices[0].message.content)
+
+
+def main() -> None:
+    greet()
+    summarize()
+    latitude.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a5"
+version = "3.0.0a6"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/constants/attributes.py
+++ b/packages/telemetry/python/src/latitude_telemetry/constants/attributes.py
@@ -9,3 +9,4 @@ class ATTRIBUTES:
     metadata = "latitude.metadata"
     session_id = "session.id"
     user_id = "user.id"
+    project = "latitude.project"

--- a/packages/telemetry/python/src/latitude_telemetry/exporter/exporter.py
+++ b/packages/telemetry/python/src/latitude_telemetry/exporter/exporter.py
@@ -6,7 +6,7 @@ from latitude_telemetry.util import Model
 
 class ExporterOptions(Model):
     api_key: str
-    project_slug: str
+    project_slug: str | None
     endpoint: str
     timeout: float
 
@@ -15,11 +15,13 @@ def create_exporter(options: ExporterOptions) -> SpanExporter:
     """
     Create an OTLP span exporter configured for Latitude.
     """
+    headers = {
+        "Authorization": f"Bearer {options.api_key}",
+    }
+    if options.project_slug:
+        headers["X-Latitude-Project"] = options.project_slug
     return OTLPSpanExporter(
         endpoint=f"{options.endpoint}/v1/traces",
-        headers={
-            "Authorization": f"Bearer {options.api_key}",
-            "X-Latitude-Project": options.project_slug,
-        },
+        headers=headers,
         timeout=int(options.timeout),
     )

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
@@ -43,12 +43,14 @@ class _LatitudeContextData:
         metadata: dict[str, object] | None = None,
         session_id: str | None = None,
         user_id: str | None = None,
+        project_slug: str | None = None,
     ):
         self.name = name
         self.tags = tags
         self.metadata = metadata
         self.session_id = session_id
         self.user_id = user_id
+        self.project_slug = project_slug
 
 
 def get_latitude_context(ctx: Context) -> _LatitudeContextData | None:
@@ -82,6 +84,7 @@ def _set_capture_context(name: str, base_context: Context, options: ContextOptio
         metadata=merged_metadata,
         session_id=opts.get("session_id") or (existing_data.session_id if existing_data else None),
         user_id=opts.get("user_id") or (existing_data.user_id if existing_data else None),
+        project_slug=opts.get("project_slug") or (existing_data.project_slug if existing_data else None),
     )
 
     return otel_context.set_value(LATITUDE_CONTEXT_KEY, merged_data, base_context)

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -73,7 +73,7 @@ class Latitude:
         self,
         *,
         api_key: str,
-        project_slug: str,
+        project_slug: str | None = None,
         instrumentations: list[InstrumentationType] | None = None,
         disable_redact: bool = False,
         redact: RedactSpanProcessorOptions | None = None,
@@ -87,8 +87,7 @@ class Latitude:
     ):
         if not api_key or not api_key.strip():
             raise ValueError("[Latitude] api_key is required and cannot be empty")
-        if not project_slug or not project_slug.strip():
-            raise ValueError("[Latitude] project_slug is required and cannot be empty")
+        normalized_project_slug = project_slug.strip() if project_slug and project_slug.strip() else None
 
         target_provider = tracer_provider or _get_registered_tracer_provider()
 
@@ -100,7 +99,7 @@ class Latitude:
 
         self._latitude_processor = LatitudeSpanProcessor(
             api_key=api_key,
-            project_slug=project_slug,
+            project_slug=normalized_project_slug,
             options=LatitudeSpanProcessorOptions(
                 disable_batch=disable_batch,
                 disable_redact=disable_redact,
@@ -194,7 +193,7 @@ class Latitude:
 
 def init_latitude(
     api_key: str,
-    project_slug: str,
+    project_slug: str | None = None,
     instrumentations: list[InstrumentationType] | None = None,
     disable_redact: bool = False,
     redact: RedactSpanProcessorOptions | None = None,

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
@@ -2,7 +2,7 @@
 Type definitions for the Latitude Telemetry SDK.
 """
 
-from typing import Callable, Literal, Required, TypedDict
+from typing import Callable, Literal, NotRequired, Required, TypedDict
 
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SpanExporter
@@ -35,11 +35,18 @@ class ContextOptions(TypedDict, total=False):
     metadata: dict[str, object]
     session_id: str
     user_id: str
+    # Route the capture (and all child spans) to a specific Latitude project.
+    # Overrides the ctor `project_slug` default for this capture only.
+    project_slug: str
 
 
 class LatitudeOptions(SmartFilterOptions, total=False):
     api_key: Required[str]
-    project_slug: Required[str]
+    # Optional default project slug. When omitted, every `capture()` MUST set its own
+    # `project_slug` (or rely on a per-span / OTEL resource attribute). When set, the SDK
+    # forwards it as the `X-Latitude-Project` header so spans without a per-span override
+    # land in this project.
+    project_slug: NotRequired[str]
     instrumentations: list[InstrumentationType]
     disable_redact: bool
     redact: RedactSpanProcessorOptions

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
@@ -100,7 +100,7 @@ class LatitudeSpanProcessor(SpanProcessor):
     def __init__(
         self,
         api_key: str,
-        project_slug: str,
+        project_slug: str | None,
         options: LatitudeSpanProcessorOptions | None = None,
     ):
         options = options or LatitudeSpanProcessorOptions()
@@ -165,6 +165,8 @@ class LatitudeSpanProcessor(SpanProcessor):
                 span.set_attribute(ATTRIBUTES.session_id, latitude_data.session_id)
             if latitude_data.user_id:
                 span.set_attribute(ATTRIBUTES.user_id, latitude_data.user_id)
+            if latitude_data.project_slug:
+                span.set_attribute(ATTRIBUTES.project, latitude_data.project_slug)
 
         self._tail.on_start(span, parent_context)
 

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -809,34 +809,34 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.3"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/92/ec9ad04d0b5728dca387a45af7bc98fbb0d73b2118759f5f6038b61a57e8/hf_xet-1.4.3.tar.gz", hash = "sha256:8ddedb73c8c08928c793df2f3401ec26f95be7f7e516a7bee2fbb546f6676113", size = 670477, upload-time = "2026-03-31T22:40:07.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/43/724d307b34e353da0abd476e02f72f735cdd2bc86082dee1b32ea0bfee1d/hf_xet-1.4.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7551659ba4f1e1074e9623996f28c3873682530aee0a846b7f2f066239228144", size = 3800935, upload-time = "2026-03-31T22:39:49.618Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/d2/8bee5996b699262edb87dbb54118d287c0e1b2fc78af7cdc41857ba5e3c4/hf_xet-1.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:bee693ada985e7045997f05f081d0e12c4c08bd7626dc397f8a7c487e6c04f7f", size = 3558942, upload-time = "2026-03-31T22:39:47.938Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/a1/e993d09cbe251196fb60812b09a58901c468127b7259d2bf0f68bf6088eb/hf_xet-1.4.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21644b404bb0100fe3857892f752c4d09642586fd988e61501c95bbf44b393a3", size = 4207657, upload-time = "2026-03-31T22:39:39.69Z" },
-    { url = "https://files.pythonhosted.org/packages/64/44/9eb6d21e5c34c63e5e399803a6932fa983cabdf47c0ecbcfe7ea97684b8c/hf_xet-1.4.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:987f09cfe418237812896a6736b81b1af02a3a6dcb4b4944425c4c4fca7a7cf8", size = 3986765, upload-time = "2026-03-31T22:39:37.936Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7b/8ad6f16fdb82f5f7284a34b5ec48645bd575bdcd2f6f0d1644775909c486/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:60cf7fc43a99da0a853345cf86d23738c03983ee5249613a6305d3e57a5dca74", size = 4188162, upload-time = "2026-03-31T22:39:58.382Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/c4/39d6e136cbeea9ca5a23aad4b33024319222adbdc059ebcda5fc7d9d5ff4/hf_xet-1.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2815a49a7a59f3e2edf0cf113ae88e8cb2ca2a221bf353fb60c609584f4884d4", size = 4424525, upload-time = "2026-03-31T22:40:00.225Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f2/adc32dae6bdbc367853118b9878139ac869419a4ae7ba07185dc31251b76/hf_xet-1.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:42ee323265f1e6a81b0e11094564fb7f7e0ec75b5105ffd91ae63f403a11931b", size = 3671610, upload-time = "2026-03-31T22:40:10.42Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/19/25d897dcc3f81953e0c2cde9ec186c7a0fee413eb0c9a7a9130d87d94d3a/hf_xet-1.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:27c976ba60079fb8217f485b9c5c7fcd21c90b0367753805f87cb9f3cdc4418a", size = 3528529, upload-time = "2026-03-31T22:40:09.106Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/36/3e8f85ca9fe09b8de2b2e10c63b3b3353d7dda88a0b3d426dffbe7b8313b/hf_xet-1.4.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5251d5ece3a81815bae9abab41cf7ddb7bcb8f56411bce0827f4a3071c92fdc6", size = 3801019, upload-time = "2026-03-31T22:39:56.651Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/9c/defb6cb1de28bccb7bd8d95f6e60f72a3d3fa4cb3d0329c26fb9a488bfe7/hf_xet-1.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2", size = 3558746, upload-time = "2026-03-31T22:39:54.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/bd/8d001191893178ff8e826e46ad5299446e62b93cd164e17b0ffea08832ec/hf_xet-1.4.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b301fc150290ca90b4fccd079829b84bb4786747584ae08b94b4577d82fb791", size = 4207692, upload-time = "2026-03-31T22:39:46.246Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/48/6790b402803250e9936435613d3a78b9aaeee7973439f0918848dde58309/hf_xet-1.4.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d972fbe95ddc0d3c0fc49b31a8a69f47db35c1e3699bf316421705741aab6653", size = 3986281, upload-time = "2026-03-31T22:39:44.648Z" },
-    { url = "https://files.pythonhosted.org/packages/51/56/ea62552fe53db652a9099eda600b032d75554d0e86c12a73824bfedef88b/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c5b48db1ee344a805a1b9bd2cda9b6b65fe77ed3787bd6e87ad5521141d317cd", size = 4187414, upload-time = "2026-03-31T22:40:04.951Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/f5/bc1456d4638061bea997e6d2db60a1a613d7b200e0755965ec312dc1ef79/hf_xet-1.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:22bdc1f5fb8b15bf2831440b91d1c9bbceeb7e10c81a12e8d75889996a5c9da8", size = 4424368, upload-time = "2026-03-31T22:40:06.347Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/76/ab597bae87e1f06d18d3ecb8ed7f0d3c9a37037fc32ce76233d369273c64/hf_xet-1.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07", size = 3672280, upload-time = "2026-03-31T22:40:16.401Z" },
-    { url = "https://files.pythonhosted.org/packages/62/05/2e462d34e23a09a74d73785dbed71cc5dbad82a72eee2ad60a72a554155d/hf_xet-1.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:681c92a07796325778a79d76c67011764ecc9042a8c3579332b61b63ae512075", size = 3528945, upload-time = "2026-03-31T22:40:14.995Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/9f/9c23e4a447b8f83120798f9279d0297a4d1360bdbf59ef49ebec78fe2545/hf_xet-1.4.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d0da85329eaf196e03e90b84c2d0aca53bd4573d097a75f99609e80775f98025", size = 3805048, upload-time = "2026-03-31T22:39:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/f8/7aacb8e5f4a7899d39c787b5984e912e6c18b11be136ef13947d7a66d265/hf_xet-1.4.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583", size = 3562178, upload-time = "2026-03-31T22:39:51.295Z" },
-    { url = "https://files.pythonhosted.org/packages/df/9a/a24b26dc8a65f0ecc0fe5be981a19e61e7ca963b85e062c083f3a9100529/hf_xet-1.4.3-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08", size = 4212320, upload-time = "2026-03-31T22:39:42.922Z" },
-    { url = "https://files.pythonhosted.org/packages/53/60/46d493db155d2ee2801b71fb1b0fd67696359047fdd8caee2c914cc50c79/hf_xet-1.4.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39f2d2e9654cd9b4319885733993807aab6de9dfbd34c42f0b78338d6617421f", size = 3991546, upload-time = "2026-03-31T22:39:41.335Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f5/067363e1c96c6b17256910830d1b54099d06287e10f4ec6ec4e7e08371fc/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:49ad8a8cead2b56051aa84d7fce3e1335efe68df3cf6c058f22a65513885baac", size = 4193200, upload-time = "2026-03-31T22:40:01.936Z" },
-    { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/8fc8996afe5815fa1a6be8e9e5c02f24500f409d599e905800d498a4e14d/hf_xet-1.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c", size = 4023495, upload-time = "2026-05-06T06:18:01.94Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/93d84463c00cecb561a7508aa6303e35ee2894294eac14245526924415fe/hf_xet-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73", size = 3792731, upload-time = "2026-05-06T06:18:00.021Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/5a/8ec8e0c863b382d00b3c2e2af6ded6b06371be617144a625903a6d562f4b/hf_xet-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682", size = 4456738, upload-time = "2026-05-06T06:17:49.574Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ca/f7effa1a67717da2bcc6b6c28f71c6ca648c77acaec4e2c32f40cbe16d85/hf_xet-1.5.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761", size = 4251622, upload-time = "2026-05-06T06:17:47.096Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f2/19247dba3e231cf77dec59ddfb878f00057635ff773d099c9b59d37812c3/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded", size = 4445667, upload-time = "2026-05-06T06:18:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/64/6f116801a3bcfb6f59f5c251f48cadc47ea54026441c4a385079286a94fa/hf_xet-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702", size = 4664619, upload-time = "2026-05-06T06:18:13.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/069542d37946ed08669b127e1496fa99e78196d71de8d41eda5e9f1b7a58/hf_xet-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e", size = 3966802, upload-time = "2026-05-06T06:18:28.162Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/91/fc6fdec27b14d04e88c386ac0a0129732b53fa23f7c4a78f4b83a039c567/hf_xet-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0", size = 3797168, upload-time = "2026-05-06T06:18:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
 ]
 
 [[package]]
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.13.0"
+version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -891,9 +891,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/ff/ec7ed2eb43bd7ce8bb2233d109cc235c3e807ffe5e469dc09db261fac05e/huggingface_hub-1.13.0.tar.gz", hash = "sha256:f6df2dac5abe82ce2fe05873d10d5ff47bc677d616a2f521f4ee26db9415d9d0", size = 781788, upload-time = "2026-04-30T11:57:33.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/db/4b1cdae9460ae1f3ca020cd767f013430ce23eb1d9c890ae3a0609b38d26/huggingface_hub-1.13.0-py3-none-any.whl", hash = "sha256:e942cb50d6a08dd5306688b1ac05bda157fd2fcc88b63dae405f7bd0d3234005", size = 660643, upload-time = "2026-04-30T11:57:31.802Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.0.0a5"
+version = "3.0.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.10] - 2026-05-14
+
+### Added
+
+- **Per-span project scoping** — `capture({ projectSlug })` routes the wrapping span (and its OTel children) to a specific Latitude project by stamping `latitude.project` on the span. Useful when one process emits to multiple projects (e.g. multiple agents sharing a runtime). Server-side precedence: span attribute `latitude.project` → OTEL resource attribute `latitude.project` → `X-Latitude-Project` header.
+- **Optional ctor `projectSlug`** — `new Latitude({ apiKey })` is now valid without a default project. When omitted the SDK sends no `X-Latitude-Project` header, and each `capture()` must set its own `projectSlug` (or rely on a resource/span attribute). Existing customers passing `projectSlug` in the ctor see no behavior change.
+
 ## [3.0.0-alpha.9] - 2026-05-13
 
 ### Breaking Changes

--- a/packages/telemetry/typescript/examples/test_project_scoping_env.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_env.ts
@@ -1,0 +1,73 @@
+/**
+ * Project scoping — env-driven default + per-capture override.
+ *
+ * Reads the default project slug from `LATITUDE_PROJECT_SLUG` and lets specific captures
+ * override it via `capture({ projectSlug })`. A common shape for services that run in many
+ * environments (staging/prod each have their own project slug) but still need to route a
+ * subset of spans elsewhere.
+ *
+ * Resolution precedence (highest → lowest):
+ *   1. `capture({ projectSlug })`           — emits `latitude.project` on the span
+ *   2. OTEL resource attribute `latitude.project`  — bare-OTEL setups
+ *   3. ctor `projectSlug`                   — sent as `X-Latitude-Project` header
+ *
+ * The override slug (`evaluation-runs` below) must exist in the same org as `LATITUDE_API_KEY`.
+ *
+ * Required env vars:
+ *   - LATITUDE_API_KEY
+ *   - LATITUDE_PROJECT_SLUG  (env-driven default for the ctor)
+ *   - OPENAI_API_KEY
+ *
+ * Install:  npm install openai
+ * Run from `packages/telemetry/typescript/`:
+ *   npx tsx --env-file=examples/.env examples/test_project_scoping_env.ts
+ */
+
+import OpenAI from "openai"
+import { capture, Latitude } from "../src"
+
+const DEFAULT_SLUG = process.env.LATITUDE_PROJECT_SLUG!
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: DEFAULT_SLUG,
+  disableBatch: true,
+  instrumentations: ["openai"],
+})
+
+const OVERRIDE_SLUG = "evaluation-runs"
+
+async function main() {
+  await latitude.ready
+  const client = new OpenAI()
+
+  // Inherits the env-driven default — lands in `LATITUDE_PROJECT_SLUG`.
+  await capture("default-route", async () => {
+    const r = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: `Reply with '${DEFAULT_SLUG}' in one word.` }],
+      max_tokens: 10,
+    })
+    console.log("default-route →", r.choices[0]?.message?.content)
+  })
+
+  // Per-capture override beats the ctor default. Routes to `evaluation-runs` regardless of env.
+  await capture(
+    "evaluation-batch",
+    async () => {
+      const r = await client.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "Reply with 'override' in one word." }],
+        max_tokens: 10,
+      })
+      console.log(`${OVERRIDE_SLUG} →`, r.choices[0]?.message?.content)
+    },
+    { projectSlug: OVERRIDE_SLUG },
+  )
+
+  await latitude.flush()
+}
+
+void main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
@@ -1,0 +1,79 @@
+/**
+ * Project scoping — multi-project per-capture override.
+ *
+ * `new Latitude({ apiKey })` is initialized *without* a default `projectSlug`. Every `capture()`
+ * must declare its own `projectSlug` and spans are routed per-capture via the
+ * `latitude.project` span attribute. Use this when a single process emits to several Latitude
+ * projects (e.g. multiple agents sharing one runtime).
+ *
+ * Both projects must exist in the org behind `LATITUDE_API_KEY`. The slugs below default to
+ * `primary` / `secondary` to match what `pnpm --filter @tools/live-seeds seed:multi-project-demo`
+ * provisions — run that once first and this example works without any UI clicks. Or override
+ * via `LATITUDE_PRIMARY_PROJECT_SLUG` / `LATITUDE_SECONDARY_PROJECT_SLUG` to target your own.
+ *
+ * Required env vars:
+ *   - LATITUDE_API_KEY
+ *   - OPENAI_API_KEY
+ *
+ * Optional env vars:
+ *   - LATITUDE_PRIMARY_PROJECT_SLUG    (defaults to "primary")
+ *   - LATITUDE_SECONDARY_PROJECT_SLUG  (defaults to "secondary")
+ *
+ * Install:  npm install openai
+ * Run from `packages/telemetry/typescript/`:
+ *   npx tsx --env-file=examples/.env examples/test_project_scoping_multi.ts
+ */
+
+import OpenAI from "openai"
+import { capture, Latitude } from "../src"
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  disableBatch: true,
+  instrumentations: ["openai"],
+})
+
+const FULL_STACK_AGENT_SLUG = "primary"
+const CALL_SUMMARISER_SLUG = "secondary"
+
+async function main() {
+  await latitude.ready
+  const client = new OpenAI()
+
+  await capture(
+    "full-stack-agent-run",
+    async () => {
+      const r = await client.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "Ship feature X — what's step 1? Reply in 5 words." }],
+        max_tokens: 30,
+      })
+      console.log(`${FULL_STACK_AGENT_SLUG} →`, r.choices[0]?.message?.content)
+    },
+    { projectSlug: FULL_STACK_AGENT_SLUG, tags: ["agent:full-stack"] },
+  )
+
+  await capture(
+    "call-summariser-run",
+    async () => {
+      const r = await client.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "Summarize: 'Customer asked for refund.' in 4 words." }],
+        max_tokens: 30,
+      })
+      console.log(`${CALL_SUMMARISER_SLUG} →`, r.choices[0]?.message?.content)
+    },
+    { projectSlug: CALL_SUMMARISER_SLUG, tags: ["agent:summariser"] },
+  )
+
+  // Spans with no `projectSlug` AND no ctor default are rejected by the ingest service with
+  // a `partial_success` body — exporters log the rejection but don't retry. Always set a slug
+  // either on the ctor or on each `capture()` when running this pattern.
+
+  await latitude.flush()
+}
+
+void main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/telemetry/typescript/examples/test_project_scoping_single.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_single.ts
@@ -1,0 +1,62 @@
+/**
+ * Project scoping — single-project default (existing pattern).
+ *
+ * `new Latitude({ apiKey, projectSlug })` sets a default project for every span. `capture()`
+ * inherits it, so all spans land in the same Latitude project. This is the recommended setup
+ * for processes that emit to one project.
+ *
+ * Required env vars:
+ *   - LATITUDE_API_KEY
+ *   - LATITUDE_PROJECT_SLUG
+ *   - OPENAI_API_KEY
+ *
+ * Install:  npm install openai
+ * Run from `packages/telemetry/typescript/`:
+ *   npx tsx --env-file=examples/.env examples/test_project_scoping_single.ts
+ */
+
+import OpenAI from "openai"
+import { capture, Latitude } from "../src"
+
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  disableBatch: true,
+  instrumentations: ["openai"],
+})
+
+async function main() {
+  await latitude.ready
+  const client = new OpenAI()
+
+  // Both captures inherit the ctor `projectSlug` (sent as the `X-Latitude-Project` header).
+  // The OpenAI spans land in the default project alongside the capture root span.
+  await capture("greet", async () => {
+    const r = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: "Say 'Hello!' in exactly 2 words." }],
+      max_tokens: 20,
+    })
+    console.log("greet →", r.choices[0]?.message?.content)
+  })
+
+  await capture(
+    "summarize",
+    async () => {
+      const r = await client.chat.completions.create({
+        model: "gpt-4o-mini",
+        messages: [{ role: "user", content: "Summarize 'OpenAI is fun' in 3 words." }],
+        max_tokens: 20,
+      })
+      console.log("summarize →", r.choices[0]?.message?.content)
+    },
+    { tags: ["demo"] },
+  )
+
+  await latitude.flush()
+}
+
+void main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.9",
+  "version": "3.0.0-alpha.10",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/constants/attributes.ts
+++ b/packages/telemetry/typescript/src/constants/attributes.ts
@@ -4,4 +4,5 @@ export const ATTRIBUTES = {
   metadata: "latitude.metadata",
   sessionId: "session.id",
   userId: "user.id",
+  project: "latitude.project",
 } as const

--- a/packages/telemetry/typescript/src/sdk/context.test.ts
+++ b/packages/telemetry/typescript/src/sdk/context.test.ts
@@ -73,6 +73,54 @@ describe("capture", () => {
     )
   })
 
+  it("propagates projectSlug from capture options onto the context", () => {
+    capture(
+      "scoped",
+      () => {
+        const ctx = context.active()
+        const data = getLatitudeContext(ctx)
+        expect(data?.projectSlug).toBe("call-summariser")
+      },
+      { projectSlug: "call-summariser" },
+    )
+  })
+
+  it("nested capture without projectSlug inherits the outer one", () => {
+    capture(
+      "outer",
+      () => {
+        capture(
+          "inner",
+          () => {
+            const ctx = context.active()
+            const data = getLatitudeContext(ctx)
+            expect(data?.projectSlug).toBe("primary")
+          },
+          { tags: ["inner"] },
+        )
+      },
+      { projectSlug: "primary" },
+    )
+  })
+
+  it("inner capture's projectSlug overrides the outer default", () => {
+    capture(
+      "outer",
+      () => {
+        capture(
+          "inner",
+          () => {
+            const ctx = context.active()
+            const data = getLatitudeContext(ctx)
+            expect(data?.projectSlug).toBe("evaluation-runs")
+          },
+          { projectSlug: "evaluation-runs" },
+        )
+      },
+      { projectSlug: "primary" },
+    )
+  })
+
   it("should allow inner capture to override sessionId and userId", () => {
     capture(
       "outer",

--- a/packages/telemetry/typescript/src/sdk/context.ts
+++ b/packages/telemetry/typescript/src/sdk/context.ts
@@ -20,6 +20,7 @@ type LatitudeContextData = {
   metadata: Record<string, unknown> | undefined
   sessionId: string | undefined
   userId: string | undefined
+  projectSlug: string | undefined
 }
 
 export function getLatitudeContext(ctx: Context): LatitudeContextData | undefined {
@@ -49,6 +50,7 @@ export function capture<T>(name: string, fn: () => T | Promise<T>, options: Cont
     metadata: { ...existingData?.metadata, ...options.metadata },
     sessionId: options.sessionId ?? existingData?.sessionId,
     userId: options.userId ?? existingData?.userId,
+    projectSlug: options.projectSlug ?? existingData?.projectSlug,
   }
 
   const newContext = parentContext.setValue(LATITUDE_CONTEXT_KEY, mergedData)

--- a/packages/telemetry/typescript/src/sdk/init.test.ts
+++ b/packages/telemetry/typescript/src/sdk/init.test.ts
@@ -16,8 +16,9 @@ describe("Latitude", () => {
     expect(() => new Latitude({ apiKey: "", projectSlug: "test" })).toThrow("apiKey is required")
   })
 
-  it("should throw if projectSlug is missing", () => {
-    expect(() => new Latitude({ apiKey: "test", projectSlug: "" })).toThrow("projectSlug is required")
+  it("accepts an empty or omitted projectSlug (per-capture scoping covers the rest)", () => {
+    expect(() => new Latitude({ apiKey: "test", projectSlug: "" })).not.toThrow()
+    expect(() => new Latitude({ apiKey: "test" })).not.toThrow()
   })
 
   it("should return provider, flush, shutdown, and ready functions", async () => {

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -76,9 +76,6 @@ export class Latitude {
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")
     }
-    if (!projectSlug || projectSlug.trim() === "") {
-      throw new Error("[Latitude] projectSlug is required and cannot be empty")
-    }
 
     const targetProvider = tracerProvider ?? getRegisteredTracerProvider()
 

--- a/packages/telemetry/typescript/src/sdk/processor.test.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.test.ts
@@ -31,8 +31,37 @@ describe("LatitudeSpanProcessor", () => {
     expect(() => new LatitudeSpanProcessor("", projectSlug)).toThrow("apiKey is required")
   })
 
-  it("should throw if projectSlug is empty", () => {
-    expect(() => new LatitudeSpanProcessor(apiKey, "")).toThrow("projectSlug is required")
+  it("allows an undefined projectSlug (per-capture scoping covers the rest)", () => {
+    expect(() => new LatitudeSpanProcessor(apiKey, undefined)).not.toThrow()
+    expect(() => new LatitudeSpanProcessor(apiKey, "")).not.toThrow()
+  })
+
+  it("stamps `latitude.project` on the span when capture sets projectSlug", () => {
+    const processor = new LatitudeSpanProcessor(apiKey, "fallback-slug")
+    const mockSpan = createMockRootSpan()
+
+    capture(
+      "agent-run",
+      () => {
+        const ctx = context.active()
+        processor.onStart(mockSpan as unknown as Span, ctx)
+
+        expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.project, "call-summariser")
+      },
+      { projectSlug: "call-summariser" },
+    )
+  })
+
+  it("does not stamp `latitude.project` when no projectSlug is provided anywhere", () => {
+    const processor = new LatitudeSpanProcessor(apiKey, undefined)
+    const mockSpan = createMockRootSpan()
+
+    capture("agent-run", () => {
+      const ctx = context.active()
+      processor.onStart(mockSpan as unknown as Span, ctx)
+
+      expect(mockSpan.setAttribute).not.toHaveBeenCalledWith(ATTRIBUTES.project, expect.anything())
+    })
   })
 
   it("should stamp latitude attributes from context on span start", () => {

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -62,23 +62,23 @@ class ServiceNameResourceExporter implements SpanExporter {
 export class LatitudeSpanProcessor implements SpanProcessor {
   private readonly tail: SpanProcessor
 
-  constructor(apiKey: string, projectSlug: string, options?: LatitudeSpanProcessorOptions) {
+  constructor(apiKey: string, projectSlug: string | undefined, options?: LatitudeSpanProcessorOptions) {
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")
     }
-    if (!projectSlug || projectSlug.trim() === "") {
-      throw new Error("[Latitude] projectSlug is required and cannot be empty")
+
+    const normalizedProjectSlug = projectSlug && projectSlug.trim() !== "" ? projectSlug : undefined
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
     }
+    if (normalizedProjectSlug) headers["X-Latitude-Project"] = normalizedProjectSlug
 
     const baseExporter =
       options?.exporter ??
       new OTLPTraceExporter({
         url: `${env.EXPORTER_URL}/v1/traces`,
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-          "X-Latitude-Project": projectSlug,
-        },
+        headers,
         timeoutMillis: 30_000,
       })
 
@@ -126,6 +126,9 @@ export class LatitudeSpanProcessor implements SpanProcessor {
       }
       if (latitudeData.userId) {
         span.setAttribute(ATTRIBUTES.userId, latitudeData.userId)
+      }
+      if (latitudeData.projectSlug) {
+        span.setAttribute(ATTRIBUTES.project, latitudeData.projectSlug)
       }
     }
 

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -10,11 +10,28 @@ export type ContextOptions = {
   metadata?: Record<string, unknown>
   sessionId?: string
   userId?: string
+  /**
+   * Route the capture (and all child spans) to a specific Latitude project.
+   *
+   * Overrides the ctor `projectSlug` default for this capture only. Useful when one process
+   * emits to multiple projects (e.g. multiple agents in the same service).
+   */
+  projectSlug?: string
 }
 
 export type LatitudeOptions = SmartFilterOptions & {
   apiKey: string
-  projectSlug: string
+  /**
+   * Default project slug for spans emitted by this SDK instance.
+   *
+   * Optional — when omitted, every `capture()` call MUST set its own `projectSlug` (or rely on
+   * an OTEL resource attribute / per-span attribute). When set, the SDK forwards it as the
+   * `X-Latitude-Project` header so spans without a per-span override land in this project.
+   *
+   * Precedence on the server (highest first): span attribute `latitude.project` →
+   * OTEL resource attribute `latitude.project` → `X-Latitude-Project` header.
+   */
+  projectSlug?: string
   instrumentations?: InstrumentationType[]
   disableRedact?: boolean
   redact?: RedactSpanProcessorOptions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,9 +292,6 @@ importers:
       '@domain/billing':
         specifier: workspace:*
         version: link:../../packages/domain/billing
-      '@domain/projects':
-        specifier: workspace:^
-        version: link:../../packages/domain/projects
       '@domain/queue':
         specifier: workspace:*
         version: link:../../packages/domain/queue

--- a/tools/live-seeds/package.json
+++ b/tools/live-seeds/package.json
@@ -13,7 +13,8 @@
     "format": "biome format --write src && biome check --fix src",
     "typecheck": "tsgo -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests --dir src",
-    "seed:live-seeds": "node --import tsx src/scripts/send-live-seeds.ts"
+    "seed:live-seeds": "node --import tsx src/scripts/send-live-seeds.ts",
+    "seed:multi-project-demo": "node --import tsx src/scripts/send-multi-project-demo.ts"
   },
   "dependencies": {
     "@domain/annotation-queues": "workspace:*",

--- a/tools/live-seeds/src/runtime.ts
+++ b/tools/live-seeds/src/runtime.ts
@@ -905,7 +905,8 @@ async function postSpanToIngest(
     body: JSON.stringify(request),
   })
 
-  if (response.status !== 202) {
+  // OTLP allows 200 (full success / partial_success) and we also accept the legacy 202.
+  if (response.status < 200 || response.status >= 300) {
     const body = await response.text()
     throw new Error(`Failed to ingest trace ${traceId}: ${response.status} ${response.statusText}\n${body}`)
   }

--- a/tools/live-seeds/src/scripts/send-multi-project-demo.ts
+++ b/tools/live-seeds/src/scripts/send-multi-project-demo.ts
@@ -1,0 +1,303 @@
+/**
+ * Multi-project ingest smoke test.
+ *
+ * Sends one OTLP batch that mixes spans across two projects (`primary`, `secondary`) and one
+ * unscoped span, then a second batch with only unscoped spans. Used to verify the per-span
+ * project resolution chain and the OTLP `partial_success` response shape end-to-end against a
+ * locally-running ingest service.
+ *
+ * Default flow:
+ *   1. Resolves the seeded org (Acme) and ensures the `primary` and `secondary` projects exist.
+ *   2. POSTs one batch with three spans:
+ *        - span A: `latitude.project = primary`
+ *        - span B: `latitude.project = secondary`
+ *        - span C: no `latitude.project` (falls back to `X-Latitude-Project: primary`)
+ *      Expected: 200 OK with no `partialSuccess`.
+ *   3. POSTs a second batch with one span carrying an unknown slug AND no header default.
+ *      Expected: 400 with a `google.rpc.Status`-shaped body `{ code, message }`.
+ *
+ * Run with `pnpm --filter @tools/live-seeds exec tsx src/scripts/send-multi-project-demo.ts`.
+ */
+
+import { randomBytes } from "node:crypto"
+import { existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { parseArgs } from "node:util"
+import { createProjectUseCase, ProjectRepository } from "@domain/projects"
+import { SEED_API_KEY_TOKEN, SEED_ORG_ID } from "@domain/shared/seeding"
+import {
+  closePostgres,
+  createPostgresClient,
+  OutboxEventWriterLive,
+  ProjectRepositoryLive,
+  withPostgres,
+} from "@platform/db-postgres"
+import { parseEnv } from "@platform/env"
+import { Effect, Layer } from "effect"
+
+function loadEnv(importMetaUrl: string): void {
+  const nodeEnv = process.env.NODE_ENV ?? "development"
+  const envPath = fileURLToPath(new URL(`../../../../.env.${nodeEnv}`, importMetaUrl))
+  if (existsSync(envPath)) process.loadEnvFile(envPath)
+}
+
+function resolveIngestBaseUrl(): string {
+  const port = Effect.runSync(parseEnv("LAT_INGEST_PORT", "number", 3002))
+  return `http://127.0.0.1:${port.toString()}`
+}
+
+const PRIMARY_SLUG = "primary"
+const SECONDARY_SLUG = "secondary"
+
+async function ensureProjects(): Promise<void> {
+  const client = createPostgresClient()
+  try {
+    for (const slug of [PRIMARY_SLUG, SECONDARY_SLUG]) {
+      const existing = await Effect.runPromise(
+        Effect.gen(function* () {
+          const repo = yield* ProjectRepository
+          return yield* repo.findBySlug(slug)
+        }).pipe(withPostgres(ProjectRepositoryLive, client, SEED_ORG_ID)),
+      ).catch((error: unknown) => {
+        if (error instanceof Error && "_tag" in error && error._tag === "NotFoundError") {
+          return null
+        }
+        throw error
+      })
+
+      if (existing) continue
+
+      // Go through the use case (not `repo.save` directly) so the ProjectCreated
+      // outbox event is written. That triggers the projects:provision queue and
+      // flagger auto-provisioning, matching the path taken by real user-created
+      // projects.
+      const created = await Effect.runPromise(
+        createProjectUseCase({ name: slug }).pipe(
+          withPostgres(Layer.mergeAll(ProjectRepositoryLive, OutboxEventWriterLive), client, SEED_ORG_ID),
+        ),
+      )
+      if (created.slug !== slug) {
+        throw new Error(`[live-seeds] expected slug "${slug}" but use case derived "${created.slug}"`)
+      }
+      console.log(`[live-seeds] Created project "${slug}" in the Acme seed org`)
+    }
+  } finally {
+    await closePostgres(client.pool)
+  }
+}
+
+const hexId = (bytes: number) => randomBytes(bytes).toString("hex")
+
+// Unique trace per script run so reruns don't dedupe in ClickHouse and each Batch shows up as
+// its own trace in the UI.
+const RUN_TRACE_ID = hexId(16) // 32-char OTLP trace id
+
+function nowNanos(offsetMs = 0): string {
+  return (BigInt(Date.now() + offsetMs) * 1_000_000n).toString()
+}
+
+type OtlpAttr = { key: string; value: { stringValue: string } } | { key: string; value: { intValue: string } }
+
+/**
+ * Builds a realistic OTel GenAI "chat" span — model, provider, input/output messages, token
+ * usage — so the UI shows the routed traces with full content. Matches the attribute keys the
+ * server-side transform reads (`gen_ai.*`).
+ */
+function buildSpan(
+  name: string,
+  options: {
+    projectSlug?: string
+    userPrompt: string
+    assistantReply: string
+    tags: readonly string[]
+  },
+) {
+  const { projectSlug, userPrompt, assistantReply, tags } = options
+  const attributes: OtlpAttr[] = [
+    { key: "gen_ai.operation.name", value: { stringValue: "chat" } },
+    { key: "gen_ai.provider.name", value: { stringValue: "openai" } },
+    { key: "gen_ai.request.model", value: { stringValue: "gpt-4o-mini" } },
+    { key: "gen_ai.response.model", value: { stringValue: "gpt-4o-mini-2026-01-01" } },
+    { key: "gen_ai.response.id", value: { stringValue: `chatcmpl-${hexId(6)}` } },
+    { key: "gen_ai.usage.input_tokens", value: { intValue: String(20 + userPrompt.length) } },
+    { key: "gen_ai.usage.output_tokens", value: { intValue: String(10 + assistantReply.length) } },
+    {
+      key: "gen_ai.input.messages",
+      value: {
+        stringValue: JSON.stringify([{ role: "user", parts: [{ type: "text", content: userPrompt }] }]),
+      },
+    },
+    {
+      key: "gen_ai.output.messages",
+      value: {
+        stringValue: JSON.stringify([{ role: "assistant", parts: [{ type: "text", content: assistantReply }] }]),
+      },
+    },
+    // Latitude tags travel as a JSON-stringified array under `latitude.tags`.
+    { key: "latitude.tags", value: { stringValue: JSON.stringify(tags) } },
+  ]
+  if (projectSlug) attributes.push({ key: "latitude.project", value: { stringValue: projectSlug } })
+
+  return {
+    traceId: RUN_TRACE_ID,
+    spanId: hexId(8), // 16-char OTLP span id
+    name,
+    kind: 3, // CLIENT — matches OTel convention for outbound LLM calls
+    startTimeUnixNano: nowNanos(),
+    endTimeUnixNano: nowNanos(250),
+    attributes,
+    status: { code: 1 },
+  }
+}
+
+function buildBatch(spans: ReturnType<typeof buildSpan>[]) {
+  return {
+    resourceSpans: [
+      {
+        resource: { attributes: [{ key: "service.name", value: { stringValue: "live-seeds" } }] },
+        scopeSpans: [{ scope: { name: "multi-project-demo", version: "1.0.0" }, spans }],
+      },
+    ],
+  }
+}
+
+async function postBatch(
+  ingestBaseUrl: string,
+  apiKey: string,
+  body: object,
+  options: { readonly defaultProjectSlug?: string } = {},
+): Promise<{ status: number; body: string }> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  }
+  if (options.defaultProjectSlug) headers["X-Latitude-Project"] = options.defaultProjectSlug
+
+  const response = await fetch(`${ingestBaseUrl.replace(/\/$/, "")}/v1/traces`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  })
+  const text = await response.text()
+  return { status: response.status, body: text }
+}
+
+async function main(): Promise<void> {
+  loadEnv(import.meta.url)
+
+  const { values } = parseArgs({
+    options: {
+      "ingest-url": { type: "string" },
+      "api-key-token": { type: "string" },
+      help: { type: "boolean", default: false },
+    },
+  })
+
+  if (values.help) {
+    console.log(`
+Usage: pnpm --filter @tools/live-seeds exec tsx src/scripts/send-multi-project-demo.ts [options]
+
+Options:
+  --ingest-url <url>     Base URL for the ingest service (default: LAT_INGEST_PORT)
+  --api-key-token <tok>  Ingest API key (default: seed token)
+  --help                 Show this help
+`)
+    process.exit(0)
+  }
+
+  const ingestBaseUrl = values["ingest-url"] ?? resolveIngestBaseUrl()
+  const apiKey = values["api-key-token"] ?? SEED_API_KEY_TOKEN
+
+  console.log("[live-seeds] Ensuring `primary` and `secondary` projects exist in the seed org...")
+  await ensureProjects()
+
+  console.log("\n[live-seeds] Batch 1 — mixed (primary span + secondary span + header-default span)")
+  const mixedBatch = buildBatch([
+    buildSpan("chat gpt-4o-mini", {
+      projectSlug: PRIMARY_SLUG,
+      tags: ["batch-1", "primary"],
+      userPrompt: "Summarize the day's standup notes in 2 sentences.",
+      assistantReply: "Team shipped the new ingest path and unblocked Carlos on the Realtie agent.",
+    }),
+    buildSpan("chat gpt-4o-mini", {
+      projectSlug: SECONDARY_SLUG,
+      tags: ["batch-1", "secondary"],
+      userPrompt: "Transcribe the customer call snippet attached.",
+      assistantReply: "Customer asked about pricing for the enterprise plan; said they'd email next week.",
+    }),
+    buildSpan("chat gpt-4o-mini", {
+      tags: ["batch-1", "header-default"],
+      userPrompt: "What's the weather like in Barcelona today?",
+      assistantReply: "Sunny, around 22°C — typical late-spring weather.",
+    }),
+  ])
+  const r1 = await postBatch(ingestBaseUrl, apiKey, mixedBatch, { defaultProjectSlug: PRIMARY_SLUG })
+  console.log(`  HTTP ${r1.status}\n  ${r1.body}`)
+  if (r1.status !== 200) {
+    console.error("Expected 200 for the mixed-but-all-resolvable batch")
+    process.exitCode = 1
+  }
+
+  console.log("\n[live-seeds] Batch 2 — all spans rejected (unknown slug + no header, expect 400 + Status body)")
+  const rejectedBatch = buildBatch([
+    buildSpan("chat gpt-4o-mini", {
+      projectSlug: "no-such-project-slug",
+      tags: ["batch-2", "should-not-appear"],
+      userPrompt: "This span should never land — its slug doesn't exist in the org.",
+      assistantReply: "(should be rejected by ingest)",
+    }),
+  ])
+  const r2 = await postBatch(ingestBaseUrl, apiKey, rejectedBatch)
+  console.log(`  HTTP ${r2.status}\n  ${r2.body}`)
+  if (r2.status !== 400) {
+    console.error("Expected 400 for the all-rejected batch (unknown slug + no header)")
+    process.exitCode = 1
+  }
+
+  console.log("\n[live-seeds] Batch 3 — partial_success (one valid + one wrong-org slug)")
+  const partialBatch = buildBatch([
+    buildSpan("chat gpt-4o-mini", {
+      projectSlug: PRIMARY_SLUG,
+      tags: ["batch-3", "primary"],
+      userPrompt: "Draft a follow-up email to the customer.",
+      assistantReply: "Hi Alex, thanks for the chat — sharing the enterprise pricing breakdown below…",
+    }),
+    buildSpan("chat gpt-4o-mini", {
+      projectSlug: "no-such-project-slug",
+      tags: ["batch-3", "should-not-appear"],
+      userPrompt: "This one should be rejected (wrong-org slug).",
+      assistantReply: "(should be counted in partialSuccess.rejectedSpans)",
+    }),
+  ])
+  const r3 = await postBatch(ingestBaseUrl, apiKey, partialBatch)
+  console.log(`  HTTP ${r3.status}\n  ${r3.body}`)
+  if (r3.status !== 200 || !r3.body.includes("partialSuccess")) {
+    console.error("Expected 200 with partialSuccess for the mixed-rejection batch")
+    process.exitCode = 1
+  }
+
+  console.log(`
+[live-seeds] What to expect in the Latitude UI (trace id = ${RUN_TRACE_ID}):
+
+  primary    → 1 trace, 3 spans
+                 - Batch 1 "Summarize standup notes"           (tags: batch-1, primary)
+                 - Batch 1 "Weather in Barcelona"              (tags: batch-1, header-default)  ← routed via X-Latitude-Project header
+                 - Batch 3 "Draft follow-up email"             (tags: batch-3, primary)
+
+  secondary  → 1 trace, 1 span
+                 - Batch 1 "Transcribe customer call snippet"  (tags: batch-1, secondary)
+
+  Rejected (not persisted anywhere — visible only in the HTTP responses above):
+    - Batch 2 span (unknown slug + no header)  → 400 Status body
+    - Batch 3 span (wrong-org slug)            → counted in partialSuccess.rejectedSpans
+
+Total: 4 spans persisted across 2 traces (1 per project, sharing the same trace id), 2 rejected.
+Filter by tag \`batch-1\`, \`batch-2\`, or \`batch-3\` to isolate the batches in the UI.
+`)
+}
+
+void main().catch((error: unknown) => {
+  console.error("Failed to run multi-project demo:")
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

One OTLP batch can now route spans to multiple Latitude projects in the same org. Customers
running several agents in one process no longer need to spin up multiple SDK instances —
`.capture({ projectSlug })` tags each span with `latitude.project` and the ingest service
resolves a `projectId` per span (span attr → resource attr → header).

Closes [AGE-92](https://linear.app/latitude/issue/AGE-92/per-span-project-scoping-via-capture-projectslug-and-latitudeproject).

### SDK (TS + Python)
- Ctor `projectSlug` is now optional. When omitted, no `X-Latitude-Project` header is sent.
- `capture({ projectSlug })` (TS) / `capture({"project_slug": ...})` (Py) propagates `latitude.project` to every span via the OTel context, same mechanism as `tags`.
- Three runnable examples per SDK: single-project default / multi-project override / env-driven default with override.

### Ingest
- `transformOtlpToSpans` resolves `projectId` per span using a pre-built `slug → projectId` map plus a header default. Returns `{ spans, rejectedSpans }`.
- `ingestSpansUseCase` decodes the payload at request time, looks up each unique slug exactly once via `ProjectRepository`, accumulates `{ totalSpans, acceptedSpans, rejectedSpans }`, and only publishes the queue message when at least one span is accepted.
- Worker (`process-ingested-spans`) groups persisted spans by `projectId` and emits one `TracesIngested` event per project so downstream consumers (issues/billing/flaggers) stay project-scoped.
- Queue message: drops `projectId`, adds `defaultProjectId` + `projectIdBySlug`.

### HTTP boundary (OTLP spec)
- Middleware becomes best-effort — only reads the optional `X-Latitude-Project` header.
- Route response shape:
  - all valid → **200 OK** with empty `ExportTraceServiceResponse`.
  - mixed → **200 OK** with `partialSuccess { rejectedSpans, errorMessage }`.
  - all rejected → **400** with a `google.rpc.Status`-shaped body `{ code, message }` (OTLP spec §3.2: `partialSuccess` is 2xx-only).
- `errorMessage` hard-codes `https://docs.latitude.so/telemetry/project-scoping` so exporter logs point operators at one page. A CI guard test fails loudly if that page is moved or unwired from the nav.

### Rate-limit refactor
- Bucket drops `projectId`: `ratelimit:ingest:traces:{org}:{apiKey}`. Matches billing's org-scoped check; two projects in the same org now share one allowance (which they should have all along).

### Docs
- New `docs/telemetry/project-scoping.md` covers the resolution chain, `partial_success` contract, and all three patterns with links to the runnable examples.

### Live seeds
- New `pnpm --filter @tools/live-seeds seed:multi-project-demo` script ensures `primary` + `secondary` projects exist in the seed org and POSTs three batches (mixed, all-rejected, partial-success) so the end-to-end path is easy to smoke-test locally.

## Test plan

### Automated (all green locally — re-run in CI)
- [x] `pnpm --filter @latitude-data/telemetry test` — TS SDK context/processor/init tests, including the new `projectSlug` propagation cases.
- [x] `pnpm --filter @domain/spans test` — adds `otlp/tests/project-scoping.test.ts` covering all four resolver outcomes + mixed batch; existing transform fixtures updated; new ingest-spans cases (zero/mixed/all-rejected/dedup).
- [x] `pnpm --filter @app/ingest test` — rate-limit key now org+apiKey (no `projectId`), plus the docs-link integrity guard.
- [x] `pnpm --filter @app/workers test --run src/workers/span-ingestion.test.ts` — worker reads the new message shape and groups events per project.
- [x] Workspace `pnpm typecheck` (the pre-existing `@app/api` flaggers failure is unrelated to this branch and reproduces on `git stash`).

### Manual QA against a running stack

Start the dev stack (`pnpm dev:up`, ingest on `LAT_INGEST_PORT`) and run through this list. Each item maps to a concrete check on a real OTLP batch.

#### 1. Existing single-project flow (no regression)
- [x] Run `pnpm --filter @latitude-data/telemetry exec tsx examples/test_project_scoping_single.ts` with `LATITUDE_PROJECT_SLUG` set. Confirm:
  - HTTP **200 OK** with empty `{}` body (no `partialSuccess`).
  - Spans appear in the Latitude UI under that project.
  - `X-Latitude-Project` header is still being sent by the SDK (network panel / curl mirror).
- [x] Same with the Python example (`uv run python examples/test_project_scoping_single.py`).

#### 2. Multi-project per-capture (the headline feature)
- [x] Run `pnpm --filter @tools/live-seeds seed:multi-project-demo`. Confirm:
  - Batch 1 (mixed primary + secondary + header fallback) → HTTP **200** with no `partialSuccess`.
  - Batch 2 (only an unknown slug, no header) → HTTP **400** with body `{ code: 400, message }` (NOT `partialSuccess` — see HTTP boundary section above) and the docs URL in `message`.
  - Batch 3 (valid + wrong-org slug) → HTTP **200** + `partialSuccess.rejectedSpans = 1`.
- [x] In the Latitude UI: spans from Batch 1 land in `primary` and `secondary`. Wait ~10s for the worker; confirm one `TracesIngested` event per project (logs / Datadog), not a fused one.
- [x] Re-run the TS example `test_project_scoping_multi.ts` with two existing slugs and confirm the SDK emits no `X-Latitude-Project` header (since the ctor has no default).

#### 3. Per-span override on top of a default
- [x] Run `test_project_scoping_env.ts` with `LATITUDE_PROJECT_SLUG=primary` set. Confirm:
  - `default-route` span lands in `primary`.
  - `evaluation-batch` span lands in `evaluation-runs` (must exist in the org — create via UI or live-seeds first).
- [x] Try the same with the slug only set via OTEL resource attribute (use bare OTel exporter, not the SDK). Confirm spans route by the resource attribute when no per-span attr is set.

#### 4. OTLP partial_success contract
- [x] cURL a batch with all-unscoped spans and no header → expect **400** with `{ code, message }` body. Verify the `message` contains `https://docs.latitude.so/telemetry/project-scoping`.
- [x] cURL a batch with a wrong-org slug (a slug from a different org) → expect **200** + `partialSuccess.rejectedSpans = N`, and that the valid spans still land.
- [x] cURL with a malformed JSON body → expect **400** with `SpanDecodingError`. (Pre-existing behavior; just confirm we didn't regress.)
- [x] cURL with an empty body → expect **202** (existing no-op behavior).

#### 5. Rate-limit shared bucket
- [x] Hammer the ingest endpoint with two different `latitude.project` slugs (same org, same API key). Confirm the rate-limit kicks in based on combined volume (since the bucket no longer splits by `projectId`).
- [x] Inspect Redis: keys should be `ratelimit:ingest:traces:{orgId}:{apiKeyId}:requests` (and `:bytes`) — no `projectId` segment.

#### 6. Worker / downstream events
- [x] After a multi-project batch lands, check the workers log: one `TracesIngested` event per `projectId` (not one fused event).
- [x] Verify issues discovery / billing / flaggers jobs fire **per project**, not for spans that don't belong to them.

#### 7. Docs integrity
- [x] `pnpm --filter @app/ingest test --run src/routes/project-scoping-docs.test.ts` — the test fails loudly if anyone moves `docs/telemetry/project-scoping.md` or drops it from the Telemetry nav. Try renaming the file locally to confirm the failure message tells the next person to coordinate a server-side update before the docs URL 404s.

#### 8. Backwards compatibility for existing customers
- [x] An SDK instance with ctor `projectSlug` set (the current shape) must keep working untouched: header sent, spans land, no `partialSuccess`.
- [x] An SDK instance upgraded but still using the same ctor shape (no `capture({ projectSlug })`) must keep working untouched.
- [x] A customer batch sent with the bare-OTel exporter pattern (resource attribute only) routes correctly without the SDK.

### Rollout watch (first 24h after merge)
- [ ] Datadog: `ingest.spans` rejection traces (filter on the `ingestSpans` span's `rejectedSpans` annotation > 0). Expect close to zero unless a customer is exercising the new pattern.
- [ ] Sentry / logs: no spike in `SpanDecodingError` or `NoCreditsRemaining` (unrelated, just sanity).
- [ ] Confirm at least one real customer multi-project batch lands successfully (Carlos/Realtie case in the original Linear ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
