### PR TITLE
fix(release): verify cherry-picks by reverse-applying patches

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,9 +36,11 @@ git diff --shortstat origin/main..origin/development
 echo ""
 
 # Candidate main-only commits by SHA reachability. We verify each below by
-# checking whether the files it touched still differ between main and
-# development — this catches cherry-picks that were squash-merged, which
-# `git log --cherry-pick` (patch-id based) cannot detect.
+# reverse-applying the commit's patch against an `origin/development`
+# worktree — this is what `git rebase` uses to detect already-applied
+# commits, and it catches squash-merged cherry-picks even when development
+# has additional changes on the same files (which a per-file diff check
+# would misreport as missing).
 candidate_shas=$(git log \
   --format='%H' \
   --right-only \
@@ -47,20 +49,17 @@ candidate_shas=$(git log \
   --grep='^Release -' \
   origin/development...origin/main)
 
+verify_worktree=$(mktemp -d -t release-verify.XXXXXX)
+trap 'git worktree remove --force "$verify_worktree" >/dev/null 2>&1; rm -rf "$verify_worktree"' EXIT
+git worktree add --detach --quiet "$verify_worktree" origin/development
+
 main_only_commits=""
 while IFS= read -r sha; do
   [ -z "$sha" ] && continue
-  reflected=true
-  while IFS= read -r file; do
-    [ -z "$file" ] && continue
-    if ! git diff --quiet origin/development origin/main -- "$file" 2>/dev/null; then
-      reflected=false
-      break
-    fi
-  done < <(git show --name-only --format='' "$sha")
-  if [ "$reflected" = false ]; then
-    main_only_commits+="$(git log -1 --format='%h %s' "$sha")"$'\n'
+  if git diff --binary "$sha^..$sha" | git -C "$verify_worktree" apply --check --reverse >/dev/null 2>&1; then
+    continue
   fi
+  main_only_commits+="$(git log -1 --format='%h %s' "$sha")"$'\n'
 done <<<"$candidate_shas"
 
 if [ -n "$main_only_commits" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #3101. The per-file diff check still produced false positives when `development` edited any of a cherry-picked commit's files *after* the cherry-pick landed. Replace it with a reverse-apply of the candidate commit's patch against an `origin/development` worktree — the same trick `git rebase` uses to detect already-applied commits.

### What was wrong

For each main-only SHA, #3101 verified the cherry-pick by checking that every file the commit touched matched between `origin/main` and `origin/development`. That over-constrains: a file can legitimately differ because some later PR on development edited it on top of the cherry-pick.

Concretely, running the script today flagged `d19880ec3` (#3091 docs refresh) as missing from development. It wasn't — #3099 brought it in — but #3098 ("Add segmented trace search editor") subsequently edited `docs/observability/traces.mdx`, so that one file no longer matched, and the whole commit was reported as unreflected.

### The new check

Spin up a detached worktree at `origin/development`, then for each candidate run:

```
git diff --binary "$sha^..$sha" | git -C "$worktree" apply --check --reverse
```

If the patch reverse-applies cleanly, the commit's changes are present in development (with or without later edits on top). If it fails, they're genuinely absent or reverted, and the commit is flagged. The worktree is removed via an `EXIT` trap.

`--binary` is required because #3091 also added PNG screenshots; without it `git diff` emits abbreviated `Binary files differ` markers that `git apply` rejects.

## Test plan

- [x] `./scripts/release.sh` against current `origin/main` / `origin/development` no longer flags `d19880ec3` and proceeds to the release-PR prompt.
- [x] Verify temp worktree is cleaned up after the script exits (normal and via Ctrl-C).