### PR TITLE
chore(infra): finalize encrypted production Aurora

### DIFF
--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -4,6 +4,8 @@ config:
   latitude-infra:domainName: latitude.so
   latitude-infra:githubOwner: latitude-dev
   latitude-infra:githubRepo: latitude-llm
+  # Pinned to avoid automatic bastion replacement when AWS publishes newer AL2023 AMIs.
+  latitude-infra:bastionAmiId: ami-00b105a12aa2a60eb
   # Temporal Cloud (workflows ECS task)
   latitude-infra:temporalCloudNamespace: "latitude-llm.naqqz"
   # latitude-infra:temporalCloudAddress: "eu-central-1.aws.api.temporal.io:7233"

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -4,6 +4,8 @@ config:
   latitude-infra:domainName: latitude.so
   latitude-infra:githubOwner: latitude-dev
   latitude-infra:githubRepo: latitude-llm
+  # Pinned to avoid automatic bastion replacement when AWS publishes newer AL2023 AMIs.
+  latitude-infra:bastionAmiId: ami-00b105a12aa2a60eb
   # Temporal Cloud (workflows ECS task): set namespace before enabling the worker
   latitude-infra:temporalCloudNamespace: "latitude-llm-staging.naqqz"
   # latitude-infra:temporalCloudAddress: "eu-central-1.aws.api.temporal.io:7233"

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -23,6 +23,7 @@ const hostedZoneId = config.get("hostedZoneId") ?? defaults.hostedZoneId
 const domainName = config.get("domainName") ?? defaults.domainName
 const githubOwner = config.get("githubOwner") ?? "latitude-dev"
 const githubRepo = config.get("githubRepo") ?? "latitude"
+const bastionAmiId = config.require("bastionAmiId")
 
 const temporalCloudAddress = config.get("temporalCloudAddress") ?? `${envConfig.region}.aws.api.temporal.io:7233`
 const temporalCloudNamespace = config.get("temporalCloudNamespace") ?? ""
@@ -71,7 +72,7 @@ const rds = createRds(name, envConfig, vpc.privateSubnets, securityGroups.rds)
 
 const redis = createRedis(name, envConfig, vpc.privateSubnets, securityGroups.redis)
 
-const bastion = createBastion(name, envConfig, vpc.vpc, vpc.publicSubnets, securityGroups.bastion)
+const bastion = createBastion(name, envConfig, vpc.vpc, vpc.publicSubnets, securityGroups.bastion, bastionAmiId)
 
 const s3 = createS3(name, envConfig)
 

--- a/infra/lib/bastion.ts
+++ b/infra/lib/bastion.ts
@@ -15,6 +15,7 @@ export function createBastion(
   vpc: Ec2Vpc,
   publicSubnets: Ec2Subnet[],
   securityGroup: Ec2SecurityGroup,
+  amiId: pulumi.Input<string>,
 ): BastionOutput {
   const ssmRole = new aws.iam.Role(`${name}-bastion-ssm-role`, {
     assumeRolePolicy: JSON.stringify({
@@ -48,24 +49,9 @@ export function createBastion(
     },
   })
 
-  const ami = aws.ec2.getAmiOutput({
-    owners: ["amazon"],
-    mostRecent: true,
-    filters: [
-      {
-        name: "name",
-        values: ["al2023-ami-2023.*-x86_64"],
-      },
-      {
-        name: "state",
-        values: ["available"],
-      },
-    ],
-  })
-
   const instance = new aws.ec2.Instance(`${name}-bastion`, {
     instanceType: "t3.nano",
-    ami: ami.id,
+    ami: amiId,
     subnetId: publicSubnets[0].id,
     vpcSecurityGroupIds: [securityGroup.id],
     iamInstanceProfile: instanceProfile.name,

--- a/infra/lib/rds.ts
+++ b/infra/lib/rds.ts
@@ -98,6 +98,9 @@ function createAuroraServerless(
   username: string,
   databaseName: string,
 ): RdsOutput {
+  const auroraPostgresVersion = "16.11"
+  const isProduction = config.name === "production"
+
   const parameterGroup = new aws.rds.ParameterGroup(`${name}-rds-params`, {
     family: "aurora-postgresql16",
     description: "Custom parameter group for Latitude",
@@ -114,42 +117,46 @@ function createAuroraServerless(
   })
 
   const cluster = new aws.rds.Cluster(`${name}-aurora`, {
+    clusterIdentifier: `${name}-aurora`,
     engine: "aurora-postgresql",
-    engineVersion: "16.4",
+    engineVersion: auroraPostgresVersion,
     databaseName: databaseName,
     masterUsername: username,
     masterPassword: password,
     dbSubnetGroupName: subnetGroup.name,
     vpcSecurityGroupIds: [securityGroup.id],
     skipFinalSnapshot: config.name === "staging",
-    finalSnapshotIdentifier: config.name === "production" ? `${name}-final-snapshot` : undefined,
+    finalSnapshotIdentifier: isProduction ? `${name}-encrypted-final-snapshot` : undefined,
     serverlessv2ScalingConfiguration: {
       minCapacity: config.rds.minAcu!,
       maxCapacity: config.rds.maxAcu!,
     },
     backupRetentionPeriod: config.rds.backupDays,
+    storageEncrypted: true,
     preferredBackupWindow: "03:00-04:00",
     enabledCloudwatchLogsExports: ["postgresql"],
     tags: {
       Name: `${name}-aurora`,
       Environment: config.name,
     },
+  }, {
+    aliases: isProduction ? [{ name: `${name}-aurora-encrypted-migration` }] : undefined,
+    protect: isProduction,
   })
 
   const instance = new aws.rds.ClusterInstance(`${name}-aurora-instance`, {
+    identifier: `${name}-aurora-instance`,
     clusterIdentifier: cluster.id,
     instanceClass: "db.serverless",
     engine: "aurora-postgresql",
-    engineVersion: "16.4",
+    engineVersion: auroraPostgresVersion,
     tags: {
       Name: `${name}-aurora-instance`,
       Environment: config.name,
     },
-  })
-
-  const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
-    secretId: secret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`,
+  }, {
+    aliases: isProduction ? [{ name: `${name}-aurora-encrypted-migration-instance` }] : undefined,
+    protect: isProduction,
   })
 
   const adminSecret = new aws.secretsmanager.Secret(`${name}-admin-db-secret`, {
@@ -161,9 +168,38 @@ function createAuroraServerless(
     },
   })
 
+  const updateDatabaseUrlHost = (databaseUrl: pulumi.Output<string>, host: pulumi.Output<string>) =>
+    pulumi.all([databaseUrl, host]).apply(([value, targetHost]) => {
+      const url = new URL(value)
+      url.hostname = targetHost
+      url.port = "5432"
+      return url.toString()
+    })
+
+  const existingAppSecretVersion = isProduction
+    ? aws.secretsmanager.getSecretVersionOutput({ secretId: secret.id })
+    : undefined
+
+  const existingAdminSecretVersion = isProduction
+    ? aws.secretsmanager.getSecretVersionOutput({ secretId: adminSecret.id })
+    : undefined
+
+  const appSecretString = existingAppSecretVersion?.secretString
+    ? updateDatabaseUrlHost(existingAppSecretVersion.secretString, cluster.endpoint)
+    : pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`
+
+  const adminSecretString = existingAdminSecretVersion?.secretString
+    ? updateDatabaseUrlHost(existingAdminSecretVersion.secretString, cluster.endpoint)
+    : pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`
+
+  const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
+    secretId: secret.id,
+    secretString: appSecretString,
+  })
+
   const adminSecretVersion = new aws.secretsmanager.SecretVersion(`${name}-admin-db-secret-version`, {
     secretId: adminSecret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`,
+    secretString: adminSecretString,
   })
 
   const connectionInfo = pulumi.output({
@@ -212,12 +248,14 @@ function createStandardInstance(
   })
 
   const dbInstance = new aws.rds.Instance(`${name}-postgres`, {
+    identifier: `${name}-postgres`,
     engine: "postgres",
     engineVersion: "16.6",
     instanceClass: config.rds.instanceType!,
     allocatedStorage: 20,
     maxAllocatedStorage: 100,
     storageType: "gp3",
+    storageEncrypted: true,
     dbName: databaseName,
     username: username,
     password: password,
@@ -237,7 +275,7 @@ function createStandardInstance(
 
   const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
     secretId: secret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}`,
+    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}?uselibpqcompat=true&sslmode=require`,
   })
 
   const adminSecret = new aws.secretsmanager.Secret(`${name}-admin-db-secret`, {
@@ -251,7 +289,7 @@ function createStandardInstance(
 
   const adminSecretVersion = new aws.secretsmanager.SecretVersion(`${name}-admin-db-secret-version`, {
     secretId: adminSecret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}`,
+    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}?uselibpqcompat=true&sslmode=require`,
   })
 
   const connectionInfo = pulumi.output({


### PR DESCRIPTION
## Summary

Finalizes the production Aurora encryption migration in Pulumi after the live cutover completed.

The production RDS model now treats `latitude-production-aurora` as the normal managed Aurora Serverless cluster instead of a temporary encrypted migration cluster. It removes migration-specific outputs and resource fields, keeps the production cluster protected, and keeps aliases from the temporary migration resource names so Pulumi retains ownership of the existing encrypted cluster under the stable logical names.

## Context

Production was cut over from the old unencrypted Aurora cluster to the encrypted Aurora cluster during the maintenance window. The old cluster has been deleted, production secrets point at the encrypted cluster, and the app is running against it.

This PR only cleans up the infrastructure code so future changes do not have to reason about migration-era `encryptedMigration*` resources.

## Validation

- `cd infra && pnpm typecheck`
- `cd infra && pulumi preview --stack production` showed no changes after the cleanup apply
- Verified production health after apply:
  - `https://api.latitude.so/health`
  - `https://ingest.latitude.so/health`
  - `https://console.latitude.so/api/health`
