### PR TITLE
feat(wrapped): rebalance personality routing

### DIFF
--- a/packages/domain/email/src/templates/wrapped/claude-code/v1/EmailTemplateV1.tsx
+++ b/packages/domain/email/src/templates/wrapped/claude-code/v1/EmailTemplateV1.tsx
@@ -303,6 +303,7 @@ ClaudeCodeWrappedEmailV1.PreviewProps = {
       repos: 1,
       streakDays: 5,
       testsRun: 32,
+      gitWriteOps: 28,
     },
     toolMix: { bash: 87, read: 168, edit: 142, write: 21, search: 52, research: 4, plan: 12, other: 0 },
     loc: {

--- a/packages/domain/spans/src/wrapped/types/claude-code/entities/report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/entities/report.ts
@@ -166,8 +166,15 @@ export const reportV1Schema = z.object({
     repos: z.number().int().nonnegative(),
     /** Distinct UTC calendar days with at least one Claude Code span. Max 7. */
     streakDays: z.number().int().nonnegative(),
-    /** Count of Bash invocations that look like a test runner. */
+    /** Count of Bash segments that look like a test runner. */
     testsRun: z.number().int().nonnegative(),
+    /**
+     * Count of git operations that mutate repo state (commit / push / merge
+     * / rebase / tag / revert / cherry-pick). Sibling of `commits` (which
+     * counts distinct git-commit SHAs from span metadata). Feeds the
+     * Shipper archetype.
+     */
+    gitWriteOps: z.number().int().nonnegative(),
   }),
 
   toolMix: toolMixSchema,

--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -101,6 +101,15 @@ export interface ToolMixRow {
    */
   readonly bashSecondToken: string
   /**
+   * Lowercased third token of the Bash command segment — required for
+   * `gh` sub-subcommand classification (`gh pr create` vs `gh pr view`
+   * vs `gh issue list` — same prefix + second token, different intent).
+   * Empty string for non-Bash rows, segments with fewer than three
+   * tokens, or commands where the third token isn't structurally
+   * meaningful.
+   */
+  readonly bashThirdToken: string
+  /**
    * Path classification for `Edit`/`Write`/`Read`/`MultiEdit`/`NotebookEdit`/
    * `NotebookRead` calls based on the span's `tool_input.file_path` and
    * `metadata['workspace.path']`:

--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -95,18 +95,23 @@ export interface ToolMixRow {
    */
   readonly bashPrefix: string
   /**
-   * Lowercased second token of the Bash command segment — used to
-   * sub-classify `git` invocations (commit / push / status / …). Empty
-   * string for non-Bash rows or when the segment has only one token.
+   * Lowercased **first non-flag** token after the prefix — i.e. the
+   * subcommand keyword. Flag-like tokens (starting with `-`, `@`, or
+   * `.`; containing `/` or `=`; or purely numeric) are skipped during
+   * extraction. So `git -C /repo status -s` produces
+   * `bashSecondToken = "status"`, not `"-c"`, and `gh -R owner/repo pr
+   * create` produces `bashSecondToken = "pr"`, not `"owner/repo"`.
+   *
+   * Empty string for non-Bash rows or segments with no non-flag tokens
+   * after the prefix. See `extractBashTokens` for the canonical spec.
    */
   readonly bashSecondToken: string
   /**
-   * Lowercased third token of the Bash command segment — required for
-   * `gh` sub-subcommand classification (`gh pr create` vs `gh pr view`
-   * vs `gh issue list` — same prefix + second token, different intent).
-   * Empty string for non-Bash rows, segments with fewer than three
-   * tokens, or commands where the third token isn't structurally
-   * meaningful.
+   * Lowercased **second non-flag** token after the prefix. Used to
+   * disambiguate `gh`'s three-deep CLI: `gh pr create` vs `gh pr view`
+   * (same prefix + second, different intent). Same flag-skipping rule
+   * as `bashSecondToken`. Empty string when the segment has fewer than
+   * two non-flag tokens after the prefix.
    */
   readonly bashThirdToken: string
   /**

--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -28,6 +28,11 @@ export interface WrappedTotalsRow {
   readonly sessions: number
   readonly toolCalls: number
   readonly filesTouched: number
+  /**
+   * Total Bash command *segments* — a single Bash tool call carrying
+   * `cd foo && grep bar && git push` contributes three. The denominator
+   * for the "1,471 commands" headline.
+   */
   readonly commandsRun: number
   readonly workspaces: number
   readonly branches: number
@@ -35,8 +40,15 @@ export interface WrappedTotalsRow {
   readonly repos: number
   /** Distinct UTC calendar days with at least one Claude Code span. Max 7. */
   readonly streakDays: number
-  /** Count of Bash invocations that look like a test-runner command. */
+  /** Count of Bash segments that look like a test-runner command. */
   readonly testsRun: number
+  /**
+   * Count of git operations that mutate repo state (`commit`/`push`/`merge`/
+   * `rebase`/`tag`/`revert`/`cherry-pick`). Sibling of `commits` (which
+   * counts distinct git-commit SHAs from span metadata). Feeds the
+   * Shipper archetype's score and gate.
+   */
+  readonly gitWriteOps: number
 }
 
 export interface LocStatsRow {
@@ -62,9 +74,44 @@ export interface SessionDurationStatsRow {
   readonly longestWorkspace: string | null
 }
 
+/**
+ * One row per group of tool calls sharing a classification key. Bash calls
+ * are pre-split into command segments by the adapter and exploded into
+ * rows keyed on `(bashPrefix, bashSecondToken)`; path-aware tools (`Edit`,
+ * `Write`, `Read`, …) get a per-row `fileDisposition` derived from the
+ * `tool_input.file_path` vs `metadata['workspace.path']` comparison.
+ *
+ * The domain-side classifier in `build-report.ts` turns each row into a
+ * `ToolBucket` (or drops it as "excluded"). The shape stays raw so the
+ * routing rules live in TS where they're unit-testable.
+ */
 export interface ToolMixRow {
   readonly toolName: string
+  /** Number of tool calls / Bash segments in this group. */
   readonly uses: number
+  /**
+   * Lowercased first token of the Bash command segment. Empty string for
+   * non-Bash rows.
+   */
+  readonly bashPrefix: string
+  /**
+   * Lowercased second token of the Bash command segment — used to
+   * sub-classify `git` invocations (commit / push / status / …). Empty
+   * string for non-Bash rows or when the segment has only one token.
+   */
+  readonly bashSecondToken: string
+  /**
+   * Path classification for `Edit`/`Write`/`Read`/`MultiEdit`/`NotebookEdit`/
+   * `NotebookRead` calls based on the span's `tool_input.file_path` and
+   * `metadata['workspace.path']`:
+   *
+   * - `"plan-file"`: file is `**` /`.claude/plans/<id>.md` → routes to `plan`
+   * - `"claude-noise"`: file is under `.claude/` but not `plans/` → excluded
+   * - `"external"`: file is outside the workspace (and not `.claude/`) → excluded
+   * - `"workspace"`: file is inside the workspace (the common case) → existing bucket
+   * - `""`: not a path-aware tool, or no `file_path` carried (e.g. `LS`)
+   */
+  readonly fileDisposition: "" | "workspace" | "plan-file" | "claude-noise" | "external"
 }
 
 export interface FileTouchesRow {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
@@ -264,6 +264,19 @@ describe("assignPersonality (gate-then-rank)", () => {
     expect(result.kind).toBe("consultant")
   })
 
+  it("Shipper fires when shipping happens via `gh pr create` / `merge` even with zero git commits", () => {
+    // `gh` write triplets feed gitWriteOps the same way `git push` does.
+    // A user who works mostly through `gh pr create` + `gh pr merge`
+    // (e.g. CLI-first PR flow) should still land on Shipper.
+    const result = run({
+      toolMix: { ...baseMix, bash: 40, edit: 30, read: 30 },
+      sessions: 8,
+      commits: 0,
+      gitWriteOps: 32, // 4 per session — saturates the write-ops-per-session score
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
   it("Shipper fires on push-heavy / squash flows even with low commit count", () => {
     // The reason we added `gitWriteOps`: a user who force-pushes / rebases
     // / tags but has few unique commit SHAs over the window. Old algorithm

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
@@ -19,6 +19,7 @@ const argsBase = {
   filesTouched: 0,
   commandsRun: 0,
   commits: 0,
+  gitWriteOps: 0,
   testsRun: 0,
   editAdded: 5_000,
   writeLines: 5_000,
@@ -199,6 +200,95 @@ describe("assignPersonality (gate-then-rank)", () => {
     const strat = run({ toolMix: { ...baseMix, plan: 80, edit: 20 } })
     expect(strat.score).toBeLessThanOrEqual(1)
     expect(strat.score).toBeGreaterThan(0.5)
+  })
+
+  it("regression: heavy power user (User A) lands on Shipper, not Conductor", () => {
+    // Snapshot of the production-traced User A profile after the bash
+    // sub-classification rewrite: 1,471 bash calls collapse to ~750 in
+    // the `bash` bucket once grep / find / cd / git-status are routed
+    // away. Shipper's gitWriteOps + commitsPerSession both fire; the
+    // rarity bonus pushes it well above any tool-mix winner.
+    const result = run({
+      toolMix: {
+        ...baseMix,
+        bash: 750, // build / test / git-write / runtime invocations
+        read: 1200,
+        edit: 900,
+        write: 80,
+        search: 1100, // grep, ls, find — most of which used to be in bash
+        plan: 30,
+        research: 5,
+        other: 10,
+      },
+      sessions: 16,
+      filesTouched: 259,
+      commandsRun: 1471,
+      commits: 34,
+      gitWriteOps: 50, // commit + push + rebase across the week
+      testsRun: 44,
+      editAdded: 22_000,
+      writeLines: 1_469,
+      linesRead: 200_000,
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
+  it("regression: light explorer (User B) lands on Consultant, not Conductor", () => {
+    // Snapshot of User B: 6 sessions, only 90 lines touched, 48 commands.
+    // After bash sub-classification, most of those 48 commands route
+    // away from `bash`: 8 ls + 6 grep → search, 1 cat → read, 1 curl →
+    // research, 2 excluded (open + claude). Remaining bash bucket is
+    // tiny; Consultant's gate (sessions ≥ 5 AND lines < 200) wins.
+    const result = run({
+      toolMix: {
+        ...baseMix,
+        bash: 14, // python3, git, the rest of the 48 — minus search/read/research
+        read: 50,
+        edit: 15,
+        write: 5,
+        search: 14, // ls + grep moved here
+        plan: 0,
+        research: 1, // curl
+        other: 1,
+      },
+      sessions: 6,
+      filesTouched: 7,
+      commandsRun: 48,
+      commits: 0,
+      gitWriteOps: 0,
+      testsRun: 1,
+      editAdded: 80,
+      writeLines: 10,
+      linesRead: 800,
+    })
+    expect(result.kind).toBe("consultant")
+  })
+
+  it("Shipper fires on push-heavy / squash flows even with low commit count", () => {
+    // The reason we added `gitWriteOps`: a user who force-pushes / rebases
+    // / tags but has few unique commit SHAs over the window. Old algorithm
+    // missed them. With the new disjunctive gate, they still land here.
+    const result = run({
+      toolMix: { ...baseMix, bash: 40, edit: 40, read: 20 },
+      sessions: 8,
+      commits: 2, // below SHIPPER_GATE_COMMITS
+      gitWriteOps: 24, // 3 per session — clears SHIPPER_GATE_WRITE_OPS_PER_SESSION
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
+  it("Conductor still wins for a genuinely shell-heavy user (bash bucket post-routing)", () => {
+    // After the rebalance, Conductor isn't dead — it's reserved for users
+    // whose `bash` bucket (after grep / cd / git-status routed away) is
+    // actually dominated by genuine shell orchestration.
+    const result = run({
+      toolMix: { ...baseMix, bash: 70, read: 20, edit: 10 },
+      sessions: 8,
+      commandsRun: 300,
+      commits: 0,
+      gitWriteOps: 0,
+    })
+    expect(result.kind).toBe("conductor")
   })
 
   it("evidence always has exactly 3 strings", () => {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.ts
@@ -24,10 +24,14 @@ const BASELINE_SHARE: Record<ToolBucket, number> = {
 // Each archetype has a `gate` (minimum signal floor — below it, the
 // archetype can't fire at all) and a `score` formula mapping its signal
 // into [0, 1]. `assignPersonality` filters to gate-passers and returns
-// the highest-scoring one. The rare archetypes (Strategist, Scholar)
-// saturate earlier than the tool-mix archetypes so a strong rare signal
-// can beat a moderately-strong common one — otherwise a heavy editor
-// would always out-score a heavy planner.
+// the highest-scoring one.
+//
+// The 5 *conditional* archetypes (Strategist/Scholar/Consultant/Shipper/
+// Tester) get a multiplicative `RARE_BONUS` over their normalised score:
+// once their gate passes (which requires a real, non-trivial signal),
+// they deserve to beat a moderate (~0.5) tool-mix winner. Otherwise the
+// always-firing tool-mix archetypes drown out genuine planner / shipper /
+// tester signals at every realistic activity level.
 
 const STRATEGIST_GATE_EXCESS = 0.05
 const STRATEGIST_GATE_CALLS = 10
@@ -41,13 +45,27 @@ const SCHOLAR_SCORE_HIGH = 0.2
 
 const CONSULTANT_GATE_SESSIONS = 5
 const CONSULTANT_GATE_MAX_LINES = 200
-const CONSULTANT_SCORE_LOW = 5
-const CONSULTANT_SCORE_HIGH = 15
+// `LOW` sits below the gate floor on purpose: at exactly 5 sessions the gate
+// passes and the normalised score is `(5-4)/(8-4) = 0.25`, which then gets
+// the rarity bonus. Otherwise a borderline Consultant would score 0 and
+// always lose to any tool-mix winner.
+const CONSULTANT_SCORE_LOW = 4
+const CONSULTANT_SCORE_HIGH = 8
 
+// Shipper now reads from two complementary signals:
+//   - distinct commit SHAs over the window  → `commits` / `commitsPerSession`
+//   - git write-ops (push/merge/rebase/...) → `gitWriteOps`
+// Either can fire the gate; the score takes the max of both normalised
+// signals so squash-pushers, force-pushers, and tag-and-release flows
+// aren't penalised for low commit counts.
 const SHIPPER_GATE_COMMITS = 5
-const SHIPPER_GATE_RATIO = 1.0
-const SHIPPER_SCORE_LOW = 1.0
-const SHIPPER_SCORE_HIGH = 4.0
+const SHIPPER_GATE_WRITE_OPS = 8
+const SHIPPER_GATE_COMMITS_PER_SESSION = 1.0
+const SHIPPER_GATE_WRITE_OPS_PER_SESSION = 1.5
+const SHIPPER_COMMITS_PER_SESSION_LOW = 1.0
+const SHIPPER_COMMITS_PER_SESSION_HIGH = 2.5
+const SHIPPER_WRITE_OPS_PER_SESSION_LOW = 1.5
+const SHIPPER_WRITE_OPS_PER_SESSION_HIGH = 4.0
 
 const TESTER_GATE_TESTS = 20
 const TESTER_GATE_RATIO = 2.0
@@ -55,6 +73,12 @@ const TESTER_SCORE_LOW = 2.0
 const TESTER_SCORE_HIGH = 8.0
 
 const TOOL_MIX_SCORE_HIGH = 0.3
+
+// Multiplier applied to the 5 conditional archetypes' raw scores. Their
+// gates already require a meaningful signal floor, so once they fire we
+// want them to outrank a moderate tool-mix winner. Score is still capped
+// to [0, 1] downstream.
+const RARE_BONUS = 1.5
 
 const sumMix = (mix: ToolMix): number =>
   mix.bash + mix.read + mix.edit + mix.write + mix.search + mix.research + mix.plan + mix.other
@@ -76,6 +100,12 @@ interface AssignPersonalityInput {
   readonly filesTouched: number
   readonly commandsRun: number
   readonly commits: number
+  /**
+   * Count of git operations that mutate repo state (commit / push / merge
+   * / rebase / tag / revert / cherry-pick). Used alongside `commits` so
+   * users who squash-push or tag-release still register as shippers.
+   */
+  readonly gitWriteOps: number
   readonly testsRun: number
   /** Lines added by Edit / MultiEdit / NotebookEdit — the "+N" component. */
   readonly editAdded: number
@@ -110,7 +140,18 @@ interface Candidate {
  * stable sort — a small bias toward the rarer archetypes when scores match.
  */
 export function assignPersonality(input: AssignPersonalityInput): Personality {
-  const { toolMix, sessions, filesTouched, commandsRun, commits, testsRun, editAdded, writeLines, linesRead } = input
+  const {
+    toolMix,
+    sessions,
+    filesTouched,
+    commandsRun,
+    commits,
+    gitWriteOps,
+    testsRun,
+    editAdded,
+    writeLines,
+    linesRead,
+  } = input
   const total = sumMix(toolMix)
 
   // Guarded by the no-activity short-circuit upstream — but defend in depth
@@ -134,15 +175,21 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
   const bashExcess = excessOf("bash")
 
   const commitsPerSession = sessions > 0 ? commits / sessions : 0
+  const writeOpsPerSession = sessions > 0 ? gitWriteOps / sessions : 0
   const testsPerSession = sessions > 0 ? testsRun / sessions : 0
   // Total lines of code touched this week (disjoint components — no overlap).
   const linesTouchedTotal = editAdded + writeLines
+
+  // Bound to ≤ 1.0 so a saturated conditional score doesn't run away into
+  // [1, 1.5]; the relative ordering between archetypes is still the lift
+  // that matters.
+  const applyRareBonus = (s: number) => Math.min(1, s * RARE_BONUS)
 
   const candidates: readonly Candidate[] = [
     {
       kind: "strategist",
       gatePasses: planExcess >= STRATEGIST_GATE_EXCESS && toolMix.plan >= STRATEGIST_GATE_CALLS,
-      score: normaliseScore(planExcess, STRATEGIST_SCORE_LOW, STRATEGIST_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(planExcess, STRATEGIST_SCORE_LOW, STRATEGIST_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatPercent(shareOf("plan"))} of your tool calls were planning steps`,
         `${formatCount(toolMix.plan)} TaskCreate / TaskUpdate / TodoWrite calls`,
@@ -152,7 +199,7 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     {
       kind: "scholar",
       gatePasses: researchExcess >= SCHOLAR_GATE_EXCESS && toolMix.research >= SCHOLAR_GATE_CALLS,
-      score: normaliseScore(researchExcess, SCHOLAR_SCORE_LOW, SCHOLAR_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(researchExcess, SCHOLAR_SCORE_LOW, SCHOLAR_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatPercent(shareOf("research"))} of your tool calls were web research`,
         `${formatCount(toolMix.research)} WebFetch / WebSearch call${toolMix.research === 1 ? "" : "s"}`,
@@ -162,7 +209,7 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     {
       kind: "consultant",
       gatePasses: sessions >= CONSULTANT_GATE_SESSIONS && linesTouchedTotal < CONSULTANT_GATE_MAX_LINES,
-      score: normaliseScore(sessions, CONSULTANT_SCORE_LOW, CONSULTANT_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(sessions, CONSULTANT_SCORE_LOW, CONSULTANT_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatCount(sessions)} session${sessions === 1 ? "" : "s"} this week`,
         linesTouchedTotal === 0
@@ -173,18 +220,30 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     },
     {
       kind: "shipper",
-      gatePasses: commits >= SHIPPER_GATE_COMMITS && commitsPerSession >= SHIPPER_GATE_RATIO,
-      score: normaliseScore(commitsPerSession, SHIPPER_SCORE_LOW, SHIPPER_SCORE_HIGH),
+      gatePasses:
+        (commits >= SHIPPER_GATE_COMMITS || gitWriteOps >= SHIPPER_GATE_WRITE_OPS) &&
+        (commitsPerSession >= SHIPPER_GATE_COMMITS_PER_SESSION ||
+          writeOpsPerSession >= SHIPPER_GATE_WRITE_OPS_PER_SESSION),
+      score: applyRareBonus(
+        Math.max(
+          normaliseScore(commitsPerSession, SHIPPER_COMMITS_PER_SESSION_LOW, SHIPPER_COMMITS_PER_SESSION_HIGH),
+          normaliseScore(writeOpsPerSession, SHIPPER_WRITE_OPS_PER_SESSION_LOW, SHIPPER_WRITE_OPS_PER_SESSION_HIGH),
+        ),
+      ),
       buildEvidence: () => [
-        `${formatCount(commits)} commit${commits === 1 ? "" : "s"} this week`,
-        `${commitsPerSession.toFixed(1)} commits per session, on average`,
+        commits >= gitWriteOps
+          ? `${formatCount(commits)} commit${commits === 1 ? "" : "s"} this week`
+          : `${formatCount(gitWriteOps)} git push / commit / merge operation${gitWriteOps === 1 ? "" : "s"}`,
+        commitsPerSession >= writeOpsPerSession
+          ? `${commitsPerSession.toFixed(1)} commits per session, on average`
+          : `${writeOpsPerSession.toFixed(1)} shipping actions per session, on average`,
         `${formatCount(sessions)} session${sessions === 1 ? "" : "s"} of focused work`,
       ],
     },
     {
       kind: "tester",
       gatePasses: testsRun >= TESTER_GATE_TESTS && testsPerSession >= TESTER_GATE_RATIO,
-      score: normaliseScore(testsPerSession, TESTER_SCORE_LOW, TESTER_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(testsPerSession, TESTER_SCORE_LOW, TESTER_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatCount(testsRun)} test run${testsRun === 1 ? "" : "s"} this week`,
         `${testsPerSession.toFixed(1)} test runs per session, on average`,

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -2,7 +2,30 @@ import type { Project } from "@domain/projects"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { reportV1Schema } from "../entities/report.ts"
-import { type AssembleReportInput, assembleReport, toolBucketFor } from "./build-report.ts"
+import type { ToolMixRow } from "../ports/claude-code-span-reader.ts"
+import {
+  type AssembleReportInput,
+  assembleReport,
+  classifyToolMixRow,
+  isGitWriteSegment,
+  toolBucketFor,
+} from "./build-report.ts"
+
+/**
+ * Convenience builder for `ToolMixRow` fixtures — most tests only care
+ * about the `(toolName, uses)` pair; the post-refactor row carries three
+ * extra fields (bash prefix, bash second token, file disposition) that we
+ * default to empty / "workspace" so the existing tests still exercise the
+ * pre-refactor routing.
+ */
+const row = (toolName: string, uses: number, extras: Partial<ToolMixRow> = {}): ToolMixRow => ({
+  toolName,
+  uses,
+  bashPrefix: "",
+  bashSecondToken: "",
+  fileDisposition: toolName === "Bash" ? "" : (extras.fileDisposition ?? ""),
+  ...extras,
+})
 
 const ORG_ID = OrganizationId("org-build".padEnd(24, "x").slice(0, 24))
 const PROJECT_ID = ProjectId("proj-build".padEnd(24, "x").slice(0, 24))
@@ -38,6 +61,7 @@ const baseInput: AssembleReportInput = {
     repos: 1,
     streakDays: 5,
     testsRun: 9,
+    gitWriteOps: 0,
   },
   durationStats: {
     totalDurationMs: 30 * 60 * 1000,
@@ -51,11 +75,11 @@ const baseInput: AssembleReportInput = {
     readLines: 9_200,
   },
   toolMix: [
-    { toolName: "Edit", uses: 50 },
-    { toolName: "Read", uses: 25 },
-    { toolName: "Bash", uses: 15 },
-    { toolName: "Write", uses: 5 },
-    { toolName: "Grep", uses: 5 },
+    row("Edit", 50, { fileDisposition: "workspace" }),
+    row("Read", 25, { fileDisposition: "workspace" }),
+    row("Bash", 15),
+    row("Write", 5, { fileDisposition: "workspace" }),
+    row("Grep", 5),
   ],
   topBash: [
     { pattern: "pnpm", uses: 9 },
@@ -131,6 +155,108 @@ describe("toolBucketFor", () => {
   })
 })
 
+describe("classifyToolMixRow — Bash sub-classification", () => {
+  it("routes investigation-style binaries to search", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "grep" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "rg" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "find" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "ls" }))).toBe("search")
+  })
+
+  it("routes content-reading binaries (cat/head/tail) to read", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "cat" }))).toBe("read")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "head" }))).toBe("read")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "tail" }))).toBe("read")
+  })
+
+  it("routes curl / wget to research", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "curl" }))).toBe("research")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "wget" }))).toBe("research")
+  })
+
+  it("drops navigation-only commands (cd / pwd / open / claude)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "cd" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "pwd" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "open" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "claude" }))).toBe("excluded")
+  })
+
+  it("routes git status / log / diff to search (investigation)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "status" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "log" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "diff" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "blame" }))).toBe("search")
+  })
+
+  it("drops git checkout / switch / config (navigation / setup)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "checkout" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "switch" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "config" }))).toBe("excluded")
+  })
+
+  it("keeps git commit / push / merge in bash (genuine shell orchestration)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "commit" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "push" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "merge" }))).toBe("bash")
+  })
+
+  it("keeps unrecognised binaries in bash (build / test / runtime / infra)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "pnpm" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "xcodebuild" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "python3" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "railway" }))).toBe("bash")
+  })
+})
+
+describe("classifyToolMixRow — file-path disposition", () => {
+  it("routes plan-file edits/reads to the plan bucket", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+    expect(classifyToolMixRow(row("Write", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+  })
+
+  it("drops `.claude/` config edits/reads entirely", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "claude-noise" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "claude-noise" }))).toBe("excluded")
+  })
+
+  it("drops out-of-workspace edits/reads entirely", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "external" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "external" }))).toBe("excluded")
+  })
+
+  it("counts workspace edits/reads via the existing tool-name map", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "workspace" }))).toBe("edit")
+    expect(classifyToolMixRow(row("Write", 1, { fileDisposition: "workspace" }))).toBe("write")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "workspace" }))).toBe("read")
+  })
+
+  it("falls back to the tool-name map when no file_path was on the call", () => {
+    expect(classifyToolMixRow(row("Edit", 1))).toBe("edit")
+    expect(classifyToolMixRow(row("Grep", 1))).toBe("search")
+    expect(classifyToolMixRow(row("TodoWrite", 1))).toBe("plan")
+  })
+})
+
+describe("isGitWriteSegment", () => {
+  it("returns true for the git write-ops subcommands", () => {
+    for (const sub of ["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"]) {
+      expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "git", bashSecondToken: sub }))).toBe(true)
+    }
+  })
+
+  it("returns false for git investigation / navigation subcommands", () => {
+    for (const sub of ["status", "log", "diff", "checkout", "switch", "config"]) {
+      expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "git", bashSecondToken: sub }))).toBe(false)
+    }
+  })
+
+  it("returns false for non-git Bash segments and non-Bash rows", () => {
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "pnpm" }))).toBe(false)
+    expect(isGitWriteSegment(row("Edit", 1, { fileDisposition: "workspace" }))).toBe(false)
+  })
+})
+
 describe("assembleReport", () => {
   it("produces a report that validates against the schema", () => {
     const report = assembleReport(baseInput)
@@ -153,9 +279,9 @@ describe("assembleReport", () => {
     const report = assembleReport({
       ...baseInput,
       toolMix: [
-        { toolName: "Edit", uses: 10 },
-        { toolName: "NotebookEdit", uses: 3 },
-        { toolName: "MultiEdit", uses: 2 },
+        row("Edit", 10, { fileDisposition: "workspace" }),
+        row("NotebookEdit", 3, { fileDisposition: "workspace" }),
+        row("MultiEdit", 2, { fileDisposition: "workspace" }),
       ],
     })
     expect(report.toolMix.edit).toBe(15)

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -246,6 +246,39 @@ describe("extractBashTokens", () => {
       thirdToken: "origin",
     })
   })
+
+  it("strips bash line continuations (`\\<NEWLINE>`) before tokenising", () => {
+    // Claude Code emits multi-line commands like:
+    //   foo bar \
+    //     echo continued
+    // The literal char sequence stored is `foo bar \<NL>  echo continued`.
+    // Without normalisation, the `\<NL>` becomes a junk token and surfaces
+    // as `\ echo` in the top-commands display.
+    expect(extractBashTokens("foo bar \\\n  echo continued")).toEqual({
+      prefix: "foo",
+      secondToken: "bar",
+      thirdToken: "echo",
+    })
+  })
+
+  it("normalises a segment that begins with a line-continuation join", () => {
+    // After splitting on `&&` / `;` / `|`, a segment can start with `\<NL>`
+    // when the chain operator appeared at end-of-line just before the
+    // continuation. The prefix should be the first real token, not `\<NL>`.
+    expect(extractBashTokens("\\\n  echo something")).toEqual({
+      prefix: "echo",
+      secondToken: "something",
+      thirdToken: "",
+    })
+  })
+
+  it("treats embedded tabs and newlines as whitespace", () => {
+    expect(extractBashTokens("git\tpush\norigin")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
 })
 
 describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", () => {
@@ -293,6 +326,14 @@ describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", 
 
   it("`cd /Users/sans/src` is excluded (navigation)", () => {
     expect(classify("cd /Users/sans/src")).toBe("excluded")
+  })
+
+  it("a line-continuation `echo` segment classifies as excluded plumbing", () => {
+    // Pre-normalisation this segment produced prefix `\<NL>` which wasn't
+    // in any classifier set → fell through to plain `bash` and showed up
+    // as "\ echo" in top-commands. After normalisation, the prefix is
+    // `echo` → plumbing → excluded.
+    expect(classify("\\\n  echo something")).toBe("excluded")
   })
 })
 

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -23,6 +23,7 @@ const row = (toolName: string, uses: number, extras: Partial<ToolMixRow> = {}): 
   uses,
   bashPrefix: "",
   bashSecondToken: "",
+  bashThirdToken: "",
   fileDisposition: toolName === "Bash" ? "" : (extras.fileDisposition ?? ""),
   ...extras,
 })
@@ -163,10 +164,30 @@ describe("classifyToolMixRow — Bash sub-classification", () => {
     expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "ls" }))).toBe("search")
   })
 
-  it("routes content-reading binaries (cat/head/tail) to read", () => {
-    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "cat" }))).toBe("read")
-    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "head" }))).toBe("read")
-    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "tail" }))).toBe("read")
+  it("drops shell plumbing entirely (cat/head/tail/echo/sed/awk/…)", () => {
+    // These are almost always used as `… | tail -8` or `… | sed s/x/y/`
+    // shapers — never standalone Claude work. Dropping them entirely
+    // keeps the `read` bucket clean and the top-commands surface free
+    // of "Your favourite command: tail" results.
+    for (const prefix of [
+      "cat",
+      "head",
+      "tail",
+      "less",
+      "more",
+      "echo",
+      "printf",
+      "sed",
+      "awk",
+      "wc",
+      "sort",
+      "cut",
+      "tr",
+      "xargs",
+      "tee",
+    ]) {
+      expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: prefix }))).toBe("excluded")
+    }
   })
 
   it("routes curl / wget to research", () => {
@@ -238,6 +259,45 @@ describe("classifyToolMixRow — file-path disposition", () => {
   })
 })
 
+describe("classifyToolMixRow — gh sub-subcommand routing", () => {
+  it("routes gh pr view / list / checks / comment to research (external investigation)", () => {
+    for (const third of ["view", "list", "checks", "comment", "diff", "status"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe("research")
+    }
+  })
+
+  it("routes gh issue / api / run / workflow to research regardless of third token", () => {
+    for (const second of ["issue", "api", "run", "workflow"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: second, bashThirdToken: "anything" })),
+      ).toBe("research")
+      expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: second }))).toBe("research")
+    }
+  })
+
+  it("keeps gh write-ops in bash (and feeds gitWriteOps)", () => {
+    for (const third of ["create", "merge", "ready", "edit", "review"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe("bash")
+    }
+  })
+
+  it("keeps gh auth / config / repo view in bash (not shipping, not research)", () => {
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "auth", bashThirdToken: "login" })),
+    ).toBe("bash")
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "config", bashThirdToken: "set" })),
+    ).toBe("bash")
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "repo", bashThirdToken: "view" })),
+    ).toBe("bash")
+  })
+})
+
 describe("isGitWriteSegment", () => {
   it("returns true for the git write-ops subcommands", () => {
     for (const sub of ["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"]) {
@@ -245,10 +305,40 @@ describe("isGitWriteSegment", () => {
     }
   })
 
+  it("returns true for the gh write-op triplets (gh pr create / merge / ready / edit / review)", () => {
+    for (const third of ["create", "merge", "ready", "edit", "review"]) {
+      expect(
+        isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe(true)
+    }
+  })
+
+  it("returns true for gh release create / edit / upload and gh repo create", () => {
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "release", bashThirdToken: "create" })),
+    ).toBe(true)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "release", bashThirdToken: "upload" })),
+    ).toBe(true)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "repo", bashThirdToken: "create" })),
+    ).toBe(true)
+  })
+
   it("returns false for git investigation / navigation subcommands", () => {
     for (const sub of ["status", "log", "diff", "checkout", "switch", "config"]) {
       expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "git", bashSecondToken: sub }))).toBe(false)
     }
+  })
+
+  it("returns false for gh read-side calls (view / list / api / issue)", () => {
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: "view" }))).toBe(
+      false,
+    )
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "api" }))).toBe(false)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "issue", bashThirdToken: "list" })),
+    ).toBe(false)
   })
 
   it("returns false for non-git Bash segments and non-Bash rows", () => {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -7,6 +7,7 @@ import {
   type AssembleReportInput,
   assembleReport,
   classifyToolMixRow,
+  extractBashTokens,
   isGitWriteSegment,
   toolBucketFor,
 } from "./build-report.ts"
@@ -153,6 +154,145 @@ describe("toolBucketFor", () => {
   it("falls back to other for unknown tools", () => {
     expect(toolBucketFor("MysteryTool")).toBe("other")
     expect(toolBucketFor("")).toBe("other")
+  })
+})
+
+describe("extractBashTokens", () => {
+  it("plain `git push origin main` → prefix=git, second=push, third=origin", () => {
+    expect(extractBashTokens("git push origin main")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
+
+  it("`git -C /path status -s` → skips -C and the absolute path", () => {
+    // Claude Code emits this pattern constantly. Pre-fix, secondToken
+    // was "-c" (the literal second whitespace token) and the segment
+    // mis-classified as `bash` instead of `search`. After the fix the
+    // flag-like tokens are filtered so the meaningful subcommand
+    // surfaces.
+    expect(extractBashTokens("git -C /Users/sans/src/worktrees/repo status -s")).toEqual({
+      prefix: "git",
+      secondToken: "status",
+      thirdToken: "",
+    })
+  })
+
+  it("`gh -R owner/repo pr create --title foo` → triplet pr/create surfaces", () => {
+    expect(extractBashTokens("gh -R owner/repo pr create --title foo")).toEqual({
+      prefix: "gh",
+      secondToken: "pr",
+      thirdToken: "create",
+    })
+  })
+
+  it("`pnpm --filter @domain/spans test` → skips --filter and the scoped arg", () => {
+    expect(extractBashTokens("pnpm --filter @domain/spans test")).toEqual({
+      prefix: "pnpm",
+      secondToken: "test",
+      thirdToken: "",
+    })
+  })
+
+  it("`git --version` → no subcommand, second/third empty", () => {
+    expect(extractBashTokens("git --version")).toEqual({
+      prefix: "git",
+      secondToken: "",
+      thirdToken: "",
+    })
+  })
+
+  it("`./scripts/build.sh --release` → prefix keeps its leading dot (it IS the command)", () => {
+    // Only the *suffix* tokens are flag-filtered. The prefix is the
+    // literal first token — a script path is its own command name.
+    expect(extractBashTokens("./scripts/build.sh --release")).toEqual({
+      prefix: "./scripts/build.sh",
+      secondToken: "",
+      thirdToken: "",
+    })
+  })
+
+  it("`GIT STATUS` → both prefix and tokens are lowercased", () => {
+    expect(extractBashTokens("GIT STATUS")).toEqual({
+      prefix: "git",
+      secondToken: "status",
+      thirdToken: "",
+    })
+  })
+
+  it("`git -c user.email=x commit -m msg` → skips =-containing tokens and -m flag", () => {
+    expect(extractBashTokens("git -c user.email=x commit -m msg")).toEqual({
+      prefix: "git",
+      secondToken: "commit",
+      thirdToken: "msg",
+    })
+  })
+
+  it("`head -n 50 foo.log` → numeric `50` is skipped", () => {
+    expect(extractBashTokens("head -n 50 foo.log")).toEqual({
+      prefix: "head",
+      secondToken: "foo.log",
+      thirdToken: "",
+    })
+  })
+
+  it("collapses runs of whitespace and handles empty input", () => {
+    expect(extractBashTokens("")).toEqual({ prefix: "", secondToken: "", thirdToken: "" })
+    expect(extractBashTokens("   ")).toEqual({ prefix: "", secondToken: "", thirdToken: "" })
+    expect(extractBashTokens("git   push   origin")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
+})
+
+describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", () => {
+  // Bridges the SQL-level extraction to the classifier — proves that a
+  // raw Claude Code Bash segment lands in the right toolMix bucket.
+  const classify = (segment: string): ReturnType<typeof classifyToolMixRow> => {
+    const t = extractBashTokens(segment)
+    return classifyToolMixRow(
+      row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken }),
+    )
+  }
+
+  it("`git -C /path status -s` lands in search (not bash)", () => {
+    expect(classify("git -C /Users/sans/src/worktrees/repo status -s")).toBe("search")
+  })
+
+  it("`git -C /path commit -m msg` lands in bash (and counts as a write-op)", () => {
+    const t = extractBashTokens("git -C /repo commit -m msg")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("bash")
+    expect(isGitWriteSegment(r)).toBe(true)
+  })
+
+  it("`gh -R owner/repo pr create` is a write-op (feeds gitWriteOps)", () => {
+    const t = extractBashTokens("gh -R owner/repo pr create --title foo")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("bash")
+    expect(isGitWriteSegment(r)).toBe(true)
+  })
+
+  it("`gh -R owner/repo pr view 123` is research, not a write-op", () => {
+    const t = extractBashTokens("gh -R owner/repo pr view 123")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("research")
+    expect(isGitWriteSegment(r)).toBe(false)
+  })
+
+  it("`pnpm --filter @domain/spans test` is bash (genuine shell orchestration)", () => {
+    expect(classify("pnpm --filter @domain/spans test")).toBe("bash")
+  })
+
+  it("`tail -8` (raw plumbing) is excluded entirely", () => {
+    expect(classify("tail -8")).toBe("excluded")
+  })
+
+  it("`cd /Users/sans/src` is excluded (navigation)", () => {
+    expect(classify("cd /Users/sans/src")).toBe("excluded")
   })
 })
 

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -69,14 +69,67 @@ const PATH_AWARE_TOOLS = new Set(["Edit", "MultiEdit", "NotebookEdit", "Write", 
 
 // Bash command-prefix routing. Lowercased; the adapter does the lowercase.
 const BASH_SEARCH_PREFIXES = new Set(["grep", "rg", "ag", "find", "ls", "tree"])
-const BASH_READ_PREFIXES = new Set(["cat", "head", "tail"])
 const BASH_RESEARCH_PREFIXES = new Set(["curl", "wget"])
-const BASH_EXCLUDED_PREFIXES = new Set(["cd", "pwd", "pushd", "popd", "clear", "exit", "open", "claude"])
+
+/**
+ * Pure output-shaping / orchestration commands. Almost always after a `|`
+ * to format something else's output (`… | tail -8`, `… | head`, `cat foo |
+ * less`), never standalone work in the Claude Code context. Excluded
+ * entirely from segment counting so they don't pad `commandsRun` or
+ * dominate the top-commands list.
+ *
+ * Includes the pure navigation commands too (`cd`, `pwd`, `open`, `claude`,
+ * …) for the same reason.
+ */
+const BASH_PLUMBING_PREFIXES = new Set([
+  "head",
+  "tail",
+  "cat",
+  "less",
+  "more",
+  "echo",
+  "printf",
+  "sed",
+  "awk",
+  "wc",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "xargs",
+  "tee",
+  "cd",
+  "pwd",
+  "pushd",
+  "popd",
+  "clear",
+  "exit",
+  "open",
+  "claude",
+])
 
 // git sub-command routing.
 const GIT_SEARCH_SUBCOMMANDS = new Set(["status", "log", "diff", "show", "blame", "branch", "ls-files", "reflog"])
 const GIT_EXCLUDED_SUBCOMMANDS = new Set(["checkout", "switch", "restore", "config", "init", "remote"])
 const GIT_WRITE_SUBCOMMANDS = new Set(["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"])
+
+// gh sub-subcommand routing. Keyed on (secondToken, thirdToken). `gh` is
+// the only command we look at three deep — its surface (`gh pr create`,
+// `gh issue list`, `gh api`) reads more like a 3-level CLI than git's
+// 2-level one, and the second token alone (`pr`, `issue`, `release`) is
+// too coarse to tell shipping from investigation apart.
+const GH_RESEARCH_SECOND_TOKENS = new Set(["issue", "api", "run", "workflow"])
+const GH_PR_RESEARCH_SUBCOMMANDS = new Set(["view", "list", "checks", "comment", "diff", "status"])
+/**
+ * gh write-ops triplets — these increment `gitWriteOps` AND stay in the
+ * `bash` bucket. Keyed by (secondToken → set of thirdToken). Anything
+ * not enumerated falls through to plain `bash`.
+ */
+const GH_WRITE_OPS: Record<string, ReadonlySet<string>> = {
+  pr: new Set(["create", "merge", "ready", "edit", "review"]),
+  release: new Set(["create", "edit", "upload"]),
+  repo: new Set(["create"]),
+}
 
 /**
  * Pure routing rule for one `ToolMixRow`. Returns the bucket the row counts
@@ -86,7 +139,7 @@ const GIT_WRITE_SUBCOMMANDS = new Set(["commit", "push", "merge", "rebase", "tag
  */
 export const classifyToolMixRow = (row: ToolMixRow): ToolBucket | "excluded" => {
   if (row.toolName === "Bash") {
-    return classifyBashSegment(row.bashPrefix, row.bashSecondToken)
+    return classifyBashSegment(row.bashPrefix, row.bashSecondToken, row.bashThirdToken)
   }
   if (PATH_AWARE_TOOLS.has(row.toolName)) {
     if (row.fileDisposition === "plan-file") return "plan"
@@ -97,23 +150,46 @@ export const classifyToolMixRow = (row: ToolMixRow): ToolBucket | "excluded" => 
   return TOOL_NAME_TO_BUCKET[row.toolName] ?? "other"
 }
 
-const classifyBashSegment = (prefix: string, secondToken: string): ToolBucket | "excluded" => {
+const classifyBashSegment = (prefix: string, secondToken: string, thirdToken: string): ToolBucket | "excluded" => {
+  if (BASH_PLUMBING_PREFIXES.has(prefix)) return "excluded"
   if (BASH_SEARCH_PREFIXES.has(prefix)) return "search"
-  if (BASH_READ_PREFIXES.has(prefix)) return "read"
   if (BASH_RESEARCH_PREFIXES.has(prefix)) return "research"
-  if (BASH_EXCLUDED_PREFIXES.has(prefix)) return "excluded"
   if (prefix === "git") {
     if (GIT_SEARCH_SUBCOMMANDS.has(secondToken)) return "search"
     if (GIT_EXCLUDED_SUBCOMMANDS.has(secondToken)) return "excluded"
     // Including GIT_WRITE_SUBCOMMANDS, GIT_NEUTRAL (add/rm/mv/stash/pull/…)
     // and unknown subcommands — stays in `bash` (genuine shell orchestration).
   }
+  if (prefix === "gh") {
+    // Read-side gh hits api.github.com, mirroring curl / wget — research.
+    if (GH_RESEARCH_SECOND_TOKENS.has(secondToken)) return "research"
+    if (secondToken === "pr" && GH_PR_RESEARCH_SUBCOMMANDS.has(thirdToken)) return "research"
+    // Everything else under gh stays in `bash` — including the write-ops
+    // triplets (which also feed `gitWriteOps`), `gh auth` / `gh config`,
+    // and `gh repo view` / `gh repo clone`.
+  }
   return "bash"
 }
 
-/** True when this row's command segment increments `gitWriteOps`. */
-export const isGitWriteSegment = (row: ToolMixRow): boolean =>
-  row.toolName === "Bash" && row.bashPrefix === "git" && GIT_WRITE_SUBCOMMANDS.has(row.bashSecondToken)
+/**
+ * True when this row's command segment increments `gitWriteOps`. Covers
+ * both raw `git` write-subcommands and the `gh` write-op triplets
+ * (`gh pr create`, `gh release upload`, `gh repo create`, …). Name stays
+ * `gitWriteOps`-flavoured even though it includes `gh` because the
+ * persisted field is named that way and a rename would force a schema
+ * migration for no behavioural gain.
+ */
+export const isGitWriteSegment = (row: ToolMixRow): boolean => {
+  if (row.toolName !== "Bash") return false
+  if (row.bashPrefix === "git") {
+    return GIT_WRITE_SUBCOMMANDS.has(row.bashSecondToken)
+  }
+  if (row.bashPrefix === "gh") {
+    const writes = GH_WRITE_OPS[row.bashSecondToken]
+    return writes !== undefined && writes.has(row.bashThirdToken)
+  }
+  return false
+}
 
 const emptyToolMix = (): ToolMix => ({
   bash: 0,

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -172,6 +172,74 @@ const classifyBashSegment = (prefix: string, secondToken: string, thirdToken: st
 }
 
 /**
+ * True if a token should be skipped when looking for the meaningful
+ * subcommand keyword inside a Bash segment. Mirrors the SQL
+ * `FLAG_LIKE_TOKEN_PREDICATE` in the CH adapter — both files must move
+ * in lockstep.
+ *
+ *   `-flag` / `--flag`         : POSIX / GNU CLI flags
+ *   tokens starting with `@`   : pnpm / npm / yarn scoped package args
+ *   tokens containing `/`      : absolute paths (`/Users/.../repo`),
+ *                                relative paths (`./scripts/x`), and
+ *                                `owner/repo`-style slugs (`gh -R x/y …`)
+ *   tokens starting with `.`   : relative paths without `/` (`./bin`)
+ *   tokens containing `=`      : `--key=value` syntax
+ *   purely numeric tokens      : counts / indices (`head -n 50`)
+ *
+ * Subcommands are by convention single bare keywords (`status`, `create`,
+ * `install`, `build`), so none of these patterns produce false positives
+ * in practice.
+ */
+const isFlagLikeToken = (t: string): boolean => {
+  if (t === "") return true
+  const c = t.charAt(0)
+  if (c === "-" || c === "@" || c === ".") return true
+  if (t.includes("/")) return true
+  if (t.includes("=")) return true
+  if (/^\d+$/.test(t)) return true
+  return false
+}
+
+interface BashTokens {
+  readonly prefix: string
+  readonly secondToken: string
+  readonly thirdToken: string
+}
+
+/**
+ * Extracts `(prefix, secondToken, thirdToken)` from a Bash command
+ * segment using the same flag-skipping rule the CH adapter applies. The
+ * adapter SQL must stay in lockstep with this function; tests against
+ * this function effectively validate the SQL by proxy.
+ *
+ * - `prefix` is the literal first whitespace token, lowercased. NOT
+ *   filtered, so a script invocation like `./scripts/build.sh` keeps its
+ *   leading `.` and is treated as the command name.
+ * - `secondToken` is the **first non-flag** token after the prefix.
+ * - `thirdToken` is the **second non-flag** token after the prefix.
+ *
+ * Examples (see `build-report.test.ts` for the full grid):
+ *
+ *   `git -C /path status -s`            → (git, status, "")
+ *   `gh -R owner/repo pr create --t x`  → (gh, pr, create)
+ *   `pnpm --filter @domain/spans test`  → (pnpm, test, "")
+ *   `git --version`                     → (git, "", "")
+ *   `head -n 50 foo.log`                → (head, foo.log, "")
+ */
+export const extractBashTokens = (segment: string): BashTokens => {
+  const trimmed = segment.trim()
+  if (trimmed === "") return { prefix: "", secondToken: "", thirdToken: "" }
+  const tokens = trimmed.split(/\s+/)
+  const prefix = (tokens[0] ?? "").toLowerCase()
+  const meaningful = tokens.slice(1).filter((t) => !isFlagLikeToken(t))
+  return {
+    prefix,
+    secondToken: (meaningful[0] ?? "").toLowerCase(),
+    thirdToken: (meaningful[1] ?? "").toLowerCase(),
+  }
+}
+
+/**
  * True when this row's command segment increments `gitWriteOps`. Covers
  * both raw `git` write-subcommands and the `gh` write-op triplets
  * (`gh pr create`, `gh release upload`, `gh repo create`, …). Name stays

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -35,9 +35,15 @@ const QUERY_CONCURRENCY = 6
 const DEEP_DIVE_CONCURRENCY = 3
 
 /**
- * Tool-name → bucket map. Maps every Claude Code tool we ship today and
- * funnels everything else into `other` so the bucket sums always equal the
- * total tool-call count.
+ * Tool-name → bucket map. Used for two paths:
+ *   1. The non-Bash, non-path-aware classifier branch in `classifyToolMixRow`.
+ *   2. Coarse name-only mapping for `dominantTool` on the workspace deep
+ *      dive, where the display field is "what kind of tool was most-used
+ *      in this workspace" — a per-span path/command analysis would be
+ *      overkill for that bit of copy.
+ *
+ * `Bash` maps to `bash` here for case (2); the per-segment classifier in
+ * `classifyBashSegment` is what drives the toolMix shares.
  */
 const TOOL_NAME_TO_BUCKET: Record<string, ToolBucket> = {
   Bash: "bash",
@@ -59,6 +65,56 @@ const TOOL_NAME_TO_BUCKET: Record<string, ToolBucket> = {
 
 export const toolBucketFor = (toolName: string): ToolBucket => TOOL_NAME_TO_BUCKET[toolName] ?? "other"
 
+const PATH_AWARE_TOOLS = new Set(["Edit", "MultiEdit", "NotebookEdit", "Write", "Read", "NotebookRead"])
+
+// Bash command-prefix routing. Lowercased; the adapter does the lowercase.
+const BASH_SEARCH_PREFIXES = new Set(["grep", "rg", "ag", "find", "ls", "tree"])
+const BASH_READ_PREFIXES = new Set(["cat", "head", "tail"])
+const BASH_RESEARCH_PREFIXES = new Set(["curl", "wget"])
+const BASH_EXCLUDED_PREFIXES = new Set(["cd", "pwd", "pushd", "popd", "clear", "exit", "open", "claude"])
+
+// git sub-command routing.
+const GIT_SEARCH_SUBCOMMANDS = new Set(["status", "log", "diff", "show", "blame", "branch", "ls-files", "reflog"])
+const GIT_EXCLUDED_SUBCOMMANDS = new Set(["checkout", "switch", "restore", "config", "init", "remote"])
+const GIT_WRITE_SUBCOMMANDS = new Set(["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"])
+
+/**
+ * Pure routing rule for one `ToolMixRow`. Returns the bucket the row counts
+ * toward, or `"excluded"` to drop it entirely (so the toolMix denominator
+ * isn't padded by navigation/scratch noise). Mirrors the SQL classification
+ * in the CH adapter — both live here so unit tests pin the contract.
+ */
+export const classifyToolMixRow = (row: ToolMixRow): ToolBucket | "excluded" => {
+  if (row.toolName === "Bash") {
+    return classifyBashSegment(row.bashPrefix, row.bashSecondToken)
+  }
+  if (PATH_AWARE_TOOLS.has(row.toolName)) {
+    if (row.fileDisposition === "plan-file") return "plan"
+    if (row.fileDisposition === "claude-noise" || row.fileDisposition === "external") return "excluded"
+    // "workspace" or "" (no file_path on this call) fall through to the
+    // tool-name map.
+  }
+  return TOOL_NAME_TO_BUCKET[row.toolName] ?? "other"
+}
+
+const classifyBashSegment = (prefix: string, secondToken: string): ToolBucket | "excluded" => {
+  if (BASH_SEARCH_PREFIXES.has(prefix)) return "search"
+  if (BASH_READ_PREFIXES.has(prefix)) return "read"
+  if (BASH_RESEARCH_PREFIXES.has(prefix)) return "research"
+  if (BASH_EXCLUDED_PREFIXES.has(prefix)) return "excluded"
+  if (prefix === "git") {
+    if (GIT_SEARCH_SUBCOMMANDS.has(secondToken)) return "search"
+    if (GIT_EXCLUDED_SUBCOMMANDS.has(secondToken)) return "excluded"
+    // Including GIT_WRITE_SUBCOMMANDS, GIT_NEUTRAL (add/rm/mv/stash/pull/…)
+    // and unknown subcommands — stays in `bash` (genuine shell orchestration).
+  }
+  return "bash"
+}
+
+/** True when this row's command segment increments `gitWriteOps`. */
+export const isGitWriteSegment = (row: ToolMixRow): boolean =>
+  row.toolName === "Bash" && row.bashPrefix === "git" && GIT_WRITE_SUBCOMMANDS.has(row.bashSecondToken)
+
 const emptyToolMix = (): ToolMix => ({
   bash: 0,
   read: 0,
@@ -73,7 +129,9 @@ const emptyToolMix = (): ToolMix => ({
 const bucketise = (rows: readonly ToolMixRow[]): ToolMix => {
   const mix = emptyToolMix()
   for (const row of rows) {
-    mix[toolBucketFor(row.toolName)] += row.uses
+    const bucket = classifyToolMixRow(row)
+    if (bucket === "excluded") continue
+    mix[bucket] += row.uses
   }
   return mix
 }
@@ -203,6 +261,7 @@ export const assembleReport = (input: AssembleReportInput): Report => {
     filesTouched: input.totals.filesTouched,
     commandsRun: input.totals.commandsRun,
     commits: input.totals.commits,
+    gitWriteOps: input.totals.gitWriteOps,
     testsRun: input.totals.testsRun,
     editAdded,
     writeLines,
@@ -245,6 +304,7 @@ export const assembleReport = (input: AssembleReportInput): Report => {
       repos: input.totals.repos,
       streakDays: input.totals.streakDays,
       testsRun: input.totals.testsRun,
+      gitWriteOps: input.totals.gitWriteOps,
     },
     toolMix,
     loc: {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -227,9 +227,18 @@ interface BashTokens {
  *   `head -n 50 foo.log`                → (head, foo.log, "")
  */
 export const extractBashTokens = (segment: string): BashTokens => {
-  const trimmed = segment.trim()
-  if (trimmed === "") return { prefix: "", secondToken: "", thirdToken: "" }
-  const tokens = trimmed.split(/\s+/)
+  // Normalise before tokenising:
+  //   1. Strip bash line continuations (`\<NEWLINE>`) — a multi-line
+  //      command like `foo bar \<NL>  echo continued` would otherwise
+  //      tokenise as `foo`, `bar`, `\<NL>`, `echo`, `continued`, and the
+  //      `\<NL>` token becomes a junk "command" in the top-commands
+  //      display ("\ echo").
+  //   2. Collapse any whitespace run (spaces, tabs, leftover newlines)
+  //      to a single space so `splitByChar(' ', …)` produces clean
+  //      tokens with no empty entries.
+  const normalised = segment.replace(/\\\n/g, " ").replace(/\s+/g, " ").trim()
+  if (normalised === "") return { prefix: "", secondToken: "", thirdToken: "" }
+  const tokens = normalised.split(" ")
   const prefix = (tokens[0] ?? "").toLowerCase()
   const meaningful = tokens.slice(1).filter((t) => !isFlagLikeToken(t))
   return {

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
@@ -80,6 +80,7 @@ const makeReader = (overrides?: Partial<ClaudeCodeSpanReaderShape>): ClaudeCodeS
       repos: 0,
       streakDays: 0,
       testsRun: 0,
+      gitWriteOps: 0,
     }),
   getSessionDurationStats: () => Effect.succeed({ totalDurationMs: 0, longestDurationMs: 0, longestWorkspace: null }),
   getLocStats: () => Effect.succeed({ writeLines: 0, editAdded: 0, editRemoved: 0, readLines: 0 }),

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -143,6 +143,40 @@ const BASH_PLUMBING_PREFIXES_SQL = `(
 )`
 
 /**
+ * Generic investigation tools — route to the `search` bucket for personality
+ * purposes (a heavy grepper is a Detective) but are filtered out of the
+ * top-commands display. The display is reserved for shell orchestration
+ * the user actually drove; investigation is summarised by the `search`
+ * bucket's share.
+ */
+const BASH_SEARCH_PREFIXES_SQL = `('grep','rg','ag','find','ls','tree')`
+
+/**
+ * Git sub-commands that don't route to `bash` (i.e. `git status` /
+ * `log` / `diff` etc. → `search`; `git checkout` / `switch` etc. →
+ * `excluded`). Used by the top-commands display filter to keep only
+ * segments that route to `bash` or `research`.
+ */
+const GIT_NON_BASH_SUBCOMMANDS_SQL = `(
+  'status','log','diff','show','blame','branch','ls-files','reflog',
+  'checkout','switch','restore','config','init','remote'
+)`
+
+/**
+ * Normalises a Bash command segment before tokenisation:
+ *   1. Replace `\\<NEWLINE>` (literal backslash + newline) with a single
+ *      space — multi-line bash continuations would otherwise tokenise
+ *      as `\\<NL>` and surface as junk "commands" in the display.
+ *   2. Collapse any whitespace run (spaces, tabs, leftover newlines) to
+ *      a single space so \`splitByChar(' ', …)\` produces clean tokens.
+ *   3. Trim leading/trailing whitespace.
+ *
+ * Mirrors the JS normalisation in \`extractBashTokens\` (build-report.ts).
+ */
+const normalizeSegmentSql = (segmentExpr: string): string =>
+  `trim(replaceRegexpAll(replaceAll(${segmentExpr}, '\\\\\\n', ' '), '\\\\s+', ' '))`
+
+/**
  * gh sub-subcommand triplets that count as shipping write-ops (they
  * increment `gitWriteOps` alongside the raw git write-subcommands).
  * Encoded as a SQL OR predicate so the same expression can be reused
@@ -209,44 +243,68 @@ const FLAG_LIKE_TOKEN_PREDICATE = `(t = ''
   OR position(t, '=') > 0
   OR match(t, '^[0-9]+$'))`
 
-const subcommandAwarePatternSql = (segmentExpr: string): string => `
-  multiIf(
-    -- Plumbing prefixes contribute no displayable pattern at all.
-    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) IN ${BASH_PLUMBING_PREFIXES_SQL}, '',
+const subcommandAwarePatternSql = (segmentExpr: string): string => {
+  // Each branch needs the normalised segment, its first token (prefix),
+  // and the first non-flag token after the prefix (the subcommand
+  // candidate). Substitute these once so the multiIf body stays readable.
+  const norm = normalizeSegmentSql(segmentExpr)
+  const prefix = `lowerUTF8(splitByChar(' ', ${norm})[1])`
+  const firstNonFlagAfterPrefix = `coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                       arraySlice(splitByChar(' ', ${norm}), 2)), '')`
+  const secondNonFlagAfterPrefix = `coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                        arraySlice(splitByChar(' ', ${norm}),
+                                                                   indexOf(splitByChar(' ', ${norm}),
+                                                                           arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                                                      arraySlice(splitByChar(' ', ${norm}), 2))) + 1)), '')`
+  return `
+    multiIf(
+      -- Plumbing prefixes → empty (no displayable pattern at all).
+      ${prefix} IN ${BASH_PLUMBING_PREFIXES_SQL}, '',
 
-    -- gh: two-deep extraction. Skip flag-like tokens at every level.
-    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) = 'gh',
-    arrayStringConcat(
-      arrayFilter(p -> p != '',
-        [
-          'gh',
-          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                               arraySlice(splitByChar(' ', trim(${segmentExpr})), 2)), ''),
-          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                               arraySlice(splitByChar(' ', trim(${segmentExpr})),
-                                          indexOf(splitByChar(' ', trim(${segmentExpr})),
-                                                  arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                                                             arraySlice(splitByChar(' ', trim(${segmentExpr})), 2))) + 1)), '')
-        ]),
-      ' '
-    ),
+      -- Search prefixes → empty. Option C: top-commands shows only
+      -- segments routing to \`bash\` or \`research\`; investigation
+      -- tools (grep / ls / find / …) are summarised by the search
+      -- bucket's share in the personality, not by surfacing each
+      -- command in the display.
+      ${prefix} IN ${BASH_SEARCH_PREFIXES_SQL}, '',
 
-    -- 1-deep extraction for the known multi-action prefixes.
-    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) IN ${SUBCOMMAND_AWARE_PREFIXES_SQL},
-    arrayStringConcat(
-      arrayFilter(p -> p != '',
-        [
-          splitByChar(' ', trim(${segmentExpr}))[1],
-          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                               arraySlice(splitByChar(' ', trim(${segmentExpr})), 2)), '')
-        ]),
-      ' '
-    ),
+      -- Git non-bash subcommands → empty. \`git status\` / \`git log\`
+      -- / \`git diff\` etc. are search; \`git checkout\` / \`switch\`
+      -- etc. are excluded. Either way they don't belong in the
+      -- top-commands display.
+      ${prefix} = 'git' AND lowerUTF8(${firstNonFlagAfterPrefix}) IN ${GIT_NON_BASH_SUBCOMMANDS_SQL}, '',
 
-    -- Default: just the first token.
-    splitByChar(' ', trim(${segmentExpr}))[1]
-  )
-`
+      -- gh: two-deep extraction (\`gh pr create\` is meaningfully
+      -- different from \`gh pr view\`). All gh segments are kept
+      -- because they route to either \`bash\` (write-ops + auth/config)
+      -- or \`research\` (read-side) — both allowed under Option C.
+      ${prefix} = 'gh',
+      arrayStringConcat(
+        arrayFilter(p -> p != '',
+          [
+            'gh',
+            ${firstNonFlagAfterPrefix},
+            ${secondNonFlagAfterPrefix}
+          ]),
+        ' '
+      ),
+
+      -- 1-deep extraction for the known multi-action prefixes.
+      ${prefix} IN ${SUBCOMMAND_AWARE_PREFIXES_SQL},
+      arrayStringConcat(
+        arrayFilter(p -> p != '',
+          [
+            splitByChar(' ', ${norm})[1],
+            ${firstNonFlagAfterPrefix}
+          ]),
+        ' '
+      ),
+
+      -- Default: just the first token.
+      splitByChar(' ', ${norm})[1]
+    )
+  `
+}
 
 // Shared filter parameters appended to every project-window query so the same
 // keys are used everywhere and the centralised filter stays in sync.
@@ -457,18 +515,20 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   -- second_token / third_token use flag-skipping so
                   -- \`git -C /path status -s\` matches the git_write_ops
                   -- predicate correctly (second_token = "status", not
-                  -- the literal "-c"). Mirrors extractBashTokens in
+                  -- the literal "-c"). Segment normalisation strips
+                  -- line continuations and collapses whitespace before
+                  -- tokenising. Mirrors extractBashTokens in
                   -- build-report.ts.
                   SELECT
-                    lowerUTF8(splitByChar(' ', trim(segment))[1])                                   AS prefix,
+                    lowerUTF8(splitByChar(' ', ${normalizeSegmentSql("segment")})[1])               AS prefix,
                     lowerUTF8(arrayElement(
                       arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
                       1
                     ))                                                                              AS second_token,
                     lowerUTF8(arrayElement(
                       arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
                       2
                     ))                                                                              AS third_token,
                     segment
@@ -730,20 +790,22 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   -- post-prefix slice, then take the 1st / 2nd of what
                   -- remains. So \`git -C /path status -s\` produces
                   -- (git, status, "") and \`gh -R owner/repo pr create\`
-                  -- produces (gh, pr, create). Mirrors \`extractBashTokens\`
-                  -- in build-report.ts — both must move in lockstep.
+                  -- produces (gh, pr, create). Segment normalisation
+                  -- strips line continuations + collapses whitespace
+                  -- first so multi-line bash commands tokenise cleanly.
+                  -- Mirrors \`extractBashTokens\` in build-report.ts.
                   SELECT
                     'Bash' AS tool_name,
                     ''     AS file_disposition,
-                    lowerUTF8(splitByChar(' ', trim(segment))[1])                                   AS bash_prefix,
+                    lowerUTF8(splitByChar(' ', ${normalizeSegmentSql("segment")})[1])               AS bash_prefix,
                     lowerUTF8(arrayElement(
                       arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
                       1
                     ))                                                                              AS bash_second_token,
                     lowerUTF8(arrayElement(
                       arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
-                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
                       2
                     ))                                                                              AS bash_third_token
                   FROM spans

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -188,11 +188,24 @@ const SUBCOMMAND_AWARE_PREFIXES_SQL = `(
  *
  * Built with `arrayFirst` over `arraySlice` to walk tokens.
  */
+/**
+ * Mirrors `isFlagLikeToken` in `@domain/spans/.../build-report.ts` — both
+ * must stay in lockstep. Skips:
+ *   `-flag` / `--flag`         : CLI flags
+ *   `@scope/...`               : scoped package args
+ *   any `/`-containing token   : paths AND `owner/repo`-style slugs
+ *                                 (`gh -R owner/repo …` would otherwise
+ *                                 have `owner/repo` survive as the
+ *                                 "subcommand")
+ *   `.foo`                     : relative paths without `/`
+ *   `key=value`                : `--key=value` syntax
+ *   purely numeric             : counts (`head -n 50`)
+ */
 const FLAG_LIKE_TOKEN_PREDICATE = `(t = ''
   OR startsWith(t, '-')
   OR startsWith(t, '@')
-  OR startsWith(t, '/')
   OR startsWith(t, '.')
+  OR position(t, '/') > 0
   OR position(t, '=') > 0
   OR match(t, '^[0-9]+$'))`
 
@@ -441,10 +454,23 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
             const result = await client.query({
               query: `
                 WITH bash_segments AS (
+                  -- second_token / third_token use flag-skipping so
+                  -- \`git -C /path status -s\` matches the git_write_ops
+                  -- predicate correctly (second_token = "status", not
+                  -- the literal "-c"). Mirrors extractBashTokens in
+                  -- build-report.ts.
                   SELECT
-                    lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS prefix,
-                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS second_token,
-                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 3))         AS third_token,
+                    lowerUTF8(splitByChar(' ', trim(segment))[1])                                   AS prefix,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                      1
+                    ))                                                                              AS second_token,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                      2
+                    ))                                                                              AS third_token,
                     segment
                   FROM spans
                   ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
@@ -698,12 +724,28 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
 
                   UNION ALL
 
+                  -- Bash second/third tokens use flag-skipping (same rule
+                  -- as the display layer): filter out flag-like tokens
+                  -- (-flag, paths, scopes, k=v, numerics) from the
+                  -- post-prefix slice, then take the 1st / 2nd of what
+                  -- remains. So \`git -C /path status -s\` produces
+                  -- (git, status, "") and \`gh -R owner/repo pr create\`
+                  -- produces (gh, pr, create). Mirrors \`extractBashTokens\`
+                  -- in build-report.ts — both must move in lockstep.
                   SELECT
                     'Bash' AS tool_name,
                     ''     AS file_disposition,
-                    lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS bash_prefix,
-                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS bash_second_token,
-                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 3))         AS bash_third_token
+                    lowerUTF8(splitByChar(' ', trim(segment))[1])                                   AS bash_prefix,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                      1
+                    ))                                                                              AS bash_second_token,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', trim(segment)), 2)),
+                      2
+                    ))                                                                              AS bash_third_token
                   FROM spans
                   ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
                                             JSONExtractString(tool_input, 'command')) AS segment

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -130,6 +130,111 @@ const workspaceStrictPathPredicate = (workspacePathExpr: string, filePathExpr: s
 // SQL list literals for the Bash sub-classification. Lowercased.
 const GIT_WRITE_SUBCOMMANDS_SQL = `('commit','push','merge','rebase','tag','revert','cherry-pick')`
 
+/**
+ * Pure output-shaping / orchestration commands. Excluded from segment
+ * counting so they don't pollute `commandsRun` or dominate the
+ * top-commands list. Mirrors `BASH_PLUMBING_PREFIXES` in `build-report.ts`
+ * — these two lists must stay in lockstep.
+ */
+const BASH_PLUMBING_PREFIXES_SQL = `(
+  'head','tail','cat','less','more',
+  'echo','printf','sed','awk','wc','sort','uniq','cut','tr','xargs','tee',
+  'cd','pwd','pushd','popd','clear','exit','open','claude'
+)`
+
+/**
+ * gh sub-subcommand triplets that count as shipping write-ops (they
+ * increment `gitWriteOps` alongside the raw git write-subcommands).
+ * Encoded as a SQL OR predicate so the same expression can be reused
+ * across the totals query and any future per-segment aggregation.
+ */
+const GH_WRITE_OPS_PREDICATE = `(
+  (second_token = 'pr'      AND third_token IN ('create','merge','ready','edit','review'))
+  OR (second_token = 'release' AND third_token IN ('create','edit','upload'))
+  OR (second_token = 'repo'    AND third_token = 'create')
+)`
+
+/**
+ * Prefixes for which the "top commands" surface should display
+ * `prefix + first-non-flag-token` instead of just `prefix`. `git push` is
+ * a meaningfully different story from `git status`; `pnpm test` is
+ * different from `pnpm install`. For most tools, the first token is
+ * descriptive enough.
+ *
+ * `gh` gets two-deep treatment (handled separately) because its CLI is
+ * structurally 3-level (`gh pr create` vs `gh pr view`).
+ */
+const SUBCOMMAND_AWARE_PREFIXES_SQL = `(
+  'git','pnpm','npm','yarn','bun','cargo','brew','docker','kubectl',
+  'mix','rake','gradle','mvn','go','poetry','pipx','terraform',
+  'fly','railway','vercel'
+)`
+
+/**
+ * SQL expression that takes a tokens array (from `splitByChar(' ',
+ * segment)`) and the prefix, and emits the displayable pattern:
+ *
+ *   - empty if the prefix is in the plumbing set (filtered out upstream
+ *     of this helper, but defended in depth here too)
+ *   - `prefix subcommand` for known multi-action prefixes — `subcommand`
+ *     is the first non-flag-like token after the prefix
+ *   - `gh second third` for `gh` — both sub and sub-sub, again skipping
+ *     flag-like tokens
+ *   - just `prefix` otherwise
+ *
+ * "Flag-like" token = starts with `-`, `@`, `/`, or `.`, or contains `=`,
+ * or is purely numeric. These are CLI flag syntax / scoped-package args
+ * / paths / counts — none of them are subcommand keywords.
+ *
+ * Built with `arrayFirst` over `arraySlice` to walk tokens.
+ */
+const FLAG_LIKE_TOKEN_PREDICATE = `(t = ''
+  OR startsWith(t, '-')
+  OR startsWith(t, '@')
+  OR startsWith(t, '/')
+  OR startsWith(t, '.')
+  OR position(t, '=') > 0
+  OR match(t, '^[0-9]+$'))`
+
+const subcommandAwarePatternSql = (segmentExpr: string): string => `
+  multiIf(
+    -- Plumbing prefixes contribute no displayable pattern at all.
+    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) IN ${BASH_PLUMBING_PREFIXES_SQL}, '',
+
+    -- gh: two-deep extraction. Skip flag-like tokens at every level.
+    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) = 'gh',
+    arrayStringConcat(
+      arrayFilter(p -> p != '',
+        [
+          'gh',
+          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                               arraySlice(splitByChar(' ', trim(${segmentExpr})), 2)), ''),
+          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                               arraySlice(splitByChar(' ', trim(${segmentExpr})),
+                                          indexOf(splitByChar(' ', trim(${segmentExpr})),
+                                                  arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                             arraySlice(splitByChar(' ', trim(${segmentExpr})), 2))) + 1)), '')
+        ]),
+      ' '
+    ),
+
+    -- 1-deep extraction for the known multi-action prefixes.
+    lowerUTF8(splitByChar(' ', trim(${segmentExpr}))[1]) IN ${SUBCOMMAND_AWARE_PREFIXES_SQL},
+    arrayStringConcat(
+      arrayFilter(p -> p != '',
+        [
+          splitByChar(' ', trim(${segmentExpr}))[1],
+          coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                               arraySlice(splitByChar(' ', trim(${segmentExpr})), 2)), '')
+        ]),
+      ' '
+    ),
+
+    -- Default: just the first token.
+    splitByChar(' ', trim(${segmentExpr}))[1]
+  )
+`
+
 // Shared filter parameters appended to every project-window query so the same
 // keys are used everywhere and the centralised filter stays in sync.
 const projectWindowParams = (params: {
@@ -201,6 +306,7 @@ interface ToolMixCHRow {
   readonly file_disposition: string
   readonly bash_prefix: string
   readonly bash_second_token: string
+  readonly bash_third_token: string
   readonly uses: number | string
 }
 
@@ -338,6 +444,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   SELECT
                     lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS prefix,
                     lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS second_token,
+                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 3))         AS third_token,
                     segment
                   FROM spans
                   ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
@@ -355,7 +462,12 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                     AND JSONExtractString(tool_input, 'file_path') != ''
                     AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   )                                                                                   AS files_touched,
-                  (SELECT count() FROM bash_segments)                                                 AS commands_run,
+                  -- "Commands run" excludes pure plumbing (head/tail/echo/sed/…
+                  -- and navigation cd/pwd/open/…). These are never standalone
+                  -- work; they'd inflate the headline number without telling
+                  -- a story.
+                  (SELECT countIf(prefix NOT IN ${BASH_PLUMBING_PREFIXES_SQL})
+                    FROM bash_segments)                                                               AS commands_run,
                   countDistinctIf(metadata['workspace.name'], metadata['workspace.name'] != '')       AS workspaces,
                   countDistinctIf(metadata['git.branch'],     metadata['git.branch']     != '')       AS branches,
                   countDistinctIf(metadata['git.commit'],     metadata['git.commit']     != '')       AS commits,
@@ -364,8 +476,13 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   (SELECT countIf(match(segment,
                       '(?i)(^|\\\\s)(test(\\\\s|:|$)|pytest|vitest|jest|mocha|rspec)'))
                     FROM bash_segments)                                                               AS tests_run,
-                  (SELECT countIf(prefix = 'git' AND second_token IN ${GIT_WRITE_SUBCOMMANDS_SQL})
-                    FROM bash_segments)                                                               AS git_write_ops
+                  -- Both git write-subcommands AND gh write-op triplets feed
+                  -- gitWriteOps. The persisted field name stays gitWriteOps
+                  -- (no schema migration) even though gh is now included.
+                  (SELECT countIf(
+                    (prefix = 'git' AND second_token IN ${GIT_WRITE_SUBCOMMANDS_SQL})
+                    OR (prefix = 'gh' AND ${GH_WRITE_OPS_PREDICATE})
+                  ) FROM bash_segments)                                                               AS git_write_ops
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
               `,
@@ -565,13 +682,14 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
             // first-two-token pairs in user Bash + 4 disposition values.
             const result = await client.query({
               query: `
-                SELECT tool_name, file_disposition, bash_prefix, bash_second_token, count() AS uses
+                SELECT tool_name, file_disposition, bash_prefix, bash_second_token, bash_third_token, count() AS uses
                 FROM (
                   SELECT
                     tool_name,
                     ${filePathDispositionSql("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")} AS file_disposition,
                     ''  AS bash_prefix,
-                    ''  AS bash_second_token
+                    ''  AS bash_second_token,
+                    ''  AS bash_third_token
                   FROM spans
                   WHERE ${PROJECT_WINDOW_FILTER}
                     AND operation = 'execute_tool'
@@ -584,7 +702,8 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                     'Bash' AS tool_name,
                     ''     AS file_disposition,
                     lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS bash_prefix,
-                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS bash_second_token
+                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS bash_second_token,
+                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 3))         AS bash_third_token
                   FROM spans
                   ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
                                             JSONExtractString(tool_input, 'command')) AS segment
@@ -592,7 +711,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                     AND tool_name = 'Bash'
                     AND segment != ''
                 )
-                GROUP BY tool_name, file_disposition, bash_prefix, bash_second_token
+                GROUP BY tool_name, file_disposition, bash_prefix, bash_second_token, bash_third_token
               `,
               query_params: projectWindowParams(params),
               format: "JSONEachRow",
@@ -606,6 +725,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                 fileDisposition: (row.file_disposition || "") as ToolMixRow["fileDisposition"],
                 bashPrefix: row.bash_prefix,
                 bashSecondToken: row.bash_second_token,
+                bashThirdToken: row.bash_third_token,
                 uses: num(row.uses),
               })),
             ),
@@ -654,21 +774,25 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
-            // Counts segments, not whole tool calls — `cd foo && grep bar`
-            // contributes a `cd` and a `grep` rather than just the `cd`.
-            // Without the split, the most-chained-after commands (which
-            // are usually the *important* ones) get under-counted.
+            // Counts command segments (a chained `cd foo && grep bar`
+            // contributes a `cd` and a `grep`). Plumbing prefixes
+            // (tail/head/echo/sed/…) are excluded so the list reflects
+            // intentional work. For multi-action prefixes (git, pnpm,
+            // gh, …) the pattern is `prefix subcommand` instead of just
+            // the prefix — `git push` and `git status` show distinctly.
             const result = await client.query({
               query: `
-                SELECT
-                  splitByChar(' ', trim(segment))[1] AS pattern,
-                  count() AS uses
-                FROM spans
-                ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
-                                          JSONExtractString(tool_input, 'command')) AS segment
-                WHERE ${PROJECT_WINDOW_FILTER}
-                  AND tool_name = 'Bash'
-                  AND segment != ''
+                SELECT pattern, count() AS uses
+                FROM (
+                  SELECT ${subcommandAwarePatternSql("segment")} AS pattern
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
+                WHERE pattern != ''
                 GROUP BY pattern
                 ORDER BY uses DESC
                 LIMIT 5
@@ -791,16 +915,18 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   LIMIT 3
                 ),
                 commands AS (
-                  SELECT
-                    splitByChar(' ', trim(segment))[1] AS pattern,
-                    count() AS uses
-                  FROM spans
-                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
-                                            JSONExtractString(tool_input, 'command')) AS segment
-                  WHERE ${PROJECT_WINDOW_FILTER}
-                    AND metadata['workspace.name'] = {workspaceName:String}
-                    AND tool_name = 'Bash'
-                    AND segment != ''
+                  SELECT pattern, count() AS uses
+                  FROM (
+                    SELECT ${subcommandAwarePatternSql("segment")} AS pattern
+                    FROM spans
+                    ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                              JSONExtractString(tool_input, 'command')) AS segment
+                    WHERE ${PROJECT_WINDOW_FILTER}
+                      AND metadata['workspace.name'] = {workspaceName:String}
+                      AND tool_name = 'Bash'
+                      AND segment != ''
+                  )
+                  WHERE pattern != ''
                   GROUP BY pattern
                   ORDER BY uses DESC
                   LIMIT 3

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -40,6 +40,60 @@ const toClickhouseDateTime = (date: Date): string => date.toISOString().replace(
 // embedded SQL matches what the spans adapter actually inserts.
 const FILE_PATH_TOOLS = ["Read", "Edit", "Write", "NotebookEdit", "MultiEdit"] as const
 
+// SQL list literal for the path-aware tool set — `Read`/`Edit`/`Write` plus
+// the two notebook variants. Used by every query that filters or routes on
+// file path.
+const FILE_PATH_TOOLS_SQL = FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")
+const PATH_AWARE_TOOLS_SQL = `('Edit','MultiEdit','NotebookEdit','Write','Read','NotebookRead')`
+
+// Splits a Bash command string into its `&&` / `||` / `;` / `|`-separated
+// segments. Order in the alternation matters — `||` and `&&` are tried
+// before the single `|` so the two-char operators win at each position
+// (RE2 alternation is greedy left-to-right per position).
+//
+// Wraps each operator in optional whitespace so the resulting segments
+// come back already trimmed. Subshells (`$(…)`, backticks) are *not*
+// handled — rare enough that the regex approach is good enough and
+// proper handling needs a tokeniser.
+const BASH_SEGMENT_REGEX = "\\\\s*(?:&&|\\\\|\\\\||;|\\\\|)\\\\s*"
+
+// Path classifier used by every query that has to decide whether a file
+// touch counts. Mirrors the TS `classifyToolMixRow` rules in
+// `@domain/spans/.../build-report.ts` — both must move in lockstep.
+//
+//   plan-file:    `**/.claude/plans/<id>.md`            → routes to `plan`
+//   claude-noise: any other path under `**/.claude/**`  → excluded
+//   external:     outside the workspace root            → excluded
+//   workspace:    inside the workspace                  → existing bucket
+//   "":           the call carries no `file_path`       → existing bucket
+//
+// Empty string is the "no file_path" case (LS / a Read with `offset`
+// only / a malformed input) — the call still counts toward the existing
+// tool-name bucket; only path-bearing calls can be excluded by path.
+const filePathDispositionSql = (workspacePathExpr: string, filePathExpr: string): string => `
+  multiIf(
+    ${filePathExpr} = '', '',
+    match(${filePathExpr}, '/\\\\.claude/plans/[^/]+\\\\.md$'), 'plan-file',
+    positionUTF8(${filePathExpr}, '/.claude/') > 0, 'claude-noise',
+    ${workspacePathExpr} != '' AND NOT startsWith(${filePathExpr}, ${workspacePathExpr}), 'external',
+    'workspace'
+  )
+`
+
+/** SQL predicate selecting only file_paths that should count toward LOC stats. */
+const workspaceFilePathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
+  (
+    ${filePathExpr} = ''
+    OR (
+      positionUTF8(${filePathExpr}, '/.claude/') = 0
+      AND (${workspacePathExpr} = '' OR startsWith(${filePathExpr}, ${workspacePathExpr}))
+    )
+  )
+`
+
+// SQL list literals for the Bash sub-classification. Lowercased.
+const GIT_WRITE_SUBCOMMANDS_SQL = `('commit','push','merge','rebase','tag','revert','cherry-pick')`
+
 // Shared filter parameters appended to every project-window query so the same
 // keys are used everywhere and the centralised filter stays in sync.
 const projectWindowParams = (params: {
@@ -83,6 +137,7 @@ interface TotalsCHRow {
   readonly repos: number | string
   readonly streak_days: number | string
   readonly tests_run: number | string
+  readonly git_write_ops: number | string
 }
 
 interface LocStatsCHRow {
@@ -107,6 +162,9 @@ interface DurationStatsCHRow {
 
 interface ToolMixCHRow {
   readonly tool_name: string
+  readonly file_disposition: string
+  readonly bash_prefix: string
+  readonly bash_second_token: string
   readonly uses: number | string
 }
 
@@ -232,27 +290,46 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // `commands_run`, `tests_run` and `git_write_ops` derive from
+            // *Bash segments* (so `cd foo && grep bar && git push` counts
+            // as three segments — one navigation, one search, one push).
+            // The bash_segments CTE explodes each Bash tool call into its
+            // operator-split segments; the outer query joins the segment
+            // counters in with the rest of the per-span aggregates.
             const result = await client.query({
               query: `
+                WITH bash_segments AS (
+                  SELECT
+                    lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS prefix,
+                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS second_token,
+                    segment
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
                 SELECT
                   countDistinctIf(session_id, session_id != '')                                       AS sessions,
                   countIf(operation = 'execute_tool')                                                 AS tool_calls,
                   countDistinctIf(
                     JSONExtractString(tool_input, 'file_path'),
-                    tool_name IN (${FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")})
+                    tool_name IN (${FILE_PATH_TOOLS_SQL})
                     AND JSONExtractString(tool_input, 'file_path') != ''
+                    AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   )                                                                                   AS files_touched,
-                  countIf(tool_name = 'Bash')                                                         AS commands_run,
+                  (SELECT count() FROM bash_segments)                                                 AS commands_run,
                   countDistinctIf(metadata['workspace.name'], metadata['workspace.name'] != '')       AS workspaces,
                   countDistinctIf(metadata['git.branch'],     metadata['git.branch']     != '')       AS branches,
                   countDistinctIf(metadata['git.commit'],     metadata['git.commit']     != '')       AS commits,
                   countDistinctIf(metadata['git.repo'],       metadata['git.repo']       != '')       AS repos,
                   uniqExact(toDate(start_time))                                                       AS streak_days,
-                  countIf(
-                    tool_name = 'Bash'
-                    AND match(JSONExtractString(tool_input, 'command'),
-                      '(?i)(^|\\s)(test(\\s|:|$)|pytest|vitest|jest|mocha|rspec)')
-                  )                                                                                   AS tests_run
+                  (SELECT countIf(match(segment,
+                      '(?i)(^|\\\\s)(test(\\\\s|:|$)|pytest|vitest|jest|mocha|rspec)'))
+                    FROM bash_segments)                                                               AS tests_run,
+                  (SELECT countIf(prefix = 'git' AND second_token IN ${GIT_WRITE_SUBCOMMANDS_SQL})
+                    FROM bash_segments)                                                               AS git_write_ops
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
               `,
@@ -271,6 +348,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
               repos: 0,
               streakDays: 0,
               testsRun: 0,
+              gitWriteOps: 0,
             }
             if (!row) return empty
             return {
@@ -284,6 +362,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
               repos: num(row.repos),
               streakDays: num(row.streak_days),
               testsRun: num(row.tests_run),
+              gitWriteOps: num(row.git_write_ops),
             }
           })
           .pipe(Effect.mapError((error) => toRepositoryError(error, "getTotalsForProject")))
@@ -297,25 +376,42 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
             // countSubstrings counts non-overlapping occurrences — equivalent
             // to "lines of code" when measured by '\n'. We treat the final
             // line as "complete enough" for the aggregate.
+            //
+            // Each per-tool-name aggregation also gates on
+            // `workspaceFilePathPredicate` so edits to `.claude/**` and
+            // out-of-workspace scratch files don't inflate the headline
+            // "lines written" / "lines read" numbers.
             const result = await client.query({
               query: `
                 SELECT
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'content'),    '\\n'),
-                        tool_name = 'Write')                                          AS write_lines,
+                        tool_name = 'Write'
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS write_lines,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'new_string'), '\\n'),
-                        tool_name IN ('Edit', 'NotebookEdit'))                        AS edit_added,
+                        tool_name IN ('Edit', 'NotebookEdit')
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS edit_added,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'old_string'), '\\n'),
-                        tool_name IN ('Edit', 'NotebookEdit'))                        AS edit_removed,
+                        tool_name IN ('Edit', 'NotebookEdit')
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS edit_removed,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'new_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
-                        )), tool_name = 'MultiEdit')                                  AS multiedit_added,
+                        )), tool_name = 'MultiEdit'
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS multiedit_added,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'old_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
-                        )), tool_name = 'MultiEdit')                                  AS multiedit_removed,
+                        )), tool_name = 'MultiEdit'
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS multiedit_removed,
                   sumIf(countSubstrings(tool_output, '\\n'),
-                        tool_name IN ('Read', 'NotebookRead'))                        AS read_lines
+                        tool_name IN ('Read', 'NotebookRead')
+                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS read_lines
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
               `,
@@ -349,6 +445,11 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                 WHERE ${PROJECT_WINDOW_FILTER}
                   AND tool_name = 'Write'
                   AND JSONExtractString(tool_input, 'file_path') != ''
+                  AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
+                  AND (
+                    metadata['workspace.path'] = ''
+                    OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
+                  )
                 ORDER BY lines DESC
                 LIMIT 1
               `,
@@ -408,14 +509,57 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // The query unions two row sources:
+            //
+            //   1. Non-Bash tool calls — one row each, with a path
+            //      disposition tag for the path-aware tools (Read / Edit /
+            //      Write / NotebookEdit / NotebookRead / MultiEdit). The
+            //      domain-side classifier in `build-report.ts` uses the
+            //      disposition to route `.claude/plans/*.md` edits to the
+            //      `plan` bucket and drop `.claude/**` config + scratch
+            //      paths entirely.
+            //
+            //   2. Bash command *segments* — every Bash tool call is
+            //      exploded on `&&` / `||` / `;` / `|`, each segment's
+            //      first two tokens are lowercased, and the row carries
+            //      `(bash_prefix, bash_second_token)`. The classifier
+            //      routes by prefix (`grep` → search, `cat` → read, etc.)
+            //      and `git`-by-subcommand (`git status` → search,
+            //      `git push` → bash, `git checkout` → excluded).
+            //
+            // GROUP BY collapses repeats so the wire payload stays
+            // bounded; cardinality is bounded by tool names × distinct
+            // first-two-token pairs in user Bash + 4 disposition values.
             const result = await client.query({
               query: `
-                SELECT tool_name, count() AS uses
-                FROM spans
-                WHERE ${PROJECT_WINDOW_FILTER}
-                  AND operation = 'execute_tool'
-                  AND tool_name != ''
-                GROUP BY tool_name
+                SELECT tool_name, file_disposition, bash_prefix, bash_second_token, count() AS uses
+                FROM (
+                  SELECT
+                    tool_name,
+                    ${filePathDispositionSql("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")} AS file_disposition,
+                    ''  AS bash_prefix,
+                    ''  AS bash_second_token
+                  FROM spans
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND operation = 'execute_tool'
+                    AND tool_name != ''
+                    AND tool_name != 'Bash'
+
+                  UNION ALL
+
+                  SELECT
+                    'Bash' AS tool_name,
+                    ''     AS file_disposition,
+                    lowerUTF8(splitByChar(' ', trim(segment))[1])                       AS bash_prefix,
+                    lowerUTF8(arrayElement(splitByChar(' ', trim(segment)), 2))         AS bash_second_token
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
+                GROUP BY tool_name, file_disposition, bash_prefix, bash_second_token
               `,
               query_params: projectWindowParams(params),
               format: "JSONEachRow",
@@ -424,7 +568,13 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
           })
           .pipe(
             Effect.map((rows): readonly ToolMixRow[] =>
-              rows.map((row) => ({ toolName: row.tool_name, uses: num(row.uses) })),
+              rows.map((row) => ({
+                toolName: row.tool_name,
+                fileDisposition: (row.file_disposition || "") as ToolMixRow["fileDisposition"],
+                bashPrefix: row.bash_prefix,
+                bashSecondToken: row.bash_second_token,
+                uses: num(row.uses),
+              })),
             ),
             Effect.mapError((error) => toRepositoryError(error, "getToolMix")),
           )
@@ -435,6 +585,10 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // Excludes `.claude/**` and out-of-workspace paths — the
+            // "top files" table reflects *this project's* hot files only,
+            // so a Read against `/Users/x/notes.md` or an Edit on
+            // `.claude/settings.local.json` doesn't crowd the list.
             const result = await client.query({
               query: `
                 SELECT
@@ -442,8 +596,13 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   count() AS touches
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
-                  AND tool_name IN (${FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")})
+                  AND tool_name IN (${FILE_PATH_TOOLS_SQL})
                   AND JSONExtractString(tool_input, 'file_path') != ''
+                  AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
+                  AND (
+                    metadata['workspace.path'] = ''
+                    OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
+                  )
                 GROUP BY path
                 ORDER BY touches DESC
                 LIMIT 5
@@ -466,15 +625,21 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // Counts segments, not whole tool calls — `cd foo && grep bar`
+            // contributes a `cd` and a `grep` rather than just the `cd`.
+            // Without the split, the most-chained-after commands (which
+            // are usually the *important* ones) get under-counted.
             const result = await client.query({
               query: `
                 SELECT
-                  splitByChar(' ', trim(BOTH ' ' FROM JSONExtractString(tool_input, 'command')))[1] AS pattern,
+                  splitByChar(' ', trim(segment))[1] AS pattern,
                   count() AS uses
                 FROM spans
+                ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                          JSONExtractString(tool_input, 'command')) AS segment
                 WHERE ${PROJECT_WINDOW_FILTER}
                   AND tool_name = 'Bash'
-                  AND JSONExtractString(tool_input, 'command') != ''
+                  AND segment != ''
                 GROUP BY pattern
                 ORDER BY uses DESC
                 LIMIT 5
@@ -589,21 +754,28 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   FROM spans
                   WHERE ${PROJECT_WINDOW_FILTER}
                     AND metadata['workspace.name'] = {workspaceName:String}
-                    AND tool_name IN ('Read','NotebookRead','Edit','NotebookEdit','MultiEdit','Write')
+                    AND tool_name IN ${PATH_AWARE_TOOLS_SQL}
                     AND JSONExtractString(tool_input, 'file_path') != ''
+                    AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
+                    AND (
+                      metadata['workspace.path'] = ''
+                      OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
+                    )
                   GROUP BY path
                   ORDER BY touches DESC
                   LIMIT 3
                 ),
                 commands AS (
                   SELECT
-                    splitByChar(' ', trim(BOTH ' ' FROM JSONExtractString(tool_input, 'command')))[1] AS pattern,
+                    splitByChar(' ', trim(segment))[1] AS pattern,
                     count() AS uses
                   FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
                   WHERE ${PROJECT_WINDOW_FILTER}
                     AND metadata['workspace.name'] = {workspaceName:String}
                     AND tool_name = 'Bash'
-                    AND JSONExtractString(tool_input, 'command') != ''
+                    AND segment != ''
                   GROUP BY pattern
                   ORDER BY uses DESC
                   LIMIT 3

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -80,14 +80,50 @@ const filePathDispositionSql = (workspacePathExpr: string, filePathExpr: string)
   )
 `
 
-/** SQL predicate selecting only file_paths that should count toward LOC stats. */
-const workspaceFilePathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
+/**
+ * Lenient predicate — keeps anything that represents "real iteration this
+ * week" regardless of which workspace it happened in. Used for the
+ * *headline* LOC / file-touch counters that are presented at the project
+ * level ("Lines written: 14,832"). Includes plan-mode files because
+ * iterating on a plan is genuine writing work.
+ *
+ *   workspace files     ✓ count
+ *   .claude/plans/*.md  ✓ count (real iteration)
+ *   other .claude/**    ✗ excluded (config / history noise)
+ *   external scratch    ✗ excluded (not part of this project's week)
+ *
+ * `file_path = ''` is allowed defensively — the path-aware tools always
+ * carry a `file_path`, but if a malformed input ever lands the row's line
+ * counts still aggregate.
+ */
+const loCountablePathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
   (
     ${filePathExpr} = ''
+    OR match(${filePathExpr}, '/\\\\.claude/plans/[^/]+\\\\.md$')
     OR (
       positionUTF8(${filePathExpr}, '/.claude/') = 0
-      AND (${workspacePathExpr} = '' OR startsWith(${filePathExpr}, ${workspacePathExpr}))
+      AND ${workspacePathExpr} != ''
+      AND startsWith(${filePathExpr}, ${workspacePathExpr})
     )
+  )
+`
+
+/**
+ * Strict predicate — keeps only file_paths that sit inside the span's own
+ * `workspace.path`. Used for the *workspace-specific* views (top files
+ * per workspace, "biggest write" display, "mostly X" dominant-tool
+ * inference). Plan files are explicitly excluded — they're not part of
+ * any project's source tree.
+ *
+ * Requires `workspace.path` to be present; an empty workspace path makes
+ * the span ambiguous as to "what counts as inside" and we err on the
+ * side of excluding rather than allowing.
+ */
+const workspaceStrictPathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
+  (
+    positionUTF8(${filePathExpr}, '/.claude/') = 0
+    AND ${workspacePathExpr} != ''
+    AND startsWith(${filePathExpr}, ${workspacePathExpr})
   )
 `
 
@@ -317,7 +353,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                     JSONExtractString(tool_input, 'file_path'),
                     tool_name IN (${FILE_PATH_TOOLS_SQL})
                     AND JSONExtractString(tool_input, 'file_path') != ''
-                    AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
+                    AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   )                                                                                   AS files_touched,
                   (SELECT count() FROM bash_segments)                                                 AS commands_run,
                   countDistinctIf(metadata['workspace.name'], metadata['workspace.name'] != '')       AS workspaces,
@@ -377,40 +413,41 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
             // to "lines of code" when measured by '\n'. We treat the final
             // line as "complete enough" for the aggregate.
             //
-            // Each per-tool-name aggregation also gates on
-            // `workspaceFilePathPredicate` so edits to `.claude/**` and
-            // out-of-workspace scratch files don't inflate the headline
-            // "lines written" / "lines read" numbers.
+            // These are the *headline* LOC counters — they include
+            // plan-mode iterations (`~/.claude/plans/*.md` edits) because
+            // those are real lines you wrote this week, while still
+            // excluding `.claude/` config noise and out-of-workspace
+            // scratch.
             const result = await client.query({
               query: `
                 SELECT
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'content'),    '\\n'),
                         tool_name = 'Write'
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS write_lines,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'new_string'), '\\n'),
                         tool_name IN ('Edit', 'NotebookEdit')
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS edit_added,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'old_string'), '\\n'),
                         tool_name IN ('Edit', 'NotebookEdit')
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS edit_removed,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'new_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
                         )), tool_name = 'MultiEdit'
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS multiedit_added,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'old_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
                         )), tool_name = 'MultiEdit'
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS multiedit_removed,
                   sumIf(countSubstrings(tool_output, '\\n'),
                         tool_name IN ('Read', 'NotebookRead')
-                        AND ${workspaceFilePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
                                                                                        AS read_lines
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
@@ -445,11 +482,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                 WHERE ${PROJECT_WINDOW_FILTER}
                   AND tool_name = 'Write'
                   AND JSONExtractString(tool_input, 'file_path') != ''
-                  AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
-                  AND (
-                    metadata['workspace.path'] = ''
-                    OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
-                  )
+                  AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                 ORDER BY lines DESC
                 LIMIT 1
               `,
@@ -598,11 +631,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                 WHERE ${PROJECT_WINDOW_FILTER}
                   AND tool_name IN (${FILE_PATH_TOOLS_SQL})
                   AND JSONExtractString(tool_input, 'file_path') != ''
-                  AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
-                  AND (
-                    metadata['workspace.path'] = ''
-                    OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
-                  )
+                  AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                 GROUP BY path
                 ORDER BY touches DESC
                 LIMIT 5
@@ -756,11 +785,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                     AND metadata['workspace.name'] = {workspaceName:String}
                     AND tool_name IN ${PATH_AWARE_TOOLS_SQL}
                     AND JSONExtractString(tool_input, 'file_path') != ''
-                    AND positionUTF8(JSONExtractString(tool_input, 'file_path'), '/.claude/') = 0
-                    AND (
-                      metadata['workspace.path'] = ''
-                      OR startsWith(JSONExtractString(tool_input, 'file_path'), metadata['workspace.path'])
-                    )
+                    AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   GROUP BY path
                   ORDER BY touches DESC
                   LIMIT 3
@@ -797,7 +822,23 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   (SELECT topKIf(3)(metadata['git.branch'], metadata['git.branch'] != '') FROM spans
                     WHERE ${PROJECT_WINDOW_FILTER}
                       AND metadata['workspace.name'] = {workspaceName:String}) AS top_branches,
-                  (SELECT topKIf(1)(tool_name, operation = 'execute_tool' AND tool_name != '') FROM spans
+                  -- "Mostly X" descriptor. Path-aware tools (Read/Edit/Write/…)
+                  -- only count when their file_path is inside the workspace
+                  -- path — an Edit targeting a sibling project shouldn't make
+                  -- you look like an "Edit-mostly" user *in this workspace*.
+                  -- Non-path-aware tools (Bash/Grep/Glob/TaskCreate/…) carry
+                  -- no file_path and count as-is.
+                  (SELECT topKIf(1)(tool_name,
+                    operation = 'execute_tool'
+                    AND tool_name != ''
+                    AND (
+                      tool_name NOT IN ${PATH_AWARE_TOOLS_SQL}
+                      OR (
+                        JSONExtractString(tool_input, 'file_path') != ''
+                        AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
+                      )
+                    )
+                  ) FROM spans
                     WHERE ${PROJECT_WINDOW_FILTER}
                       AND metadata['workspace.name'] = {workspaceName:String}) AS dominant_tool,
                   (SELECT groupArray(path)          FROM files) AS top_file_paths,

--- a/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
@@ -33,6 +33,7 @@ const sampleReport: Report = {
     repos: 1,
     streakDays: 5,
     testsRun: 9,
+    gitWriteOps: 4,
   },
   toolMix: { bash: 15, read: 25, edit: 50, write: 5, search: 5, research: 0, plan: 0, other: 0 },
   loc: {


### PR DESCRIPTION
## summary

Two production users with very different activity levels both got "The Conductor." Root cause: the `bash` bucket received every `Bash` tool call regardless of what the command actually did, and the conditional archetypes (Strategist/Scholar/Consultant/Shipper/Tester) scored too low to compete. Path-aware tools also miscounted `.claude/` config, plan files, and out-of-workspace scratch as code.

This PR overhauls bucket routing, command tokenization, the display layer, and the Shipper formula. Expected post-merge: user A → Shipper; user B → Consultant; genuine shell-heavy users still → Conductor.

## bash segment splitting + sub-classification

Bash now splits on `&&` / `||` / `;` / `|`, so `cd foo && grep bar && git push` contributes three segments. Each segment routes by command prefix (and for `git` / `gh`, by sub-subcommand):

- `grep` / `rg` / `ag` / `find` / `ls` / `tree` and `git status` / `log` / `diff` / `show` / `blame` / `branch` / `ls-files` / `reflog` → **search**
- `curl` / `wget` and `gh pr view` / `list` / `checks` / `comment` / `diff` / `status`, `gh issue *`, `gh api`, `gh run *`, `gh workflow *` → **research**
- `head` / `tail` / `cat` / `less` / `more` / `echo` / `printf` / `sed` / `awk` / `wc` / `sort` / `uniq` / `cut` / `tr` / `xargs` / `tee` → **excluded** (output-shaping noise, never standalone work)
- `cd` / `pwd` / `pushd` / `popd` / `open` / `claude` / `clear` / `exit` and `git checkout` / `switch` / `restore` / `config` / `init` / `remote` → **excluded** (pure navigation/setup)
- `git commit` / `push` / `merge` / `rebase` / `tag` / `revert` / `cherry-pick`, plus `gh pr create` / `merge` / `ready` / `edit` / `review`, `gh release create` / `edit` / `upload`, `gh repo create` → **bash** AND increment `gitWriteOps`
- everything else → **bash**

Also fixes a pre-existing display bug: `splitByChar(' ', segment)[1]` was dropping every chained-after command in `getTopBashCommands` and the workspace deep-dive. Top-commands tables under-counted real work.

## flag-skipping token extraction

Claude Code regularly emits `git -C /Users/sans/repo status -s` and `gh -R owner/repo pr create`. The naive "second whitespace token" extraction misclassified those as `git -c` / `gh -r`, falling through to plain `bash`.

`extractBashTokens` now skips flag-like tokens when finding the meaningful subcommand: tokens starting with `-` (CLI flags), `@` (scoped package args), `.` (relative paths); or containing `/` (absolute paths AND `owner/repo` slugs); or containing `=` (`--key=value`); or purely numeric (`-n 50`). The CH adapter SQL mirrors the rule, with the TS function as the unit-testable spec.

## subcommand-aware display

The "top commands" table now shows `git push` distinct from `git status`, `pnpm install` distinct from `pnpm test`, `gh pr create` distinct from `gh pr view`. For a small set of multi-action prefixes (`git` / `pnpm` / `npm` / `yarn` / `bun` / `cargo` / `brew` / `docker` / `kubectl` / `mix` / `rake` / `gradle` / `mvn` / `go` / `poetry` / `pipx` / `terraform` / `fly` / `railway` / `vercel`), the displayed pattern is `prefix + first non-flag token` instead of just `prefix`. `gh` gets two-deep treatment because of its three-level CLI.

## path-aware classification for file-touching tools

Every `Edit` / `Write` / `Read` / `MultiEdit` / `NotebookEdit` / `NotebookRead` is now classified by `(tool_input.file_path, metadata['workspace.path'])`:

- `**/.claude/plans/*.md` → **plan** bucket — plan-mode iteration now registers as planning
- `**/.claude/**` (anything else) → **excluded** — config + history are noise
- inside workspace, not under `.claude/` → existing bucket (`edit` / `write` / `read`)
- outside workspace, not under `.claude/` → **excluded** — scratch / cross-project

Two predicates exist for the different surfaces:

- **lo-countable** (workspace OR plan-file) drives the headline `writeLines` / `editAdded` / `readLines` / `filesTouched` numbers — plan-mode iteration counts as real work toward those.
- **workspace-strict** (workspace-prefix only, no plan files) drives top-files tables, the biggest-write display, and "mostly X" dominant-tool inference — plan files aren't part of any project's source tree.

The dominant-tool inference also filters path-aware tool calls by workspace path: an Edit targeting a sibling project no longer makes you look Edit-mostly *in this workspace*. Non-path-aware tools (Bash / Grep / Glob / TaskCreate / …) carry no `file_path` and count as-is.

## new `gitWriteOps` counter

Sibling of `commits` (distinct SHAs from span metadata). Counts segments matching the `git` / `gh` write-op set above per project per window. Catches squash-pushers, force-pushers, tag-and-release flows, and CLI-first PR workflows that the old commit-only metric missed. The name stays `gitWriteOps` even though `gh` triplets feed it — a rename would force a schema migration for no behavioural gain.

## shipper rewrite + scoring rebalance

Shipper now reads from a disjunction over `commits` and `gitWriteOps`: either path can fire the gate, and the score is the max of the two normalised signals. So a user who ships via `gh pr create` with zero local commits still lands here, and so does a user who commits heavily without using `gh`.

Score ranges tightened so a passing conditional gate produces a meaningful score:

- Shipper commits/session: `[1.0, 4.0]` → `[1.0, 2.5]`
- Shipper write-ops/session: `[1.5, 4.0]` (new)
- Consultant sessions: `[5, 15]` → `[4, 8]` (LOW sits below the gate floor so even a borderline 5-session user produces a non-zero score)

A `×1.5` rarity multiplier applies to all five conditional archetypes (Strategist / Scholar / Consultant / Shipper / Tester). Their gates already require a meaningful signal floor; once they fire, the bonus pushes them above moderate tool-mix winners. `BASELINE_SHARE` stays untouched — wait for a clean week of reports under the new routing before retuning.

## expected outcomes

| profile | before | after |
|---|---|---|
| heavy power user (34 commits, 50 git writes, 44 tests) | Conductor | Shipper |
| light explorer (6 sessions, 90 lines) | Conductor | Consultant |
| CLI-first PR shipper (`gh pr create`/`merge` heavy, zero local commits) | Conductor | Shipper |
| genuine shell-heavy user | Conductor | Conductor (asserted in tests so the archetype isn't dead) |

## not in scope

- Empirical baseline retuning (`BASELINE_SHARE`) — wait for a clean week of reports under the new routing.
- New archetypes (Marathoner, Tinkerer) — revisit once the existing nine distribute sensibly across real users.
- A `Task` (Claude Code subagent) bucket — currently lands in `other`. Routing decision can wait until subagent use is more common.

## test plan

- [x] `pnpm --filter @domain/spans test` — 552 tests pass. Covers `extractBashTokens` (10 cases for `git -C`, `gh -R`, `pnpm --filter`, numeric flags, `=`-syntax, etc.), end-to-end raw-segment → bucket bridging (7 cases), classifier rules per bucket, `isGitWriteSegment` for both `git` and `gh` triplets, the two production user profiles, the CLI-first PR shipper, and a "Conductor still wins for genuine shell-heavy" regression.
- [x] `pnpm --filter @platform/db-postgres test src/repositories/wrapped-report-repository.test.ts` — 7 tests pass.
- [x] `pnpm --filter @platform/db-clickhouse --filter @domain/spans --filter @domain/email typecheck` clean for everything in this PR. Pre-existing errors in unrelated `@domain/issues` / `@domain/alerts` / oauth-keys are not from this branch.
- [x] `pnpm biome check packages/domain/spans/src packages/platform/db-clickhouse/src packages/platform/db-postgres/src` — clean.
- [ ] Manual sanity after merge: trigger the Wrapped backoffice for both production projects and confirm the archetype assignments flip as expected. Also spot-check that the top-commands tables no longer show `tail` / `echo`, and that `git push` / `gh pr create` show distinctly from `git status` / `gh pr view`.
