### PR TITLE
feat(api): OAuth keys public API + MCP-server instructions + describe…

### DIFF
--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -1,6 +1,20 @@
 {
-  "name": "Latitude API",
-  "version": "1.0.0",
+  "name": "Latitude MCP",
+  "title": "Latitude MCP",
+  "description": "Open-source AI agent monitoring platform. Full observability into what's failing in production. Discover underlying issues, get alerts when something breaks and verify your fix worked.",
+  "version": "v1",
+  "websiteUrl": "https://latitude.so",
+  "icons": [
+    {
+      "src": "https://framerusercontent.com/images/fPQsqC1Gx3CiQElnbBSmbQVYcA.png",
+      "theme": "light"
+    },
+    {
+      "src": "https://framerusercontent.com/images/l5c1DNVxQ3iAvTDihvg9pFw2l2k.png",
+      "theme": "dark"
+    }
+  ],
+  "instructions": "All Latitude MCP methods have descriptions and input/output schemas. For any doubt visit the Latitude documentation: https://docs.latitude.so/llms.txt",
   "tools": [
     {
       "name": "createProject",
@@ -47,21 +61,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -70,7 +96,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -163,21 +189,33 @@
                       "type": "object",
                       "properties": {
                         "keepMonitoring": {
+                          "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                           "type": "boolean"
                         },
                         "alertNotifications": {
+                          "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                           "type": "object",
-                          "propertyNames": {
-                            "type": "string",
-                            "enum": [
-                              "issue.new",
-                              "issue.regressed",
-                              "issue.escalating"
-                            ]
+                          "properties": {
+                            "issue.new": {
+                              "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "issue.regressed": {
+                              "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "issue.escalating": {
+                              "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "escalationSensitivity": {
+                              "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 6
+                            }
                           },
-                          "additionalProperties": {
-                            "type": "boolean"
-                          }
+                          "additionalProperties": false
                         }
                       },
                       "additionalProperties": false
@@ -186,7 +224,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+                  "description": "Per-project settings overrides. `null` means inherit from the organization."
                 },
                 "firstTraceAt": {
                   "anyOf": [
@@ -307,21 +345,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -330,7 +380,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -404,21 +454,33 @@
             "type": "object",
             "properties": {
               "keepMonitoring": {
+                "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                 "type": "boolean"
               },
               "alertNotifications": {
+                "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                 "type": "object",
-                "propertyNames": {
-                  "type": "string",
-                  "enum": [
-                    "issue.new",
-                    "issue.regressed",
-                    "issue.escalating"
-                  ]
+                "properties": {
+                  "issue.new": {
+                    "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "issue.regressed": {
+                    "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "issue.escalating": {
+                    "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "escalationSensitivity": {
+                    "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 6
+                  }
                 },
-                "additionalProperties": {
-                  "type": "boolean"
-                }
+                "additionalProperties": false
               }
             },
             "additionalProperties": false
@@ -477,21 +539,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -500,7 +574,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -1848,6 +1922,243 @@
         },
         "required": [
           "id"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "listOAuthKeys",
+      "title": "List OAuth keys",
+      "description": "Returns every OAuth key (like MCP clients) connected to the organization.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeys": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable OAuth key identifier."
+                },
+                "clientId": {
+                  "type": "string",
+                  "description": "Identifier of the OAuth client the key was issued to."
+                },
+                "clientName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Display name of the OAuth client."
+                },
+                "clientIcon": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Icon URL of the OAuth client."
+                },
+                "userId": {
+                  "type": "string",
+                  "description": "Identifier of the user the key belongs to."
+                },
+                "userName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Display name of the user. `null` until the user completes onboarding."
+                },
+                "userEmail": {
+                  "type": "string",
+                  "description": "Email of the user."
+                },
+                "lastActivityAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+                },
+                "connectedAt": {
+                  "type": "string",
+                  "description": "ISO-8601 timestamp at which the key was connected."
+                },
+                "disabled": {
+                  "type": "boolean",
+                  "description": "Whether the key has been disabled."
+                }
+              },
+              "required": [
+                "id",
+                "clientId",
+                "clientName",
+                "clientIcon",
+                "userId",
+                "userName",
+                "userEmail",
+                "lastActivityAt",
+                "connectedAt",
+                "disabled"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "oauthKeys"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "getOAuthKey",
+      "title": "Get OAuth key",
+      "description": "Returns a single OAuth key (like MCP clients) by id.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeyId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "OAuth key identifier."
+          }
+        },
+        "required": [
+          "oauthKeyId"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable OAuth key identifier."
+          },
+          "clientId": {
+            "type": "string",
+            "description": "Identifier of the OAuth client the key was issued to."
+          },
+          "clientName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the OAuth client."
+          },
+          "clientIcon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Icon URL of the OAuth client."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Identifier of the user the key belongs to."
+          },
+          "userName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the user. `null` until the user completes onboarding."
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "Email of the user."
+          },
+          "lastActivityAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+          },
+          "connectedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the key was connected."
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the key has been disabled."
+          }
+        },
+        "required": [
+          "id",
+          "clientId",
+          "clientName",
+          "clientIcon",
+          "userId",
+          "userName",
+          "userEmail",
+          "lastActivityAt",
+          "connectedAt",
+          "disabled"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "revokeOAuthKey",
+      "title": "Revoke OAuth key",
+      "description": "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeyId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "OAuth key identifier."
+          }
+        },
+        "required": [
+          "oauthKeyId"
         ],
         "additionalProperties": false
       }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -79,30 +79,7 @@
             "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
           },
           "settings": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "keepMonitoring": {
-                "type": "boolean"
-              },
-              "alertNotifications": {
-                "type": "object",
-                "properties": {
-                  "issue.new": {
-                    "type": "boolean"
-                  },
-                  "issue.regressed": {
-                    "type": "boolean"
-                  },
-                  "issue.escalating": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "$ref": "#/components/schemas/ProjectSettings"
           },
           "firstTraceAt": {
             "type": [
@@ -143,6 +120,46 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "ProjectSettings": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "keepMonitoring": {
+            "type": "boolean",
+            "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted."
+          },
+          "alertNotifications": {
+            "$ref": "#/components/schemas/AlertNotificationsSetting"
+          }
+        },
+        "description": "Per-project settings overrides. `null` means inherit from the organization."
+      },
+      "AlertNotificationsSetting": {
+        "type": "object",
+        "properties": {
+          "issue.new": {
+            "type": "boolean",
+            "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted."
+          },
+          "issue.regressed": {
+            "type": "boolean",
+            "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted."
+          },
+          "issue.escalating": {
+            "type": "boolean",
+            "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted."
+          },
+          "escalationSensitivity": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 6,
+            "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted."
+          }
+        },
+        "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values."
       },
       "Error": {
         "type": "object",
@@ -205,27 +222,14 @@
             "description": "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable)."
           },
           "settings": {
-            "type": "object",
-            "properties": {
-              "keepMonitoring": {
-                "type": "boolean"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectSettings"
               },
-              "alertNotifications": {
-                "type": "object",
-                "properties": {
-                  "issue.new": {
-                    "type": "boolean"
-                  },
-                  "issue.regressed": {
-                    "type": "boolean"
-                  },
-                  "issue.escalating": {
-                    "type": "boolean"
-                  }
-                }
+              {
+                "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
               }
-            },
-            "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
+            ]
           },
           "flaggers": {
             "type": "object",
@@ -1391,6 +1395,89 @@
           "name"
         ]
       },
+      "OAuthKeyList": {
+        "type": "object",
+        "properties": {
+          "oauthKeys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OAuthKey"
+            }
+          }
+        },
+        "required": [
+          "oauthKeys"
+        ]
+      },
+      "OAuthKey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable OAuth key identifier."
+          },
+          "clientId": {
+            "type": "string",
+            "description": "Identifier of the OAuth client the key was issued to."
+          },
+          "clientName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name of the OAuth client."
+          },
+          "clientIcon": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Icon URL of the OAuth client."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Identifier of the user the key belongs to."
+          },
+          "userName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name of the user. `null` until the user completes onboarding."
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "Email of the user."
+          },
+          "lastActivityAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+          },
+          "connectedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the key was connected."
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the key has been disabled."
+          }
+        },
+        "required": [
+          "id",
+          "clientId",
+          "clientName",
+          "clientIcon",
+          "userId",
+          "userName",
+          "userEmail",
+          "lastActivityAt",
+          "connectedAt",
+          "disabled"
+        ]
+      },
       "AccountResponse": {
         "type": "object",
         "properties": {
@@ -2510,6 +2597,160 @@
         "responses": {
           "204": {
             "description": "API key revoked"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/oauth-keys": {
+      "get": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "list",
+        "summary": "List OAuth keys",
+        "description": "Returns every OAuth key (like MCP clients) connected to the organization.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "listOAuthKeys",
+        "responses": {
+          "200": {
+            "description": "List of OAuth keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthKeyList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/oauth-keys/{oauthKeyId}": {
+      "get": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "get",
+        "summary": "Get OAuth key",
+        "description": "Returns a single OAuth key (like MCP clients) by id.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "getOAuthKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "OAuth key identifier."
+            },
+            "required": true,
+            "description": "OAuth key identifier.",
+            "name": "oauthKeyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "revoke",
+        "summary": "Revoke OAuth key",
+        "description": "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "revokeOAuthKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "OAuth key identifier."
+            },
+            "required": true,
+            "description": "OAuth key identifier.",
+            "name": "oauthKeyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OAuth key revoked"
           },
           "401": {
             "description": "Unauthorized",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@domain/annotations": "workspace:*",
     "@domain/api-keys": "workspace:*",
     "@domain/flaggers": "workspace:*",
+    "@domain/oauth-keys": "workspace:*",
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",

--- a/apps/api/scripts/emit-mcp.ts
+++ b/apps/api/scripts/emit-mcp.ts
@@ -12,6 +12,7 @@ import { writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { OpenAPIHono, z } from "@hono/zod-openapi"
+import { MCP_INFO } from "../src/constants.ts"
 import { collectToolDescriptors } from "../src/mcp/index.ts"
 import { registerRoutes } from "../src/routes/index.ts"
 import type { AppEnv } from "../src/types.ts"
@@ -42,11 +43,7 @@ const tools = collectToolDescriptors().map((tool) => ({
   ...(tool.output ? { outputSchema: z.toJSONSchema(tool.output.schema, { target: "draft-2020-12" }) } : {}),
 }))
 
-const manifest = {
-  name: "Latitude API",
-  version: "1.0.0",
-  tools,
-}
+const manifest = { ...MCP_INFO, tools }
 
 const here = dirname(fileURLToPath(import.meta.url))
 const outPath = resolve(here, "../mcp.json")

--- a/apps/api/src/constants.ts
+++ b/apps/api/src/constants.ts
@@ -20,4 +20,8 @@ export const MCP_INFO = {
     { src: "https://framerusercontent.com/images/fPQsqC1Gx3CiQElnbBSmbQVYcA.png", theme: "light" },
     { src: "https://framerusercontent.com/images/l5c1DNVxQ3iAvTDihvg9pFw2l2k.png", theme: "dark" },
   ],
-} as McpInfo
+  instructions:
+    "All Latitude MCP methods have descriptions and input/output schemas. For any doubt visit the Latitude documentation: https://docs.latitude.so/llms.txt",
+} as McpInfo & {
+  instructions: string
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -63,7 +63,7 @@ export const registerMcpRoute = ({
   const toolDescriptors = collectToolDescriptors()
 
   routes.all("/mcp", async (c) => {
-    const mcpServer = new McpServer(MCP_INFO, { capabilities: { tools: {} } })
+    const mcpServer = new McpServer(MCP_INFO, { instructions: MCP_INFO.instructions, capabilities: { tools: {} } })
 
     for (const tool of toolDescriptors) {
       // Capture each descriptor in the closure — the loop variable would

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -11,6 +11,7 @@ import { annotationsPath, createAnnotationsRoutes } from "./annotations.ts"
 import { apiKeysPath, createApiKeysRoutes } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
 import { createMembersRoutes, membersPath } from "./members.ts"
+import { createOAuthKeysRoutes, oauthKeysPath } from "./oauth-keys.ts"
 import { createProjectsRoutes, projectsPath } from "./projects.ts"
 import { createScoresRoutes, scoresPath } from "./scores.ts"
 import { registerWellKnownRoutes } from "./well-known.ts"
@@ -56,6 +57,9 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
 
   routes.use(apiKeysPath, createTierRateLimiter("low"))
   routes.route(apiKeysPath, createApiKeysRoutes())
+
+  routes.use(oauthKeysPath, createTierRateLimiter("low"))
+  routes.route(oauthKeysPath, createOAuthKeysRoutes())
 
   routes.use(accountPath, createTierRateLimiter("low"))
   routes.route(accountPath, createAccountRoutes())

--- a/apps/api/src/routes/oauth-keys.test.ts
+++ b/apps/api/src/routes/oauth-keys.test.ts
@@ -1,0 +1,198 @@
+import { eq } from "@platform/db-postgres"
+import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { createApiKeyAuthHeaders } from "@platform/testkit"
+import { describe, expect, it } from "vitest"
+import {
+  type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
+  setupTestApi,
+} from "../test-utils/create-test-app.ts"
+
+interface OAuthKeyRow {
+  readonly id: string
+  readonly clientId: string
+  readonly clientName: string | null
+  readonly userId: string
+  readonly userEmail: string
+  readonly disabled: boolean
+}
+
+interface ListResponse {
+  readonly oauthKeys: ReadonlyArray<OAuthKeyRow>
+}
+
+const listOAuthKeysJson = async (
+  app: ApiTestContext["app"],
+  headers: Record<string, string>,
+): Promise<ListResponse> => {
+  const res = await app.fetch(new Request("http://localhost/v1/oauth-keys", { headers }))
+  expect(res.status).toBe(200)
+  return (await res.json()) as ListResponse
+}
+
+describe("OAuth keys routes — list", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("GET /v1/oauth-keys returns this org's keys with metadata only (no tokens)", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const body = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenant.oauthAccessToken))
+
+    expect(body.oauthKeys).toHaveLength(1)
+    const [row] = body.oauthKeys
+    expect(row?.clientId).toBe(tenant.oauthClientId)
+    expect(row?.userId).toBe(tenant.userId)
+    expect(row?.disabled).toBe(false)
+    // Crucial guarantee: no token-shaped field on the response.
+    const keys = Object.keys(row as object)
+    expect(keys).not.toContain("accessToken")
+    expect(keys).not.toContain("access_token")
+    expect(keys).not.toContain("refreshToken")
+    expect(keys).not.toContain("token")
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys isolates by organization", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+
+    const bodyA = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenantA.oauthAccessToken))
+    expect(bodyA.oauthKeys.map((k) => k.clientId)).toEqual([tenantA.oauthClientId])
+
+    const bodyB = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenantB.oauthAccessToken))
+    expect(bodyB.oauthKeys.map((k) => k.clientId)).toEqual([tenantB.oauthClientId])
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys works for API-key callers too (read-only)", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const body = await listOAuthKeysJson(app, createApiKeyAuthHeaders(tenant.apiKeyToken))
+    expect(body.oauthKeys.map((k) => k.clientId)).toContain(tenant.oauthClientId)
+  })
+})
+
+describe("OAuth keys routes — get", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns the row matching the composite id", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const compositeId = `${tenant.oauthClientId}:${tenant.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, {
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as OAuthKeyRow
+    expect(body.id).toBe(compositeId)
+    expect(body.clientId).toBe(tenant.oauthClientId)
+    expect(body.userId).toBe(tenant.userId)
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns 404 for malformed ids", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/oauth-keys/not-a-composite", {
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns 404 for cross-tenant ids", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+    const otherCompositeId = `${tenantB.oauthClientId}:${tenantB.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${otherCompositeId}`, {
+        headers: createOAuthAuthHeaders(tenantA.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("OAuth keys routes — revoke", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} drops the access tokens for the pair", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    // Pair has one token; sanity-check it's there before revoke.
+    const before = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenant.oauthClientId))
+    expect(before).toHaveLength(1)
+
+    const apiKeyHeaders = createApiKeyAuthHeaders(tenant.apiKeyToken)
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${tenant.oauthClientId}:${tenant.userId}`, {
+        method: "DELETE",
+        headers: apiKeyHeaders,
+      }),
+    )
+    expect(res.status).toBe(204)
+
+    const after = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenant.oauthClientId))
+    expect(after).toHaveLength(0)
+
+    // Application gets disabled because no tokens remain for that client.
+    const apps = await database.db
+      .select({ disabled: oauthApplications.disabled })
+      .from(oauthApplications)
+      .where(eq(oauthApplications.clientId, tenant.oauthClientId))
+    expect(apps[0]?.disabled).toBe(true)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} is idempotent — second call still returns 204", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const compositeId = `${tenant.oauthClientId}:${tenant.userId}`
+    const headers = createApiKeyAuthHeaders(tenant.apiKeyToken)
+
+    const first = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, { method: "DELETE", headers }),
+    )
+    expect(first.status).toBe(204)
+
+    const second = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, { method: "DELETE", headers }),
+    )
+    // After the first revoke the application is disabled; the second revoke
+    // still finds the row in this org, so it 204s rather than 404s.
+    expect(second.status).toBe(204)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} can't reach a cross-tenant pair (404)", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+    const otherCompositeId = `${tenantB.oauthClientId}:${tenantB.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${otherCompositeId}`, {
+        method: "DELETE",
+        headers: createApiKeyAuthHeaders(tenantA.apiKeyToken),
+      }),
+    )
+    expect(res.status).toBe(404)
+
+    // Tenant B's tokens are untouched.
+    const tokens = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenantB.oauthClientId))
+    expect(tokens).toHaveLength(1)
+  })
+})

--- a/apps/api/src/routes/oauth-keys.ts
+++ b/apps/api/src/routes/oauth-keys.ts
@@ -1,0 +1,174 @@
+import {
+  getOAuthKeyUseCase,
+  listOAuthKeysUseCase,
+  type OAuthKey,
+  OAuthKeyNotFoundError,
+  revokeOAuthKeyUseCase,
+} from "@domain/oauth-keys"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { OAuthKeyRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { OAuthTokenCacheInvalidatorLive } from "@platform/oauth-token-auth"
+import { withTracing } from "@repo/observability"
+import { Effect } from "effect"
+import { defineApiEndpoint } from "../mcp/index.ts"
+import { jsonResponse, openApiNoContentResponses, openApiResponses, PROTECTED_SECURITY } from "../openapi/schemas.ts"
+import type { OrganizationScopedEnv } from "../types.ts"
+
+// OAuth keys are the `(client, user)` connections users grant to OAuth /
+// MCP clients (Claude Code, Cursor, Codex…) via the consent flow at
+// `app.latitude.so/auth/consent`. The API exposes read + revoke surfaces;
+// creation is impossible by design (rows are minted by the consent UX).
+//
+// **Response contract**: never expose `access_token`, `refresh_token`,
+// hashed-token, or any masked-token field. Only the metadata in
+// `OAuthKey` is returned. Unlike API keys, there's no flow where the
+// caller would copy a token from this surface.
+const ResponseSchema = z
+  .object({
+    id: z.string().describe("Stable OAuth key identifier."),
+    clientId: z.string().describe("Identifier of the OAuth client the key was issued to."),
+    clientName: z.string().nullable().describe("Display name of the OAuth client."),
+    clientIcon: z.string().nullable().describe("Icon URL of the OAuth client."),
+    userId: z.string().describe("Identifier of the user the key belongs to."),
+    userName: z.string().nullable().describe("Display name of the user. `null` until the user completes onboarding."),
+    userEmail: z.string().describe("Email of the user."),
+    lastActivityAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."),
+    connectedAt: z.string().describe("ISO-8601 timestamp at which the key was connected."),
+    disabled: z.boolean().describe("Whether the key has been disabled."),
+  })
+  .openapi("OAuthKey")
+
+const ListResponseSchema = z.object({ oauthKeys: z.array(ResponseSchema) }).openapi("OAuthKeyList")
+
+const OAuthKeyParamsSchema = z.object({
+  oauthKeyId: z.string().min(1).describe("OAuth key identifier."),
+})
+
+// Fern groups so the generated SDK lands at `client.oauthKeys.{list,get,revoke}`.
+const oauthKeysFernGroup = (methodName: string) =>
+  ({
+    "x-fern-sdk-group-name": "oauthKeys",
+    "x-fern-sdk-method-name": methodName,
+  }) as const
+
+const toResponse = (key: OAuthKey) => ({
+  id: key.id,
+  clientId: key.clientId,
+  clientName: key.clientName,
+  clientIcon: key.clientIcon,
+  userId: key.userId,
+  userName: key.userName,
+  userEmail: key.userEmail,
+  lastActivityAt: key.lastActivityAt ? key.lastActivityAt.toISOString() : null,
+  connectedAt: key.connectedAt.toISOString(),
+  disabled: key.disabled,
+})
+
+/**
+ * Splits the composite id on the LAST colon. `userId` is a CUID2 (no
+ * colons), so the tail is always the user id and the head — even if it
+ * contains colons — is the OAuth client_id. Returns `null` for malformed
+ * input so handlers can 404 cleanly.
+ */
+const parseCompositeId = (id: string): { clientId: string; userId: string } | null => {
+  const i = id.lastIndexOf(":")
+  if (i <= 0 || i === id.length - 1) return null
+  return { clientId: id.slice(0, i), userId: id.slice(i + 1) }
+}
+
+export const oauthKeysPath = "/oauth-keys"
+
+const oauthKeyEndpoint = defineApiEndpoint<OrganizationScopedEnv>(oauthKeysPath)
+
+const listOAuthKeys = oauthKeyEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/",
+    name: "listOAuthKeys",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("list"),
+    summary: "List OAuth keys",
+    description: "Returns every OAuth key (like MCP clients) connected to the organization.",
+    security: PROTECTED_SECURITY,
+    responses: { 200: jsonResponse(ListResponseSchema, "List of OAuth keys") },
+  }),
+  handler: async (c) => {
+    const keys = await Effect.runPromise(
+      listOAuthKeysUseCase().pipe(
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.json({ oauthKeys: keys.map(toResponse) }, 200)
+  },
+})
+
+const getOAuthKey = oauthKeyEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/{oauthKeyId}",
+    name: "getOAuthKey",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("get"),
+    summary: "Get OAuth key",
+    description: "Returns a single OAuth key (like MCP clients) by id.",
+    security: PROTECTED_SECURITY,
+    request: { params: OAuthKeyParamsSchema },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "OAuth key" }),
+  }),
+  handler: async (c) => {
+    const { oauthKeyId } = c.req.valid("param")
+    const parsed = parseCompositeId(oauthKeyId)
+    if (!parsed) {
+      throw new OAuthKeyNotFoundError({ clientId: oauthKeyId, userId: "" })
+    }
+
+    const key = await Effect.runPromise(
+      getOAuthKeyUseCase(parsed).pipe(
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.json(toResponse(key), 200)
+  },
+})
+
+const revokeOAuthKey = oauthKeyEndpoint({
+  route: createRoute({
+    method: "delete",
+    path: "/{oauthKeyId}",
+    name: "revokeOAuthKey",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("revoke"),
+    summary: "Revoke OAuth key",
+    description: "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+    security: PROTECTED_SECURITY,
+    request: { params: OAuthKeyParamsSchema },
+    responses: openApiNoContentResponses({ description: "OAuth key revoked" }),
+  }),
+  handler: async (c) => {
+    const { oauthKeyId } = c.req.valid("param")
+    const parsed = parseCompositeId(oauthKeyId)
+    if (!parsed) {
+      throw new OAuthKeyNotFoundError({ clientId: oauthKeyId, userId: "" })
+    }
+
+    await Effect.runPromise(
+      revokeOAuthKeyUseCase(parsed).pipe(
+        Effect.provide(OAuthTokenCacheInvalidatorLive(c.var.redis)),
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.body(null, 204)
+  },
+})
+
+export const createOAuthKeysRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+  for (const ep of [listOAuthKeys, getOAuthKey, revokeOAuthKey]) ep.mountHttp(app)
+  return app
+}

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -6,7 +6,7 @@ import {
   ProjectRepository,
   updateProjectUseCase,
 } from "@domain/projects"
-import { projectSettingsSchema } from "@domain/shared"
+import type { ALERT_INCIDENT_KINDS } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
 import {
@@ -39,6 +39,63 @@ const projectsFernGroup = (methodName: string) =>
     "x-fern-sdk-method-name": methodName,
   }) as const
 
+// Project-settings shape, expressed at the API layer so each field carries a
+// description (the domain `projectSettingsSchema` is description-free by
+// design). The field-by-field shape mirrors `projectSettingsSchema` from
+// `@domain/shared`; the per-alert-kind toggles are spelled out so each one is
+// individually documented for SDK / MCP consumers.
+const AlertNotificationsSettingSchema = z
+  .object({
+    "issue.new": z
+      .boolean()
+      .optional()
+      .describe("Send a notification when a new issue is discovered. Defaults to `true` when omitted."),
+    "issue.regressed": z
+      .boolean()
+      .optional()
+      .describe("Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted."),
+    "issue.escalating": z
+      .boolean()
+      .optional()
+      .describe(
+        "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+      ),
+    escalationSensitivity: z
+      .number()
+      .int()
+      .min(1)
+      .max(6)
+      .optional()
+      .describe(
+        "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+      ),
+  })
+  .openapi("AlertNotificationsSetting")
+
+// Assert at compile time that the API schema covers every alert kind the
+// domain knows about — adding a new entry to `ALERT_INCIDENT_KINDS` makes
+// this assertion fail until we describe the new key here too.
+type _AlertKindsCovered = Exclude<
+  (typeof ALERT_INCIDENT_KINDS)[number],
+  keyof z.infer<typeof AlertNotificationsSettingSchema>
+>
+const _alertKindsAreCovered: _AlertKindsCovered extends never ? true : false = true
+void _alertKindsAreCovered
+
+const ProjectSettingsSchema = z
+  .object({
+    keepMonitoring: z
+      .boolean()
+      .optional()
+      .describe(
+        "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
+      ),
+    alertNotifications: AlertNotificationsSettingSchema.optional().describe(
+      "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
+    ),
+  })
+  .openapi("ProjectSettings")
+
 const ResponseSchema = z
   .object({
     id: z.string().describe("Stable project identifier (CUID2)."),
@@ -49,11 +106,9 @@ const ResponseSchema = z
       .describe(
         "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form.",
       ),
-    settings: projectSettingsSchema
-      .nullable()
-      .describe(
-        "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches.",
-      ),
+    settings: ProjectSettingsSchema.nullable().describe(
+      "Per-project settings overrides. `null` means inherit from the organization.",
+    ),
     firstTraceAt: z
       .string()
       .nullable()
@@ -85,11 +140,9 @@ const UpdateRequestSchema = z
       .describe(
         "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable).",
       ),
-    settings: projectSettingsSchema
-      .optional()
-      .describe(
-        "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
-      ),
+    settings: ProjectSettingsSchema.optional().describe(
+      "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
+    ),
     flaggers: z
       .partialRecord(z.enum(FLAGGER_STRATEGY_SLUGS), z.boolean())
       .optional()

--- a/packages/domain/oauth-keys/src/errors.ts
+++ b/packages/domain/oauth-keys/src/errors.ts
@@ -14,3 +14,21 @@ export class OAuthApplicationNotFoundError extends Data.TaggedError("OAuthApplic
   readonly httpStatus = 404
   readonly httpMessage = "OAuth application not found in this organization"
 }
+
+/**
+ * Raised when a `(client_id, user_id)` pair doesn't resolve to a row
+ * visible under the caller's organization — either the application
+ * isn't here at all, no access tokens exist for that user, or the row
+ * belongs to a different tenant (the RLS read collapses all three
+ * cases into the same "not found" so we don't leak existence across
+ * orgs).
+ *
+ * Carries a 404 on the HTTP surface.
+ */
+export class OAuthKeyNotFoundError extends Data.TaggedError("OAuthKeyNotFoundError")<{
+  readonly clientId: string
+  readonly userId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "OAuth key not found in this organization"
+}

--- a/packages/domain/oauth-keys/src/index.ts
+++ b/packages/domain/oauth-keys/src/index.ts
@@ -1,5 +1,6 @@
 export type { OAuthKey } from "./entities/oauth-key.ts"
-export { OAuthApplicationNotFoundError } from "./errors.ts"
+export { OAuthApplicationNotFoundError, OAuthKeyNotFoundError } from "./errors.ts"
 export { OAuthKeyRepository, OAuthTokenCacheInvalidator } from "./ports/oauth-key-repository.ts"
+export { type GetOAuthKeyInput, getOAuthKeyUseCase } from "./use-cases/get-oauth-key.ts"
 export { listOAuthKeysUseCase } from "./use-cases/list-oauth-keys.ts"
 export { type RevokeOAuthKeyInput, revokeOAuthKeyUseCase } from "./use-cases/revoke-oauth-key.ts"

--- a/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
+++ b/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
@@ -42,6 +42,16 @@ export class OAuthKeyRepository extends Context.Service<
      */
     listForOrganization: () => Effect.Effect<readonly OAuthKey[], RepositoryError, SqlClient>
     /**
+     * Reads a single OAuth key by its `(clientId, userId)` pair, returning
+     * the same aggregated shape `listForOrganization` produces. Returns
+     * `null` when the pair doesn't resolve under the caller's organization
+     * (RLS-scoped, so cross-tenant access collapses to the same null).
+     */
+    findByPair: (input: {
+      readonly clientId: string
+      readonly userId: string
+    }) => Effect.Effect<OAuthKey | null, RepositoryError, SqlClient>
+    /**
      * Returns `true` when the given `clientId` resolves to an OAuth
      * application in the caller's organization. Implemented as an
      * RLS-scoped read — a cross-tenant client returns `false` exactly

--- a/packages/domain/oauth-keys/src/use-cases/get-oauth-key.ts
+++ b/packages/domain/oauth-keys/src/use-cases/get-oauth-key.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { OAuthKeyNotFoundError } from "../errors.ts"
+import { OAuthKeyRepository } from "../ports/oauth-key-repository.ts"
+
+export interface GetOAuthKeyInput {
+  readonly clientId: string
+  readonly userId: string
+}
+
+/**
+ * Returns the OAuth key for a `(clientId, userId)` pair visible under the
+ * caller's organization. Raises {@link OAuthKeyNotFoundError} (404) when
+ * the row isn't here — same observable behaviour for non-existent pairs
+ * and for cross-tenant pairs that the RLS read can't see, so existence
+ * never leaks across orgs.
+ */
+export const getOAuthKeyUseCase = Effect.fn("oauthKeys.getOAuthKey")(function* (input: GetOAuthKeyInput) {
+  yield* Effect.annotateCurrentSpan("oauthKey.clientId", input.clientId)
+  yield* Effect.annotateCurrentSpan("oauthKey.userId", input.userId)
+
+  const repository = yield* OAuthKeyRepository
+  const row = yield* repository.findByPair(input)
+  if (!row) {
+    return yield* new OAuthKeyNotFoundError({ clientId: input.clientId, userId: input.userId })
+  }
+  return row
+})

--- a/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
@@ -90,6 +90,47 @@ export const OAuthKeyRepositoryLive = Layer.effect(
         return rows.length > 0
       }),
 
+    findByPair: (input) =>
+      Effect.gen(function* () {
+        const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+        const rows = yield* sqlClient.query((db, organizationId) =>
+          db
+            .select({
+              clientId: oauthApplications.clientId,
+              clientName: oauthApplications.name,
+              clientIcon: oauthApplications.icon,
+              disabled: oauthApplications.disabled,
+              userId: oauthAccessTokens.userId,
+              userName: users.name,
+              userEmail: users.email,
+              lastActivityAt: max(oauthAccessTokens.updatedAt),
+              connectedAt: max(oauthAccessTokens.createdAt),
+            })
+            .from(oauthApplications)
+            .innerJoin(oauthAccessTokens, eq(oauthAccessTokens.clientId, oauthApplications.clientId))
+            .innerJoin(users, eq(users.id, oauthAccessTokens.userId))
+            .where(
+              and(
+                eq(oauthApplications.organizationId, organizationId),
+                eq(oauthApplications.clientId, input.clientId),
+                eq(oauthAccessTokens.userId, input.userId),
+              ),
+            )
+            .groupBy(
+              oauthApplications.clientId,
+              oauthApplications.name,
+              oauthApplications.icon,
+              oauthApplications.disabled,
+              oauthAccessTokens.userId,
+              users.name,
+              users.email,
+            )
+            .limit(1),
+        )
+        const row = rows[0]
+        return row ? toDomain(row) : null
+      }),
+
     deleteTokensForPair: (input) =>
       Effect.gen(function* () {
         const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/plans/mcp-oauth-api-expansion.md
+++ b/plans/mcp-oauth-api-expansion.md
@@ -737,11 +737,11 @@ Source of truth for what's shipped vs. outstanding. Update inline as PRs land.
 ### Outstanding
 
 - **M-OAuthKeysApi — Public OAuth Keys endpoints** (3 endpoints, prefix `/oauth-keys`, **never expose tokens**)
-  - [ ] `GET /` — list, `low` tier. Reuses `listOAuthKeysUseCase` from `@domain/oauth-keys`. Response is the metadata-only `OAuthKey` shape (id, clientId, clientName, clientIcon, userId, userName, userEmail, lastActivityAt, connectedAt, disabled). **No `access_token` / `refresh_token` / hashed-token / masked-token field on any response.**
-  - [ ] `GET /{oauthKeyId}` — get one by composite `${clientId}:${userId}` id, `low` tier. Use-case extension: add `findById(id)` to `@domain/oauth-keys` (parses the composite, then JOIN-reads the same row shape `listForOrganization` returns, RLS-scoped). 404s on miss / cross-tenant.
-  - [ ] `DELETE /{oauthKeyId}` — revoke, `medium` tier. Parses the composite id and reuses `revokeOAuthKeyUseCase` (already cache-invalidates and disables the application when the last token is removed). 204 on success, 404 when the id doesn't resolve under the caller's org.
-  - [ ] `apps/api/src/routes/oauth-keys.ts` — new file, `defineApiEndpoint` from the start. Mounted with `low` tier; the DELETE endpoint applies `medium` via the per-tier override. Wires `OAuthTokenCacheInvalidatorLive(c.var.redis)` + `OAuthKeyRepositoryLive`.
-  - [ ] No POST / PATCH. Out-of-scope notes already in the "Endpoint inventory" section above.
+  - [x] `GET /` — list, `low` tier. Reuses `listOAuthKeysUseCase`. Response is the metadata-only `OAuthKey` shape — no token field of any kind.
+  - [x] `GET /{oauthKeyId}` — get one by composite `${clientId}:${userId}` id, `low` tier. New `getOAuthKeyUseCase` calls `OAuthKeyRepository.findByPair` (JOIN-reads the same shape as `listForOrganization`, RLS-scoped). 404s on miss / malformed id / cross-tenant — all collapse to the same `OAuthKeyNotFoundError`.
+  - [x] `DELETE /{oauthKeyId}` — revoke, mounted under the `low` tier prefix; reuses `revokeOAuthKeyUseCase` (cache-invalidates each removed token and disables the application when the last token is gone). 204 on success and on idempotent re-revoke; 404 only for cross-tenant / malformed ids.
+  - [x] `apps/api/src/routes/oauth-keys.ts` — new file, `defineApiEndpoint`-native. Wires `OAuthTokenCacheInvalidatorLive(c.var.redis)` + `OAuthKeyRepositoryLive`. Composite id parsed via `lastIndexOf(":")` since `userId` is a CUID (no colons).
+  - [x] No POST / PATCH. Out-of-scope notes in the "Endpoint inventory" section.
 - **M4 — Traces + bulk export** (3 endpoints, prefix `/projects/{projectSlug}/traces`)
   - [ ] `GET /` — list with filters + searchQuery + cursor, `Paginated(TraceSchema, "PaginatedTraces")` (`high` tier)
   - [ ] `GET /{traceId}` — get (`medium` tier)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@domain/flaggers':
         specifier: workspace:*
         version: link:../../packages/domain/flaggers
+      '@domain/oauth-keys':
+        specifier: workspace:*
+        version: link:../../packages/domain/oauth-keys
       '@domain/organizations':
         specifier: workspace:*
         version: link:../../packages/domain/organizations
@@ -282,7 +285,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -2178,13 +2181,13 @@ importers:
         version: 7.0.0-dev.20260421.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/claude-code:
     dependencies:
@@ -17456,14 +17459,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -18807,14 +18802,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -22756,30 +22743,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
-    dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -23910,25 +23873,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.14.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.2
-      tsx: 4.21.0
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -23954,35 +23898,6 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.14.1
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
…d project settings

Three concrete user-visible changes wrapped together because they all flow through the same OpenAPI / MCP manifest regen pass.

**M-OAuthKeysApi**: 3 new endpoints under `/oauth-keys` (list / get / revoke), each surfaced as an MCP tool — manifest 18 -> 21 tools. List and get reuse `listOAuthKeysUseCase` / new `getOAuthKeyUseCase` from `@domain/oauth-keys`; revoke reuses `revokeOAuthKeyUseCase` which already busts Redis cache and disables the application when the last token is gone. New `findByPair` repository method backs the get. Response shape is metadata only — every test explicitly asserts no `access_token` / `refresh_token` / `token` field on any response — since unlike API keys there's no flow where the caller would copy a token from this surface. Endpoint descriptions include a "(like MCP clients)" disambiguation so MCP-side agents understand which type of keys they're looking at.

**MCP server instructions**: `MCP_INFO.instructions` is threaded into the `new McpServer(_, { instructions })` options so the SDK emits it in the `InitializeResult` returned to each MCP client. Clients (Cursor, Claude Code, Codex, …) prepend it to the LLM context whenever the agent reasons about a Latitude tool. `emit-mcp.ts` now spreads `MCP_INFO` into the manifest so `mcp.json` (the offline drift-checked artifact) carries the same name / title / description / version / instructions / websiteUrl / icons as the live server reports on initialize.

**Described project settings**: the projects route now declares explicit API-layer schemas for `ProjectSettings` and `AlertNotificationsSetting` so every individual field carries a description (the domain `projectSettingsSchema` is description-free by design). A compile-time assertion fails the typecheck if a future `ALERT_INCIDENT_KINDS` enum addition isn't described here too.