### PR TITLE
fix(api): align OAuth discovery metadata with strict MCP clients (Zed)

### DIFF
--- a/apps/api/src/routes/well-known.test.ts
+++ b/apps/api/src/routes/well-known.test.ts
@@ -9,19 +9,30 @@ describe("GET /.well-known/oauth-protected-resource", () => {
     expect(res.status).toBe(200)
   })
 
-  it<ApiTestContext>("returns the API origin as `resource` and the web AS as `authorization_servers`", async ({
+  it<ApiTestContext>("returns the API origin as `resource` and the web origin as `authorization_servers`", async ({
     app,
   }) => {
     const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource"))
     const body = (await res.json()) as { resource: string; authorization_servers: string[] }
 
     // Test env sets LAT_API_URL=http://localhost:3001, LAT_WEB_URL=http://localhost:3000.
+    // Bare origin (not `${webUrl}/api/auth`) so the value matches the issuer BA
+    // emits — strict OAuth clients (Zed) reject when issuer ≠ AS URL.
     expect(body.resource).toBe(process.env.LAT_API_URL)
-    expect(body.authorization_servers).toEqual([`${process.env.LAT_WEB_URL}/api/auth`])
+    expect(body.authorization_servers).toEqual([process.env.LAT_WEB_URL])
   })
 
   it<ApiTestContext>("returns JSON content type", async ({ app }) => {
     const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource"))
     expect(res.headers.get("content-type")).toContain("application/json")
+  })
+
+  it<ApiTestContext>("RFC 9728 path-suffix form returns the same metadata", async ({ app }) => {
+    // Zed and other strict MCP clients probe the path-suffixed form first.
+    const res = await app.fetch(new Request("http://localhost/.well-known/oauth-protected-resource/v1/mcp"))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { resource: string; authorization_servers: string[] }
+    expect(body.resource).toBe(process.env.LAT_API_URL)
+    expect(body.authorization_servers).toEqual([process.env.LAT_WEB_URL])
   })
 })

--- a/apps/api/src/routes/well-known.ts
+++ b/apps/api/src/routes/well-known.ts
@@ -49,16 +49,32 @@ const buildMetadata = () =>
     const webUrl = yield* parseEnv("LAT_WEB_URL", "string")
     return {
       resource: apiUrl,
-      // BA serves the AS metadata at `<webUrl>/api/auth/.well-known/oauth-authorization-server`;
-      // RFC 8414 lets clients derive the metadata path from the issuer, so the
-      // value here is the issuer (`<webUrl>/api/auth`) without the
-      // `.well-known/...` suffix.
-      authorization_servers: [`${webUrl}/api/auth`],
+      // Bare web origin, not `${webUrl}/api/auth` — Better Auth's OIDC plugin
+      // emits the AS metadata with `issuer = baseURL` (i.e. `${webUrl}`,
+      // without the `/api/auth` path; cf. `better-auth/dist/plugins/oidc-
+      // provider/index.mjs:53`). Strict clients (Zed) enforce RFC 8414 §3.3
+      // and reject when the issuer doesn't match the AS URL we advertise.
+      // The web app's root-level `/.well-known/oauth-authorization-server`
+      // redirect funnels probes to BA's actual `<webUrl>/api/auth/...`
+      // location, so the discovery still resolves end-to-end.
+      authorization_servers: [webUrl],
     }
   })
 
 export const registerWellKnownRoutes = ({ app }: { app: OpenAPIHono<AppEnv> }) => {
   app.openapi(oauthProtectedResourceRoute, async (c) => {
+    const metadata = await Effect.runPromise(buildMetadata())
+    return c.json(metadata, 200)
+  })
+
+  // RFC 9728 §3 path-suffixed form: when a resource lives at a non-root path
+  // (e.g. `/v1/mcp`), the metadata location is
+  // `<origin>/.well-known/oauth-protected-resource<resource-path>`. Cursor
+  // probes the unscoped form; Zed probes the path-suffixed form first.
+  // Serving the same payload at every suffix satisfies both — the metadata
+  // describes the entire `apiUrl` resource server regardless of which sub-
+  // path the client probed from.
+  app.get("/.well-known/oauth-protected-resource/*", async (c) => {
     const metadata = await Effect.runPromise(buildMetadata())
     return c.json(metadata, 200)
   })

--- a/apps/web/src/routes/_authenticated/settings/keys.tsx
+++ b/apps/web/src/routes/_authenticated/settings/keys.tsx
@@ -323,7 +323,7 @@ function OAuthKeysTable({ oauthKeys }: { oauthKeys: OAuthKeyRecord[] }) {
                       className="h-6 w-6 inline-flex shrink-0 overflow-hidden rounded-full"
                     />
                   ) : (
-                    <Avatar name="Unknown" size="sm" />
+                    <Avatar name={row.clientName ?? "Unknown"} size="sm" />
                   )}
                   <div className="flex flex-col">
                     <Text.H5>{row.clientName ?? "Unknown"}</Text.H5>


### PR DESCRIPTION
Two issues stopped Zed from completing the OAuth dance against our `/v1/mcp` endpoint; Cursor tolerated both:

1. The `/.well-known/oauth-protected-resource` route only served the un-suffixed form. RFC 9728 §3 says the metadata for a resource at `/v1/mcp` lives at `/.well-known/oauth-protected-resource/v1/mcp`. Zed probes the path-suffixed form first and 404s out. Now we serve the same payload at any sub-path under `/.well-known/oauth-protected- resource/*` so both probe styles resolve.

2. The protected-resource metadata advertised `authorization_servers: [<webUrl>/api/auth]`, but Better Auth's OIDC plugin emits the AS metadata with `issuer = baseURL` (i.e. `<webUrl>`, without the `/api/auth` path — cf. `oidc-provider/index.mjs:53`). RFC 8414 §3.3 requires `issuer` to match the AS URL the client used; Zed enforces this and rejected the metadata. The existing root-level `/.well-known/oauth-authorization-server` redirect on the web app already funnels probes to BA's actual location, so advertising the bare web origin keeps discovery resolving end-to-end while matching the issuer BA actually returns.

Also: tiny polish on the OAuth keys table — when the client icon is missing we now seed the fallback avatar from the client name so the initials match what the row shows instead of always reading "Un".