### PR TITLE
Release 14-05-2026-13-06

### DIFF
--- a/.github/actions/publish-npm-package/action.yml
+++ b/.github/actions/publish-npm-package/action.yml
@@ -1,8 +1,9 @@
 name: Publish NPM Package
 description: >-
   Compare the repo version against npm and, if different, install/build/test,
-  publish, and cut a GitHub Release. No-ops when versions match. Assumes the
-  repository has already been checked out by the caller.
+  publish with npm Trusted Publishing/provenance, and cut a GitHub Release.
+  No-ops when versions match. Assumes the repository has already been checked out
+  by the caller.
 
 inputs:
   package_path:
@@ -19,9 +20,6 @@ inputs:
     required: true
   release_name:
     description: GitHub release name prefix (e.g. TypeScript Telemetry).
-    required: true
-  npm_token:
-    description: npm publish token (pass secrets.NPM_TOKEN from the caller workflow).
     required: true
 
 runs:
@@ -85,9 +83,7 @@ runs:
     - name: Publish to npm
       if: steps.check_version.outputs.should_publish == 'true'
       shell: bash
-      run: pnpm publish --access public --filter ${{ inputs.pnpm_filter }} --no-git-checks
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm_token }}
+      run: pnpm publish --access public --provenance --filter ${{ inputs.pnpm_filter }} --no-git-checks
 
     - name: Extract changelog
       if: steps.check_version.outputs.should_publish == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: eu-central-1
 
       - name: Run migrations
@@ -455,7 +455,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: eu-central-1
 
       - name: Run migrations
@@ -808,6 +808,7 @@ jobs:
     needs: production-apply
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-typescript-telemetry.yml
     secrets: inherit
 
@@ -815,6 +816,7 @@ jobs:
     needs: production-apply
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-typescript-sdk.yml
     secrets: inherit
 
@@ -822,6 +824,7 @@ jobs:
     needs: production-apply
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-claude-code-telemetry.yml
     secrets: inherit
 
@@ -829,6 +832,7 @@ jobs:
     needs: production-apply
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-openclaw-telemetry.yml
     secrets: inherit
 
@@ -836,6 +840,7 @@ jobs:
     needs: production-apply
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-openclaw-telemetry-cli.yml
     secrets: inherit
 

--- a/.github/workflows/publish-claude-code-telemetry.yml
+++ b/.github/workflows/publish-claude-code-telemetry.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,4 +22,3 @@ jobs:
           pnpm_filter: "@latitude-data/claude-code-telemetry"
           tag_prefix: claude-code-telemetry
           release_name: Claude Code Telemetry
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-openclaw-telemetry-cli.yml
+++ b/.github/workflows/publish-openclaw-telemetry-cli.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,4 +22,3 @@ jobs:
           pnpm_filter: "@latitude-data/openclaw-telemetry-cli"
           tag_prefix: openclaw-telemetry-cli
           release_name: OpenClaw Telemetry CLI
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-openclaw-telemetry.yml
+++ b/.github/workflows/publish-openclaw-telemetry.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,4 +22,3 @@ jobs:
           pnpm_filter: "@latitude-data/openclaw-telemetry"
           tag_prefix: openclaw-telemetry
           release_name: OpenClaw Telemetry
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-typescript-sdk.yml
+++ b/.github/workflows/publish-typescript-sdk.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,4 +22,3 @@ jobs:
           pnpm_filter: "@latitude-data/sdk"
           tag_prefix: typescript-sdk
           release_name: TypeScript SDK
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-typescript-telemetry.yml
+++ b/.github/workflows/publish-typescript-telemetry.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,4 +22,3 @@ jobs:
           pnpm_filter: "@latitude-data/telemetry"
           tag_prefix: typescript-telemetry
           release_name: TypeScript Telemetry
-          npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: eu-central-1
 
       - name: Rollback services

--- a/apps/api/mcp.json
+++ b/apps/api/mcp.json
@@ -1,6 +1,20 @@
 {
-  "name": "Latitude API",
-  "version": "1.0.0",
+  "name": "Latitude MCP",
+  "title": "Latitude MCP",
+  "description": "Open-source AI agent monitoring platform. Full observability into what's failing in production. Discover underlying issues, get alerts when something breaks and verify your fix worked.",
+  "version": "v1",
+  "websiteUrl": "https://latitude.so",
+  "icons": [
+    {
+      "src": "https://framerusercontent.com/images/fPQsqC1Gx3CiQElnbBSmbQVYcA.png",
+      "theme": "light"
+    },
+    {
+      "src": "https://framerusercontent.com/images/l5c1DNVxQ3iAvTDihvg9pFw2l2k.png",
+      "theme": "dark"
+    }
+  ],
+  "instructions": "All Latitude MCP methods have descriptions and input/output schemas. For any doubt visit the Latitude documentation: https://docs.latitude.so/llms.txt",
   "tools": [
     {
       "name": "createProject",
@@ -47,21 +61,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -70,7 +96,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -163,21 +189,33 @@
                       "type": "object",
                       "properties": {
                         "keepMonitoring": {
+                          "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                           "type": "boolean"
                         },
                         "alertNotifications": {
+                          "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                           "type": "object",
-                          "propertyNames": {
-                            "type": "string",
-                            "enum": [
-                              "issue.new",
-                              "issue.regressed",
-                              "issue.escalating"
-                            ]
+                          "properties": {
+                            "issue.new": {
+                              "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "issue.regressed": {
+                              "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "issue.escalating": {
+                              "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                              "type": "boolean"
+                            },
+                            "escalationSensitivity": {
+                              "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 6
+                            }
                           },
-                          "additionalProperties": {
-                            "type": "boolean"
-                          }
+                          "additionalProperties": false
                         }
                       },
                       "additionalProperties": false
@@ -186,7 +224,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+                  "description": "Per-project settings overrides. `null` means inherit from the organization."
                 },
                 "firstTraceAt": {
                   "anyOf": [
@@ -307,21 +345,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -330,7 +380,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -404,21 +454,33 @@
             "type": "object",
             "properties": {
               "keepMonitoring": {
+                "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                 "type": "boolean"
               },
               "alertNotifications": {
+                "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                 "type": "object",
-                "propertyNames": {
-                  "type": "string",
-                  "enum": [
-                    "issue.new",
-                    "issue.regressed",
-                    "issue.escalating"
-                  ]
+                "properties": {
+                  "issue.new": {
+                    "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "issue.regressed": {
+                    "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "issue.escalating": {
+                    "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                    "type": "boolean"
+                  },
+                  "escalationSensitivity": {
+                    "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 6
+                  }
                 },
-                "additionalProperties": {
-                  "type": "boolean"
-                }
+                "additionalProperties": false
               }
             },
             "additionalProperties": false
@@ -477,21 +539,33 @@
                 "type": "object",
                 "properties": {
                   "keepMonitoring": {
+                    "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
                     "type": "boolean"
                   },
                   "alertNotifications": {
+                    "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
                     "type": "object",
-                    "propertyNames": {
-                      "type": "string",
-                      "enum": [
-                        "issue.new",
-                        "issue.regressed",
-                        "issue.escalating"
-                      ]
+                    "properties": {
+                      "issue.new": {
+                        "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.regressed": {
+                        "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "issue.escalating": {
+                        "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+                        "type": "boolean"
+                      },
+                      "escalationSensitivity": {
+                        "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 6
+                      }
                     },
-                    "additionalProperties": {
-                      "type": "boolean"
-                    }
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -500,7 +574,7 @@
                 "type": "null"
               }
             ],
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "description": "Per-project settings overrides. `null` means inherit from the organization."
           },
           "firstTraceAt": {
             "anyOf": [
@@ -1848,6 +1922,243 @@
         },
         "required": [
           "id"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "listOAuthKeys",
+      "title": "List OAuth keys",
+      "description": "Returns every OAuth key (like MCP clients) connected to the organization.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeys": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "Stable OAuth key identifier."
+                },
+                "clientId": {
+                  "type": "string",
+                  "description": "Identifier of the OAuth client the key was issued to."
+                },
+                "clientName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Display name of the OAuth client."
+                },
+                "clientIcon": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Icon URL of the OAuth client."
+                },
+                "userId": {
+                  "type": "string",
+                  "description": "Identifier of the user the key belongs to."
+                },
+                "userName": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Display name of the user. `null` until the user completes onboarding."
+                },
+                "userEmail": {
+                  "type": "string",
+                  "description": "Email of the user."
+                },
+                "lastActivityAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+                },
+                "connectedAt": {
+                  "type": "string",
+                  "description": "ISO-8601 timestamp at which the key was connected."
+                },
+                "disabled": {
+                  "type": "boolean",
+                  "description": "Whether the key has been disabled."
+                }
+              },
+              "required": [
+                "id",
+                "clientId",
+                "clientName",
+                "clientIcon",
+                "userId",
+                "userName",
+                "userEmail",
+                "lastActivityAt",
+                "connectedAt",
+                "disabled"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "oauthKeys"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "getOAuthKey",
+      "title": "Get OAuth key",
+      "description": "Returns a single OAuth key (like MCP clients) by id.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeyId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "OAuth key identifier."
+          }
+        },
+        "required": [
+          "oauthKeyId"
+        ],
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable OAuth key identifier."
+          },
+          "clientId": {
+            "type": "string",
+            "description": "Identifier of the OAuth client the key was issued to."
+          },
+          "clientName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the OAuth client."
+          },
+          "clientIcon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Icon URL of the OAuth client."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Identifier of the user the key belongs to."
+          },
+          "userName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name of the user. `null` until the user completes onboarding."
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "Email of the user."
+          },
+          "lastActivityAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+          },
+          "connectedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the key was connected."
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the key has been disabled."
+          }
+        },
+        "required": [
+          "id",
+          "clientId",
+          "clientName",
+          "clientIcon",
+          "userId",
+          "userName",
+          "userEmail",
+          "lastActivityAt",
+          "connectedAt",
+          "disabled"
+        ],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "revokeOAuthKey",
+      "title": "Revoke OAuth key",
+      "description": "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "oauthKeyId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "OAuth key identifier."
+          }
+        },
+        "required": [
+          "oauthKeyId"
         ],
         "additionalProperties": false
       }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -79,30 +79,7 @@
             "description": "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form."
           },
           "settings": {
-            "type": [
-              "object",
-              "null"
-            ],
-            "properties": {
-              "keepMonitoring": {
-                "type": "boolean"
-              },
-              "alertNotifications": {
-                "type": "object",
-                "properties": {
-                  "issue.new": {
-                    "type": "boolean"
-                  },
-                  "issue.regressed": {
-                    "type": "boolean"
-                  },
-                  "issue.escalating": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "description": "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches."
+            "$ref": "#/components/schemas/ProjectSettings"
           },
           "firstTraceAt": {
             "type": [
@@ -143,6 +120,46 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "ProjectSettings": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "keepMonitoring": {
+            "type": "boolean",
+            "description": "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted."
+          },
+          "alertNotifications": {
+            "$ref": "#/components/schemas/AlertNotificationsSetting"
+          }
+        },
+        "description": "Per-project settings overrides. `null` means inherit from the organization."
+      },
+      "AlertNotificationsSetting": {
+        "type": "object",
+        "properties": {
+          "issue.new": {
+            "type": "boolean",
+            "description": "Send a notification when a new issue is discovered. Defaults to `true` when omitted."
+          },
+          "issue.regressed": {
+            "type": "boolean",
+            "description": "Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted."
+          },
+          "issue.escalating": {
+            "type": "boolean",
+            "description": "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted."
+          },
+          "escalationSensitivity": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 6,
+            "description": "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted."
+          }
+        },
+        "description": "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values."
       },
       "Error": {
         "type": "object",
@@ -205,27 +222,14 @@
             "description": "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable)."
           },
           "settings": {
-            "type": "object",
-            "properties": {
-              "keepMonitoring": {
-                "type": "boolean"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProjectSettings"
               },
-              "alertNotifications": {
-                "type": "object",
-                "properties": {
-                  "issue.new": {
-                    "type": "boolean"
-                  },
-                  "issue.regressed": {
-                    "type": "boolean"
-                  },
-                  "issue.escalating": {
-                    "type": "boolean"
-                  }
-                }
+              {
+                "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
               }
-            },
-            "description": "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI."
+            ]
           },
           "flaggers": {
             "type": "object",
@@ -1391,6 +1395,89 @@
           "name"
         ]
       },
+      "OAuthKeyList": {
+        "type": "object",
+        "properties": {
+          "oauthKeys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OAuthKey"
+            }
+          }
+        },
+        "required": [
+          "oauthKeys"
+        ]
+      },
+      "OAuthKey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable OAuth key identifier."
+          },
+          "clientId": {
+            "type": "string",
+            "description": "Identifier of the OAuth client the key was issued to."
+          },
+          "clientName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name of the OAuth client."
+          },
+          "clientIcon": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Icon URL of the OAuth client."
+          },
+          "userId": {
+            "type": "string",
+            "description": "Identifier of the user the key belongs to."
+          },
+          "userName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Display name of the user. `null` until the user completes onboarding."
+          },
+          "userEmail": {
+            "type": "string",
+            "description": "Email of the user."
+          },
+          "lastActivityAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."
+          },
+          "connectedAt": {
+            "type": "string",
+            "description": "ISO-8601 timestamp at which the key was connected."
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the key has been disabled."
+          }
+        },
+        "required": [
+          "id",
+          "clientId",
+          "clientName",
+          "clientIcon",
+          "userId",
+          "userName",
+          "userEmail",
+          "lastActivityAt",
+          "connectedAt",
+          "disabled"
+        ]
+      },
       "AccountResponse": {
         "type": "object",
         "properties": {
@@ -2510,6 +2597,160 @@
         "responses": {
           "204": {
             "description": "API key revoked"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/oauth-keys": {
+      "get": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "list",
+        "summary": "List OAuth keys",
+        "description": "Returns every OAuth key (like MCP clients) connected to the organization.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "listOAuthKeys",
+        "responses": {
+          "200": {
+            "description": "List of OAuth keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthKeyList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/oauth-keys/{oauthKeyId}": {
+      "get": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "get",
+        "summary": "Get OAuth key",
+        "description": "Returns a single OAuth key (like MCP clients) by id.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "getOAuthKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "OAuth key identifier."
+            },
+            "required": true,
+            "description": "OAuth key identifier.",
+            "name": "oauthKeyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthKey"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "OAuth Keys"
+        ],
+        "x-fern-sdk-group-name": "oauthKeys",
+        "x-fern-sdk-method-name": "revoke",
+        "summary": "Revoke OAuth key",
+        "description": "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "operationId": "revokeOAuthKey",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "description": "OAuth key identifier."
+            },
+            "required": true,
+            "description": "OAuth key identifier.",
+            "name": "oauthKeyId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OAuth key revoked"
           },
           "401": {
             "description": "Unauthorized",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "@domain/annotations": "workspace:*",
     "@domain/api-keys": "workspace:*",
     "@domain/flaggers": "workspace:*",
+    "@domain/oauth-keys": "workspace:*",
     "@domain/organizations": "workspace:*",
     "@domain/projects": "workspace:*",
     "@domain/queue": "workspace:*",

--- a/apps/api/scripts/emit-mcp.ts
+++ b/apps/api/scripts/emit-mcp.ts
@@ -12,6 +12,7 @@ import { writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { OpenAPIHono, z } from "@hono/zod-openapi"
+import { MCP_INFO } from "../src/constants.ts"
 import { collectToolDescriptors } from "../src/mcp/index.ts"
 import { registerRoutes } from "../src/routes/index.ts"
 import type { AppEnv } from "../src/types.ts"
@@ -42,11 +43,7 @@ const tools = collectToolDescriptors().map((tool) => ({
   ...(tool.output ? { outputSchema: z.toJSONSchema(tool.output.schema, { target: "draft-2020-12" }) } : {}),
 }))
 
-const manifest = {
-  name: "Latitude API",
-  version: "1.0.0",
-  tools,
-}
+const manifest = { ...MCP_INFO, tools }
 
 const here = dirname(fileURLToPath(import.meta.url))
 const outPath = resolve(here, "../mcp.json")

--- a/apps/api/src/constants.ts
+++ b/apps/api/src/constants.ts
@@ -20,4 +20,8 @@ export const MCP_INFO = {
     { src: "https://framerusercontent.com/images/fPQsqC1Gx3CiQElnbBSmbQVYcA.png", theme: "light" },
     { src: "https://framerusercontent.com/images/l5c1DNVxQ3iAvTDihvg9pFw2l2k.png", theme: "dark" },
   ],
-} as McpInfo
+  instructions:
+    "All Latitude MCP methods have descriptions and input/output schemas. For any doubt visit the Latitude documentation: https://docs.latitude.so/llms.txt",
+} as McpInfo & {
+  instructions: string
+}

--- a/apps/api/src/mcp/server.ts
+++ b/apps/api/src/mcp/server.ts
@@ -63,7 +63,7 @@ export const registerMcpRoute = ({
   const toolDescriptors = collectToolDescriptors()
 
   routes.all("/mcp", async (c) => {
-    const mcpServer = new McpServer(MCP_INFO, { capabilities: { tools: {} } })
+    const mcpServer = new McpServer(MCP_INFO, { instructions: MCP_INFO.instructions, capabilities: { tools: {} } })
 
     for (const tool of toolDescriptors) {
       // Capture each descriptor in the closure — the loop variable would

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -11,6 +11,7 @@ import { annotationsPath, createAnnotationsRoutes } from "./annotations.ts"
 import { apiKeysPath, createApiKeysRoutes } from "./api-keys.ts"
 import { registerHealthRoute } from "./health.ts"
 import { createMembersRoutes, membersPath } from "./members.ts"
+import { createOAuthKeysRoutes, oauthKeysPath } from "./oauth-keys.ts"
 import { createProjectsRoutes, projectsPath } from "./projects.ts"
 import { createScoresRoutes, scoresPath } from "./scores.ts"
 import { registerWellKnownRoutes } from "./well-known.ts"
@@ -56,6 +57,9 @@ export const registerRoutes = (app: OpenAPIHono<AppEnv>, options: ApiOptions) =>
 
   routes.use(apiKeysPath, createTierRateLimiter("low"))
   routes.route(apiKeysPath, createApiKeysRoutes())
+
+  routes.use(oauthKeysPath, createTierRateLimiter("low"))
+  routes.route(oauthKeysPath, createOAuthKeysRoutes())
 
   routes.use(accountPath, createTierRateLimiter("low"))
   routes.route(accountPath, createAccountRoutes())

--- a/apps/api/src/routes/oauth-keys.test.ts
+++ b/apps/api/src/routes/oauth-keys.test.ts
@@ -1,0 +1,198 @@
+import { eq } from "@platform/db-postgres"
+import { oauthAccessTokens, oauthApplications } from "@platform/db-postgres/schema/better-auth"
+import { createApiKeyAuthHeaders } from "@platform/testkit"
+import { describe, expect, it } from "vitest"
+import {
+  type ApiTestContext,
+  createOAuthAuthHeaders,
+  createOAuthTenantSetup,
+  setupTestApi,
+} from "../test-utils/create-test-app.ts"
+
+interface OAuthKeyRow {
+  readonly id: string
+  readonly clientId: string
+  readonly clientName: string | null
+  readonly userId: string
+  readonly userEmail: string
+  readonly disabled: boolean
+}
+
+interface ListResponse {
+  readonly oauthKeys: ReadonlyArray<OAuthKeyRow>
+}
+
+const listOAuthKeysJson = async (
+  app: ApiTestContext["app"],
+  headers: Record<string, string>,
+): Promise<ListResponse> => {
+  const res = await app.fetch(new Request("http://localhost/v1/oauth-keys", { headers }))
+  expect(res.status).toBe(200)
+  return (await res.json()) as ListResponse
+}
+
+describe("OAuth keys routes — list", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("GET /v1/oauth-keys returns this org's keys with metadata only (no tokens)", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const body = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenant.oauthAccessToken))
+
+    expect(body.oauthKeys).toHaveLength(1)
+    const [row] = body.oauthKeys
+    expect(row?.clientId).toBe(tenant.oauthClientId)
+    expect(row?.userId).toBe(tenant.userId)
+    expect(row?.disabled).toBe(false)
+    // Crucial guarantee: no token-shaped field on the response.
+    const keys = Object.keys(row as object)
+    expect(keys).not.toContain("accessToken")
+    expect(keys).not.toContain("access_token")
+    expect(keys).not.toContain("refreshToken")
+    expect(keys).not.toContain("token")
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys isolates by organization", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+
+    const bodyA = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenantA.oauthAccessToken))
+    expect(bodyA.oauthKeys.map((k) => k.clientId)).toEqual([tenantA.oauthClientId])
+
+    const bodyB = await listOAuthKeysJson(app, createOAuthAuthHeaders(tenantB.oauthAccessToken))
+    expect(bodyB.oauthKeys.map((k) => k.clientId)).toEqual([tenantB.oauthClientId])
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys works for API-key callers too (read-only)", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const body = await listOAuthKeysJson(app, createApiKeyAuthHeaders(tenant.apiKeyToken))
+    expect(body.oauthKeys.map((k) => k.clientId)).toContain(tenant.oauthClientId)
+  })
+})
+
+describe("OAuth keys routes — get", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns the row matching the composite id", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const compositeId = `${tenant.oauthClientId}:${tenant.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, {
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as OAuthKeyRow
+    expect(body.id).toBe(compositeId)
+    expect(body.clientId).toBe(tenant.oauthClientId)
+    expect(body.userId).toBe(tenant.userId)
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns 404 for malformed ids", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+
+    const res = await app.fetch(
+      new Request("http://localhost/v1/oauth-keys/not-a-composite", {
+        headers: createOAuthAuthHeaders(tenant.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it<ApiTestContext>("GET /v1/oauth-keys/{id} returns 404 for cross-tenant ids", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+    const otherCompositeId = `${tenantB.oauthClientId}:${tenantB.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${otherCompositeId}`, {
+        headers: createOAuthAuthHeaders(tenantA.oauthAccessToken),
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("OAuth keys routes — revoke", () => {
+  setupTestApi()
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} drops the access tokens for the pair", async ({ app, database }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    // Pair has one token; sanity-check it's there before revoke.
+    const before = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenant.oauthClientId))
+    expect(before).toHaveLength(1)
+
+    const apiKeyHeaders = createApiKeyAuthHeaders(tenant.apiKeyToken)
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${tenant.oauthClientId}:${tenant.userId}`, {
+        method: "DELETE",
+        headers: apiKeyHeaders,
+      }),
+    )
+    expect(res.status).toBe(204)
+
+    const after = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenant.oauthClientId))
+    expect(after).toHaveLength(0)
+
+    // Application gets disabled because no tokens remain for that client.
+    const apps = await database.db
+      .select({ disabled: oauthApplications.disabled })
+      .from(oauthApplications)
+      .where(eq(oauthApplications.clientId, tenant.oauthClientId))
+    expect(apps[0]?.disabled).toBe(true)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} is idempotent — second call still returns 204", async ({
+    app,
+    database,
+  }) => {
+    const tenant = await createOAuthTenantSetup(database)
+    const compositeId = `${tenant.oauthClientId}:${tenant.userId}`
+    const headers = createApiKeyAuthHeaders(tenant.apiKeyToken)
+
+    const first = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, { method: "DELETE", headers }),
+    )
+    expect(first.status).toBe(204)
+
+    const second = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${compositeId}`, { method: "DELETE", headers }),
+    )
+    // After the first revoke the application is disabled; the second revoke
+    // still finds the row in this org, so it 204s rather than 404s.
+    expect(second.status).toBe(204)
+  })
+
+  it<ApiTestContext>("DELETE /v1/oauth-keys/{id} can't reach a cross-tenant pair (404)", async ({ app, database }) => {
+    const tenantA = await createOAuthTenantSetup(database)
+    const tenantB = await createOAuthTenantSetup(database)
+    const otherCompositeId = `${tenantB.oauthClientId}:${tenantB.userId}`
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/oauth-keys/${otherCompositeId}`, {
+        method: "DELETE",
+        headers: createApiKeyAuthHeaders(tenantA.apiKeyToken),
+      }),
+    )
+    expect(res.status).toBe(404)
+
+    // Tenant B's tokens are untouched.
+    const tokens = await database.db
+      .select({ id: oauthAccessTokens.id })
+      .from(oauthAccessTokens)
+      .where(eq(oauthAccessTokens.clientId, tenantB.oauthClientId))
+    expect(tokens).toHaveLength(1)
+  })
+})

--- a/apps/api/src/routes/oauth-keys.ts
+++ b/apps/api/src/routes/oauth-keys.ts
@@ -1,0 +1,174 @@
+import {
+  getOAuthKeyUseCase,
+  listOAuthKeysUseCase,
+  type OAuthKey,
+  OAuthKeyNotFoundError,
+  revokeOAuthKeyUseCase,
+} from "@domain/oauth-keys"
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { OAuthKeyRepositoryLive, withPostgres } from "@platform/db-postgres"
+import { OAuthTokenCacheInvalidatorLive } from "@platform/oauth-token-auth"
+import { withTracing } from "@repo/observability"
+import { Effect } from "effect"
+import { defineApiEndpoint } from "../mcp/index.ts"
+import { jsonResponse, openApiNoContentResponses, openApiResponses, PROTECTED_SECURITY } from "../openapi/schemas.ts"
+import type { OrganizationScopedEnv } from "../types.ts"
+
+// OAuth keys are the `(client, user)` connections users grant to OAuth /
+// MCP clients (Claude Code, Cursor, Codex…) via the consent flow at
+// `app.latitude.so/auth/consent`. The API exposes read + revoke surfaces;
+// creation is impossible by design (rows are minted by the consent UX).
+//
+// **Response contract**: never expose `access_token`, `refresh_token`,
+// hashed-token, or any masked-token field. Only the metadata in
+// `OAuthKey` is returned. Unlike API keys, there's no flow where the
+// caller would copy a token from this surface.
+const ResponseSchema = z
+  .object({
+    id: z.string().describe("Stable OAuth key identifier."),
+    clientId: z.string().describe("Identifier of the OAuth client the key was issued to."),
+    clientName: z.string().nullable().describe("Display name of the OAuth client."),
+    clientIcon: z.string().nullable().describe("Icon URL of the OAuth client."),
+    userId: z.string().describe("Identifier of the user the key belongs to."),
+    userName: z.string().nullable().describe("Display name of the user. `null` until the user completes onboarding."),
+    userEmail: z.string().describe("Email of the user."),
+    lastActivityAt: z
+      .string()
+      .nullable()
+      .describe("ISO-8601 timestamp of the last refresh on the key. `null` if the key has never been used."),
+    connectedAt: z.string().describe("ISO-8601 timestamp at which the key was connected."),
+    disabled: z.boolean().describe("Whether the key has been disabled."),
+  })
+  .openapi("OAuthKey")
+
+const ListResponseSchema = z.object({ oauthKeys: z.array(ResponseSchema) }).openapi("OAuthKeyList")
+
+const OAuthKeyParamsSchema = z.object({
+  oauthKeyId: z.string().min(1).describe("OAuth key identifier."),
+})
+
+// Fern groups so the generated SDK lands at `client.oauthKeys.{list,get,revoke}`.
+const oauthKeysFernGroup = (methodName: string) =>
+  ({
+    "x-fern-sdk-group-name": "oauthKeys",
+    "x-fern-sdk-method-name": methodName,
+  }) as const
+
+const toResponse = (key: OAuthKey) => ({
+  id: key.id,
+  clientId: key.clientId,
+  clientName: key.clientName,
+  clientIcon: key.clientIcon,
+  userId: key.userId,
+  userName: key.userName,
+  userEmail: key.userEmail,
+  lastActivityAt: key.lastActivityAt ? key.lastActivityAt.toISOString() : null,
+  connectedAt: key.connectedAt.toISOString(),
+  disabled: key.disabled,
+})
+
+/**
+ * Splits the composite id on the LAST colon. `userId` is a CUID2 (no
+ * colons), so the tail is always the user id and the head — even if it
+ * contains colons — is the OAuth client_id. Returns `null` for malformed
+ * input so handlers can 404 cleanly.
+ */
+const parseCompositeId = (id: string): { clientId: string; userId: string } | null => {
+  const i = id.lastIndexOf(":")
+  if (i <= 0 || i === id.length - 1) return null
+  return { clientId: id.slice(0, i), userId: id.slice(i + 1) }
+}
+
+export const oauthKeysPath = "/oauth-keys"
+
+const oauthKeyEndpoint = defineApiEndpoint<OrganizationScopedEnv>(oauthKeysPath)
+
+const listOAuthKeys = oauthKeyEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/",
+    name: "listOAuthKeys",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("list"),
+    summary: "List OAuth keys",
+    description: "Returns every OAuth key (like MCP clients) connected to the organization.",
+    security: PROTECTED_SECURITY,
+    responses: { 200: jsonResponse(ListResponseSchema, "List of OAuth keys") },
+  }),
+  handler: async (c) => {
+    const keys = await Effect.runPromise(
+      listOAuthKeysUseCase().pipe(
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.json({ oauthKeys: keys.map(toResponse) }, 200)
+  },
+})
+
+const getOAuthKey = oauthKeyEndpoint({
+  route: createRoute({
+    method: "get",
+    path: "/{oauthKeyId}",
+    name: "getOAuthKey",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("get"),
+    summary: "Get OAuth key",
+    description: "Returns a single OAuth key (like MCP clients) by id.",
+    security: PROTECTED_SECURITY,
+    request: { params: OAuthKeyParamsSchema },
+    responses: openApiResponses({ status: 200, schema: ResponseSchema, description: "OAuth key" }),
+  }),
+  handler: async (c) => {
+    const { oauthKeyId } = c.req.valid("param")
+    const parsed = parseCompositeId(oauthKeyId)
+    if (!parsed) {
+      throw new OAuthKeyNotFoundError({ clientId: oauthKeyId, userId: "" })
+    }
+
+    const key = await Effect.runPromise(
+      getOAuthKeyUseCase(parsed).pipe(
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.json(toResponse(key), 200)
+  },
+})
+
+const revokeOAuthKey = oauthKeyEndpoint({
+  route: createRoute({
+    method: "delete",
+    path: "/{oauthKeyId}",
+    name: "revokeOAuthKey",
+    tags: ["OAuth Keys"],
+    ...oauthKeysFernGroup("revoke"),
+    summary: "Revoke OAuth key",
+    description: "Revokes an OAuth key (like MCP clients). The connected client immediately loses access.",
+    security: PROTECTED_SECURITY,
+    request: { params: OAuthKeyParamsSchema },
+    responses: openApiNoContentResponses({ description: "OAuth key revoked" }),
+  }),
+  handler: async (c) => {
+    const { oauthKeyId } = c.req.valid("param")
+    const parsed = parseCompositeId(oauthKeyId)
+    if (!parsed) {
+      throw new OAuthKeyNotFoundError({ clientId: oauthKeyId, userId: "" })
+    }
+
+    await Effect.runPromise(
+      revokeOAuthKeyUseCase(parsed).pipe(
+        Effect.provide(OAuthTokenCacheInvalidatorLive(c.var.redis)),
+        withPostgres(OAuthKeyRepositoryLive, c.var.postgresClient, c.var.organization.id),
+        withTracing,
+      ),
+    )
+    return c.body(null, 204)
+  },
+})
+
+export const createOAuthKeysRoutes = () => {
+  const app = new OpenAPIHono<OrganizationScopedEnv>()
+  for (const ep of [listOAuthKeys, getOAuthKey, revokeOAuthKey]) ep.mountHttp(app)
+  return app
+}

--- a/apps/api/src/routes/projects.ts
+++ b/apps/api/src/routes/projects.ts
@@ -6,7 +6,7 @@ import {
   ProjectRepository,
   updateProjectUseCase,
 } from "@domain/projects"
-import { projectSettingsSchema } from "@domain/shared"
+import type { ALERT_INCIDENT_KINDS } from "@domain/shared"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { RedisCacheStoreLive } from "@platform/cache-redis"
 import {
@@ -39,6 +39,63 @@ const projectsFernGroup = (methodName: string) =>
     "x-fern-sdk-method-name": methodName,
   }) as const
 
+// Project-settings shape, expressed at the API layer so each field carries a
+// description (the domain `projectSettingsSchema` is description-free by
+// design). The field-by-field shape mirrors `projectSettingsSchema` from
+// `@domain/shared`; the per-alert-kind toggles are spelled out so each one is
+// individually documented for SDK / MCP consumers.
+const AlertNotificationsSettingSchema = z
+  .object({
+    "issue.new": z
+      .boolean()
+      .optional()
+      .describe("Send a notification when a new issue is discovered. Defaults to `true` when omitted."),
+    "issue.regressed": z
+      .boolean()
+      .optional()
+      .describe("Send a notification when a previously-resolved issue regresses. Defaults to `true` when omitted."),
+    "issue.escalating": z
+      .boolean()
+      .optional()
+      .describe(
+        "Send a notification when an active issue is escalating in volume or severity. Defaults to `true` when omitted.",
+      ),
+    escalationSensitivity: z
+      .number()
+      .int()
+      .min(1)
+      .max(6)
+      .optional()
+      .describe(
+        "Sensitivity of the escalation detector, 1 (most sensitive, more notifications) to 6 (least sensitive, fewer notifications). Defaults to a balanced value when omitted.",
+      ),
+  })
+  .openapi("AlertNotificationsSetting")
+
+// Assert at compile time that the API schema covers every alert kind the
+// domain knows about — adding a new entry to `ALERT_INCIDENT_KINDS` makes
+// this assertion fail until we describe the new key here too.
+type _AlertKindsCovered = Exclude<
+  (typeof ALERT_INCIDENT_KINDS)[number],
+  keyof z.infer<typeof AlertNotificationsSettingSchema>
+>
+const _alertKindsAreCovered: _AlertKindsCovered extends never ? true : false = true
+void _alertKindsAreCovered
+
+const ProjectSettingsSchema = z
+  .object({
+    keepMonitoring: z
+      .boolean()
+      .optional()
+      .describe(
+        "When `true`, the evaluation linked to an issue keeps running after the issue is resolved. When `false`, resolving the issue stops the evaluation. Defaults to `true` when omitted.",
+      ),
+    alertNotifications: AlertNotificationsSettingSchema.optional().describe(
+      "Per-alert-kind in-app notification toggles plus escalation-detector tuning. Omit to keep current values.",
+    ),
+  })
+  .openapi("ProjectSettings")
+
 const ResponseSchema = z
   .object({
     id: z.string().describe("Stable project identifier (CUID2)."),
@@ -49,11 +106,9 @@ const ResponseSchema = z
       .describe(
         "URL-safe slug derived from `name`. Regenerated when the name changes in a way that affects the slug form.",
       ),
-    settings: projectSettingsSchema
-      .nullable()
-      .describe(
-        "Per-project settings overrides. `null` means inherit from the organization. See the `ProjectSettings` schema for the available switches.",
-      ),
+    settings: ProjectSettingsSchema.nullable().describe(
+      "Per-project settings overrides. `null` means inherit from the organization.",
+    ),
     firstTraceAt: z
       .string()
       .nullable()
@@ -85,11 +140,9 @@ const UpdateRequestSchema = z
       .describe(
         "New human-readable name. Triggers slug regeneration when the change affects the slug form (cosmetic edits like capitalization keep the URL stable).",
       ),
-    settings: projectSettingsSchema
-      .optional()
-      .describe(
-        "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
-      ),
+    settings: ProjectSettingsSchema.optional().describe(
+      "Replace the project's settings overrides. Omit to leave settings untouched. To clear overrides entirely, edit via the web UI.",
+    ),
     flaggers: z
       .partialRecord(z.enum(FLAGGER_STRATEGY_SLUGS), z.boolean())
       .optional()

--- a/apps/web/src/domains/wrapped/og/claude-code/render-og-image.tsx
+++ b/apps/web/src/domains/wrapped/og/claude-code/render-og-image.tsx
@@ -1,8 +1,15 @@
-import { readFile } from "node:fs/promises"
-import { fileURLToPath } from "node:url"
-import type { WrappedReportRecord } from "@domain/spans"
+import type { PersonalityKind, WrappedReportRecord } from "@domain/spans"
 import { Resvg } from "@resvg/resvg-js"
 import satori from "satori"
+import architectPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/architect.png?inline"
+import conductorPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/conductor.png?inline"
+import consultantPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/consultant.png?inline"
+import detectivePng from "../../../../../public/email-branding/claude-code-wrapped/personalities/detective.png?inline"
+import scholarPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/scholar.png?inline"
+import shipperPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/shipper.png?inline"
+import strategistPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/strategist.png?inline"
+import surgeonPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/surgeon.png?inline"
+import testerPng from "../../../../../public/email-branding/claude-code-wrapped/personalities/tester.png?inline"
 import {
   TITLE_FOR_KIND,
   WRAPPED_COLORS,
@@ -41,28 +48,26 @@ const OG_HEIGHT = 630
 // orange.
 const BLACKISH_CREAM = "#2A2520"
 
-const personalityImageCache = new Map<string, string>()
-
-const readPersonalityImageAsDataUrl = async (kind: string): Promise<string> => {
-  const cached = personalityImageCache.get(kind)
-  if (cached) return cached
-  // The personality PNGs live under `apps/web/public/email-branding/...`.
-  // This module is at `apps/web/src/domains/wrapped/og/claude-code/`, so the
-  // file is five directories up from here.
-  const path = fileURLToPath(
-    new URL(`../../../../../public/email-branding/claude-code-wrapped/personalities/${kind}.png`, import.meta.url),
-  )
-  const buf = await readFile(path)
-  const dataUrl = `data:image/png;base64,${buf.toString("base64")}`
-  personalityImageCache.set(kind, dataUrl)
-  return dataUrl
+// Personality PNGs are inlined as base64 data URLs at build time. Reading
+// them from disk at request time would break in the Nitro production bundle
+// — `import.meta.url` points at a chunk under `.output/server/chunks/...`,
+// not the source location, so the relative `../public/...` traversal
+// resolves to a path that doesn't exist in the runtime image.
+const PERSONALITY_IMAGE_BY_KIND: Record<PersonalityKind, string> = {
+  architect: architectPng,
+  conductor: conductorPng,
+  consultant: consultantPng,
+  detective: detectivePng,
+  scholar: scholarPng,
+  shipper: shipperPng,
+  strategist: strategistPng,
+  surgeon: surgeonPng,
+  tester: testerPng,
 }
 
 export const renderClaudeCodeOgImage = async (record: WrappedReportRecord): Promise<Buffer> => {
-  const [{ regular, semibold }, imageDataUrl] = await Promise.all([
-    getOgFonts(),
-    readPersonalityImageAsDataUrl(record.report.personality.kind),
-  ])
+  const { regular, semibold } = await getOgFonts()
+  const imageDataUrl = PERSONALITY_IMAGE_BY_KIND[record.report.personality.kind]
 
   const archetype = TITLE_FOR_KIND[record.report.personality.kind] ?? "The Wrapped"
   const linesWritten = record.report.loc.written.toLocaleString("en-US")

--- a/infra/Pulumi.production.yaml
+++ b/infra/Pulumi.production.yaml
@@ -4,6 +4,8 @@ config:
   latitude-infra:domainName: latitude.so
   latitude-infra:githubOwner: latitude-dev
   latitude-infra:githubRepo: latitude-llm
+  # Pinned to avoid automatic bastion replacement when AWS publishes newer AL2023 AMIs.
+  latitude-infra:bastionAmiId: ami-00b105a12aa2a60eb
   # Temporal Cloud (workflows ECS task)
   latitude-infra:temporalCloudNamespace: "latitude-llm.naqqz"
   # latitude-infra:temporalCloudAddress: "eu-central-1.aws.api.temporal.io:7233"

--- a/infra/Pulumi.staging.yaml
+++ b/infra/Pulumi.staging.yaml
@@ -4,6 +4,8 @@ config:
   latitude-infra:domainName: latitude.so
   latitude-infra:githubOwner: latitude-dev
   latitude-infra:githubRepo: latitude-llm
+  # Pinned to avoid automatic bastion replacement when AWS publishes newer AL2023 AMIs.
+  latitude-infra:bastionAmiId: ami-00b105a12aa2a60eb
   # Temporal Cloud (workflows ECS task): set namespace before enabling the worker
   latitude-infra:temporalCloudNamespace: "latitude-llm-staging.naqqz"
   # latitude-infra:temporalCloudAddress: "eu-central-1.aws.api.temporal.io:7233"

--- a/infra/README.md
+++ b/infra/README.md
@@ -157,7 +157,7 @@ Manual deployments must be dispatched from the matching branch:
 - Dispatch from `development` when deploying to the `staging` environment
 - Dispatch from `main` when deploying to the `production` environment
 
-The deployment workflow uses OIDC authentication (no long-lived AWS credentials).
+The deployment workflow uses GitHub Actions OIDC authentication (no long-lived AWS access keys). Each GitHub Environment must define `AWS_DEPLOY_ROLE_ARN` as an environment variable (not a secret), pointing at the Pulumi output `outputs.githubActionsRoleArn` for the matching stack. Keep any legacy deployment IAM user in place until both staging and production deployments have been verified with the new role, then retire the user manually.
 
 ## Secret lifecycle
 

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -9,6 +9,7 @@ import { createRds } from "./lib/rds.ts"
 import { createRedis } from "./lib/redis.ts"
 import { createS3 } from "./lib/s3.ts"
 import { createApplicationSecrets } from "./lib/secrets.ts"
+import { createSecurityCompliance } from "./lib/security-compliance.ts"
 import { createSecurityGroups } from "./lib/security-groups.ts"
 import { createVpc } from "./lib/vpc.ts"
 import { createVpcEndpoints } from "./lib/vpc-endpoints.ts"
@@ -23,6 +24,7 @@ const hostedZoneId = config.get("hostedZoneId") ?? defaults.hostedZoneId
 const domainName = config.get("domainName") ?? defaults.domainName
 const githubOwner = config.get("githubOwner") ?? "latitude-dev"
 const githubRepo = config.get("githubRepo") ?? "latitude"
+const bastionAmiId = config.require("bastionAmiId")
 
 const temporalCloudAddress = config.get("temporalCloudAddress") ?? `${envConfig.region}.aws.api.temporal.io:7233`
 const temporalCloudNamespace = config.get("temporalCloudNamespace") ?? ""
@@ -71,9 +73,11 @@ const rds = createRds(name, envConfig, vpc.privateSubnets, securityGroups.rds)
 
 const redis = createRedis(name, envConfig, vpc.privateSubnets, securityGroups.redis)
 
-const bastion = createBastion(name, envConfig, vpc.vpc, vpc.publicSubnets, securityGroups.bastion)
+const bastion = createBastion(name, envConfig, vpc.vpc, vpc.publicSubnets, securityGroups.bastion, bastionAmiId)
 
 const s3 = createS3(name, envConfig)
+
+const securityCompliance = environment === "staging" ? createSecurityCompliance(name, envConfig) : undefined
 
 const appSecrets = createApplicationSecrets(name, environment)
 
@@ -131,6 +135,15 @@ export const outputs = {
   githubActionsRoleArn: githubActions.deployRole.arn,
 
   bastionInstanceId: bastion.instance.id,
+
+  ...(securityCompliance
+    ? {
+        awsConfigRecorderName: securityCompliance.configRecorder.name,
+        cloudTrailName: securityCompliance.cloudTrail.name,
+        cloudTrailLogGroupName: securityCompliance.cloudTrailLogGroup.name,
+        guardDutyDetectorId: securityCompliance.guardDutyDetector.id,
+      }
+    : {}),
 
   domains: envConfig.domains,
 

--- a/infra/lib/bastion.ts
+++ b/infra/lib/bastion.ts
@@ -15,6 +15,7 @@ export function createBastion(
   vpc: Ec2Vpc,
   publicSubnets: Ec2Subnet[],
   securityGroup: Ec2SecurityGroup,
+  amiId: pulumi.Input<string>,
 ): BastionOutput {
   const ssmRole = new aws.iam.Role(`${name}-bastion-ssm-role`, {
     assumeRolePolicy: JSON.stringify({
@@ -48,24 +49,9 @@ export function createBastion(
     },
   })
 
-  const ami = aws.ec2.getAmiOutput({
-    owners: ["amazon"],
-    mostRecent: true,
-    filters: [
-      {
-        name: "name",
-        values: ["al2023-ami-2023.*-x86_64"],
-      },
-      {
-        name: "state",
-        values: ["available"],
-      },
-    ],
-  })
-
   const instance = new aws.ec2.Instance(`${name}-bastion`, {
     instanceType: "t3.nano",
-    ami: ami.id,
+    ami: amiId,
     subnetId: publicSubnets[0].id,
     vpcSecurityGroupIds: [securityGroup.id],
     iamInstanceProfile: instanceProfile.name,

--- a/infra/lib/github-actions.ts
+++ b/infra/lib/github-actions.ts
@@ -6,6 +6,41 @@ export interface GithubActionsOutput {
   deployRole: IamRole
 }
 
+function createDeployPolicy(environment: string): aws.iam.RolePolicyArgs["policy"] {
+  return {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "ECSOperations",
+        Effect: "Allow",
+        Action: [
+          "ecs:UpdateService",
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "ecs:RegisterTaskDefinition",
+          "ecs:RunTask",
+          "ecs:ListTasks",
+          "ecs:ListServices",
+          "ecs:DescribeTasks",
+        ],
+        Resource: "*",
+      },
+      {
+        Sid: "CloudWatchLogs",
+        Effect: "Allow",
+        Action: ["logs:DescribeLogStreams", "logs:GetLogEvents"],
+        Resource: `arn:aws:logs:*:*:log-group:/ecs/latitude-${environment}*:log-stream:*`,
+      },
+      {
+        Sid: "IAMPassRole",
+        Effect: "Allow",
+        Action: ["iam:PassRole"],
+        Resource: `arn:aws:iam::*:role/latitude-${environment}-*`,
+      },
+    ],
+  }
+}
+
 export function createGithubActionsOidc(
   name: string,
   environment: string,
@@ -27,58 +62,27 @@ export function createGithubActionsOidc(
         "Action": "sts:AssumeRoleWithWebIdentity",
         "Condition": {
           "StringEquals": {
-            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-          },
-          "StringLike": {
-            "token.actions.githubusercontent.com:sub": "repo:${githubOwner}/${githubRepo}:*"
+            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+            "token.actions.githubusercontent.com:sub": "repo:${githubOwner}/${githubRepo}:environment:${environment}"
           }
         }
       }
     ]
   }`
 
-  const deployRole = new aws.iam.Role(`${name}-github-deploy-role`, {
+  const deployRole = new aws.iam.Role(`${name}-github-environment-deploy-role`, {
     assumeRolePolicy: assumeRolePolicy,
     tags: {
-      Name: `${name}-github-deploy-role`,
+      Name: `${name}-github-environment-deploy-role`,
       Environment: environment,
+      ManagedBy: "pulumi",
+      Purpose: "github-actions-deploy-oidc",
     },
   })
 
-  new aws.iam.RolePolicy(`${name}-deploy-policy`, {
+  new aws.iam.RolePolicy(`${name}-environment-deploy-policy`, {
     role: deployRole.name,
-    policy: {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Sid: "ECSOperations",
-          Effect: "Allow",
-          Action: [
-            "ecs:UpdateService",
-            "ecs:DescribeServices",
-            "ecs:DescribeTaskDefinition",
-            "ecs:RegisterTaskDefinition",
-            "ecs:RunTask",
-            "ecs:ListTasks",
-            "ecs:ListServices",
-            "ecs:DescribeTasks",
-          ],
-          Resource: "*",
-        },
-        {
-          Sid: "CloudWatchLogs",
-          Effect: "Allow",
-          Action: ["logs:DescribeLogStreams", "logs:GetLogEvents"],
-          Resource: `arn:aws:logs:*:*:log-group:/ecs/latitude-${environment}*:log-stream:*`,
-        },
-        {
-          Sid: "IAMPassRole",
-          Effect: "Allow",
-          Action: ["iam:PassRole"],
-          Resource: `arn:aws:iam::*:role/latitude-${environment}-*`,
-        },
-      ],
-    },
+    policy: createDeployPolicy(environment),
   })
 
   return {

--- a/infra/lib/rds.ts
+++ b/infra/lib/rds.ts
@@ -98,6 +98,9 @@ function createAuroraServerless(
   username: string,
   databaseName: string,
 ): RdsOutput {
+  const auroraPostgresVersion = "16.11"
+  const isProduction = config.name === "production"
+
   const parameterGroup = new aws.rds.ParameterGroup(`${name}-rds-params`, {
     family: "aurora-postgresql16",
     description: "Custom parameter group for Latitude",
@@ -114,42 +117,46 @@ function createAuroraServerless(
   })
 
   const cluster = new aws.rds.Cluster(`${name}-aurora`, {
+    clusterIdentifier: `${name}-aurora`,
     engine: "aurora-postgresql",
-    engineVersion: "16.4",
+    engineVersion: auroraPostgresVersion,
     databaseName: databaseName,
     masterUsername: username,
     masterPassword: password,
     dbSubnetGroupName: subnetGroup.name,
     vpcSecurityGroupIds: [securityGroup.id],
     skipFinalSnapshot: config.name === "staging",
-    finalSnapshotIdentifier: config.name === "production" ? `${name}-final-snapshot` : undefined,
+    finalSnapshotIdentifier: isProduction ? `${name}-encrypted-final-snapshot` : undefined,
     serverlessv2ScalingConfiguration: {
       minCapacity: config.rds.minAcu!,
       maxCapacity: config.rds.maxAcu!,
     },
     backupRetentionPeriod: config.rds.backupDays,
+    storageEncrypted: true,
     preferredBackupWindow: "03:00-04:00",
     enabledCloudwatchLogsExports: ["postgresql"],
     tags: {
       Name: `${name}-aurora`,
       Environment: config.name,
     },
+  }, {
+    aliases: isProduction ? [{ name: `${name}-aurora-encrypted-migration` }] : undefined,
+    protect: isProduction,
   })
 
   const instance = new aws.rds.ClusterInstance(`${name}-aurora-instance`, {
+    identifier: `${name}-aurora-instance`,
     clusterIdentifier: cluster.id,
     instanceClass: "db.serverless",
     engine: "aurora-postgresql",
-    engineVersion: "16.4",
+    engineVersion: auroraPostgresVersion,
     tags: {
       Name: `${name}-aurora-instance`,
       Environment: config.name,
     },
-  })
-
-  const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
-    secretId: secret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`,
+  }, {
+    aliases: isProduction ? [{ name: `${name}-aurora-encrypted-migration-instance` }] : undefined,
+    protect: isProduction,
   })
 
   const adminSecret = new aws.secretsmanager.Secret(`${name}-admin-db-secret`, {
@@ -161,9 +168,38 @@ function createAuroraServerless(
     },
   })
 
+  const updateDatabaseUrlHost = (databaseUrl: pulumi.Output<string>, host: pulumi.Output<string>) =>
+    pulumi.all([databaseUrl, host]).apply(([value, targetHost]) => {
+      const url = new URL(value)
+      url.hostname = targetHost
+      url.port = "5432"
+      return url.toString()
+    })
+
+  const existingAppSecretVersion = isProduction
+    ? aws.secretsmanager.getSecretVersionOutput({ secretId: secret.id })
+    : undefined
+
+  const existingAdminSecretVersion = isProduction
+    ? aws.secretsmanager.getSecretVersionOutput({ secretId: adminSecret.id })
+    : undefined
+
+  const appSecretString = existingAppSecretVersion?.secretString
+    ? updateDatabaseUrlHost(existingAppSecretVersion.secretString, cluster.endpoint)
+    : pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`
+
+  const adminSecretString = existingAdminSecretVersion?.secretString
+    ? updateDatabaseUrlHost(existingAdminSecretVersion.secretString, cluster.endpoint)
+    : pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`
+
+  const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
+    secretId: secret.id,
+    secretString: appSecretString,
+  })
+
   const adminSecretVersion = new aws.secretsmanager.SecretVersion(`${name}-admin-db-secret-version`, {
     secretId: adminSecret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${cluster.endpoint}:5432/${databaseName}`,
+    secretString: adminSecretString,
   })
 
   const connectionInfo = pulumi.output({
@@ -212,12 +248,14 @@ function createStandardInstance(
   })
 
   const dbInstance = new aws.rds.Instance(`${name}-postgres`, {
+    identifier: `${name}-postgres`,
     engine: "postgres",
     engineVersion: "16.6",
     instanceClass: config.rds.instanceType!,
     allocatedStorage: 20,
     maxAllocatedStorage: 100,
     storageType: "gp3",
+    storageEncrypted: true,
     dbName: databaseName,
     username: username,
     password: password,
@@ -237,7 +275,7 @@ function createStandardInstance(
 
   const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-db-secret-version`, {
     secretId: secret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}`,
+    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}?uselibpqcompat=true&sslmode=require`,
   })
 
   const adminSecret = new aws.secretsmanager.Secret(`${name}-admin-db-secret`, {
@@ -251,7 +289,7 @@ function createStandardInstance(
 
   const adminSecretVersion = new aws.secretsmanager.SecretVersion(`${name}-admin-db-secret-version`, {
     secretId: adminSecret.id,
-    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}`,
+    secretString: pulumi.interpolate`postgres://${username}:${password}@${dbInstance.address}:5432/${databaseName}?uselibpqcompat=true&sslmode=require`,
   })
 
   const connectionInfo = pulumi.output({

--- a/infra/lib/security-compliance.ts
+++ b/infra/lib/security-compliance.ts
@@ -1,0 +1,324 @@
+import * as aws from "@pulumi/aws"
+import * as pulumi from "@pulumi/pulumi"
+import type { EnvironmentConfig } from "../config.ts"
+
+export interface SecurityComplianceOutput {
+  configRecorder: aws.cfg.Recorder
+  configDeliveryChannel: aws.cfg.DeliveryChannel
+  cloudTrail: aws.cloudtrail.Trail
+  cloudTrailLogGroup: aws.cloudwatch.LogGroup
+  guardDutyDetector: aws.guardduty.Detector
+}
+
+const serviceAssumeRolePolicy = (service: string) =>
+  JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: {
+          Service: service,
+        },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  })
+
+function createComplianceBucket(name: string, config: EnvironmentConfig, purpose: string): aws.s3.Bucket {
+  const bucket = new aws.s3.Bucket(
+    `${name}-${purpose}`,
+    {
+      bucket: `${name}-${purpose}`,
+      forceDestroy: config.name !== "production",
+      tags: {
+        Name: `${name}-${purpose}`,
+        Environment: config.name,
+        Purpose: purpose,
+      },
+    },
+    {
+      protect: config.name === "production",
+    },
+  )
+
+  new aws.s3.BucketVersioning(`${name}-${purpose}-versioning`, {
+    bucket: bucket.id,
+    versioningConfiguration: {
+      status: "Enabled",
+    },
+  })
+
+  new aws.s3.BucketServerSideEncryptionConfiguration(`${name}-${purpose}-encryption`, {
+    bucket: bucket.id,
+    rules: [
+      {
+        applyServerSideEncryptionByDefault: {
+          sseAlgorithm: "AES256",
+        },
+      },
+    ],
+  })
+
+  new aws.s3.BucketPublicAccessBlock(`${name}-${purpose}-public-access-block`, {
+    bucket: bucket.id,
+    blockPublicAcls: true,
+    blockPublicPolicy: true,
+    ignorePublicAcls: true,
+    restrictPublicBuckets: true,
+  })
+
+  return bucket
+}
+
+function awsConfigServiceRoleArn(name: string, config: EnvironmentConfig): pulumi.Output<string> {
+  if (config.name === "staging") {
+    return new aws.iam.ServiceLinkedRole(`${name}-aws-config-service-linked-role`, {
+      awsServiceName: "config.amazonaws.com",
+      description: "Service-linked role for AWS Config compliance recording.",
+    }).arn
+  }
+
+  return aws.iam.getRoleOutput({ name: "AWSServiceRoleForConfig" }).arn
+}
+
+function createAwsConfigRecorder(name: string, config: EnvironmentConfig): {
+  recorder: aws.cfg.Recorder
+  deliveryChannel: aws.cfg.DeliveryChannel
+} {
+  const bucket = createComplianceBucket(name, config, "aws-config")
+  const callerIdentity = aws.getCallerIdentityOutput({})
+  const serviceRoleArn = awsConfigServiceRoleArn(name, config)
+
+  const bucketPolicy = new aws.s3.BucketPolicy(`${name}-aws-config-bucket-policy`, {
+    bucket: bucket.id,
+    policy: pulumi.all([bucket.arn, callerIdentity.accountId]).apply(([bucketArn, accountId]) =>
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Sid: "AWSConfigBucketPermissionsCheck",
+            Effect: "Allow",
+            Principal: { Service: "config.amazonaws.com" },
+            Action: ["s3:GetBucketAcl", "s3:ListBucket"],
+            Resource: bucketArn,
+            Condition: {
+              StringEquals: {
+                "AWS:SourceAccount": accountId,
+              },
+            },
+          },
+          {
+            Sid: "AWSConfigBucketDelivery",
+            Effect: "Allow",
+            Principal: { Service: "config.amazonaws.com" },
+            Action: "s3:PutObject",
+            Resource: `${bucketArn}/AWSConfig/AWSLogs/${accountId}/Config/*`,
+            Condition: {
+              StringEquals: {
+                "AWS:SourceAccount": accountId,
+                "s3:x-amz-acl": "bucket-owner-full-control",
+              },
+            },
+          },
+        ],
+      }),
+    ),
+  })
+
+  const recorder = new aws.cfg.Recorder(
+    `${name}-aws-config-recorder`,
+    {
+      name: "compai-config-recorder",
+      roleArn: serviceRoleArn,
+      recordingGroup: {
+        allSupported: true,
+        includeGlobalResourceTypes: true,
+      },
+      recordingMode: {
+        recordingFrequency: "CONTINUOUS",
+      },
+    },
+    {
+      deleteBeforeReplace: true,
+      dependsOn: [bucketPolicy],
+    },
+  )
+
+  const deliveryChannel = new aws.cfg.DeliveryChannel(
+    `${name}-aws-config-delivery-channel`,
+    {
+      name: "compai-delivery-channel",
+      s3BucketName: bucket.bucket,
+      s3KeyPrefix: "AWSConfig",
+      snapshotDeliveryProperties: {
+        deliveryFrequency: "TwentyFour_Hours",
+      },
+    },
+    {
+      deleteBeforeReplace: true,
+      dependsOn: [recorder],
+    },
+  )
+
+  new aws.cfg.RecorderStatus(
+    `${name}-aws-config-recorder-status`,
+    {
+      name: recorder.name,
+      isEnabled: true,
+    },
+    {
+      deleteBeforeReplace: true,
+      dependsOn: [deliveryChannel],
+    },
+  )
+
+  return { recorder, deliveryChannel }
+}
+
+function createCloudTrailWithCloudWatch(name: string, config: EnvironmentConfig): {
+  trail: aws.cloudtrail.Trail
+  logGroup: aws.cloudwatch.LogGroup
+} {
+  const callerIdentity = aws.getCallerIdentityOutput({})
+  const bucket = createComplianceBucket(name, config, "cloudtrail")
+  const trailName = `${name}-management-events`
+
+  const bucketPolicy = new aws.s3.BucketPolicy(`${name}-cloudtrail-bucket-policy`, {
+    bucket: bucket.id,
+    policy: pulumi.all([bucket.arn, callerIdentity.accountId]).apply(([bucketArn, accountId]) =>
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Sid: "AWSCloudTrailAclCheck",
+            Effect: "Allow",
+            Principal: { Service: "cloudtrail.amazonaws.com" },
+            Action: "s3:GetBucketAcl",
+            Resource: bucketArn,
+            Condition: {
+              StringEquals: {
+                "aws:SourceArn": `arn:aws:cloudtrail:${config.region}:${accountId}:trail/${trailName}`,
+              },
+            },
+          },
+          {
+            Sid: "AWSCloudTrailWrite",
+            Effect: "Allow",
+            Principal: { Service: "cloudtrail.amazonaws.com" },
+            Action: "s3:PutObject",
+            Resource: `${bucketArn}/AWSLogs/${accountId}/*`,
+            Condition: {
+              StringEquals: {
+                "s3:x-amz-acl": "bucket-owner-full-control",
+                "aws:SourceArn": `arn:aws:cloudtrail:${config.region}:${accountId}:trail/${trailName}`,
+              },
+            },
+          },
+        ],
+      }),
+    ),
+  })
+
+  const logGroup = new aws.cloudwatch.LogGroup(`${name}-cloudtrail-log-group`, {
+    name: `/aws/cloudtrail/${name}`,
+    retentionInDays: 365,
+    tags: {
+      Name: `/aws/cloudtrail/${name}`,
+      Environment: config.name,
+      Purpose: "cloudtrail-management-events",
+    },
+  })
+
+  const role = new aws.iam.Role(`${name}-cloudtrail-cloudwatch-role`, {
+    assumeRolePolicy: serviceAssumeRolePolicy("cloudtrail.amazonaws.com"),
+    tags: {
+      Name: `${name}-cloudtrail-cloudwatch-role`,
+      Environment: config.name,
+      Purpose: "cloudtrail-cloudwatch-logs-delivery",
+    },
+  })
+
+  const rolePolicy = new aws.iam.RolePolicy(`${name}-cloudtrail-cloudwatch-policy`, {
+    role: role.id,
+    policy: pulumi.all([logGroup.arn]).apply(([logGroupArn]) =>
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["logs:CreateLogStream", "logs:PutLogEvents"],
+            Resource: `${logGroupArn}:log-stream:*`,
+          },
+        ],
+      }),
+    ),
+  })
+
+  const trail = new aws.cloudtrail.Trail(
+    `${name}-cloudtrail`,
+    {
+      name: trailName,
+      s3BucketName: bucket.bucket,
+      cloudWatchLogsGroupArn: pulumi.interpolate`${logGroup.arn}:*`,
+      cloudWatchLogsRoleArn: role.arn,
+      includeGlobalServiceEvents: true,
+      isMultiRegionTrail: true,
+      enableLogFileValidation: true,
+      enableLogging: true,
+      tags: {
+        Name: trailName,
+        Environment: config.name,
+        Purpose: "management-event-audit-logging",
+      },
+    },
+    {
+      dependsOn: [bucketPolicy, rolePolicy],
+    },
+  )
+
+  return { trail, logGroup }
+}
+
+function createGuardDutyServiceLinkedRole(name: string, config: EnvironmentConfig): aws.iam.ServiceLinkedRole | undefined {
+  if (config.name !== "staging") return undefined
+
+  return new aws.iam.ServiceLinkedRole(
+    `${name}-guardduty-service-linked-role`,
+    {
+      awsServiceName: "guardduty.amazonaws.com",
+      description: "A service-linked role required for Amazon GuardDuty to access your resources. ",
+    },
+    {
+      protect: true,
+    },
+  )
+}
+
+export function createSecurityCompliance(name: string, config: EnvironmentConfig): SecurityComplianceOutput {
+  const awsConfig = createAwsConfigRecorder(name, config)
+  const cloudTrail = createCloudTrailWithCloudWatch(name, config)
+  const guardDutyServiceLinkedRole = createGuardDutyServiceLinkedRole(name, config)
+  const guardDutyDetector = new aws.guardduty.Detector(
+    `${name}-guardduty-detector`,
+    {
+      enable: true,
+      findingPublishingFrequency: "FIFTEEN_MINUTES",
+      tags: {
+        Name: `${name}-guardduty-detector`,
+        Environment: config.name,
+        Purpose: "threat-detection",
+      },
+    },
+    {
+      dependsOn: guardDutyServiceLinkedRole ? [guardDutyServiceLinkedRole] : [],
+    },
+  )
+
+  return {
+    configRecorder: awsConfig.recorder,
+    configDeliveryChannel: awsConfig.deliveryChannel,
+    cloudTrail: cloudTrail.trail,
+    cloudTrailLogGroup: cloudTrail.logGroup,
+    guardDutyDetector,
+  }
+}

--- a/packages/domain/email/src/templates/wrapped/claude-code/v1/EmailTemplateV1.tsx
+++ b/packages/domain/email/src/templates/wrapped/claude-code/v1/EmailTemplateV1.tsx
@@ -303,6 +303,7 @@ ClaudeCodeWrappedEmailV1.PreviewProps = {
       repos: 1,
       streakDays: 5,
       testsRun: 32,
+      gitWriteOps: 28,
     },
     toolMix: { bash: 87, read: 168, edit: 142, write: 21, search: 52, research: 4, plan: 12, other: 0 },
     loc: {

--- a/packages/domain/models/src/data/models.dev.json
+++ b/packages/domain/models/src/data/models.dev.json
@@ -32973,6 +32973,88 @@
       }
     }
   },
+  "ambient": {
+    "id": "ambient",
+    "env": [
+      "AMBIENT_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.ambient.xyz/v1",
+    "name": "Ambient",
+    "doc": "https://ambient.xyz",
+    "models": {
+      "zai-org/GLM-5.1-FP8": {
+        "id": "zai-org/GLM-5.1-FP8",
+        "name": "GLM-5.1",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-27",
+        "last_updated": "2026-03-27",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        },
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cache_read": 0,
+          "cache_write": 0
+        }
+      },
+      "moonshotai/kimi-k2.6": {
+        "id": "moonshotai/kimi-k2.6",
+        "name": "Kimi K2.6",
+        "family": "kimi-k2.6",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-21",
+        "last_updated": "2026-04-21",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.95,
+          "output": 4,
+          "cache_read": 0.2,
+          "cache_write": 0
+        }
+      }
+    }
+  },
   "kimi-for-coding": {
     "id": "kimi-for-coding",
     "env": [
@@ -64522,6 +64604,600 @@
       }
     }
   },
+  "auriko": {
+    "id": "auriko",
+    "env": [
+      "AURIKO_API_KEY"
+    ],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.auriko.ai/v1",
+    "name": "Auriko",
+    "doc": "https://docs.auriko.ai",
+    "models": {
+      "kimi-k2.5": {
+        "id": "kimi-k2.5",
+        "name": "Kimi K2.5",
+        "family": "kimi-k2.5",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-01",
+        "last_updated": "2026-01",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 2.8
+        }
+      },
+      "grok-4.3": {
+        "id": "grok-4.3",
+        "name": "Grok 4.3",
+        "family": "grok",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-05-01",
+        "last_updated": "2026-05-01",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 30000
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 2.5,
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 5,
+            "cache_read": 0.4
+          },
+          "tiers": [
+            {
+              "input": 2.5,
+              "output": 5,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ]
+        }
+      },
+      "minimax-m2-7-highspeed": {
+        "id": "minimax-m2-7-highspeed",
+        "name": "MiniMax-M2.7-highspeed",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.6,
+          "output": 2.4,
+          "cache_write": 0.375
+        }
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "family": "claude-sonnet",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-02-17",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "gemini-3.1-pro-preview": {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-02-19",
+        "last_updated": "2026-02-19",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video",
+            "audio",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          },
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ]
+        }
+      },
+      "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 30,
+                "output": 150,
+                "cache_read": 3,
+                "cache_write": 37.5
+              },
+              "provider": {
+                "body": {
+                  "speed": "fast"
+                },
+                "headers": {
+                  "anthropic-beta": "fast-mode-2026-02-01"
+                }
+              }
+            }
+          }
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "gemini-2.5-pro": {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "family": "gemini-pro",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2025-03-20",
+        "last_updated": "2025-06-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125,
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 15,
+            "cache_read": 0.25
+          },
+          "tiers": [
+            {
+              "input": 2.5,
+              "output": 15,
+              "cache_read": 0.25,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ]
+        }
+      },
+      "qwen-3.6-plus": {
+        "id": "qwen-3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-02",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.1,
+          "context_over_200k": {
+            "input": 2,
+            "output": 6,
+            "cache_read": 0.2,
+            "cache_write": 2.5
+          },
+          "tiers": [
+            {
+              "input": 2,
+              "output": 6,
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ]
+        }
+      },
+      "glm-5.1": {
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-27",
+        "last_updated": "2026-03-27",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 200000,
+          "output": 131072
+        },
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cache_read": 0.26
+        }
+      },
+      "gemini-2.5-flash": {
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "family": "gemini-flash",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2025-03-20",
+        "last_updated": "2025-06-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1048576,
+          "output": 65536
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.03
+        }
+      },
+      "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "cost": {
+          "input": 0.14,
+          "output": 0.28,
+          "cache_read": 0.0028
+        }
+      },
+      "kimi-k2.6": {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "family": "kimi-k2.6",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-21",
+        "last_updated": "2026-04-21",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        },
+        "cost": {
+          "input": 0.95,
+          "output": 4,
+          "cache_read": 0.16
+        }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "cost": {
+          "input": 0.435,
+          "output": 0.87,
+          "cache_read": 0.003625
+        }
+      },
+      "minimax-m2-7": {
+        "id": "minimax-m2-7",
+        "name": "MiniMax-M2.7",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2,
+          "cache_write": 0.375
+        }
+      }
+    }
+  },
   "morph": {
     "id": "morph",
     "env": [
@@ -79685,8 +80361,8 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2024-12-01",
-        "last_updated": "2024-12-01",
+        "release_date": "2025-10-29",
+        "last_updated": "2025-10-29",
         "modalities": {
           "input": [
             "text"
@@ -79698,7 +80374,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
-          "output": 4096
+          "output": 16384
         },
         "cost": {
           "input": 0.15,
@@ -79712,6 +80388,7 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "release_date": "2025-12-23",
         "last_updated": "2025-12-23",
@@ -79740,6 +80417,7 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-11",
         "last_updated": "2026-03-11",
@@ -79923,6 +80601,7 @@
         "attachment": false,
         "reasoning": false,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-02-17",
         "last_updated": "2026-02-17",
@@ -80367,8 +81046,8 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2024-12-01",
-        "last_updated": "2024-12-01",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
         "modalities": {
           "input": [
             "text"
@@ -80380,7 +81059,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
-          "output": 4096
+          "output": 16384
         },
         "cost": {
           "input": 0.07,
@@ -80397,6 +81076,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-18",
         "last_updated": "2026-03-18",
@@ -80455,6 +81135,7 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2024-07",
         "release_date": "2026-02-06",
@@ -80518,6 +81199,7 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
         "release_date": "2026-01-19",
@@ -80984,6 +81666,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
         "release_date": "2025-12-22",
@@ -81167,8 +81850,8 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2024-12-01",
-        "last_updated": "2024-12-01",
+        "release_date": "2025-08-05",
+        "last_updated": "2025-08-05",
         "modalities": {
           "input": [
             "text"
@@ -81180,7 +81863,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
-          "output": 4096
+          "output": 16384
         },
         "cost": {
           "input": 0.15,
@@ -81413,6 +82096,7 @@
         "reasoning": true,
         "tool_call": true,
         "interleaved": true,
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-02-06",
         "last_updated": "2026-02-06",
@@ -81478,8 +82162,8 @@
         "tool_call": true,
         "structured_output": true,
         "temperature": true,
-        "release_date": "2024-12-01",
-        "last_updated": "2024-12-01",
+        "release_date": "2025-10-29",
+        "last_updated": "2025-10-29",
         "modalities": {
           "input": [
             "text"
@@ -81491,7 +82175,7 @@
         "open_weights": false,
         "limit": {
           "context": 128000,
-          "output": 4096
+          "output": 16384
         },
         "cost": {
           "input": 0.07,
@@ -86325,11 +87009,15 @@
     "models": {
       "minimax-m2.7": {
         "id": "minimax-m2.7",
-        "name": "MiniMax-M2.7",
+        "name": "MiniMax M2.7",
         "family": "minimax",
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-18",
         "last_updated": "2026-03-18",
@@ -86343,19 +87031,20 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 200000,
+          "context": 204800,
           "output": 128000
         },
         "cost": {
-          "input": 0.2958,
-          "output": 1.1832,
-          "cache_read": 0.05916
+          "input": 0.3,
+          "output": 1.2,
+          "cache_read": 0.06,
+          "cache_write": 0.375
         }
       },
       "coding-glm-5.1-free": {
         "id": "coding-glm-5.1-free",
         "name": "Coding GLM 5.1 (free)",
-        "family": "glm",
+        "family": "glm-free",
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
@@ -86374,15 +87063,14 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
-          "context": 204800,
+          "context": 200000,
           "output": 128000
         },
         "cost": {
           "input": 0,
-          "output": 0,
-          "cache_read": 0
+          "output": 0
         }
       },
       "gemini-3.1-pro-preview-customtools": {
@@ -86440,7 +87128,7 @@
         "id": "kimi-k2.5",
         "name": "Kimi K2.5",
         "family": "kimi-k2.5",
-        "attachment": false,
+        "attachment": true,
         "reasoning": true,
         "tool_call": true,
         "interleaved": {
@@ -86463,19 +87151,53 @@
         },
         "open_weights": true,
         "limit": {
-          "context": 256000,
-          "output": 0
+          "context": 262144,
+          "output": 32768
         },
         "cost": {
           "input": 0.6,
           "output": 3,
-          "cache_read": 0.105
+          "cache_read": 0.1
+        }
+      },
+      "deep-deepseek-v4-flash": {
+        "id": "deep-deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash (DeepSeek)",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "cost": {
+          "input": 0.154,
+          "output": 0.308,
+          "cache_read": 0.0308
         }
       },
       "glm-5v-turbo": {
         "id": "glm-5v-turbo",
         "name": "GLM 5 Vision Turbo",
-        "family": "glm",
+        "family": "glmv",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
@@ -86561,6 +87283,9 @@
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-18",
@@ -86576,7 +87301,7 @@
         "open_weights": true,
         "limit": {
           "context": 204800,
-          "output": 13100
+          "output": 128100
         },
         "cost": {
           "input": 0.2,
@@ -86590,10 +87315,12 @@
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": true,
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2025-08-31",
         "release_date": "2026-02-17",
-        "last_updated": "2026-02-17",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
@@ -86606,7 +87333,7 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
+          "context": 1000000,
           "output": 64000
         },
         "cost": {
@@ -86666,12 +87393,28 @@
         "cost": {
           "input": 2,
           "output": 12,
-          "cache_read": 0.2
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          }
         }
       },
       "coding-glm-5.1": {
         "id": "coding-glm-5.1",
-        "name": "Coding-GLM-5.1",
+        "name": "Coding GLM 5.1",
         "family": "glm",
         "attachment": false,
         "reasoning": true,
@@ -86679,6 +87422,7 @@
         "interleaved": {
           "field": "reasoning_content"
         },
+        "structured_output": true,
         "temperature": true,
         "release_date": "2026-04-11",
         "last_updated": "2026-04-11",
@@ -86690,14 +87434,15 @@
             "text"
           ]
         },
-        "open_weights": false,
+        "open_weights": true,
         "limit": {
           "context": 200000,
           "output": 128000
         },
         "cost": {
           "input": 0.06,
-          "output": 0.22
+          "output": 0.22,
+          "cache_read": 0.013
         }
       },
       "gemini-3-flash-preview": {
@@ -86732,7 +87477,23 @@
         "cost": {
           "input": 0.5,
           "output": 3,
-          "cache_read": 0.05
+          "cache_read": 0.05,
+          "tiers": [
+            {
+              "input": 0.5,
+              "output": 3,
+              "cache_read": 0.05,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 0.5,
+            "output": 3,
+            "cache_read": 0.05
+          }
         }
       },
       "gpt-5.5": {
@@ -86760,12 +87521,45 @@
         "open_weights": false,
         "limit": {
           "context": 1050000,
+          "input": 922000,
           "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 12.5,
+                "output": 75,
+                "cache_read": 1.25
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
         },
         "cost": {
           "input": 5,
           "output": 30,
-          "cache_read": 0.5
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
         }
       },
       "claude-opus-4-7": {
@@ -86775,6 +87569,8 @@
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2026-01-31",
         "release_date": "2026-04-16",
@@ -86798,41 +87594,25 @@
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
-          "cache_write": 6.25
-        }
-      },
-      "deepseek-v4-flash-think": {
-        "id": "deepseek-v4-flash-think",
-        "name": "DeepSeek V4 Flash Think",
-        "family": "deepseek",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2025-05",
-        "release_date": "2026-04-24",
-        "last_updated": "2026-04-24",
-        "modalities": {
-          "input": [
-            "text"
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
           ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 1000000,
-          "output": 384000
-        },
-        "cost": {
-          "input": 0.154,
-          "output": 0.308,
-          "cache_read": 0.0308
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
       "gpt-5.3-codex": {
@@ -86901,7 +87681,23 @@
         "cost": {
           "input": 1.25,
           "output": 10,
-          "cache_read": 0.125
+          "cache_read": 0.125,
+          "tiers": [
+            {
+              "input": 2.5,
+              "output": 15,
+              "cache_read": 0.25,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 15,
+            "cache_read": 0.25
+          }
         }
       },
       "gpt-5.2": {
@@ -86911,6 +87707,7 @@
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "structured_output": true,
         "temperature": false,
         "knowledge": "2025-08-31",
         "release_date": "2025-12-11",
@@ -86927,6 +87724,7 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "cost": {
@@ -86938,10 +87736,13 @@
       "qwen3.6-plus": {
         "id": "qwen3.6-plus",
         "name": "Qwen3.6 Plus",
-        "family": "qwen",
+        "family": "qwen3.6",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
@@ -86963,23 +87764,42 @@
           "output": 64000
         },
         "cost": {
-          "input": 0.282,
-          "output": 1.692,
+          "input": 0.28,
+          "output": 1.69,
           "cache_read": 0.0282,
-          "cache_write": 0.3525
+          "cache_write": 0.3525,
+          "tiers": [
+            {
+              "input": 1.13,
+              "output": 6.77,
+              "cache_read": 0.1128,
+              "cache_write": 1.41,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 1.13,
+            "output": 6.77,
+            "cache_read": 0.1128,
+            "cache_write": 1.41
+          }
         }
       },
       "gpt-5.4-mini": {
         "id": "gpt-5.4-mini",
-        "name": "GPT-5.4-Mini",
+        "name": "GPT-5.4 mini",
         "family": "gpt-mini",
         "attachment": true,
-        "reasoning": false,
+        "reasoning": true,
         "tool_call": true,
         "structured_output": true,
         "temperature": false,
-        "release_date": "2026-03-11",
-        "last_updated": "2026-03-11",
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-17",
+        "last_updated": "2026-03-17",
         "modalities": {
           "input": [
             "text",
@@ -86992,7 +87812,24 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 1.5,
+                "output": 9,
+                "cache_read": 0.15
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
         },
         "cost": {
           "input": 0.75,
@@ -87000,86 +87837,23 @@
           "cache_read": 0.075
         }
       },
-      "glm-5.1": {
-        "id": "glm-5.1",
-        "name": "GLM-5.1",
-        "family": "glm",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "structured_output": true,
-        "temperature": true,
-        "release_date": "2026-03-27",
-        "last_updated": "2026-03-27",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 200000,
-          "output": 128000
-        },
-        "cost": {
-          "input": 0.845,
-          "output": 3.38,
-          "cache_read": 0.183112
-        }
-      },
-      "o4-mini": {
-        "id": "o4-mini",
-        "name": "o4-mini",
-        "family": "o-mini",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "knowledge": "2024-05",
-        "release_date": "2025-04-16",
-        "last_updated": "2025-04-16",
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 200000,
-          "output": 100000
-        },
-        "cost": {
-          "input": 1.1,
-          "output": 4.4,
-          "cache_read": 0.275
-        }
-      },
       "gpt-5.2-codex": {
         "id": "gpt-5.2-codex",
-        "name": "GPT-5.2-Codex",
+        "name": "GPT-5.2 Codex",
         "family": "gpt-codex",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
         "structured_output": true,
+        "temperature": false,
         "knowledge": "2025-08-31",
-        "release_date": "2026-01-14",
-        "last_updated": "2026-01-14",
+        "release_date": "2025-12-11",
+        "last_updated": "2025-12-11",
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -87088,12 +87862,71 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "cost": {
           "input": 1.75,
           "output": 14,
           "cache_read": 0.175
+        }
+      },
+      "doubao-seed-2-0-lite-260428": {
+        "id": "doubao-seed-2-0-lite-260428",
+        "name": "Doubao Seed 2.0 Lite 260428",
+        "family": "seed",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-28",
+        "last_updated": "2026-04-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.08,
+          "output": 0.51,
+          "cache_read": 0.01692,
+          "input_audio": 1.269,
+          "tiers": [
+            {
+              "input": 0.13,
+              "output": 0.76,
+              "cache_read": 0.02536,
+              "input_audio": 1.902,
+              "tier": {
+                "type": "context",
+                "size": 32000
+              }
+            },
+            {
+              "input": 0.25,
+              "output": 1.52,
+              "cache_read": 0.05072,
+              "input_audio": 3.804,
+              "tier": {
+                "type": "context",
+                "size": 128000
+              }
+            }
+          ]
         }
       },
       "gemini-2.5-flash": {
@@ -87127,8 +87960,9 @@
         },
         "cost": {
           "input": 0.3,
-          "output": 2.499,
-          "cache_read": 0.03
+          "output": 2.5,
+          "cache_read": 0.03,
+          "input_audio": 1
         }
       },
       "gpt-5.1-codex-mini": {
@@ -87174,8 +88008,8 @@
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-01",
-        "release_date": "2026-03-03",
-        "last_updated": "2026-03-03",
+        "release_date": "2026-05-07",
+        "last_updated": "2026-05-07",
         "modalities": {
           "input": [
             "text",
@@ -87196,7 +88030,8 @@
         "cost": {
           "input": 0.25,
           "output": 1.5,
-          "cache_read": 0.25
+          "cache_read": 0.025,
+          "cache_write": 1
         }
       },
       "gpt-5.1": {
@@ -87206,10 +88041,11 @@
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-11",
-        "release_date": "2025-11-15",
-        "last_updated": "2025-11-15",
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2024-09-30",
+        "release_date": "2025-11-13",
+        "last_updated": "2025-11-13",
         "modalities": {
           "input": [
             "text",
@@ -87222,212 +88058,18 @@
         "open_weights": false,
         "limit": {
           "context": 400000,
+          "input": 272000,
           "output": 128000
         },
         "cost": {
           "input": 1.25,
           "output": 10,
-          "cache_read": 0.125
+          "cache_read": 0.13
         }
       },
-      "claude-opus-4-6-think": {
-        "id": "claude-opus-4-6-think",
-        "name": "Claude Opus 4.6",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-05-31",
-        "release_date": "2026-02-05",
-        "last_updated": "2026-03-13",
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 200000,
-          "output": 32000
-        },
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cache_read": 0.5,
-          "cache_write": 6.25
-        }
-      },
-      "coding-minimax-m2.7-free": {
-        "id": "coding-minimax-m2.7-free",
-        "name": "Coding-MiniMax-M2.7-Free",
-        "family": "minimax",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "release_date": "2026-03-18",
-        "last_updated": "2026-03-18",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 204800,
-          "output": 13100
-        },
-        "cost": {
-          "input": 0,
-          "output": 0
-        }
-      },
-      "deepseek-v4-flash": {
-        "id": "deepseek-v4-flash",
-        "name": "DeepSeek V4 Flash",
-        "family": "deepseek-flash",
-        "attachment": false,
-        "reasoning": true,
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2025-05",
-        "release_date": "2026-04-24",
-        "last_updated": "2026-04-24",
-        "modalities": {
-          "input": [
-            "text"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 1000000,
-          "output": 384000
-        },
-        "cost": {
-          "input": 0.154,
-          "output": 0.308,
-          "cache_read": 0.0308
-        }
-      },
-      "kimi-k2.6": {
-        "id": "kimi-k2.6",
-        "name": "Kimi K2.6",
-        "family": "kimi-k2.6",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "interleaved": {
-          "field": "reasoning_content"
-        },
-        "structured_output": true,
-        "temperature": true,
-        "knowledge": "2025-01",
-        "release_date": "2026-04-21",
-        "last_updated": "2026-04-21",
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "video"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 262144,
-          "output": 262144
-        },
-        "cost": {
-          "input": 0.95,
-          "output": 3.9995,
-          "cache_read": 0.160835
-        }
-      },
-      "gpt-5.4": {
-        "id": "gpt-5.4",
-        "name": "GPT-5.4",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": false,
-        "release_date": "2026-03-11",
-        "last_updated": "2026-03-11",
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 400000,
-          "output": 128000
-        },
-        "cost": {
-          "input": 2.5,
-          "output": 15,
-          "cache_read": 0.25
-        }
-      },
-      "claude-opus-4-6": {
-        "id": "claude-opus-4-6",
-        "name": "Claude Opus 4.6",
-        "family": "claude-opus",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2025-05-31",
-        "release_date": "2026-02-05",
-        "last_updated": "2026-03-13",
-        "modalities": {
-          "input": [
-            "text",
-            "image",
-            "pdf"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 1000000,
-          "output": 128000
-        },
-        "cost": {
-          "input": 5,
-          "output": 25,
-          "cache_read": 0.5,
-          "cache_write": 6.25
-        }
-      },
-      "deepseek-v4-pro": {
-        "id": "deepseek-v4-pro",
-        "name": "DeepSeek V4 Pro",
+      "deep-deepseek-v4-pro": {
+        "id": "deep-deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro (DeepSeek)",
         "family": "deepseek-thinking",
         "attachment": false,
         "reasoning": true,
@@ -87459,22 +88101,26 @@
           "cache_read": 0.004302
         }
       },
-      "claude-opus-4-7-think": {
-        "id": "claude-opus-4-7-think",
-        "name": "Claude Opus 4.7 Thinking",
+      "claude-opus-4-6-think": {
+        "id": "claude-opus-4-6-think",
+        "name": "Claude Opus 4.6 Thinking",
         "family": "claude-opus",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
-        "temperature": false,
-        "knowledge": "2026-01-31",
-        "release_date": "2026-04-16",
-        "last_updated": "2026-04-16",
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
-            "image"
+            "image",
+            "pdf"
           ],
           "output": [
             "text"
@@ -87482,23 +88128,44 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
-          "output": 32000
+          "context": 1000000,
+          "output": 128000
         },
         "cost": {
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
-          "cache_write": 6.25
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
-      "coding-minimax-m2.7": {
-        "id": "coding-minimax-m2.7",
-        "name": "Coding MiniMax M2.7",
-        "family": "minimax",
+      "coding-minimax-m2.7-free": {
+        "id": "coding-minimax-m2.7-free",
+        "name": "Coding MiniMax M2.7 (Free)",
+        "family": "minimax-free",
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "release_date": "2026-03-18",
@@ -87514,20 +88181,568 @@
         "open_weights": true,
         "limit": {
           "context": 204800,
-          "output": 13100
+          "output": 128100
+        },
+        "cost": {
+          "input": 0,
+          "output": 0
+        }
+      },
+      "alicloud-deepseek-v4-flash": {
+        "id": "alicloud-deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash (Alibaba Cloud)",
+        "family": "deepseek-flash",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "cost": {
+          "input": 0.14,
+          "output": 0.28,
+          "cache_read": 0.028
+        }
+      },
+      "kimi-k2.6": {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "family": "kimi-k2.6",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-21",
+        "last_updated": "2026-04-21",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 32768
+        },
+        "cost": {
+          "input": 0.95,
+          "output": 4,
+          "cache_read": 0.16
+        }
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "family": "gpt",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2025-08-31",
+        "release_date": "2026-03-05",
+        "last_updated": "2026-03-05",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "experimental": {
+          "modes": {
+            "fast": {
+              "cost": {
+                "input": 5,
+                "output": 30,
+                "cache_read": 0.5
+              },
+              "provider": {
+                "body": {
+                  "service_tier": "priority"
+                }
+              }
+            }
+          }
+        },
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "tiers": [
+            {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
+        }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": true,
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-03-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
+      "doubao-seed-2-0-code-preview": {
+        "id": "doubao-seed-2-0-code-preview",
+        "name": "Doubao Seed 2.0 Code Preview",
+        "family": "seed",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-14",
+        "last_updated": "2026-02-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.48,
+          "output": 2.41,
+          "cache_read": 0.09644,
+          "tiers": [
+            {
+              "input": 0.72,
+              "output": 3.62,
+              "cache_read": 0.144656,
+              "tier": {
+                "type": "context",
+                "size": 32000
+              }
+            },
+            {
+              "input": 1.45,
+              "output": 7.23,
+              "cache_read": 0.28932,
+              "tier": {
+                "type": "context",
+                "size": 128000
+              }
+            }
+          ]
+        }
+      },
+      "alicloud-deepseek-v4-pro": {
+        "id": "alicloud-deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro (Alibaba Cloud)",
+        "family": "deepseek-thinking",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "knowledge": "2025-05",
+        "release_date": "2026-04-24",
+        "last_updated": "2026-04-24",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1000000,
+          "output": 384000
+        },
+        "cost": {
+          "input": 1.69,
+          "output": 3.38,
+          "cache_read": 0.13
+        }
+      },
+      "zai-glm-5.1": {
+        "id": "zai-glm-5.1",
+        "name": "GLM-5.1 (Z.ai)",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-27",
+        "last_updated": "2026-03-27",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.845,
+          "output": 3.38,
+          "cache_read": 0.183112
+        }
+      },
+      "alicloud-glm-5.1": {
+        "id": "alicloud-glm-5.1",
+        "name": "GLM-5.1 (Alibaba Cloud)",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-27",
+        "last_updated": "2026-03-27",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 200000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.84,
+          "output": 3.38,
+          "cache_read": 0.169,
+          "cache_write": 1.05625
+        }
+      },
+      "claude-opus-4-7-think": {
+        "id": "claude-opus-4-7-think",
+        "name": "Claude Opus 4.7 Thinking",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": false,
+        "knowledge": "2026-01-31",
+        "release_date": "2026-04-16",
+        "last_updated": "2026-04-16",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "pdf"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
+      "doubao-seed-2-0-mini-260428": {
+        "id": "doubao-seed-2-0-mini-260428",
+        "name": "Doubao Seed 2.0 Mini 260428",
+        "family": "seed",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-04-28",
+        "last_updated": "2026-04-28",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.03,
+          "output": 0.28,
+          "cache_read": 0.00564,
+          "input_audio": 0.423,
+          "tiers": [
+            {
+              "input": 0.06,
+              "output": 0.56,
+              "cache_read": 0.01128,
+              "input_audio": 0.846,
+              "tier": {
+                "type": "context",
+                "size": 32000
+              }
+            },
+            {
+              "input": 0.11,
+              "output": 1.13,
+              "cache_read": 0.02256,
+              "input_audio": 1.692,
+              "tier": {
+                "type": "context",
+                "size": 128000
+              }
+            }
+          ]
+        }
+      },
+      "coding-minimax-m2.7": {
+        "id": "coding-minimax-m2.7",
+        "name": "Coding MiniMax M2.7",
+        "family": "minimax",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-03-18",
+        "last_updated": "2026-03-18",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 204800,
+          "output": 128100
         },
         "cost": {
           "input": 0.2,
           "output": 0.2
         }
       },
+      "doubao-seed-2-0-pro": {
+        "id": "doubao-seed-2-0-pro",
+        "name": "Doubao Seed 2.0 Pro",
+        "family": "seed",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
+        "temperature": true,
+        "release_date": "2026-02-14",
+        "last_updated": "2026-02-14",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": false,
+        "limit": {
+          "context": 256000,
+          "output": 128000
+        },
+        "cost": {
+          "input": 0.48,
+          "output": 2.41,
+          "cache_read": 0.09644,
+          "tiers": [
+            {
+              "input": 0.72,
+              "output": 3.62,
+              "cache_read": 0.144656,
+              "tier": {
+                "type": "context",
+                "size": 32000
+              }
+            },
+            {
+              "input": 1.45,
+              "output": 7.23,
+              "cache_read": 0.28932,
+              "tier": {
+                "type": "context",
+                "size": 128000
+              }
+            }
+          ]
+        }
+      },
       "qwen3.6-max-preview": {
         "id": "qwen3.6-max-preview",
         "name": "Qwen3.6 Max Preview",
-        "family": "qwen",
+        "family": "qwen3.6",
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
@@ -87547,72 +88762,22 @@
           "output": 64000
         },
         "cost": {
-          "input": 1.268,
-          "output": 7.608,
+          "input": 1.27,
+          "output": 7.61,
           "cache_read": 0.1268,
-          "cache_write": 1.585
-        }
-      },
-      "gpt-4.1": {
-        "id": "gpt-4.1",
-        "name": "GPT-4.1",
-        "family": "gpt",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-04",
-        "release_date": "2025-04-14",
-        "last_updated": "2025-04-14",
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
+          "cache_write": 1.585,
+          "tiers": [
+            {
+              "input": 2.11,
+              "output": 12.67,
+              "cache_read": 0.2112,
+              "cache_write": 2.64,
+              "tier": {
+                "type": "context",
+                "size": 128000
+              }
+            }
           ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "cost": {
-          "input": 2,
-          "output": 8,
-          "cache_read": 0.5
-        }
-      },
-      "gpt-4.1-mini": {
-        "id": "gpt-4.1-mini",
-        "name": "GPT-4.1 mini",
-        "family": "gpt-mini",
-        "attachment": true,
-        "reasoning": false,
-        "tool_call": true,
-        "temperature": true,
-        "knowledge": "2024-04",
-        "release_date": "2025-04-14",
-        "last_updated": "2025-04-14",
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": false,
-        "limit": {
-          "context": 1047576,
-          "output": 32768
-        },
-        "cost": {
-          "input": 0.4,
-          "output": 1.6,
-          "cache_read": 0.1
         }
       },
       "gpt-5.1-codex": {
@@ -87650,15 +88815,19 @@
       },
       "claude-sonnet-4-6-think": {
         "id": "claude-sonnet-4-6-think",
-        "name": "Claude Sonnet 4.6 Think",
+        "name": "Claude Sonnet 4.6 Thinking",
         "family": "claude-sonnet",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "structured_output": true,
         "temperature": true,
         "knowledge": "2025-08-31",
         "release_date": "2026-02-17",
-        "last_updated": "2026-02-17",
+        "last_updated": "2026-03-13",
         "modalities": {
           "input": [
             "text",
@@ -87671,7 +88840,7 @@
         },
         "open_weights": false,
         "limit": {
-          "context": 200000,
+          "context": 1000000,
           "output": 64000
         },
         "cost": {
@@ -87702,10 +88871,13 @@
       "qwen3.6-flash": {
         "id": "qwen3.6-flash",
         "name": "Qwen3.6 Flash",
-        "family": "qwen",
+        "family": "qwen3.6",
         "attachment": true,
         "reasoning": true,
         "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "structured_output": true,
         "temperature": true,
         "knowledge": "2025-04",
@@ -87727,10 +88899,299 @@
           "output": 64000
         },
         "cost": {
-          "input": 0.169,
-          "output": 1.014,
+          "input": 0.17,
+          "output": 1.01,
           "cache_read": 0.0169,
-          "cache_write": 0.21125
+          "cache_write": 0.21125,
+          "tiers": [
+            {
+              "input": 0.68,
+              "output": 4.06,
+              "cache_read": 0.0676,
+              "cache_write": 0.845,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 0.68,
+            "output": 4.06,
+            "cache_read": 0.0676,
+            "cache_write": 0.845
+          }
+        }
+      },
+      "coding-xiaomi-mimo-v2.5-pro": {
+        "id": "coding-xiaomi-mimo-v2.5-pro",
+        "name": "Coding Xiaomi MiMo-V2.5-Pro",
+        "family": "mimo-v2.5-pro",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.2,
+          "output": 0.6,
+          "cache_read": 0.04,
+          "context_over_200k": {
+            "input": 0.4,
+            "output": 1.2,
+            "cache_read": 0.08
+          },
+          "tiers": [
+            {
+              "input": 0.4,
+              "output": 1.2,
+              "cache_read": 0.08,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ]
+        }
+      },
+      "coding-xiaomi-mimo-v2.5": {
+        "id": "coding-xiaomi-mimo-v2.5",
+        "name": "Coding Xiaomi MiMo-V2.5",
+        "family": "mimo-v2.5",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.08,
+          "output": 0.4,
+          "cache_read": 0.016,
+          "context_over_200k": {
+            "input": 0.16,
+            "output": 0.8,
+            "cache_read": 0.032
+          },
+          "tiers": [
+            {
+              "input": 0.16,
+              "output": 0.8,
+              "cache_read": 0.032,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ]
+        }
+      },
+      "xiaomi-mimo-v2.5-pro-free": {
+        "id": "xiaomi-mimo-v2.5-pro-free",
+        "name": "Xiaomi MiMo-V2.5-Pro (free)",
+        "family": "mimo-v2.5-pro",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cache_read": 0
+        }
+      },
+      "xiaomi-mimo-v2.5": {
+        "id": "xiaomi-mimo-v2.5",
+        "name": "Xiaomi MiMo-V2.5",
+        "family": "mimo-v2.5",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0.44,
+          "output": 2.2,
+          "cache_read": 0.088,
+          "context_over_200k": {
+            "input": 0.88,
+            "output": 4.4,
+            "cache_read": 0.176
+          },
+          "tiers": [
+            {
+              "input": 0.88,
+              "output": 4.4,
+              "cache_read": 0.176,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ]
+        }
+      },
+      "xiaomi-mimo-v2.5-free": {
+        "id": "xiaomi-mimo-v2.5-free",
+        "name": "Xiaomi MiMo-V2.5 (free)",
+        "family": "mimo-v2.5",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text",
+            "image",
+            "audio",
+            "video"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cache_read": 0
+        }
+      },
+      "xiaomi-mimo-v2.5-pro": {
+        "id": "xiaomi-mimo-v2.5-pro",
+        "name": "Xiaomi MiMo-V2.5-Pro",
+        "family": "mimo-v2.5-pro",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "temperature": true,
+        "knowledge": "2024-12",
+        "release_date": "2026-04-22",
+        "last_updated": "2026-05-13",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 1048576,
+          "output": 131072
+        },
+        "cost": {
+          "input": 1.1,
+          "output": 3.3,
+          "cache_read": 0.22,
+          "context_over_200k": {
+            "input": 2.2,
+            "output": 6.6,
+            "cache_read": 0.44
+          },
+          "tiers": [
+            {
+              "input": 2.2,
+              "output": 6.6,
+              "cache_read": 0.44,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ]
         }
       }
     }

--- a/packages/domain/oauth-keys/src/errors.ts
+++ b/packages/domain/oauth-keys/src/errors.ts
@@ -14,3 +14,21 @@ export class OAuthApplicationNotFoundError extends Data.TaggedError("OAuthApplic
   readonly httpStatus = 404
   readonly httpMessage = "OAuth application not found in this organization"
 }
+
+/**
+ * Raised when a `(client_id, user_id)` pair doesn't resolve to a row
+ * visible under the caller's organization — either the application
+ * isn't here at all, no access tokens exist for that user, or the row
+ * belongs to a different tenant (the RLS read collapses all three
+ * cases into the same "not found" so we don't leak existence across
+ * orgs).
+ *
+ * Carries a 404 on the HTTP surface.
+ */
+export class OAuthKeyNotFoundError extends Data.TaggedError("OAuthKeyNotFoundError")<{
+  readonly clientId: string
+  readonly userId: string
+}> {
+  readonly httpStatus = 404
+  readonly httpMessage = "OAuth key not found in this organization"
+}

--- a/packages/domain/oauth-keys/src/index.ts
+++ b/packages/domain/oauth-keys/src/index.ts
@@ -1,5 +1,6 @@
 export type { OAuthKey } from "./entities/oauth-key.ts"
-export { OAuthApplicationNotFoundError } from "./errors.ts"
+export { OAuthApplicationNotFoundError, OAuthKeyNotFoundError } from "./errors.ts"
 export { OAuthKeyRepository, OAuthTokenCacheInvalidator } from "./ports/oauth-key-repository.ts"
+export { type GetOAuthKeyInput, getOAuthKeyUseCase } from "./use-cases/get-oauth-key.ts"
 export { listOAuthKeysUseCase } from "./use-cases/list-oauth-keys.ts"
 export { type RevokeOAuthKeyInput, revokeOAuthKeyUseCase } from "./use-cases/revoke-oauth-key.ts"

--- a/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
+++ b/packages/domain/oauth-keys/src/ports/oauth-key-repository.ts
@@ -42,6 +42,16 @@ export class OAuthKeyRepository extends Context.Service<
      */
     listForOrganization: () => Effect.Effect<readonly OAuthKey[], RepositoryError, SqlClient>
     /**
+     * Reads a single OAuth key by its `(clientId, userId)` pair, returning
+     * the same aggregated shape `listForOrganization` produces. Returns
+     * `null` when the pair doesn't resolve under the caller's organization
+     * (RLS-scoped, so cross-tenant access collapses to the same null).
+     */
+    findByPair: (input: {
+      readonly clientId: string
+      readonly userId: string
+    }) => Effect.Effect<OAuthKey | null, RepositoryError, SqlClient>
+    /**
      * Returns `true` when the given `clientId` resolves to an OAuth
      * application in the caller's organization. Implemented as an
      * RLS-scoped read — a cross-tenant client returns `false` exactly

--- a/packages/domain/oauth-keys/src/use-cases/get-oauth-key.ts
+++ b/packages/domain/oauth-keys/src/use-cases/get-oauth-key.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { OAuthKeyNotFoundError } from "../errors.ts"
+import { OAuthKeyRepository } from "../ports/oauth-key-repository.ts"
+
+export interface GetOAuthKeyInput {
+  readonly clientId: string
+  readonly userId: string
+}
+
+/**
+ * Returns the OAuth key for a `(clientId, userId)` pair visible under the
+ * caller's organization. Raises {@link OAuthKeyNotFoundError} (404) when
+ * the row isn't here — same observable behaviour for non-existent pairs
+ * and for cross-tenant pairs that the RLS read can't see, so existence
+ * never leaks across orgs.
+ */
+export const getOAuthKeyUseCase = Effect.fn("oauthKeys.getOAuthKey")(function* (input: GetOAuthKeyInput) {
+  yield* Effect.annotateCurrentSpan("oauthKey.clientId", input.clientId)
+  yield* Effect.annotateCurrentSpan("oauthKey.userId", input.userId)
+
+  const repository = yield* OAuthKeyRepository
+  const row = yield* repository.findByPair(input)
+  if (!row) {
+    return yield* new OAuthKeyNotFoundError({ clientId: input.clientId, userId: input.userId })
+  }
+  return row
+})

--- a/packages/domain/spans/src/wrapped/types/claude-code/entities/report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/entities/report.ts
@@ -166,8 +166,15 @@ export const reportV1Schema = z.object({
     repos: z.number().int().nonnegative(),
     /** Distinct UTC calendar days with at least one Claude Code span. Max 7. */
     streakDays: z.number().int().nonnegative(),
-    /** Count of Bash invocations that look like a test runner. */
+    /** Count of Bash segments that look like a test runner. */
     testsRun: z.number().int().nonnegative(),
+    /**
+     * Count of git operations that mutate repo state (commit / push / merge
+     * / rebase / tag / revert / cherry-pick). Sibling of `commits` (which
+     * counts distinct git-commit SHAs from span metadata). Feeds the
+     * Shipper archetype.
+     */
+    gitWriteOps: z.number().int().nonnegative(),
   }),
 
   toolMix: toolMixSchema,

--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -28,6 +28,11 @@ export interface WrappedTotalsRow {
   readonly sessions: number
   readonly toolCalls: number
   readonly filesTouched: number
+  /**
+   * Total Bash command *segments* — a single Bash tool call carrying
+   * `cd foo && grep bar && git push` contributes three. The denominator
+   * for the "1,471 commands" headline.
+   */
   readonly commandsRun: number
   readonly workspaces: number
   readonly branches: number
@@ -35,8 +40,15 @@ export interface WrappedTotalsRow {
   readonly repos: number
   /** Distinct UTC calendar days with at least one Claude Code span. Max 7. */
   readonly streakDays: number
-  /** Count of Bash invocations that look like a test-runner command. */
+  /** Count of Bash segments that look like a test-runner command. */
   readonly testsRun: number
+  /**
+   * Count of git operations that mutate repo state (`commit`/`push`/`merge`/
+   * `rebase`/`tag`/`revert`/`cherry-pick`). Sibling of `commits` (which
+   * counts distinct git-commit SHAs from span metadata). Feeds the
+   * Shipper archetype's score and gate.
+   */
+  readonly gitWriteOps: number
 }
 
 export interface LocStatsRow {
@@ -62,9 +74,58 @@ export interface SessionDurationStatsRow {
   readonly longestWorkspace: string | null
 }
 
+/**
+ * One row per group of tool calls sharing a classification key. Bash calls
+ * are pre-split into command segments by the adapter and exploded into
+ * rows keyed on `(bashPrefix, bashSecondToken)`; path-aware tools (`Edit`,
+ * `Write`, `Read`, …) get a per-row `fileDisposition` derived from the
+ * `tool_input.file_path` vs `metadata['workspace.path']` comparison.
+ *
+ * The domain-side classifier in `build-report.ts` turns each row into a
+ * `ToolBucket` (or drops it as "excluded"). The shape stays raw so the
+ * routing rules live in TS where they're unit-testable.
+ */
 export interface ToolMixRow {
   readonly toolName: string
+  /** Number of tool calls / Bash segments in this group. */
   readonly uses: number
+  /**
+   * Lowercased first token of the Bash command segment. Empty string for
+   * non-Bash rows.
+   */
+  readonly bashPrefix: string
+  /**
+   * Lowercased **first non-flag** token after the prefix — i.e. the
+   * subcommand keyword. Flag-like tokens (starting with `-`, `@`, or
+   * `.`; containing `/` or `=`; or purely numeric) are skipped during
+   * extraction. So `git -C /repo status -s` produces
+   * `bashSecondToken = "status"`, not `"-c"`, and `gh -R owner/repo pr
+   * create` produces `bashSecondToken = "pr"`, not `"owner/repo"`.
+   *
+   * Empty string for non-Bash rows or segments with no non-flag tokens
+   * after the prefix. See `extractBashTokens` for the canonical spec.
+   */
+  readonly bashSecondToken: string
+  /**
+   * Lowercased **second non-flag** token after the prefix. Used to
+   * disambiguate `gh`'s three-deep CLI: `gh pr create` vs `gh pr view`
+   * (same prefix + second, different intent). Same flag-skipping rule
+   * as `bashSecondToken`. Empty string when the segment has fewer than
+   * two non-flag tokens after the prefix.
+   */
+  readonly bashThirdToken: string
+  /**
+   * Path classification for `Edit`/`Write`/`Read`/`MultiEdit`/`NotebookEdit`/
+   * `NotebookRead` calls based on the span's `tool_input.file_path` and
+   * `metadata['workspace.path']`:
+   *
+   * - `"plan-file"`: file is `**` /`.claude/plans/<id>.md` → routes to `plan`
+   * - `"claude-noise"`: file is under `.claude/` but not `plans/` → excluded
+   * - `"external"`: file is outside the workspace (and not `.claude/`) → excluded
+   * - `"workspace"`: file is inside the workspace (the common case) → existing bucket
+   * - `""`: not a path-aware tool, or no `file_path` carried (e.g. `LS`)
+   */
+  readonly fileDisposition: "" | "workspace" | "plan-file" | "claude-noise" | "external"
 }
 
 export interface FileTouchesRow {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.test.ts
@@ -19,6 +19,7 @@ const argsBase = {
   filesTouched: 0,
   commandsRun: 0,
   commits: 0,
+  gitWriteOps: 0,
   testsRun: 0,
   editAdded: 5_000,
   writeLines: 5_000,
@@ -199,6 +200,108 @@ describe("assignPersonality (gate-then-rank)", () => {
     const strat = run({ toolMix: { ...baseMix, plan: 80, edit: 20 } })
     expect(strat.score).toBeLessThanOrEqual(1)
     expect(strat.score).toBeGreaterThan(0.5)
+  })
+
+  it("regression: heavy power user (User A) lands on Shipper, not Conductor", () => {
+    // Snapshot of the production-traced User A profile after the bash
+    // sub-classification rewrite: 1,471 bash calls collapse to ~750 in
+    // the `bash` bucket once grep / find / cd / git-status are routed
+    // away. Shipper's gitWriteOps + commitsPerSession both fire; the
+    // rarity bonus pushes it well above any tool-mix winner.
+    const result = run({
+      toolMix: {
+        ...baseMix,
+        bash: 750, // build / test / git-write / runtime invocations
+        read: 1200,
+        edit: 900,
+        write: 80,
+        search: 1100, // grep, ls, find — most of which used to be in bash
+        plan: 30,
+        research: 5,
+        other: 10,
+      },
+      sessions: 16,
+      filesTouched: 259,
+      commandsRun: 1471,
+      commits: 34,
+      gitWriteOps: 50, // commit + push + rebase across the week
+      testsRun: 44,
+      editAdded: 22_000,
+      writeLines: 1_469,
+      linesRead: 200_000,
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
+  it("regression: light explorer (User B) lands on Consultant, not Conductor", () => {
+    // Snapshot of User B: 6 sessions, only 90 lines touched, 48 commands.
+    // After bash sub-classification, most of those 48 commands route
+    // away from `bash`: 8 ls + 6 grep → search, 1 cat → read, 1 curl →
+    // research, 2 excluded (open + claude). Remaining bash bucket is
+    // tiny; Consultant's gate (sessions ≥ 5 AND lines < 200) wins.
+    const result = run({
+      toolMix: {
+        ...baseMix,
+        bash: 14, // python3, git, the rest of the 48 — minus search/read/research
+        read: 50,
+        edit: 15,
+        write: 5,
+        search: 14, // ls + grep moved here
+        plan: 0,
+        research: 1, // curl
+        other: 1,
+      },
+      sessions: 6,
+      filesTouched: 7,
+      commandsRun: 48,
+      commits: 0,
+      gitWriteOps: 0,
+      testsRun: 1,
+      editAdded: 80,
+      writeLines: 10,
+      linesRead: 800,
+    })
+    expect(result.kind).toBe("consultant")
+  })
+
+  it("Shipper fires when shipping happens via `gh pr create` / `merge` even with zero git commits", () => {
+    // `gh` write triplets feed gitWriteOps the same way `git push` does.
+    // A user who works mostly through `gh pr create` + `gh pr merge`
+    // (e.g. CLI-first PR flow) should still land on Shipper.
+    const result = run({
+      toolMix: { ...baseMix, bash: 40, edit: 30, read: 30 },
+      sessions: 8,
+      commits: 0,
+      gitWriteOps: 32, // 4 per session — saturates the write-ops-per-session score
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
+  it("Shipper fires on push-heavy / squash flows even with low commit count", () => {
+    // The reason we added `gitWriteOps`: a user who force-pushes / rebases
+    // / tags but has few unique commit SHAs over the window. Old algorithm
+    // missed them. With the new disjunctive gate, they still land here.
+    const result = run({
+      toolMix: { ...baseMix, bash: 40, edit: 40, read: 20 },
+      sessions: 8,
+      commits: 2, // below SHIPPER_GATE_COMMITS
+      gitWriteOps: 24, // 3 per session — clears SHIPPER_GATE_WRITE_OPS_PER_SESSION
+    })
+    expect(result.kind).toBe("shipper")
+  })
+
+  it("Conductor still wins for a genuinely shell-heavy user (bash bucket post-routing)", () => {
+    // After the rebalance, Conductor isn't dead — it's reserved for users
+    // whose `bash` bucket (after grep / cd / git-status routed away) is
+    // actually dominated by genuine shell orchestration.
+    const result = run({
+      toolMix: { ...baseMix, bash: 70, read: 20, edit: 10 },
+      sessions: 8,
+      commandsRun: 300,
+      commits: 0,
+      gitWriteOps: 0,
+    })
+    expect(result.kind).toBe("conductor")
   })
 
   it("evidence always has exactly 3 strings", () => {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/assign-personality.ts
@@ -24,10 +24,14 @@ const BASELINE_SHARE: Record<ToolBucket, number> = {
 // Each archetype has a `gate` (minimum signal floor — below it, the
 // archetype can't fire at all) and a `score` formula mapping its signal
 // into [0, 1]. `assignPersonality` filters to gate-passers and returns
-// the highest-scoring one. The rare archetypes (Strategist, Scholar)
-// saturate earlier than the tool-mix archetypes so a strong rare signal
-// can beat a moderately-strong common one — otherwise a heavy editor
-// would always out-score a heavy planner.
+// the highest-scoring one.
+//
+// The 5 *conditional* archetypes (Strategist/Scholar/Consultant/Shipper/
+// Tester) get a multiplicative `RARE_BONUS` over their normalised score:
+// once their gate passes (which requires a real, non-trivial signal),
+// they deserve to beat a moderate (~0.5) tool-mix winner. Otherwise the
+// always-firing tool-mix archetypes drown out genuine planner / shipper /
+// tester signals at every realistic activity level.
 
 const STRATEGIST_GATE_EXCESS = 0.05
 const STRATEGIST_GATE_CALLS = 10
@@ -41,13 +45,27 @@ const SCHOLAR_SCORE_HIGH = 0.2
 
 const CONSULTANT_GATE_SESSIONS = 5
 const CONSULTANT_GATE_MAX_LINES = 200
-const CONSULTANT_SCORE_LOW = 5
-const CONSULTANT_SCORE_HIGH = 15
+// `LOW` sits below the gate floor on purpose: at exactly 5 sessions the gate
+// passes and the normalised score is `(5-4)/(8-4) = 0.25`, which then gets
+// the rarity bonus. Otherwise a borderline Consultant would score 0 and
+// always lose to any tool-mix winner.
+const CONSULTANT_SCORE_LOW = 4
+const CONSULTANT_SCORE_HIGH = 8
 
+// Shipper now reads from two complementary signals:
+//   - distinct commit SHAs over the window  → `commits` / `commitsPerSession`
+//   - git write-ops (push/merge/rebase/...) → `gitWriteOps`
+// Either can fire the gate; the score takes the max of both normalised
+// signals so squash-pushers, force-pushers, and tag-and-release flows
+// aren't penalised for low commit counts.
 const SHIPPER_GATE_COMMITS = 5
-const SHIPPER_GATE_RATIO = 1.0
-const SHIPPER_SCORE_LOW = 1.0
-const SHIPPER_SCORE_HIGH = 4.0
+const SHIPPER_GATE_WRITE_OPS = 8
+const SHIPPER_GATE_COMMITS_PER_SESSION = 1.0
+const SHIPPER_GATE_WRITE_OPS_PER_SESSION = 1.5
+const SHIPPER_COMMITS_PER_SESSION_LOW = 1.0
+const SHIPPER_COMMITS_PER_SESSION_HIGH = 2.5
+const SHIPPER_WRITE_OPS_PER_SESSION_LOW = 1.5
+const SHIPPER_WRITE_OPS_PER_SESSION_HIGH = 4.0
 
 const TESTER_GATE_TESTS = 20
 const TESTER_GATE_RATIO = 2.0
@@ -55,6 +73,12 @@ const TESTER_SCORE_LOW = 2.0
 const TESTER_SCORE_HIGH = 8.0
 
 const TOOL_MIX_SCORE_HIGH = 0.3
+
+// Multiplier applied to the 5 conditional archetypes' raw scores. Their
+// gates already require a meaningful signal floor, so once they fire we
+// want them to outrank a moderate tool-mix winner. Score is still capped
+// to [0, 1] downstream.
+const RARE_BONUS = 1.5
 
 const sumMix = (mix: ToolMix): number =>
   mix.bash + mix.read + mix.edit + mix.write + mix.search + mix.research + mix.plan + mix.other
@@ -76,6 +100,12 @@ interface AssignPersonalityInput {
   readonly filesTouched: number
   readonly commandsRun: number
   readonly commits: number
+  /**
+   * Count of git operations that mutate repo state (commit / push / merge
+   * / rebase / tag / revert / cherry-pick). Used alongside `commits` so
+   * users who squash-push or tag-release still register as shippers.
+   */
+  readonly gitWriteOps: number
   readonly testsRun: number
   /** Lines added by Edit / MultiEdit / NotebookEdit — the "+N" component. */
   readonly editAdded: number
@@ -110,7 +140,18 @@ interface Candidate {
  * stable sort — a small bias toward the rarer archetypes when scores match.
  */
 export function assignPersonality(input: AssignPersonalityInput): Personality {
-  const { toolMix, sessions, filesTouched, commandsRun, commits, testsRun, editAdded, writeLines, linesRead } = input
+  const {
+    toolMix,
+    sessions,
+    filesTouched,
+    commandsRun,
+    commits,
+    gitWriteOps,
+    testsRun,
+    editAdded,
+    writeLines,
+    linesRead,
+  } = input
   const total = sumMix(toolMix)
 
   // Guarded by the no-activity short-circuit upstream — but defend in depth
@@ -134,15 +175,21 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
   const bashExcess = excessOf("bash")
 
   const commitsPerSession = sessions > 0 ? commits / sessions : 0
+  const writeOpsPerSession = sessions > 0 ? gitWriteOps / sessions : 0
   const testsPerSession = sessions > 0 ? testsRun / sessions : 0
   // Total lines of code touched this week (disjoint components — no overlap).
   const linesTouchedTotal = editAdded + writeLines
+
+  // Bound to ≤ 1.0 so a saturated conditional score doesn't run away into
+  // [1, 1.5]; the relative ordering between archetypes is still the lift
+  // that matters.
+  const applyRareBonus = (s: number) => Math.min(1, s * RARE_BONUS)
 
   const candidates: readonly Candidate[] = [
     {
       kind: "strategist",
       gatePasses: planExcess >= STRATEGIST_GATE_EXCESS && toolMix.plan >= STRATEGIST_GATE_CALLS,
-      score: normaliseScore(planExcess, STRATEGIST_SCORE_LOW, STRATEGIST_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(planExcess, STRATEGIST_SCORE_LOW, STRATEGIST_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatPercent(shareOf("plan"))} of your tool calls were planning steps`,
         `${formatCount(toolMix.plan)} TaskCreate / TaskUpdate / TodoWrite calls`,
@@ -152,7 +199,7 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     {
       kind: "scholar",
       gatePasses: researchExcess >= SCHOLAR_GATE_EXCESS && toolMix.research >= SCHOLAR_GATE_CALLS,
-      score: normaliseScore(researchExcess, SCHOLAR_SCORE_LOW, SCHOLAR_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(researchExcess, SCHOLAR_SCORE_LOW, SCHOLAR_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatPercent(shareOf("research"))} of your tool calls were web research`,
         `${formatCount(toolMix.research)} WebFetch / WebSearch call${toolMix.research === 1 ? "" : "s"}`,
@@ -162,7 +209,7 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     {
       kind: "consultant",
       gatePasses: sessions >= CONSULTANT_GATE_SESSIONS && linesTouchedTotal < CONSULTANT_GATE_MAX_LINES,
-      score: normaliseScore(sessions, CONSULTANT_SCORE_LOW, CONSULTANT_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(sessions, CONSULTANT_SCORE_LOW, CONSULTANT_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatCount(sessions)} session${sessions === 1 ? "" : "s"} this week`,
         linesTouchedTotal === 0
@@ -173,18 +220,30 @@ export function assignPersonality(input: AssignPersonalityInput): Personality {
     },
     {
       kind: "shipper",
-      gatePasses: commits >= SHIPPER_GATE_COMMITS && commitsPerSession >= SHIPPER_GATE_RATIO,
-      score: normaliseScore(commitsPerSession, SHIPPER_SCORE_LOW, SHIPPER_SCORE_HIGH),
+      gatePasses:
+        (commits >= SHIPPER_GATE_COMMITS || gitWriteOps >= SHIPPER_GATE_WRITE_OPS) &&
+        (commitsPerSession >= SHIPPER_GATE_COMMITS_PER_SESSION ||
+          writeOpsPerSession >= SHIPPER_GATE_WRITE_OPS_PER_SESSION),
+      score: applyRareBonus(
+        Math.max(
+          normaliseScore(commitsPerSession, SHIPPER_COMMITS_PER_SESSION_LOW, SHIPPER_COMMITS_PER_SESSION_HIGH),
+          normaliseScore(writeOpsPerSession, SHIPPER_WRITE_OPS_PER_SESSION_LOW, SHIPPER_WRITE_OPS_PER_SESSION_HIGH),
+        ),
+      ),
       buildEvidence: () => [
-        `${formatCount(commits)} commit${commits === 1 ? "" : "s"} this week`,
-        `${commitsPerSession.toFixed(1)} commits per session, on average`,
+        commits >= gitWriteOps
+          ? `${formatCount(commits)} commit${commits === 1 ? "" : "s"} this week`
+          : `${formatCount(gitWriteOps)} git push / commit / merge operation${gitWriteOps === 1 ? "" : "s"}`,
+        commitsPerSession >= writeOpsPerSession
+          ? `${commitsPerSession.toFixed(1)} commits per session, on average`
+          : `${writeOpsPerSession.toFixed(1)} shipping actions per session, on average`,
         `${formatCount(sessions)} session${sessions === 1 ? "" : "s"} of focused work`,
       ],
     },
     {
       kind: "tester",
       gatePasses: testsRun >= TESTER_GATE_TESTS && testsPerSession >= TESTER_GATE_RATIO,
-      score: normaliseScore(testsPerSession, TESTER_SCORE_LOW, TESTER_SCORE_HIGH),
+      score: applyRareBonus(normaliseScore(testsPerSession, TESTER_SCORE_LOW, TESTER_SCORE_HIGH)),
       buildEvidence: () => [
         `${formatCount(testsRun)} test run${testsRun === 1 ? "" : "s"} this week`,
         `${testsPerSession.toFixed(1)} test runs per session, on average`,

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -2,7 +2,32 @@ import type { Project } from "@domain/projects"
 import { OrganizationId, ProjectId } from "@domain/shared"
 import { describe, expect, it } from "vitest"
 import { reportV1Schema } from "../entities/report.ts"
-import { type AssembleReportInput, assembleReport, toolBucketFor } from "./build-report.ts"
+import type { ToolMixRow } from "../ports/claude-code-span-reader.ts"
+import {
+  type AssembleReportInput,
+  assembleReport,
+  classifyToolMixRow,
+  extractBashTokens,
+  isGitWriteSegment,
+  toolBucketFor,
+} from "./build-report.ts"
+
+/**
+ * Convenience builder for `ToolMixRow` fixtures — most tests only care
+ * about the `(toolName, uses)` pair; the post-refactor row carries three
+ * extra fields (bash prefix, bash second token, file disposition) that we
+ * default to empty / "workspace" so the existing tests still exercise the
+ * pre-refactor routing.
+ */
+const row = (toolName: string, uses: number, extras: Partial<ToolMixRow> = {}): ToolMixRow => ({
+  toolName,
+  uses,
+  bashPrefix: "",
+  bashSecondToken: "",
+  bashThirdToken: "",
+  fileDisposition: toolName === "Bash" ? "" : (extras.fileDisposition ?? ""),
+  ...extras,
+})
 
 const ORG_ID = OrganizationId("org-build".padEnd(24, "x").slice(0, 24))
 const PROJECT_ID = ProjectId("proj-build".padEnd(24, "x").slice(0, 24))
@@ -38,6 +63,7 @@ const baseInput: AssembleReportInput = {
     repos: 1,
     streakDays: 5,
     testsRun: 9,
+    gitWriteOps: 0,
   },
   durationStats: {
     totalDurationMs: 30 * 60 * 1000,
@@ -51,11 +77,11 @@ const baseInput: AssembleReportInput = {
     readLines: 9_200,
   },
   toolMix: [
-    { toolName: "Edit", uses: 50 },
-    { toolName: "Read", uses: 25 },
-    { toolName: "Bash", uses: 15 },
-    { toolName: "Write", uses: 5 },
-    { toolName: "Grep", uses: 5 },
+    row("Edit", 50, { fileDisposition: "workspace" }),
+    row("Read", 25, { fileDisposition: "workspace" }),
+    row("Bash", 15),
+    row("Write", 5, { fileDisposition: "workspace" }),
+    row("Grep", 5),
   ],
   topBash: [
     { pattern: "pnpm", uses: 9 },
@@ -131,6 +157,377 @@ describe("toolBucketFor", () => {
   })
 })
 
+describe("extractBashTokens", () => {
+  it("plain `git push origin main` → prefix=git, second=push, third=origin", () => {
+    expect(extractBashTokens("git push origin main")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
+
+  it("`git -C /path status -s` → skips -C and the absolute path", () => {
+    // Claude Code emits this pattern constantly. Pre-fix, secondToken
+    // was "-c" (the literal second whitespace token) and the segment
+    // mis-classified as `bash` instead of `search`. After the fix the
+    // flag-like tokens are filtered so the meaningful subcommand
+    // surfaces.
+    expect(extractBashTokens("git -C /Users/sans/src/worktrees/repo status -s")).toEqual({
+      prefix: "git",
+      secondToken: "status",
+      thirdToken: "",
+    })
+  })
+
+  it("`gh -R owner/repo pr create --title foo` → triplet pr/create surfaces", () => {
+    expect(extractBashTokens("gh -R owner/repo pr create --title foo")).toEqual({
+      prefix: "gh",
+      secondToken: "pr",
+      thirdToken: "create",
+    })
+  })
+
+  it("`pnpm --filter @domain/spans test` → skips --filter and the scoped arg", () => {
+    expect(extractBashTokens("pnpm --filter @domain/spans test")).toEqual({
+      prefix: "pnpm",
+      secondToken: "test",
+      thirdToken: "",
+    })
+  })
+
+  it("`git --version` → no subcommand, second/third empty", () => {
+    expect(extractBashTokens("git --version")).toEqual({
+      prefix: "git",
+      secondToken: "",
+      thirdToken: "",
+    })
+  })
+
+  it("`./scripts/build.sh --release` → prefix keeps its leading dot (it IS the command)", () => {
+    // Only the *suffix* tokens are flag-filtered. The prefix is the
+    // literal first token — a script path is its own command name.
+    expect(extractBashTokens("./scripts/build.sh --release")).toEqual({
+      prefix: "./scripts/build.sh",
+      secondToken: "",
+      thirdToken: "",
+    })
+  })
+
+  it("`GIT STATUS` → both prefix and tokens are lowercased", () => {
+    expect(extractBashTokens("GIT STATUS")).toEqual({
+      prefix: "git",
+      secondToken: "status",
+      thirdToken: "",
+    })
+  })
+
+  it("`git -c user.email=x commit -m msg` → skips =-containing tokens and -m flag", () => {
+    expect(extractBashTokens("git -c user.email=x commit -m msg")).toEqual({
+      prefix: "git",
+      secondToken: "commit",
+      thirdToken: "msg",
+    })
+  })
+
+  it("`head -n 50 foo.log` → numeric `50` is skipped", () => {
+    expect(extractBashTokens("head -n 50 foo.log")).toEqual({
+      prefix: "head",
+      secondToken: "foo.log",
+      thirdToken: "",
+    })
+  })
+
+  it("collapses runs of whitespace and handles empty input", () => {
+    expect(extractBashTokens("")).toEqual({ prefix: "", secondToken: "", thirdToken: "" })
+    expect(extractBashTokens("   ")).toEqual({ prefix: "", secondToken: "", thirdToken: "" })
+    expect(extractBashTokens("git   push   origin")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
+
+  it("strips bash line continuations (`\\<NEWLINE>`) before tokenising", () => {
+    // Claude Code emits multi-line commands like:
+    //   foo bar \
+    //     echo continued
+    // The literal char sequence stored is `foo bar \<NL>  echo continued`.
+    // Without normalisation, the `\<NL>` becomes a junk token and surfaces
+    // as `\ echo` in the top-commands display.
+    expect(extractBashTokens("foo bar \\\n  echo continued")).toEqual({
+      prefix: "foo",
+      secondToken: "bar",
+      thirdToken: "echo",
+    })
+  })
+
+  it("normalises a segment that begins with a line-continuation join", () => {
+    // After splitting on `&&` / `;` / `|`, a segment can start with `\<NL>`
+    // when the chain operator appeared at end-of-line just before the
+    // continuation. The prefix should be the first real token, not `\<NL>`.
+    expect(extractBashTokens("\\\n  echo something")).toEqual({
+      prefix: "echo",
+      secondToken: "something",
+      thirdToken: "",
+    })
+  })
+
+  it("treats embedded tabs and newlines as whitespace", () => {
+    expect(extractBashTokens("git\tpush\norigin")).toEqual({
+      prefix: "git",
+      secondToken: "push",
+      thirdToken: "origin",
+    })
+  })
+})
+
+describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", () => {
+  // Bridges the SQL-level extraction to the classifier — proves that a
+  // raw Claude Code Bash segment lands in the right toolMix bucket.
+  const classify = (segment: string): ReturnType<typeof classifyToolMixRow> => {
+    const t = extractBashTokens(segment)
+    return classifyToolMixRow(
+      row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken }),
+    )
+  }
+
+  it("`git -C /path status -s` lands in search (not bash)", () => {
+    expect(classify("git -C /Users/sans/src/worktrees/repo status -s")).toBe("search")
+  })
+
+  it("`git -C /path commit -m msg` lands in bash (and counts as a write-op)", () => {
+    const t = extractBashTokens("git -C /repo commit -m msg")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("bash")
+    expect(isGitWriteSegment(r)).toBe(true)
+  })
+
+  it("`gh -R owner/repo pr create` is a write-op (feeds gitWriteOps)", () => {
+    const t = extractBashTokens("gh -R owner/repo pr create --title foo")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("bash")
+    expect(isGitWriteSegment(r)).toBe(true)
+  })
+
+  it("`gh -R owner/repo pr view 123` is research, not a write-op", () => {
+    const t = extractBashTokens("gh -R owner/repo pr view 123")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("research")
+    expect(isGitWriteSegment(r)).toBe(false)
+  })
+
+  it("`pnpm --filter @domain/spans test` is bash (genuine shell orchestration)", () => {
+    expect(classify("pnpm --filter @domain/spans test")).toBe("bash")
+  })
+
+  it("`tail -8` (raw plumbing) is excluded entirely", () => {
+    expect(classify("tail -8")).toBe("excluded")
+  })
+
+  it("`cd /Users/sans/src` is excluded (navigation)", () => {
+    expect(classify("cd /Users/sans/src")).toBe("excluded")
+  })
+
+  it("a line-continuation `echo` segment classifies as excluded plumbing", () => {
+    // Pre-normalisation this segment produced prefix `\<NL>` which wasn't
+    // in any classifier set → fell through to plain `bash` and showed up
+    // as "\ echo" in top-commands. After normalisation, the prefix is
+    // `echo` → plumbing → excluded.
+    expect(classify("\\\n  echo something")).toBe("excluded")
+  })
+})
+
+describe("classifyToolMixRow — Bash sub-classification", () => {
+  it("routes investigation-style binaries to search", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "grep" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "rg" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "find" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "ls" }))).toBe("search")
+  })
+
+  it("drops shell plumbing entirely (cat/head/tail/echo/sed/awk/…)", () => {
+    // These are almost always used as `… | tail -8` or `… | sed s/x/y/`
+    // shapers — never standalone Claude work. Dropping them entirely
+    // keeps the `read` bucket clean and the top-commands surface free
+    // of "Your favourite command: tail" results.
+    for (const prefix of [
+      "cat",
+      "head",
+      "tail",
+      "less",
+      "more",
+      "echo",
+      "printf",
+      "sed",
+      "awk",
+      "wc",
+      "sort",
+      "cut",
+      "tr",
+      "xargs",
+      "tee",
+    ]) {
+      expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: prefix }))).toBe("excluded")
+    }
+  })
+
+  it("routes curl / wget to research", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "curl" }))).toBe("research")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "wget" }))).toBe("research")
+  })
+
+  it("drops navigation-only commands (cd / pwd / open / claude)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "cd" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "pwd" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "open" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "claude" }))).toBe("excluded")
+  })
+
+  it("routes git status / log / diff to search (investigation)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "status" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "log" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "diff" }))).toBe("search")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "blame" }))).toBe("search")
+  })
+
+  it("drops git checkout / switch / config (navigation / setup)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "checkout" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "switch" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "config" }))).toBe("excluded")
+  })
+
+  it("keeps git commit / push / merge in bash (genuine shell orchestration)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "commit" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "push" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "git", bashSecondToken: "merge" }))).toBe("bash")
+  })
+
+  it("keeps unrecognised binaries in bash (build / test / runtime / infra)", () => {
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "pnpm" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "xcodebuild" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "python3" }))).toBe("bash")
+    expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "railway" }))).toBe("bash")
+  })
+})
+
+describe("classifyToolMixRow — file-path disposition", () => {
+  it("routes plan-file edits/reads to the plan bucket", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+    expect(classifyToolMixRow(row("Write", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "plan-file" }))).toBe("plan")
+  })
+
+  it("drops `.claude/` config edits/reads entirely", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "claude-noise" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "claude-noise" }))).toBe("excluded")
+  })
+
+  it("drops out-of-workspace edits/reads entirely", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "external" }))).toBe("excluded")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "external" }))).toBe("excluded")
+  })
+
+  it("counts workspace edits/reads via the existing tool-name map", () => {
+    expect(classifyToolMixRow(row("Edit", 1, { fileDisposition: "workspace" }))).toBe("edit")
+    expect(classifyToolMixRow(row("Write", 1, { fileDisposition: "workspace" }))).toBe("write")
+    expect(classifyToolMixRow(row("Read", 1, { fileDisposition: "workspace" }))).toBe("read")
+  })
+
+  it("falls back to the tool-name map when no file_path was on the call", () => {
+    expect(classifyToolMixRow(row("Edit", 1))).toBe("edit")
+    expect(classifyToolMixRow(row("Grep", 1))).toBe("search")
+    expect(classifyToolMixRow(row("TodoWrite", 1))).toBe("plan")
+  })
+})
+
+describe("classifyToolMixRow — gh sub-subcommand routing", () => {
+  it("routes gh pr view / list / checks / comment to research (external investigation)", () => {
+    for (const third of ["view", "list", "checks", "comment", "diff", "status"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe("research")
+    }
+  })
+
+  it("routes gh issue / api / run / workflow to research regardless of third token", () => {
+    for (const second of ["issue", "api", "run", "workflow"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: second, bashThirdToken: "anything" })),
+      ).toBe("research")
+      expect(classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: second }))).toBe("research")
+    }
+  })
+
+  it("keeps gh write-ops in bash (and feeds gitWriteOps)", () => {
+    for (const third of ["create", "merge", "ready", "edit", "review"]) {
+      expect(
+        classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe("bash")
+    }
+  })
+
+  it("keeps gh auth / config / repo view in bash (not shipping, not research)", () => {
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "auth", bashThirdToken: "login" })),
+    ).toBe("bash")
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "config", bashThirdToken: "set" })),
+    ).toBe("bash")
+    expect(
+      classifyToolMixRow(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "repo", bashThirdToken: "view" })),
+    ).toBe("bash")
+  })
+})
+
+describe("isGitWriteSegment", () => {
+  it("returns true for the git write-ops subcommands", () => {
+    for (const sub of ["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"]) {
+      expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "git", bashSecondToken: sub }))).toBe(true)
+    }
+  })
+
+  it("returns true for the gh write-op triplets (gh pr create / merge / ready / edit / review)", () => {
+    for (const third of ["create", "merge", "ready", "edit", "review"]) {
+      expect(
+        isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: third })),
+      ).toBe(true)
+    }
+  })
+
+  it("returns true for gh release create / edit / upload and gh repo create", () => {
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "release", bashThirdToken: "create" })),
+    ).toBe(true)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "release", bashThirdToken: "upload" })),
+    ).toBe(true)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "repo", bashThirdToken: "create" })),
+    ).toBe(true)
+  })
+
+  it("returns false for git investigation / navigation subcommands", () => {
+    for (const sub of ["status", "log", "diff", "checkout", "switch", "config"]) {
+      expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "git", bashSecondToken: sub }))).toBe(false)
+    }
+  })
+
+  it("returns false for gh read-side calls (view / list / api / issue)", () => {
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "pr", bashThirdToken: "view" }))).toBe(
+      false,
+    )
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "api" }))).toBe(false)
+    expect(
+      isGitWriteSegment(row("Bash", 1, { bashPrefix: "gh", bashSecondToken: "issue", bashThirdToken: "list" })),
+    ).toBe(false)
+  })
+
+  it("returns false for non-git Bash segments and non-Bash rows", () => {
+    expect(isGitWriteSegment(row("Bash", 1, { bashPrefix: "pnpm" }))).toBe(false)
+    expect(isGitWriteSegment(row("Edit", 1, { fileDisposition: "workspace" }))).toBe(false)
+  })
+})
+
 describe("assembleReport", () => {
   it("produces a report that validates against the schema", () => {
     const report = assembleReport(baseInput)
@@ -153,9 +550,9 @@ describe("assembleReport", () => {
     const report = assembleReport({
       ...baseInput,
       toolMix: [
-        { toolName: "Edit", uses: 10 },
-        { toolName: "NotebookEdit", uses: 3 },
-        { toolName: "MultiEdit", uses: 2 },
+        row("Edit", 10, { fileDisposition: "workspace" }),
+        row("NotebookEdit", 3, { fileDisposition: "workspace" }),
+        row("MultiEdit", 2, { fileDisposition: "workspace" }),
       ],
     })
     expect(report.toolMix.edit).toBe(15)

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -35,9 +35,15 @@ const QUERY_CONCURRENCY = 6
 const DEEP_DIVE_CONCURRENCY = 3
 
 /**
- * Tool-name → bucket map. Maps every Claude Code tool we ship today and
- * funnels everything else into `other` so the bucket sums always equal the
- * total tool-call count.
+ * Tool-name → bucket map. Used for two paths:
+ *   1. The non-Bash, non-path-aware classifier branch in `classifyToolMixRow`.
+ *   2. Coarse name-only mapping for `dominantTool` on the workspace deep
+ *      dive, where the display field is "what kind of tool was most-used
+ *      in this workspace" — a per-span path/command analysis would be
+ *      overkill for that bit of copy.
+ *
+ * `Bash` maps to `bash` here for case (2); the per-segment classifier in
+ * `classifyBashSegment` is what drives the toolMix shares.
  */
 const TOOL_NAME_TO_BUCKET: Record<string, ToolBucket> = {
   Bash: "bash",
@@ -59,6 +65,209 @@ const TOOL_NAME_TO_BUCKET: Record<string, ToolBucket> = {
 
 export const toolBucketFor = (toolName: string): ToolBucket => TOOL_NAME_TO_BUCKET[toolName] ?? "other"
 
+const PATH_AWARE_TOOLS = new Set(["Edit", "MultiEdit", "NotebookEdit", "Write", "Read", "NotebookRead"])
+
+// Bash command-prefix routing. Lowercased; the adapter does the lowercase.
+const BASH_SEARCH_PREFIXES = new Set(["grep", "rg", "ag", "find", "ls", "tree"])
+const BASH_RESEARCH_PREFIXES = new Set(["curl", "wget"])
+
+/**
+ * Pure output-shaping / orchestration commands. Almost always after a `|`
+ * to format something else's output (`… | tail -8`, `… | head`, `cat foo |
+ * less`), never standalone work in the Claude Code context. Excluded
+ * entirely from segment counting so they don't pad `commandsRun` or
+ * dominate the top-commands list.
+ *
+ * Includes the pure navigation commands too (`cd`, `pwd`, `open`, `claude`,
+ * …) for the same reason.
+ */
+const BASH_PLUMBING_PREFIXES = new Set([
+  "head",
+  "tail",
+  "cat",
+  "less",
+  "more",
+  "echo",
+  "printf",
+  "sed",
+  "awk",
+  "wc",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "xargs",
+  "tee",
+  "cd",
+  "pwd",
+  "pushd",
+  "popd",
+  "clear",
+  "exit",
+  "open",
+  "claude",
+])
+
+// git sub-command routing.
+const GIT_SEARCH_SUBCOMMANDS = new Set(["status", "log", "diff", "show", "blame", "branch", "ls-files", "reflog"])
+const GIT_EXCLUDED_SUBCOMMANDS = new Set(["checkout", "switch", "restore", "config", "init", "remote"])
+const GIT_WRITE_SUBCOMMANDS = new Set(["commit", "push", "merge", "rebase", "tag", "revert", "cherry-pick"])
+
+// gh sub-subcommand routing. Keyed on (secondToken, thirdToken). `gh` is
+// the only command we look at three deep — its surface (`gh pr create`,
+// `gh issue list`, `gh api`) reads more like a 3-level CLI than git's
+// 2-level one, and the second token alone (`pr`, `issue`, `release`) is
+// too coarse to tell shipping from investigation apart.
+const GH_RESEARCH_SECOND_TOKENS = new Set(["issue", "api", "run", "workflow"])
+const GH_PR_RESEARCH_SUBCOMMANDS = new Set(["view", "list", "checks", "comment", "diff", "status"])
+/**
+ * gh write-ops triplets — these increment `gitWriteOps` AND stay in the
+ * `bash` bucket. Keyed by (secondToken → set of thirdToken). Anything
+ * not enumerated falls through to plain `bash`.
+ */
+const GH_WRITE_OPS: Record<string, ReadonlySet<string>> = {
+  pr: new Set(["create", "merge", "ready", "edit", "review"]),
+  release: new Set(["create", "edit", "upload"]),
+  repo: new Set(["create"]),
+}
+
+/**
+ * Pure routing rule for one `ToolMixRow`. Returns the bucket the row counts
+ * toward, or `"excluded"` to drop it entirely (so the toolMix denominator
+ * isn't padded by navigation/scratch noise). Mirrors the SQL classification
+ * in the CH adapter — both live here so unit tests pin the contract.
+ */
+export const classifyToolMixRow = (row: ToolMixRow): ToolBucket | "excluded" => {
+  if (row.toolName === "Bash") {
+    return classifyBashSegment(row.bashPrefix, row.bashSecondToken, row.bashThirdToken)
+  }
+  if (PATH_AWARE_TOOLS.has(row.toolName)) {
+    if (row.fileDisposition === "plan-file") return "plan"
+    if (row.fileDisposition === "claude-noise" || row.fileDisposition === "external") return "excluded"
+    // "workspace" or "" (no file_path on this call) fall through to the
+    // tool-name map.
+  }
+  return TOOL_NAME_TO_BUCKET[row.toolName] ?? "other"
+}
+
+const classifyBashSegment = (prefix: string, secondToken: string, thirdToken: string): ToolBucket | "excluded" => {
+  if (BASH_PLUMBING_PREFIXES.has(prefix)) return "excluded"
+  if (BASH_SEARCH_PREFIXES.has(prefix)) return "search"
+  if (BASH_RESEARCH_PREFIXES.has(prefix)) return "research"
+  if (prefix === "git") {
+    if (GIT_SEARCH_SUBCOMMANDS.has(secondToken)) return "search"
+    if (GIT_EXCLUDED_SUBCOMMANDS.has(secondToken)) return "excluded"
+    // Including GIT_WRITE_SUBCOMMANDS, GIT_NEUTRAL (add/rm/mv/stash/pull/…)
+    // and unknown subcommands — stays in `bash` (genuine shell orchestration).
+  }
+  if (prefix === "gh") {
+    // Read-side gh hits api.github.com, mirroring curl / wget — research.
+    if (GH_RESEARCH_SECOND_TOKENS.has(secondToken)) return "research"
+    if (secondToken === "pr" && GH_PR_RESEARCH_SUBCOMMANDS.has(thirdToken)) return "research"
+    // Everything else under gh stays in `bash` — including the write-ops
+    // triplets (which also feed `gitWriteOps`), `gh auth` / `gh config`,
+    // and `gh repo view` / `gh repo clone`.
+  }
+  return "bash"
+}
+
+/**
+ * True if a token should be skipped when looking for the meaningful
+ * subcommand keyword inside a Bash segment. Mirrors the SQL
+ * `FLAG_LIKE_TOKEN_PREDICATE` in the CH adapter — both files must move
+ * in lockstep.
+ *
+ *   `-flag` / `--flag`         : POSIX / GNU CLI flags
+ *   tokens starting with `@`   : pnpm / npm / yarn scoped package args
+ *   tokens containing `/`      : absolute paths (`/Users/.../repo`),
+ *                                relative paths (`./scripts/x`), and
+ *                                `owner/repo`-style slugs (`gh -R x/y …`)
+ *   tokens starting with `.`   : relative paths without `/` (`./bin`)
+ *   tokens containing `=`      : `--key=value` syntax
+ *   purely numeric tokens      : counts / indices (`head -n 50`)
+ *
+ * Subcommands are by convention single bare keywords (`status`, `create`,
+ * `install`, `build`), so none of these patterns produce false positives
+ * in practice.
+ */
+const isFlagLikeToken = (t: string): boolean => {
+  if (t === "") return true
+  const c = t.charAt(0)
+  if (c === "-" || c === "@" || c === ".") return true
+  if (t.includes("/")) return true
+  if (t.includes("=")) return true
+  if (/^\d+$/.test(t)) return true
+  return false
+}
+
+interface BashTokens {
+  readonly prefix: string
+  readonly secondToken: string
+  readonly thirdToken: string
+}
+
+/**
+ * Extracts `(prefix, secondToken, thirdToken)` from a Bash command
+ * segment using the same flag-skipping rule the CH adapter applies. The
+ * adapter SQL must stay in lockstep with this function; tests against
+ * this function effectively validate the SQL by proxy.
+ *
+ * - `prefix` is the literal first whitespace token, lowercased. NOT
+ *   filtered, so a script invocation like `./scripts/build.sh` keeps its
+ *   leading `.` and is treated as the command name.
+ * - `secondToken` is the **first non-flag** token after the prefix.
+ * - `thirdToken` is the **second non-flag** token after the prefix.
+ *
+ * Examples (see `build-report.test.ts` for the full grid):
+ *
+ *   `git -C /path status -s`            → (git, status, "")
+ *   `gh -R owner/repo pr create --t x`  → (gh, pr, create)
+ *   `pnpm --filter @domain/spans test`  → (pnpm, test, "")
+ *   `git --version`                     → (git, "", "")
+ *   `head -n 50 foo.log`                → (head, foo.log, "")
+ */
+export const extractBashTokens = (segment: string): BashTokens => {
+  // Normalise before tokenising:
+  //   1. Strip bash line continuations (`\<NEWLINE>`) — a multi-line
+  //      command like `foo bar \<NL>  echo continued` would otherwise
+  //      tokenise as `foo`, `bar`, `\<NL>`, `echo`, `continued`, and the
+  //      `\<NL>` token becomes a junk "command" in the top-commands
+  //      display ("\ echo").
+  //   2. Collapse any whitespace run (spaces, tabs, leftover newlines)
+  //      to a single space so `splitByChar(' ', …)` produces clean
+  //      tokens with no empty entries.
+  const normalised = segment.replace(/\\\n/g, " ").replace(/\s+/g, " ").trim()
+  if (normalised === "") return { prefix: "", secondToken: "", thirdToken: "" }
+  const tokens = normalised.split(" ")
+  const prefix = (tokens[0] ?? "").toLowerCase()
+  const meaningful = tokens.slice(1).filter((t) => !isFlagLikeToken(t))
+  return {
+    prefix,
+    secondToken: (meaningful[0] ?? "").toLowerCase(),
+    thirdToken: (meaningful[1] ?? "").toLowerCase(),
+  }
+}
+
+/**
+ * True when this row's command segment increments `gitWriteOps`. Covers
+ * both raw `git` write-subcommands and the `gh` write-op triplets
+ * (`gh pr create`, `gh release upload`, `gh repo create`, …). Name stays
+ * `gitWriteOps`-flavoured even though it includes `gh` because the
+ * persisted field is named that way and a rename would force a schema
+ * migration for no behavioural gain.
+ */
+export const isGitWriteSegment = (row: ToolMixRow): boolean => {
+  if (row.toolName !== "Bash") return false
+  if (row.bashPrefix === "git") {
+    return GIT_WRITE_SUBCOMMANDS.has(row.bashSecondToken)
+  }
+  if (row.bashPrefix === "gh") {
+    const writes = GH_WRITE_OPS[row.bashSecondToken]
+    return writes !== undefined && writes.has(row.bashThirdToken)
+  }
+  return false
+}
+
 const emptyToolMix = (): ToolMix => ({
   bash: 0,
   read: 0,
@@ -73,7 +282,9 @@ const emptyToolMix = (): ToolMix => ({
 const bucketise = (rows: readonly ToolMixRow[]): ToolMix => {
   const mix = emptyToolMix()
   for (const row of rows) {
-    mix[toolBucketFor(row.toolName)] += row.uses
+    const bucket = classifyToolMixRow(row)
+    if (bucket === "excluded") continue
+    mix[bucket] += row.uses
   }
   return mix
 }
@@ -203,6 +414,7 @@ export const assembleReport = (input: AssembleReportInput): Report => {
     filesTouched: input.totals.filesTouched,
     commandsRun: input.totals.commandsRun,
     commits: input.totals.commits,
+    gitWriteOps: input.totals.gitWriteOps,
     testsRun: input.totals.testsRun,
     editAdded,
     writeLines,
@@ -245,6 +457,7 @@ export const assembleReport = (input: AssembleReportInput): Report => {
       repos: input.totals.repos,
       streakDays: input.totals.streakDays,
       testsRun: input.totals.testsRun,
+      gitWriteOps: input.totals.gitWriteOps,
     },
     toolMix,
     loc: {

--- a/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
+++ b/packages/domain/spans/src/wrapped/use-cases/run-wrapped.test.ts
@@ -80,6 +80,7 @@ const makeReader = (overrides?: Partial<ClaudeCodeSpanReaderShape>): ClaudeCodeS
       repos: 0,
       streakDays: 0,
       testsRun: 0,
+      gitWriteOps: 0,
     }),
   getSessionDurationStats: () => Effect.succeed({ totalDurationMs: 0, longestDurationMs: 0, longestWorkspace: null }),
   getLocStats: () => Effect.succeed({ writeLines: 0, editAdded: 0, editRemoved: 0, readLines: 0 }),

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -40,6 +40,272 @@ const toClickhouseDateTime = (date: Date): string => date.toISOString().replace(
 // embedded SQL matches what the spans adapter actually inserts.
 const FILE_PATH_TOOLS = ["Read", "Edit", "Write", "NotebookEdit", "MultiEdit"] as const
 
+// SQL list literal for the path-aware tool set — `Read`/`Edit`/`Write` plus
+// the two notebook variants. Used by every query that filters or routes on
+// file path.
+const FILE_PATH_TOOLS_SQL = FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")
+const PATH_AWARE_TOOLS_SQL = `('Edit','MultiEdit','NotebookEdit','Write','Read','NotebookRead')`
+
+// Splits a Bash command string into its `&&` / `||` / `;` / `|`-separated
+// segments. Order in the alternation matters — `||` and `&&` are tried
+// before the single `|` so the two-char operators win at each position
+// (RE2 alternation is greedy left-to-right per position).
+//
+// Wraps each operator in optional whitespace so the resulting segments
+// come back already trimmed. Subshells (`$(…)`, backticks) are *not*
+// handled — rare enough that the regex approach is good enough and
+// proper handling needs a tokeniser.
+const BASH_SEGMENT_REGEX = "\\\\s*(?:&&|\\\\|\\\\||;|\\\\|)\\\\s*"
+
+// Path classifier used by every query that has to decide whether a file
+// touch counts. Mirrors the TS `classifyToolMixRow` rules in
+// `@domain/spans/.../build-report.ts` — both must move in lockstep.
+//
+//   plan-file:    `**/.claude/plans/<id>.md`            → routes to `plan`
+//   claude-noise: any other path under `**/.claude/**`  → excluded
+//   external:     outside the workspace root            → excluded
+//   workspace:    inside the workspace                  → existing bucket
+//   "":           the call carries no `file_path`       → existing bucket
+//
+// Empty string is the "no file_path" case (LS / a Read with `offset`
+// only / a malformed input) — the call still counts toward the existing
+// tool-name bucket; only path-bearing calls can be excluded by path.
+const filePathDispositionSql = (workspacePathExpr: string, filePathExpr: string): string => `
+  multiIf(
+    ${filePathExpr} = '', '',
+    match(${filePathExpr}, '/\\\\.claude/plans/[^/]+\\\\.md$'), 'plan-file',
+    positionUTF8(${filePathExpr}, '/.claude/') > 0, 'claude-noise',
+    ${workspacePathExpr} != '' AND NOT startsWith(${filePathExpr}, ${workspacePathExpr}), 'external',
+    'workspace'
+  )
+`
+
+/**
+ * Lenient predicate — keeps anything that represents "real iteration this
+ * week" regardless of which workspace it happened in. Used for the
+ * *headline* LOC / file-touch counters that are presented at the project
+ * level ("Lines written: 14,832"). Includes plan-mode files because
+ * iterating on a plan is genuine writing work.
+ *
+ *   workspace files     ✓ count
+ *   .claude/plans/*.md  ✓ count (real iteration)
+ *   other .claude/**    ✗ excluded (config / history noise)
+ *   external scratch    ✗ excluded (not part of this project's week)
+ *
+ * `file_path = ''` is allowed defensively — the path-aware tools always
+ * carry a `file_path`, but if a malformed input ever lands the row's line
+ * counts still aggregate.
+ */
+const loCountablePathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
+  (
+    ${filePathExpr} = ''
+    OR match(${filePathExpr}, '/\\\\.claude/plans/[^/]+\\\\.md$')
+    OR (
+      positionUTF8(${filePathExpr}, '/.claude/') = 0
+      AND ${workspacePathExpr} != ''
+      AND startsWith(${filePathExpr}, ${workspacePathExpr})
+    )
+  )
+`
+
+/**
+ * Strict predicate — keeps only file_paths that sit inside the span's own
+ * `workspace.path`. Used for the *workspace-specific* views (top files
+ * per workspace, "biggest write" display, "mostly X" dominant-tool
+ * inference). Plan files are explicitly excluded — they're not part of
+ * any project's source tree.
+ *
+ * Requires `workspace.path` to be present; an empty workspace path makes
+ * the span ambiguous as to "what counts as inside" and we err on the
+ * side of excluding rather than allowing.
+ */
+const workspaceStrictPathPredicate = (workspacePathExpr: string, filePathExpr: string): string => `
+  (
+    positionUTF8(${filePathExpr}, '/.claude/') = 0
+    AND ${workspacePathExpr} != ''
+    AND startsWith(${filePathExpr}, ${workspacePathExpr})
+  )
+`
+
+// SQL list literals for the Bash sub-classification. Lowercased.
+const GIT_WRITE_SUBCOMMANDS_SQL = `('commit','push','merge','rebase','tag','revert','cherry-pick')`
+
+/**
+ * Pure output-shaping / orchestration commands. Excluded from segment
+ * counting so they don't pollute `commandsRun` or dominate the
+ * top-commands list. Mirrors `BASH_PLUMBING_PREFIXES` in `build-report.ts`
+ * — these two lists must stay in lockstep.
+ */
+const BASH_PLUMBING_PREFIXES_SQL = `(
+  'head','tail','cat','less','more',
+  'echo','printf','sed','awk','wc','sort','uniq','cut','tr','xargs','tee',
+  'cd','pwd','pushd','popd','clear','exit','open','claude'
+)`
+
+/**
+ * Generic investigation tools — route to the `search` bucket for personality
+ * purposes (a heavy grepper is a Detective) but are filtered out of the
+ * top-commands display. The display is reserved for shell orchestration
+ * the user actually drove; investigation is summarised by the `search`
+ * bucket's share.
+ */
+const BASH_SEARCH_PREFIXES_SQL = `('grep','rg','ag','find','ls','tree')`
+
+/**
+ * Git sub-commands that don't route to `bash` (i.e. `git status` /
+ * `log` / `diff` etc. → `search`; `git checkout` / `switch` etc. →
+ * `excluded`). Used by the top-commands display filter to keep only
+ * segments that route to `bash` or `research`.
+ */
+const GIT_NON_BASH_SUBCOMMANDS_SQL = `(
+  'status','log','diff','show','blame','branch','ls-files','reflog',
+  'checkout','switch','restore','config','init','remote'
+)`
+
+/**
+ * Normalises a Bash command segment before tokenisation:
+ *   1. Replace `\\<NEWLINE>` (literal backslash + newline) with a single
+ *      space — multi-line bash continuations would otherwise tokenise
+ *      as `\\<NL>` and surface as junk "commands" in the display.
+ *   2. Collapse any whitespace run (spaces, tabs, leftover newlines) to
+ *      a single space so \`splitByChar(' ', …)\` produces clean tokens.
+ *   3. Trim leading/trailing whitespace.
+ *
+ * Mirrors the JS normalisation in \`extractBashTokens\` (build-report.ts).
+ */
+const normalizeSegmentSql = (segmentExpr: string): string =>
+  `trim(replaceRegexpAll(replaceAll(${segmentExpr}, '\\\\\\n', ' '), '\\\\s+', ' '))`
+
+/**
+ * gh sub-subcommand triplets that count as shipping write-ops (they
+ * increment `gitWriteOps` alongside the raw git write-subcommands).
+ * Encoded as a SQL OR predicate so the same expression can be reused
+ * across the totals query and any future per-segment aggregation.
+ */
+const GH_WRITE_OPS_PREDICATE = `(
+  (second_token = 'pr'      AND third_token IN ('create','merge','ready','edit','review'))
+  OR (second_token = 'release' AND third_token IN ('create','edit','upload'))
+  OR (second_token = 'repo'    AND third_token = 'create')
+)`
+
+/**
+ * Prefixes for which the "top commands" surface should display
+ * `prefix + first-non-flag-token` instead of just `prefix`. `git push` is
+ * a meaningfully different story from `git status`; `pnpm test` is
+ * different from `pnpm install`. For most tools, the first token is
+ * descriptive enough.
+ *
+ * `gh` gets two-deep treatment (handled separately) because its CLI is
+ * structurally 3-level (`gh pr create` vs `gh pr view`).
+ */
+const SUBCOMMAND_AWARE_PREFIXES_SQL = `(
+  'git','pnpm','npm','yarn','bun','cargo','brew','docker','kubectl',
+  'mix','rake','gradle','mvn','go','poetry','pipx','terraform',
+  'fly','railway','vercel'
+)`
+
+/**
+ * SQL expression that takes a tokens array (from `splitByChar(' ',
+ * segment)`) and the prefix, and emits the displayable pattern:
+ *
+ *   - empty if the prefix is in the plumbing set (filtered out upstream
+ *     of this helper, but defended in depth here too)
+ *   - `prefix subcommand` for known multi-action prefixes — `subcommand`
+ *     is the first non-flag-like token after the prefix
+ *   - `gh second third` for `gh` — both sub and sub-sub, again skipping
+ *     flag-like tokens
+ *   - just `prefix` otherwise
+ *
+ * "Flag-like" token = starts with `-`, `@`, `/`, or `.`, or contains `=`,
+ * or is purely numeric. These are CLI flag syntax / scoped-package args
+ * / paths / counts — none of them are subcommand keywords.
+ *
+ * Built with `arrayFirst` over `arraySlice` to walk tokens.
+ */
+/**
+ * Mirrors `isFlagLikeToken` in `@domain/spans/.../build-report.ts` — both
+ * must stay in lockstep. Skips:
+ *   `-flag` / `--flag`         : CLI flags
+ *   `@scope/...`               : scoped package args
+ *   any `/`-containing token   : paths AND `owner/repo`-style slugs
+ *                                 (`gh -R owner/repo …` would otherwise
+ *                                 have `owner/repo` survive as the
+ *                                 "subcommand")
+ *   `.foo`                     : relative paths without `/`
+ *   `key=value`                : `--key=value` syntax
+ *   purely numeric             : counts (`head -n 50`)
+ */
+const FLAG_LIKE_TOKEN_PREDICATE = `(t = ''
+  OR startsWith(t, '-')
+  OR startsWith(t, '@')
+  OR startsWith(t, '.')
+  OR position(t, '/') > 0
+  OR position(t, '=') > 0
+  OR match(t, '^[0-9]+$'))`
+
+const subcommandAwarePatternSql = (segmentExpr: string): string => {
+  // Each branch needs the normalised segment, its first token (prefix),
+  // and the first non-flag token after the prefix (the subcommand
+  // candidate). Substitute these once so the multiIf body stays readable.
+  const norm = normalizeSegmentSql(segmentExpr)
+  const prefix = `lowerUTF8(splitByChar(' ', ${norm})[1])`
+  const firstNonFlagAfterPrefix = `coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                       arraySlice(splitByChar(' ', ${norm}), 2)), '')`
+  const secondNonFlagAfterPrefix = `coalesce(arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                        arraySlice(splitByChar(' ', ${norm}),
+                                                                   indexOf(splitByChar(' ', ${norm}),
+                                                                           arrayFirst(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                                                                      arraySlice(splitByChar(' ', ${norm}), 2))) + 1)), '')`
+  return `
+    multiIf(
+      -- Plumbing prefixes → empty (no displayable pattern at all).
+      ${prefix} IN ${BASH_PLUMBING_PREFIXES_SQL}, '',
+
+      -- Search prefixes → empty. Option C: top-commands shows only
+      -- segments routing to \`bash\` or \`research\`; investigation
+      -- tools (grep / ls / find / …) are summarised by the search
+      -- bucket's share in the personality, not by surfacing each
+      -- command in the display.
+      ${prefix} IN ${BASH_SEARCH_PREFIXES_SQL}, '',
+
+      -- Git non-bash subcommands → empty. \`git status\` / \`git log\`
+      -- / \`git diff\` etc. are search; \`git checkout\` / \`switch\`
+      -- etc. are excluded. Either way they don't belong in the
+      -- top-commands display.
+      ${prefix} = 'git' AND lowerUTF8(${firstNonFlagAfterPrefix}) IN ${GIT_NON_BASH_SUBCOMMANDS_SQL}, '',
+
+      -- gh: two-deep extraction (\`gh pr create\` is meaningfully
+      -- different from \`gh pr view\`). All gh segments are kept
+      -- because they route to either \`bash\` (write-ops + auth/config)
+      -- or \`research\` (read-side) — both allowed under Option C.
+      ${prefix} = 'gh',
+      arrayStringConcat(
+        arrayFilter(p -> p != '',
+          [
+            'gh',
+            ${firstNonFlagAfterPrefix},
+            ${secondNonFlagAfterPrefix}
+          ]),
+        ' '
+      ),
+
+      -- 1-deep extraction for the known multi-action prefixes.
+      ${prefix} IN ${SUBCOMMAND_AWARE_PREFIXES_SQL},
+      arrayStringConcat(
+        arrayFilter(p -> p != '',
+          [
+            splitByChar(' ', ${norm})[1],
+            ${firstNonFlagAfterPrefix}
+          ]),
+        ' '
+      ),
+
+      -- Default: just the first token.
+      splitByChar(' ', ${norm})[1]
+    )
+  `
+}
+
 // Shared filter parameters appended to every project-window query so the same
 // keys are used everywhere and the centralised filter stays in sync.
 const projectWindowParams = (params: {
@@ -83,6 +349,7 @@ interface TotalsCHRow {
   readonly repos: number | string
   readonly streak_days: number | string
   readonly tests_run: number | string
+  readonly git_write_ops: number | string
 }
 
 interface LocStatsCHRow {
@@ -107,6 +374,10 @@ interface DurationStatsCHRow {
 
 interface ToolMixCHRow {
   readonly tool_name: string
+  readonly file_disposition: string
+  readonly bash_prefix: string
+  readonly bash_second_token: string
+  readonly bash_third_token: string
   readonly uses: number | string
 }
 
@@ -232,27 +503,72 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // `commands_run`, `tests_run` and `git_write_ops` derive from
+            // *Bash segments* (so `cd foo && grep bar && git push` counts
+            // as three segments — one navigation, one search, one push).
+            // The bash_segments CTE explodes each Bash tool call into its
+            // operator-split segments; the outer query joins the segment
+            // counters in with the rest of the per-span aggregates.
             const result = await client.query({
               query: `
+                WITH bash_segments AS (
+                  -- second_token / third_token use flag-skipping so
+                  -- \`git -C /path status -s\` matches the git_write_ops
+                  -- predicate correctly (second_token = "status", not
+                  -- the literal "-c"). Segment normalisation strips
+                  -- line continuations and collapses whitespace before
+                  -- tokenising. Mirrors extractBashTokens in
+                  -- build-report.ts.
+                  SELECT
+                    lowerUTF8(splitByChar(' ', ${normalizeSegmentSql("segment")})[1])               AS prefix,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
+                      1
+                    ))                                                                              AS second_token,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
+                      2
+                    ))                                                                              AS third_token,
+                    segment
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
                 SELECT
                   countDistinctIf(session_id, session_id != '')                                       AS sessions,
                   countIf(operation = 'execute_tool')                                                 AS tool_calls,
                   countDistinctIf(
                     JSONExtractString(tool_input, 'file_path'),
-                    tool_name IN (${FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")})
+                    tool_name IN (${FILE_PATH_TOOLS_SQL})
                     AND JSONExtractString(tool_input, 'file_path') != ''
+                    AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   )                                                                                   AS files_touched,
-                  countIf(tool_name = 'Bash')                                                         AS commands_run,
+                  -- "Commands run" excludes pure plumbing (head/tail/echo/sed/…
+                  -- and navigation cd/pwd/open/…). These are never standalone
+                  -- work; they'd inflate the headline number without telling
+                  -- a story.
+                  (SELECT countIf(prefix NOT IN ${BASH_PLUMBING_PREFIXES_SQL})
+                    FROM bash_segments)                                                               AS commands_run,
                   countDistinctIf(metadata['workspace.name'], metadata['workspace.name'] != '')       AS workspaces,
                   countDistinctIf(metadata['git.branch'],     metadata['git.branch']     != '')       AS branches,
                   countDistinctIf(metadata['git.commit'],     metadata['git.commit']     != '')       AS commits,
                   countDistinctIf(metadata['git.repo'],       metadata['git.repo']       != '')       AS repos,
                   uniqExact(toDate(start_time))                                                       AS streak_days,
-                  countIf(
-                    tool_name = 'Bash'
-                    AND match(JSONExtractString(tool_input, 'command'),
-                      '(?i)(^|\\s)(test(\\s|:|$)|pytest|vitest|jest|mocha|rspec)')
-                  )                                                                                   AS tests_run
+                  (SELECT countIf(match(segment,
+                      '(?i)(^|\\\\s)(test(\\\\s|:|$)|pytest|vitest|jest|mocha|rspec)'))
+                    FROM bash_segments)                                                               AS tests_run,
+                  -- Both git write-subcommands AND gh write-op triplets feed
+                  -- gitWriteOps. The persisted field name stays gitWriteOps
+                  -- (no schema migration) even though gh is now included.
+                  (SELECT countIf(
+                    (prefix = 'git' AND second_token IN ${GIT_WRITE_SUBCOMMANDS_SQL})
+                    OR (prefix = 'gh' AND ${GH_WRITE_OPS_PREDICATE})
+                  ) FROM bash_segments)                                                               AS git_write_ops
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
               `,
@@ -271,6 +587,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
               repos: 0,
               streakDays: 0,
               testsRun: 0,
+              gitWriteOps: 0,
             }
             if (!row) return empty
             return {
@@ -284,6 +601,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
               repos: num(row.repos),
               streakDays: num(row.streak_days),
               testsRun: num(row.tests_run),
+              gitWriteOps: num(row.git_write_ops),
             }
           })
           .pipe(Effect.mapError((error) => toRepositoryError(error, "getTotalsForProject")))
@@ -297,25 +615,43 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
             // countSubstrings counts non-overlapping occurrences — equivalent
             // to "lines of code" when measured by '\n'. We treat the final
             // line as "complete enough" for the aggregate.
+            //
+            // These are the *headline* LOC counters — they include
+            // plan-mode iterations (`~/.claude/plans/*.md` edits) because
+            // those are real lines you wrote this week, while still
+            // excluding `.claude/` config noise and out-of-workspace
+            // scratch.
             const result = await client.query({
               query: `
                 SELECT
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'content'),    '\\n'),
-                        tool_name = 'Write')                                          AS write_lines,
+                        tool_name = 'Write'
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS write_lines,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'new_string'), '\\n'),
-                        tool_name IN ('Edit', 'NotebookEdit'))                        AS edit_added,
+                        tool_name IN ('Edit', 'NotebookEdit')
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS edit_added,
                   sumIf(countSubstrings(JSONExtractString(tool_input, 'old_string'), '\\n'),
-                        tool_name IN ('Edit', 'NotebookEdit'))                        AS edit_removed,
+                        tool_name IN ('Edit', 'NotebookEdit')
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS edit_removed,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'new_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
-                        )), tool_name = 'MultiEdit')                                  AS multiedit_added,
+                        )), tool_name = 'MultiEdit'
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS multiedit_added,
                   sumIf(arraySum(arrayMap(
                           x -> countSubstrings(JSONExtractString(x, 'old_string'), '\\n'),
                           JSONExtractArrayRaw(tool_input, 'edits')
-                        )), tool_name = 'MultiEdit')                                  AS multiedit_removed,
+                        )), tool_name = 'MultiEdit'
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS multiedit_removed,
                   sumIf(countSubstrings(tool_output, '\\n'),
-                        tool_name IN ('Read', 'NotebookRead'))                        AS read_lines
+                        tool_name IN ('Read', 'NotebookRead')
+                        AND ${loCountablePathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")})
+                                                                                       AS read_lines
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
               `,
@@ -349,6 +685,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                 WHERE ${PROJECT_WINDOW_FILTER}
                   AND tool_name = 'Write'
                   AND JSONExtractString(tool_input, 'file_path') != ''
+                  AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                 ORDER BY lines DESC
                 LIMIT 1
               `,
@@ -408,14 +745,77 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // The query unions two row sources:
+            //
+            //   1. Non-Bash tool calls — one row each, with a path
+            //      disposition tag for the path-aware tools (Read / Edit /
+            //      Write / NotebookEdit / NotebookRead / MultiEdit). The
+            //      domain-side classifier in `build-report.ts` uses the
+            //      disposition to route `.claude/plans/*.md` edits to the
+            //      `plan` bucket and drop `.claude/**` config + scratch
+            //      paths entirely.
+            //
+            //   2. Bash command *segments* — every Bash tool call is
+            //      exploded on `&&` / `||` / `;` / `|`, each segment's
+            //      first two tokens are lowercased, and the row carries
+            //      `(bash_prefix, bash_second_token)`. The classifier
+            //      routes by prefix (`grep` → search, `cat` → read, etc.)
+            //      and `git`-by-subcommand (`git status` → search,
+            //      `git push` → bash, `git checkout` → excluded).
+            //
+            // GROUP BY collapses repeats so the wire payload stays
+            // bounded; cardinality is bounded by tool names × distinct
+            // first-two-token pairs in user Bash + 4 disposition values.
             const result = await client.query({
               query: `
-                SELECT tool_name, count() AS uses
-                FROM spans
-                WHERE ${PROJECT_WINDOW_FILTER}
-                  AND operation = 'execute_tool'
-                  AND tool_name != ''
-                GROUP BY tool_name
+                SELECT tool_name, file_disposition, bash_prefix, bash_second_token, bash_third_token, count() AS uses
+                FROM (
+                  SELECT
+                    tool_name,
+                    ${filePathDispositionSql("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")} AS file_disposition,
+                    ''  AS bash_prefix,
+                    ''  AS bash_second_token,
+                    ''  AS bash_third_token
+                  FROM spans
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND operation = 'execute_tool'
+                    AND tool_name != ''
+                    AND tool_name != 'Bash'
+
+                  UNION ALL
+
+                  -- Bash second/third tokens use flag-skipping (same rule
+                  -- as the display layer): filter out flag-like tokens
+                  -- (-flag, paths, scopes, k=v, numerics) from the
+                  -- post-prefix slice, then take the 1st / 2nd of what
+                  -- remains. So \`git -C /path status -s\` produces
+                  -- (git, status, "") and \`gh -R owner/repo pr create\`
+                  -- produces (gh, pr, create). Segment normalisation
+                  -- strips line continuations + collapses whitespace
+                  -- first so multi-line bash commands tokenise cleanly.
+                  -- Mirrors \`extractBashTokens\` in build-report.ts.
+                  SELECT
+                    'Bash' AS tool_name,
+                    ''     AS file_disposition,
+                    lowerUTF8(splitByChar(' ', ${normalizeSegmentSql("segment")})[1])               AS bash_prefix,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
+                      1
+                    ))                                                                              AS bash_second_token,
+                    lowerUTF8(arrayElement(
+                      arrayFilter(t -> NOT ${FLAG_LIKE_TOKEN_PREDICATE},
+                                  arraySlice(splitByChar(' ', ${normalizeSegmentSql("segment")}), 2)),
+                      2
+                    ))                                                                              AS bash_third_token
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
+                GROUP BY tool_name, file_disposition, bash_prefix, bash_second_token, bash_third_token
               `,
               query_params: projectWindowParams(params),
               format: "JSONEachRow",
@@ -424,7 +824,14 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
           })
           .pipe(
             Effect.map((rows): readonly ToolMixRow[] =>
-              rows.map((row) => ({ toolName: row.tool_name, uses: num(row.uses) })),
+              rows.map((row) => ({
+                toolName: row.tool_name,
+                fileDisposition: (row.file_disposition || "") as ToolMixRow["fileDisposition"],
+                bashPrefix: row.bash_prefix,
+                bashSecondToken: row.bash_second_token,
+                bashThirdToken: row.bash_third_token,
+                uses: num(row.uses),
+              })),
             ),
             Effect.mapError((error) => toRepositoryError(error, "getToolMix")),
           )
@@ -435,6 +842,10 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // Excludes `.claude/**` and out-of-workspace paths — the
+            // "top files" table reflects *this project's* hot files only,
+            // so a Read against `/Users/x/notes.md` or an Edit on
+            // `.claude/settings.local.json` doesn't crowd the list.
             const result = await client.query({
               query: `
                 SELECT
@@ -442,8 +853,9 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   count() AS touches
                 FROM spans
                 WHERE ${PROJECT_WINDOW_FILTER}
-                  AND tool_name IN (${FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")})
+                  AND tool_name IN (${FILE_PATH_TOOLS_SQL})
                   AND JSONExtractString(tool_input, 'file_path') != ''
+                  AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                 GROUP BY path
                 ORDER BY touches DESC
                 LIMIT 5
@@ -466,15 +878,25 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // Counts command segments (a chained `cd foo && grep bar`
+            // contributes a `cd` and a `grep`). Plumbing prefixes
+            // (tail/head/echo/sed/…) are excluded so the list reflects
+            // intentional work. For multi-action prefixes (git, pnpm,
+            // gh, …) the pattern is `prefix subcommand` instead of just
+            // the prefix — `git push` and `git status` show distinctly.
             const result = await client.query({
               query: `
-                SELECT
-                  splitByChar(' ', trim(BOTH ' ' FROM JSONExtractString(tool_input, 'command')))[1] AS pattern,
-                  count() AS uses
-                FROM spans
-                WHERE ${PROJECT_WINDOW_FILTER}
-                  AND tool_name = 'Bash'
-                  AND JSONExtractString(tool_input, 'command') != ''
+                SELECT pattern, count() AS uses
+                FROM (
+                  SELECT ${subcommandAwarePatternSql("segment")} AS pattern
+                  FROM spans
+                  ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                            JSONExtractString(tool_input, 'command')) AS segment
+                  WHERE ${PROJECT_WINDOW_FILTER}
+                    AND tool_name = 'Bash'
+                    AND segment != ''
+                )
+                WHERE pattern != ''
                 GROUP BY pattern
                 ORDER BY uses DESC
                 LIMIT 5
@@ -589,21 +1011,26 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   FROM spans
                   WHERE ${PROJECT_WINDOW_FILTER}
                     AND metadata['workspace.name'] = {workspaceName:String}
-                    AND tool_name IN ('Read','NotebookRead','Edit','NotebookEdit','MultiEdit','Write')
+                    AND tool_name IN ${PATH_AWARE_TOOLS_SQL}
                     AND JSONExtractString(tool_input, 'file_path') != ''
+                    AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
                   GROUP BY path
                   ORDER BY touches DESC
                   LIMIT 3
                 ),
                 commands AS (
-                  SELECT
-                    splitByChar(' ', trim(BOTH ' ' FROM JSONExtractString(tool_input, 'command')))[1] AS pattern,
-                    count() AS uses
-                  FROM spans
-                  WHERE ${PROJECT_WINDOW_FILTER}
-                    AND metadata['workspace.name'] = {workspaceName:String}
-                    AND tool_name = 'Bash'
-                    AND JSONExtractString(tool_input, 'command') != ''
+                  SELECT pattern, count() AS uses
+                  FROM (
+                    SELECT ${subcommandAwarePatternSql("segment")} AS pattern
+                    FROM spans
+                    ARRAY JOIN splitByRegexp('${BASH_SEGMENT_REGEX}',
+                                              JSONExtractString(tool_input, 'command')) AS segment
+                    WHERE ${PROJECT_WINDOW_FILTER}
+                      AND metadata['workspace.name'] = {workspaceName:String}
+                      AND tool_name = 'Bash'
+                      AND segment != ''
+                  )
+                  WHERE pattern != ''
                   GROUP BY pattern
                   ORDER BY uses DESC
                   LIMIT 3
@@ -625,7 +1052,23 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   (SELECT topKIf(3)(metadata['git.branch'], metadata['git.branch'] != '') FROM spans
                     WHERE ${PROJECT_WINDOW_FILTER}
                       AND metadata['workspace.name'] = {workspaceName:String}) AS top_branches,
-                  (SELECT topKIf(1)(tool_name, operation = 'execute_tool' AND tool_name != '') FROM spans
+                  -- "Mostly X" descriptor. Path-aware tools (Read/Edit/Write/…)
+                  -- only count when their file_path is inside the workspace
+                  -- path — an Edit targeting a sibling project shouldn't make
+                  -- you look like an "Edit-mostly" user *in this workspace*.
+                  -- Non-path-aware tools (Bash/Grep/Glob/TaskCreate/…) carry
+                  -- no file_path and count as-is.
+                  (SELECT topKIf(1)(tool_name,
+                    operation = 'execute_tool'
+                    AND tool_name != ''
+                    AND (
+                      tool_name NOT IN ${PATH_AWARE_TOOLS_SQL}
+                      OR (
+                        JSONExtractString(tool_input, 'file_path') != ''
+                        AND ${workspaceStrictPathPredicate("metadata['workspace.path']", "JSONExtractString(tool_input, 'file_path')")}
+                      )
+                    )
+                  ) FROM spans
                     WHERE ${PROJECT_WINDOW_FILTER}
                       AND metadata['workspace.name'] = {workspaceName:String}) AS dominant_tool,
                   (SELECT groupArray(path)          FROM files) AS top_file_paths,

--- a/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
+++ b/packages/platform/db-postgres/src/repositories/oauth-key-repository.ts
@@ -90,6 +90,47 @@ export const OAuthKeyRepositoryLive = Layer.effect(
         return rows.length > 0
       }),
 
+    findByPair: (input) =>
+      Effect.gen(function* () {
+        const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>
+        const rows = yield* sqlClient.query((db, organizationId) =>
+          db
+            .select({
+              clientId: oauthApplications.clientId,
+              clientName: oauthApplications.name,
+              clientIcon: oauthApplications.icon,
+              disabled: oauthApplications.disabled,
+              userId: oauthAccessTokens.userId,
+              userName: users.name,
+              userEmail: users.email,
+              lastActivityAt: max(oauthAccessTokens.updatedAt),
+              connectedAt: max(oauthAccessTokens.createdAt),
+            })
+            .from(oauthApplications)
+            .innerJoin(oauthAccessTokens, eq(oauthAccessTokens.clientId, oauthApplications.clientId))
+            .innerJoin(users, eq(users.id, oauthAccessTokens.userId))
+            .where(
+              and(
+                eq(oauthApplications.organizationId, organizationId),
+                eq(oauthApplications.clientId, input.clientId),
+                eq(oauthAccessTokens.userId, input.userId),
+              ),
+            )
+            .groupBy(
+              oauthApplications.clientId,
+              oauthApplications.name,
+              oauthApplications.icon,
+              oauthApplications.disabled,
+              oauthAccessTokens.userId,
+              users.name,
+              users.email,
+            )
+            .limit(1),
+        )
+        const row = rows[0]
+        return row ? toDomain(row) : null
+      }),
+
     deleteTokensForPair: (input) =>
       Effect.gen(function* () {
         const sqlClient = (yield* SqlClient) as SqlClientShape<Operator>

--- a/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
+++ b/packages/platform/db-postgres/src/repositories/wrapped-report-repository.test.ts
@@ -33,6 +33,7 @@ const sampleReport: Report = {
     repos: 1,
     streakDays: 5,
     testsRun: 9,
+    gitWriteOps: 4,
   },
   toolMix: { bash: 15, read: 25, edit: 50, write: 5, search: 5, research: 0, plan: 0, other: 0 },
   loc: {

--- a/plans/mcp-oauth-api-expansion.md
+++ b/plans/mcp-oauth-api-expansion.md
@@ -737,11 +737,11 @@ Source of truth for what's shipped vs. outstanding. Update inline as PRs land.
 ### Outstanding
 
 - **M-OAuthKeysApi — Public OAuth Keys endpoints** (3 endpoints, prefix `/oauth-keys`, **never expose tokens**)
-  - [ ] `GET /` — list, `low` tier. Reuses `listOAuthKeysUseCase` from `@domain/oauth-keys`. Response is the metadata-only `OAuthKey` shape (id, clientId, clientName, clientIcon, userId, userName, userEmail, lastActivityAt, connectedAt, disabled). **No `access_token` / `refresh_token` / hashed-token / masked-token field on any response.**
-  - [ ] `GET /{oauthKeyId}` — get one by composite `${clientId}:${userId}` id, `low` tier. Use-case extension: add `findById(id)` to `@domain/oauth-keys` (parses the composite, then JOIN-reads the same row shape `listForOrganization` returns, RLS-scoped). 404s on miss / cross-tenant.
-  - [ ] `DELETE /{oauthKeyId}` — revoke, `medium` tier. Parses the composite id and reuses `revokeOAuthKeyUseCase` (already cache-invalidates and disables the application when the last token is removed). 204 on success, 404 when the id doesn't resolve under the caller's org.
-  - [ ] `apps/api/src/routes/oauth-keys.ts` — new file, `defineApiEndpoint` from the start. Mounted with `low` tier; the DELETE endpoint applies `medium` via the per-tier override. Wires `OAuthTokenCacheInvalidatorLive(c.var.redis)` + `OAuthKeyRepositoryLive`.
-  - [ ] No POST / PATCH. Out-of-scope notes already in the "Endpoint inventory" section above.
+  - [x] `GET /` — list, `low` tier. Reuses `listOAuthKeysUseCase`. Response is the metadata-only `OAuthKey` shape — no token field of any kind.
+  - [x] `GET /{oauthKeyId}` — get one by composite `${clientId}:${userId}` id, `low` tier. New `getOAuthKeyUseCase` calls `OAuthKeyRepository.findByPair` (JOIN-reads the same shape as `listForOrganization`, RLS-scoped). 404s on miss / malformed id / cross-tenant — all collapse to the same `OAuthKeyNotFoundError`.
+  - [x] `DELETE /{oauthKeyId}` — revoke, mounted under the `low` tier prefix; reuses `revokeOAuthKeyUseCase` (cache-invalidates each removed token and disables the application when the last token is gone). 204 on success and on idempotent re-revoke; 404 only for cross-tenant / malformed ids.
+  - [x] `apps/api/src/routes/oauth-keys.ts` — new file, `defineApiEndpoint`-native. Wires `OAuthTokenCacheInvalidatorLive(c.var.redis)` + `OAuthKeyRepositoryLive`. Composite id parsed via `lastIndexOf(":")` since `userId` is a CUID (no colons).
+  - [x] No POST / PATCH. Out-of-scope notes in the "Endpoint inventory" section.
 - **M4 — Traces + bulk export** (3 endpoints, prefix `/projects/{projectSlug}/traces`)
   - [ ] `GET /` — list with filters + searchQuery + cursor, `Paginated(TraceSchema, "PaginatedTraces")` (`high` tier)
   - [ ] `GET /{traceId}` — get (`medium` tier)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@domain/flaggers':
         specifier: workspace:*
         version: link:../../packages/domain/flaggers
+      '@domain/oauth-keys':
+        specifier: workspace:*
+        version: link:../../packages/domain/oauth-keys
       '@domain/organizations':
         specifier: workspace:*
         version: link:../../packages/domain/organizations
@@ -282,7 +285,7 @@ importers:
         version: link:../../packages/platform/testkit
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
 
   apps/ingest:
     dependencies:
@@ -2178,13 +2181,13 @@ importers:
         version: 7.0.0-dev.20260421.2
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.3)
+        version: 0.21.9(@typescript/native-preview@7.0.0-dev.20260421.2)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/telemetry/claude-code:
     dependencies:
@@ -17456,14 +17459,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -18807,14 +18802,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -22756,30 +22743,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
-    dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   rolldown@1.0.0-rc.16:
     dependencies:
       '@oxc-project/types': 0.126.0
@@ -23910,25 +23873,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 22.14.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.2
-      tsx: 4.21.0
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vitefu@1.1.3(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -23954,35 +23898,6 @@ snapshots:
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.14.1
-      jsdom: 29.0.2(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@22.14.1)(jsdom@29.0.2(@noble/hashes@2.2.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.1)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,7 +34,7 @@ catalog:
   fast-json-stable-stringify: 2.1.0
   "@effect/opentelemetry": 4.0.0-beta.57
   effect: 4.0.0-beta.57
-  hono: 4.12.16
+  hono: 4.12.18
   ioredis: 5.10.1
   pg: 8.16.0
   react: 19.2.5

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,9 +36,11 @@ git diff --shortstat origin/main..origin/development
 echo ""
 
 # Candidate main-only commits by SHA reachability. We verify each below by
-# checking whether the files it touched still differ between main and
-# development — this catches cherry-picks that were squash-merged, which
-# `git log --cherry-pick` (patch-id based) cannot detect.
+# reverse-applying the commit's patch against an `origin/development`
+# worktree — this is what `git rebase` uses to detect already-applied
+# commits, and it catches squash-merged cherry-picks even when development
+# has additional changes on the same files (which a per-file diff check
+# would misreport as missing).
 candidate_shas=$(git log \
   --format='%H' \
   --right-only \
@@ -47,20 +49,17 @@ candidate_shas=$(git log \
   --grep='^Release -' \
   origin/development...origin/main)
 
+verify_worktree=$(mktemp -d -t release-verify.XXXXXX)
+trap 'git worktree remove --force "$verify_worktree" >/dev/null 2>&1; rm -rf "$verify_worktree"' EXIT
+git worktree add --detach --quiet "$verify_worktree" origin/development
+
 main_only_commits=""
 while IFS= read -r sha; do
   [ -z "$sha" ] && continue
-  reflected=true
-  while IFS= read -r file; do
-    [ -z "$file" ] && continue
-    if ! git diff --quiet origin/development origin/main -- "$file" 2>/dev/null; then
-      reflected=false
-      break
-    fi
-  done < <(git show --name-only --format='' "$sha")
-  if [ "$reflected" = false ]; then
-    main_only_commits+="$(git log -1 --format='%h %s' "$sha")"$'\n'
+  if git diff --binary "$sha^..$sha" | git -C "$verify_worktree" apply --check --reverse >/dev/null 2>&1; then
+    continue
   fi
+  main_only_commits+="$(git log -1 --format='%h %s' "$sha")"$'\n'
 done <<<"$candidate_shas"
 
 if [ -n "$main_only_commits" ]; then


### PR DESCRIPTION
Promotes `development` to `main` for a release.

## Commits

- 85c54786b ci(npm): use trusted publishing for packages
- eb261d750 feat(wrapped): rebalance personality routing (#3117)
- b133e6ef1 fix(release): verify cherry-picks by reverse-applying patches (#3114)
- 53187a799 fix(web): inline wrapped OG personality PNGs at build time (#3118)
- e4ea741bc feat(infra): add SOC II security compliance controls
- 63bfc630d feat(api): OAuth keys public API + MCP-server instructions + described project settings (#3119)
- a14ef96a6 chore(infra): remove legacy GitHub deploy role
- 19ca2557e feat(infra): use GitHub OIDC deploy roles
- 1a09b8a82 chore(infra): finalize encrypted production Aurora (#3115)
- f379bccc4 chore(deps): bump hono in the npm_and_yarn group across 1 directory (#3094)
- 393edac17 chore: update bundled models.dev data (#3112)
- 6c67cd665 feat(web): sessions section + OAuth keys settings page (#3110)
- 7bffc7972 fix(db-clickhouse): lock sequential migration creation
- 1482ff3de feat(issues): seasonal anomaly detection for issue escalation (#3054)
- 21f94f145 feat: Claude Code Wrapped — public shareable reports (#3109)
- 33461b2f5 feat: add Latitude telemetry bootstrap class (#3063)
- 28372e502 fix(ai-vercel): avoid exporting effect generate spans
- 27499ae1d fix(spans): optimize trace detail span queries (#3105)
- cc60f3edb fix(flaggers): swap FLAGGER_MODEL to MiniMax M2.5 and align max tokens (#3106)
- 1554b776d Add segmented trace search editor (#3098)
- a35386fe8 feat(api): annotations + scores routes through defineApiEndpoint (#3107)
- 0b2706617 feat: Claude Code Wrapped — rebalance personalities and emphasize LOC anchor (#3104)
- e4b35f231 fix(flaggers): provide fake sql client in run flagger tests
- 97fe1482a fix(flaggers): prevent disabled flaggers from running LLM phase
- 2667de628 Fix LAT-573 by enabling latitude telemetry for latitude (#3103)
- 9b4084fe9 fix(release): detect squash-merged cherry-picks and disable pagers (#3101)
- 89db8ff9d feat(api): toggle project flaggers via PATCH /projects/{slug} (#3102)
- 1087effe1 docs: teach agents the PR base branch convention (#3099)
- d973f86e1 feat(api): projects routes through defineApiEndpoint with paginated list (#3097)
- e2384584e chore: update bundled models.dev data (#3066)
- acdf5c139 docs(skills): register temporal-developer skill and document workflow versioning (#3096)
- 7bb95e958 feat(api): members endpoints + invitation parity with Better Auth (#3095)
- cb30a0371 feat: Claude Code Wrapped — per-project weekly digest emails (#3093)
- 7d797877f fix(web): show agent annotations on conversation tab (LAT-572, LAT-568) (#3058)
- c3ac35ed9 docs: add llms.txt for AI-readable docs index (#2969)
- 3e69aff99 fix(flaggers): use minimax for draft annotations
- 367270f4c fix(flaggers): use haiku for draft annotations
- dd6d474e2 fix(web): make evaluation filter modal popups clickable (#3070)
- 6b31b4c99 fix: vertically center user avatar in navbar (#3010)
- 01cf53391 fix(flaggers): improve draft generation diagnostics
- be652e708 feat(api): GET /api-keys/:id, PATCH /api-keys/:id, masked token on list (#3090)
- 0f1135719 feat(api): GET /v1/account — caller account snapshot (#3089)
- 4a093f660 chore(security): pin every dep and harden supply-chain config (#3069)
- a0b37b230 feat(evaluations): scope which traces an evaluation runs on (LAT-570) (#3062)
- 2464e31ea fix(infra): set cache redis eviction policy
- 03108e859 chore(tooling): allow MCP inspector script in knip
- 159508a28 chore(db-clickhouse): drop legacy trace search embeddings table
- 4a86c24da chore(deps): pin TanStack deps and add 7-day minimum-release-age guard (#3067)
- 734f2c1b1 Lat 567/polish some mcp devex (#3059)
- c630be06f Add screen redirect for mobile users (#3064)