### PR TITLE
fix(wrapped): narrow bash splitter to && / ||; exclude shell keywords

### DIFF
--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -335,6 +335,27 @@ describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", 
     // `echo` → plumbing → excluded.
     expect(classify("\\\n  echo something")).toBe("excluded")
   })
+
+  it("bash block-start keywords (`for`/`while`/`if`/`case`) classify as excluded", () => {
+    // After dropping `;` from the chain splitter, a loop or conditional
+    // is a single segment whose prefix is the block-start keyword.
+    // `for x in *; do something; done` → prefix `for`. None of these
+    // are commands the user "ran" — they're bash reserved words.
+    expect(classify("for x in *; do echo $x; done")).toBe("excluded")
+    expect(classify("while read line; do something; done < file")).toBe("excluded")
+    expect(classify("if [ -z $x ]; then echo empty; fi")).toBe("excluded")
+    expect(classify("case $x in foo) bar;; esac")).toBe("excluded")
+  })
+
+  it("after-`;` keywords (`do`/`then`/`fi`) also classify as excluded if they ever surface as a prefix", () => {
+    // Defensive: covers the edge case where some other split lands a
+    // keyword at the start of a segment. With `;` no longer in the
+    // splitter this is rare in practice, but the plumbing entry keeps
+    // the contract clean.
+    for (const kw of ["do", "done", "then", "else", "elif", "fi", "esac", "in"]) {
+      expect(classify(`${kw} something`)).toBe("excluded")
+    }
+  })
 })
 
 describe("classifyToolMixRow — Bash sub-classification", () => {

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.test.ts
@@ -9,6 +9,7 @@ import {
   classifyToolMixRow,
   extractBashTokens,
   isGitWriteSegment,
+  splitBashSegments,
   toolBucketFor,
 } from "./build-report.ts"
 
@@ -154,6 +155,60 @@ describe("toolBucketFor", () => {
   it("falls back to other for unknown tools", () => {
     expect(toolBucketFor("MysteryTool")).toBe("other")
     expect(toolBucketFor("")).toBe("other")
+  })
+})
+
+describe("splitBashSegments (the regex that maps to the CH adapter)", () => {
+  it("splits on && and ||", () => {
+    expect(splitBashSegments("a && b")).toEqual(["a", "b"])
+    expect(splitBashSegments("a || b")).toEqual(["a", "b"])
+    expect(splitBashSegments("a && b || c")).toEqual(["a", "b", "c"])
+  })
+
+  it("does NOT split on a literal `|` (which appears inside grep regex alternations and shell pipes)", () => {
+    // Before this fix, `grep "service.name\|api[_-]key"` was split at
+    // the `\|` mid-regex, producing junk segments like `api[_-]key\`
+    // in the top-commands list.
+    expect(splitBashSegments('grep "service.name\\|api[_-]key" file')).toEqual([
+      'grep "service.name\\|api[_-]key" file',
+    ])
+    // Shell pipes also collapse into one segment now.
+    expect(splitBashSegments("pnpm test 2>&1 | tail -8")).toEqual(["pnpm test 2>&1 | tail -8"])
+    // Multiple pipes don't split either.
+    expect(splitBashSegments("find . | xargs grep | sort")).toEqual(["find . | xargs grep | sort"])
+  })
+
+  it("does NOT split on `;` (SQL statement separators and shell loop bodies)", () => {
+    // Before this fix, `psql -c "alter …; set(x); …"` was split at the
+    // `;` mid-SQL, producing a segment starting with `set(evals_sched)`.
+    expect(splitBashSegments('psql -c "alter ...; set(x); reset();"')).toEqual([
+      'psql -c "alter ...; set(x); reset();"',
+    ])
+    // Similarly, a for-loop body stays in one segment so `do` doesn't
+    // surface as a "command."
+    expect(splitBashSegments("for x in *; do echo $x; done")).toEqual(["for x in *; do echo $x; done"])
+  })
+
+  it("trims whitespace around operators", () => {
+    expect(splitBashSegments("a  &&  b")).toEqual(["a", "b"])
+    expect(splitBashSegments("a\t&&\tb")).toEqual(["a", "b"])
+  })
+
+  it("filters out empty segments", () => {
+    expect(splitBashSegments("a &&")).toEqual(["a"])
+    expect(splitBashSegments("&& a")).toEqual(["a"])
+    expect(splitBashSegments("")).toEqual([])
+    expect(splitBashSegments("   ")).toEqual([])
+  })
+
+  it("handles the canonical mixed case: real chain operators split, embedded pipes/semicolons don't", () => {
+    // `cd .. && grep "foo\|bar" file && pnpm test | tail`
+    // → 3 segments (split on the two `&&`s, not on `\|` or `|`).
+    expect(splitBashSegments('cd .. && grep "foo\\|bar" file && pnpm test | tail')).toEqual([
+      "cd ..",
+      'grep "foo\\|bar" file',
+      "pnpm test | tail",
+    ])
   })
 })
 
@@ -355,6 +410,69 @@ describe("extractBashTokens + classifyToolMixRow (end-to-end on raw segments)", 
     for (const kw of ["do", "done", "then", "else", "elif", "fi", "esac", "in"]) {
       expect(classify(`${kw} something`)).toBe("excluded")
     }
+  })
+})
+
+describe("splitter + classifier (full pipeline, raw bash → bucket)", () => {
+  // Walks raw bash command strings through the same three steps the CH
+  // adapter does at scale: split → extract tokens → classify. If ANY
+  // stage of the pipeline regresses (splitter, tokeniser, or
+  // classifier), one of these assertions fails.
+  const classifyRawCommand = (rawCommand: string): readonly ReturnType<typeof classifyToolMixRow>[] =>
+    splitBashSegments(rawCommand).map((segment) => {
+      const t = extractBashTokens(segment)
+      return classifyToolMixRow(
+        row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken }),
+      )
+    })
+
+  it("grep with `\\|` alternation is ONE search segment (not three junk segments)", () => {
+    // Pre-fix this command produced segments `grep "service.name\`,
+    // `api[_-]key\`, and `openclaw" file` — the middle one showed up as
+    // a "top command." After the splitter narrows to `&&` and `||`,
+    // it's a single segment that routes cleanly to `search`.
+    expect(classifyRawCommand('grep "service.name\\|api[_-]key\\|openclaw" file')).toEqual(["search"])
+  })
+
+  it("psql with `;` inside SQL is ONE bash segment (not junk segments per statement)", () => {
+    // Pre-fix this command split at every `;` inside the SQL, producing
+    // segments like `set(evals_sched)` as top commands. After the fix
+    // it's a single segment routed to `bash`.
+    expect(classifyRawCommand('psql -c "alter table foo; set(evals_sched); reset();"')).toEqual(["bash"])
+  })
+
+  it("`for x in *; do echo $x; done` is ONE excluded segment (not three with `do` as a command)", () => {
+    expect(classifyRawCommand("for x in *; do echo $x; done")).toEqual(["excluded"])
+  })
+
+  it("a pipe-chained command stays one segment (the first command owns it)", () => {
+    // `pnpm test | tail -8` → one segment, prefix `pnpm` → bash.
+    expect(classifyRawCommand("pnpm test 2>&1 | tail -8")).toEqual(["bash"])
+  })
+
+  it("real `&&` chains DO split into separate segments", () => {
+    // Mixed: cd (excluded), grep with embedded `\|` (search, single
+    // segment), pnpm test piped to tail (bash, single segment because
+    // pipe doesn't split anymore).
+    expect(classifyRawCommand('cd .. && grep "foo\\|bar" file && pnpm test | tail')).toEqual([
+      "excluded",
+      "search",
+      "bash",
+    ])
+  })
+
+  it('`gh pr create --title "a;b"` is ONE bash segment + gitWriteOps trigger', () => {
+    // The `;` inside the quoted title doesn't split. The whole command
+    // is recognised as `gh pr create` (write op).
+    const segments = splitBashSegments('gh pr create --title "fix: a; b"')
+    expect(segments).toHaveLength(1)
+    const t = extractBashTokens(segments[0] ?? "")
+    expect(t.prefix).toBe("gh")
+    expect(t.secondToken).toBe("pr")
+    expect(t.thirdToken).toBe("create")
+    const r = row("Bash", 1, { bashPrefix: t.prefix, bashSecondToken: t.secondToken, bashThirdToken: t.thirdToken })
+    expect(classifyToolMixRow(r)).toBe("bash")
+    expect(isGitWriteSegment(r)).toBe(true)
   })
 })
 

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -250,6 +250,27 @@ interface BashTokens {
  *   `git --version`                     → (git, "", "")
  *   `head -n 50 foo.log`                → (head, foo.log, "")
  */
+/**
+ * Splits a raw Bash command string on its `&&` / `||` chain operators
+ * and returns the trimmed, non-empty segments. Mirrors
+ * `BASH_SEGMENT_REGEX` in the CH adapter — both must stay in lockstep,
+ * and tests against this function effectively pin the splitter contract.
+ *
+ * Deliberately does NOT split on `|` or `;`:
+ *   - `|` appears constantly inside grep / sed regex alternations
+ *     (`grep "foo\|bar"`), shell pipes for plumbing, and quoted strings.
+ *   - `;` appears inside SQL statements and shell loop bodies.
+ *
+ * Subshells (`$(…)`, backticks) are NOT handled — splits inside them
+ * would still happen if `&&` / `||` appeared there literally. Rare
+ * enough that the regex approach is good enough.
+ */
+export const splitBashSegments = (command: string): readonly string[] =>
+  command
+    .split(/\s*(?:&&|\|\|)\s*/)
+    .map((s) => s.trim())
+    .filter((s) => s !== "")
+
 export const extractBashTokens = (segment: string): BashTokens => {
   // Normalise before tokenising:
   //   1. Strip bash line continuations (`\<NEWLINE>`) — a multi-line

--- a/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/use-cases/build-report.ts
@@ -72,14 +72,18 @@ const BASH_SEARCH_PREFIXES = new Set(["grep", "rg", "ag", "find", "ls", "tree"])
 const BASH_RESEARCH_PREFIXES = new Set(["curl", "wget"])
 
 /**
- * Pure output-shaping / orchestration commands. Almost always after a `|`
- * to format something else's output (`… | tail -8`, `… | head`, `cat foo |
- * less`), never standalone work in the Claude Code context. Excluded
- * entirely from segment counting so they don't pad `commandsRun` or
- * dominate the top-commands list.
+ * Tokens that look like commands but aren't. Excluded entirely from
+ * segment counting so they don't pad `commandsRun` or dominate the
+ * top-commands list. Three categories:
  *
- * Includes the pure navigation commands too (`cd`, `pwd`, `open`, `claude`,
- * …) for the same reason.
+ *   - Output shapers (`head`, `tail`, `cat`, `sed`, `awk`, …): almost
+ *     always after a `|` to format something else's output, never
+ *     standalone work in the Claude Code context.
+ *   - Navigation / shell admin (`cd`, `pwd`, `open`, `claude`, …): pure
+ *     context changes, no work.
+ *   - Bash control-flow keywords (`for`, `while`, `if`, `do`, …): bash
+ *     reserved words that surface as a segment prefix when a loop or
+ *     conditional starts the segment. Not commands.
  */
 const BASH_PLUMBING_PREFIXES = new Set([
   "head",
@@ -106,6 +110,26 @@ const BASH_PLUMBING_PREFIXES = new Set([
   "exit",
   "open",
   "claude",
+  // Bash control-flow keywords. They appear as a segment prefix when a
+  // loop or conditional is the start of a chain (`for x in *; do …` etc.)
+  // — they're not commands the user "ran." Includes both block-start
+  // keywords (`for`, `while`, `if`, `case`) and the after-`;` keywords
+  // (`do`, `done`, `then`, `else`, `fi`) for completeness.
+  "do",
+  "done",
+  "if",
+  "then",
+  "else",
+  "elif",
+  "fi",
+  "for",
+  "while",
+  "until",
+  "case",
+  "esac",
+  "in",
+  "select",
+  "function",
 ])
 
 // git sub-command routing.

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -46,16 +46,27 @@ const FILE_PATH_TOOLS = ["Read", "Edit", "Write", "NotebookEdit", "MultiEdit"] a
 const FILE_PATH_TOOLS_SQL = FILE_PATH_TOOLS.map((t) => `'${t}'`).join(",")
 const PATH_AWARE_TOOLS_SQL = `('Edit','MultiEdit','NotebookEdit','Write','Read','NotebookRead')`
 
-// Splits a Bash command string into its `&&` / `||` / `;` / `|`-separated
-// segments. Order in the alternation matters — `||` and `&&` are tried
-// before the single `|` so the two-char operators win at each position
-// (RE2 alternation is greedy left-to-right per position).
+// Splits a Bash command string into its `&&` / `||`-separated segments.
 //
-// Wraps each operator in optional whitespace so the resulting segments
-// come back already trimmed. Subshells (`$(…)`, backticks) are *not*
-// handled — rare enough that the regex approach is good enough and
-// proper handling needs a tokeniser.
-const BASH_SEGMENT_REGEX = "\\\\s*(?:&&|\\\\|\\\\||;|\\\\|)\\\\s*"
+// We deliberately do NOT split on `|` or `;`:
+//   - `|` appears constantly inside grep / sed regex alternations
+//     (`grep "foo\|bar"`), shell pipes for plumbing (`… | tail`), and
+//     quoted strings. Splitting on it produced junk segments like
+//     `api[_-]key\` and `BUILD)"` from quote-broken content.
+//   - `;` appears inside SQL strings (`psql -c "INSERT …; UPDATE …;"`)
+//     and shell loop bodies (`for x in *; do …; done`). Splitting on it
+//     produced segments starting with `set(evals_sched)` or `do`.
+//
+// Cost: piped-after commands and bare-`;`-chained commands don't get
+// their own segment. In practice the RHS of a pipe is almost always a
+// plumbing tool (`| tail`, `| grep`, `| wc`) we already exclude, and
+// Claude rarely uses bare `;` for chaining (it uses `&&`). So the net
+// change to `commandsRun` and bucket counts is small, and the
+// junk-token elimination is worth far more.
+//
+// Subshells (`$(…)`, backticks) are still not handled — proper handling
+// would need a real shell tokeniser, not worth it.
+const BASH_SEGMENT_REGEX = "\\\\s*(?:&&|\\\\|\\\\|)\\\\s*"
 
 // Path classifier used by every query that has to decide whether a file
 // touch counts. Mirrors the TS `classifyToolMixRow` rules in
@@ -131,15 +142,20 @@ const workspaceStrictPathPredicate = (workspacePathExpr: string, filePathExpr: s
 const GIT_WRITE_SUBCOMMANDS_SQL = `('commit','push','merge','rebase','tag','revert','cherry-pick')`
 
 /**
- * Pure output-shaping / orchestration commands. Excluded from segment
+ * Tokens that look like commands but aren't. Excluded from segment
  * counting so they don't pollute `commandsRun` or dominate the
- * top-commands list. Mirrors `BASH_PLUMBING_PREFIXES` in `build-report.ts`
- * — these two lists must stay in lockstep.
+ * top-commands list. Three groups: output shapers, navigation, and bash
+ * control-flow keywords. Mirrors `BASH_PLUMBING_PREFIXES` in
+ * `build-report.ts` — these two lists must stay in lockstep.
  */
 const BASH_PLUMBING_PREFIXES_SQL = `(
+  -- output shapers (almost always after a pipe)
   'head','tail','cat','less','more',
   'echo','printf','sed','awk','wc','sort','uniq','cut','tr','xargs','tee',
-  'cd','pwd','pushd','popd','clear','exit','open','claude'
+  -- navigation / shell admin
+  'cd','pwd','pushd','popd','clear','exit','open','claude',
+  -- bash control-flow keywords (loop/conditional bodies)
+  'do','done','if','then','else','elif','fi','for','while','until','case','esac','in','select','function'
 )`
 
 /**


### PR DESCRIPTION
## summary

After PR #3117 shipped, real Wrapped reports surfaced strange "top commands" entries — `BUILD)"`, `warning:"`, `api[_-]key\`, `service.name\`, `set(evals_sched)`, `do`, `"`. Root cause: the segment splitter regex broke commands on `|` and `;` even when those characters appeared *inside* shell-quoted strings or regex patterns.

A `grep "service.name\|api[_-]key" file` was split at the `\|` mid-regex into junk segments. A `psql -c "alter …; set(evals_sched);"` was split at the `;` mid-SQL. A `for x in *; do …; done` was split at the `;`, leaving `do` as the prefix of a downstream segment.

The principled fix would be a quote-aware shell tokeniser. The pragmatic fix is to be much more selective about which operators we split on.

## what changed

**Bash splitter narrowed to `&&` and `||` only.** `|` and `;` are now treated as content. They live inside their segment.

**Shell control-flow keywords added to the plumbing set.** With the splitter change, a `for x in *; do …; done` command becomes one segment with prefix `for` — that prefix needs to be excluded too. Adds `for`, `while`, `until`, `if`, `case`, `select`, `function` plus the after-`;` keywords (`do`, `done`, `then`, `else`, `elif`, `fi`, `esac`, `in`) for completeness. The TS classifier set (`BASH_PLUMBING_PREFIXES`) and the SQL literal (`BASH_PLUMBING_PREFIXES_SQL`) move together.

## trade-offs

Piped-after commands (`pnpm test | tail`) and bare-`;`-chained commands (`cd ..; pnpm test`) no longer get their own segment — the first command owns the whole thing. The right-hand-side of a pipe is almost always a plumbing tool we'd exclude anyway (`tail`, `head`, `wc`, `xargs`), and Claude rarely uses bare `;` for chaining (it uses `&&`). So `commandsRun` drops only marginally and bucket routing is unchanged for the common case.

Edge case not handled: a literal `&&` or `||` inside a quoted string would still produce a false split. A proper quote-aware tokeniser would catch that but isn't worth it for a display surface.

## test plan

- [x] 558 tests pass on `@domain/spans`. 2 new cases: block-start keywords (`for`/`while`/`if`/`case`) excluded; after-`;` keywords (`do`/`done`/`then`/`else`/`elif`/`fi`/`esac`/`in`) excluded.
- [x] `pnpm --filter @platform/db-clickhouse --filter @domain/spans typecheck` clean.
- [x] `pnpm biome check packages/domain/spans/src packages/platform/db-clickhouse/src` clean.
- [ ] Trigger a Wrapped post-merge for the projects that surfaced the issue. Confirm `BUILD)"`, `set(evals_sched)`, `do`, `api[_-]key\` etc. no longer appear in any workspace's top commands.

Refs #3117
