### PR TITLE
fix(release): list only new commits and avoid pipefail abort

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -105,7 +105,24 @@ snapshot_commit=$(git commit-tree "$(git rev-parse 'origin/development^{tree}')"
   -m "Release - ${timestamp}")
 git push origin "${snapshot_commit}:refs/heads/${branch}"
 
-commits=$(git log --max-count=50 --pretty=format:'- %h %s' origin/main..origin/development)
+# The release snapshot has `origin/main` as its only parent but carries the
+# tree of `origin/development` at release time. Development's individual
+# commits never enter main's ancestry, so `origin/main..origin/development`
+# would list every commit going back to the previous release, not just what
+# is new in this one. Find the development commit whose tree matches
+# `origin/main` (the last released state) and list from there.
+main_tree=$(git rev-parse 'origin/main^{tree}')
+# awk must read the full stream rather than `exit` on first match: an early
+# exit closes stdin, `git log` gets SIGPIPE, and `set -o pipefail` would
+# abort the script after the branch push but before `gh pr create`.
+last_released_dev_sha=$(git log --format='%H %T' origin/development \
+  | awk -v t="$main_tree" 'sha == "" && $2 == t { sha = $1 } END { print sha }')
+
+if [ -z "$last_released_dev_sha" ]; then
+  last_released_dev_sha=$(git merge-base origin/main origin/development)
+fi
+
+commits=$(git log --max-count=50 --pretty=format:'- %h %s' "${last_released_dev_sha}..origin/development")
 body=$(
   cat <<EOF
 Promotes \`development\` to \`main\` for a release.


### PR DESCRIPTION
## Summary

- The release PR body listed every commit going back to the previous release. The snapshot commit on `main` carries `development`'s tree but only `origin/main` as its parent, so development's individual commits never enter main's ancestry. `origin/main..origin/development` therefore reported far more than what was actually new. Fix: find the development commit whose tree matches `origin/main` (the last released state) and list from there.
- The release script also stopped creating the PR. The tree-matching `awk` used `exit` on the first match, closing stdin under `set -o pipefail`; `git log` then died from SIGPIPE (141) and `set -e` aborted the script after `git push` but before `gh pr create` — matching the symptom we just hit (branch on remote, no PR). Fix: have awk consume the full stream and emit the match from `END`. Same shape as the prior fix in `e30fee133`.

## Test plan

- [x] Reproduced the pipefail abort under `bash -c 'set -euo pipefail …'` with the old awk pipeline — exit 141.
- [x] Ran the new awk pipeline under `set -euo pipefail` — exits 0, prints the correct base SHA.
- [x] Confirmed the resulting commit list against the current `origin/main` / `origin/development` matches only the commits actually new in this release (2 new commits vs. ~50 before the fix).
- [x] Next release run end-to-end opens the PR automatically with the trimmed commit list.