### PR TITLE
fix(wrapped): "Claude time" measures active work, not session-open wall-clock

### DIFF
--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -69,8 +69,22 @@ export interface BiggestWriteRow {
 }
 
 export interface SessionDurationStatsRow {
+  /**
+   * Total active "Claude time" across all sessions in the window —
+   * computed as the sum of per-session durations, where each session's
+   * duration is the sum of its traces' wall-clock bursts. Excludes
+   * between-turn idle time (user reading output, thinking, typing the
+   * next prompt) so the number reflects work, not session-open time.
+   */
   readonly totalDurationMs: number
+  /**
+   * The single session with the largest summed turn-burst duration.
+   * Same "active time only" semantics as `totalDurationMs` — a session
+   * that stayed open for 6 hours but only had 30 minutes of actual
+   * turns reads as 30 minutes.
+   */
   readonly longestDurationMs: number
+  /** Workspace name of the longest session (by `longestDurationMs`). */
   readonly longestWorkspace: string | null
 }
 

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -751,13 +751,19 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                   argMax(workspace, session_duration_s) AS longest_workspace
                 FROM (
                   SELECT
-                    session_id,
+                    sess_id,
                     sum(trace_duration_s) AS session_duration_s,
                     any(workspace)        AS workspace
                   FROM (
+                    -- Aliases are deliberately NOT named after the underlying
+                    -- columns (e.g. \`any(session_id) AS sess_id\` rather than
+                    -- \`… AS session_id\`). ClickHouse's analyser resolves
+                    -- the WHERE clause against SELECT-list aliases and would
+                    -- otherwise complain "Aggregate function any(session_id)
+                    -- found in WHERE" when it sees \`AND session_id != ''\`.
                     SELECT
                       trace_id,
-                      any(session_id)                                    AS session_id,
+                      any(session_id)                                    AS sess_id,
                       any(metadata['workspace.name'])                    AS workspace,
                       dateDiff('second', min(start_time), max(end_time)) AS trace_duration_s
                     FROM spans
@@ -766,7 +772,7 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
                       AND trace_id != ''
                     GROUP BY trace_id
                   )
-                  GROUP BY session_id
+                  GROUP BY sess_id
                 )
               `,
               query_params: projectWindowParams(params),

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -720,20 +720,52 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // "Claude time" = sum-of-active-turn-bursts across all sessions.
+            //
+            // A Claude Code session contains many traces; each trace is one
+            // user turn (Claude processing one prompt → running tools →
+            // responding). The OLD implementation computed wall-clock as
+            // `max(end_time) - min(start_time)` grouped by `session_id`,
+            // which inflated the number with idle time *between* turns
+            // (user reading output, thinking, typing the next prompt).
+            // A 30-minute session of actual work could read as 4 hours.
+            //
+            // The fix: aggregate at the *trace* level first, then sum
+            // trace durations per session. Two nested GROUP BYs:
+            //
+            //   1. Inner GROUP BY trace_id  → per-trace wall-clock burst
+            //      (first span start to last span end of that trace).
+            //   2. Middle GROUP BY session_id → sum of trace durations
+            //      gives the session's "active work time."
+            //   3. Outer aggregation → total/longest across sessions.
+            //
+            // The PROJECT_WINDOW_FILTER already restricts to spans with
+            // `metadata['claude_code.version']` set, so traces from
+            // unrelated telemetry sources in the same project don't
+            // pollute the number.
             const result = await client.query({
               query: `
                 SELECT
-                  sumOrNull(duration_s)         AS total_duration_s,
-                  maxOrNull(duration_s)         AS longest_duration_s,
-                  argMax(workspace, duration_s) AS longest_workspace
+                  sumOrNull(session_duration_s)         AS total_duration_s,
+                  maxOrNull(session_duration_s)         AS longest_duration_s,
+                  argMax(workspace, session_duration_s) AS longest_workspace
                 FROM (
                   SELECT
                     session_id,
-                    dateDiff('second', min(start_time), max(end_time)) AS duration_s,
-                    any(metadata['workspace.name'])                    AS workspace
-                  FROM spans
-                  WHERE ${PROJECT_WINDOW_FILTER}
-                    AND session_id != ''
+                    sum(trace_duration_s) AS session_duration_s,
+                    any(workspace)        AS workspace
+                  FROM (
+                    SELECT
+                      trace_id,
+                      any(session_id)                                    AS session_id,
+                      any(metadata['workspace.name'])                    AS workspace,
+                      dateDiff('second', min(start_time), max(end_time)) AS trace_duration_s
+                    FROM spans
+                    WHERE ${PROJECT_WINDOW_FILTER}
+                      AND session_id != ''
+                      AND trace_id != ''
+                    GROUP BY trace_id
+                  )
                   GROUP BY session_id
                 )
               `,


### PR DESCRIPTION
## summary

"Claude time" and "Longest session" on the Wrapped report were measuring the wrong thing: wall-clock from the first span's start to the last span's end, grouped by session. That includes idle time *between* user turns (reading output, thinking, typing the next prompt). A 30-minute session of actual work could read as 4+ hours; production reports were showing 175h+ "Claude time" for a 7-day window — physically impossible for a single user.

This PR switches the calculation to a two-stage aggregation that follows how Claude Code's telemetry is shaped: a session contains many *traces*, and each trace is one user turn. We aggregate at the trace level first, then sum trace durations per session.

## the calculation

Two nested GROUP BYs on the spans table:

1. `GROUP BY trace_id` → per-trace wall-clock burst (first span's start to last span's end of that trace).
2. `GROUP BY session_id` → sum of trace durations gives the session's active work time.
3. Outer aggregation → total + longest across sessions.

The `PROJECT_WINDOW_FILTER` already restricts to spans where `metadata['claude_code.version']` is set, so traces from unrelated telemetry sources in the same project don't pad the number.

## why not use the `traces` materialized view

It was the obvious shortcut, but it doesn't carry `session_id` or `workspace.name` — those live on spans. Using the materialized view would force a JOIN back to spans for the per-session mapping, negating the pre-aggregation benefit. The two-stage GROUP BY directly on spans is the same scan profile we already do for everything else in the Wrapped fan-out.

## performance

Comparable to the old query. Same scan profile (one project × seven days), one extra GROUP BY layer on tiny intermediate data (~100–2,000 traces per project per week). Tens of milliseconds at typical sizes.

## effect on the numbers

- **"Claude time" drops significantly** for users who keep sessions open for hours between bursts of work. The 175h-in-a-week figures should come back to plausible territory.
- **"Longest session" becomes "session with the most active work"**, not "session that stayed open longest." A 6-hour-open session with 30 minutes of real turns reads as 30 minutes — closer to what the user actually did.
- **Concurrent sessions can still over-count** if turns overlap in wall-clock (two Claude Code instances running at once). That's the same as today and a separate interval-merge problem; not in scope here.

## implementation note: aggregate-alias shadowing

The inner-subquery aliases are deliberately not named after the underlying spans columns. The natural alias for `any(session_id)` would be `session_id`, but ClickHouse's analyser resolves WHERE-clause column references against SELECT-list aliases — so an `AND session_id != ''` filter would match the aggregate alias and fail with `ILLEGAL_AGGREGATION` ("Aggregate function any(session_id) found in WHERE"). Aliased as `sess_id` to dodge the shadow, with an inline comment so future tidy-up passes don't undo it.

## test plan

- [x] `pnpm --filter @platform/db-clickhouse --filter @domain/spans typecheck` clean.
- [x] `pnpm --filter @domain/spans test` — 583 tests pass.
- [x] `pnpm biome check packages/domain/spans/src packages/platform/db-clickhouse/src` clean.
- [x] Ran against real ClickHouse via a manual Wrapped trigger; first attempt hit the alias-shadow bug above and is now fixed. Query executes cleanly.
- [ ] Manual post-merge: trigger a Wrapped for a heavy user and confirm "Claude time" lands in plausible single-week range, and "Longest session" reflects active turns not session-open time.
