### PR TITLE
Release 14-05-2026-17-02

### DIFF
--- a/apps/web/src/lib/auth/oauth-redirects.test.ts
+++ b/apps/web/src/lib/auth/oauth-redirects.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { buildOAuthCallbackUrls, safeRelativeRedirect } from "./oauth-redirects.ts"
+
+describe("safeRelativeRedirect", () => {
+  it("keeps relative redirects and rejects absolute URLs", () => {
+    expect(safeRelativeRedirect("/auth/invite?invitationId=abc")).toBe("/auth/invite?invitationId=abc")
+    expect(safeRelativeRedirect("https://evil.example/path")).toBe("/")
+    expect(safeRelativeRedirect(null)).toBe("/")
+  })
+})
+
+describe("buildOAuthCallbackUrls", () => {
+  it("sends brand new OAuth users back to the invite flow when login started from an invitation", () => {
+    const urls = buildOAuthCallbackUrls({
+      provider: "google",
+      redirect: "/auth/invite?invitationId=invite_123",
+      tracking: {},
+    })
+
+    expect(urls.callbackURL).toBe("/auth/invite?invitationId=invite_123")
+    expect(urls.newUserCallbackURL).toBe("/auth/invite?invitationId=invite_123&signup=google")
+    expect(urls.errorCallbackURL).toBe("/login")
+  })
+
+  it.each([
+    null,
+    "https://evil.example/path",
+  ])("keeps the regular signup welcome page when OAuth login has no safe redirect: %s", (redirect) => {
+    const urls = buildOAuthCallbackUrls({
+      provider: "github",
+      redirect,
+      tracking: { utm_source: "newsletter" },
+    })
+
+    expect(urls.callbackURL).toBe("/?utm_source=newsletter")
+    expect(urls.newUserCallbackURL).toBe("/welcome?utm_source=newsletter&signup=github")
+    expect(urls.errorCallbackURL).toBe("/login?utm_source=newsletter")
+  })
+})

--- a/apps/web/src/lib/auth/oauth-redirects.ts
+++ b/apps/web/src/lib/auth/oauth-redirects.ts
@@ -1,0 +1,24 @@
+import { appendTrackingParams } from "../analytics/gtm.ts"
+
+export function safeRelativeRedirect(redirect: string | null): string {
+  return redirect?.startsWith("/") ? redirect : "/"
+}
+
+export function buildOAuthCallbackUrls({
+  provider,
+  redirect,
+  tracking,
+}: {
+  readonly provider: "google" | "github"
+  readonly redirect: string | null
+  readonly tracking: Record<string, string>
+}) {
+  const hasSafeRedirect = redirect?.startsWith("/") === true
+  const safeRedirect = safeRelativeRedirect(redirect)
+  const callbackURL = appendTrackingParams(safeRedirect, tracking)
+  const newUserPath = hasSafeRedirect ? safeRedirect : "/welcome"
+  const newUserCallbackURL = appendTrackingParams(newUserPath, { ...tracking, signup: provider })
+  const errorCallbackURL = appendTrackingParams("/login", tracking)
+
+  return { callbackURL, newUserCallbackURL, errorCallbackURL }
+}

--- a/apps/web/src/routes/api/auth/$provider/start.ts
+++ b/apps/web/src/routes/api/auth/$provider/start.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { appendTrackingParams, pickTrackingParams } from "../../../../lib/analytics/gtm.ts"
+import { pickTrackingParams } from "../../../../lib/analytics/gtm.ts"
+import { buildOAuthCallbackUrls } from "../../../../lib/auth/oauth-redirects.ts"
 import { getBetterAuth } from "../../../../server/clients.ts"
 
 const SUPPORTED_PROVIDERS = new Set(["google", "github"])
@@ -21,12 +22,11 @@ export const Route = createFileRoute("/api/auth/$provider/start")({
 
         const url = new URL(request.url)
         const tracking = pickTrackingParams(url.searchParams)
-        const redirectParam = url.searchParams.get("redirect") ?? "/"
-        const safeRedirect = redirectParam.startsWith("/") ? redirectParam : "/"
-
-        const callbackURL = appendTrackingParams(safeRedirect, tracking)
-        const newUserCallbackURL = appendTrackingParams("/welcome", { ...tracking, signup: provider })
-        const errorCallbackURL = appendTrackingParams("/login", tracking)
+        const { callbackURL, newUserCallbackURL, errorCallbackURL } = buildOAuthCallbackUrls({
+          provider: provider as "google" | "github",
+          redirect: url.searchParams.get("redirect"),
+          tracking,
+        })
 
         const apiResponse = await getBetterAuth().api.signInSocial({
           body: {

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -12,6 +12,36 @@ import { createMiddleware, createStart } from "@tanstack/react-start"
 
 type Logger = ReturnType<typeof createLogger>
 
+type ServerFnMeta = {
+  readonly id?: string
+  readonly name?: string
+  readonly filename?: string
+}
+
+type ServerFnMiddlewareArgs = {
+  readonly data?: unknown
+  readonly request?: Request
+  readonly serverFnMeta?: ServerFnMeta
+}
+
+const getStringField = (value: unknown, key: string): string | undefined => {
+  if (typeof value !== "object" || value === null) return undefined
+  const field = (value as Record<string, unknown>)[key]
+  return typeof field === "string" && field.length > 0 ? field : undefined
+}
+
+const getDataKeys = (data: unknown): string[] => {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) return []
+  return Object.keys(data).sort()
+}
+
+const SERVER_FN_ID_PATTERN = /^\/[A-Za-z0-9_-]+\/([a-f0-9]{64})$/
+
+const getServerFnIdFromPath = (pathname: string): string | undefined => {
+  const match = pathname.match(SERVER_FN_ID_PATTERN)
+  return match?.[1]
+}
+
 export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
   createMiddleware({ type: "request" }).server(async ({ next, request }) => {
     const url = new URL(request.url)
@@ -45,23 +75,53 @@ export const tracingRequestMiddleware = ({ tracer }: { tracer: Tracer }) =>
   })
 
 export const tracingFnMiddleware = ({ tracer, logger }: { tracer: Tracer; logger: Logger }) =>
-  createMiddleware({ type: "function" }).server(async (args) => {
-    const request = (args as { readonly request?: Request }).request
+  createMiddleware({ type: "function" }).server(async (rawArgs) => {
+    const args = rawArgs as typeof rawArgs & ServerFnMiddlewareArgs
+    const request = args.request
     const url = request ? new URL(request.url) : undefined
-    const spanName = request && url ? `server-fn ${request.method} ${url.pathname}` : "server-fn"
+    const serverFnMeta = args.serverFnMeta
+    const serverFnName = serverFnMeta?.name
+    const serverFnId = serverFnMeta?.id ?? (url ? getServerFnIdFromPath(url.pathname) : undefined)
+    const route = serverFnName ? `/_serverFn/${serverFnName}` : url?.pathname
+    const spanName = serverFnName
+      ? `server-fn ${serverFnName}`
+      : request && url
+        ? `server-fn ${request.method} ${url.pathname}`
+        : "server-fn"
 
     return tracer.startActiveSpan(spanName, async (span: Span) => {
       if (request && url) {
         span.setAttributes({
           "http.method": request.method,
           "http.url": request.url,
-          "http.route": url.pathname,
+          "http.route": route ?? url.pathname,
           "http.host": url.host,
         })
       }
 
+      if (serverFnName) span.updateName(`server-fn ${serverFnName}`)
+
+      const dataKeys = getDataKeys(args.data)
+      const projectId = getStringField(args.data, "projectId")
+      const traceId = getStringField(args.data, "traceId")
+      const issueId = getStringField(args.data, "issueId")
+      const datasetId = getStringField(args.data, "datasetId")
+
+      span.setAttributes({
+        "server_fn.name": serverFnName ?? "unknown",
+        "server_fn.id": serverFnId ?? "unknown",
+        "server_fn.filename": serverFnMeta?.filename ?? "unknown",
+        "server_fn.input.keys": dataKeys.join(","),
+        "server_fn.input.has_project_id": projectId !== undefined,
+        "server_fn.input.has_trace_id": traceId !== undefined,
+      })
+      if (projectId) span.setAttribute("project.id", projectId)
+      if (traceId) span.setAttribute("trace.trace_id", traceId)
+      if (issueId) span.setAttribute("issue.id", issueId)
+      if (datasetId) span.setAttribute("dataset.id", datasetId)
+
       try {
-        const result = await args.next()
+        const result = await rawArgs.next()
         span.setStatus({ code: SpanStatusCode.OK })
         return result
       } catch (e) {
@@ -78,7 +138,17 @@ export const tracingFnMiddleware = ({ tracer, logger }: { tracer: Tracer; logger
 
         if (e instanceof Error && e.stack) error.stack = e.stack
 
-        logger.error({ _tag: tag, message, status })
+        logger.error({
+          _tag: tag,
+          message,
+          status,
+          serverFnName,
+          serverFnId,
+          serverFnFilename: serverFnMeta?.filename,
+          dataKeys,
+          hasProjectId: projectId !== undefined,
+          hasTraceId: traceId !== undefined,
+        })
 
         throw error
       } finally {

--- a/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
+++ b/packages/domain/spans/src/wrapped/types/claude-code/ports/claude-code-span-reader.ts
@@ -69,8 +69,22 @@ export interface BiggestWriteRow {
 }
 
 export interface SessionDurationStatsRow {
+  /**
+   * Total active "Claude time" across all sessions in the window —
+   * computed as the sum of per-session durations, where each session's
+   * duration is the sum of its traces' wall-clock bursts. Excludes
+   * between-turn idle time (user reading output, thinking, typing the
+   * next prompt) so the number reflects work, not session-open time.
+   */
   readonly totalDurationMs: number
+  /**
+   * The single session with the largest summed turn-burst duration.
+   * Same "active time only" semantics as `totalDurationMs` — a session
+   * that stayed open for 6 hours but only had 30 minutes of actual
+   * turns reads as 30 minutes.
+   */
   readonly longestDurationMs: number
+  /** Workspace name of the longest session (by `longestDurationMs`). */
   readonly longestWorkspace: string | null
 }
 

--- a/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
+++ b/packages/platform/db-clickhouse/src/repositories/claude-code-span-reader.ts
@@ -720,21 +720,59 @@ export const ClaudeCodeSpanReaderLive = Layer.effect(
         const chSqlClient = (yield* ChSqlClient) as ChSqlClientShape<ClickHouseClient>
         return yield* chSqlClient
           .query(async (client) => {
+            // "Claude time" = sum-of-active-turn-bursts across all sessions.
+            //
+            // A Claude Code session contains many traces; each trace is one
+            // user turn (Claude processing one prompt → running tools →
+            // responding). The OLD implementation computed wall-clock as
+            // `max(end_time) - min(start_time)` grouped by `session_id`,
+            // which inflated the number with idle time *between* turns
+            // (user reading output, thinking, typing the next prompt).
+            // A 30-minute session of actual work could read as 4 hours.
+            //
+            // The fix: aggregate at the *trace* level first, then sum
+            // trace durations per session. Two nested GROUP BYs:
+            //
+            //   1. Inner GROUP BY trace_id  → per-trace wall-clock burst
+            //      (first span start to last span end of that trace).
+            //   2. Middle GROUP BY session_id → sum of trace durations
+            //      gives the session's "active work time."
+            //   3. Outer aggregation → total/longest across sessions.
+            //
+            // The PROJECT_WINDOW_FILTER already restricts to spans with
+            // `metadata['claude_code.version']` set, so traces from
+            // unrelated telemetry sources in the same project don't
+            // pollute the number.
             const result = await client.query({
               query: `
                 SELECT
-                  sumOrNull(duration_s)         AS total_duration_s,
-                  maxOrNull(duration_s)         AS longest_duration_s,
-                  argMax(workspace, duration_s) AS longest_workspace
+                  sumOrNull(session_duration_s)         AS total_duration_s,
+                  maxOrNull(session_duration_s)         AS longest_duration_s,
+                  argMax(workspace, session_duration_s) AS longest_workspace
                 FROM (
                   SELECT
-                    session_id,
-                    dateDiff('second', min(start_time), max(end_time)) AS duration_s,
-                    any(metadata['workspace.name'])                    AS workspace
-                  FROM spans
-                  WHERE ${PROJECT_WINDOW_FILTER}
-                    AND session_id != ''
-                  GROUP BY session_id
+                    sess_id,
+                    sum(trace_duration_s) AS session_duration_s,
+                    any(workspace)        AS workspace
+                  FROM (
+                    -- Aliases are deliberately NOT named after the underlying
+                    -- columns (e.g. \`any(session_id) AS sess_id\` rather than
+                    -- \`… AS session_id\`). ClickHouse's analyser resolves
+                    -- the WHERE clause against SELECT-list aliases and would
+                    -- otherwise complain "Aggregate function any(session_id)
+                    -- found in WHERE" when it sees \`AND session_id != ''\`.
+                    SELECT
+                      trace_id,
+                      any(session_id)                                    AS sess_id,
+                      any(metadata['workspace.name'])                    AS workspace,
+                      dateDiff('second', min(start_time), max(end_time)) AS trace_duration_s
+                    FROM spans
+                    WHERE ${PROJECT_WINDOW_FILTER}
+                      AND session_id != ''
+                      AND trace_id != ''
+                    GROUP BY trace_id
+                  )
+                  GROUP BY sess_id
                 )
               `,
               query_params: projectWindowParams(params),


### PR DESCRIPTION
Promotes `development` to `main` for a release.

## Commits

- 17431ea00 fix(wrapped): "Claude time" measures active work, not session-open wall-clock (#3134)
- 8324c6bfa fix(auth): preserve invite redirects for oauth signups
- 073ca2ace fix(web): enrich server function tracing