### PR TITLE
fix(telemetry): LAT-581 pass LLM SDK modules via instrumentations

### DIFF
--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -72,11 +72,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { ChatOpenAI } from "@langchain/openai"
         import { HumanMessage } from "@langchain/core/messages"
+        import * as LangChain from "langchain"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["langchain"],
+          instrumentations: { langchain: LangChain },
         })
 
         await latitude.ready
@@ -94,13 +95,14 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="Python">
         ```python
         from latitude_telemetry import Latitude, capture
+        import langchain_core
         from langchain_openai import ChatOpenAI
         from langchain_core.messages import HumanMessage
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["langchain"],
+            instrumentations={"langchain": langchain_core},
         )
 
         llm = ChatOpenAI(model="gpt-4o")

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -71,13 +71,14 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { Settings } from "llamaindex"
+        import * as LlamaIndex from "llamaindex"
         import { openai } from "@llamaindex/openai"
         import { agent } from "@llamaindex/workflow"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["llamaindex"],
+          instrumentations: { llamaindex: LlamaIndex },
         })
 
         await latitude.ready
@@ -95,13 +96,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import llama_index
         from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["llamaindex"],
+            instrumentations={"llamaindex": llama_index},
         )
 
         documents = SimpleDirectoryReader("data").load_data()

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -73,12 +73,13 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { Agent, run, tool } from "@openai/agents"
+        import * as OpenAIAgentsSDK from "@openai/agents"
         import { z } from "zod"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["openai-agents"],
+          instrumentations: { "openai-agents": OpenAIAgentsSDK },
         })
 
         await latitude.ready
@@ -106,13 +107,15 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import agents
         from agents import Agent, Runner
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["openai-agents"],
+            instrumentations={"openai-agents": agents},
         )
 
         agent = Agent(

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -229,6 +229,7 @@ Latitude works alongside your existing observability tools. In TypeScript, `new 
 ### With Datadog (TypeScript)
 
 ```ts
+import OpenAI from "openai"
 import tracer from "dd-trace"
 import { Latitude } from "@latitude-data/telemetry"
 
@@ -237,13 +238,14 @@ tracer.init({ service: "my-app", env: "production" })
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 ```
 
 ### With Sentry (TypeScript)
 
 ```ts
+import OpenAI from "openai"
 import * as Sentry from "@sentry/node"
 import { Latitude } from "@latitude-data/telemetry"
 
@@ -255,7 +257,7 @@ Sentry.init({
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 ```
 
@@ -265,12 +267,13 @@ Enable New Relic's OpenTelemetry bridge first, then construct `new Latitude()`. 
 
 ```ts
 import "newrelic"
+import OpenAI from "openai"
 import { Latitude } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 ```
 
@@ -279,6 +282,7 @@ const latitude = new Latitude({
 Start Honeycomb's `HoneycombSDK` first, then construct `new Latitude()`. Honeycomb registers an OpenTelemetry provider that Latitude can reuse.
 
 ```ts
+import OpenAI from "openai"
 import { HoneycombSDK } from "@honeycombio/opentelemetry-node"
 import { Latitude } from "@latitude-data/telemetry"
 
@@ -288,7 +292,7 @@ honeycomb.start()
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 ```
 

--- a/docs/telemetry/overview.mdx
+++ b/docs/telemetry/overview.mdx
@@ -50,7 +50,7 @@ One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude e
     const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
       projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-      instrumentations: ["openai"],
+      instrumentations: { openai: OpenAI },
     })
 
     await latitude.ready
@@ -70,13 +70,15 @@ One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude e
     ```
 
     ```python
-    from latitude_telemetry import Latitude
+    import openai
     from openai import OpenAI
+
+    from latitude_telemetry import Latitude
 
     latitude = Latitude(
         api_key="your-api-key",
         project_slug="your-project-slug",
-        instrumentations=["openai"],
+        instrumentations={"openai": openai},
     )
 
     client = OpenAI()
@@ -100,11 +102,12 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
   <Tab title="TypeScript">
     ```ts
     import { Latitude, capture } from "@latitude-data/telemetry"
+    import OpenAI from "openai"
 
     const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
       projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-      instrumentations: ["openai"],
+      instrumentations: { openai: OpenAI },
     })
 
     await latitude.ready
@@ -131,12 +134,14 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
   </Tab>
   <Tab title="Python">
     ```python
+    import openai
+
     from latitude_telemetry import Latitude, capture
 
     latitude = Latitude(
         api_key="your-api-key",
         project_slug="your-project-slug",
-        instrumentations=["openai"],
+        instrumentations={"openai": openai},
     )
 
     capture(

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -74,11 +74,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
           BedrockRuntimeClient,
           InvokeModelCommand,
         } from "@aws-sdk/client-bedrock-runtime"
+        import * as BedrockSDK from "@aws-sdk/client-bedrock-runtime"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["bedrock"],
+          instrumentations: { bedrock: BedrockSDK },
         })
 
         await latitude.ready
@@ -105,13 +106,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="Python">
         ```python
         import json
-        from latitude_telemetry import Latitude, capture
+
         import boto3
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["bedrock"],
+            instrumentations={"bedrock": boto3},
         )
 
         client = boto3.client("bedrock-runtime", region_name="us-east-1")

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -70,12 +70,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="TypeScript">
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
-        import Anthropic from "@anthropic-ai/sdk"
+        import Anthropic, * as AnthropicSDK from "@anthropic-ai/sdk"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["anthropic"],
+          instrumentations: { anthropic: AnthropicSDK },
         })
 
         await latitude.ready
@@ -96,13 +96,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import anthropic
         from anthropic import Anthropic
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["anthropic"],
+            instrumentations={"anthropic": anthropic},
         )
 
         client = Anthropic()

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -72,12 +72,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="TypeScript">
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
-        import { AzureOpenAI } from "openai"
+        import { AzureOpenAI, OpenAI } from "openai"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["openai"],
+          instrumentations: { openai: OpenAI },
         })
 
         await latitude.ready
@@ -101,13 +101,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import openai
         from openai import AzureOpenAI
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["openai"],
+            instrumentations={"openai": openai},
         )
 
         client = AzureOpenAI(

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -71,11 +71,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { CohereClient } from "cohere-ai"
+        import * as CohereSDK from "cohere-ai"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["cohere"],
+          instrumentations: { cohere: CohereSDK },
         })
 
         await latitude.ready
@@ -95,13 +96,14 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
         import cohere
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["cohere"],
+            instrumentations={"cohere": cohere},
         )
 
         client = cohere.Client()

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -71,11 +71,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { PredictionServiceClient } from "@google-cloud/aiplatform"
+        import * as AIPlatformSDK from "@google-cloud/aiplatform"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["aiplatform"],
+          instrumentations: { aiplatform: AIPlatformSDK },
         })
 
         await latitude.ready
@@ -96,13 +97,14 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
         from google.cloud import aiplatform
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["aiplatform"],
+            instrumentations={"aiplatform": aiplatform},
         )
 
         aiplatform.init(project="your-gcp-project", location="us-central1")

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -79,7 +79,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["openai"],
+          instrumentations: { openai: OpenAI },
         })
 
         await latitude.ready
@@ -99,13 +99,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import openai
         from openai import OpenAI
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["openai"],
+            instrumentations={"openai": openai},
         )
 
         client = OpenAI()

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -70,12 +70,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       <Tab title="TypeScript">
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
-        import Together from "together-ai"
+        import Together, * as TogetherSDK from "together-ai"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["togetherai"],
+          instrumentations: { togetherai: TogetherSDK },
         })
 
         await latitude.ready
@@ -95,13 +95,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
+        import together
         from together import Together
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["togetherai"],
+            instrumentations={"togetherai": together},
         )
 
         client = Together()

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -71,11 +71,12 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
         ```ts
         import { Latitude, capture } from "@latitude-data/telemetry"
         import { VertexAI } from "@google-cloud/vertexai"
+        import * as VertexAISDK from "@google-cloud/vertexai"
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
           projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-          instrumentations: ["vertexai"],
+          instrumentations: { vertexai: VertexAISDK },
         })
 
         await latitude.ready
@@ -96,14 +97,15 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
       </Tab>
       <Tab title="Python">
         ```python
-        from latitude_telemetry import Latitude, capture
         import vertexai
         from vertexai.generative_models import GenerativeModel
+
+        from latitude_telemetry import Latitude, capture
 
         latitude = Latitude(
             api_key="your-api-key",
             project_slug="your-project-slug",
-            instrumentations=["vertexai"],
+            instrumentations={"vertexai": vertexai},
         )
 
         vertexai.init(project="your-gcp-project", location="us-central1")

--- a/docs/telemetry/python.md
+++ b/docs/telemetry/python.md
@@ -20,13 +20,15 @@ Requires Python 3.11+.
 The fastest way to start. One class sets up a complete OpenTelemetry pipeline with LLM auto-instrumentation and the Latitude exporter:
 
 ```python
-from latitude_telemetry import Latitude
+import openai
 from openai import OpenAI
+
+from latitude_telemetry import Latitude
 
 latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
 )
 
 client = OpenAI()
@@ -38,6 +40,8 @@ response = client.chat.completions.create(
 latitude.shutdown()
 ```
 
+`instrumentations` takes a dict mapping integration name (`openai`, `anthropic`, …) to the LLM SDK module the consumer imports. Passing the user's own module reference sidesteps a class of import-cache bugs where the SDK could patch a different module instance than the app loads.
+
 ## Using `capture()` for Context
 
 Auto-instrumentation traces LLM calls without `capture()`. Use `capture()` when you want to:
@@ -48,12 +52,14 @@ Auto-instrumentation traces LLM calls without `capture()`. Use `capture()` when 
 - **Filter and analyze**: Use tags and metadata to filter traces in Latitude
 
 ```python
+import openai
+
 from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
 )
 
 capture(
@@ -89,6 +95,8 @@ latitude.shutdown()
 If your app already uses OpenTelemetry, add Latitude alongside your existing processors:
 
 ```python
+import openai
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
@@ -99,7 +107,7 @@ provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
 trace.set_tracer_provider(provider)
 
 register_latitude_instrumentations(
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     tracer_provider=provider,
 )
 ```
@@ -130,8 +138,10 @@ class Latitude:
         self,
         *,
         api_key: str,
-        project_slug: str,
-        instrumentations: list[str] | None = None,
+        project_slug: str | None = None,
+        # Dict mapping integration name → the LLM SDK module the consumer imports.
+        # Anything else (list, primitive, unknown key, non-dict) raises TypeError.
+        instrumentations: InstrumentationsInput | None = None,
         service_name: str | None = None,
         disable_batch: bool = False,
         disable_smart_filter: bool = False,
@@ -212,26 +222,71 @@ class LatitudeSpanProcessorOptions:
 Registers LLM auto-instrumentations against a specific tracer provider.
 
 ```python
+# InstrumentationName = Literal[
+#   "openai", "openai-agents", "anthropic", "bedrock", "cohere",
+#   "langchain", "llamaindex", "togetherai", "vertexai", "aiplatform",
+#   "aleph_alpha", "crewai", "dspy", "google_generativeai", "groq",
+#   "haystack", "litellm", "mistralai", "ollama", "replicate",
+#   "sagemaker", "transformers", "watsonx",
+# ]
+# InstrumentationsInput = dict[InstrumentationName, object]
+
 def register_latitude_instrumentations(
-    instrumentations: list[str],
+    # Dict mapping integration name → the LLM SDK module the consumer imports.
+    # Anything else throws at register time.
+    instrumentations: InstrumentationsInput,
     tracer_provider: TracerProvider,
 ) -> None:
     ...
 ```
 
+## Migrating from `instrumentations=["openai"]` (3.0.0a6 and earlier)
+
+The list-of-strings form is removed with no fallback in `3.0.0a7`. Anything other than a plain dict raises `TypeError` at register time. Migration:
+
+```diff
+- from latitude_telemetry import Latitude
++ import openai
++ import anthropic
++ from latitude_telemetry import Latitude
+
+  latitude = Latitude(
+      api_key="your-api-key",
+      project_slug="your-project-slug",
+-     instrumentations=["openai", "anthropic"],
++     instrumentations={"openai": openai, "anthropic": anthropic},
+  )
+```
+
 ## Supported Providers
 
-| Identifier | Package |
-|---|---|
-| `"openai"` | `openai` |
-| `"anthropic"` | `anthropic` |
-| `"bedrock"` | `boto3` |
-| `"cohere"` | `cohere` |
-| `"langchain"` | `langchain-core` |
-| `"llamaindex"` | `llama-index` |
-| `"togetherai"` | `together` |
-| `"vertexai"` | `google-cloud-aiplatform` |
-| `"aiplatform"` | `google-cloud-aiplatform` |
+Set the integration's key on the `instrumentations` dict to the LLM SDK module the consumer imports.
+
+| Key                   | PyPI package                  | What to pass                                |
+| --------------------- | ----------------------------- | ------------------------------------------- |
+| `openai`              | `openai`                      | `import openai` → `openai`                  |
+| `openai-agents`       | `openai-agents`               | `import agents` → `agents`                  |
+| `anthropic`           | `anthropic`                   | `import anthropic` → `anthropic`            |
+| `bedrock`             | `boto3`                       | `import boto3` → `boto3`                    |
+| `cohere`              | `cohere`                      | `import cohere` → `cohere`                  |
+| `langchain`           | `langchain-core`              | `import langchain_core` → that module       |
+| `llamaindex`          | `llama-index`                 | `import llama_index` → that module          |
+| `togetherai`          | `together`                    | `import together` → `together`              |
+| `vertexai`            | `google-cloud-aiplatform`     | `import vertexai` → `vertexai`              |
+| `aiplatform`          | `google-cloud-aiplatform`     | `import google.cloud.aiplatform` → that module |
+| `aleph_alpha`         | `aleph-alpha-client`          | `import aleph_alpha_client`                 |
+| `crewai`              | `crewai`                      | `import crewai`                             |
+| `dspy`                | `dspy-ai`                     | `import dspy`                               |
+| `google_generativeai` | `google-generativeai`         | `from google import genai` → `genai`        |
+| `groq`                | `groq`                        | `import groq`                               |
+| `haystack`            | `haystack-ai`                 | `import haystack`                           |
+| `litellm`             | `litellm`                     | `import litellm`                            |
+| `mistralai`           | `mistralai`                   | `import mistralai`                          |
+| `ollama`              | `ollama`                      | `import ollama`                             |
+| `replicate`           | `replicate`                   | `import replicate`                          |
+| `sagemaker`           | `boto3`                       | `import boto3` → `boto3`                    |
+| `transformers`        | `transformers`                | `import transformers`                       |
+| `watsonx`             | `ibm-watson-machine-learning` | `import ibm_watsonx_ai`                     |
 
 ## Configuration
 

--- a/docs/telemetry/typescript.md
+++ b/docs/telemetry/typescript.md
@@ -18,23 +18,28 @@ npm install @latitude-data/telemetry
 The fastest way to start. One class detects an existing OpenTelemetry pipeline (Sentry, Datadog, New Relic, Honeycomb, etc.) or creates one when none exists, then adds LLM auto-instrumentation and the Latitude exporter:
 
 ```ts
+import OpenAI from "openai"
 import { Latitude } from "@latitude-data/telemetry"
+
+const client = new OpenAI()
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 await latitude.ready
 
-const response = await openai.chat.completions.create({
+const response = await client.chat.completions.create({
   model: "gpt-4o",
   messages: [{ role: "user", content: "Hello" }],
 })
 
 await latitude.shutdown()
 ```
+
+`instrumentations` takes a plain object mapping integration name (`openai`, `anthropic`, …) to the LLM SDK module the consumer imports in app code. The same module instance is used for both the patch and the actual LLM call, sidestepping the CJS/ESM dual-load class of bugs.
 
 `new Latitude()` returns **immediately**. Instrumentation registration happens in the background. This avoids top-level await issues in CommonJS environments while still supporting ESM.
 
@@ -52,12 +57,13 @@ Auto-instrumentation traces LLM calls without `capture()`. Use `capture()` when 
 - **Filter and analyze**: Use tags and metadata to filter traces in Latitude
 
 ```ts
+import OpenAI from "openai"
 import { Latitude, capture } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 await latitude.ready
@@ -95,6 +101,7 @@ await latitude.shutdown()
 For Sentry, Datadog, New Relic, Honeycomb, and other OpenTelemetry-compatible SDKs, initialize the existing SDK first and construct `new Latitude()` second. Latitude detects the installed provider and attaches its processor when possible without replacing the existing SDK's context manager, propagator, sampler, or processors:
 
 ```ts
+import OpenAI from "openai"
 import * as Sentry from "@sentry/node"
 import { Latitude } from "@latitude-data/telemetry"
 
@@ -106,7 +113,7 @@ Sentry.init({
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 await latitude.ready
@@ -119,6 +126,7 @@ await latitude.shutdown()
 If you want full control over provider construction, add Latitude alongside your existing processors explicitly:
 
 ```ts
+import OpenAI from "openai"
 import { NodeSDK } from "@opentelemetry/sdk-node"
 import {
   LatitudeSpanProcessor,
@@ -138,7 +146,7 @@ const sdk = new NodeSDK({
 sdk.start()
 
 await registerLatitudeInstrumentations({
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   tracerProvider: sdk.getTracerProvider(),
 })
 ```
@@ -163,8 +171,10 @@ Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude
 ```ts
 type LatitudeOptions = {
   apiKey: string
-  projectSlug: string
-  instrumentations?: InstrumentationType[]
+  projectSlug?: string
+  // Map of integration name → LLM SDK module reference (e.g. { openai: OpenAI }).
+  // Anything else (string array, primitive, unknown key, non-object) throws at register time.
+  instrumentations?: InstrumentationsInput
   serviceName?: string
   disableBatch?: boolean
   disableSmartFilter?: boolean
@@ -242,8 +252,9 @@ type LatitudeSpanProcessorOptions = {
 Registers patch-based AI SDK instrumentations against a specific tracer provider.
 
 ```ts
-type InstrumentationType =
+type InstrumentationName =
   | "openai"
+  | "openai-agents"
   | "anthropic"
   | "bedrock"
   | "cohere"
@@ -253,32 +264,55 @@ type InstrumentationType =
   | "vertexai"
   | "aiplatform"
 
+// `object | undefined` rejects primitive values (`true`, `42`, `"openai"`, …)
+// at compile time while still admitting class constructors (functions),
+// namespace imports, and explicit-undefined-for-conditional-config.
+type InstrumentationsInput = Partial<Record<InstrumentationName, object | undefined>>
+
 function registerLatitudeInstrumentations(options: {
-  instrumentations: InstrumentationType[]
+  // Map of integration name → LLM SDK module reference (e.g. { openai: OpenAI }).
+  // Anything else throws at register time.
+  instrumentations: InstrumentationsInput
   tracerProvider: TracerProvider
-  modules?: Partial<Record<InstrumentationType, unknown>>
-  enrichTokens?: Partial<Record<InstrumentationType, boolean>>
 }): Promise<void>
 ```
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `modules` | `Partial<Record<InstrumentationType, unknown>>` | Auto-required | Explicit module references for instrumentations that can't be auto-required |
-| `enrichTokens` | `Partial<Record<InstrumentationType, boolean>>` | `{ openai: true, togetherai: false }` | Enable or disable token usage enrichment per instrumentation |
-
 ## Supported Providers
 
-| Identifier | Package |
-|---|---|
-| `"openai"` | `openai` |
-| `"anthropic"` | `@anthropic-ai/sdk` |
-| `"bedrock"` | `@aws-sdk/client-bedrock-runtime` |
-| `"cohere"` | `cohere-ai` |
-| `"langchain"` | `langchain` |
-| `"llamaindex"` | `llamaindex` |
-| `"togetherai"` | `together-ai` |
-| `"vertexai"` | `@google-cloud/vertexai` |
-| `"aiplatform"` | `@google-cloud/aiplatform` |
+Set the integration's key on the `instrumentations` object to the LLM SDK module the consumer imports. For SDKs whose Traceloop patch reads off the package namespace, pass `import * as X from "<package>"`.
+
+| Key | Package | What to pass |
+|---|---|---|
+| `openai` | `openai` | `openai: OpenAI` (default class — also accepts the namespace) |
+| `openai-agents` | `@openai/agents` | `"openai-agents": OpenAIAgentsSDK` (namespace) |
+| `anthropic` | `@anthropic-ai/sdk` | `anthropic: AnthropicSDK` (namespace; bare default class also accepted and rewrapped) |
+| `bedrock` | `@aws-sdk/client-bedrock-runtime` | `bedrock: BedrockSDK` (namespace) |
+| `cohere` | `cohere-ai` | `cohere: CohereSDK` (namespace) |
+| `langchain` | `langchain` | `langchain: LangChain` (namespace) |
+| `llamaindex` | `llamaindex` | `llamaindex: LlamaIndex` (namespace) |
+| `togetherai` | `together-ai` | `togetherai: TogetherSDK` (namespace) |
+| `vertexai` | `@google-cloud/vertexai` | `vertexai: VertexAISDK` (namespace) |
+| `aiplatform` | `@google-cloud/aiplatform` | `aiplatform: AIPlatformSDK` (namespace) |
+
+## Migrating from `instrumentations: ["openai"]` (3.0.0-alpha.10 and earlier)
+
+The string-array form is removed with no fallback in `3.0.0-alpha.11`. Anything other than a plain object — including the old string array — **throws at register time**, so any existing install below `alpha.11` must be bumped *and* its call sites rewritten in the same change. Migration:
+
+```diff
+- import { Latitude } from "@latitude-data/telemetry"
++ import OpenAI from "openai"
++ import * as AnthropicSDK from "@anthropic-ai/sdk"
++ import { Latitude } from "@latitude-data/telemetry"
+
+  new Latitude({
+    apiKey: process.env.LATITUDE_API_KEY!,
+    projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+-   instrumentations: ["openai", "anthropic"],
++   instrumentations: { openai: OpenAI, anthropic: AnthropicSDK },
+  })
+```
+
+The `modules` option on `registerLatitudeInstrumentations` is also removed — pass the SDK module under its integration key on `instrumentations` instead.
 
 ## Configuration
 
@@ -332,9 +366,10 @@ new LatitudeSpanProcessor(apiKey, projectSlug, {
 
 1. **Check API key and project slug**: Must be non-empty strings.
 2. **Verify instrumentations are registered**: Use `await latitude.ready` or `await registerLatitudeInstrumentations()`.
-3. **Flush before exit**: Call `await latitude.flush()` or `await provider.forceFlush()`.
-4. **Check smart filter**: Only LLM spans are exported by default. Use `disableSmartFilter: true` to export all spans.
-5. **Ensure `capture()` wraps the code that creates spans**: `capture()` itself doesn't create spans; it only attaches context.
+3. **Did the bootstrap throw a migration error?**: On `3.0.0-alpha.11`+, `instrumentations: ["openai"]` (or any non-object value) throws `TypeError: [Latitude] instrumentations must be an object mapping…`. Migrate to `instrumentations: { openai: OpenAI }`. See the Migration section above.
+4. **Flush before exit**: Call `await latitude.flush()` or `await provider.forceFlush()`.
+5. **Check smart filter**: Only LLM spans are exported by default. Use `disableSmartFilter: true` to export all spans.
+6. **Ensure `capture()` wraps the code that creates spans**: `capture()` itself doesn't create spans; it only attaches context.
 
 ### No spans created inside `capture()`
 

--- a/knip.json
+++ b/knip.json
@@ -72,7 +72,7 @@
       "entry": ["examples/**/*.ts"],
       "project": ["src/**/*.ts", "examples/**/*.ts"],
       "ignore": ["src/constants/**/*.ts"],
-      "ignoreDependencies": ["@sentry/node", "dd-trace", "together-ai"]
+      "ignoreDependencies": ["@sentry/node", "dd-trace", "langchain", "together-ai"]
     },
     "tools/ai-benchmarks": {
       "entry": ["src/scripts/**/*.ts"],

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0a7] - 2026-05-15
+
+### Breaking Changes
+
+- **`instrumentations` is now a dict mapping integration name → LLM SDK module.** Replaces the list-of-strings form. Example: `instrumentations={"openai": openai, "anthropic": anthropic}`. The caller passes the module they already imported in app code, so the patch lands on the same module instance the app actually uses. Mirrors the TypeScript SDK's object-form API for full feature parity.
+- **The list-of-strings form (`instrumentations=["openai"]`) is removed with no fallback.** Anything other than a plain dict — including the old list — raises `TypeError` at register time with a migration hint. See the README's "Migrating from `instrumentations=[\"openai\"]`" section.
+- **Unknown integration keys raise `TypeError`.** Previously a typo in an integration name silently no-op'd with a `logging.warning`. Now the bootstrap fails loudly, naming the supported keys.
+
+### Added
+
+- New `InstrumentationName` literal type and `InstrumentationsInput` alias exported from `latitude_telemetry`.
+- **13 additional integrations** wired into the registry (the PyPI deps were already pinned in `pyproject.toml` but the registry only registered 10): `aleph_alpha`, `crewai`, `dspy`, `google_generativeai`, `groq`, `haystack`, `litellm`, `mistralai`, `ollama`, `replicate`, `sagemaker`, `transformers`, `watsonx`. Each takes the corresponding user-imported module.
+
+### Removed
+
+- The internal `INSTRUMENTATION_MAP` lookup with its `module/class/package/manual` fields, replaced by the typed `IntegrationDef` dataclass + a flat `INTEGRATIONS` dict.
+- Internal `__import__` of the user's SDK module — the user now passes it directly.
+
 ## [3.0.0a6] - 2026-05-14
 
 ### Added

--- a/packages/telemetry/python/README.md
+++ b/packages/telemetry/python/README.md
@@ -17,12 +17,17 @@ Requires Python 3.11+.
 The fastest way to start tracing your LLM calls. One class sets up everything:
 
 ```python
+import openai
+from openai import OpenAI
+
 from latitude_telemetry import Latitude
+
+client = OpenAI()
 
 latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
-    instrumentations=["openai"],  # Auto-instrument OpenAI, Anthropic, etc.
+    instrumentations={"openai": openai},  # Pass the LLM SDK module you use in app code.
 )
 
 # Your LLM calls will now be traced and sent to Latitude
@@ -33,6 +38,8 @@ response = client.chat.completions.create(
 
 latitude.shutdown()
 ```
+
+`instrumentations` takes a dict mapping integration name (`openai`, `anthropic`, …) to the LLM SDK module the consumer imports. Passing the module reference the consumer's own code uses sidesteps a class of import-cache bugs where the SDK could patch a different module instance than the app loads.
 
 **What this does:**
 
@@ -54,6 +61,9 @@ latitude.shutdown()
 If your app already uses OpenTelemetry, add Latitude alongside your existing setup:
 
 ```python
+import openai
+from openai import OpenAI
+
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
@@ -67,11 +77,12 @@ trace.set_tracer_provider(provider)
 
 # Enable LLM auto-instrumentation
 register_latitude_instrumentations(
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     tracer_provider=provider,
 )
 
 # Your LLM calls will now be traced and sent to Latitude
+client = OpenAI()
 response = client.chat.completions.create(
     model="gpt-4",
     messages=[{"role": "user", "content": "Hello"}],
@@ -104,12 +115,14 @@ You don't need `capture()` to get started—auto-instrumentation handles LLM cal
 ### Example
 
 ```python
+import openai
+
 from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key="your-api-key",
     project_slug="your-project-slug",
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
 )
 
 # Wrap a request or agent run to add context
@@ -169,8 +182,11 @@ class Latitude:
         self,
         *,
         api_key: str,
-        project_slug: str,
-        instrumentations: list[str] | None = None,
+        project_slug: str | None = None,
+        # Dict mapping integration name → the LLM SDK module the consumer imports.
+        # Example: {"openai": openai, "anthropic": anthropic}.
+        # Anything else (list, primitive, unknown key, non-dict) raises TypeError at register time.
+        instrumentations: InstrumentationsInput | None = None,
         service_name: str | None = None,
         disable_batch: bool = False,
         disable_smart_filter: bool = False,
@@ -249,26 +265,71 @@ def capture(
 Registers LLM auto-instrumentations against a specific tracer provider.
 
 ```python
+# InstrumentationName = Literal[
+#   "openai", "openai-agents", "anthropic", "bedrock", "cohere",
+#   "langchain", "llamaindex", "togetherai", "vertexai", "aiplatform",
+#   "aleph_alpha", "crewai", "dspy", "google_generativeai", "groq",
+#   "haystack", "litellm", "mistralai", "ollama", "replicate",
+#   "sagemaker", "transformers", "watsonx",
+# ]
+# InstrumentationsInput = dict[InstrumentationName, object]
+
 def register_latitude_instrumentations(
-    instrumentations: list[str],
+    # Dict mapping integration name → the LLM SDK module the consumer imports.
+    # Anything else throws at register time.
+    instrumentations: InstrumentationsInput,
     tracer_provider: TracerProvider,
 ) -> None:
     ...
 ```
 
+## Migrating from `instrumentations=["openai"]` (3.0.0a6 and earlier)
+
+The list-of-strings form is removed with no fallback in `3.0.0a7`. Anything other than a plain dict — including the old string list — **raises `TypeError`** at register time. Migration:
+
+```diff
+- from latitude_telemetry import Latitude
++ import openai
++ import anthropic
++ from latitude_telemetry import Latitude
+
+  latitude = Latitude(
+      api_key="your-api-key",
+      project_slug="your-project-slug",
+-     instrumentations=["openai", "anthropic"],
++     instrumentations={"openai": openai, "anthropic": anthropic},
+  )
+```
+
 ## Supported AI Providers
 
-| Identifier     | Package                           |
-| -------------- | --------------------------------- |
-| `"openai"`     | `openai`                          |
-| `"anthropic"`  | `anthropic`                       |
-| `"bedrock"`    | `boto3`                           |
-| `"cohere"`     | `cohere`                          |
-| `"langchain"`  | `langchain-core`                  |
-| `"llamaindex"` | `llama-index`                     |
-| `"togetherai"` | `together`                        |
-| `"vertexai"`   | `google-cloud-aiplatform`         |
-| `"aiplatform"` | `google-cloud-aiplatform`         |
+Set the integration's key on the `instrumentations` dict to the LLM SDK module the consumer imports.
+
+| Key                   | PyPI package                | What to pass                                |
+| --------------------- | --------------------------- | ------------------------------------------- |
+| `openai`              | `openai`                    | `import openai` → `openai`                  |
+| `openai-agents`       | `openai-agents`             | `import agents` → `agents`                  |
+| `anthropic`           | `anthropic`                 | `import anthropic` → `anthropic`            |
+| `bedrock`             | `boto3`                     | `import boto3` → `boto3`                    |
+| `cohere`              | `cohere`                    | `import cohere` → `cohere`                  |
+| `langchain`           | `langchain-core`            | `import langchain_core` → `langchain_core`  |
+| `llamaindex`          | `llama-index`               | `import llama_index` → `llama_index`        |
+| `togetherai`          | `together`                  | `import together` → `together`              |
+| `vertexai`            | `google-cloud-aiplatform`   | `import vertexai` → `vertexai`              |
+| `aiplatform`          | `google-cloud-aiplatform`   | `import google.cloud.aiplatform` → that module |
+| `aleph_alpha`         | `aleph-alpha-client`        | `import aleph_alpha_client`                 |
+| `crewai`              | `crewai`                    | `import crewai`                             |
+| `dspy`                | `dspy-ai`                   | `import dspy`                               |
+| `google_generativeai` | `google-generativeai`       | `from google import genai` → `genai`        |
+| `groq`                | `groq`                      | `import groq`                               |
+| `haystack`            | `haystack-ai`               | `import haystack`                           |
+| `litellm`             | `litellm`                   | `import litellm`                            |
+| `mistralai`           | `mistralai`                 | `import mistralai`                          |
+| `ollama`              | `ollama`                    | `import ollama`                             |
+| `replicate`           | `replicate`                 | `import replicate`                          |
+| `sagemaker`           | `boto3`                     | `import boto3` → `boto3`                    |
+| `transformers`        | `transformers`              | `import transformers`                       |
+| `watsonx`             | `ibm-watson-machine-learning` | `import ibm_watsonx_ai`                   |
 
 ## Context Options
 

--- a/packages/telemetry/python/examples/README.md
+++ b/packages/telemetry/python/examples/README.md
@@ -133,12 +133,14 @@ Each example should:
 Example pattern:
 
 ```python
+import openai
+
 from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 

--- a/packages/telemetry/python/examples/test_aleph_alpha.py
+++ b/packages/telemetry/python/examples/test_aleph_alpha.py
@@ -11,6 +11,7 @@ Install: uv add aleph-alpha-client
 
 import os
 
+import aleph_alpha_client
 from aleph_alpha_client import Client, CompletionRequest, Prompt
 
 from latitude_telemetry import Latitude, capture
@@ -19,12 +20,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["aleph_alpha"],
+    instrumentations={"aleph_alpha": aleph_alpha_client},
     disable_batch=True,
 )
 
 
-@capture("test-aleph-alpha-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-aleph-alpha-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_aleph_alpha_completion():
     client = Client(token=os.environ["ALEPH_ALPHA_API_KEY"])
 

--- a/packages/telemetry/python/examples/test_anthropic.py
+++ b/packages/telemetry/python/examples/test_anthropic.py
@@ -11,6 +11,7 @@ Install: uv add anthropic
 
 import os
 
+import anthropic
 from anthropic import Anthropic
 
 from latitude_telemetry import Latitude, capture
@@ -19,12 +20,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["anthropic"],
+    instrumentations={"anthropic": anthropic},
     disable_batch=True,
 )
 
 
-@capture("test-anthropic-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-anthropic-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_anthropic_completion():
     client = Anthropic()
 

--- a/packages/telemetry/python/examples/test_azure.py
+++ b/packages/telemetry/python/examples/test_azure.py
@@ -12,13 +12,15 @@ Install: uv add openai
 
 import os
 
+import openai
+
 from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing openai so instrumentation can patch it
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
@@ -26,7 +28,7 @@ latitude = Latitude(
 from openai import AzureOpenAI
 
 
-@capture("test-azure-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-azure-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_azure_completion():
     client = AzureOpenAI(
         api_key=os.environ["AZURE_OPENAI_API_KEY"],

--- a/packages/telemetry/python/examples/test_bedrock.py
+++ b/packages/telemetry/python/examples/test_bedrock.py
@@ -22,12 +22,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["bedrock"],
+    instrumentations={"bedrock": boto3},
     disable_batch=True,
 )
 
 
-@capture("test-bedrock-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-bedrock-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_bedrock_completion():
     client = boto3.client(
         "bedrock-runtime",

--- a/packages/telemetry/python/examples/test_capture_nesting.py
+++ b/packages/telemetry/python/examples/test_capture_nesting.py
@@ -16,6 +16,7 @@ Install: uv add openai
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -24,7 +25,7 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
@@ -32,7 +33,7 @@ latitude = Latitude(
 @capture(
     "outer-capture",
     {
-        "tags": ["outer-tag", "shared-tag"],
+        "tags": ["python", "outer-tag", "shared-tag"],
         "session_id": "outer-session",
         "user_id": "outer-user",
         "metadata": {"outer_key": "outer_value", "shared_key": "outer_shared"},
@@ -69,7 +70,7 @@ def outer_function():
 @capture(
     "inner-capture",
     {
-        "tags": ["inner-tag", "shared-tag"],  # shared-tag should be deduplicated
+        "tags": ["python", "inner-tag", "shared-tag"],  # shared-tag should be deduplicated
         "session_id": "inner-session",  # should override outer-session
         "user_id": "inner-user",  # should override outer-user
         "metadata": {"inner_key": "inner_value", "shared_key": "inner_shared"},  # shared_key should be overridden
@@ -108,7 +109,7 @@ def test_nested_capture_with_callback():
             "callback-inner",
             inner_callback,
             {
-                "tags": ["callback-inner"],
+                "tags": ["python", "callback-inner"],
                 "session_id": "callback-inner-session",
                 "user_id": "callback-inner-user",
                 "metadata": {"callback_inner": "value"},
@@ -130,7 +131,7 @@ def test_nested_capture_with_callback():
         "callback-outer",
         outer_callback,
         {
-            "tags": ["callback-outer"],
+            "tags": ["python", "callback-outer"],
             "session_id": "callback-outer-session",
             "user_id": "callback-outer-user",
             "metadata": {"callback_outer": "value"},

--- a/packages/telemetry/python/examples/test_cohere.py
+++ b/packages/telemetry/python/examples/test_cohere.py
@@ -19,12 +19,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["cohere"],
+    instrumentations={"cohere": cohere},
     disable_batch=True,
 )
 
 
-@capture("test-cohere-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-cohere-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_cohere_completion():
     client = cohere.Client(api_key=os.environ["COHERE_API_KEY"])
 

--- a/packages/telemetry/python/examples/test_crewai.py
+++ b/packages/telemetry/python/examples/test_crewai.py
@@ -11,6 +11,8 @@ Install: uv add crewai
 
 import os
 
+import crewai
+import openai
 from crewai import Agent, Crew, Task
 
 from latitude_telemetry import Latitude, capture
@@ -20,12 +22,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["crewai", "openai"],
+    instrumentations={"crewai": crewai, "openai": openai},
     disable_batch=True,
 )
 
 
-@capture("test-crewai-crew", {"tags": ["test"], "session_id": "example"})
+@capture("test-crewai-crew", {"tags": ["python", "test"], "session_id": "example"})
 def test_crewai_crew():
     researcher = Agent(
         role="Researcher",

--- a/packages/telemetry/python/examples/test_dspy.py
+++ b/packages/telemetry/python/examples/test_dspy.py
@@ -10,18 +10,17 @@ Install: uv add dspy
 
 import os
 
+import dspy
+
 from latitude_telemetry import Latitude, capture
 
-# Initialize telemetry BEFORE importing dspy so instrumentation can patch it
+# Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["dspy"],
+    instrumentations={"dspy": dspy},
     disable_batch=True,
 )
-
-# Import after telemetry is initialized
-import dspy
 
 
 # Define a simple DSPy signature
@@ -32,7 +31,7 @@ class SimpleQA(dspy.Signature):
     answer: str = dspy.OutputField()
 
 
-@capture("test-dspy-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-dspy-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_dspy_completion():
     # Configure DSPy with OpenAI
     lm = dspy.LM("openai/gpt-4o-mini")

--- a/packages/telemetry/python/examples/test_gemini.py
+++ b/packages/telemetry/python/examples/test_gemini.py
@@ -10,21 +10,20 @@ Install: uv add google-genai
 
 import os
 
+from google import genai
+
 from latitude_telemetry import Latitude, capture
 
-# Initialize telemetry BEFORE importing google.genai so instrumentation can patch it
+# Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["google_generativeai"],
+    instrumentations={"google_generativeai": genai},
     disable_batch=True,
 )
 
-# Import after telemetry is initialized
-from google import genai
 
-
-@capture("test-gemini-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-gemini-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_gemini_completion():
     client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 

--- a/packages/telemetry/python/examples/test_groq.py
+++ b/packages/telemetry/python/examples/test_groq.py
@@ -10,6 +10,7 @@ Install: uv add groq
 
 import os
 
+import groq
 from groq import Groq
 
 from latitude_telemetry import Latitude, capture
@@ -18,12 +19,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["groq"],
+    instrumentations={"groq": groq},
     disable_batch=True,
 )
 
 
-@capture("test-groq-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-groq-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_groq_completion():
     client = Groq()
 

--- a/packages/telemetry/python/examples/test_haystack.py
+++ b/packages/telemetry/python/examples/test_haystack.py
@@ -10,6 +10,7 @@ Install: uv add haystack-ai
 
 import os
 
+import haystack
 from haystack import Pipeline
 from haystack.components.builders import PromptBuilder
 from haystack.components.generators import OpenAIGenerator
@@ -20,12 +21,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["haystack"],
+    instrumentations={"haystack": haystack},
     disable_batch=True,
 )
 
 
-@capture("test-haystack-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-haystack-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_haystack_completion():
     # Build a simple pipeline
     pipeline = Pipeline()

--- a/packages/telemetry/python/examples/test_langchain.py
+++ b/packages/telemetry/python/examples/test_langchain.py
@@ -10,13 +10,15 @@ Install: uv add langchain-core langchain-openai
 
 import os
 
+import langchain_core
+
 from latitude_telemetry import Latitude, capture
 
 # Initialize telemetry BEFORE importing langchain so instrumentation can patch it
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["langchain"],
+    instrumentations={"langchain": langchain_core},
     disable_batch=True,
 )
 
@@ -25,7 +27,7 @@ from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 
 
-@capture("test-langchain-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-langchain-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_langchain_completion():
     llm = ChatOpenAI(model="gpt-4o-mini", max_tokens=50)
 

--- a/packages/telemetry/python/examples/test_litellm.py
+++ b/packages/telemetry/python/examples/test_litellm.py
@@ -18,12 +18,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["litellm"],
+    instrumentations={"litellm": litellm},
     disable_batch=True,
 )
 
 
-@capture("test-litellm-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-litellm-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_litellm_completion():
     # LiteLLM can call any provider - using OpenAI here as example
     response = litellm.completion(

--- a/packages/telemetry/python/examples/test_llamaindex.py
+++ b/packages/telemetry/python/examples/test_llamaindex.py
@@ -10,6 +10,7 @@ Install: uv add llama-index llama-index-llms-openai
 
 import os
 
+import llama_index
 from llama_index.llms.openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -18,12 +19,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["llamaindex"],
+    instrumentations={"llamaindex": llama_index},
     disable_batch=True,
 )
 
 
-@capture("test-llamaindex-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-llamaindex-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_llamaindex_completion():
     llm = OpenAI(model="gpt-4o-mini", max_tokens=50)
 

--- a/packages/telemetry/python/examples/test_manual_instrumentation.py
+++ b/packages/telemetry/python/examples/test_manual_instrumentation.py
@@ -17,6 +17,7 @@ Install: uv add openai
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -25,7 +26,7 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
@@ -33,7 +34,7 @@ latitude = Latitude(
 @capture(
     "agent-with-custom-spans",
     {
-        "tags": ["manual-instrumentation", "test"],
+        "tags": ["python", "manual-instrumentation", "test"],
         "session_id": "manual-test-session",
         "user_id": "manual-test-user",
         "metadata": {"agent_type": "custom-span-test"},
@@ -94,7 +95,7 @@ def agent_with_manual_spans():
 @capture(
     "nested-capture-with-manual-spans",
     {
-        "tags": ["nested-manual"],
+        "tags": ["python", "nested-manual"],
         "session_id": "nested-session",
         "metadata": {"outer": True},
     },
@@ -127,7 +128,7 @@ def outer_with_manual_spans():
 @capture(
     "inner-capture-manual",
     {
-        "tags": ["inner-manual"],
+        "tags": ["python", "inner-manual"],
         "metadata": {"inner": True},
     },
 )
@@ -187,7 +188,7 @@ def test_manual_spans_with_callback():
         "callback-manual-test",
         agent_logic,
         {
-            "tags": ["callback-manual"],
+            "tags": ["python", "callback-manual"],
             "session_id": "callback-session",
             "metadata": {"test_type": "callback"},
         },

--- a/packages/telemetry/python/examples/test_mistral.py
+++ b/packages/telemetry/python/examples/test_mistral.py
@@ -10,21 +10,21 @@ Install: uv add mistralai
 
 import os
 
+import mistralai
+from mistralai import Mistral
+
 from latitude_telemetry import Latitude, capture
 
-# Initialize telemetry BEFORE importing mistralai so instrumentation can patch it
+# Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["mistralai"],
+    instrumentations={"mistralai": mistralai},
     disable_batch=True,
 )
 
-# Import after telemetry is initialized
-from mistralai import Mistral
 
-
-@capture("test-mistral-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-mistral-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_mistral_completion():
     from mistralai.models import UserMessage
 

--- a/packages/telemetry/python/examples/test_ollama.py
+++ b/packages/telemetry/python/examples/test_ollama.py
@@ -20,12 +20,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["ollama"],
+    instrumentations={"ollama": ollama},
     disable_batch=True,
 )
 
 
-@capture("test-ollama-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-ollama-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_ollama_completion():
     response = ollama.chat(
         model="llama3.2",

--- a/packages/telemetry/python/examples/test_openai.py
+++ b/packages/telemetry/python/examples/test_openai.py
@@ -11,6 +11,7 @@ Install: uv add openai
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -19,7 +20,7 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
@@ -48,7 +49,7 @@ def test_openai_completion():
 @capture(
     "test-openai-streaming",
     {
-        "tags": ["test"],
+        "tags": ["python", "test"],
         "session_id": "example",
         "user_id": "user_123",
         "metadata": {"test_type": "streaming", "environment": "local"},
@@ -100,7 +101,7 @@ def test_openai_completion_callback():
         "test-openai-callback",
         make_completion,
         {
-            "tags": ["callback-test"],
+            "tags": ["python", "callback-test"],
             "session_id": "callback-example",
             "user_id": "user_callback",
             "metadata": {"test_type": "callback", "environment": "local"},

--- a/packages/telemetry/python/examples/test_openai_agents.py
+++ b/packages/telemetry/python/examples/test_openai_agents.py
@@ -12,6 +12,7 @@ Install: uv add openai-agents
 import asyncio
 import os
 
+import agents
 from agents import Agent, Runner, function_tool
 
 from latitude_telemetry import Latitude, capture
@@ -20,7 +21,7 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai-agents"],
+    instrumentations={"openai-agents": agents},
     disable_batch=True,
 )
 
@@ -48,7 +49,7 @@ def test_openai_agents_run():
         "weather-agent-run",
         lambda: asyncio.run(run_agent()),
         {
-            "tags": ["test", "openai-agents"],
+            "tags": ["python", "test", "openai-agents"],
             "session_id": "example",
             "user_id": "user_123",
             "metadata": {"test_type": "agent_run", "environment": "local"},

--- a/packages/telemetry/python/examples/test_openai_responses.py
+++ b/packages/telemetry/python/examples/test_openai_responses.py
@@ -11,6 +11,7 @@ Install: uv add openai
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -18,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 

--- a/packages/telemetry/python/examples/test_project_scoping_env.py
+++ b/packages/telemetry/python/examples/test_project_scoping_env.py
@@ -25,6 +25,7 @@ Run from `packages/telemetry/python/`:
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -32,14 +33,14 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
 OVERRIDE_SLUG = "evaluation-runs"
 
 
-@capture("default-route")
+@capture("default-route", {"tags": ["python"]})
 def default_route() -> None:
     client = OpenAI()
     r = client.chat.completions.create(
@@ -50,7 +51,7 @@ def default_route() -> None:
     print("default-route →", r.choices[0].message.content)
 
 
-@capture("evaluation-batch", {"project_slug": OVERRIDE_SLUG})
+@capture("evaluation-batch", {"project_slug": OVERRIDE_SLUG, "tags": ["python"]})
 def evaluation_batch() -> None:
     client = OpenAI()
     r = client.chat.completions.create(

--- a/packages/telemetry/python/examples/test_project_scoping_multi.py
+++ b/packages/telemetry/python/examples/test_project_scoping_multi.py
@@ -26,13 +26,14 @@ Run from `packages/telemetry/python/`:
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
@@ -42,7 +43,7 @@ CALL_SUMMARISER_SLUG = os.environ.get("LATITUDE_SECONDARY_PROJECT_SLUG", "second
 
 @capture(
     "full-stack-agent-run",
-    {"project_slug": FULL_STACK_AGENT_SLUG, "tags": ["agent:full-stack"]},
+    {"project_slug": FULL_STACK_AGENT_SLUG, "tags": ["python", "agent:full-stack"]},
 )
 def run_full_stack_agent() -> None:
     client = OpenAI()
@@ -56,7 +57,7 @@ def run_full_stack_agent() -> None:
 
 @capture(
     "call-summariser-run",
-    {"project_slug": CALL_SUMMARISER_SLUG, "tags": ["agent:summariser"]},
+    {"project_slug": CALL_SUMMARISER_SLUG, "tags": ["python", "agent:summariser"]},
 )
 def run_call_summariser() -> None:
     client = OpenAI()

--- a/packages/telemetry/python/examples/test_project_scoping_single.py
+++ b/packages/telemetry/python/examples/test_project_scoping_single.py
@@ -17,6 +17,7 @@ Run from `packages/telemetry/python/`:
 
 import os
 
+import openai
 from openai import OpenAI
 
 from latitude_telemetry import Latitude, capture
@@ -24,12 +25,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["openai"],
+    instrumentations={"openai": openai},
     disable_batch=True,
 )
 
 
-@capture("greet")
+@capture("greet", {"tags": ["python"]})
 def greet() -> None:
     client = OpenAI()
     r = client.chat.completions.create(
@@ -40,7 +41,7 @@ def greet() -> None:
     print("greet →", r.choices[0].message.content)
 
 
-@capture("summarize", {"tags": ["demo"]})
+@capture("summarize", {"tags": ["python", "demo"]})
 def summarize() -> None:
     client = OpenAI()
     r = client.chat.completions.create(

--- a/packages/telemetry/python/examples/test_replicate.py
+++ b/packages/telemetry/python/examples/test_replicate.py
@@ -18,12 +18,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["replicate"],
+    instrumentations={"replicate": replicate},
     disable_batch=True,
 )
 
 
-@capture("test-replicate-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-replicate-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_replicate_completion():
     output = replicate.run(
         "meta/meta-llama-3-8b-instruct",

--- a/packages/telemetry/python/examples/test_sagemaker.py
+++ b/packages/telemetry/python/examples/test_sagemaker.py
@@ -22,12 +22,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["sagemaker"],
+    instrumentations={"sagemaker": boto3},
     disable_batch=True,
 )
 
 
-@capture("test-sagemaker-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-sagemaker-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_sagemaker_completion():
     client = boto3.client(
         "sagemaker-runtime",

--- a/packages/telemetry/python/examples/test_together.py
+++ b/packages/telemetry/python/examples/test_together.py
@@ -10,6 +10,7 @@ Install: uv add together
 
 import os
 
+import together
 from together import Together
 
 from latitude_telemetry import Latitude, capture
@@ -18,12 +19,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["together"],
+    instrumentations={"togetherai": together},
     disable_batch=True,
 )
 
 
-@capture("test-together-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-together-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_together_completion():
     client = Together()
 

--- a/packages/telemetry/python/examples/test_transformers.py
+++ b/packages/telemetry/python/examples/test_transformers.py
@@ -9,6 +9,7 @@ Install: uv add transformers torch
 
 import os
 
+import transformers
 from transformers import pipeline
 
 from latitude_telemetry import Latitude, capture
@@ -17,12 +18,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["transformers"],
+    instrumentations={"transformers": transformers},
     disable_batch=True,
 )
 
 
-@capture("test-transformers-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-transformers-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_transformers_completion():
     # Using a small model for testing
     generator = pipeline(

--- a/packages/telemetry/python/examples/test_vertex.py
+++ b/packages/telemetry/python/examples/test_vertex.py
@@ -20,12 +20,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["vertexai"],
+    instrumentations={"vertexai": vertexai},
     disable_batch=True,
 )
 
 
-@capture("test-vertex-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-vertex-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_vertex_completion():
     # Initialize Vertex AI
     vertexai.init(

--- a/packages/telemetry/python/examples/test_watsonx.py
+++ b/packages/telemetry/python/examples/test_watsonx.py
@@ -12,6 +12,7 @@ Install: uv add ibm-watsonx-ai
 
 import os
 
+import ibm_watsonx_ai
 from ibm_watsonx_ai.foundation_models import Model
 from ibm_watsonx_ai.metanames import GenTextParamsMetaNames as GenParams
 
@@ -21,12 +22,12 @@ from latitude_telemetry import Latitude, capture
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
     project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
-    instrumentations=["watsonx"],
+    instrumentations={"watsonx": ibm_watsonx_ai},
     disable_batch=True,
 )
 
 
-@capture("test-watsonx-completion", {"tags": ["test"], "session_id": "example"})
+@capture("test-watsonx-completion", {"tags": ["python", "test"], "session_id": "example"})
 def test_watsonx_completion():
     model = Model(
         model_id="ibm/granite-13b-chat-v2",

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a6"
+version = "3.0.0a7"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/__init__.py
+++ b/packages/telemetry/python/src/latitude_telemetry/__init__.py
@@ -5,12 +5,15 @@ Instruments AI provider calls and forwards traces to Latitude.
 Built on OpenTelemetry.
 
 Example (Bootstrap - Recommended):
+    import anthropic
+    import openai
+
     from latitude_telemetry import Latitude, capture
 
     latitude = Latitude(
         api_key="your-api-key",
         project_slug="my-project",
-        instrumentations=["openai", "anthropic"],
+        instrumentations={"openai": openai, "anthropic": anthropic},
     )
 
     @capture("agent-run", {"tags": ["prod"], "user_id": "user_123"})
@@ -25,6 +28,8 @@ Example (Bootstrap - Recommended):
     latitude.shutdown()
 
 Example (Advanced - Existing OTel Setup):
+    import openai
+
     from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
     from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
@@ -33,13 +38,15 @@ Example (Advanced - Existing OTel Setup):
     provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
     trace.set_tracer_provider(provider)
 
-    register_latitude_instrumentations(["openai"], provider)
+    register_latitude_instrumentations({"openai": openai}, provider)
 """
 
 from latitude_telemetry.constants import ATTRIBUTES
 from latitude_telemetry.sdk import (
     ContextOptions,
     InitLatitudeOptions,
+    InstrumentationName,
+    InstrumentationsInput,
     InstrumentationType,
     Latitude,
     LatitudeOptions,
@@ -77,6 +84,8 @@ __all__ = [
     # Types
     "ContextOptions",
     "InitLatitudeOptions",
+    "InstrumentationName",
+    "InstrumentationsInput",
     "InstrumentationType",
     "LatitudeOptions",
     "LatitudeSpanProcessorOptions",

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/__init__.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/__init__.py
@@ -8,6 +8,8 @@ from latitude_telemetry.sdk.instrumentations import register_latitude_instrument
 from latitude_telemetry.sdk.types import (
     ContextOptions,
     InitLatitudeOptions,
+    InstrumentationName,
+    InstrumentationsInput,
     InstrumentationType,
     LatitudeOptions,
     LatitudeSpanProcessorOptions,
@@ -22,6 +24,8 @@ __all__ = [
     "register_latitude_instrumentations",
     "ContextOptions",
     "InitLatitudeOptions",
+    "InstrumentationName",
+    "InstrumentationsInput",
     "InstrumentationType",
     "LatitudeOptions",
     "LatitudeSpanProcessorOptions",

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -19,7 +19,7 @@ from opentelemetry.trace import NoOpTracerProvider, ProxyTracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
-from latitude_telemetry.sdk.types import InstrumentationType, SmartFilterOptions
+from latitude_telemetry.sdk.types import InstrumentationsInput, SmartFilterOptions
 from latitude_telemetry.telemetry.latitude_span_processor import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
 from latitude_telemetry.telemetry.redact_span_processor import RedactSpanProcessorOptions
 
@@ -74,7 +74,7 @@ class Latitude:
         *,
         api_key: str,
         project_slug: str | None = None,
-        instrumentations: list[InstrumentationType] | None = None,
+        instrumentations: InstrumentationsInput | None = None,
         disable_redact: bool = False,
         redact: RedactSpanProcessorOptions | None = None,
         disable_batch: bool = False,
@@ -194,7 +194,7 @@ class Latitude:
 def init_latitude(
     api_key: str,
     project_slug: str | None = None,
-    instrumentations: list[InstrumentationType] | None = None,
+    instrumentations: InstrumentationsInput | None = None,
     disable_redact: bool = False,
     redact: RedactSpanProcessorOptions | None = None,
     disable_batch: bool = False,

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/instrumentations.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/instrumentations.py
@@ -1,143 +1,238 @@
 """
 LLM instrumentation registration for Latitude Telemetry SDK.
+
+Mirrors the TypeScript SDK's object-form `instrumentations` API: callers pass
+a dict mapping integration name → the LLM SDK module they imported in app
+code. The registry below resolves each name to the matching OpenTelemetry
+instrumentor and hands it the user-supplied module so the patch lands on the
+same module instance the app actually uses.
 """
 
 import logging
-from typing import cast
+from dataclasses import dataclass
+from typing import Mapping, cast
 
 from opentelemetry.sdk.trace import TracerProvider
 
-from latitude_telemetry.sdk.types import InstrumentationType
-from latitude_telemetry.util import is_package_installed
+from latitude_telemetry.sdk.types import InstrumentationName, InstrumentationsInput
 
 logger = logging.getLogger(__name__)
 
-# Instrumentation config type
-InstrConfig = dict[str, object]
+DOCS_URL = "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/python#readme"
 
-INSTRUMENTATION_MAP: dict[InstrumentationType, InstrConfig] = {
-    "openai": {
-        "module": "opentelemetry.instrumentation.openai",
-        "class": "OpenAIInstrumentor",
-        "package": "openai",
-        "manual": False,
-    },
-    "openai-agents": {
-        "module": "openinference.instrumentation.openai_agents",
-        "class": "OpenAIAgentsInstrumentor",
+
+@dataclass(frozen=True)
+class IntegrationDef:
+    """One row in the supported-integrations registry."""
+
+    instrumentor_module: str
+    """Dotted path to the OpenTelemetry instrumentor module (e.g. `opentelemetry.instrumentation.openai`)."""
+
+    instrumentor_class: str
+    """Name of the instrumentor class inside `instrumentor_module`."""
+
+    pypi_dist_name: str
+    """PyPI distribution name surfaced in the not-installed warning + pip-install hint."""
+
+
+INTEGRATIONS: dict[InstrumentationName, IntegrationDef] = {
+    "openai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.openai",
+        instrumentor_class="OpenAIInstrumentor",
+        pypi_dist_name="openai",
+    ),
+    "openai-agents": IntegrationDef(
+        instrumentor_module="openinference.instrumentation.openai_agents",
+        instrumentor_class="OpenAIAgentsInstrumentor",
         # The host package's PyPI distribution name is `openai-agents` (its import
-        # name is `agents`). `is_package_installed` checks PyPI distribution names,
-        # and the warning text doubles as a `pip install` hint, so use the PyPI name.
-        "package": "openai-agents",
-        "manual": False,
-    },
-    "anthropic": {
-        "module": "opentelemetry.instrumentation.anthropic",
-        "class": "AnthropicInstrumentor",
-        "package": "anthropic",
-        "manual": True,
-    },
-    "bedrock": {
-        "module": "opentelemetry.instrumentation.bedrock",
-        "class": "BedrockInstrumentor",
-        "package": "boto3",
-        "manual": True,
-    },
-    "cohere": {
-        "module": "opentelemetry.instrumentation.cohere",
-        "class": "CohereInstrumentor",
-        "package": "cohere",
-        "manual": True,
-    },
-    "langchain": {
-        "module": "opentelemetry.instrumentation.langchain",
-        "class": "LangchainInstrumentor",
-        "package": "langchain-core",
-        "manual": True,
-    },
-    "llamaindex": {
-        "module": "opentelemetry.instrumentation.llamaindex",
-        "class": "LlamaIndexInstrumentor",
-        "package": "llama-index",
-        "manual": True,
-    },
-    "togetherai": {
-        "module": "opentelemetry.instrumentation.together",
-        "class": "TogetherAiInstrumentor",
-        "package": "together",
-        "manual": True,
-    },
-    "vertexai": {
-        "module": "opentelemetry.instrumentation.vertexai",
-        "class": "VertexAIInstrumentor",
-        "package": "google-cloud-aiplatform",
-        "manual": True,
-    },
-    "aiplatform": {
-        "module": "opentelemetry.instrumentation.vertexai",
-        "class": "AIPlatformInstrumentor",
-        "package": "google-cloud-aiplatform",
-        "manual": True,
-    },
+        # name is `agents`). The pip-install hint uses this.
+        pypi_dist_name="openai-agents",
+    ),
+    "anthropic": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.anthropic",
+        instrumentor_class="AnthropicInstrumentor",
+        pypi_dist_name="anthropic",
+    ),
+    "bedrock": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.bedrock",
+        instrumentor_class="BedrockInstrumentor",
+        pypi_dist_name="boto3",
+    ),
+    "cohere": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.cohere",
+        instrumentor_class="CohereInstrumentor",
+        pypi_dist_name="cohere",
+    ),
+    "langchain": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.langchain",
+        instrumentor_class="LangchainInstrumentor",
+        pypi_dist_name="langchain-core",
+    ),
+    "llamaindex": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.llamaindex",
+        instrumentor_class="LlamaIndexInstrumentor",
+        pypi_dist_name="llama-index",
+    ),
+    "togetherai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.together",
+        instrumentor_class="TogetherAiInstrumentor",
+        pypi_dist_name="together",
+    ),
+    "vertexai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.vertexai",
+        instrumentor_class="VertexAIInstrumentor",
+        pypi_dist_name="google-cloud-aiplatform",
+    ),
+    "aiplatform": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.vertexai",
+        instrumentor_class="AIPlatformInstrumentor",
+        pypi_dist_name="google-cloud-aiplatform",
+    ),
+    # Python-only — the OpenLLMetry Python ecosystem ships more pre-built
+    # instrumentors than the TypeScript side. Adding these here is a pure
+    # capability addition for Python users; nothing analogous exists in TS.
+    "aleph_alpha": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.alephalpha",
+        instrumentor_class="AlephAlphaInstrumentor",
+        pypi_dist_name="aleph-alpha-client",
+    ),
+    "crewai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.crewai",
+        instrumentor_class="CrewAIInstrumentor",
+        pypi_dist_name="crewai",
+    ),
+    "dspy": IntegrationDef(
+        instrumentor_module="openinference.instrumentation.dspy",
+        instrumentor_class="DSPyInstrumentor",
+        pypi_dist_name="dspy-ai",
+    ),
+    "google_generativeai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.google_generativeai",
+        instrumentor_class="GoogleGenerativeAiInstrumentor",
+        pypi_dist_name="google-generativeai",
+    ),
+    "groq": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.groq",
+        instrumentor_class="GroqInstrumentor",
+        pypi_dist_name="groq",
+    ),
+    "haystack": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.haystack",
+        instrumentor_class="HaystackInstrumentor",
+        pypi_dist_name="haystack-ai",
+    ),
+    "litellm": IntegrationDef(
+        instrumentor_module="openinference.instrumentation.litellm",
+        instrumentor_class="LiteLLMInstrumentor",
+        pypi_dist_name="litellm",
+    ),
+    "mistralai": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.mistralai",
+        instrumentor_class="MistralAiInstrumentor",
+        pypi_dist_name="mistralai",
+    ),
+    "ollama": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.ollama",
+        instrumentor_class="OllamaInstrumentor",
+        pypi_dist_name="ollama",
+    ),
+    "replicate": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.replicate",
+        instrumentor_class="ReplicateInstrumentor",
+        pypi_dist_name="replicate",
+    ),
+    "sagemaker": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.sagemaker",
+        instrumentor_class="SageMakerInstrumentor",
+        pypi_dist_name="boto3",
+    ),
+    "transformers": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.transformers",
+        instrumentor_class="TransformersInstrumentor",
+        pypi_dist_name="transformers",
+    ),
+    "watsonx": IntegrationDef(
+        instrumentor_module="opentelemetry.instrumentation.watsonx",
+        instrumentor_class="WatsonxInstrumentor",
+        pypi_dist_name="ibm-watson-machine-learning",
+    ),
 }
 
 
+def _is_plain_dict(value: object) -> bool:
+    """A plain dict, not a list, not a string, not a tuple, not None."""
+    return isinstance(value, dict)
+
+
 def register_latitude_instrumentations(
-    instrumentations: list[InstrumentationType],
+    instrumentations: InstrumentationsInput,
     tracer_provider: TracerProvider,
 ) -> None:
     """
     Register LLM instrumentations with the given tracer provider.
 
     Args:
-        instrumentations: List of instrumentation types to enable
-        tracer_provider: The tracer provider to register instrumentations with
+        instrumentations: Mapping of integration name → the LLM SDK module the consumer imports
+            (e.g. ``{"openai": openai, "anthropic": anthropic}``). Anything other than a plain dict
+            (including the legacy list-of-strings form) raises :class:`TypeError` at register time.
+        tracer_provider: The tracer provider to register instrumentations with.
 
     Example:
+        import openai
+        import anthropic
+
         register_latitude_instrumentations(
-            instrumentations=["openai", "anthropic"],
+            instrumentations={"openai": openai, "anthropic": anthropic},
             tracer_provider=provider,
         )
     """
-    for inst_type in instrumentations:
+    if not _is_plain_dict(instrumentations):
+        raise TypeError(
+            f"[Latitude] instrumentations must be a dict mapping integration names to LLM SDK modules "
+            f"(e.g. {{'openai': openai, 'anthropic': anthropic}}). Received: {instrumentations!r}. "
+            f"See {DOCS_URL}."
+        )
+
+    typed = cast(Mapping[str, object], instrumentations)
+    for raw_name, module in typed.items():
+        if module is None:
+            continue
+
+        if raw_name not in INTEGRATIONS:
+            raise TypeError(
+                f"[Latitude] instrumentations: unknown integration {raw_name!r}. "
+                f"Expected one of: {', '.join(INTEGRATIONS.keys())}. See {DOCS_URL}."
+            )
+
+        name = raw_name
+        config = INTEGRATIONS[name]
+
         try:
-            config: dict[str, object] | None = INSTRUMENTATION_MAP.get(inst_type)
-            if not config:
-                logger.warning(f"Unknown instrumentation type: {inst_type}")
-                continue
+            instrumentor_module = __import__(config.instrumentor_module, fromlist=[config.instrumentor_class])
+            instrumentor_class = getattr(instrumentor_module, config.instrumentor_class)
+        except (ImportError, AttributeError):
+            logger.warning(
+                "[Latitude] Instrumentation package not installed for %s: %s. "
+                "Add it as a dependency to enable this instrumentation.",
+                name,
+                config.pypi_dist_name,
+            )
+            continue
 
-            package_name = cast(str, config["package"])
-            if not is_package_installed(package_name):
-                logger.warning(
-                    f"Package '{package_name}' is not installed. Install it to use the {inst_type} instrumentation."
-                )
-                continue
-
-            try:
-                module_name = cast(str, config["module"])
-                class_name = cast(str, config["class"])
-                module = __import__(module_name, fromlist=[class_name])
-                instrumentor_class = getattr(module, class_name)
-            except (ImportError, AttributeError) as e:
-                logger.warning(f"Failed to import {inst_type} instrumentation: {e}")
-                continue
-
-            try:
-                instrumentor = instrumentor_class()
-
-                is_manual: bool = config.get("manual")  # type: ignore[assignment]
-                if is_manual:
-                    package_module_name = cast(str, config["package"])
-                    package_module = __import__(package_module_name)
-                    if hasattr(instrumentor, "manually_instrument"):
-                        instrumentor.manually_instrument(package_module)
-                    elif hasattr(instrumentor, "instrument"):
-                        instrumentor.instrument(tracer_provider=tracer_provider)
-                else:
-                    instrumentor.instrument(tracer_provider=tracer_provider)
-            except Exception as e:
-                logger.warning(f"Failed to register {inst_type} instrumentation: {e}")
-                continue
+        try:
+            instrumentor = instrumentor_class()
         except Exception as e:
-            logger.warning(f"Unexpected error registering {inst_type} instrumentation: {e}")
+            logger.warning("[Latitude] Failed to instantiate %s instrumentor: %s", name, e)
+            continue
+
+        try:
+            # Prefer manually_instrument() when the instrumentor exposes it — that's the
+            # path where the user-supplied module reference is actually used. Fall back to
+            # the standard instrument(tracer_provider=...) call otherwise.
+            if hasattr(instrumentor, "manually_instrument"):
+                instrumentor.manually_instrument(module)  # type: ignore[reportUnknownMemberType]
+            else:
+                instrumentor.instrument(tracer_provider=tracer_provider)  # type: ignore[reportUnknownMemberType]
+        except Exception as e:
+            logger.warning("[Latitude] Failed to register %s instrumentation: %s", name, e)
             continue

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
@@ -9,7 +9,7 @@ from opentelemetry.sdk.trace.export import SpanExporter
 
 from latitude_telemetry.telemetry.redact_span_processor import RedactSpanProcessorOptions
 
-InstrumentationType = Literal[
+InstrumentationName = Literal[
     "openai",
     "openai-agents",
     "anthropic",
@@ -20,7 +20,30 @@ InstrumentationType = Literal[
     "togetherai",
     "vertexai",
     "aiplatform",
+    "aleph_alpha",
+    "crewai",
+    "dspy",
+    "google_generativeai",
+    "groq",
+    "haystack",
+    "litellm",
+    "mistralai",
+    "ollama",
+    "replicate",
+    "sagemaker",
+    "transformers",
+    "watsonx",
 ]
+
+# Back-compat alias — kept so existing imports of `InstrumentationType` keep
+# working while the canonical name aligns with the TypeScript SDK.
+InstrumentationType = InstrumentationName
+
+# Map of integration name → the LLM SDK module the consumer imports in app code.
+# Example: ``{"openai": openai, "anthropic": anthropic}``. Anything other than a
+# plain dict (including the legacy list-of-strings form) raises ``TypeError`` at
+# register time.
+InstrumentationsInput = dict[InstrumentationName, object]
 
 
 class SmartFilterOptions(TypedDict, total=False):
@@ -47,7 +70,7 @@ class LatitudeOptions(SmartFilterOptions, total=False):
     # forwards it as the `X-Latitude-Project` header so spans without a per-span override
     # land in this project.
     project_slug: NotRequired[str]
-    instrumentations: list[InstrumentationType]
+    instrumentations: InstrumentationsInput
     disable_redact: bool
     redact: RedactSpanProcessorOptions
     disable_batch: bool

--- a/packages/telemetry/python/tests/telemetry/instrument_test.py
+++ b/packages/telemetry/python/tests/telemetry/instrument_test.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from unittest import mock
 
+import openai as openai_module
 from openai import OpenAI
 from openai.types.chat import ChatCompletion as OpenAIChatCompletion
 from openai.types.chat import ChatCompletionMessage as OpenAIChatCompletionMessage
@@ -15,7 +16,7 @@ from tests.utils import TestCase
 
 class TestInstrument(TestCase):
     def create_openai_mock(self):
-        openai = OpenAI(api_key="fake-api-key")
+        client = OpenAI(api_key="fake-api-key")
 
         completion = OpenAIChatCompletion(
             object="chat.completion",
@@ -39,15 +40,15 @@ class TestInstrument(TestCase):
             created=int(datetime.now().timestamp()),
         )
 
-        return openai, completion
+        return client, completion
 
     def test_success_instruments_openai(self):
         """Test that OpenAI instrumentation creates spans with correct attributes."""
-        openai, completion = self.create_openai_mock()
+        client, completion = self.create_openai_mock()
 
         with mock.patch("openai.resources.chat.completions.Completions.create", return_value=completion):
-            register_latitude_instrumentations(["openai"], self.provider)
-            openai.chat.completions.create(
+            register_latitude_instrumentations({"openai": openai_module}, self.provider)
+            client.chat.completions.create(
                 model="gpt-4o-mini",
                 messages=[{"role": "user", "content": "Hello..."}],
             )
@@ -62,3 +63,15 @@ class TestInstrument(TestCase):
         self.assert_span_has_attribute(span, "gen_ai.response.model", "gpt-4o-mini")
         self.assert_span_has_attribute(span, "gen_ai.usage.input_tokens", 10)
         self.assert_span_has_attribute(span, "gen_ai.usage.output_tokens", 20)
+
+    def test_rejects_legacy_list_form(self):
+        """Passing a list (legacy form) raises TypeError with a migration hint."""
+        with self.assertRaises(TypeError) as ctx:
+            register_latitude_instrumentations(["openai"], self.provider)  # type: ignore[arg-type]
+        self.assertIn("must be a dict mapping", str(ctx.exception))
+
+    def test_rejects_unknown_integration_key(self):
+        """Passing a key not in the registry raises TypeError naming the supported keys."""
+        with self.assertRaises(TypeError) as ctx:
+            register_latitude_instrumentations({"nope": openai_module}, self.provider)  # type: ignore[arg-type]
+        self.assertIn("unknown integration", str(ctx.exception))

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.0.0a6"
+version = "3.0.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.11] - 2026-05-14
+
+### Breaking Changes
+
+- **`instrumentations` is now an object mapping integration name → LLM SDK module.** Replaces the magic-string array form. Example: `instrumentations: { openai: OpenAI, anthropic: AnthropicSDK }`. The consumer passes the LLM SDK module they already imported, so the patch lands on the same prototype their app code calls.
+- **The string-array form (`instrumentations: ["openai"]`) is removed with no fallback.** Passing a string array — or anything other than a plain object — throws at register time. Migration: `instrumentations: { openai: OpenAI }`. See the README's "Migrating from `instrumentations: ["openai"]`" section.
+- **`modules` option on `registerLatitudeInstrumentations` is removed.** Pass the module directly under its integration key on `instrumentations`.
+- **Why:** `tryRequire` inside the telemetry package's ESM-compiled `__require` shim loaded the CJS build of dual-bundled LLM SDKs (`openai@6`, `@anthropic-ai/sdk@0.96`, …), while the consumer app loaded the ESM build. Patching the CJS class had no effect on instances the app code actually called, so no traces appeared while the SDK reported a healthy bootstrap. Forcing the consumer to pass the module makes that bug impossible to express.
+
+### Added
+
+- New `InstrumentationName` and `InstrumentationsInput` types exported from `@latitude-data/telemetry`.
+
+### Removed
+
+- `tryRequire` fallback (the CJS/ESM auto-resolver behind the string-array path).
+- Legacy `LEGACY_INSTRUMENTATION_MAP` lookup table.
+
 ## [3.0.0-alpha.10] - 2026-05-14
 
 ### Added

--- a/packages/telemetry/typescript/README.md
+++ b/packages/telemetry/typescript/README.md
@@ -15,19 +15,22 @@ npm install @latitude-data/telemetry
 The fastest way to start tracing your LLM calls. One class sets up everything:
 
 ```typescript
+import OpenAI from "openai";
 import { Latitude } from "@latitude-data/telemetry";
+
+const client = new OpenAI();
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"], // Auto-instrument OpenAI, Anthropic, etc.
+  instrumentations: { openai: OpenAI }, // Pass the LLM SDK module you use in app code.
 });
 
 // Optionally wait for instrumentations to be ready
 await latitude.ready;
 
 // Your LLM calls will now be traced and sent to Latitude
-const response = await openai.chat.completions.create({
+const response = await client.chat.completions.create({
   model: "gpt-4",
   messages: [{ role: "user", content: "Hello" }],
 });
@@ -62,6 +65,7 @@ await latitude.shutdown();
 If your app already uses Sentry or another OpenTelemetry-compatible SDK, initialize that SDK first and then construct `new Latitude()`:
 
 ```typescript
+import OpenAI from "openai";
 import * as Sentry from "@sentry/node";
 import { Latitude } from "@latitude-data/telemetry";
 
@@ -73,7 +77,7 @@ Sentry.init({
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 
 await latitude.ready;
@@ -86,6 +90,7 @@ await latitude.shutdown(); // Does not shut down Sentry.
 For fully custom OTel setups, you can also wire the Latitude processor explicitly:
 
 ```typescript
+import OpenAI from "openai";
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import {
   LatitudeSpanProcessor,
@@ -106,12 +111,13 @@ sdk.start();
 
 // Enable LLM auto-instrumentation
 await registerLatitudeInstrumentations({
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   tracerProvider: sdk.getTracerProvider(),
 });
 
 // Your LLM calls will now be traced and sent to Latitude
-const response = await openai.chat.completions.create({
+const client = new OpenAI();
+const response = await client.chat.completions.create({
   model: "gpt-4",
   messages: [{ role: "user", content: "Hello" }],
 });
@@ -150,12 +156,13 @@ You don't need `capture()` to get started—auto-instrumentation handles LLM cal
 ### Example
 
 ```typescript
+import OpenAI from "openai";
 import { Latitude, capture } from "@latitude-data/telemetry";
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 
 // Optional: wait for instrumentations before starting
@@ -208,8 +215,10 @@ The primary entry point. Bootstraps a complete OpenTelemetry setup with LLM inst
 ```typescript
 type LatitudeOptions = {
   apiKey: string;
-  projectSlug: string;
-  instrumentations?: InstrumentationType[]; // ["openai", "anthropic", etc.]
+  projectSlug?: string;
+  // Map of integration name → LLM SDK module the consumer imports.
+  // Anything else (string array, unknown key, non-object) throws at register time.
+  instrumentations?: InstrumentationsInput;
   serviceName?: string;
   disableBatch?: boolean;
   disableSmartFilter?: boolean;
@@ -286,7 +295,7 @@ function capture<T>(
 Registers patch-based AI SDK instrumentations against a specific tracer provider.
 
 ```typescript
-type InstrumentationType =
+type InstrumentationName =
   | "openai"
   | "openai-agents"
   | "anthropic"
@@ -298,10 +307,16 @@ type InstrumentationType =
   | "vertexai"
   | "aiplatform";
 
+// `object | undefined` rejects primitive values (`true`, `42`, `"openai"`, …)
+// at compile time while still admitting class constructors (functions),
+// namespace imports, and explicit-undefined-for-conditional-config.
+type InstrumentationsInput = Partial<Record<InstrumentationName, object | undefined>>;
+
 function registerLatitudeInstrumentations(options: {
-  instrumentations: InstrumentationType[];
+  // Map of integration name → LLM SDK module reference (e.g. { openai: OpenAI }).
+  // Anything else throws at register time.
+  instrumentations: InstrumentationsInput;
   tracerProvider: TracerProvider;
-  instrumentationModules?: Partial<Record<InstrumentationType, unknown>>;
 }): Promise<void>;
 ```
 
@@ -314,6 +329,7 @@ For users with existing observability infrastructure.
 Initialize Datadog first, then construct `new Latitude()` so Latitude can attach to Datadog's OTel provider when possible:
 
 ```typescript
+import OpenAI from "openai";
 import tracer from "dd-trace";
 import { Latitude } from "@latitude-data/telemetry";
 
@@ -322,7 +338,7 @@ tracer.init({ service: "my-app", env: "production" });
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 
 await latitude.ready;
@@ -339,6 +355,7 @@ await latitude.shutdown(); // Does not shut down Datadog.
 Initialize Sentry first, then Latitude. Sentry installs an OpenTelemetry `BasicTracerProvider`; Latitude detects it and adds its processor without replacing Sentry's context manager, propagator, sampler, or span processor:
 
 ```typescript
+import OpenAI from "openai";
 import * as Sentry from "@sentry/node";
 import { Latitude } from "@latitude-data/telemetry";
 
@@ -350,7 +367,7 @@ Sentry.init({
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 
 await latitude.ready;
@@ -368,12 +385,13 @@ Enable New Relic's OpenTelemetry bridge first, then construct `new Latitude()`. 
 
 ```typescript
 import "newrelic";
+import OpenAI from "openai";
 import { Latitude } from "@latitude-data/telemetry";
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 ```
 
@@ -382,6 +400,7 @@ const latitude = new Latitude({
 Start Honeycomb's `HoneycombSDK` first, then construct `new Latitude()`. Honeycomb extends OpenTelemetry's `NodeSDK`, so Latitude reuses the global provider created by `sdk.start()`.
 
 ```typescript
+import OpenAI from "openai";
 import { HoneycombSDK } from "@honeycombio/opentelemetry-node";
 import { Latitude } from "@latitude-data/telemetry";
 
@@ -391,9 +410,34 @@ honeycomb.start();
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 });
 ```
+
+## Migrating from `instrumentations: ["openai"]` (3.0.0-alpha.10 and earlier)
+
+The string-array form is removed with no fallback in `3.0.0-alpha.11`. Passing
+a string array — or anything other than a plain object — throws at register
+time. Switch to the object form, mapping integration name → LLM SDK module:
+
+```diff
+- import { Latitude } from "@latitude-data/telemetry";
++ import OpenAI from "openai";
++ import * as AnthropicSDK from "@anthropic-ai/sdk";
++ import { Latitude } from "@latitude-data/telemetry";
+
+  new Latitude({
+    apiKey: process.env.LATITUDE_API_KEY!,
+    projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+-   instrumentations: ["openai", "anthropic"],
++   instrumentations: { openai: OpenAI, anthropic: AnthropicSDK },
+  });
+```
+
+For `anthropic`, pass the namespace (`import * as AnthropicSDK from "@anthropic-ai/sdk"`)
+— the underlying Traceloop patch reads `module.Anthropic.Messages.prototype`. The
+SDK also accepts a bare default-export class (it wraps it back into `{ Anthropic }`),
+but the namespace form is the recommended shape.
 
 ## Supported AI Providers
 
@@ -476,9 +520,10 @@ new LatitudeSpanProcessor(apiKey, projectSlug, {
 
 1. **Check API key and project slug** — Must be non-empty strings
 2. **Verify instrumentations are registered** — Use `await registerLatitudeInstrumentations()`
-3. **Flush before exit** — Call `await latitude.flush()` or `await provider.forceFlush()`
-4. **Check smart filter** — Only LLM spans are exported by default. Use `disableSmartFilter: true` to export all spans
-5. **Ensure `capture()` wraps the code that creates spans** — `capture()` itself doesn't create spans; it only attaches context to spans created by instrumentations
+3. **Did the bootstrap throw a migration error?** — `instrumentations: ["openai"]` (or any array / non-object form) is no longer accepted in `3.0.0-alpha.11`+. Switch to the object form: `instrumentations: { openai: OpenAI }`. See the Migration section above.
+4. **Flush before exit** — Call `await latitude.flush()` or `await provider.forceFlush()`
+5. **Check smart filter** — Only LLM spans are exported by default. Use `disableSmartFilter: true` to export all spans
+6. **Ensure `capture()` wraps the code that creates spans** — `capture()` itself doesn't create spans; it only attaches context to spans created by instrumentations
 
 ### No spans created inside `capture()`
 

--- a/packages/telemetry/typescript/examples/README.md
+++ b/packages/telemetry/typescript/examples/README.md
@@ -4,33 +4,33 @@ This directory contains examples demonstrating how to use the Latitude Telemetry
 
 ## Quick Start (Happy Path)
 
-The simplest way to use Latitude is with `LatitudeTelemetry` — no existing OpenTelemetry setup required.
+The simplest way to use Latitude is with `new Latitude({...})` — no existing OpenTelemetry setup required.
 
 ```typescript
-import { LatitudeTelemetry } from "@latitude-data/telemetry"
 import OpenAI from "openai"
+import { Latitude, capture } from "@latitude-data/telemetry"
 
-const telemetry = new LatitudeTelemetry(
-  process.env.LATITUDE_API_KEY!,
-  process.env.LATITUDE_PROJECT_SLUG!,
-  {
-    instrumentations: ["openai"], // Auto-instrument OpenAI
-  }
-)
+const latitude = new Latitude({
+  apiKey: process.env.LATITUDE_API_KEY!,
+  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  instrumentations: { openai: OpenAI }, // Pass the LLM SDK module you use in app code.
+})
 
+await latitude.ready
 const client = new OpenAI()
 
-await telemetry.capture(
-  { tags: ["production"], userId: "user-123" },
+await capture(
+  "chat-call",
   async () => {
     return await client.chat.completions.create({
       model: "gpt-4o-mini",
       messages: [{ role: "user", content: "Hello!" }],
     })
-  }
+  },
+  { tags: ["production"], userId: "user-123" },
 )
 
-await telemetry.flush()
+await latitude.flush()
 ```
 
 See `test_openai.ts` for a complete working example.
@@ -133,6 +133,7 @@ Use composable mode when:
 - You need multiple telemetry backends simultaneously
 
 ```typescript
+import OpenAI from "openai"
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
 import { LatitudeSpanProcessor, registerLatitudeInstrumentations } from "@latitude-data/telemetry"
 
@@ -143,7 +144,7 @@ const provider = new NodeTracerProvider({
 })
 
 await registerLatitudeInstrumentations({
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   tracerProvider: provider,
 })
 
@@ -208,17 +209,10 @@ Check the Latitude dashboard to verify:
 
 ### ESM module loading issues
 
-If auto-instrumentation fails, pass modules explicitly:
-
-```typescript
-import * as OpenAI from "openai"
-
-await registerLatitudeInstrumentations({
-  instrumentations: ["openai"],
-  modules: { openai: OpenAI },
-  tracerProvider: provider,
-})
-```
+The object form of `instrumentations` always passes the consumer's own module reference,
+so ESM/CJS dual-bundle mismatches can't happen by design. If spans are still missing, make
+sure the module you pass is the same one your LLM client is constructed from (e.g. one
+`openai` resolution in the dependency tree, not two duplicates).
 
 ### Type errors in examples
 

--- a/packages/telemetry/typescript/examples/test_anthropic.ts
+++ b/packages/telemetry/typescript/examples/test_anthropic.ts
@@ -9,14 +9,14 @@
  * Install: npm install @anthropic-ai/sdk
  */
 
-import Anthropic from "@anthropic-ai/sdk"
+import Anthropic, * as AnthropicSDK from "@anthropic-ai/sdk"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["anthropic"],
+  instrumentations: { anthropic: AnthropicSDK },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_azure.ts
+++ b/packages/telemetry/typescript/examples/test_azure.ts
@@ -11,7 +11,7 @@
  * Install: npm install openai
  */
 
-import { AzureOpenAI } from "openai"
+import { AzureOpenAI, OpenAI } from "openai"
 import { capture, Latitude } from "../src"
 
 // Note: Azure OpenAI uses the same OpenAI instrumentor
@@ -19,7 +19,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_bedrock.ts
+++ b/packages/telemetry/typescript/examples/test_bedrock.ts
@@ -12,13 +12,14 @@
  */
 
 import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime"
+import * as BedrockSDK from "@aws-sdk/client-bedrock-runtime"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["bedrock"],
+  instrumentations: { bedrock: BedrockSDK },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_capture_nesting.ts
+++ b/packages/telemetry/typescript/examples/test_capture_nesting.ts
@@ -21,7 +21,7 @@ import OpenAI from "openai"
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   disableBatch: true,
 })
 

--- a/packages/telemetry/typescript/examples/test_cohere.ts
+++ b/packages/telemetry/typescript/examples/test_cohere.ts
@@ -10,13 +10,14 @@
  */
 
 import { CohereClient } from "cohere-ai"
+import * as CohereSDK from "cohere-ai"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["cohere"],
+  instrumentations: { cohere: CohereSDK },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_existing_otel.ts
+++ b/packages/telemetry/typescript/examples/test_existing_otel.ts
@@ -45,7 +45,7 @@ provider.register()
 
 // Enable LLM auto-instrumentation
 await registerLatitudeInstrumentations({
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   tracerProvider: provider,
 })
 

--- a/packages/telemetry/typescript/examples/test_langchain.ts
+++ b/packages/telemetry/typescript/examples/test_langchain.ts
@@ -11,13 +11,14 @@
 
 import { HumanMessage } from "@langchain/core/messages"
 import { ChatOpenAI } from "@langchain/openai"
+import * as LangChain from "langchain"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["langchain"],
+  instrumentations: { langchain: LangChain },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_llamaindex.ts
+++ b/packages/telemetry/typescript/examples/test_llamaindex.ts
@@ -10,13 +10,14 @@
  */
 
 import { OpenAI } from "llamaindex"
+import * as LlamaIndex from "llamaindex"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["llamaindex"],
+  instrumentations: { llamaindex: LlamaIndex },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
+++ b/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
@@ -23,7 +23,7 @@ import { capture, Latitude } from "../src"
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
   disableBatch: true,
 })
 

--- a/packages/telemetry/typescript/examples/test_openai.ts
+++ b/packages/telemetry/typescript/examples/test_openai.ts
@@ -16,7 +16,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_openai_agents.ts
+++ b/packages/telemetry/typescript/examples/test_openai_agents.ts
@@ -10,6 +10,7 @@
  */
 
 import { Agent, run, tool } from "@openai/agents"
+import * as OpenAIAgentsSDK from "@openai/agents"
 import { z } from "zod"
 import { capture, Latitude } from "../src"
 
@@ -17,7 +18,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["openai-agents"],
+  instrumentations: { "openai-agents": OpenAIAgentsSDK },
 })
 
 const getWeather = tool({

--- a/packages/telemetry/typescript/examples/test_openai_responses.ts
+++ b/packages/telemetry/typescript/examples/test_openai_responses.ts
@@ -16,7 +16,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_project_scoping_env.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_env.ts
@@ -31,7 +31,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: DEFAULT_SLUG,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 const OVERRIDE_SLUG = "evaluation-runs"

--- a/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
@@ -30,7 +30,7 @@ import { capture, Latitude } from "../src"
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 const FULL_STACK_AGENT_SLUG = "primary"

--- a/packages/telemetry/typescript/examples/test_project_scoping_single.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_single.ts
@@ -22,7 +22,7 @@ const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_sentry.ts
+++ b/packages/telemetry/typescript/examples/test_sentry.ts
@@ -31,7 +31,7 @@ Sentry.init({
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
-  instrumentations: ["openai"],
+  instrumentations: { openai: OpenAI },
 })
 
 await latitude.ready

--- a/packages/telemetry/typescript/examples/test_together.ts
+++ b/packages/telemetry/typescript/examples/test_together.ts
@@ -9,14 +9,14 @@
  * Install: npm install together-ai
  */
 
-import Together from "together-ai"
+import Together, * as TogetherSDK from "together-ai"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["togetherai"],
+  instrumentations: { togetherai: TogetherSDK },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/examples/test_vertex.ts
+++ b/packages/telemetry/typescript/examples/test_vertex.ts
@@ -11,13 +11,14 @@
  */
 
 import { VertexAI } from "@google-cloud/vertexai"
+import * as VertexAISDK from "@google-cloud/vertexai"
 import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
   projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
-  instrumentations: ["vertexai"],
+  instrumentations: { vertexai: VertexAISDK },
 })
 
 async function main() {

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.10",
+  "version": "3.0.0-alpha.11",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/sdk/index.ts
+++ b/packages/telemetry/typescript/src/sdk/index.ts
@@ -1,6 +1,6 @@
 export { capture } from "./context.ts"
 export { initLatitude, Latitude } from "./init.ts"
-export type { InstrumentationType } from "./instrumentations.ts"
+export type { InstrumentationName, InstrumentationsInput } from "./instrumentations.ts"
 export { registerLatitudeInstrumentations } from "./instrumentations.ts"
 export { LatitudeSpanProcessor } from "./processor.ts"
 export {

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -71,7 +71,7 @@ export class Latitude {
   private readonly ownsProvider: boolean
 
   constructor(options: LatitudeOptions) {
-    const { apiKey, projectSlug, instrumentations = [], tracerProvider, ...processorOptionsRaw } = options
+    const { apiKey, projectSlug, instrumentations = {}, tracerProvider, ...processorOptionsRaw } = options
 
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")

--- a/packages/telemetry/typescript/src/sdk/instrumentations.test.ts
+++ b/packages/telemetry/typescript/src/sdk/instrumentations.test.ts
@@ -1,0 +1,99 @@
+import type { Tracer, TracerProvider } from "@opentelemetry/api"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { InstrumentationsInput } from "./instrumentations.ts"
+import { normalizeAnthropic, normalizeOpenAI, registerLatitudeInstrumentations } from "./instrumentations.ts"
+
+// Compile-time assertions that InstrumentationsInput rejects primitives and unknown keys.
+// If any of these stop erroring, the input type has been loosened — fix the type, not the test.
+class _FakeClass {}
+const _validClass: InstrumentationsInput = { openai: _FakeClass }
+const _validNamespace: InstrumentationsInput = { openai: { OpenAI: _FakeClass } }
+const _validUndefined: InstrumentationsInput = { openai: undefined }
+// @ts-expect-error — `true` is a primitive, not an object
+const _rejectsBoolean: InstrumentationsInput = { openai: true }
+// @ts-expect-error — strings are primitives
+const _rejectsString: InstrumentationsInput = { openai: "openai" }
+// @ts-expect-error — `nope` is not a supported integration name
+const _rejectsUnknownKey: InstrumentationsInput = { nope: _FakeClass }
+void [_validClass, _validNamespace, _validUndefined, _rejectsBoolean, _rejectsString, _rejectsUnknownKey]
+
+const noopProvider: TracerProvider = { getTracer: () => ({}) as Tracer }
+
+describe("normalizeOpenAI", () => {
+  it("unwraps the OpenAI class from the package namespace", () => {
+    class FakeOpenAI {}
+    expect(normalizeOpenAI({ OpenAI: FakeOpenAI })).toBe(FakeOpenAI)
+  })
+
+  it("falls back to the default export when OpenAI is absent", () => {
+    class FakeOpenAI {}
+    expect(normalizeOpenAI({ default: FakeOpenAI })).toBe(FakeOpenAI)
+  })
+
+  it("passes through when neither field exists (user already gave the class)", () => {
+    class FakeOpenAI {}
+    expect(normalizeOpenAI(FakeOpenAI)).toBe(FakeOpenAI)
+  })
+})
+
+describe("normalizeAnthropic", () => {
+  it("passes namespace shape through unchanged", () => {
+    const ns = { Anthropic: class {} }
+    expect(normalizeAnthropic(ns)).toBe(ns)
+  })
+
+  it("wraps a bare class into { Anthropic } so the Traceloop patch can find it", () => {
+    class FakeAnthropic {}
+    expect(normalizeAnthropic(FakeAnthropic)).toEqual({ Anthropic: FakeAnthropic })
+  })
+})
+
+describe("registerLatitudeInstrumentations", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it("accepts an empty object (registers nothing, does not throw)", async () => {
+    await expect(
+      registerLatitudeInstrumentations({
+        instrumentations: {},
+        tracerProvider: noopProvider,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("throws when instrumentations is not a plain object (e.g. legacy string array)", async () => {
+    await expect(
+      registerLatitudeInstrumentations({
+        // biome-ignore lint/suspicious/noExplicitAny: testing the runtime guard
+        instrumentations: ["openai"] as any,
+        tracerProvider: noopProvider,
+      }),
+    ).rejects.toThrow(/must be an object mapping/)
+  })
+
+  it("throws on unknown integration keys", async () => {
+    await expect(
+      registerLatitudeInstrumentations({
+        // biome-ignore lint/suspicious/noExplicitAny: testing the runtime guard for unknown keys
+        instrumentations: { nope: {} } as any,
+        tracerProvider: noopProvider,
+      }),
+    ).rejects.toThrow(/unknown integration "nope"/)
+  })
+
+  it("ignores undefined values (lets users build the object programmatically)", async () => {
+    await expect(
+      registerLatitudeInstrumentations({
+        instrumentations: { openai: undefined, anthropic: undefined },
+        tracerProvider: noopProvider,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/telemetry/typescript/src/sdk/instrumentations.ts
+++ b/packages/telemetry/typescript/src/sdk/instrumentations.ts
@@ -1,11 +1,39 @@
 import type { TracerProvider } from "@opentelemetry/api"
 import { type Instrumentation, registerInstrumentations } from "@opentelemetry/instrumentation"
 
-/**
- * Supported LLM instrumentation types.
- * Use these string identifiers to enable auto-instrumentation.
- */
-export type InstrumentationType =
+const DOCS_URL = "https://github.com/latitude-dev/latitude-llm/tree/main/packages/telemetry/typescript#readme"
+
+interface LlmInstrumentation extends Instrumentation {
+  manuallyInstrument?(module: unknown): void
+}
+
+type InstrumentationCtor = new (config?: Record<string, unknown>) => LlmInstrumentation
+
+interface IntegrationDef {
+  /** Async loader for the underlying instrumentation ctor. */
+  loadCtor: () => Promise<InstrumentationCtor>
+  /** npm package the instrumentation is published from (surfaced in install hints). */
+  packageName: string
+  /** Optional shape normalizer — only set when the SDK accepts more than one valid input shape. */
+  normalize?: (mod: unknown) => unknown
+  /** Optional Traceloop ctor flag. */
+  enrichTokens?: boolean
+}
+
+/** Exported for direct unit testing — internal otherwise. */
+export const normalizeOpenAI = (mod: unknown): unknown => {
+  const ns = mod as { OpenAI?: unknown; default?: unknown } | null | undefined
+  return ns?.OpenAI ?? ns?.default ?? mod
+}
+
+/** Exported for direct unit testing — internal otherwise. */
+export const normalizeAnthropic = (mod: unknown): unknown => {
+  const hasAnthropicField = mod !== null && typeof mod === "object" && "Anthropic" in (mod as object)
+  return hasAnthropicField ? mod : { Anthropic: mod }
+}
+
+/** Supported integration keys — exhaustive list. */
+export type InstrumentationName =
   | "openai"
   | "openai-agents"
   | "anthropic"
@@ -17,199 +45,147 @@ export type InstrumentationType =
   | "vertexai"
   | "aiplatform"
 
-/**
- * Minimal interface for LLM instrumentation instances.
- * Extends OpenTelemetry's Instrumentation interface.
- */
-interface LlmInstrumentation extends Instrumentation {
-  manuallyInstrument?(module: unknown): void
-}
-
-/**
- * Options for creating LLM instrumentations.
- */
-interface CreateInstrumentationsOptions {
-  /** List of instrumentation types to enable. */
-  instrumentations: InstrumentationType[]
-  /**
-   * Optional module references for auto-instrumentation.
-   * If not provided, the instrumentation will attempt to require the module.
-   * Used for Traceloop-based instrumentations.
-   */
-  modules?: Partial<Record<InstrumentationType, unknown>>
-  /**
-   * Per-instrumentation token enrichment settings.
-   * @default { openai: true }
-   */
-  enrichTokens?: Partial<Record<InstrumentationType, boolean>>
-}
-
-type InstrumentationCtor = new (config?: Record<string, unknown>) => LlmInstrumentation
-
-interface InstrumentationConfig {
-  loadCtor: () => Promise<InstrumentationCtor>
-  packageName: string
-  moduleName: string
-  defaultEnrichTokens?: boolean
-  /**
-   * Picks the object handed to `manuallyInstrument`. Defaults to the imported namespace.
-   * Traceloop's `manuallyInstrument` shape is inconsistent across SDKs — anthropic's
-   * reads `module.Anthropic.Messages`, but openai's reads `module.Chat.Completions`,
-   * so the openai entry unwraps to the `OpenAI` class rather than the namespace.
-   */
-  resolveInstrumentationTarget?: (moduleRef: unknown) => unknown
-}
-
-const resolveOpenAITarget = (moduleRef: unknown): unknown => {
-  const ns = moduleRef as { OpenAI?: unknown; default?: unknown } | null | undefined
-  return ns?.OpenAI ?? ns?.default ?? moduleRef
-}
-
-const INSTRUMENTATION_MAP: Record<InstrumentationType, InstrumentationConfig> = {
+const INTEGRATIONS: Record<InstrumentationName, IntegrationDef> = {
   openai: {
     loadCtor: async () =>
       (await import("./instrumentations/openai/instrumentation.ts")).OpenAIInstrumentationWithResponses,
     packageName: "@traceloop/instrumentation-openai",
-    moduleName: "openai",
-    defaultEnrichTokens: true,
-    resolveInstrumentationTarget: resolveOpenAITarget,
+    normalize: normalizeOpenAI,
+    enrichTokens: true,
   },
   "openai-agents": {
     loadCtor: async () =>
       (await import("./instrumentations/openai-agents/instrumentation.ts")).OpenAIAgentsInstrumentation,
     packageName: "@openai/agents",
-    moduleName: "@openai/agents",
   },
   anthropic: {
     loadCtor: async () => (await import("@traceloop/instrumentation-anthropic")).AnthropicInstrumentation,
     packageName: "@traceloop/instrumentation-anthropic",
-    moduleName: "@anthropic-ai/sdk",
+    normalize: normalizeAnthropic,
   },
   bedrock: {
     loadCtor: async () => (await import("@traceloop/instrumentation-bedrock")).BedrockInstrumentation,
     packageName: "@traceloop/instrumentation-bedrock",
-    moduleName: "@aws-sdk/client-bedrock-runtime",
   },
   cohere: {
     loadCtor: async () => (await import("@traceloop/instrumentation-cohere")).CohereInstrumentation,
     packageName: "@traceloop/instrumentation-cohere",
-    moduleName: "cohere-ai",
   },
   langchain: {
     loadCtor: async () => (await import("@traceloop/instrumentation-langchain")).LangChainInstrumentation,
     packageName: "@traceloop/instrumentation-langchain",
-    moduleName: "langchain",
   },
   llamaindex: {
     loadCtor: async () => (await import("@traceloop/instrumentation-llamaindex")).LlamaIndexInstrumentation,
     packageName: "@traceloop/instrumentation-llamaindex",
-    moduleName: "llamaindex",
   },
   togetherai: {
     loadCtor: async () => (await import("@traceloop/instrumentation-together")).TogetherInstrumentation,
     packageName: "@traceloop/instrumentation-together",
-    moduleName: "together-ai",
-    defaultEnrichTokens: false,
+    enrichTokens: false,
   },
   vertexai: {
     loadCtor: async () => (await import("@traceloop/instrumentation-vertexai")).VertexAIInstrumentation,
     packageName: "@traceloop/instrumentation-vertexai",
-    moduleName: "@google-cloud/vertexai",
   },
   aiplatform: {
     loadCtor: async () => (await import("@traceloop/instrumentation-vertexai")).AIPlatformInstrumentation,
     packageName: "@traceloop/instrumentation-vertexai",
-    moduleName: "@google-cloud/aiplatform",
   },
 }
 
 /**
- * Internal function to create LLM instrumentation instances.
- * Not exported publicly - use registerLatitudeInstrumentations instead.
+ * Map of integration name → LLM SDK module reference the consumer uses in app code.
+ *
+ * The value type is `object`, which admits both class constructors (functions,
+ * like the default-export `OpenAI` class) and namespace imports (like
+ * `import * as AnthropicSDK from "@anthropic-ai/sdk"`), but rejects primitives
+ * (`true`, `42`, `"openai"`, `null`) at the type level.
+ *
+ * ```ts
+ * import OpenAI from "openai"
+ * import * as AnthropicSDK from "@anthropic-ai/sdk"
+ *
+ * new Latitude({
+ *   apiKey: "...",
+ *   instrumentations: {
+ *     openai: OpenAI,
+ *     anthropic: AnthropicSDK,
+ *   },
+ * })
+ * ```
  */
-async function createLatitudeInstrumentations(options: CreateInstrumentationsOptions): Promise<LlmInstrumentation[]> {
+export type InstrumentationsInput = Partial<Record<InstrumentationName, object | undefined>>
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+async function createLatitudeInstrumentations(input: InstrumentationsInput): Promise<LlmInstrumentation[]> {
+  if (!isPlainObject(input)) {
+    throw new TypeError(
+      `[Latitude] instrumentations must be an object mapping integration names to LLM SDK modules ` +
+        `(e.g. { openai: OpenAI, anthropic: AnthropicSDK }). Received: ${JSON.stringify(input)}. See ${DOCS_URL}.`,
+    )
+  }
+
   const result: LlmInstrumentation[] = []
 
-  for (const type of options.instrumentations) {
-    const config = INSTRUMENTATION_MAP[type]
-    if (!config) {
-      console.warn(`[Latitude] Unknown instrumentation type: ${type}`)
-      continue
+  for (const [name, mod] of Object.entries(input)) {
+    if (mod === undefined) continue
+    const def = (INTEGRATIONS as Record<string, IntegrationDef | undefined>)[name]
+    if (!def) {
+      throw new TypeError(
+        `[Latitude] instrumentations: unknown integration "${name}". ` +
+          `Expected one of: ${Object.keys(INTEGRATIONS).join(", ")}. See ${DOCS_URL}.`,
+      )
     }
 
     let Ctor: InstrumentationCtor
     try {
-      Ctor = await config.loadCtor()
+      Ctor = await def.loadCtor()
     } catch {
       console.warn(
-        `[Latitude] Instrumentation package not installed for ${type}: ${config.packageName}. Add it as a dependency to enable this instrumentation.`,
+        `[Latitude] Instrumentation package not installed for ${name}: ${def.packageName}. Add it as a dependency to enable this instrumentation.`,
       )
       continue
     }
 
-    const enrichTokens = options.enrichTokens?.[type] ?? config.defaultEnrichTokens
-    const inst = new Ctor(enrichTokens !== undefined ? { enrichTokens } : undefined)
-
-    // Get module from explicit options or try to auto-require
-    const moduleRef = options.modules?.[type] ?? (await tryRequire(config.moduleName))
-    if (!moduleRef) {
-      console.warn(
-        `[Latitude] Module not found for ${type}: ${config.moduleName}. Install it or pass it explicitly in 'modules'.`,
-      )
-      continue
-    }
-    const target = config.resolveInstrumentationTarget?.(moduleRef) ?? moduleRef
+    const inst = new Ctor(def.enrichTokens !== undefined ? { enrichTokens: def.enrichTokens } : undefined)
+    const target = def.normalize ? def.normalize(mod) : mod
     inst.manuallyInstrument?.(target)
-
     result.push(inst)
   }
 
   return result
 }
 
-async function tryRequire(moduleName: string): Promise<unknown | undefined> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require(moduleName)
-  } catch {
-    // Fallback to dynamic import for ESM environments. Return the full module
-    // namespace; traceloop instrumentations expect the namespace shape (e.g.
-    // anthropic reaches into `module.Anthropic.Messages.prototype`).
-    try {
-      return await import(/* @vite-ignore */ moduleName)
-    } catch {
-      return undefined
-    }
-  }
-}
-
 /**
  * Registers LLM instrumentations with the global OpenTelemetry instrumentation registry.
  *
- * This is a convenience wrapper around `createLatitudeInstrumentations` and
- * `@opentelemetry/instrumentation`'s `registerInstrumentations`.
- *
  * @example
  * ```typescript
+ * import OpenAI from "openai"
  * import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
- * import { registerLatitudeInstrumentations, LatitudeSpanProcessor } from "@latitude-data/telemetry"
+ * import { LatitudeSpanProcessor, registerLatitudeInstrumentations } from "@latitude-data/telemetry"
  *
  * const provider = new NodeTracerProvider({
  *   spanProcessors: [new LatitudeSpanProcessor(apiKey, projectSlug)],
  * })
  *
  * await registerLatitudeInstrumentations({
- *   instrumentations: ["openai", "anthropic"],
+ *   instrumentations: { openai: OpenAI },
  *   tracerProvider: provider,
  * })
  *
  * provider.register()
  * ```
  */
-export async function registerLatitudeInstrumentations(
-  options: CreateInstrumentationsOptions & { tracerProvider: TracerProvider },
-): Promise<void> {
-  const instrumentations = await createLatitudeInstrumentations(options)
+export async function registerLatitudeInstrumentations(options: {
+  instrumentations: InstrumentationsInput
+  tracerProvider: TracerProvider
+}): Promise<void> {
+  const instrumentations = await createLatitudeInstrumentations(options.instrumentations)
   registerInstrumentations({
     instrumentations,
     tracerProvider: options.tracerProvider,

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -1,6 +1,6 @@
 import type { TracerProvider } from "@opentelemetry/api"
 import type { SpanExporter } from "@opentelemetry/sdk-trace-node"
-import type { InstrumentationType } from "./instrumentations.ts"
+import type { InstrumentationsInput } from "./instrumentations.ts"
 import type { RedactSpanProcessorOptions } from "./redact.ts"
 import type { SmartFilterOptions } from "./span-filter.ts"
 
@@ -32,7 +32,12 @@ export type LatitudeOptions = SmartFilterOptions & {
    * OTEL resource attribute `latitude.project` → `X-Latitude-Project` header.
    */
   projectSlug?: string
-  instrumentations?: InstrumentationType[]
+  /**
+   * Map of integration name → LLM SDK module reference the user imports in app code.
+   * Example: `{ openai: OpenAI, anthropic: AnthropicSDK }`. The patch lands on the same
+   * prototype the consumer's code calls.
+   */
+  instrumentations?: InstrumentationsInput
   disableRedact?: boolean
   redact?: RedactSpanProcessorOptions
   disableBatch?: boolean
@@ -71,6 +76,5 @@ export type LatitudeSpanProcessorOptions = SmartFilterOptions & {
   serviceName?: string
 }
 
-export type { InstrumentationType } from "./instrumentations.ts"
 export type { RedactSpanProcessorOptions } from "./redact.ts"
 export type { SmartFilterOptions } from "./span-filter.ts"


### PR DESCRIPTION
## Summary

- `instrumentations` on `new Latitude(...)` / `registerLatitudeInstrumentations(...)` now takes a plain object mapping integration name → LLM SDK module the consumer imports — e.g. `{ openai: OpenAI, anthropic: AnthropicSDK }`. Replaces the magic-string-array form, which silently failed in modern apps because the SDK's internal `require` resolved the CJS build of dual-bundled LLM SDKs while the consumer app loaded the ESM build (the patch landed on a class the app never invoked).
- `InstrumentationsInput` is typed as `Partial<Record<InstrumentationName, object | undefined>>` so unknown keys and primitive values (`true`, `42`, `"openai"`, …) are rejected at compile time. Non-object input throws at register time. Compile-time `@ts-expect-error` assertions in the test file lock the type behavior in place.
- Removed `tryRequire`, the legacy `LEGACY_INSTRUMENTATION_MAP`, and the `modules` option on `registerLatitudeInstrumentations`. All 18 example files migrated. Version bump to `3.0.0-alpha.11`.

Linear: [LAT-581](https://linear.app/latitude-dev/issue/LAT-581)

## Test plan

- [x] `pnpm --filter @latitude-data/telemetry typecheck` — passes
- [x] `pnpm --filter @latitude-data/telemetry test` — 115 tests passing
- [x] `pnpm --filter @latitude-data/telemetry check` — biome clean
- [x] `pnpm --filter @latitude-data/telemetry build` — build artifacts produced
- [x] `pnpm knip` — no unused exports / unlisted deps
- [x] Manual smoke test from \`examples/test_openai.ts\` against a local Latitude instance — \`@traceloop/instrumentation-openai\` spans land in the trace UI under the \`capture()\` envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)