### PR TITLE
fix(core): route Azure provider options through the openai key

### DIFF
--- a/packages/core/src/services/ai/providers/rules/all.test.ts
+++ b/packages/core/src/services/ai/providers/rules/all.test.ts
@@ -46,6 +46,35 @@ describe('rules', () => {
     })
   })
 
+  it('wraps Azure providerOptions under the openai key', () => {
+    expect(
+      applyAllRules({
+        providerType: Providers.Azure,
+        messages: [],
+        config: {
+          model: 'gpt-5.1',
+          reasoning_effort: 'high',
+          azure: { resourceName: 'my-resource' },
+        },
+      }),
+    ).toEqual({
+      rules: [],
+      messages: [],
+      config: {
+        model: 'gpt-5.1',
+        reasoning_effort: 'high',
+        azure: { resourceName: 'my-resource' },
+        providerOptions: {
+          openai: {
+            model: 'gpt-5.1',
+            reasoningEffort: 'high',
+            azure: { resourceName: 'my-resource' },
+          },
+        },
+      },
+    })
+  })
+
   it('camelCase all providerOptions', () => {
     expect(
       applyAllRules({

--- a/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
+++ b/packages/core/src/services/ai/providers/rules/providerMetadata/index.ts
@@ -8,7 +8,7 @@ export const PROVIDER_TO_METADATA_KEY: Record<Providers, string> = {
   [Providers.Anthropic]: 'anthropic',
   [Providers.Groq]: 'groq',
   [Providers.Mistral]: 'mistral',
-  [Providers.Azure]: 'azure',
+  [Providers.Azure]: 'openai',
   [Providers.Google]: 'google',
   [Providers.Custom]: 'custom',
   [Providers.GoogleVertex]: 'google',


### PR DESCRIPTION
## Summary

The Vercel `@ai-sdk/azure` adapter is a thin wrapper that delegates to `OpenAIChatLanguageModel`/`OpenAIResponsesLanguageModel` from `@ai-sdk/openai`. The underlying OpenAI model reads provider options with a hardcoded key of `"openai"`:

```js
// node_modules/@ai-sdk/openai/dist/index.mjs:553
const openaiOptions = await parseProviderOptions({
  provider: "openai",
  providerOptions,
})
...
reasoning_effort: openaiOptions.reasoningEffort,  // line 613
```

Latitude was wrapping the prompt config under `providerOptions.azure` (`PROVIDER_TO_METADATA_KEY[Providers.Azure] = 'azure'`), so the OpenAI adapter never saw any of these fields. Symptom: `reasoning_effort: high` in frontmatter for `gpt-5.1` on Azure produced 0 `reasoning_tokens` because the param was silently dropped before the request left the SDK.

This flips the Azure entry in `PROVIDER_TO_METADATA_KEY` to `'openai'`, which fixes all three call sites that use the map:

- `applyAllRules` — top-level prompt config (reasoningEffort, reasoningSummary, serviceTier, structuredOutputs, etc.)
- `extractContentMetadata` — per-content-part attributes (e.g. image detail, cache control)
- `extractMessageMetadata` — per-message attributes

Safe because Latitude's Azure provider always instantiates `@ai-sdk/azure`, which is Azure OpenAI specifically — there is no other model family routed through this code path that would expect an `azure`-keyed providerOptions block.

## Test plan

- [x] Type check passes (`pnpm --filter @latitude-data/core tc`)
- [x] New unit test in `all.test.ts` pins `providerOptions.openai` for `Providers.Azure` with `reasoning_effort: high`
- [ ] Manual: run a prompt with `provider: Azure`, `model: gpt-5.1`, `reasoning_effort: high` and confirm `reasoning_tokens > 0` in the trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)