### PR TITLE
fix(issues): de-flake check-issue-escalation 'still new' test

### DIFF
--- a/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
+++ b/packages/domain/issues/src/use-cases/check-issue-escalation.test.ts
@@ -182,7 +182,7 @@ describe("checkIssueEscalationUseCase", () => {
   })
 
   it("does not emit IssueEscalated while the issue is still new", async () => {
-    const issue = makeIssue({ createdAt: new Date("2026-05-08T10:00:00.000Z") })
+    const issue = makeIssue({ createdAt: new Date(Date.now() - 60 * 60 * 1000) })
     const events: OutboxWriteEvent[] = []
     const { apply } = provideTestLayers({
       issue,


### PR DESCRIPTION
## Summary

`src/use-cases/check-issue-escalation.test.ts > does not emit IssueEscalated while the issue is still new` is failing intermittently on CI. The test hardcoded `createdAt` to `2026-05-08T10:00:00.000Z` — exactly 7 days before today's date (`2026-05-15`) — and asserted `isIssueNew` returns `true`. `isIssueNew` returns `firstSeenAt > now - NEW_ISSUE_AGE_DAYS * 1 day` against `new Date()` from inside the use case, so once wall-clock time crosses `2026-05-15T10:00:00Z` the issue stops being new, the band-crossing signals (`recent1h: 100`, `recent6h: 600`) trip the entry path, and `transition` becomes `"entered"` instead of `"none"`. The failing CI run started at `10:18:46` — 18 minutes past that cutoff.

## Fix

Use `new Date(Date.now() - 60 * 60 * 1000)` (1h ago) for `createdAt` so the issue is always well within the 7-day window relative to whatever `now` the use case observes.

## Test plan

- [x] `pnpm --filter @domain/issues test` — all 126 tests pass locally