### PR TITLE
fix(telemetry-python): isolate OTel global tracer provider in span tests

### DIFF
--- a/packages/telemetry/python/tests/telemetry/conftest.py
+++ b/packages/telemetry/python/tests/telemetry/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest fixtures for telemetry tests."""
+
+import pytest
+from opentelemetry import trace
+
+
+@pytest.fixture(autouse=True)
+def reset_global_tracer_provider():
+    """Reset OTel's global tracer provider between tests.
+
+    `trace.set_tracer_provider` is single-write — once set, subsequent calls log
+    a warning and are silent no-ops. Tests that construct `Latitude(tracer_provider=None)`
+    (e.g. `test_init_latitude_keeps_dict_compatibility`) register a real provider
+    globally; a later test on the same worker then piggy-backs on it and silently
+    drops `service_name` (init.py:98). The public API can't undo the registration,
+    so we reach into the private `Once` lock and cached provider to clear both.
+    """
+    yield
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
+    trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1173,7 +1173,7 @@ dev = [
     { name = "anthropic", specifier = "==0.40.0" },
     { name = "litellm", extras = ["proxy"], specifier = "==1.83.7" },
     { name = "openai", specifier = "==2.30.0" },
-    { name = "pyright", specifier = "==1.1.408" },
+    { name = "pyright", specifier = "==1.1.409" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
@@ -2463,15 +2463,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `tests/telemetry/span_test.py` was flaky in CI: `TestServiceNameOverride::test_service_name_is_a_resource_attribute_when_latitude_owns_the_provider` failed when `pytest-xdist` happened to schedule it on the same worker as `test_init_latitude_keeps_dict_compatibility`.
- Root cause: OTel's `trace.set_tracer_provider` is **single-write**. The dict-compat test constructs `Latitude(tracer_provider=None)`, which registers a real provider globally (`init.py:147`). A later test in the same worker process then sees that provider, makes Latitude piggy-back on it, and `service_name` is intentionally ignored (`init.py:98`) — so the resource keeps the default `latitude-telemetry-python`.
- Added an autouse fixture in `span_test.py` that resets OTel's private `_TRACER_PROVIDER_SET_ONCE._done` and `_TRACER_PROVIDER` between tests. The public API can't undo `set_tracer_provider`, so the fixture documents why it reaches into the private symbols.

## Test plan

- [x] `uv run pytest tests/telemetry/span_test.py -v -n 0` — 8/8 pass (worst-case serial ordering reproduces the CI failure without this patch)
- [x] `uv run pytest tests/ -n 0` — 54/54 pass serially
- [x] `uv run pytest tests/` — 54/54 pass under default xdist parallelism
- [ ] CI green on the same job that failed (`packages/telemetry/python` pytest step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)