### PR TITLE
feat(telemetry): rename projectSlug to project on SDK options

### DIFF
--- a/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
+++ b/apps/web/src/routes/_authenticated/projects/$projectSlug/-components/onboarding-flow.tsx
@@ -704,6 +704,28 @@ export function OnboardingFlow({
                     up Latitude telemetry in your project.
                   </Text.H5>
                   <CodeBlock value={codingAgentPrompt} copyable wrapLines />
+                  <Text.H5 color="foregroundMuted">
+                    For the smoothest experience, install both the{" "}
+                    <a
+                      href="https://github.com/latitude-dev/skills"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline-offset-2 hover:underline"
+                    >
+                      Latitude telemetry skill
+                    </a>{" "}
+                    and the{" "}
+                    <a
+                      href="https://docs.latitude.so/getting-started/mcp"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline-offset-2 hover:underline"
+                    >
+                      Latitude MCP server
+                    </a>{" "}
+                    in your agent. The MCP lets the agent create projects and look up API keys directly; the skill wires
+                    tracing into your codebase.
+                  </Text.H5>
                 </div>
               ) : (
                 <>

--- a/docs/telemetry/frameworks/langchain.mdx
+++ b/docs/telemetry/frameworks/langchain.mdx
@@ -76,7 +76,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { langchain: LangChain },
         })
 
@@ -101,7 +101,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"langchain": langchain_core},
         )
 

--- a/docs/telemetry/frameworks/llamaindex.mdx
+++ b/docs/telemetry/frameworks/llamaindex.mdx
@@ -77,7 +77,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { llamaindex: LlamaIndex },
         })
 
@@ -103,7 +103,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"llamaindex": llama_index},
         )
 

--- a/docs/telemetry/frameworks/openai-agents.mdx
+++ b/docs/telemetry/frameworks/openai-agents.mdx
@@ -78,7 +78,7 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { "openai-agents": OpenAIAgentsSDK },
         })
 
@@ -114,7 +114,7 @@ The Agents SDK uses the OpenAI **Responses API**, which is not covered by the st
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"openai-agents": agents},
         )
 

--- a/docs/telemetry/frameworks/vercel-ai-sdk.mdx
+++ b/docs/telemetry/frameworks/vercel-ai-sdk.mdx
@@ -62,7 +62,7 @@ The Vercel AI SDK has built-in OpenTelemetry support via its `experimental_telem
 
     const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
-      projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+      project: process.env.LATITUDE_PROJECT_SLUG!,
     })
 
     await latitude.ready

--- a/docs/telemetry/otel-exporter.md
+++ b/docs/telemetry/otel-exporter.md
@@ -237,7 +237,7 @@ tracer.init({ service: "my-app", env: "production" })
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 ```
@@ -256,7 +256,7 @@ Sentry.init({
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 ```
@@ -272,7 +272,7 @@ import { Latitude } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 ```
@@ -291,7 +291,7 @@ honeycomb.start()
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 ```

--- a/docs/telemetry/overview.mdx
+++ b/docs/telemetry/overview.mdx
@@ -11,11 +11,21 @@ Once connected, every LLM execution becomes a trace in Latitude that you can ins
 
 The fastest way to add Latitude is to let your coding agent (Claude Code, Cursor, Windsurf, etc.) install it for you. The [Latitude skill](https://github.com/latitude-dev/skills) guides the agent through codebase discovery (existing OpenTelemetry, conflicting LLM-observability vendors, which LLM SDKs are in use, where LLM calls actually happen), picks the right install path, places initialization correctly, and verifies that traces land in your project.
 
+<Tip>
+  **Fastest path: skill + MCP together.** Install the [Latitude MCP server](../getting-started/mcp)
+  in your agent alongside the telemetry skill. The MCP lets the agent create the Latitude project
+  and look up your API key directly; the skill then wires tracing into your codebase. Together they
+  finish the install without you leaving the editor.
+</Tip>
+
 ### Ask your coding agent
 
 Paste this prompt into your agent:
 
-> Install the Latitude AI skill from github.com/latitude-dev/skills and use it to add tracing to this application with Latitude following best practices.
+```text
+Install the Latitude AI skill from github.com/latitude-dev/skills and use
+it to add tracing to this application with Latitude following best practices.
+```
 
 The agent will fetch the skill, read your codebase, ask only the questions it can't answer from the code, and produce a working install.
 
@@ -29,7 +39,9 @@ npx skills add latitude-dev/skills --skill "latitude-telemetry"
 
 Then in your agent:
 
-> Add tracing to this application with Latitude following best practices.
+```text
+Add tracing to this application with Latitude following best practices.
+```
 
 The skill covers TypeScript and Python, the providers and frameworks listed in [Supported Integrations](#supported-integrations), and audits existing OpenTelemetry setups for compatibility.
 
@@ -49,7 +61,7 @@ One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude e
 
     const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
-      projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+      project: process.env.LATITUDE_PROJECT_SLUG!,
       instrumentations: { openai: OpenAI },
     })
 
@@ -77,7 +89,7 @@ One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude e
 
     latitude = Latitude(
         api_key="your-api-key",
-        project_slug="your-project-slug",
+        project="your-project-slug",
         instrumentations={"openai": openai},
     )
 
@@ -94,6 +106,14 @@ One SDK bootstrap class sets up everything: auto-instrumentation, the Latitude e
 
 That's it. Your LLM calls now appear as traces in Latitude.
 
+<Note>
+  **Tracing several agents into separate Latitude projects from one process?** You don't need
+  a separate SDK instance per project. Skip the constructor `project` and pass `project` on each
+  `capture()` instead — spans route to whichever project the active capture declares. See
+  [Project scoping](./project-scoping) for the full pattern, the precedence rules, and the
+  bare-OpenTelemetry alternative.
+</Note>
+
 ## Adding Context with `capture()`
 
 Auto-instrumentation traces LLM calls without any extra code. Use `capture()` when you want to attach business context such as user IDs, session IDs, tags, or metadata to group and filter traces in Latitude.
@@ -106,7 +126,7 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
 
     const latitude = new Latitude({
       apiKey: process.env.LATITUDE_API_KEY!,
-      projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+      project: process.env.LATITUDE_PROJECT_SLUG!,
       instrumentations: { openai: OpenAI },
     })
 
@@ -140,7 +160,7 @@ Auto-instrumentation traces LLM calls without any extra code. Use `capture()` wh
 
     latitude = Latitude(
         api_key="your-api-key",
-        project_slug="your-project-slug",
+        project="your-project-slug",
         instrumentations={"openai": openai},
     )
 

--- a/docs/telemetry/project-scoping.md
+++ b/docs/telemetry/project-scoping.md
@@ -13,15 +13,23 @@ agents that should each show up as a distinct Latitude project).
 For every span Latitude ingests, the server applies this order (highest priority first):
 
 1. **Span attribute** `latitude.project`
-   Set by `capture({ projectSlug })` in the TypeScript SDK or `capture({"project_slug": ...})`
-   in Python. The slug travels on the span itself, so a single OTLP export can carry spans
+   Set by `capture({ project })` in the TypeScript SDK or `capture({"project": ...})` in
+   Python. The slug travels on the span itself, so a single OTLP export can carry spans
    for multiple projects.
 2. **OTEL resource attribute** `latitude.project`
    For bare-OpenTelemetry setups: set `latitude.project` once on the SDK's `Resource` and every
    span inherits it.
 3. **HTTP header** `X-Latitude-Project`
-   The Latitude SDKs send this automatically when a `projectSlug` is passed to the constructor.
+   The Latitude SDKs send this automatically when `project` is passed to the SDK constructor.
    Acts as the per-batch default.
+
+<Note>
+  The SDK option was renamed from `projectSlug` / `project_slug` to `project` in
+  `@latitude-data/telemetry` ≥ `3.0.0-alpha.12` and `latitude-telemetry` ≥ `3.0.0a8`. The old
+  names still work but log a deprecation warning — see each SDK's CHANGELOG for the migration
+  diff. The `X-Latitude-Project` header name and the `latitude.project` span attribute are
+  unchanged.
+</Note>
 
 If none of those resolve to a project that belongs to your organization, the span is rejected.
 
@@ -52,7 +60,7 @@ Three runnable examples ship with each SDK. Start with the one that matches your
 
 ### 1. Single-project default (existing setup)
 
-For services that emit to exactly one Latitude project. The ctor `projectSlug` is sent on
+For services that emit to exactly one Latitude project. The constructor `project` is sent on
 every export as `X-Latitude-Project`, and every `capture()` inherits it.
 
 **TypeScript** — see [`examples/test_project_scoping_single.ts`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/typescript/examples/test_project_scoping_single.ts):
@@ -62,7 +70,7 @@ import { capture, Latitude } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
 })
 
 await capture("greet", async () => {
@@ -77,7 +85,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
 )
 
 @capture("greet")
@@ -85,10 +93,10 @@ def greet():
     ...  # routed to LATITUDE_PROJECT_SLUG
 ```
 
-### 2. Multi-project from day 1 (no ctor default)
+### 2. Multi-project from day 1 (no constructor default)
 
 For services that emit to multiple Latitude projects — e.g. one process that runs several
-agents. Skip the ctor `projectSlug` and set `projectSlug` on every `capture()`.
+agents. Skip the constructor `project` and set `project` on every `capture()`.
 
 **TypeScript** — see [`examples/test_project_scoping_multi.ts`](https://github.com/latitude-dev/latitude-llm/blob/main/packages/telemetry/typescript/examples/test_project_scoping_multi.ts):
 
@@ -100,13 +108,13 @@ const latitude = new Latitude({ apiKey: process.env.LATITUDE_API_KEY! })
 await capture(
   "full-stack-agent-run",
   async () => { /* ... */ },
-  { projectSlug: "full-stack-agent" },
+  { project: "full-stack-agent" },
 )
 
 await capture(
   "call-summariser-run",
   async () => { /* ... */ },
-  { projectSlug: "call-summariser" },
+  { project: "call-summariser" },
 )
 ```
 
@@ -117,16 +125,16 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(api_key=os.environ["LATITUDE_API_KEY"])
 
-@capture("full-stack-agent-run", {"project_slug": "full-stack-agent"})
+@capture("full-stack-agent-run", {"project": "full-stack-agent"})
 def run_full_stack_agent():
     ...
 
-@capture("call-summariser-run", {"project_slug": "call-summariser"})
+@capture("call-summariser-run", {"project": "call-summariser"})
 def run_call_summariser():
     ...
 ```
 
-A `capture()` that doesn't set `projectSlug` AND a SDK that doesn't have a ctor default →
+A `capture()` that doesn't set `project` AND an SDK that doesn't have a constructor default →
 the spans are rejected with `partialSuccess`. Pick one of the two so every span has a route.
 
 ### 3. Per-span override on top of a default
@@ -139,17 +147,17 @@ elsewhere (e.g. shipping evaluation runs to a separate project).
 ```ts
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,  // env-driven default
+  project: process.env.LATITUDE_PROJECT_SLUG!,  // env-driven default
 })
 
 // inherits the default
 await capture("default-route", async () => { /* ... */ })
 
-// per-capture override — wins over the ctor default
+// per-capture override — wins over the constructor default
 await capture(
   "evaluation-batch",
   async () => { /* ... */ },
-  { projectSlug: "evaluation-runs" },
+  { project: "evaluation-runs" },
 )
 ```
 
@@ -158,14 +166,14 @@ await capture(
 ```python
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
 )
 
 @capture("default-route")
 def default_route():
     ...
 
-@capture("evaluation-batch", {"project_slug": "evaluation-runs"})
+@capture("evaluation-batch", {"project": "evaluation-runs"})
 def evaluation_batch():
     ...
 ```

--- a/docs/telemetry/providers/amazon-bedrock.mdx
+++ b/docs/telemetry/providers/amazon-bedrock.mdx
@@ -78,7 +78,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { bedrock: BedrockSDK },
         })
 
@@ -113,7 +113,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"bedrock": boto3},
         )
 

--- a/docs/telemetry/providers/anthropic.mdx
+++ b/docs/telemetry/providers/anthropic.mdx
@@ -74,7 +74,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { anthropic: AnthropicSDK },
         })
 
@@ -103,7 +103,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"anthropic": anthropic},
         )
 

--- a/docs/telemetry/providers/azure.mdx
+++ b/docs/telemetry/providers/azure.mdx
@@ -76,7 +76,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { openai: OpenAI },
         })
 
@@ -108,7 +108,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"openai": openai},
         )
 

--- a/docs/telemetry/providers/cohere.mdx
+++ b/docs/telemetry/providers/cohere.mdx
@@ -75,7 +75,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { cohere: CohereSDK },
         })
 
@@ -102,7 +102,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"cohere": cohere},
         )
 

--- a/docs/telemetry/providers/google-ai-platform.mdx
+++ b/docs/telemetry/providers/google-ai-platform.mdx
@@ -75,7 +75,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { aiplatform: AIPlatformSDK },
         })
 
@@ -103,7 +103,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"aiplatform": aiplatform},
         )
 

--- a/docs/telemetry/providers/openai.mdx
+++ b/docs/telemetry/providers/openai.mdx
@@ -78,7 +78,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { openai: OpenAI },
         })
 
@@ -106,7 +106,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"openai": openai},
         )
 

--- a/docs/telemetry/providers/together-ai.mdx
+++ b/docs/telemetry/providers/together-ai.mdx
@@ -74,7 +74,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { togetherai: TogetherSDK },
         })
 
@@ -102,7 +102,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"togetherai": together},
         )
 

--- a/docs/telemetry/providers/vertex-ai.mdx
+++ b/docs/telemetry/providers/vertex-ai.mdx
@@ -75,7 +75,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         const latitude = new Latitude({
           apiKey: process.env.LATITUDE_API_KEY!,
-          projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+          project: process.env.LATITUDE_PROJECT_SLUG!,
           instrumentations: { vertexai: VertexAISDK },
         })
 
@@ -104,7 +104,7 @@ This guide shows you how to integrate **Latitude Telemetry** into an application
 
         latitude = Latitude(
             api_key="your-api-key",
-            project_slug="your-project-slug",
+            project="your-project-slug",
             instrumentations={"vertexai": vertexai},
         )
 

--- a/docs/telemetry/python.md
+++ b/docs/telemetry/python.md
@@ -27,7 +27,7 @@ from latitude_telemetry import Latitude
 
 latitude = Latitude(
     api_key="your-api-key",
-    project_slug="your-project-slug",
+    project="your-project-slug",
     instrumentations={"openai": openai},
 )
 
@@ -58,7 +58,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key="your-api-key",
-    project_slug="your-project-slug",
+    project="your-project-slug",
     instrumentations={"openai": openai},
 )
 
@@ -138,6 +138,10 @@ class Latitude:
         self,
         *,
         api_key: str,
+        # Default project for spans. Optional — every `capture()` can override.
+        # Sent as the `X-Latitude-Project` header on every export.
+        project: str | None = None,
+        # DEPRECATED alias for `project`. Still accepted; logs a one-time warning.
         project_slug: str | None = None,
         # Dict mapping integration name → the LLM SDK module the consumer imports.
         # Anything else (list, primitive, unknown key, non-dict) raises TypeError.
@@ -180,6 +184,9 @@ def capture(
 #     "session_id": str | None,
 #     "tags": list[str] | None,
 #     "metadata": dict | None,
+#     "project": str | None,        # Route this capture (and child spans) to a
+#                                   # specific Latitude project, overriding the default.
+#     "project_slug": str | None,   # DEPRECATED alias for `project`. Still accepted.
 # }
 ```
 
@@ -190,6 +197,7 @@ def capture(
 | `metadata` | `dict[str, Any]` | `latitude.metadata` | Arbitrary key-value metadata |
 | `session_id` | `str` | `session.id` | Group traces by session |
 | `user_id` | `str` | `user.id` | Associate traces with a user |
+| `project` | `str` | `latitude.project` | Route this capture to a specific Latitude project (overrides the constructor default) |
 
 ### `LatitudeSpanProcessor`
 
@@ -200,7 +208,7 @@ class LatitudeSpanProcessor:
     def __init__(
         self,
         api_key: str,
-        project_slug: str,
+        project: str | None,
         options: LatitudeSpanProcessorOptions | None = None,
     ):
         ...
@@ -252,7 +260,7 @@ The list-of-strings form is removed with no fallback in `3.0.0a7`. Anything othe
 
   latitude = Latitude(
       api_key="your-api-key",
-      project_slug="your-project-slug",
+      project="your-project-slug",
 -     instrumentations=["openai", "anthropic"],
 +     instrumentations={"openai": openai, "anthropic": anthropic},
   )

--- a/docs/telemetry/typescript.md
+++ b/docs/telemetry/typescript.md
@@ -25,7 +25,7 @@ const client = new OpenAI()
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 
@@ -62,7 +62,7 @@ import { Latitude, capture } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 
@@ -112,7 +112,7 @@ Sentry.init({
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 
@@ -171,6 +171,10 @@ Bootstraps a complete OpenTelemetry setup with LLM instrumentations and Latitude
 ```ts
 type LatitudeOptions = {
   apiKey: string
+  // Default project for spans emitted by this SDK instance. Optional — every
+  // `capture()` can override. Sent as the `X-Latitude-Project` header on each export.
+  project?: string
+  // DEPRECATED alias for `project`. Still accepted; logs a one-time warning.
   projectSlug?: string
   // Map of integration name → LLM SDK module reference (e.g. { openai: OpenAI }).
   // Anything else (string array, primitive, unknown key, non-object) throws at register time.
@@ -206,6 +210,11 @@ type ContextOptions = {
   sessionId?: string
   tags?: string[]
   metadata?: Record<string, unknown>
+  // Route this capture (and its child spans) to a specific Latitude project,
+  // overriding the constructor's `project` default for the duration of the capture.
+  project?: string
+  // DEPRECATED alias for `project`. Still accepted; logs a one-time warning.
+  projectSlug?: string
 }
 
 function capture<T>(
@@ -231,7 +240,7 @@ Span processor for shared-provider setups. Reads Latitude context from OTel cont
 class LatitudeSpanProcessor implements SpanProcessor {
   constructor(
     apiKey: string,
-    projectSlug: string,
+    project: string | undefined,
     options?: LatitudeSpanProcessorOptions,
   )
 }
@@ -306,7 +315,7 @@ The string-array form is removed with no fallback in `3.0.0-alpha.11`. Anything 
 
   new Latitude({
     apiKey: process.env.LATITUDE_API_KEY!,
-    projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+    project: process.env.LATITUDE_PROJECT_SLUG!,
 -   instrumentations: ["openai", "anthropic"],
 +   instrumentations: { openai: OpenAI, anthropic: AnthropicSDK },
   })
@@ -321,7 +330,7 @@ The `modules` option on `registerLatitudeInstrumentations` is also removed — p
 By default, only LLM-relevant spans are exported (spans with `gen_ai.*`, `llm.*`, `openinference.*`, or `ai.*` attributes, plus known LLM instrumentation scopes):
 
 ```ts
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   disableSmartFilter: true, // Export all spans
 })
 ```
@@ -336,7 +345,7 @@ PII redaction is enabled by default for security-sensitive attributes:
 - Database statements
 
 ```ts
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   disableRedact: true, // Disable all redaction
   redact: {
     attributes: [/^password$/i, /secret/i], // Add custom patterns
@@ -348,7 +357,7 @@ new LatitudeSpanProcessor(apiKey, projectSlug, {
 ### Custom Filtering
 
 ```ts
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   shouldExportSpan: (span) => span.attributes["custom"] === true,
   blockedInstrumentationScopes: ["opentelemetry.instrumentation.fs"],
 })

--- a/packages/telemetry/python/CHANGELOG.md
+++ b/packages/telemetry/python/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0a8] - 2026-05-16
+
+### Changed
+
+- **Renamed `project_slug` → `project` on the `Latitude` constructor, `init_latitude()`, and `capture()` options.** The `Slug` suffix leaked an internal database concept into the SDK surface. Affects:
+  - `Latitude(api_key=..., project=...)`
+  - `init_latitude(api_key=..., project=...)`
+  - `capture("name", fn, {"project": ...})`
+
+### Deprecated
+
+- `project_slug` on both the constructor and `capture()` options still works but logs a one-time `logging.warning` and will be removed in a future release. When both `project` and `project_slug` are passed, `project` wins.
+
+### Migration
+
+```diff
+- Latitude(api_key=..., project_slug="my-project")
++ Latitude(api_key=..., project="my-project")
+
+- capture("run", fn, {"project_slug": "evaluations"})
++ capture("run", fn, {"project": "evaluations"})
+```
+
+The `X-Latitude-Project` HTTP header name, the `latitude.project` span attribute, and the `LATITUDE_PROJECT_SLUG` environment variable convention are all unchanged — they're independent of the SDK option name.
+
 ## [3.0.0a7] - 2026-05-15
 
 ### Breaking Changes

--- a/packages/telemetry/python/README.md
+++ b/packages/telemetry/python/README.md
@@ -26,7 +26,7 @@ client = OpenAI()
 
 latitude = Latitude(
     api_key="your-api-key",
-    project_slug="your-project-slug",
+    project="your-project-slug",
     instrumentations={"openai": openai},  # Pass the LLM SDK module you use in app code.
 )
 
@@ -121,7 +121,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key="your-api-key",
-    project_slug="your-project-slug",
+    project="your-project-slug",
     instrumentations={"openai": openai},
 )
 
@@ -182,6 +182,11 @@ class Latitude:
         self,
         *,
         api_key: str,
+        # Default project for spans. Optional — every `capture()` can override.
+        # Sent as the `X-Latitude-Project` header on every export.
+        project: str | None = None,
+        # DEPRECATED alias for `project`. Still accepted; logs a one-time warning and will be
+        # removed in a future release. When both are passed, `project` wins.
         project_slug: str | None = None,
         # Dict mapping integration name → the LLM SDK module the consumer imports.
         # Example: {"openai": openai, "anthropic": anthropic}.
@@ -215,7 +220,7 @@ class LatitudeSpanProcessor:
     def __init__(
         self,
         api_key: str,
-        project_slug: str,
+        project: str | None,
         options: LatitudeSpanProcessorOptions | None = None,
     ):
         ...
@@ -250,6 +255,9 @@ def capture(
 #     "session_id": str | None,  # Session identifier (user.id attribute)
 #     "tags": list[str] | None,  # Tags for filtering traces
 #     "metadata": dict | None,   # Arbitrary key-value metadata
+#     "project": str | None,     # Route this capture (and child spans) to a specific
+#                                # Latitude project, overriding the constructor default.
+#     "project_slug": str | None, # DEPRECATED alias for `project`. Still accepted.
 # }
 ```
 
@@ -295,7 +303,7 @@ The list-of-strings form is removed with no fallback in `3.0.0a7`. Anything othe
 
   latitude = Latitude(
       api_key="your-api-key",
-      project_slug="your-project-slug",
+      project="your-project-slug",
 -     instrumentations=["openai", "anthropic"],
 +     instrumentations={"openai": openai, "anthropic": anthropic},
   )

--- a/packages/telemetry/python/examples/README.md
+++ b/packages/telemetry/python/examples/README.md
@@ -139,7 +139,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_aleph_alpha.py
+++ b/packages/telemetry/python/examples/test_aleph_alpha.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"aleph_alpha": aleph_alpha_client},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_anthropic.py
+++ b/packages/telemetry/python/examples/test_anthropic.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"anthropic": anthropic},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_azure.py
+++ b/packages/telemetry/python/examples/test_azure.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry BEFORE importing openai so instrumentation can patch it
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_bedrock.py
+++ b/packages/telemetry/python/examples/test_bedrock.py
@@ -21,7 +21,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"bedrock": boto3},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_capture_nesting.py
+++ b/packages/telemetry/python/examples/test_capture_nesting.py
@@ -24,7 +24,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_cohere.py
+++ b/packages/telemetry/python/examples/test_cohere.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"cohere": cohere},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_crewai.py
+++ b/packages/telemetry/python/examples/test_crewai.py
@@ -21,7 +21,7 @@ from latitude_telemetry import Latitude, capture
 # Note: CrewAI uses OpenAI by default, so we instrument both
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"crewai": crewai, "openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_dspy.py
+++ b/packages/telemetry/python/examples/test_dspy.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"dspy": dspy},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_gemini.py
+++ b/packages/telemetry/python/examples/test_gemini.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"google_generativeai": genai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_groq.py
+++ b/packages/telemetry/python/examples/test_groq.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"groq": groq},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_haystack.py
+++ b/packages/telemetry/python/examples/test_haystack.py
@@ -20,7 +20,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"haystack": haystack},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_langchain.py
+++ b/packages/telemetry/python/examples/test_langchain.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry BEFORE importing langchain so instrumentation can patch it
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"langchain": langchain_core},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_litellm.py
+++ b/packages/telemetry/python/examples/test_litellm.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"litellm": litellm},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_llamaindex.py
+++ b/packages/telemetry/python/examples/test_llamaindex.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"llamaindex": llama_index},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_manual_instrumentation.py
+++ b/packages/telemetry/python/examples/test_manual_instrumentation.py
@@ -25,7 +25,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_mistral.py
+++ b/packages/telemetry/python/examples/test_mistral.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"mistralai": mistralai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_ollama.py
+++ b/packages/telemetry/python/examples/test_ollama.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"ollama": ollama},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_openai.py
+++ b/packages/telemetry/python/examples/test_openai.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_openai_agents.py
+++ b/packages/telemetry/python/examples/test_openai_agents.py
@@ -20,7 +20,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai-agents": agents},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_openai_responses.py
+++ b/packages/telemetry/python/examples/test_openai_responses.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_project_scoping_env.py
+++ b/packages/telemetry/python/examples/test_project_scoping_env.py
@@ -2,14 +2,14 @@
 Project scoping — env-driven default + per-capture override.
 
 Reads the default project slug from `LATITUDE_PROJECT_SLUG` and lets specific captures
-override it via `capture({"project_slug": ...})`. A common shape for services that run in
+override it via `capture({"project": ...})`. A common shape for services that run in
 many environments (staging/prod each have their own project slug) but still need to route
 a subset of spans elsewhere.
 
 Resolution precedence (highest → lowest):
-  1. capture({"project_slug": ...})         — emits `latitude.project` on the span
+  1. capture({"project": ...})              — emits `latitude.project` on the span
   2. OTEL resource attribute `latitude.project`  — bare-OTEL setups
-  3. ctor `project_slug`                    — sent as `X-Latitude-Project` header
+  3. constructor `project`                  — sent as `X-Latitude-Project` header
 
 The override slug (`evaluation-runs` below) must exist in the same org as `LATITUDE_API_KEY`.
 
@@ -32,7 +32,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )
@@ -51,7 +51,7 @@ def default_route() -> None:
     print("default-route →", r.choices[0].message.content)
 
 
-@capture("evaluation-batch", {"project_slug": OVERRIDE_SLUG, "tags": ["python"]})
+@capture("evaluation-batch", {"project": OVERRIDE_SLUG, "tags": ["python"]})
 def evaluation_batch() -> None:
     client = OpenAI()
     r = client.chat.completions.create(

--- a/packages/telemetry/python/examples/test_project_scoping_multi.py
+++ b/packages/telemetry/python/examples/test_project_scoping_multi.py
@@ -1,8 +1,8 @@
 """
 Project scoping — multi-project per-capture override.
 
-`Latitude(api_key=...)` is initialized *without* a default `project_slug`. Every `capture()`
-must declare its own `project_slug` and spans are routed per-capture via the
+`Latitude(api_key=...)` is initialized *without* a default `project`. Every `capture()`
+must declare its own `project` and spans are routed per-capture via the
 `latitude.project` span attribute. Use this when a single process emits to several Latitude
 projects (e.g. multiple agents sharing one runtime).
 
@@ -43,7 +43,7 @@ CALL_SUMMARISER_SLUG = os.environ.get("LATITUDE_SECONDARY_PROJECT_SLUG", "second
 
 @capture(
     "full-stack-agent-run",
-    {"project_slug": FULL_STACK_AGENT_SLUG, "tags": ["python", "agent:full-stack"]},
+    {"project": FULL_STACK_AGENT_SLUG, "tags": ["python", "agent:full-stack"]},
 )
 def run_full_stack_agent() -> None:
     client = OpenAI()
@@ -57,7 +57,7 @@ def run_full_stack_agent() -> None:
 
 @capture(
     "call-summariser-run",
-    {"project_slug": CALL_SUMMARISER_SLUG, "tags": ["python", "agent:summariser"]},
+    {"project": CALL_SUMMARISER_SLUG, "tags": ["python", "agent:summariser"]},
 )
 def run_call_summariser() -> None:
     client = OpenAI()
@@ -73,9 +73,9 @@ def main() -> None:
     run_full_stack_agent()
     run_call_summariser()
 
-    # Spans with no `project_slug` AND no ctor default are rejected by the ingest service
+    # Spans with no `project` AND no constructor default are rejected by the ingest service
     # with a `partial_success` body — exporters log the rejection but don't retry. Always
-    # set a slug either on the ctor or on each `capture()` when running this pattern.
+    # set a project either on the constructor or on each `capture()` when running this pattern.
 
     latitude.flush()
 

--- a/packages/telemetry/python/examples/test_project_scoping_single.py
+++ b/packages/telemetry/python/examples/test_project_scoping_single.py
@@ -1,7 +1,7 @@
 """
 Project scoping — single-project default (existing pattern).
 
-`Latitude(api_key=..., project_slug=...)` sets a default project for every span. `capture()`
+`Latitude(api_key=..., project=...)` sets a default project for every span. `capture()`
 inherits it, so all spans land in the same Latitude project. This is the recommended setup
 for processes that emit to one project.
 
@@ -24,7 +24,7 @@ from latitude_telemetry import Latitude, capture
 
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"openai": openai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_replicate.py
+++ b/packages/telemetry/python/examples/test_replicate.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"replicate": replicate},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_sagemaker.py
+++ b/packages/telemetry/python/examples/test_sagemaker.py
@@ -21,7 +21,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"sagemaker": boto3},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_together.py
+++ b/packages/telemetry/python/examples/test_together.py
@@ -18,7 +18,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"togetherai": together},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_transformers.py
+++ b/packages/telemetry/python/examples/test_transformers.py
@@ -17,7 +17,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"transformers": transformers},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_vertex.py
+++ b/packages/telemetry/python/examples/test_vertex.py
@@ -19,7 +19,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"vertexai": vertexai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/examples/test_watsonx.py
+++ b/packages/telemetry/python/examples/test_watsonx.py
@@ -21,7 +21,7 @@ from latitude_telemetry import Latitude, capture
 # Initialize telemetry pointing to local instance
 latitude = Latitude(
     api_key=os.environ["LATITUDE_API_KEY"],
-    project_slug=os.environ["LATITUDE_PROJECT_SLUG"],
+    project=os.environ["LATITUDE_PROJECT_SLUG"],
     instrumentations={"watsonx": ibm_watsonx_ai},
     disable_batch=True,
 )

--- a/packages/telemetry/python/pyproject.toml
+++ b/packages/telemetry/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latitude-telemetry"
-version = "3.0.0a7"
+version = "3.0.0a8"
 description = "Latitude Telemetry for Python"
 authors = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]
 maintainers = [{ name = "Latitude Data SL", email = "hello@latitude.so" }]

--- a/packages/telemetry/python/src/latitude_telemetry/__init__.py
+++ b/packages/telemetry/python/src/latitude_telemetry/__init__.py
@@ -12,7 +12,7 @@ Example (Bootstrap - Recommended):
 
     latitude = Latitude(
         api_key="your-api-key",
-        project_slug="my-project",
+        project="my-project",
         instrumentations={"openai": openai, "anthropic": anthropic},
     )
 
@@ -35,7 +35,7 @@ Example (Advanced - Existing OTel Setup):
     from latitude_telemetry import LatitudeSpanProcessor, register_latitude_instrumentations
 
     provider = TracerProvider()
-    provider.add_span_processor(LatitudeSpanProcessor("api-key", "project-slug"))
+    provider.add_span_processor(LatitudeSpanProcessor("api-key", "my-project"))
     trace.set_tracer_provider(provider)
 
     register_latitude_instrumentations({"openai": openai}, provider)

--- a/packages/telemetry/python/src/latitude_telemetry/exporter/exporter.py
+++ b/packages/telemetry/python/src/latitude_telemetry/exporter/exporter.py
@@ -6,7 +6,7 @@ from latitude_telemetry.util import Model
 
 class ExporterOptions(Model):
     api_key: str
-    project_slug: str | None
+    project: str | None
     endpoint: str
     timeout: float
 
@@ -18,8 +18,8 @@ def create_exporter(options: ExporterOptions) -> SpanExporter:
     headers = {
         "Authorization": f"Bearer {options.api_key}",
     }
-    if options.project_slug:
-        headers["X-Latitude-Project"] = options.project_slug
+    if options.project:
+        headers["X-Latitude-Project"] = options.project
     return OTLPSpanExporter(
         endpoint=f"{options.endpoint}/v1/traces",
         headers=headers,

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/_deprecation.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/_deprecation.py
@@ -1,0 +1,33 @@
+"""
+Internal helpers for one-time deprecation warnings.
+
+Lives in its own module so both ``init.py`` and ``context.py`` can depend on it
+without forming a circular import (``init`` already imports the span processor,
+which imports ``context``).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_project_slug_deprecation_warned = False
+
+
+def reset_project_slug_deprecation_warning_for_testing() -> None:
+    """Test-only helper to reset the once-per-process deprecation flag."""
+    global _project_slug_deprecation_warned
+    _project_slug_deprecation_warned = False
+
+
+def warn_project_slug_deprecated(site: str) -> None:
+    """Log a one-time deprecation warning for the legacy ``project_slug`` argument."""
+    global _project_slug_deprecation_warned
+    if _project_slug_deprecation_warned:
+        return
+    _project_slug_deprecation_warned = True
+    option = "`project_slug`" if site == "constructor" else "`project_slug` on capture()"
+    logger.warning(
+        "[Latitude] %s is deprecated and will be removed in a future release — rename it to "
+        "`project`. Both work for now; when both are passed, `project` wins.",
+        option,
+    )

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/context.py
@@ -10,6 +10,7 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.context import Context
 
+from latitude_telemetry.sdk._deprecation import warn_project_slug_deprecated
 from latitude_telemetry.sdk.types import ContextOptions
 
 LATITUDE_CONTEXT_KEY = "latitude-internal-context"
@@ -43,14 +44,14 @@ class _LatitudeContextData:
         metadata: dict[str, object] | None = None,
         session_id: str | None = None,
         user_id: str | None = None,
-        project_slug: str | None = None,
+        project: str | None = None,
     ):
         self.name = name
         self.tags = tags
         self.metadata = metadata
         self.session_id = session_id
         self.user_id = user_id
-        self.project_slug = project_slug
+        self.project = project
 
 
 def get_latitude_context(ctx: Context) -> _LatitudeContextData | None:
@@ -78,13 +79,17 @@ def _set_capture_context(name: str, base_context: Context, options: ContextOptio
     child_metadata = opts.get("metadata") or {}
     merged_metadata: dict[str, object] = {**parent_metadata, **child_metadata}
 
+    if "project" not in opts and "project_slug" in opts:
+        warn_project_slug_deprecated("capture")
+    project_from_opts = opts.get("project") or opts.get("project_slug")
+
     merged_data = _LatitudeContextData(
         name=opts.get("name") or name,
         tags=_merge_arrays(existing_data.tags if existing_data else None, opts.get("tags")),
         metadata=merged_metadata,
         session_id=opts.get("session_id") or (existing_data.session_id if existing_data else None),
         user_id=opts.get("user_id") or (existing_data.user_id if existing_data else None),
-        project_slug=opts.get("project_slug") or (existing_data.project_slug if existing_data else None),
+        project=project_from_opts or (existing_data.project if existing_data else None),
     )
 
     return otel_context.set_value(LATITUDE_CONTEXT_KEY, merged_data, base_context)

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/init.py
@@ -18,6 +18,7 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from opentelemetry.trace import NoOpTracerProvider, ProxyTracerProvider
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
+from latitude_telemetry.sdk._deprecation import warn_project_slug_deprecated
 from latitude_telemetry.sdk.instrumentations import register_latitude_instrumentations
 from latitude_telemetry.sdk.types import InstrumentationsInput, SmartFilterOptions
 from latitude_telemetry.telemetry.latitude_span_processor import LatitudeSpanProcessor, LatitudeSpanProcessorOptions
@@ -73,6 +74,7 @@ class Latitude:
         self,
         *,
         api_key: str,
+        project: str | None = None,
         project_slug: str | None = None,
         instrumentations: InstrumentationsInput | None = None,
         disable_redact: bool = False,
@@ -87,7 +89,11 @@ class Latitude:
     ):
         if not api_key or not api_key.strip():
             raise ValueError("[Latitude] api_key is required and cannot be empty")
-        normalized_project_slug = project_slug.strip() if project_slug and project_slug.strip() else None
+
+        if project is None and project_slug is not None:
+            warn_project_slug_deprecated("constructor")
+        resolved_project = project if project is not None else project_slug
+        normalized_project = resolved_project.strip() if resolved_project and resolved_project.strip() else None
 
         target_provider = tracer_provider or _get_registered_tracer_provider()
 
@@ -99,7 +105,7 @@ class Latitude:
 
         self._latitude_processor = LatitudeSpanProcessor(
             api_key=api_key,
-            project_slug=normalized_project_slug,
+            project=normalized_project,
             options=LatitudeSpanProcessorOptions(
                 disable_batch=disable_batch,
                 disable_redact=disable_redact,
@@ -193,6 +199,7 @@ class Latitude:
 
 def init_latitude(
     api_key: str,
+    project: str | None = None,
     project_slug: str | None = None,
     instrumentations: InstrumentationsInput | None = None,
     disable_redact: bool = False,
@@ -214,6 +221,7 @@ def init_latitude(
 
     latitude = Latitude(
         api_key=api_key,
+        project=project,
         project_slug=project_slug,
         instrumentations=instrumentations,
         disable_batch=disable_batch,

--- a/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
+++ b/packages/telemetry/python/src/latitude_telemetry/sdk/types.py
@@ -59,16 +59,22 @@ class ContextOptions(TypedDict, total=False):
     session_id: str
     user_id: str
     # Route the capture (and all child spans) to a specific Latitude project.
-    # Overrides the ctor `project_slug` default for this capture only.
+    # Overrides the constructor `project` default for this capture only.
+    project: str
+    # DEPRECATED: renamed to `project`. Still accepted for backwards compatibility and will
+    # be removed in a future release. When both are set, `project` wins.
     project_slug: str
 
 
 class LatitudeOptions(SmartFilterOptions, total=False):
     api_key: Required[str]
-    # Optional default project slug. When omitted, every `capture()` MUST set its own
-    # `project_slug` (or rely on a per-span / OTEL resource attribute). When set, the SDK
+    # Optional default project. When omitted, every `capture()` MUST set its own
+    # `project` (or rely on a per-span / OTEL resource attribute). When set, the SDK
     # forwards it as the `X-Latitude-Project` header so spans without a per-span override
     # land in this project.
+    project: NotRequired[str]
+    # DEPRECATED: renamed to `project`. Still accepted for backwards compatibility and will
+    # be removed in a future release. When both are set, `project` wins.
     project_slug: NotRequired[str]
     instrumentations: InstrumentationsInput
     disable_redact: bool

--- a/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
+++ b/packages/telemetry/python/src/latitude_telemetry/telemetry/latitude_span_processor.py
@@ -100,7 +100,7 @@ class LatitudeSpanProcessor(SpanProcessor):
     def __init__(
         self,
         api_key: str,
-        project_slug: str | None,
+        project: str | None,
         options: LatitudeSpanProcessorOptions | None = None,
     ):
         options = options or LatitudeSpanProcessorOptions()
@@ -108,7 +108,7 @@ class LatitudeSpanProcessor(SpanProcessor):
         base_exporter = options.exporter or create_exporter(
             ExporterOptions(
                 api_key=api_key,
-                project_slug=project_slug,
+                project=project,
                 endpoint=env.EXPORTER_URL,
                 timeout=30,
             )
@@ -165,8 +165,8 @@ class LatitudeSpanProcessor(SpanProcessor):
                 span.set_attribute(ATTRIBUTES.session_id, latitude_data.session_id)
             if latitude_data.user_id:
                 span.set_attribute(ATTRIBUTES.user_id, latitude_data.user_id)
-            if latitude_data.project_slug:
-                span.set_attribute(ATTRIBUTES.project, latitude_data.project_slug)
+            if latitude_data.project:
+                span.set_attribute(ATTRIBUTES.project, latitude_data.project)
 
         self._tail.on_start(span, parent_context)
 

--- a/packages/telemetry/python/tests/telemetry/capture_test.py
+++ b/packages/telemetry/python/tests/telemetry/capture_test.py
@@ -1,9 +1,12 @@
 """Tests for the capture() function and context propagation."""
 
+import logging
+
 import pytest
 from opentelemetry import context as otel_context
 
 from latitude_telemetry import capture, get_latitude_context
+from latitude_telemetry.sdk._deprecation import reset_project_slug_deprecation_warning_for_testing
 
 
 class TestCaptureFunction:
@@ -230,3 +233,43 @@ class TestCaptureOptions:
         assert captured_ctx.metadata == {}
         assert captured_ctx.session_id is None
         assert captured_ctx.user_id is None
+
+
+class TestCaptureProjectOption:
+    """Tests covering the new `project` option and legacy `project_slug` alias on capture()."""
+
+    def setup_method(self):
+        reset_project_slug_deprecation_warning_for_testing()
+
+    def test_project_option_lands_on_context(self):
+        captured = {}
+
+        def fn():
+            ctx = get_latitude_context(otel_context.get_current())
+            captured["project"] = ctx.project if ctx else None
+
+        capture("scoped", fn, {"project": "call-summariser"})
+        assert captured["project"] == "call-summariser"
+
+    def test_legacy_project_slug_still_works_and_logs_deprecation(self, caplog):
+        captured = {}
+
+        def fn():
+            ctx = get_latitude_context(otel_context.get_current())
+            captured["project"] = ctx.project if ctx else None
+
+        with caplog.at_level(logging.WARNING, logger="latitude_telemetry.sdk._deprecation"):
+            capture("legacy", fn, {"project_slug": "legacy-slug"})
+
+        assert captured["project"] == "legacy-slug"
+        assert any("`project_slug` on capture()" in r.message for r in caplog.records)
+
+    def test_project_wins_when_both_keys_present(self):
+        captured = {}
+
+        def fn():
+            ctx = get_latitude_context(otel_context.get_current())
+            captured["project"] = ctx.project if ctx else None
+
+        capture("both", fn, {"project": "new-name", "project_slug": "old-name"})
+        assert captured["project"] == "new-name"

--- a/packages/telemetry/python/tests/telemetry/span_test.py
+++ b/packages/telemetry/python/tests/telemetry/span_test.py
@@ -10,6 +10,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from latitude_telemetry import Latitude, init_latitude
+from latitude_telemetry.sdk._deprecation import reset_project_slug_deprecation_warning_for_testing
 
 
 class TestTracerAccess:
@@ -21,7 +22,7 @@ class TestTracerAccess:
         with patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"):
             lat = Latitude(
                 api_key="test-api-key",
-                project_slug="test-project",
+                project="test-project",
                 disable_batch=True,
                 tracer_provider=TracerProvider(),
             )
@@ -56,7 +57,7 @@ class TestTracerAccess:
         with patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"):
             lat = init_latitude(
                 api_key="test-api-key",
-                project_slug="test-project",
+                project="test-project",
                 disable_batch=True,
             )
 
@@ -74,7 +75,7 @@ class TestServiceNameOverride:
 
         lat = Latitude(
             api_key="test-api-key",
-            project_slug="test-project",
+            project="test-project",
             disable_batch=True,
             # No tracer_provider: Latitude owns the provider.
             service_name="latitude-service",
@@ -105,7 +106,7 @@ class TestServiceNameOverride:
 
         lat = Latitude(
             api_key="test-api-key",
-            project_slug="test-project",
+            project="test-project",
             disable_batch=True,
             tracer_provider=host_provider,
             service_name="latitude-service",  # explicitly passed — should be ignored
@@ -143,7 +144,7 @@ class TestUnattachableProvider:
         ):
             lat = Latitude(
                 api_key="test-api-key",
-                project_slug="test-project",
+                project="test-project",
                 disable_batch=True,
                 tracer_provider=opaque,  # type: ignore[arg-type]
             )
@@ -152,4 +153,41 @@ class TestUnattachableProvider:
         # Fallback creates a Latitude-owned provider that is NOT the passed-in opaque one.
         assert lat.provider is not opaque
 
+        lat.shutdown()
+
+
+class TestProjectArgRename:
+    """The constructor accepts both `project` (new) and `project_slug` (deprecated)."""
+
+    def setup_method(self):
+        reset_project_slug_deprecation_warning_for_testing()
+
+    def test_legacy_project_slug_still_works_and_logs_deprecation(self, caplog):
+        with (
+            patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"),
+            caplog.at_level(logging.WARNING, logger="latitude_telemetry.sdk._deprecation"),
+        ):
+            lat = Latitude(
+                api_key="test-api-key",
+                project_slug="legacy-slug",
+                disable_batch=True,
+                tracer_provider=TracerProvider(),
+            )
+
+        assert any("`project_slug` is deprecated" in r.message for r in caplog.records)
+        lat.shutdown()
+
+    def test_project_argument_does_not_log_deprecation(self, caplog):
+        with (
+            patch("latitude_telemetry.telemetry.latitude_span_processor.create_exporter"),
+            caplog.at_level(logging.WARNING, logger="latitude_telemetry.sdk._deprecation"),
+        ):
+            lat = Latitude(
+                api_key="test-api-key",
+                project="my-project",
+                disable_batch=True,
+                tracer_provider=TracerProvider(),
+            )
+
+        assert not any("deprecated" in r.message for r in caplog.records)
         lat.shutdown()

--- a/packages/telemetry/python/uv.lock
+++ b/packages/telemetry/python/uv.lock
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "latitude-telemetry"
-version = "3.0.0a7"
+version = "3.0.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "openai-agents" },

--- a/packages/telemetry/typescript/CHANGELOG.md
+++ b/packages/telemetry/typescript/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0-alpha.12] - 2026-05-16
+
+### Changed
+
+- **Renamed `projectSlug` → `project` on `LatitudeOptions` and `ContextOptions`.** Both are now spelled simply `project` — the `Slug` suffix leaked an internal concept (the database column name) into the SDK surface. Affects:
+  - `new Latitude({ apiKey, project })`
+  - `capture(name, fn, { project })`
+  - `initLatitude({ apiKey, project })`
+
+### Deprecated
+
+- `projectSlug` on both `LatitudeOptions` and `ContextOptions` still works but logs a one-time `console.warn` and will be removed in a future release. When both `project` and `projectSlug` are passed, `project` wins.
+
+### Migration
+
+```diff
+- new Latitude({ apiKey, projectSlug: "my-project" })
++ new Latitude({ apiKey, project: "my-project" })
+
+- await capture("run", fn, { projectSlug: "evaluations" })
++ await capture("run", fn, { project: "evaluations" })
+```
+
+The `X-Latitude-Project` HTTP header name, the `latitude.project` span attribute, and the `LATITUDE_PROJECT_SLUG` environment variable convention are all unchanged — they're independent of the SDK option name.
+
 ## [3.0.0-alpha.11] - 2026-05-14
 
 ### Breaking Changes

--- a/packages/telemetry/typescript/README.md
+++ b/packages/telemetry/typescript/README.md
@@ -22,7 +22,7 @@ const client = new OpenAI();
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI }, // Pass the LLM SDK module you use in app code.
 });
 
@@ -76,7 +76,7 @@ Sentry.init({
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 
@@ -161,7 +161,7 @@ import { Latitude, capture } from "@latitude-data/telemetry";
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 
@@ -215,6 +215,15 @@ The primary entry point. Bootstraps a complete OpenTelemetry setup with LLM inst
 ```typescript
 type LatitudeOptions = {
   apiKey: string;
+  /**
+   * Default project slug for spans. Optional — every `capture()` can override.
+   * Sent as the `X-Latitude-Project` header on every export.
+   */
+  project?: string;
+  /**
+   * @deprecated Renamed to `project`. Still accepted for backwards compatibility
+   * and will be removed in a future release. When both are set, `project` wins.
+   */
   projectSlug?: string;
   // Map of integration name → LLM SDK module the consumer imports.
   // Anything else (string array, unknown key, non-object) throws at register time.
@@ -247,7 +256,7 @@ Span processor for shared-provider setups. Reads Latitude context from OTel cont
 class LatitudeSpanProcessor implements SpanProcessor {
   constructor(
     apiKey: string,
-    projectSlug: string,
+    project: string | undefined,
     options?: LatitudeSpanProcessorOptions,
   );
 }
@@ -274,6 +283,16 @@ type ContextOptions = {
   sessionId?: string;
   tags?: string[];
   metadata?: Record<string, unknown>;
+  /**
+   * Routes this capture (and its child spans) to a specific Latitude project.
+   * Overrides the constructor's `project` default for the duration of the capture.
+   */
+  project?: string;
+  /**
+   * @deprecated Renamed to `project`. Still accepted for backwards compatibility
+   * and will be removed in a future release.
+   */
+  projectSlug?: string;
 };
 
 function capture<T>(
@@ -337,7 +356,7 @@ tracer.init({ service: "my-app", env: "production" });
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 
@@ -366,7 +385,7 @@ Sentry.init({
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 
@@ -390,7 +409,7 @@ import { Latitude } from "@latitude-data/telemetry";
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 ```
@@ -409,7 +428,7 @@ honeycomb.start();
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 });
 ```
@@ -428,7 +447,7 @@ time. Switch to the object form, mapping integration name → LLM SDK module:
 
   new Latitude({
     apiKey: process.env.LATITUDE_API_KEY!,
-    projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+    project: process.env.LATITUDE_PROJECT_SLUG!,
 -   instrumentations: ["openai", "anthropic"],
 +   instrumentations: { openai: OpenAI, anthropic: AnthropicSDK },
   });
@@ -473,7 +492,7 @@ but the namespace form is the recommended shape.
 By default, only LLM-relevant spans are exported:
 
 ```typescript
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   disableSmartFilter: true, // Export all spans
 });
 ```
@@ -490,7 +509,7 @@ PII redaction is enabled by default for security-sensitive attributes only:
 - Database statements
 
 ```typescript
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   disableRedact: true, // Disable all redaction
   redact: {
     attributes: [/^password$/i, /secret/i], // Add custom patterns
@@ -502,7 +521,7 @@ new LatitudeSpanProcessor(apiKey, projectSlug, {
 ### Custom Filtering
 
 ```typescript
-new LatitudeSpanProcessor(apiKey, projectSlug, {
+new LatitudeSpanProcessor(apiKey, project, {
   shouldExportSpan: (span) => span.attributes["custom"] === true,
   blockedInstrumentationScopes: ["opentelemetry.instrumentation.fs"],
 });

--- a/packages/telemetry/typescript/examples/README.md
+++ b/packages/telemetry/typescript/examples/README.md
@@ -12,7 +12,7 @@ import { Latitude, capture } from "@latitude-data/telemetry"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI }, // Pass the LLM SDK module you use in app code.
 })
 
@@ -139,7 +139,7 @@ import { LatitudeSpanProcessor, registerLatitudeInstrumentations } from "@latitu
 
 const provider = new NodeTracerProvider({
   spanProcessors: [
-    new LatitudeSpanProcessor(apiKey, projectSlug),
+    new LatitudeSpanProcessor(apiKey, project),
   ],
 })
 

--- a/packages/telemetry/typescript/examples/test_anthropic.ts
+++ b/packages/telemetry/typescript/examples/test_anthropic.ts
@@ -14,7 +14,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { anthropic: AnthropicSDK },
 })

--- a/packages/telemetry/typescript/examples/test_azure.ts
+++ b/packages/telemetry/typescript/examples/test_azure.ts
@@ -17,7 +17,7 @@ import { capture, Latitude } from "../src"
 // Note: Azure OpenAI uses the same OpenAI instrumentor
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { openai: OpenAI },
 })

--- a/packages/telemetry/typescript/examples/test_bedrock.ts
+++ b/packages/telemetry/typescript/examples/test_bedrock.ts
@@ -17,7 +17,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { bedrock: BedrockSDK },
 })

--- a/packages/telemetry/typescript/examples/test_capture_nesting.ts
+++ b/packages/telemetry/typescript/examples/test_capture_nesting.ts
@@ -20,7 +20,7 @@ import OpenAI from "openai"
 // Initialize telemetry
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
   disableBatch: true,
 })

--- a/packages/telemetry/typescript/examples/test_cohere.ts
+++ b/packages/telemetry/typescript/examples/test_cohere.ts
@@ -15,7 +15,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { cohere: CohereSDK },
 })

--- a/packages/telemetry/typescript/examples/test_langchain.ts
+++ b/packages/telemetry/typescript/examples/test_langchain.ts
@@ -16,7 +16,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { langchain: LangChain },
 })

--- a/packages/telemetry/typescript/examples/test_llamaindex.ts
+++ b/packages/telemetry/typescript/examples/test_llamaindex.ts
@@ -15,7 +15,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { llamaindex: LlamaIndex },
 })

--- a/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
+++ b/packages/telemetry/typescript/examples/test_manual_instrumentation.ts
@@ -22,7 +22,7 @@ import { capture, Latitude } from "../src"
 // Initialize telemetry
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
   disableBatch: true,
 })

--- a/packages/telemetry/typescript/examples/test_openai.ts
+++ b/packages/telemetry/typescript/examples/test_openai.ts
@@ -14,7 +14,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { openai: OpenAI },
 })

--- a/packages/telemetry/typescript/examples/test_openai_agents.ts
+++ b/packages/telemetry/typescript/examples/test_openai_agents.ts
@@ -16,7 +16,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { "openai-agents": OpenAIAgentsSDK },
 })

--- a/packages/telemetry/typescript/examples/test_openai_responses.ts
+++ b/packages/telemetry/typescript/examples/test_openai_responses.ts
@@ -14,7 +14,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { openai: OpenAI },
 })

--- a/packages/telemetry/typescript/examples/test_project_scoping_env.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_env.ts
@@ -2,14 +2,14 @@
  * Project scoping — env-driven default + per-capture override.
  *
  * Reads the default project slug from `LATITUDE_PROJECT_SLUG` and lets specific captures
- * override it via `capture({ projectSlug })`. A common shape for services that run in many
+ * override it via `capture({ project })`. A common shape for services that run in many
  * environments (staging/prod each have their own project slug) but still need to route a
  * subset of spans elsewhere.
  *
  * Resolution precedence (highest → lowest):
- *   1. `capture({ projectSlug })`           — emits `latitude.project` on the span
+ *   1. `capture({ project })`               — emits `latitude.project` on the span
  *   2. OTEL resource attribute `latitude.project`  — bare-OTEL setups
- *   3. ctor `projectSlug`                   — sent as `X-Latitude-Project` header
+ *   3. constructor `project`                — sent as `X-Latitude-Project` header
  *
  * The override slug (`evaluation-runs` below) must exist in the same org as `LATITUDE_API_KEY`.
  *
@@ -29,7 +29,7 @@ import { capture, Latitude } from "../src"
 const DEFAULT_SLUG = process.env.LATITUDE_PROJECT_SLUG!
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: DEFAULT_SLUG,
+  project: DEFAULT_SLUG,
   disableBatch: true,
   instrumentations: { openai: OpenAI },
 })
@@ -50,7 +50,7 @@ async function main() {
     console.log("default-route →", r.choices[0]?.message?.content)
   })
 
-  // Per-capture override beats the ctor default. Routes to `evaluation-runs` regardless of env.
+  // Per-capture override beats the constructor default. Routes to `evaluation-runs` regardless of env.
   await capture(
     "evaluation-batch",
     async () => {
@@ -61,7 +61,7 @@ async function main() {
       })
       console.log(`${OVERRIDE_SLUG} →`, r.choices[0]?.message?.content)
     },
-    { projectSlug: OVERRIDE_SLUG },
+    { project: OVERRIDE_SLUG },
   )
 
   await latitude.flush()

--- a/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_multi.ts
@@ -1,8 +1,8 @@
 /**
  * Project scoping — multi-project per-capture override.
  *
- * `new Latitude({ apiKey })` is initialized *without* a default `projectSlug`. Every `capture()`
- * must declare its own `projectSlug` and spans are routed per-capture via the
+ * `new Latitude({ apiKey })` is initialized *without* a default `project`. Every `capture()`
+ * must declare its own `project` and spans are routed per-capture via the
  * `latitude.project` span attribute. Use this when a single process emits to several Latitude
  * projects (e.g. multiple agents sharing one runtime).
  *
@@ -50,7 +50,7 @@ async function main() {
       })
       console.log(`${FULL_STACK_AGENT_SLUG} →`, r.choices[0]?.message?.content)
     },
-    { projectSlug: FULL_STACK_AGENT_SLUG, tags: ["agent:full-stack"] },
+    { project: FULL_STACK_AGENT_SLUG, tags: ["agent:full-stack"] },
   )
 
   await capture(
@@ -63,12 +63,12 @@ async function main() {
       })
       console.log(`${CALL_SUMMARISER_SLUG} →`, r.choices[0]?.message?.content)
     },
-    { projectSlug: CALL_SUMMARISER_SLUG, tags: ["agent:summariser"] },
+    { project: CALL_SUMMARISER_SLUG, tags: ["agent:summariser"] },
   )
 
-  // Spans with no `projectSlug` AND no ctor default are rejected by the ingest service with
-  // a `partial_success` body — exporters log the rejection but don't retry. Always set a slug
-  // either on the ctor or on each `capture()` when running this pattern.
+  // Spans with no `project` AND no constructor default are rejected by the ingest service with
+  // a `partial_success` body — exporters log the rejection but don't retry. Always set a project
+  // either on the constructor or on each `capture()` when running this pattern.
 
   await latitude.flush()
 }

--- a/packages/telemetry/typescript/examples/test_project_scoping_single.ts
+++ b/packages/telemetry/typescript/examples/test_project_scoping_single.ts
@@ -1,7 +1,7 @@
 /**
  * Project scoping — single-project default (existing pattern).
  *
- * `new Latitude({ apiKey, projectSlug })` sets a default project for every span. `capture()`
+ * `new Latitude({ apiKey, project })` sets a default project for every span. `capture()`
  * inherits it, so all spans land in the same Latitude project. This is the recommended setup
  * for processes that emit to one project.
  *
@@ -20,7 +20,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { openai: OpenAI },
 })
@@ -29,7 +29,7 @@ async function main() {
   await latitude.ready
   const client = new OpenAI()
 
-  // Both captures inherit the ctor `projectSlug` (sent as the `X-Latitude-Project` header).
+  // Both captures inherit the constructor's `project` (sent as the `X-Latitude-Project` header).
   // The OpenAI spans land in the default project alongside the capture root span.
   await capture("greet", async () => {
     const r = await client.chat.completions.create({

--- a/packages/telemetry/typescript/examples/test_sentry.ts
+++ b/packages/telemetry/typescript/examples/test_sentry.ts
@@ -30,7 +30,7 @@ Sentry.init({
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   instrumentations: { openai: OpenAI },
 })
 

--- a/packages/telemetry/typescript/examples/test_together.ts
+++ b/packages/telemetry/typescript/examples/test_together.ts
@@ -14,7 +14,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { togetherai: TogetherSDK },
 })

--- a/packages/telemetry/typescript/examples/test_vercel_ai.ts
+++ b/packages/telemetry/typescript/examples/test_vercel_ai.ts
@@ -20,19 +20,19 @@ import { generateText, streamText } from "ai"
 import { capture, Latitude } from "../src"
 
 const apiKey = process.env.LATITUDE_API_KEY
-const projectSlug = process.env.LATITUDE_PROJECT_SLUG
+const project = process.env.LATITUDE_PROJECT_SLUG
 
 if (!apiKey) {
   throw new Error("LATITUDE_API_KEY is required")
 }
 
-if (!projectSlug) {
+if (!project) {
   throw new Error("LATITUDE_PROJECT_SLUG is required")
 }
 
 const latitude = new Latitude({
   apiKey,
-  projectSlug,
+  project,
   disableBatch: true,
 })
 

--- a/packages/telemetry/typescript/examples/test_vertex.ts
+++ b/packages/telemetry/typescript/examples/test_vertex.ts
@@ -16,7 +16,7 @@ import { capture, Latitude } from "../src"
 
 const latitude = new Latitude({
   apiKey: process.env.LATITUDE_API_KEY!,
-  projectSlug: process.env.LATITUDE_PROJECT_SLUG!,
+  project: process.env.LATITUDE_PROJECT_SLUG!,
   disableBatch: true,
   instrumentations: { vertexai: VertexAISDK },
 })

--- a/packages/telemetry/typescript/package.json
+++ b/packages/telemetry/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/telemetry",
-  "version": "3.0.0-alpha.11",
+  "version": "3.0.0-alpha.12",
   "description": "Latitude Telemetry for TypeScript",
   "author": "Latitude Data SL <hello@latitude.so>",
   "license": "MIT",

--- a/packages/telemetry/typescript/src/sdk/_deprecation.ts
+++ b/packages/telemetry/typescript/src/sdk/_deprecation.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal helpers for one-time deprecation warnings.
+ *
+ * Lives in its own module so both `init.ts` and `context.ts` can depend on it
+ * without forming a circular import (`init` already imports the span processor,
+ * which imports `context`). Mirrors the Python `_deprecation.py` module.
+ */
+
+let projectSlugDeprecationWarned = false
+
+/** @internal Exposed for test resets — not part of the public API. */
+export function resetProjectSlugDeprecationWarningForTesting(): void {
+  projectSlugDeprecationWarned = false
+}
+
+export function warnProjectSlugDeprecated(site: "constructor" | "capture"): void {
+  if (projectSlugDeprecationWarned) return
+  projectSlugDeprecationWarned = true
+  const optionName = site === "constructor" ? "`projectSlug`" : "`projectSlug` on capture()"
+  console.warn(
+    `[Latitude] ${optionName} is deprecated and will be removed in a future release — rename it to \`project\`. ` +
+      "Both work for now; when both are passed, `project` wins.",
+  )
+}

--- a/packages/telemetry/typescript/src/sdk/context.test.ts
+++ b/packages/telemetry/typescript/src/sdk/context.test.ts
@@ -1,11 +1,15 @@
 import { context } from "@opentelemetry/api"
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks"
-import { beforeAll, describe, expect, it } from "vitest"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetProjectSlugDeprecationWarningForTesting } from "./_deprecation.ts"
 import { capture, getLatitudeContext } from "./context.ts"
 
 describe("capture", () => {
   beforeAll(() => {
     context.setGlobalContextManager(new AsyncLocalStorageContextManager())
+  })
+  beforeEach(() => {
+    resetProjectSlugDeprecationWarningForTesting()
   })
   it("should set context data for synchronous functions", () => {
     capture(
@@ -73,19 +77,19 @@ describe("capture", () => {
     )
   })
 
-  it("propagates projectSlug from capture options onto the context", () => {
+  it("propagates project from capture options onto the context", () => {
     capture(
       "scoped",
       () => {
         const ctx = context.active()
         const data = getLatitudeContext(ctx)
-        expect(data?.projectSlug).toBe("call-summariser")
+        expect(data?.project).toBe("call-summariser")
       },
-      { projectSlug: "call-summariser" },
+      { project: "call-summariser" },
     )
   })
 
-  it("nested capture without projectSlug inherits the outer one", () => {
+  it("nested capture without project inherits the outer one", () => {
     capture(
       "outer",
       () => {
@@ -94,16 +98,16 @@ describe("capture", () => {
           () => {
             const ctx = context.active()
             const data = getLatitudeContext(ctx)
-            expect(data?.projectSlug).toBe("primary")
+            expect(data?.project).toBe("primary")
           },
           { tags: ["inner"] },
         )
       },
-      { projectSlug: "primary" },
+      { project: "primary" },
     )
   })
 
-  it("inner capture's projectSlug overrides the outer default", () => {
+  it("inner capture's project overrides the outer default", () => {
     capture(
       "outer",
       () => {
@@ -112,12 +116,39 @@ describe("capture", () => {
           () => {
             const ctx = context.active()
             const data = getLatitudeContext(ctx)
-            expect(data?.projectSlug).toBe("evaluation-runs")
+            expect(data?.project).toBe("evaluation-runs")
           },
-          { projectSlug: "evaluation-runs" },
+          { project: "evaluation-runs" },
         )
       },
-      { projectSlug: "primary" },
+      { project: "primary" },
+    )
+  })
+
+  it("accepts the deprecated `projectSlug` option and logs a deprecation warning", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    capture(
+      "legacy",
+      () => {
+        const ctx = context.active()
+        const data = getLatitudeContext(ctx)
+        expect(data?.project).toBe("legacy-slug")
+      },
+      { projectSlug: "legacy-slug" },
+    )
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("`projectSlug` on capture()"))
+    warnSpy.mockRestore()
+  })
+
+  it("`project` wins when both `project` and `projectSlug` are passed", () => {
+    capture(
+      "both",
+      () => {
+        const ctx = context.active()
+        const data = getLatitudeContext(ctx)
+        expect(data?.project).toBe("new-name")
+      },
+      { project: "new-name", projectSlug: "old-name" },
     )
   })
 

--- a/packages/telemetry/typescript/src/sdk/context.ts
+++ b/packages/telemetry/typescript/src/sdk/context.ts
@@ -1,4 +1,5 @@
 import { type Context, context, createContextKey, type Span, trace } from "@opentelemetry/api"
+import { warnProjectSlugDeprecated } from "./_deprecation.ts"
 import type { ContextOptions } from "./types.ts"
 
 export const LATITUDE_CONTEXT_KEY = createContextKey("latitude-internal-context")
@@ -20,7 +21,7 @@ type LatitudeContextData = {
   metadata: Record<string, unknown> | undefined
   sessionId: string | undefined
   userId: string | undefined
-  projectSlug: string | undefined
+  project: string | undefined
 }
 
 export function getLatitudeContext(ctx: Context): LatitudeContextData | undefined {
@@ -44,13 +45,18 @@ export function capture<T>(name: string, fn: () => T | Promise<T>, options: Cont
   const shouldReuseTrace = shouldReuseActiveLatitudeTrace(currentContext)
   const parentContext = shouldReuseTrace ? currentContext : trace.deleteSpan(currentContext)
 
+  if (options.project === undefined && options.projectSlug !== undefined) {
+    warnProjectSlugDeprecated("capture")
+  }
+  const projectFromOptions = options.project ?? options.projectSlug
+
   const mergedData: LatitudeContextData = {
     name: options.name ?? name,
     tags: mergeArrays(existingData?.tags, options.tags),
     metadata: { ...existingData?.metadata, ...options.metadata },
     sessionId: options.sessionId ?? existingData?.sessionId,
     userId: options.userId ?? existingData?.userId,
-    projectSlug: options.projectSlug ?? existingData?.projectSlug,
+    project: projectFromOptions ?? existingData?.project,
   }
 
   const newContext = parentContext.setValue(LATITUDE_CONTEXT_KEY, mergedData)

--- a/packages/telemetry/typescript/src/sdk/init.test.ts
+++ b/packages/telemetry/typescript/src/sdk/init.test.ts
@@ -2,10 +2,15 @@ import { context, propagation, type Tracer, type TracerProvider, trace } from "@
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { resetProjectSlugDeprecationWarningForTesting } from "./_deprecation.ts"
 import { initLatitude, Latitude } from "./init.ts"
 
 describe("Latitude", () => {
+  beforeEach(() => {
+    resetProjectSlugDeprecationWarningForTesting()
+  })
+
   afterEach(() => {
     trace.disable()
     context.disable()
@@ -13,18 +18,25 @@ describe("Latitude", () => {
   })
 
   it("should throw if apiKey is missing", () => {
-    expect(() => new Latitude({ apiKey: "", projectSlug: "test" })).toThrow("apiKey is required")
+    expect(() => new Latitude({ apiKey: "", project: "test" })).toThrow("apiKey is required")
   })
 
-  it("accepts an empty or omitted projectSlug (per-capture scoping covers the rest)", () => {
-    expect(() => new Latitude({ apiKey: "test", projectSlug: "" })).not.toThrow()
+  it("accepts an empty or omitted project (per-capture scoping covers the rest)", () => {
+    expect(() => new Latitude({ apiKey: "test", project: "" })).not.toThrow()
     expect(() => new Latitude({ apiKey: "test" })).not.toThrow()
+  })
+
+  it("accepts the deprecated `projectSlug` alias and logs a deprecation warning", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    expect(() => new Latitude({ apiKey: "test", projectSlug: "legacy-slug" })).not.toThrow()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("`projectSlug` is deprecated"))
+    warnSpy.mockRestore()
   })
 
   it("should return provider, flush, shutdown, and ready functions", async () => {
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
     })
     expect(result.provider).toBeDefined()
     expect(result.flush).toBeTypeOf("function")
@@ -35,7 +47,7 @@ describe("Latitude", () => {
   it("keeps initLatitude as a deprecated compatibility wrapper", async () => {
     const result = initLatitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
     })
 
     expect(result).toBeInstanceOf(Latitude)
@@ -56,7 +68,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       exporter: latitudeExporter,
       disableBatch: true,
     })
@@ -86,7 +98,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       tracerProvider: explicitProvider,
     })
 
@@ -107,7 +119,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       tracerProvider: datadogLikeProvider,
     })
 
@@ -128,7 +140,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       tracerProvider: nodeSdkLikeProvider,
     })
 
@@ -144,7 +156,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       tracerProvider: opaqueProvider,
     })
 
@@ -163,7 +175,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       serviceName: "custom-service",
       exporter: latitudeExporter,
       disableBatch: true,
@@ -196,7 +208,7 @@ describe("Latitude", () => {
 
     const result = new Latitude({
       apiKey: "test-key",
-      projectSlug: "test-project",
+      project: "test-project",
       serviceName: "latitude-service", // explicitly passed — should be ignored when piggy-backing
       exporter: latitudeExporter,
       disableBatch: true,

--- a/packages/telemetry/typescript/src/sdk/init.ts
+++ b/packages/telemetry/typescript/src/sdk/init.ts
@@ -4,6 +4,7 @@ import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } 
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { NodeTracerProvider, type SpanProcessor } from "@opentelemetry/sdk-trace-node"
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions"
+import { warnProjectSlugDeprecated } from "./_deprecation.ts"
 import { registerLatitudeInstrumentations } from "./instrumentations.ts"
 import { LatitudeSpanProcessor } from "./processor.ts"
 import type { InitLatitudeOptions, LatitudeOptions } from "./types.ts"
@@ -71,11 +72,16 @@ export class Latitude {
   private readonly ownsProvider: boolean
 
   constructor(options: LatitudeOptions) {
-    const { apiKey, projectSlug, instrumentations = {}, tracerProvider, ...processorOptionsRaw } = options
+    const { apiKey, project, projectSlug, instrumentations = {}, tracerProvider, ...processorOptionsRaw } = options
 
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")
     }
+
+    if (project === undefined && projectSlug !== undefined) {
+      warnProjectSlugDeprecated("constructor")
+    }
+    const resolvedProject = project ?? projectSlug
 
     const targetProvider = tracerProvider ?? getRegisteredTracerProvider()
 
@@ -89,7 +95,7 @@ export class Latitude {
       processorOptions = rest
     }
 
-    this.latitudeProcessor = new LatitudeSpanProcessor(apiKey, projectSlug, processorOptions)
+    this.latitudeProcessor = new LatitudeSpanProcessor(apiKey, resolvedProject, processorOptions)
     const attached = targetProvider ? addSpanProcessor(targetProvider, this.latitudeProcessor) : false
 
     if (targetProvider && !attached) {

--- a/packages/telemetry/typescript/src/sdk/instrumentations.ts
+++ b/packages/telemetry/typescript/src/sdk/instrumentations.ts
@@ -170,7 +170,7 @@ async function createLatitudeInstrumentations(input: InstrumentationsInput): Pro
  * import { LatitudeSpanProcessor, registerLatitudeInstrumentations } from "@latitude-data/telemetry"
  *
  * const provider = new NodeTracerProvider({
- *   spanProcessors: [new LatitudeSpanProcessor(apiKey, projectSlug)],
+ *   spanProcessors: [new LatitudeSpanProcessor(apiKey, project)],
  * })
  *
  * await registerLatitudeInstrumentations({

--- a/packages/telemetry/typescript/src/sdk/processor.test.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.test.ts
@@ -25,18 +25,18 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   const apiKey = "test-api-key"
-  const projectSlug = "test-project"
+  const project = "test-project"
 
   it("should throw if apiKey is empty", () => {
-    expect(() => new LatitudeSpanProcessor("", projectSlug)).toThrow("apiKey is required")
+    expect(() => new LatitudeSpanProcessor("", project)).toThrow("apiKey is required")
   })
 
-  it("allows an undefined projectSlug (per-capture scoping covers the rest)", () => {
+  it("allows an undefined project (per-capture scoping covers the rest)", () => {
     expect(() => new LatitudeSpanProcessor(apiKey, undefined)).not.toThrow()
     expect(() => new LatitudeSpanProcessor(apiKey, "")).not.toThrow()
   })
 
-  it("stamps `latitude.project` on the span when capture sets projectSlug", () => {
+  it("stamps `latitude.project` on the span when capture sets project", () => {
     const processor = new LatitudeSpanProcessor(apiKey, "fallback-slug")
     const mockSpan = createMockRootSpan()
 
@@ -48,11 +48,11 @@ describe("LatitudeSpanProcessor", () => {
 
         expect(mockSpan.setAttribute).toHaveBeenCalledWith(ATTRIBUTES.project, "call-summariser")
       },
-      { projectSlug: "call-summariser" },
+      { project: "call-summariser" },
     )
   })
 
-  it("does not stamp `latitude.project` when no projectSlug is provided anywhere", () => {
+  it("does not stamp `latitude.project` when no project is provided anywhere", () => {
     const processor = new LatitudeSpanProcessor(apiKey, undefined)
     const mockSpan = createMockRootSpan()
 
@@ -65,7 +65,7 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   it("should stamp latitude attributes from context on span start", () => {
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug)
+    const processor = new LatitudeSpanProcessor(apiKey, project)
     const mockSpan = createMockRootSpan()
 
     capture(
@@ -86,7 +86,7 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   it("should not stamp attributes when no latitude context exists", () => {
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug)
+    const processor = new LatitudeSpanProcessor(apiKey, project)
     const mockSpan = createMockSpan()
     const ctx = context.active()
 
@@ -99,7 +99,7 @@ describe("LatitudeSpanProcessor", () => {
   it("should NOT stamp service.name as a span attribute when serviceName option is set", () => {
     // service.name is a resource attribute per OTel semantic conventions, not a span attribute.
     // It's applied via the exporter wrapper instead — covered by the init.test.ts integration tests.
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug, { serviceName: "billing-api" })
+    const processor = new LatitudeSpanProcessor(apiKey, project, { serviceName: "billing-api" })
     const mockSpan = createMockSpan()
     const ctx = context.active()
 
@@ -109,7 +109,7 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   it("should not stamp empty tags", () => {
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug)
+    const processor = new LatitudeSpanProcessor(apiKey, project)
     const mockSpan = createMockSpan()
 
     capture(
@@ -126,7 +126,7 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   it("should not stamp empty metadata", () => {
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug)
+    const processor = new LatitudeSpanProcessor(apiKey, project)
     const mockSpan = createMockSpan()
 
     capture(
@@ -143,7 +143,7 @@ describe("LatitudeSpanProcessor", () => {
   })
 
   it("should use name from options when provided", () => {
-    const processor = new LatitudeSpanProcessor(apiKey, projectSlug)
+    const processor = new LatitudeSpanProcessor(apiKey, project)
     const mockSpan = createMockRootSpan()
 
     capture("outer", () => {

--- a/packages/telemetry/typescript/src/sdk/processor.ts
+++ b/packages/telemetry/typescript/src/sdk/processor.ts
@@ -62,17 +62,17 @@ class ServiceNameResourceExporter implements SpanExporter {
 export class LatitudeSpanProcessor implements SpanProcessor {
   private readonly tail: SpanProcessor
 
-  constructor(apiKey: string, projectSlug: string | undefined, options?: LatitudeSpanProcessorOptions) {
+  constructor(apiKey: string, project: string | undefined, options?: LatitudeSpanProcessorOptions) {
     if (!apiKey || apiKey.trim() === "") {
       throw new Error("[Latitude] apiKey is required and cannot be empty")
     }
 
-    const normalizedProjectSlug = projectSlug && projectSlug.trim() !== "" ? projectSlug : undefined
+    const normalizedProject = project && project.trim() !== "" ? project : undefined
     const headers: Record<string, string> = {
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     }
-    if (normalizedProjectSlug) headers["X-Latitude-Project"] = normalizedProjectSlug
+    if (normalizedProject) headers["X-Latitude-Project"] = normalizedProject
 
     const baseExporter =
       options?.exporter ??
@@ -127,8 +127,8 @@ export class LatitudeSpanProcessor implements SpanProcessor {
       if (latitudeData.userId) {
         span.setAttribute(ATTRIBUTES.userId, latitudeData.userId)
       }
-      if (latitudeData.projectSlug) {
-        span.setAttribute(ATTRIBUTES.project, latitudeData.projectSlug)
+      if (latitudeData.project) {
+        span.setAttribute(ATTRIBUTES.project, latitudeData.project)
       }
     }
 

--- a/packages/telemetry/typescript/src/sdk/types.ts
+++ b/packages/telemetry/typescript/src/sdk/types.ts
@@ -13,8 +13,13 @@ export type ContextOptions = {
   /**
    * Route the capture (and all child spans) to a specific Latitude project.
    *
-   * Overrides the ctor `projectSlug` default for this capture only. Useful when one process
-   * emits to multiple projects (e.g. multiple agents in the same service).
+   * Overrides the constructor `project` default for this capture only. Useful when one
+   * process emits to multiple projects (e.g. multiple agents in the same service).
+   */
+  project?: string
+  /**
+   * @deprecated Renamed to `project`. Still accepted for backwards compatibility and will be
+   * removed in a future release. When both are set, `project` wins.
    */
   projectSlug?: string
 }
@@ -22,14 +27,19 @@ export type ContextOptions = {
 export type LatitudeOptions = SmartFilterOptions & {
   apiKey: string
   /**
-   * Default project slug for spans emitted by this SDK instance.
+   * Default project for spans emitted by this SDK instance.
    *
-   * Optional — when omitted, every `capture()` call MUST set its own `projectSlug` (or rely on
+   * Optional — when omitted, every `capture()` call MUST set its own `project` (or rely on
    * an OTEL resource attribute / per-span attribute). When set, the SDK forwards it as the
    * `X-Latitude-Project` header so spans without a per-span override land in this project.
    *
    * Precedence on the server (highest first): span attribute `latitude.project` →
    * OTEL resource attribute `latitude.project` → `X-Latitude-Project` header.
+   */
+  project?: string
+  /**
+   * @deprecated Renamed to `project`. Still accepted for backwards compatibility and will be
+   * removed in a future release. When both are set, `project` wins.
    */
   projectSlug?: string
   /**


### PR DESCRIPTION
## Summary

- Renames `projectSlug` / `project_slug` to `project` on the public SDK surface in both `@latitude-data/telemetry` (TS) and `latitude-telemetry` (Python). Affects the constructor (`Latitude`, `initLatitude` / `init_latitude`), `capture()` options, and the internal `LatitudeContextData` / `_LatitudeContextData` field.
- The legacy names still work and log a one-time deprecation warning (`console.warn` in TS, `logging.warning` in Python). When both are passed, `project` wins. Both flags are resettable for tests via internal helpers.
- The `X-Latitude-Project` HTTP header, `latitude.project` span attribute, and `LATITUDE_PROJECT_SLUG` env var convention are all unchanged — they're independent of the SDK option name.
- Docs and examples rewritten across `docs/telemetry/*`, both package READMEs, and every `examples/test_*.{ts,py}`. The four `ctor` abbreviations on `project-scoping.md` are replaced with full words ("constructor"). The telemetry overview gets a Mintlify `<Note>` banner pointing multi-project users to `project-scoping`.
- Versions bumped: `@latitude-data/telemetry` `3.0.0-alpha.11` → `3.0.0-alpha.12`; `latitude-telemetry` `3.0.0a7` → `3.0.0a8`. Both CHANGELOGs include a migration diff.
- A separate commit on the `latitude-dev/skills` repo (not part of this PR) updates the install/audit skill to teach the new name and adds a step instructing the agent to migrate `projectSlug` / `project_slug` call sites when bumping a consumer to the new versions.

## Test plan

- [ ] `pnpm --filter @latitude-data/telemetry typecheck`
- [ ] `pnpm --filter @latitude-data/telemetry check` (biome)
- [ ] `pnpm --filter @latitude-data/telemetry test` — new deprecation tests in `init.test.ts`, `context.test.ts` (TS); `capture_test.py`, `span_test.py` (Py) should pass; existing tests should still pass after the rename.
- [ ] Run an example end-to-end (e.g. `examples/test_openai.ts` and `examples/test_openai.py`) using `project: ...` / `project=...` and confirm spans land in the configured project.
- [ ] Run the same example with the legacy `projectSlug` / `project_slug` form once and confirm the deprecation warning appears in the logs exactly once per process.
- [ ] `npm view @latitude-data/telemetry@3.0.0-alpha.12` / `pip install latitude-telemetry==3.0.0a8` after publish — spot-check Mintlify renders the new banner on `/telemetry/overview` and `/telemetry/project-scoping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)