### PR TITLE
fix(db-clickhouse): scope chdb session per describe in score-analytics test

### DIFF
--- a/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
+++ b/packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts
@@ -12,10 +12,39 @@ import { ScoreAnalyticsRepositoryLive } from "./score-analytics-repository.ts"
 const ORG_ID = OrganizationId("oooooooooooooooooooooooo")
 const PROJECT_ID = ProjectId("pppppppppppppppppppppppp")
 
-const ch = setupTestClickHouse()
+// Each top-level describe block opens its own chdb session via `setupFixture`.
+// A shared session across all 37 tests pushed chdb's in-process memory tracker
+// past the CI runner ceiling — accumulated parts (one per insert in both
+// `scores` and the `scores_hourly_buckets_mv` target) eventually caused even
+// `TRUNCATE TABLE` in `beforeEach` to OOM. Scoping the session per describe
+// bounds part accumulation to a single block's worth of inserts.
+function setupFixture() {
+  const ch = setupTestClickHouse()
+  let repo: ScoreAnalyticsRepositoryShape | undefined
 
-const runCh = <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
-  Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID))))
+  beforeAll(async () => {
+    repo = await Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* ScoreAnalyticsRepository
+      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, ch.client, ORG_ID)),
+    )
+  })
+
+  return {
+    get repo() {
+      if (!repo) throw new Error("repo not initialized — fixture used before beforeAll ran")
+      return repo
+    },
+    runCh: <A, E>(effect: Effect.Effect<A, E, ChSqlClient>) =>
+      Effect.runPromise(effect.pipe(Effect.provide(ChSqlClientLive(ch.client, ORG_ID)))),
+    insertScores: async (rows: ReturnType<typeof makeScoreRow>[]) => {
+      await ch.client.insert({ table: "scores", values: rows, format: "JSONEachRow" })
+    },
+    insertSpans: async (rows: SpanRow[]) => {
+      await ch.client.insert({ table: "spans", values: rows, format: "JSONEachRow" })
+    },
+  }
+}
 
 // Helper to create a score analytics row for insertion
 function makeScoreRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -38,10 +67,6 @@ function makeScoreRow(overrides: Partial<Record<string, unknown>> = {}) {
     cost: (overrides.cost as number) ?? 50,
     created_at: (overrides.created_at as string) ?? "2026-03-15 12:00:00.000",
   }
-}
-
-async function insertScores(rows: ReturnType<typeof makeScoreRow>[]) {
-  await ch.client.insert({ table: "scores", values: rows, format: "JSONEachRow" })
 }
 
 function makeSpanRow(overrides: {
@@ -106,10 +131,6 @@ function makeSpanRow(overrides: {
   }
 }
 
-async function insertSpans(rows: SpanRow[]) {
-  await ch.client.insert({ table: "spans", values: rows, format: "JSONEachRow" })
-}
-
 const toClickHouseDateTime64 = (value: Date) => value.toISOString().replace("T", " ").replace("Z", "")
 
 const daysAgoDateTime = (days: number, hour: number): string => {
@@ -127,30 +148,22 @@ const daysAgoBucket = (days: number): string => {
 }
 
 describe("ScoreAnalyticsRepository", () => {
-  let repo: ScoreAnalyticsRepositoryShape
-
-  beforeAll(async () => {
-    repo = await Effect.runPromise(
-      Effect.gen(function* () {
-        return yield* ScoreAnalyticsRepository
-      }).pipe(withClickHouse(ScoreAnalyticsRepositoryLive, ch.client, ORG_ID)),
-    )
-  })
-
   // ------------------------------------------------------------------
   // existsById / insert
   // ------------------------------------------------------------------
 
   describe("existsById / insert", () => {
+    const fixture = setupFixture()
+
     it("returns false for non-existent score", async () => {
-      const exists = await runCh(repo.existsById("zzzzzzzzzzzzzzzzzzzzzzzz" as ScoreId))
+      const exists = await fixture.runCh(fixture.repo.existsById("zzzzzzzzzzzzzzzzzzzzzzzz" as ScoreId))
       expect(exists).toBe(false)
     })
 
     it("returns true after insert", async () => {
       const id = "aaaaaaaaaaaaaaaaaaaaaaaa"
-      await insertScores([makeScoreRow({ id })])
-      const exists = await runCh(repo.existsById(id as ScoreId))
+      await fixture.insertScores([makeScoreRow({ id })])
+      const exists = await fixture.runCh(fixture.repo.existsById(id as ScoreId))
       expect(exists).toBe(true)
     })
   })
@@ -160,20 +173,26 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("delete", () => {
+    const fixture = setupFixture()
+
     it("hides the score from existsById and aggregates after lightweight delete", async () => {
       const id = "dddddddddddddddddddddddd"
-      await insertScores([makeScoreRow({ id, value: 0.99, passed: true, cost: 999, tokens: 10, duration: 1 })])
+      await fixture.insertScores([makeScoreRow({ id, value: 0.99, passed: true, cost: 999, tokens: 10, duration: 1 })])
 
-      expect(await runCh(repo.existsById(id as ScoreId))).toBe(true)
+      expect(await fixture.runCh(fixture.repo.existsById(id as ScoreId))).toBe(true)
 
-      const beforeAgg = await runCh(repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+      const beforeAgg = await fixture.runCh(
+        fixture.repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }),
+      )
       const countBefore = beforeAgg.totalScores
 
-      await runCh(repo.delete(id as ScoreId))
+      await fixture.runCh(fixture.repo.delete(id as ScoreId))
 
-      expect(await runCh(repo.existsById(id as ScoreId))).toBe(false)
+      expect(await fixture.runCh(fixture.repo.existsById(id as ScoreId))).toBe(false)
 
-      const afterAgg = await runCh(repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+      const afterAgg = await fixture.runCh(
+        fixture.repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }),
+      )
       expect(afterAgg.totalScores).toBe(countBefore - 1)
     })
   })
@@ -183,8 +202,10 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("aggregateByProject", () => {
+    const fixture = setupFixture()
+
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ value: 0.9, passed: true, errored: false, cost: 100, tokens: 200, duration: 5000000 }),
         makeScoreRow({ value: 0.3, passed: false, errored: false, cost: 50, tokens: 100, duration: 3000000 }),
         makeScoreRow({ value: 0.0, passed: false, errored: true, cost: 10, tokens: 50, duration: 1000000 }),
@@ -192,7 +213,9 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns correct project-wide aggregates", async () => {
-      const agg = await runCh(repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }),
+      )
       expect(agg.totalScores).toBe(3)
       expect(agg.passedCount).toBe(1)
       expect(agg.failedCount).toBe(1)
@@ -203,8 +226,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns empty aggregate for non-existent project", async () => {
-      const agg = await runCh(
-        repo.aggregateByProject({
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateByProject({
           organizationId: ORG_ID,
           projectId: ProjectId("xxxxxxxxxxxxxxxxxxxxxxxx"),
         }),
@@ -218,11 +241,12 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("aggregateBySource", () => {
+    const fixture = setupFixture()
     const evalSourceId = "src_eval_aaaaaaaaaaaa"
     const customSourceId = "my-custom-tag"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ source: "evaluation", source_id: evalSourceId, value: 0.9, passed: true }),
         makeScoreRow({ source: "evaluation", source_id: evalSourceId, value: 0.4, passed: false }),
         makeScoreRow({ source: "custom", source_id: customSourceId, value: 0.7, passed: true }),
@@ -230,8 +254,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("scopes aggregate to the requested source", async () => {
-      const agg = await runCh(
-        repo.aggregateBySource({
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateBySource({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           source: "evaluation",
@@ -244,8 +268,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns zero for unmatched source", async () => {
-      const agg = await runCh(
-        repo.aggregateBySource({
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateBySource({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           source: "custom",
@@ -261,10 +285,11 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("trendBySource", () => {
+    const fixture = setupFixture()
     const sourceId = "trend_eval_src_aaaaaaa"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({
           source: "evaluation",
           source_id: sourceId,
@@ -290,8 +315,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns daily trend buckets", async () => {
-      const trend = await runCh(
-        repo.trendBySource({
+      const trend = await fixture.runCh(
+        fixture.repo.trendBySource({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           source: "evaluation",
@@ -311,8 +336,10 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("trendByProject", () => {
+    const fixture = setupFixture()
+
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ created_at: daysAgoDateTime(2, 10) }),
         makeScoreRow({ created_at: daysAgoDateTime(2, 14) }),
         makeScoreRow({ created_at: daysAgoDateTime(1, 8) }),
@@ -320,8 +347,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns daily project-wide trend", async () => {
-      const trend = await runCh(
-        repo.trendByProject({
+      const trend = await fixture.runCh(
+        fixture.repo.trendByProject({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           days: 30,
@@ -336,11 +363,12 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("rollupByTraceIds", () => {
+    const fixture = setupFixture()
     const traceA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     const traceB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ trace_id: traceA, passed: true, errored: false, value: 0.9, source: "evaluation" }),
         makeScoreRow({
           trace_id: traceA,
@@ -355,8 +383,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns per-trace rollups", async () => {
-      const rollups = await runCh(
-        repo.rollupByTraceIds({
+      const rollups = await fixture.runCh(
+        fixture.repo.rollupByTraceIds({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           traceIds: [TraceId(traceA), TraceId(traceB)],
@@ -381,8 +409,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns empty for no trace ids", async () => {
-      const rollups = await runCh(
-        repo.rollupByTraceIds({
+      const rollups = await fixture.runCh(
+        fixture.repo.rollupByTraceIds({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           traceIds: [],
@@ -397,18 +425,19 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("rollupBySessionIds", () => {
+    const fixture = setupFixture()
     const sessionA = "session-aaa"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ session_id: sessionA, passed: true, value: 0.8 }),
         makeScoreRow({ session_id: sessionA, passed: false, value: 0.1 }),
       ])
     })
 
     it("returns per-session rollups", async () => {
-      const rollups = await runCh(
-        repo.rollupBySessionIds({
+      const rollups = await fixture.runCh(
+        fixture.repo.rollupBySessionIds({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           sessionIds: [SessionId(sessionA)],
@@ -425,11 +454,12 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("aggregateByIssues", () => {
+    const fixture = setupFixture()
     const issueA = "issue_aaaaaaaaaaaaaaaaaa"
     const issueB = "issue_bbbbbbbbbbbbbbbbbb"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueA, created_at: "2026-03-25 10:00:00.000" }),
         makeScoreRow({ issue_id: issueA, created_at: "2026-03-20 10:00:00.000" }),
         makeScoreRow({ issue_id: issueA, created_at: "2026-03-10 10:00:00.000" }),
@@ -438,8 +468,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns per-issue occurrence aggregates", async () => {
-      const aggs = await runCh(
-        repo.aggregateByIssues({
+      const aggs = await fixture.runCh(
+        fixture.repo.aggregateByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
@@ -455,8 +485,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns empty for no issue ids", async () => {
-      const aggs = await runCh(
-        repo.aggregateByIssues({
+      const aggs = await fixture.runCh(
+        fixture.repo.aggregateByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [],
@@ -471,6 +501,7 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("aggregateTagsByIssues", () => {
+    const fixture = setupFixture()
     const issueA = "issue_tagsaaaaaaaaaaaa"
     const issueB = "issue_tagsbbbbbbbbbbbb"
     const traceA1 = `${"a".repeat(31)}1`
@@ -479,7 +510,7 @@ describe("ScoreAnalyticsRepository", () => {
     const otherOrgTrace = `${"c".repeat(31)}1`
 
     beforeEach(async () => {
-      await insertSpans([
+      await fixture.insertSpans([
         makeSpanRow({ traceId: traceA1, spanId: `11${"a".repeat(14)}`, tags: ["checkout", "billing"] }),
         // Second span on the same trace with overlapping + new tags exercises trace-level dedup.
         makeSpanRow({ traceId: traceA1, spanId: `12${"a".repeat(14)}`, tags: ["billing", "auth"] }),
@@ -492,7 +523,7 @@ describe("ScoreAnalyticsRepository", () => {
         },
       ])
 
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueA, trace_id: traceA1 }),
         makeScoreRow({ issue_id: issueA, trace_id: traceA2 }),
         makeScoreRow({ issue_id: issueB, trace_id: traceB1 }),
@@ -513,8 +544,8 @@ describe("ScoreAnalyticsRepository", () => {
     }
 
     it("returns the union of trace-level tags grouped by issue, scoped to org/project", async () => {
-      const result = await runCh(
-        repo.aggregateTagsByIssues({
+      const result = await fixture.runCh(
+        fixture.repo.aggregateTagsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
@@ -529,8 +560,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns empty for no issue ids", async () => {
-      const result = await runCh(
-        repo.aggregateTagsByIssues({
+      const result = await fixture.runCh(
+        fixture.repo.aggregateTagsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [],
@@ -542,8 +573,8 @@ describe("ScoreAnalyticsRepository", () => {
 
     it("excludes scores and traces outside the configured time range", async () => {
       // Tighten the window to skip the seeded mid-March data entirely.
-      const result = await runCh(
-        repo.aggregateTagsByIssues({
+      const result = await fixture.runCh(
+        fixture.repo.aggregateTagsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
@@ -563,10 +594,11 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("trendByIssue", () => {
+    const fixture = setupFixture()
     const issueId = "trend_issue_aaaaaaaaaaaa"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: daysAgoDateTime(2, 10) }),
         makeScoreRow({ issue_id: issueId, created_at: daysAgoDateTime(2, 18) }),
         makeScoreRow({ issue_id: issueId, created_at: daysAgoDateTime(1, 8) }),
@@ -574,8 +606,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns occurrence buckets at the requested interval", async () => {
-      const trend = await runCh(
-        repo.trendByIssue({
+      const trend = await fixture.runCh(
+        fixture.repo.trendByIssue({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueId: IssueId(issueId),
@@ -597,6 +629,7 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("issue page analytics reads", () => {
+    const fixture = setupFixture()
     const issueA = "aaaaaaaaaaaaaaaaaaaaaaaa"
     const issueB = "bbbbbbbbbbbbbbbbbbbbbbbb"
     const traceA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -605,7 +638,7 @@ describe("ScoreAnalyticsRepository", () => {
     const to = new Date("2026-04-10T23:59:59.999Z")
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({
           issue_id: issueA,
           trace_id: traceA,
@@ -638,8 +671,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("lists issue window metrics within the selected range and score filters", async () => {
-      const metrics = await runCh(
-        repo.listIssueWindowMetrics({
+      const metrics = await fixture.runCh(
+        fixture.repo.listIssueWindowMetrics({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           filters: {
@@ -660,8 +693,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("builds grouped histogram and per-issue trends for the requested issue ids", async () => {
-      const histogram = await runCh(
-        repo.histogramByIssues({
+      const histogram = await fixture.runCh(
+        fixture.repo.histogramByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
@@ -669,8 +702,8 @@ describe("ScoreAnalyticsRepository", () => {
           bucketSeconds: 24 * 60 * 60,
         }),
       )
-      const trend = await runCh(
-        repo.trendByIssues({
+      const trend = await fixture.runCh(
+        fixture.repo.trendByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueA), IssueId(issueB)],
@@ -701,8 +734,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("counts distinct traces inside the selected issue window", async () => {
-      const total = await runCh(
-        repo.countDistinctTracesByTimeRange({
+      const total = await fixture.runCh(
+        fixture.repo.countDistinctTracesByTimeRange({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           timeRange: { from, to },
@@ -713,8 +746,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("lists distinct traces for one issue newest-first with pagination", async () => {
-      const page = await runCh(
-        repo.listTracesByIssue({
+      const page = await fixture.runCh(
+        fixture.repo.listTracesByIssue({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueId: IssueId(issueA),
@@ -735,8 +768,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("counts distinct traces linked to one issue", async () => {
-      const total = await runCh(
-        repo.countTracesByIssue({
+      const total = await fixture.runCh(
+        fixture.repo.countTracesByIssue({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueId: IssueId(issueA),
@@ -752,37 +785,42 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("excludeSimulations", () => {
+    const fixture = setupFixture()
     const simId = "sim_aaaaaaaaaaaaaaaaaaaa"
 
     beforeEach(async () => {
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ simulation_id: simId, value: 0.5, passed: true, cost: 100 }),
         makeScoreRow({ simulation_id: "", value: 0.9, passed: true, cost: 200 }),
       ])
     })
 
     it("includes simulations by default", async () => {
-      const agg = await runCh(repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }))
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID }),
+      )
       expect(agg.totalScores).toBe(2)
       expect(agg.totalCost).toBe(300)
     })
 
     it("excludes simulations when requested", async () => {
       const options: ScoreAnalyticsOptions = { excludeSimulations: true }
-      const agg = await runCh(repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID, options }))
+      const agg = await fixture.runCh(
+        fixture.repo.aggregateByProject({ organizationId: ORG_ID, projectId: PROJECT_ID, options }),
+      )
       expect(agg.totalScores).toBe(1)
       expect(agg.totalCost).toBe(200)
     })
 
     it("excludes simulations in trend queries", async () => {
       const recentDate = daysAgoDateTime(1, 12)
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ simulation_id: simId, value: 0.5, passed: true, created_at: recentDate }),
         makeScoreRow({ simulation_id: "", value: 0.9, passed: true, created_at: recentDate }),
       ])
       const options: ScoreAnalyticsOptions = { excludeSimulations: true }
-      const trend = await runCh(
-        repo.trendByProject({ organizationId: ORG_ID, projectId: PROJECT_ID, days: 30, options }),
+      const trend = await fixture.runCh(
+        fixture.repo.trendByProject({ organizationId: ORG_ID, projectId: PROJECT_ID, days: 30, options }),
       )
       const totalScores = trend.reduce((sum, b) => sum + b.totalScores, 0)
       expect(totalScores).toBe(1)
@@ -790,14 +828,14 @@ describe("ScoreAnalyticsRepository", () => {
 
     it("excludes simulations in trace rollups", async () => {
       const traceId = "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ trace_id: traceId, simulation_id: simId, passed: true }),
         makeScoreRow({ trace_id: traceId, simulation_id: "", passed: false }),
       ])
 
       const options: ScoreAnalyticsOptions = { excludeSimulations: true }
-      const rollups = await runCh(
-        repo.rollupByTraceIds({
+      const rollups = await fixture.runCh(
+        fixture.repo.rollupByTraceIds({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           traceIds: [TraceId(traceId)],
@@ -818,6 +856,7 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("escalationSignalsByIssues", () => {
+    const fixture = setupFixture()
     const issueId = "esc_signals_aaaaaaaaaaaa"
     // Pick a fixed `now` so anchor arithmetic doesn't depend on the wall clock.
     // 2026-04-29T12:00:00Z is a Wednesday at noon UTC — anchors for `now - week*7d`
@@ -830,8 +869,8 @@ describe("ScoreAnalyticsRepository", () => {
     const WEEK = 7 * 24 * HOUR
 
     it("returns zero-filled signals when the issue has no scores", async () => {
-      const signals = await runCh(
-        repo.escalationSignalsByIssues({
+      const signals = await fixture.runCh(
+        fixture.repo.escalationSignalsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -859,7 +898,7 @@ describe("ScoreAnalyticsRepository", () => {
       // recent_1h = 1 (only t-30m)
       // recent_6h = 2 (t-30m, t-2h)
       // recent_24h = 4 (t-30m, t-2h, t-7h, t-20h) — t-26h is outside
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(30 * 60 * 1000)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(2 * HOUR)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(7 * HOUR)) }),
@@ -867,8 +906,8 @@ describe("ScoreAnalyticsRepository", () => {
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(26 * HOUR)) }),
       ])
 
-      const signals = await runCh(
-        repo.escalationSignalsByIssues({
+      const signals = await fixture.runCh(
+        fixture.repo.escalationSignalsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -882,14 +921,14 @@ describe("ScoreAnalyticsRepository", () => {
     it("counts samplesCount as distinct prior weeks contributing to the (dow, hour) pool", async () => {
       // Plant one row at the center anchor for each of weeks 1, 2, 3 (skip week 4)
       // so the pool gathers samples from 3 distinct prior weeks.
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(1 * WEEK)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(2 * WEEK)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(3 * WEEK)) }),
       ])
 
-      const signals = await runCh(
-        repo.escalationSignalsByIssues({
+      const signals = await fixture.runCh(
+        fixture.repo.escalationSignalsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -903,15 +942,15 @@ describe("ScoreAnalyticsRepository", () => {
     it("pools (dow, hour ± 1) buckets across prior weeks into expected1h / stddev1h", async () => {
       // Plant 1 event per week at the center anchor (week N · 7d before NOW)
       // across all 4 prior weeks. With a constant count of 1, mean = 1 and stddev = 0.
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(1 * WEEK)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(2 * WEEK)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(3 * WEEK)) }),
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(4 * WEEK)) }),
       ])
 
-      const signals = await runCh(
-        repo.escalationSignalsByIssues({
+      const signals = await fixture.runCh(
+        fixture.repo.escalationSignalsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -929,14 +968,14 @@ describe("ScoreAnalyticsRepository", () => {
 
     it("returns one signals row per requested issue", async () => {
       const otherIssue = "esc_signals_bbbbbbbbbbbb"
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: fmt(minus(30 * 60 * 1000)) }),
         makeScoreRow({ issue_id: otherIssue, created_at: fmt(minus(30 * 60 * 1000)) }),
         makeScoreRow({ issue_id: otherIssue, created_at: fmt(minus(30 * 60 * 1000)) }),
       ])
 
-      const signals = await runCh(
-        repo.escalationSignalsByIssues({
+      const signals = await fixture.runCh(
+        fixture.repo.escalationSignalsByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId), IssueId(otherIssue)],
@@ -957,11 +996,12 @@ describe("ScoreAnalyticsRepository", () => {
   // ------------------------------------------------------------------
 
   describe("escalationThresholdHistogramByIssues", () => {
+    const fixture = setupFixture()
     const issueId = "esc_thresh_aaaaaaaaaaaaa"
 
     it("returns an empty array when no issue ids are passed", async () => {
-      const series = await runCh(
-        repo.escalationThresholdHistogramByIssues({
+      const series = await fixture.runCh(
+        fixture.repo.escalationThresholdHistogramByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [],
@@ -974,8 +1014,8 @@ describe("ScoreAnalyticsRepository", () => {
     })
 
     it("returns an empty array when bucketSeconds < 1h (sub-hour buckets unsupported)", async () => {
-      const series = await runCh(
-        repo.escalationThresholdHistogramByIssues({
+      const series = await fixture.runCh(
+        fixture.repo.escalationThresholdHistogramByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -991,8 +1031,8 @@ describe("ScoreAnalyticsRepository", () => {
       const trendFrom = new Date("2026-04-22T00:00:00.000Z")
       const trendTo = new Date("2026-04-29T00:00:00.000Z")
 
-      const series = await runCh(
-        repo.escalationThresholdHistogramByIssues({
+      const series = await fixture.runCh(
+        fixture.repo.escalationThresholdHistogramByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -1014,14 +1054,14 @@ describe("ScoreAnalyticsRepository", () => {
       const trendTo = new Date("2026-04-29T00:00:00.000Z")
       // Seed history inside the prior window [trendEnd − 4w, trendEnd) so the
       // pool has data to fold into expected / σ.
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: "2026-04-08 10:00:00.000" }),
         makeScoreRow({ issue_id: issueId, created_at: "2026-04-08 11:00:00.000" }),
         makeScoreRow({ issue_id: issueId, created_at: "2026-04-15 10:00:00.000" }),
       ])
 
-      const series = await runCh(
-        repo.escalationThresholdHistogramByIssues({
+      const series = await fixture.runCh(
+        fixture.repo.escalationThresholdHistogramByIssues({
           organizationId: ORG_ID,
           projectId: PROJECT_ID,
           issueIds: [IssueId(issueId)],
@@ -1048,14 +1088,14 @@ describe("ScoreAnalyticsRepository", () => {
     it("scales the threshold with k_short — higher k widens the band", async () => {
       const trendFrom = new Date("2026-04-22T00:00:00.000Z")
       const trendTo = new Date("2026-04-29T00:00:00.000Z")
-      await insertScores([
+      await fixture.insertScores([
         makeScoreRow({ issue_id: issueId, created_at: "2026-04-08 10:00:00.000" }),
         makeScoreRow({ issue_id: issueId, created_at: "2026-04-15 10:00:00.000" }),
       ])
 
       const [low, high] = await Promise.all([
-        runCh(
-          repo.escalationThresholdHistogramByIssues({
+        fixture.runCh(
+          fixture.repo.escalationThresholdHistogramByIssues({
             organizationId: ORG_ID,
             projectId: PROJECT_ID,
             issueIds: [IssueId(issueId)],
@@ -1064,8 +1104,8 @@ describe("ScoreAnalyticsRepository", () => {
             kShort: 3,
           }),
         ),
-        runCh(
-          repo.escalationThresholdHistogramByIssues({
+        fixture.runCh(
+          fixture.repo.escalationThresholdHistogramByIssues({
             organizationId: ORG_ID,
             projectId: PROJECT_ID,
             issueIds: [IssueId(issueId)],


### PR DESCRIPTION
## what

In `packages/platform/db-clickhouse/src/repositories/score-analytics-repository.test.ts`, every top-level inner `describe` block now opens its own chdb session via a `setupFixture()` helper (which calls `setupTestClickHouse()` and initializes the repo). Previously the file used a single module-scoped session shared across all 37 tests.

## why

CI started failing on this file with cascading `MEMORY_LIMIT_EXCEEDED` errors after #3054 (seasonal anomaly detection) added the `scores_hourly_buckets_mv` materialized view and 10 new escalation tests.

Root cause: chdb is an in-process embedded ClickHouse. A long-lived `Session` accumulates state — parts metadata, MV target rows, internal caches — over every insert and query, and never returns memory below chdb's auto-detected RSS ceiling (≈90% of host RAM, ~14 GiB on the Linux runner). With the MV in place, each `INSERT INTO scores` writes a part in *both* `scores` and the MV target, doubling part-metadata pressure. By test #18 (`trendByIssue > returns occurrence buckets at the requested interval`), even `TRUNCATE TABLE` in `beforeEach` couldn't allocate, and every subsequent test failed in the same `beforeEach` — matching the CI "20 failed | 91 passed (133)" line exactly.

Locally on macOS the same workload peaks around ~777 MB and never trips the ceiling, which is why nobody hit it pre-merge.

## why this fix and not others

- Query micro-optimizations wouldn't move the needle — individual queries already run <100 ms each; the pressure is cumulative across the session.
- Skipping the MV in tests would diverge the test schema from production, and the new escalation tests specifically need it.
- Adding `OPTIMIZE TABLE` / cache drops to `truncateClickHouseTables` is a workaround that doesn't address the root (part accumulation + allocator fragmentation on glibc).
- Splitting the test into multiple files would also work (vitest forks per file), but is more churn for the same outcome.

Per-describe sessions keep the test file together while bounding chdb's working set to one block's worth of inserts (~5 tests max). Test wall-clock goes from 3.7s → 4.5s for this file — the cost of creating 15 sessions instead of 1.

## validation

- `pnpm --filter @platform/db-clickhouse test` → 133/133 pass
- `pnpm --filter @platform/db-clickhouse typecheck` → clean
- `pnpm --filter @platform/db-clickhouse check` → clean