### PR TITLE
fix(core): exclude deleted shadows from getDocumentByPath path lookup

### DIFF
--- a/packages/core/src/repositories/documentVersionsRepository/getDocumentByPath.test.ts
+++ b/packages/core/src/repositories/documentVersionsRepository/getDocumentByPath.test.ts
@@ -1,7 +1,9 @@
 import { Providers } from '@latitude-data/constants'
 import { describe, expect, it } from 'vitest'
+import { database } from '../../client'
+import { documentVersions } from '../../schema/models/documentVersions'
 import { mergeCommit } from '../../services/commits'
-import { updateDocument } from '../../services/documents'
+import { destroyDocument, updateDocument } from '../../services/documents'
 import * as factories from '../../tests/factories'
 import { DocumentVersionsRepository } from './index'
 
@@ -343,5 +345,102 @@ describe('getDocumentByPath', () => {
     })
     expect(newPathResult.ok).toBe(true)
     expect(newPathResult.unwrap().content).toContain('CONTENT')
+  })
+
+  it('returns the active document when a previously deleted document held the same path', async (ctx) => {
+    const { project, user, workspace, providers } =
+      await ctx.factories.createProject()
+
+    // commit1: create and merge "shared-path" as docA
+    const { commit: draft1 } = await factories.createDraft({ project, user })
+    const { documentVersion: docA } = await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft1,
+      path: 'shared-path',
+      content: ctx.factories.helpers.createPrompt({
+        provider: providers[0]!,
+        content: 'DELETED_CONTENT',
+      }),
+    })
+    await mergeCommit(draft1).then((r) => r.unwrap())
+
+    // commit2: soft-delete docA. The soft-delete row preserves the path.
+    const { commit: draft2 } = await factories.createDraft({ project, user })
+    await destroyDocument({ document: docA, commit: draft2, workspace }).then(
+      (r) => r.unwrap(),
+    )
+    await mergeCommit(draft2).then((r) => r.unwrap())
+
+    // commit3: create a new docB at the same path
+    const { commit: draft3 } = await factories.createDraft({ project, user })
+    await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft3,
+      path: 'shared-path',
+      content: ctx.factories.helpers.createPrompt({
+        provider: providers[0]!,
+        content: 'ACTIVE_CONTENT',
+      }),
+    })
+    const merged3 = await mergeCommit(draft3).then((r) => r.unwrap())
+
+    const repo = new DocumentVersionsRepository(project.workspaceId)
+    const result = await repo
+      .getDocumentByPath({ commit: merged3, path: 'shared-path' })
+      .then((r) => r.unwrap())
+
+    expect(result.deletedAt).toBeNull()
+    expect(result.content).toContain('ACTIVE_CONTENT')
+  })
+
+  it('does not let a deleted shadow with a higher documentUuid mask the active document at the same path', async (ctx) => {
+    // Forces the failure mode deterministically: the SELECT DISTINCT ON
+    // subquery emits rows in `document_uuid DESC` order, so a deleted shadow
+    // whose UUID sorts above the active row would be returned first by the
+    // outer LIMIT 1 without the explicit `deletedAt IS NULL` filter.
+    const { project, user, workspace, providers } =
+      await ctx.factories.createProject()
+
+    const { commit: draft1 } = await factories.createDraft({ project, user })
+    const { documentVersion: active } = await factories.createDocumentVersion({
+      workspace,
+      user,
+      commit: draft1,
+      path: 'shared-path',
+      content: ctx.factories.helpers.createPrompt({
+        provider: providers[0]!,
+        content: 'ACTIVE_CONTENT',
+      }),
+    })
+    const merged1 = await mergeCommit(draft1).then((r) => r.unwrap())
+
+    // A second merged commit holds a deleted shadow at the same path with a
+    // documentUuid that sorts above the active row.
+    const shadowCommit = await factories.createCommit({
+      projectId: project.id,
+      user,
+      mergedAt: new Date(merged1.mergedAt!.getTime() + 1000),
+    })
+
+    const higherUuid = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+    expect(higherUuid > active.documentUuid).toBe(true)
+
+    await database.insert(documentVersions).values({
+      documentUuid: higherUuid,
+      commitId: shadowCommit.id,
+      path: 'shared-path',
+      content: 'shadow',
+      deletedAt: new Date(),
+    })
+
+    const repo = new DocumentVersionsRepository(project.workspaceId)
+    const result = await repo
+      .getDocumentByPath({ commit: shadowCommit, path: 'shared-path' })
+      .then((r) => r.unwrap())
+
+    expect(result.documentUuid).toBe(active.documentUuid)
+    expect(result.content).toContain('ACTIVE_CONTENT')
   })
 })

--- a/packages/core/src/repositories/documentVersionsRepository/index.ts
+++ b/packages/core/src/repositories/documentVersionsRepository/index.ts
@@ -356,6 +356,10 @@ export class DocumentVersionsRepository extends Repository<DocumentVersionDto> {
    * Returns the latest merged version of a document at the given path, using a
    * subquery so the path filter runs after the DISTINCT ON — avoiding the need
    * to fetch all documents and filter in application memory.
+   *
+   * The outer query excludes soft-deleted latest versions (when not
+   * `includeDeleted`) so a deleted document that historically held the same
+   * path cannot shadow an active one in the `LIMIT 1` selection.
    */
   private async getLatestMergedDocumentByPath({
     projectId,
@@ -381,10 +385,14 @@ export class DocumentVersionsRepository extends Repository<DocumentVersionDto> {
       .orderBy(desc(documentVersions.documentUuid), desc(commits.mergedAt))
       .as('latest_versions')
 
+    const outerFilter = this.opts.includeDeleted
+      ? eq(latestVersions.path, path)
+      : and(eq(latestVersions.path, path), isNull(latestVersions.deletedAt))
+
     const [document] = await this.db
       .select()
       .from(latestVersions)
-      .where(eq(latestVersions.path, path))
+      .where(outerFilter)
       .limit(1)
 
     return document


### PR DESCRIPTION
## Summary

`getDocumentByPath` could return `NotFoundError` for a document that clearly existed in the live version of a project, blocking API runs of that prompt.

The optimized `getLatestMergedDocumentByPath` helper (introduced in #2392) emits one row per `documentUuid` (its latest merged version) and then filters by `path` with `LIMIT 1`. The inner subquery never excluded soft-deleted rows, so a previously deleted document whose latest row still carried the same path could win the unordered `LIMIT 1` and shadow the active document. The caller saw `deletedAt !== null` and threw `NotFoundError`.

Fix: in the outer query (when `includeDeleted` is false), explicitly require `deletedAt IS NULL`, so the latest-version-per-uuid set is filtered to active rows before the path match.

## Customer reproduction

Customer report:
> 404 from `POST /api/v3/projects/:id/versions/:uuid/documents/run` with `"No document with path executive-summary-tab/overall-performance-summary/mvp-insights at commit [REDACTED]-…"` — and the prompt is clearly present in the LIVE version.

What they observed:
- Running the same request against a different prompt → succeeds.
- Creating a draft (exact copy of LIVE), running the failing path against the draft → succeeds.
- Publishing that draft to LIVE → request fails again.

That maps to the bug exactly:
1. In their project's history, the prompt path was held at some point by a now-soft-deleted document (different `documentUuid`).
2. While they had the draft open, the prompt had a row in the draft commit, so `getDocumentByPath`'s **draft branch** (`commit.mergedAt === null`) returned it via the first `WHERE commitId = draft.id AND path = $1` query — never reaching the buggy helper.
3. On publish, `recomputeChanges → replaceCommitChanges` (`packages/core/src/services/documents/recomputeChanges/index.ts:114-124`) deletes draft-only rows for documents that didn't actually change. The shielding row was removed, and the now-merged commit went through the **merged branch**, hitting `getLatestMergedDocumentByPath`, which picked the soft-deleted shadow.

## Reproduction (test-suite)

Two new tests in `packages/core/src/repositories/documentVersionsRepository/getDocumentByPath.test.ts`:

1. **Naturalistic** — `returns the active document when a previously deleted document held the same path`: creates docA at path P, deletes docA, creates docB at path P, merges each step, and asserts the active doc is returned.
2. **Deterministic** — `does not let a deleted shadow with a higher documentUuid mask the active document at the same path`: directly inserts a soft-deleted row with a `documentUuid` of `'ffffffff-…'` so it sorts above the factory-generated active UUID. Without the fix this test fails with the exact same `NotFoundError: No document with path … at commit …` the customer sees. With the fix it passes.

Verified locally:
- Without the fix: 1 failed (the deterministic test) / 11 total.
- With the fix: 11 passed / 11 total.
- All 27 tests in `documentVersionsRepository` pass.

## Test plan

- [x] Run `pnpm test src/repositories/documentVersionsRepository/getDocumentByPath.test.ts` in `packages/core`.
- [x] Run the full `documentVersionsRepository` suite (`pnpm test src/repositories/documentVersionsRepository`).
- [x] `pnpm tc` on `@latitude-data/core` is green.
- [ ] After deploy, retry the customer's failing `documents/run` request — it should now resolve the active prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)