### PR TITLE
fix(core): invalidate getData cache on every document update

### DIFF
--- a/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.test.ts
+++ b/apps/gateway/src/routes/api/v3/projects/versions/documents/logs/create.handler.test.ts
@@ -246,7 +246,9 @@ describe('POST /projects/:projectId/versions/:versionUuid/documents/logs', () =>
       expect(completionSpan!.commitUuid).toBe(commitUuid)
 
       expect(mocks.diskPutBuffer).toHaveBeenCalledTimes(2)
-      expect(mocks.cacheDel).toHaveBeenCalledTimes(3)
+      // cacheDel calls: latte usage + getData document cache (via the
+      // createDocumentVersion setup) + prompt metadata + completion metadata.
+      expect(mocks.cacheDel).toHaveBeenCalledTimes(4)
 
       const diskPutCalls = mocks.diskPutBuffer.mock.calls
       expect(

--- a/packages/core/src/services/documents/renameDocumentPaths.ts
+++ b/packages/core/src/services/documents/renameDocumentPaths.ts
@@ -1,4 +1,3 @@
-import { cache } from '../../cache'
 import { findWorkspaceFromCommit } from '../../data-access/workspaces'
 import { BadRequestError } from '../../lib/errors'
 import { Result, TypedResult } from '../../lib/Result'
@@ -7,7 +6,6 @@ import { assertCanEditCommit } from '../../lib/assertCanEditCommit'
 import { DocumentVersionsRepository } from '../../repositories'
 import { Commit } from '../../schema/models/types/Commit'
 import { DocumentVersion } from '../../schema/models/types/DocumentVersion'
-import { getDataCacheKey } from './getDataCacheKey'
 import { updateDocument } from './update'
 
 export async function renameDocumentPaths(
@@ -61,21 +59,6 @@ export async function renameDocumentPaths(
         return updatedDoc.unwrap()
       }),
     )
-
-    try {
-      const cacheClient = await cache()
-      const keys = docsToUpdate.map((document) =>
-        getDataCacheKey({
-          workspaceId: workspace!.id,
-          projectId: commit.projectId,
-          commitUuid: commit.uuid,
-          documentPath: document.path,
-        }),
-      )
-      if (keys.length > 0) await cacheClient.del(...keys)
-    } catch (_error) {
-      // Ignore cache errors
-    }
 
     return Result.ok(updatedDocs)
   })

--- a/packages/core/src/services/documents/update.test.ts
+++ b/packages/core/src/services/documents/update.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import { Providers } from '@latitude-data/constants'
+import { cache } from '../../cache'
 import {
   CommitsRepository,
   DocumentVersionsRepository,
 } from '../../repositories'
 import { recomputeChanges } from './recomputeChanges'
 import { updateDocument } from './update'
+import { getDataCacheKey } from './getDataCacheKey'
 import { NotFoundError } from '@latitude-data/constants/errors'
 
 describe('updateDocument', () => {
@@ -348,6 +350,87 @@ This prompt contains empty tools
 
     expect(result.ok).toBe(false)
     expect(result.error!.message).toBe('Cannot modify a merged commit')
+  })
+
+  it('invalidates the gateway getData cache for the document path after editing a draft', async (ctx) => {
+    const { workspace, project, user, documents } =
+      await ctx.factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          doc1: ctx.factories.helpers.createPrompt({
+            provider: 'openai',
+            content: 'Doc 1',
+          }),
+        },
+      })
+    const doc1 = documents.find((d) => d.path === 'doc1')!
+    const { commit: draft } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
+
+    const cacheKey = getDataCacheKey({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitUuid: draft.uuid,
+      documentPath: doc1.path,
+    })
+    const redis = await cache()
+    await redis.set(cacheKey, 'stale')
+
+    await updateDocument({
+      commit: draft,
+      document: doc1,
+      content: ctx.factories.helpers.createPrompt({
+        provider: 'openai',
+        content: 'Doc 1 v2',
+      }),
+    }).then((r) => r.unwrap())
+
+    expect(await redis.get(cacheKey)).toBeNull()
+  })
+
+  it('invalidates the gateway getData cache for both old and new paths when renaming a draft document', async (ctx) => {
+    const { workspace, project, user, documents } =
+      await ctx.factories.createProject({
+        providers: [{ type: Providers.OpenAI, name: 'openai' }],
+        documents: {
+          doc1: ctx.factories.helpers.createPrompt({
+            provider: 'openai',
+            content: 'Doc 1',
+          }),
+        },
+      })
+    const doc1 = documents.find((d) => d.path === 'doc1')!
+    const { commit: draft } = await ctx.factories.createDraft({
+      project,
+      user,
+    })
+
+    const oldPathKey = getDataCacheKey({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitUuid: draft.uuid,
+      documentPath: 'doc1',
+    })
+    const newPathKey = getDataCacheKey({
+      workspaceId: workspace.id,
+      projectId: project.id,
+      commitUuid: draft.uuid,
+      documentPath: 'doc1-renamed',
+    })
+    const redis = await cache()
+    await redis.set(oldPathKey, 'stale-old')
+    await redis.set(newPathKey, 'stale-new')
+
+    await updateDocument({
+      commit: draft,
+      document: doc1,
+      path: 'doc1-renamed',
+    }).then((r) => r.unwrap())
+
+    expect(await redis.get(oldPathKey)).toBeNull()
+    expect(await redis.get(newPathKey)).toBeNull()
   })
 
   it('invalidates the resolvedContent for all documents in the commit', async (ctx) => {

--- a/packages/core/src/services/documents/updateDocumentContent/updateContent.ts
+++ b/packages/core/src/services/documents/updateDocumentContent/updateContent.ts
@@ -1,9 +1,7 @@
-import { cache } from '../../../cache'
 import { Result, TypedResult } from '../../../lib/Result'
 import { type Commit } from '../../../schema/models/types/Commit'
 import { type DocumentVersion } from '../../../schema/models/types/DocumentVersion'
 import { type Workspace } from '../../../schema/models/types/Workspace'
-import { getDataCacheKey } from '../getDataCacheKey'
 import { updateDocument } from '../update'
 import { validateDocumentMetadata } from './validateDocumentMetadata'
 
@@ -37,20 +35,6 @@ export async function updateDocumentContent({
     content: prompt,
   })
   if (result.error) return result
-
-  try {
-    const cacheClient = await cache()
-    await cacheClient.del(
-      getDataCacheKey({
-        workspaceId: workspace.id,
-        projectId: commit.projectId,
-        commitUuid: commit.uuid,
-        documentPath: document.path,
-      }),
-    )
-  } catch (_error) {
-    // Ignore cache errors
-  }
 
   return Result.ok({
     document: result.value,

--- a/packages/core/src/services/documents/updateUnsafe.ts
+++ b/packages/core/src/services/documents/updateUnsafe.ts
@@ -1,5 +1,6 @@
 import { omit } from 'lodash-es'
 import { eq } from 'drizzle-orm'
+import { cache } from '../../cache'
 import { type Commit } from '../../schema/models/types/Commit'
 import { type DocumentVersion } from '../../schema/models/types/DocumentVersion'
 import { findWorkspaceFromCommit } from '../../data-access/workspaces'
@@ -12,6 +13,7 @@ import { pingProjectUpdate } from '../projects'
 import { canInheritDocumentRelations } from './inheritRelations'
 import { updateListOfIntegrations } from './updateListOfIntegrations'
 import { getDocumentType } from './update'
+import { getDataCacheKey } from './getDataCacheKey'
 import { hashContent } from '../../lib/hashContent'
 
 /**
@@ -39,96 +41,130 @@ export async function updateDocumentUnsafe(
   },
   transaction = new Transaction(),
 ): Promise<TypedResult<DocumentVersion, Error>> {
-  return await transaction.call(async (tx) => {
-    const updatedDocData = Object.fromEntries(
-      Object.entries({
-        path,
-        content,
-        promptlVersion,
-        deletedAt,
-        mainEvaluationUuid,
-      }).filter(([_, v]) => v !== undefined),
-    )
+  let pathsToInvalidate: string[] = []
+  let workspaceIdToInvalidate: number | undefined
 
-    const workspace = await findWorkspaceFromCommit(commit, tx)
-    const docsScope = new DocumentVersionsRepository(workspace!.id, tx, {
-      includeDeleted: true,
-    })
-    const documents = (await docsScope.getDocumentsAtCommit(commit)).unwrap()
-    const doc = documents.find((d) => d.documentUuid === document.documentUuid)
+  const result = await transaction.call(
+    async (tx) => {
+      const updatedDocData = Object.fromEntries(
+        Object.entries({
+          path,
+          content,
+          promptlVersion,
+          deletedAt,
+          mainEvaluationUuid,
+        }).filter(([_, v]) => v !== undefined),
+      )
 
-    if (!doc) {
-      return Result.error(new NotFoundError('Document does not exist'))
-    }
-
-    if (path !== undefined) {
-      if (
-        documents.find(
-          (d) => d.path === path && d.documentUuid !== doc.documentUuid,
-        )
-      ) {
-        return Result.error(
-          new BadRequestError('A document with the same path already exists'),
-        )
-      }
-    }
-
-    const oldVersion = omit(document, ['id', 'commitId', 'updatedAt'])
-    const documentType = await getDocumentType({
-      content: content || oldVersion.content,
-    })
-
-    const newVersion = {
-      ...oldVersion,
-      ...updatedDocData,
-      commitId: commit.id,
-      documentType,
-    } as DocumentVersion
-
-    if (content) {
-      newVersion.contentHash = hashContent(content)
-    }
-
-    const updatedDocs = await tx
-      .insert(documentVersions)
-      .values(newVersion)
-      .onConflictDoUpdate({
-        target: [documentVersions.documentUuid, documentVersions.commitId],
-        set: newVersion,
+      const workspace = await findWorkspaceFromCommit(commit, tx)
+      const docsScope = new DocumentVersionsRepository(workspace!.id, tx, {
+        includeDeleted: true,
       })
-      .returning()
+      const documents = (await docsScope.getDocumentsAtCommit(commit)).unwrap()
+      const doc = documents.find(
+        (d) => d.documentUuid === document.documentUuid,
+      )
 
-    if (updatedDocs.length === 0) {
-      return Result.error(new NotFoundError('Document does not exist'))
-    }
+      if (!doc) {
+        return Result.error(new NotFoundError('Document does not exist'))
+      }
 
-    canInheritDocumentRelations({
-      fromVersion: document,
-      toVersion: updatedDocs[0]!,
-    }).unwrap()
+      if (path !== undefined) {
+        if (
+          documents.find(
+            (d) => d.path === path && d.documentUuid !== doc.documentUuid,
+          )
+        ) {
+          return Result.error(
+            new BadRequestError('A document with the same path already exists'),
+          )
+        }
+      }
 
-    // Invalidate all resolvedContent for this commit
-    await tx
-      .update(documentVersions)
-      .set({ resolvedContent: null })
-      .where(eq(documentVersions.commitId, commit.id))
+      const oldVersion = omit(document, ['id', 'commitId', 'updatedAt'])
+      const documentType = await getDocumentType({
+        content: content || oldVersion.content,
+      })
 
-    await updateListOfIntegrations(
-      {
-        workspace: workspace!,
-        projectId: commit.projectId,
-        documentVersion: newVersion,
-      },
-      transaction,
-    )
+      const newVersion = {
+        ...oldVersion,
+        ...updatedDocData,
+        commitId: commit.id,
+        documentType,
+      } as DocumentVersion
 
-    await pingProjectUpdate(
-      {
-        projectId: commit.projectId,
-      },
-      transaction,
-    ).then((r) => r.unwrap())
+      if (content) {
+        newVersion.contentHash = hashContent(content)
+      }
 
-    return Result.ok(updatedDocs[0]!)
-  })
+      const updatedDocs = await tx
+        .insert(documentVersions)
+        .values(newVersion)
+        .onConflictDoUpdate({
+          target: [documentVersions.documentUuid, documentVersions.commitId],
+          set: newVersion,
+        })
+        .returning()
+
+      if (updatedDocs.length === 0) {
+        return Result.error(new NotFoundError('Document does not exist'))
+      }
+
+      canInheritDocumentRelations({
+        fromVersion: document,
+        toVersion: updatedDocs[0]!,
+      }).unwrap()
+
+      // Invalidate all resolvedContent for this commit
+      await tx
+        .update(documentVersions)
+        .set({ resolvedContent: null })
+        .where(eq(documentVersions.commitId, commit.id))
+
+      await updateListOfIntegrations(
+        {
+          workspace: workspace!,
+          projectId: commit.projectId,
+          documentVersion: newVersion,
+        },
+        transaction,
+      )
+
+      await pingProjectUpdate(
+        {
+          projectId: commit.projectId,
+        },
+        transaction,
+      ).then((r) => r.unwrap())
+
+      workspaceIdToInvalidate = workspace!.id
+      pathsToInvalidate =
+        updatedDocs[0]!.path !== document.path
+          ? [document.path, updatedDocs[0]!.path]
+          : [updatedDocs[0]!.path]
+
+      return Result.ok(updatedDocs[0]!)
+    },
+    async () => {
+      if (workspaceIdToInvalidate === undefined) return
+      if (pathsToInvalidate.length === 0) return
+
+      try {
+        const cacheClient = await cache()
+        const keys = pathsToInvalidate.map((documentPath) =>
+          getDataCacheKey({
+            workspaceId: workspaceIdToInvalidate!,
+            projectId: commit.projectId,
+            commitUuid: commit.uuid,
+            documentPath,
+          }),
+        )
+        await cacheClient.del(...keys)
+      } catch (_error) {
+        // Ignore cache errors
+      }
+    },
+  )
+
+  return result
 }


### PR DESCRIPTION
## Summary

- The gateway `/run` endpoint caches `{project, commit, document}` in Redis for 1 hour at `workspace:project:commit:path`. Editing a prompt in a draft (via `updateDocumentContentAction` → `updateDocument`) wrote to the DB but never deleted that cache entry, so the API kept returning the stale prompt until the TTL expired (matches the customer's "fixed itself after ~half an hour").
- Move cache invalidation into `updateDocumentUnsafe` (single source of truth) and run it as a post-commit `Transaction.call` callback so it only fires after the outermost transaction commits. Covers both old and new paths for renames.
- Drops the now-redundant `del` calls in `updateContent` (the service) and `renameDocumentPaths`. PR #2932's `commitPublished` invalidation stays — it covers a different path.

## Why this happened despite #2932

#2932 invalidated on `commitPublished`. The new repro is editing a **draft** and calling the API with the **draft UUID**: no publish event fires, no handler runs, cache stays stale.

## Test plan

- [x] `pnpm test src/services/documents/update.test.ts` — 2 new tests cover content edit + rename invalidation
- [x] `pnpm test src/services/documents/renameDocumentPaths.test.ts` — still green after removing inline invalidation
- [x] `pnpm test src/events/handlers/clearDocumentGetDataCache.test.ts` — handler still green
- [x] `pnpm test src/actions/documents/updateContent.test.ts` (web) — action still green
- [x] `pnpm tc` on core/web/gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)