### PR TITLE
fix(web): guard parseMarkdownLinks against non-string descriptions

### DIFF
--- a/apps/web/src/components/Pipedream/utils.ts
+++ b/apps/web/src/components/Pipedream/utils.ts
@@ -1,5 +1,5 @@
-export function parseMarkdownLinks(text: string | undefined) {
-  if (!text) return ''
+export function parseMarkdownLinks(text: unknown) {
+  if (typeof text !== 'string' || !text) return ''
   return text.replace(
     /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
     `<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>`,


### PR DESCRIPTION
## Summary
- Widened `parseMarkdownLinks(text)` to accept `unknown` and added a `typeof text === 'string'` guard before calling `.replace`.
- Fixes the Tools sidebar crash when Pipedream returns a non-string `description` for some tools/components.

## Context
Datadog Error Tracking issue [`f7b3c014-52a3-11f1-8c72-da7ad0900005`](https://app.datadoghq.eu/error-tracking?query=service%3A%2A&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%22f7b3c014-52a3-11f1-8c72-da7ad0900005%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D) — `TypeError: e.replace is not a function` in `apps/web/src/components/Pipedream/utils.ts` on the document editor route, first seen on release `751aceac9`. The function is called inside `visibleTools.map(...)` on the Tools sidebar, so any tool whose `description` isn't a string takes the whole panel down.

## Test plan
- [x] `pnpm tc` (apps/web) passes
- [ ] Manually open a workspace with a Pipedream integration whose tools have non-string descriptions and confirm the Tools sidebar renders without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)